### PR TITLE
fix(agents): honor claude-cli contextTokens setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Claude CLI context budgets:** honor Anthropic model `contextTokens` overrides by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
+- **Claude CLI context budgets:** honor Anthropic model and per-agent `contextTokens` limits by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Claude CLI context budgets:** honor Anthropic model `contextTokens` overrides by passing the effective limit to Claude Code's native auto-compactor and persisting the same prepared budget in OpenClaw session state. Fixes #80933. (#93198) Thanks @mushuiyu886.
 - **Native app connection and relay reliability:** keep Android disconnects stopped across Activity recreation, fail remote camera commands without opening permission prompts, refresh mobile node registration after capability changes, surface iOS onboarding connection failures, cancel stale Talk owners on session switches, reject invalid Watch acknowledgments, preserve Watch events received during startup, and prevent older agent overview requests from replacing newer gateway state.
 - **Gateway source watch:** hand the configured port off from the installed service before starting the tmux watcher, preserve failed panes for attach/capture, and keep explicit alternate-port watches side by side with the managed Gateway.
 - **Claude CLI max-turn diagnostics:** preserve terminal max-turn results with OpenClaw and Claude session context, warn when tool actions may already have run, and stop unsafe auth-profile or model replay for potentially side-effecting turns. (#94130) Thanks @zhangguiping-xydt.

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -260,7 +260,7 @@ For CLIs that emit provider-specific JSONL events, set `jsonlDialect` on that ba
 
 Some CLI backends run an agent that compacts its own transcript, so OpenClaw must not run its safeguard summarizer against them — doing so fights the backend's own compaction and can hard-fail the turn.
 
-`claude-cli` has no harness endpoint (Claude Code compacts internally), so it declares `ownsNativeCompaction: true` and OpenClaw's compaction path returns the session entry unchanged. Native-harness sessions such as Codex keep routing to their harness compaction endpoint instead.
+`claude-cli` has no harness endpoint (Claude Code compacts internally), so it declares `ownsNativeCompaction: true` and OpenClaw's compaction path returns the session entry unchanged. OpenClaw passes the run's effective context budget through Claude Code's documented [`CLAUDE_CODE_AUTO_COMPACT_WINDOW`](https://code.claude.com/docs/en/env-vars), keeping native auto-compaction aligned with configured Anthropic `contextTokens` limits. Native-harness sessions such as Codex keep routing to their harness compaction endpoint instead.
 
 ```typescript
 api.registerCliBackend({ id: "my-cli", ownsNativeCompaction: true /* ... */ });

--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -210,7 +210,7 @@ only for behavior that really belongs to the backend.
 | ---------------------------------- | --------------------------------------------------------------------------- |
 | `normalizeConfig(config, context)` | Rewrite legacy user config after merge                                      |
 | `resolveExecutionArgs(ctx)`        | Add request-scoped flags such as thinking effort or side-question isolation |
-| `prepareExecution(ctx)`            | Create temporary auth or config bridges before launch                       |
+| `prepareExecution(ctx)`            | Create temporary auth, config, or environment bridges before launch         |
 | `transformSystemPrompt(ctx)`       | Apply a final CLI-specific system prompt transform                          |
 | `textTransforms`                   | Bidirectional prompt/output replacements                                    |
 | `defaultAuthProfileId`             | Prefer a specific OpenClaw auth profile                                     |
@@ -223,6 +223,10 @@ only for behavior that really belongs to the backend.
 
 Keep these hooks provider-owned. Do not add CLI-specific branches to core when
 a backend hook can express the behavior.
+
+`prepareExecution(ctx)` receives `ctx.contextTokenBudget`, the effective token
+limit selected for the run. Backends that own native compaction can map that
+budget into their CLI-specific launch contract.
 
 `runtimeArtifact` is plugin-owned and is not user-overridable. It is consulted
 only when a live inference turn mints or revalidates verified setup authority;

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -451,6 +451,10 @@ AI CLI backend such as `claude-cli` or `my-cli`.
   backend-native isolation flags for ephemeral `/btw` calls. If those flags
   reliably disable native tools for an otherwise always-on CLI, declare
   `sideQuestionToolMode: "disabled"` too.
+- Use `prepareExecution` for backend-owned launch environment or temporary
+  auth/config bridges. Its `ctx.contextTokenBudget` is the effective token
+  limit selected for the run, so native-compaction backends can align their
+  own threshold without provider-specific core branches.
 - Backends that can disable all native tools for a specific run may declare
   `nativeToolMode: "selectable"`. Restricted calls pass an empty
   `ctx.toolAvailability.native` tuple plus an exact host-isolated MCP allowlist;

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -100,6 +100,7 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       serialize: true,
     },
     normalizeConfig: normalizeClaudeBackendConfig,
+    autoSelectAuthProfile: false,
     prepareExecution: ({ contextTokenBudget }) => {
       const env = resolveClaudeCliAutoCompactEnv(contextTokenBudget);
       return env ? { env } : undefined;

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -14,6 +14,7 @@ import {
   CLAUDE_CLI_MODEL_ALIASES,
   CLAUDE_CLI_SESSION_ID_FIELDS,
   normalizeClaudeBackendConfig,
+  resolveClaudeCliAutoCompactEnv,
   resolveClaudeCliExecutionArgs,
 } from "./cli-shared.js";
 
@@ -99,6 +100,10 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       serialize: true,
     },
     normalizeConfig: normalizeClaudeBackendConfig,
+    prepareExecution: ({ contextTokenBudget }) => {
+      const env = resolveClaudeCliAutoCompactEnv(contextTokenBudget);
+      return env ? { env } : undefined;
+    },
     resolveExecutionArgs: resolveClaudeCliExecutionArgs,
   };
 }

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -6,12 +6,25 @@ import {
   normalizeClaudeBackendConfig,
   normalizeClaudePermissionArgs,
   normalizeClaudeSettingSourcesArgs,
+  resolveClaudeCliAutoCompactEnv,
   resolveClaudePermissionMode,
   resolveClaudeCliExecutionArgs,
 } from "./cli-shared.js";
 
 const CLAUDE_CLI_DISALLOWED_TOOLS =
   "ScheduleWakeup,CronCreate,Bash(run_in_background:true),Monitor";
+
+describe("resolveClaudeCliAutoCompactEnv", () => {
+  it("maps the effective OpenClaw context budget into Claude Code compaction", () => {
+    expect(resolveClaudeCliAutoCompactEnv(100_000.9)).toEqual({
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000",
+    });
+  });
+
+  it.each([undefined, 0, 0.5, Number.NaN])("rejects an invalid context budget: %s", (budget) => {
+    expect(resolveClaudeCliAutoCompactEnv(budget)).toBeUndefined();
+  });
+});
 
 function expectDefaultDisallowedTools(args: readonly string[] | undefined) {
   const disallowedIndex = args?.indexOf("--disallowedTools") ?? -1;
@@ -533,6 +546,7 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.clearEnv).toContain("ANTHROPIC_CUSTOM_HEADERS");
     expect(backend.config.clearEnv).toContain("ANTHROPIC_OAUTH_TOKEN");
     expect(backend.config.clearEnv).toContain("CLAUDE_CONFIG_DIR");
+    expect(backend.config.clearEnv).toContain("CLAUDE_CODE_AUTO_COMPACT_WINDOW");
     expect(backend.config.clearEnv).toContain("CLAUDE_CODE_USE_BEDROCK");
     expect(backend.config.clearEnv).toContain("CLAUDE_CODE_OAUTH_TOKEN");
     expect(backend.config.clearEnv).toContain("CLAUDE_CODE_PLUGIN_CACHE_DIR");
@@ -542,6 +556,21 @@ describe("normalizeClaudeBackendConfig", () => {
     expect(backend.config.clearEnv).toContain("OTEL_METRICS_EXPORTER");
     expect(backend.config.clearEnv).toContain("OTEL_EXPORTER_OTLP_PROTOCOL");
     expect(backend.config.clearEnv).toContain("OTEL_SDK_DISABLED");
+  });
+
+  it("passes the effective context budget to Claude Code's native compactor", () => {
+    const backend = buildAnthropicCliBackend();
+
+    expect(
+      backend.prepareExecution?.({
+        workspaceDir: "/tmp/openclaw-claude-cli",
+        provider: "claude-cli",
+        modelId: "claude-opus-4-7",
+        contextTokenBudget: 100_000,
+      }),
+    ).toEqual({
+      env: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000" },
+    });
   });
 
   it("disables native background Bash and Monitor tools in args and resumeArgs", () => {

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -32,6 +32,8 @@ export const CLAUDE_CLI_CLEAR_ENV = [
   "ANTHROPIC_OAUTH_TOKEN",
   "ANTHROPIC_UNIX_SOCKET",
   "CLAUDE_CONFIG_DIR",
+  // Re-injected per run from OpenClaw's canonical context budget.
+  "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
   "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
   "CLAUDE_CODE_ENTRYPOINT",
   "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
@@ -111,6 +113,22 @@ export const CLAUDE_CLI_OFF_THINKING_PROFILE = {
 /** Return whether a provider id refers to the Claude CLI backend. */
 export function isClaudeCliProvider(providerId: string): boolean {
   return normalizeOptionalLowercaseString(providerId) === CLAUDE_CLI_BACKEND_ID;
+}
+
+/** Map OpenClaw's effective context budget to Claude Code's native compactor. */
+export function resolveClaudeCliAutoCompactEnv(
+  contextTokenBudget: number | undefined,
+): Record<string, string> | undefined {
+  if (typeof contextTokenBudget !== "number" || !Number.isFinite(contextTokenBudget)) {
+    return undefined;
+  }
+  const normalizedBudget = Math.floor(contextTokenBudget);
+  if (normalizedBudget <= 0) {
+    return undefined;
+  }
+  return {
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(normalizedBudget),
+  };
 }
 
 function isOpenClawRequestedYolo(context?: CliBackendNormalizeConfigContext): boolean {

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -28,6 +28,7 @@ let runtimeBackendEntries: RuntimeBackendEntry[] = [];
 let setupBackendEntries: SetupBackendEntry[] = [];
 
 function createBackendEntry(params: {
+  autoSelectAuthProfile?: boolean;
   pluginId: string;
   id: string;
   config: CliBackendConfig;
@@ -56,6 +57,9 @@ function createBackendEntry(params: {
       ...(params.bundleMcpMode ? { bundleMcpMode: params.bundleMcpMode } : {}),
       ...(params.defaultAuthProfileId ? { defaultAuthProfileId: params.defaultAuthProfileId } : {}),
       ...(params.authEpochMode ? { authEpochMode: params.authEpochMode } : {}),
+      ...(params.autoSelectAuthProfile !== undefined
+        ? { autoSelectAuthProfile: params.autoSelectAuthProfile }
+        : {}),
       ...(params.ownsNativeCompaction ? { ownsNativeCompaction: params.ownsNativeCompaction } : {}),
       ...(params.prepareExecution ? { prepareExecution: params.prepareExecution } : {}),
       ...(params.resolveExecutionArgs ? { resolveExecutionArgs: params.resolveExecutionArgs } : {}),
@@ -275,6 +279,7 @@ beforeEach(() => {
       id: "claude-cli",
       bundleMcp: true,
       bundleMcpMode: "claude-config-file",
+      autoSelectAuthProfile: false,
       ownsNativeCompaction: true,
       config: {
         command: "claude",
@@ -603,6 +608,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
 
     expect(resolved?.bundleMcp).toBe(true);
     expect(resolved?.bundleMcpMode).toBe("claude-config-file");
+    expect(resolved?.autoSelectAuthProfile).toBe(false);
     expect(resolved?.config.output).toBe("jsonl");
     expect(resolved?.config.args).toContain("stream-json");
     expect(resolved?.config.args).toContain("--include-partial-messages");
@@ -981,6 +987,7 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
 
     expect(resolved?.bundleMcp).toBe(true);
     expect(resolved?.bundleMcpMode).toBe("claude-config-file");
+    expect(resolved?.autoSelectAuthProfile).toBe(false);
     expect(resolved?.config.args).toEqual([
       "-p",
       "--output-format",

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -51,6 +51,7 @@ export type ResolvedCliBackend = {
   textTransforms?: PluginTextTransforms;
   defaultAuthProfileId?: string;
   authEpochMode?: CliBackendAuthEpochMode;
+  autoSelectAuthProfile?: boolean;
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
   ownsNativeCompaction?: boolean;
   prepareExecution?: CliBackendPlugin["prepareExecution"];
@@ -88,6 +89,7 @@ type FallbackCliBackendPolicy = {
   textTransforms?: PluginTextTransforms;
   defaultAuthProfileId?: string;
   authEpochMode?: CliBackendAuthEpochMode;
+  autoSelectAuthProfile?: boolean;
   contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
   ownsNativeCompaction?: boolean;
   prepareExecution?: CliBackendPlugin["prepareExecution"];
@@ -131,6 +133,7 @@ function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolic
     textTransforms: entry.backend.textTransforms,
     defaultAuthProfileId: entry.backend.defaultAuthProfileId,
     authEpochMode: entry.backend.authEpochMode,
+    autoSelectAuthProfile: entry.backend.autoSelectAuthProfile,
     contextEngineHostCapabilities: entry.backend.contextEngineHostCapabilities,
     ownsNativeCompaction: entry.backend.ownsNativeCompaction,
     prepareExecution: entry.backend.prepareExecution,
@@ -433,6 +436,7 @@ export function resolveCliBackendConfig(
       textTransforms: mergePluginTextTransforms(runtimeTextTransforms, registered.textTransforms),
       defaultAuthProfileId: registered.defaultAuthProfileId,
       authEpochMode: registered.authEpochMode,
+      autoSelectAuthProfile: registered.autoSelectAuthProfile,
       contextEngineHostCapabilities: registered.contextEngineHostCapabilities,
       ownsNativeCompaction: registered.ownsNativeCompaction,
       prepareExecution: registered.prepareExecution,
@@ -468,6 +472,7 @@ export function resolveCliBackendConfig(
       ),
       defaultAuthProfileId: fallbackPolicy.defaultAuthProfileId,
       authEpochMode: fallbackPolicy.authEpochMode,
+      autoSelectAuthProfile: fallbackPolicy.autoSelectAuthProfile,
       contextEngineHostCapabilities: fallbackPolicy.contextEngineHostCapabilities,
       ownsNativeCompaction: fallbackPolicy.ownsNativeCompaction,
       prepareExecution: fallbackPolicy.prepareExecution,
@@ -500,6 +505,7 @@ export function resolveCliBackendConfig(
     ),
     defaultAuthProfileId: fallbackPolicy?.defaultAuthProfileId,
     authEpochMode: fallbackPolicy?.authEpochMode,
+    autoSelectAuthProfile: fallbackPolicy?.autoSelectAuthProfile,
     contextEngineHostCapabilities: fallbackPolicy?.contextEngineHostCapabilities,
     ownsNativeCompaction: fallbackPolicy?.ownsNativeCompaction,
     prepareExecution: fallbackPolicy?.prepareExecution,

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -2229,6 +2229,28 @@ describe("runCliAgent reliability", () => {
     expect(completion.finishReason).toBe("stop");
     expect(completion.stopReason).toBe("completed");
     expect(completion.refusal).toBe(false);
+    expect(result.meta.agentMeta?.contextTokens).toBeUndefined();
+  });
+
+  it("reports the prepared context budget for successful claude-cli runs", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from claude",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const result = await runPreparedCliAgent(
+      buildPreparedContext({ provider: "claude-cli", model: "claude-opus-4-7" }),
+    );
+
+    expect(result.meta.agentMeta?.contextTokens).toBe(150_000);
   });
 
   it("marks CLI runs as paused after sessions_yield", async () => {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -762,6 +762,7 @@ describe("runCliAgent reliability", () => {
     ]);
     expect(result.meta.executionTrace?.attempts?.[0]?.result).toBe("error");
     expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+    expect(result.meta.agentMeta?.contextTokens).toBe(150_000);
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
   });
 
@@ -3763,6 +3764,8 @@ describe("runCliAgent reliability", () => {
       const context = buildPreparedContext({
         sessionKey: "agent:main:main",
         runId: "run-blocked-cli",
+        provider: "claude-cli",
+        model: "opus",
       });
       context.preparedBackend.backend.sessionMode = "none";
       const run = runPreparedCliAgent({
@@ -3796,6 +3799,7 @@ describe("runCliAgent reliability", () => {
       ]);
       expect(result.meta.livenessState).toBe("blocked");
       expect(result.meta.agentMeta?.clearCliSessionBinding).toBe(true);
+      expect(result.meta.agentMeta?.contextTokens).toBe(150_000);
       expect(supervisorSpawnMock).not.toHaveBeenCalled();
       expect(hookRunner.runLlmInput).not.toHaveBeenCalled();
       const beforeRunEvent = requireRecord(

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -4969,7 +4969,7 @@ ${JSON.stringify({
     expect(input.env?.SAFE_OVERRIDE).toBe("from-override");
   });
 
-  it("clears claude-cli provider-routing, auth, telemetry, and host-managed env", async () => {
+  it("clears claude-cli provider-routing, auth, telemetry, compaction, and host-managed env", async () => {
     vi.stubEnv("ANTHROPIC_BASE_URL", "https://proxy.example.com/v1");
     vi.stubEnv("ANTHROPIC_API_TOKEN", "env-api-token");
     vi.stubEnv("ANTHROPIC_CUSTOM_HEADERS", "x-test-header: env");
@@ -4977,6 +4977,7 @@ ${JSON.stringify({
     vi.stubEnv("CLAUDE_CODE_USE_BEDROCK", "1");
     vi.stubEnv("ANTHROPIC_AUTH_TOKEN", "env-auth-token");
     vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "env-oauth-token");
+    vi.stubEnv("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "1048576");
     vi.stubEnv("CLAUDE_CODE_REMOTE", "1");
     vi.stubEnv("ANTHROPIC_UNIX_SOCKET", "/tmp/anthropic.sock");
     vi.stubEnv("OTEL_LOGS_EXPORTER", "none");
@@ -4992,6 +4993,9 @@ ${JSON.stringify({
         provider: "claude-cli",
         model: "claude-sonnet-4-6",
         runId: "run-claude-env-hardened",
+        preparedEnv: {
+          CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000",
+        },
         backend: {
           env: {
             SAFE_KEEP: "ok",
@@ -5007,6 +5011,7 @@ ${JSON.stringify({
             "CLAUDE_CODE_USE_BEDROCK",
             "ANTHROPIC_AUTH_TOKEN",
             "CLAUDE_CODE_OAUTH_TOKEN",
+            "CLAUDE_CODE_AUTO_COMPACT_WINDOW",
             "CLAUDE_CODE_REMOTE",
             "ANTHROPIC_UNIX_SOCKET",
             "OTEL_LOGS_EXPORTER",
@@ -5031,6 +5036,7 @@ ${JSON.stringify({
     expect(input.env?.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
     expect(input.env?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
     expect(input.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("override-oauth-token");
+    expect(input.env?.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("100000");
     expect(input.env?.CLAUDE_CODE_REMOTE).toBeUndefined();
     expect(input.env?.ANTHROPIC_UNIX_SOCKET).toBeUndefined();
     expect(input.env?.OTEL_LOGS_EXPORTER).toBeUndefined();

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1117,6 +1117,7 @@ export async function runPreparedCliAgent(
           sessionId: agentSessionId,
           provider: params.provider,
           model: context.modelId,
+          contextTokens: context.contextWindowInfo.tokens,
           usage: resultParams.output.usage,
           ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
           ...(persistedCliSessionId

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1117,7 +1117,7 @@ export async function runPreparedCliAgent(
           sessionId: agentSessionId,
           provider: params.provider,
           model: context.modelId,
-          contextTokens: context.contextWindowInfo.tokens,
+          ...(context.contextWindowInfo ? { contextTokens: context.contextWindowInfo.tokens } : {}),
           usage: resultParams.output.usage,
           ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
           ...(persistedCliSessionId

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -595,6 +595,10 @@ export async function runPreparedCliAgent(
   const { executePreparedCliRun } = await import("./cli-runner/execute.runtime.js");
   const { params } = context;
   const sessionBindingDisabled = context.preparedBackend.backend.sessionMode === "none";
+  const preparedContextAgentMeta =
+    isClaudeCliProvider(params.provider) && context.contextWindowInfo
+      ? { contextTokens: context.contextWindowInfo.tokens }
+      : {};
   const hookRunner = getGlobalHookRunner();
   const hasLlmInputHooks = hookRunner?.hasHooks("llm_input") === true;
   const hasLlmOutputHooks = hookRunner?.hasHooks("llm_output") === true;
@@ -716,6 +720,7 @@ export async function runPreparedCliAgent(
         sessionId: params.sessionId ?? "",
         provider: params.provider,
         model: context.modelId,
+        ...preparedContextAgentMeta,
         ...(sessionBindingDisabled ? { clearCliSessionBinding: true } : {}),
       },
     },
@@ -809,6 +814,7 @@ export async function runPreparedCliAgent(
           sessionId: "",
           provider: params.provider,
           model: context.modelId,
+          ...preparedContextAgentMeta,
           ...(sessionBindingDisabled || resolveReusableCliSessionId(context.reusableCliSession)
             ? { clearCliSessionBinding: true }
             : {}),
@@ -1117,9 +1123,7 @@ export async function runPreparedCliAgent(
           sessionId: agentSessionId,
           provider: params.provider,
           model: context.modelId,
-          ...(isClaudeCliProvider(params.provider) && context.contextWindowInfo
-            ? { contextTokens: context.contextWindowInfo.tokens }
-            : {}),
+          ...preparedContextAgentMeta,
           usage: resultParams.output.usage,
           ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
           ...(persistedCliSessionId

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1117,7 +1117,9 @@ export async function runPreparedCliAgent(
           sessionId: agentSessionId,
           provider: params.provider,
           model: context.modelId,
-          ...(context.contextWindowInfo ? { contextTokens: context.contextWindowInfo.tokens } : {}),
+          ...(isClaudeCliProvider(params.provider) && context.contextWindowInfo
+            ? { contextTokens: context.contextWindowInfo.tokens }
+            : {}),
           usage: resultParams.output.usage,
           ...(resultParams.output.usage ? { lastCallUsage: resultParams.output.usage } : {}),
           ...(persistedCliSessionId

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -182,9 +182,11 @@ function createCliBackendConfig(
 
 function setCliBackendForPrepareTest(
   params: {
+    autoSelectAuthProfile?: boolean;
     command?: string;
     id?: string;
     liveSession?: boolean;
+    modelAliases?: Record<string, string>;
     modelProvider?: string;
     pluginId?: string;
     prepareExecution?: CliBackendPlugin["prepareExecution"];
@@ -203,6 +205,9 @@ function setCliBackendForPrepareTest(
         pluginId: params.pluginId ?? "anthropic",
         modelProvider: params.modelProvider ?? "anthropic",
         bundleMcp: false,
+        ...(params.autoSelectAuthProfile !== undefined
+          ? { autoSelectAuthProfile: params.autoSelectAuthProfile }
+          : {}),
         ...(params.prepareExecution ? { prepareExecution: params.prepareExecution } : {}),
         config: {
           command: params.command ?? "claude",
@@ -211,6 +216,7 @@ function setCliBackendForPrepareTest(
           output: "jsonl",
           input: "stdin",
           sessionMode: params.sessionMode ?? "existing",
+          ...(params.modelAliases ? { modelAliases: params.modelAliases } : {}),
           ...(params.liveSession ? { liveSession: "claude-stdio" as const } : {}),
           ...(params.reseedFromRawTranscriptWhenUncompacted
             ? { reseedFromRawTranscriptWhenUncompacted: true }
@@ -272,12 +278,32 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       provider: "claude-cli",
       agentContextTokens: 80_000,
       expectedContextTokens: 80_000,
+      model: "claude-opus-4-7",
+      modelAliases: undefined,
+    },
+    {
+      name: "a Claude CLI user alias",
+      provider: "claude-cli",
+      agentContextTokens: undefined,
+      expectedContextTokens: 100_000,
+      model: "large",
+      modelAliases: { large: "claude-opus-4-7" },
+    },
+    {
+      name: "a Claude CLI-native alias",
+      provider: "claude-cli",
+      agentContextTokens: undefined,
+      expectedContextTokens: 100_000,
+      model: "claude-opus-4-7",
+      modelAliases: { "claude-opus-4-7": "deployment-large" },
     },
     {
       name: "a generic CLI backend alias",
       provider: "fixture-cli",
       agentContextTokens: undefined,
       expectedContextTokens: 100_000,
+      model: "claude-opus-4-7",
+      modelAliases: undefined,
     },
   ])("resolves canonical model budgets for $name", async (testCase) => {
     const { dir, sessionFile } = createSessionFile();
@@ -290,6 +316,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         modelProvider: "fixture-anthropic",
         pluginId: "fixture-plugin",
         prepareExecution,
+        modelAliases: testCase.modelAliases,
       });
       const context = await prepareCliRunContext({
         sessionId: "session-test",
@@ -297,7 +324,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         workspaceDir: dir,
         prompt: "latest ask",
         provider: testCase.provider,
-        model: "claude-opus-4-7",
+        model: testCase.model,
         timeoutMs: 1_000,
         runId: "run-configured-context-budget",
         config: {
@@ -312,6 +339,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
             providers: {
               "fixture-anthropic": {
                 baseUrl: "https://api.anthropic.com",
+                contextTokens: 200_000,
                 models: [
                   {
                     id: "claude-opus-4-7",
@@ -322,6 +350,36 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
                     contextWindow: 200_000,
                     maxTokens: 8_192,
                     contextTokens: 100_000,
+                  },
+                ],
+              },
+              "collision-provider": {
+                baseUrl: "https://collision.invalid",
+                models: [
+                  {
+                    id: "large",
+                    name: "Unrelated Large",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 32_000,
+                    maxTokens: 4_096,
+                    contextTokens: 32_000,
+                  },
+                ],
+              },
+              "claude-cli": {
+                baseUrl: "https://runtime.invalid",
+                models: [
+                  {
+                    id: "large",
+                    name: "Configured Alias Source",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 200_000,
+                    maxTokens: 8_192,
+                    contextTokens: 200_000,
                   },
                 ],
               },
@@ -933,6 +991,71 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         }),
       );
       expect(prepareExecution.mock.calls[0]?.[0]).not.toHaveProperty("authCredential");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "keeps implicit profile selection for auth bridges",
+      autoSelectAuthProfile: undefined,
+      expectedAuthProfileId: "claude-cli:stored",
+    },
+    {
+      name: "lets environment-only hooks opt out of profile selection",
+      autoSelectAuthProfile: false,
+      expectedAuthProfileId: undefined,
+    },
+  ])("$name", async (testCase) => {
+    const { dir, sessionFile } = createSessionFile();
+    const agentDir = path.join(dir, "agents", "main", "agent");
+    const authProfileId = "claude-cli:stored";
+    const prepareExecution = vi.fn(async () => ({ env: { TEST_PREPARED_ENV: "1" } }));
+    fs.mkdirSync(agentDir, { recursive: true });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [authProfileId]: {
+            type: "api_key",
+            provider: "claude-cli",
+            key: "stored-key",
+          },
+        },
+      },
+      agentDir,
+    );
+
+    try {
+      setCliBackendForPrepareTest({
+        prepareExecution,
+        autoSelectAuthProfile: testCase.autoSelectAuthProfile,
+      });
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:main",
+        sessionFile,
+        workspaceDir: dir,
+        agentDir,
+        prompt: "latest ask",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-test-environment-only-prepare-hook",
+        config: {
+          auth: {
+            profiles: {
+              [authProfileId]: { provider: "claude-cli", mode: "api_key" },
+            },
+          },
+        },
+      });
+
+      expect(context.effectiveAuthProfileId).toBe(testCase.expectedAuthProfileId);
+      expect(prepareExecution).toHaveBeenCalledWith(
+        expect.objectContaining({ authProfileId: testCase.expectedAuthProfileId }),
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -262,9 +262,10 @@ function appendTranscriptEntry(
 }
 
 describe("shouldSkipLocalCliCredentialEpoch", () => {
-  it("uses the prepared backend model provider for Claude CLI context tokens", async () => {
+  it("applies the backend model provider and selected agent context cap", async () => {
     const { dir, sessionFile } = createSessionFile();
     const prepareExecution = vi.fn(async () => undefined);
+    const baseConfig = createCliBackendConfig();
     try {
       setClaudeCliBackendForPrepareTest({
         modelProvider: "fixture-anthropic",
@@ -280,7 +281,11 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         timeoutMs: 1_000,
         runId: "run-configured-context-budget",
         config: {
-          ...createCliBackendConfig(),
+          ...baseConfig,
+          agents: {
+            ...baseConfig.agents,
+            list: [{ id: "main", contextTokens: 80_000 }],
+          },
           models: {
             providers: {
               "fixture-anthropic": {
@@ -304,9 +309,9 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.backendResolved.modelProvider).toBe("fixture-anthropic");
-      expect(context.contextWindowInfo?.tokens).toBe(100_000);
+      expect(context.contextWindowInfo?.tokens).toBe(80_000);
       expect(prepareExecution).toHaveBeenCalledWith(
-        expect.objectContaining({ contextTokenBudget: 100_000 }),
+        expect.objectContaining({ contextTokenBudget: 80_000 }),
       );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -182,6 +182,7 @@ function createCliBackendConfig(
 function setClaudeCliBackendForPrepareTest(
   params: {
     liveSession?: boolean;
+    modelProvider?: string;
     sessionMode?: "always" | "existing" | "none";
     reseedFromRawTranscriptWhenUncompacted?: boolean;
   } = {},
@@ -194,6 +195,7 @@ function setClaudeCliBackendForPrepareTest(
       {
         id: "claude-cli",
         pluginId: "anthropic",
+        modelProvider: params.modelProvider ?? "anthropic",
         bundleMcp: false,
         config: {
           command: "claude",
@@ -257,6 +259,46 @@ function appendTranscriptEntry(
 }
 
 describe("shouldSkipLocalCliCredentialEpoch", () => {
+  it("uses the prepared backend model provider for Claude CLI context tokens", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    try {
+      setClaudeCliBackendForPrepareTest({ modelProvider: "fixture-anthropic" });
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "claude-cli",
+        model: "claude-opus-4-7",
+        timeoutMs: 1_000,
+        runId: "run-configured-context-budget",
+        config: {
+          ...createCliBackendConfig(),
+          models: {
+            providers: {
+              "fixture-anthropic": {
+                models: [
+                  {
+                    id: "claude-opus-4-7",
+                    name: "Claude Opus 4.7",
+                    contextWindow: 200_000,
+                    maxTokens: 8_192,
+                    contextTokens: 100_000,
+                  },
+                ],
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+      });
+
+      expect(context.backendResolved.modelProvider).toBe("fixture-anthropic");
+      expect(context.contextWindowInfo.tokens).toBe(100_000);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   beforeEach(() => {
     // Install narrow test doubles for external runtime seams so preparation
     // remains about data flow, not bundled plugin or loopback startup cost.

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -21,6 +21,7 @@ import type {
   McpLoopbackClientGrant,
   McpLoopbackRequestContext,
 } from "../../gateway/mcp-grant-store.js";
+import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { clearMemoryPluginState, registerMemoryPromptSection } from "../../plugins/memory-state.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -183,6 +184,7 @@ function setClaudeCliBackendForPrepareTest(
   params: {
     liveSession?: boolean;
     modelProvider?: string;
+    prepareExecution?: CliBackendPlugin["prepareExecution"];
     sessionMode?: "always" | "existing" | "none";
     reseedFromRawTranscriptWhenUncompacted?: boolean;
   } = {},
@@ -197,6 +199,7 @@ function setClaudeCliBackendForPrepareTest(
         pluginId: "anthropic",
         modelProvider: params.modelProvider ?? "anthropic",
         bundleMcp: false,
+        ...(params.prepareExecution ? { prepareExecution: params.prepareExecution } : {}),
         config: {
           command: "claude",
           args: ["--print"],
@@ -261,8 +264,12 @@ function appendTranscriptEntry(
 describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("uses the prepared backend model provider for Claude CLI context tokens", async () => {
     const { dir, sessionFile } = createSessionFile();
+    const prepareExecution = vi.fn(async () => undefined);
     try {
-      setClaudeCliBackendForPrepareTest({ modelProvider: "fixture-anthropic" });
+      setClaudeCliBackendForPrepareTest({
+        modelProvider: "fixture-anthropic",
+        prepareExecution,
+      });
       const context = await prepareCliRunContext({
         sessionId: "session-test",
         sessionFile,
@@ -298,6 +305,9 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
       expect(context.backendResolved.modelProvider).toBe("fixture-anthropic");
       expect(context.contextWindowInfo?.tokens).toBe(100_000);
+      expect(prepareExecution).toHaveBeenCalledWith(
+        expect.objectContaining({ contextTokenBudget: 100_000 }),
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -271,15 +271,23 @@ function appendTranscriptEntry(
   );
 }
 
+type CliContextBudgetTestCase = {
+  name: string;
+  provider: string;
+  agentContextTokens?: number;
+  expectedContextTokens: number;
+  model: string;
+  modelAliases?: Record<string, string>;
+};
+
 describe("shouldSkipLocalCliCredentialEpoch", () => {
-  it.each([
+  it.each<CliContextBudgetTestCase>([
     {
       name: "Claude CLI with a selected-agent cap",
       provider: "claude-cli",
       agentContextTokens: 80_000,
       expectedContextTokens: 80_000,
       model: "claude-opus-4-7",
-      modelAliases: undefined,
     },
     {
       name: "a Claude CLI user alias",
@@ -303,7 +311,6 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       agentContextTokens: undefined,
       expectedContextTokens: 100_000,
       model: "claude-opus-4-7",
-      modelAliases: undefined,
     },
   ])("resolves canonical model budgets for $name", async (testCase) => {
     const { dir, sessionFile } = createSessionFile();

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -180,28 +180,32 @@ function createCliBackendConfig(
   } satisfies OpenClawConfig;
 }
 
-function setClaudeCliBackendForPrepareTest(
+function setCliBackendForPrepareTest(
   params: {
+    command?: string;
+    id?: string;
     liveSession?: boolean;
     modelProvider?: string;
+    pluginId?: string;
     prepareExecution?: CliBackendPlugin["prepareExecution"];
     sessionMode?: "always" | "existing" | "none";
     reseedFromRawTranscriptWhenUncompacted?: boolean;
   } = {},
 ) {
-  // Keep Claude-specific preparation behind the same runtime resolver seam that
-  // production uses; direct backend constants would bypass provider ownership.
+  const id = params.id ?? "claude-cli";
+  // Keep preparation behind the same runtime resolver seam that production
+  // uses; direct backend constants would bypass provider ownership.
   cliBackendsTesting.setDepsForTest({
     resolvePluginSetupCliBackend: () => undefined,
     resolveRuntimeCliBackends: () => [
       {
-        id: "claude-cli",
-        pluginId: "anthropic",
+        id,
+        pluginId: params.pluginId ?? "anthropic",
         modelProvider: params.modelProvider ?? "anthropic",
         bundleMcp: false,
         ...(params.prepareExecution ? { prepareExecution: params.prepareExecution } : {}),
         config: {
-          command: "claude",
+          command: params.command ?? "claude",
           args: ["--print"],
           resumeArgs: ["--resume", "{sessionId}"],
           output: "jsonl",
@@ -262,13 +266,29 @@ function appendTranscriptEntry(
 }
 
 describe("shouldSkipLocalCliCredentialEpoch", () => {
-  it("applies the backend model provider and selected agent context cap", async () => {
+  it.each([
+    {
+      name: "Claude CLI with a selected-agent cap",
+      provider: "claude-cli",
+      agentContextTokens: 80_000,
+      expectedContextTokens: 80_000,
+    },
+    {
+      name: "a generic CLI backend alias",
+      provider: "fixture-cli",
+      agentContextTokens: undefined,
+      expectedContextTokens: 100_000,
+    },
+  ])("resolves canonical model budgets for $name", async (testCase) => {
     const { dir, sessionFile } = createSessionFile();
     const prepareExecution = vi.fn(async () => undefined);
     const baseConfig = createCliBackendConfig();
     try {
-      setClaudeCliBackendForPrepareTest({
+      setCliBackendForPrepareTest({
+        id: testCase.provider,
+        command: testCase.provider === "claude-cli" ? "claude" : testCase.provider,
         modelProvider: "fixture-anthropic",
+        pluginId: "fixture-plugin",
         prepareExecution,
       });
       const context = await prepareCliRunContext({
@@ -276,7 +296,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sessionFile,
         workspaceDir: dir,
         prompt: "latest ask",
-        provider: "claude-cli",
+        provider: testCase.provider,
         model: "claude-opus-4-7",
         timeoutMs: 1_000,
         runId: "run-configured-context-budget",
@@ -284,7 +304,9 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
           ...baseConfig,
           agents: {
             ...baseConfig.agents,
-            list: [{ id: "main", contextTokens: 80_000 }],
+            ...(testCase.agentContextTokens
+              ? { list: [{ id: "main", contextTokens: testCase.agentContextTokens }] }
+              : {}),
           },
           models: {
             providers: {
@@ -309,9 +331,9 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.backendResolved.modelProvider).toBe("fixture-anthropic");
-      expect(context.contextWindowInfo?.tokens).toBe(80_000);
+      expect(context.contextWindowInfo?.tokens).toBe(testCase.expectedContextTokens);
       expect(prepareExecution).toHaveBeenCalledWith(
-        expect.objectContaining({ contextTokenBudget: 80_000 }),
+        expect.objectContaining({ contextTokenBudget: testCase.expectedContextTokens }),
       );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -3553,7 +3575,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("drops the claude-cli sessionId when the on-disk transcript is missing (#77011)", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
-      setClaudeCliBackendForPrepareTest();
+      setCliBackendForPrepareTest();
       const transcriptCheck = vi.fn(async () => false);
       const orphanCheck = vi.fn(async () => true);
       setCliRunnerPrepareTestDeps({
@@ -3603,7 +3625,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       },
     });
     try {
-      setClaudeCliBackendForPrepareTest({
+      setCliBackendForPrepareTest({
         reseedFromRawTranscriptWhenUncompacted: true,
       });
       const transcriptCheck = vi.fn(async () => false);
@@ -3654,7 +3676,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       },
     });
     try {
-      setClaudeCliBackendForPrepareTest({
+      setCliBackendForPrepareTest({
         liveSession: true,
         reseedFromRawTranscriptWhenUncompacted: true,
       });
@@ -3710,7 +3732,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("disables Claude live transport while preserving native transcript resume", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
-      setClaudeCliBackendForPrepareTest({ liveSession: true });
+      setCliBackendForPrepareTest({ liveSession: true });
       const transcriptCheck = vi.fn(async () => true);
       setCliRunnerPrepareTestDeps({
         claudeCliSessionTranscriptHasContent: transcriptCheck,
@@ -3746,7 +3768,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("ignores stored CLI session candidates when the backend disables sessions", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
-      setClaudeCliBackendForPrepareTest({
+      setCliBackendForPrepareTest({
         sessionMode: "none",
         reseedFromRawTranscriptWhenUncompacted: true,
       });
@@ -3784,7 +3806,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     const { dir, sessionFile } = createSessionFile();
 
     try {
-      setClaudeCliBackendForPrepareTest();
+      setCliBackendForPrepareTest();
       const transcriptCheck = vi.fn(async () => true);
       const orphanCheck = vi.fn(async () => true);
       setCliRunnerPrepareTestDeps({
@@ -3831,7 +3853,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     const { dir, sessionFile } = createSessionFile();
 
     try {
-      setClaudeCliBackendForPrepareTest();
+      setCliBackendForPrepareTest();
       const transcriptCheck = vi.fn(async () => true);
       const orphanCheck = vi.fn(async () => true);
       setCliRunnerPrepareTestDeps({
@@ -3872,7 +3894,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("keeps the claude-cli sessionId when the on-disk transcript is present", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
-      setClaudeCliBackendForPrepareTest();
+      setCliBackendForPrepareTest();
       const transcriptCheck = vi.fn(async () => true);
       const orphanCheck = vi.fn(async () => false);
       setCliRunnerPrepareTestDeps({

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -277,10 +277,14 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
           models: {
             providers: {
               "fixture-anthropic": {
+                baseUrl: "https://api.anthropic.com",
                 models: [
                   {
                     id: "claude-opus-4-7",
                     name: "Claude Opus 4.7",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
                     contextWindow: 200_000,
                     maxTokens: 8_192,
                     contextTokens: 100_000,
@@ -293,7 +297,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.backendResolved.modelProvider).toBe("fixture-anthropic");
-      expect(context.contextWindowInfo.tokens).toBe(100_000);
+      expect(context.contextWindowInfo?.tokens).toBe(100_000);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -649,7 +649,7 @@ export async function prepareCliRunContext(
     ? resolveContextTokensForModel({
         cfg: params.config,
         provider: params.provider,
-        configuredProvider: backendResolved.modelProvider,
+        modelProvider: backendResolved.modelProvider,
         model: resolveClaudeCliContextModelId(modelId),
         fallbackContextTokens: 200_000,
         allowAsyncLoad: false,
@@ -859,6 +859,7 @@ export async function prepareCliRunContext(
       agentDir,
       provider: params.provider,
       modelId,
+      contextTokenBudget: contextWindowInfo.tokens,
       authProfileId: effectiveAuthProfileId,
       executionMode,
       env: preparedBackend.env,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -649,6 +649,7 @@ export async function prepareCliRunContext(
     ? resolveContextTokensForModel({
         cfg: params.config,
         provider: params.provider,
+        configuredProvider: backendResolved.modelProvider,
         model: resolveClaudeCliContextModelId(modelId),
         fallbackContextTokens: 200_000,
         allowAsyncLoad: false,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -42,7 +42,7 @@ import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-ru
 import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveAgentWorkspaceDir } from "../agent-scope-config.js";
-import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
+import { resolveAgentConfig, resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
 import { externalCliDiscoveryForProviderAuth } from "../auth-profiles/external-cli-discovery.js";
 import { resolveApiKeyForProfile } from "../auth-profiles/oauth.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
@@ -529,6 +529,7 @@ export async function prepareCliRunContext(
     config: params.config,
     agentId: params.agentId,
   });
+  const agentContextTokens = resolveAgentConfig(params.config ?? {}, sessionAgentId)?.contextTokens;
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
   const requestedAuthProfileId = params.authProfileId?.trim() || undefined;
   let effectiveAuthProfileId =
@@ -660,6 +661,7 @@ export async function prepareCliRunContext(
     provider: params.provider,
     modelId,
     modelContextTokens,
+    agentContextTokens,
     defaultTokens: DEFAULT_CONTEXT_TOKENS,
   });
   const autoReseedHistoryChars = isClaudeCli

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -646,16 +646,15 @@ export async function prepareCliRunContext(
   const normalizedModel = normalizeCliModel(modelId, backendResolved.config);
   const modelDisplay = `${params.provider}/${modelId}`;
   const isClaudeCli = isClaudeCliProvider(params.provider);
-  const modelContextTokens = isClaudeCli
-    ? resolveContextTokensForModel({
-        cfg: params.config,
-        provider: params.provider,
-        modelProvider: backendResolved.modelProvider,
-        model: resolveClaudeCliContextModelId(modelId),
-        fallbackContextTokens: 200_000,
-        allowAsyncLoad: false,
-      })
-    : undefined;
+  const contextModelId = isClaudeCli ? resolveClaudeCliContextModelId(modelId) : modelId;
+  const modelContextTokens = resolveContextTokensForModel({
+    cfg: params.config,
+    provider: params.provider,
+    modelProvider: backendResolved.modelProvider,
+    model: contextModelId,
+    fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    allowAsyncLoad: false,
+  });
   const contextWindowInfo = resolveContextWindowInfo({
     cfg: params.config,
     provider: params.provider,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -549,7 +549,10 @@ export async function prepareCliRunContext(
   if (effectiveAuthProfileId) {
     authStore = loadScopedAuthStore({ profileId: effectiveAuthProfileId });
     authCredential = authStore.profiles[effectiveAuthProfileId];
-  } else if (backendResolved.prepareExecution || backendResolved.authEpochMode === "profile-only") {
+  } else if (
+    backendResolved.authEpochMode === "profile-only" ||
+    (backendResolved.prepareExecution && backendResolved.autoSelectAuthProfile !== false)
+  ) {
     authStore = loadScopedAuthStore();
     effectiveAuthProfileId =
       resolveAuthProfileOrder({
@@ -646,16 +649,47 @@ export async function prepareCliRunContext(
   const normalizedModel = normalizeCliModel(modelId, backendResolved.config);
   const modelDisplay = `${params.provider}/${modelId}`;
   const isClaudeCli = isClaudeCliProvider(params.provider);
-  const contextModelId = isClaudeCli ? resolveClaudeCliContextModelId(modelId) : modelId;
-  const modelContextTokens = resolveContextTokensForModel({
-    cfg: params.config,
-    provider: params.provider,
-    modelProvider: backendResolved.modelProvider,
-    model: contextModelId,
-    fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-    allowAsyncLoad: false,
-  });
-  const contextWindowInfo = resolveContextWindowInfo({
+  const requestedContextModelId = isClaudeCli ? resolveClaudeCliContextModelId(modelId) : modelId;
+  const normalizedContextModelId = isClaudeCli
+    ? resolveClaudeCliContextModelId(normalizedModel)
+    : normalizedModel;
+  // Aliases can map a canonical id to a CLI shorthand or a user shorthand to
+  // a canonical id. Resolve both identities and keep the safest owned limit.
+  const contextModelIds = [
+    requestedContextModelId,
+    ...(normalizedContextModelId !== requestedContextModelId ? [normalizedContextModelId] : []),
+  ];
+  const resolveContextModelTokens = (contextModelId: string, allowUnscopedModelLookup: boolean) =>
+    resolveContextTokensForModel({
+      cfg: params.config,
+      provider: params.provider,
+      modelProvider: backendResolved.modelProvider,
+      model: contextModelId,
+      allowAsyncLoad: false,
+      allowUnscopedModelLookup,
+    });
+  let modelContextTokens: number | undefined;
+  for (const contextModelId of contextModelIds) {
+    const candidateContextTokens = resolveContextModelTokens(contextModelId, false);
+    if (candidateContextTokens !== undefined) {
+      modelContextTokens =
+        modelContextTokens === undefined
+          ? candidateContextTokens
+          : Math.min(modelContextTokens, candidateContextTokens);
+    }
+  }
+  // A process-wide bare-model cache has no provider provenance. If neither id
+  // has owned metadata, prefer the actual CLI target over the requested alias.
+  if (modelContextTokens === undefined) {
+    for (const contextModelId of contextModelIds.toReversed()) {
+      modelContextTokens = resolveContextModelTokens(contextModelId, true);
+      if (modelContextTokens !== undefined) {
+        break;
+      }
+    }
+  }
+  modelContextTokens ??= DEFAULT_CONTEXT_TOKENS;
+  const resolvedContextWindowInfo = resolveContextWindowInfo({
     cfg: params.config,
     provider: params.provider,
     modelId,
@@ -663,6 +697,12 @@ export async function prepareCliRunContext(
     agentContextTokens,
     defaultTokens: DEFAULT_CONTEXT_TOKENS,
   });
+  // The generic guard rechecks the requested id in config. An alias target may
+  // have a tighter owned limit, so the alias-aware result remains an upper bound.
+  const contextWindowInfo =
+    resolvedContextWindowInfo.tokens > modelContextTokens
+      ? { tokens: modelContextTokens, source: "model" as const }
+      : resolvedContextWindowInfo;
   const autoReseedHistoryChars = isClaudeCli
     ? resolveAutoCliSessionReseedHistoryChars(contextWindowInfo.tokens)
     : undefined;

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -308,7 +308,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     );
   });
 
-  it("compacts claude-cli transcripts using the persisted Anthropic configured budget", async () => {
+  it("compacts claude-cli native harness sessions using the persisted Anthropic configured budget", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -358,20 +358,40 @@ describe("runCliTurnCompactionLifecycle", () => {
             sessionId,
             provider: "claude-cli",
             model: "claude-opus-4-7",
+            agentHarnessId: "claude-cli",
           },
         },
       } as never,
     });
 
     const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
-    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    const compactAgentHarnessSession = vi.fn(async () => ({
+      ok: true,
+      compacted: true,
+      result: { tokensBefore: 90_000, tokensAfter: 10_000 },
+    }));
+    const recordCliCompactionInStore = vi.fn(async () => ({
+      ...sessionStore[sessionKey],
+      compactionCount: 1,
+    }));
     setCliCompactionTestDeps({
+      ensureContextEnginesInitialized: vi.fn(),
       resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+      resolveCliBackendConfig: () => ({
+        id: "claude-cli",
+        modelProvider: "anthropic",
+        config: { command: "claude" },
+        bundleMcp: true,
+        ownsNativeCompaction: true,
+      }),
       createPreparedEmbeddedAgentSettingsManager: async () => ({
         getCompactionReserveTokens: () => 10_000,
         getCompactionKeepRecentTokens: () => 0,
         applyOverrides: () => {},
       }),
+      applyAgentAutoCompactionGuard: vi.fn(async () => undefined),
       shouldPreemptivelyCompactBeforePrompt: (params) => ({
         route: "fits",
         shouldCompact: false,
@@ -382,7 +402,7 @@ describe("runCliTurnCompactionLifecycle", () => {
         effectiveReserveTokens: 10_000,
       }),
       resolveLiveToolResultMaxChars: () => 20_000,
-      runContextEngineMaintenance: maintenance,
+      recordCliCompactionInStore,
     });
 
     const updatedEntry = await runCliTurnCompactionLifecycle({
@@ -399,8 +419,20 @@ describe("runCliTurnCompactionLifecycle", () => {
       model: "claude-opus-4-7",
     });
 
-    expect(compactCalls).toHaveLength(1);
-    expect(compactCalls[0]?.tokenBudget).toBe(100_000);
+    expect(sessionStore[sessionKey]?.contextTokens).toBe(100_000);
+    expect(sessionStore[sessionKey]?.agentHarnessId).toBe("claude-cli");
+    expect(compactAgentHarnessSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentHarnessId: "claude-cli",
+        contextTokenBudget: 100_000,
+        currentTokenCount: 90_000,
+        force: true,
+        provider: "claude-cli",
+        model: "claude-opus-4-7",
+      }),
+    );
+    expect(compactCalls).toHaveLength(0);
+    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
     expect(updatedEntry?.compactionCount).toBe(1);
   });
 

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -331,16 +331,19 @@ describe("runCliTurnCompactionLifecycle", () => {
     const storePath = path.join(tmpDir, "sessions-configured-budget.json");
     await writeSessionFile({ sessionFile, sessionId });
 
-    const sessionStore: Record<string, SessionEntry> = {
-      [sessionKey]: {
-        sessionId,
-        updatedAt: 1,
-        sessionFile,
-        totalTokens: 90_000,
-        totalTokensFresh: true,
-      },
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: 1,
+      sessionFile,
+      totalTokens: 90_000,
+      totalTokensFresh: true,
     };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await persistSessionEntry({
+      sessionKey,
+      storePath,
+      entry: sessionEntry,
+    });
 
     await updateSessionStoreAfterAgentRun({
       cfg,

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -335,6 +335,7 @@ describe("runCliTurnCompactionLifecycle", () => {
       sessionId,
       updatedAt: 1,
       sessionFile,
+      contextTokens: 1_048_576,
       totalTokens: 90_000,
       totalTokensFresh: true,
     };
@@ -361,6 +362,7 @@ describe("runCliTurnCompactionLifecycle", () => {
             sessionId,
             provider: "claude-cli",
             model: "claude-opus-4-7",
+            contextTokens: 100_000,
           },
         },
       } as never,

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -13,7 +13,6 @@ import {
   runCliTurnCompactionLifecycle,
   setCliCompactionTestDeps,
 } from "./cli-compaction.js";
-import { updateSessionStoreAfterAgentRun } from "./session-store.js";
 
 function buildContextEngine(params: {
   compactCalls: Array<Parameters<ContextEngine["compact"]>[0]>;
@@ -306,123 +305,6 @@ describe("runCliTurnCompactionLifecycle", () => {
         tokensAfter: 100,
       }),
     );
-  });
-
-  it("persists the configured Anthropic budget before ordinary claude-cli compaction defers to its backend", async () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          cliBackends: {
-            "claude-cli": { command: "claude" },
-          },
-        },
-      },
-      models: {
-        providers: {
-          anthropic: {
-            models: [{ id: "claude-opus-4-7", contextTokens: 100_000 }],
-          },
-        },
-      },
-    } as unknown as OpenClawConfig;
-    const sessionKey = "agent:main:cli-configured-budget";
-    const sessionId = "session-cli-configured-budget";
-    const sessionFile = path.join(tmpDir, "session-configured-budget.jsonl");
-    const storePath = path.join(tmpDir, "sessions-configured-budget.json");
-    await writeSessionFile({ sessionFile, sessionId });
-
-    const sessionEntry: SessionEntry = {
-      sessionId,
-      updatedAt: 1,
-      sessionFile,
-      contextTokens: 1_048_576,
-      totalTokens: 90_000,
-      totalTokensFresh: true,
-    };
-    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    await persistSessionEntry({
-      sessionKey,
-      storePath,
-      entry: sessionEntry,
-    });
-
-    await updateSessionStoreAfterAgentRun({
-      cfg,
-      sessionId,
-      sessionKey,
-      storePath,
-      sessionStore,
-      defaultProvider: "claude-cli",
-      defaultModel: "claude-opus-4-7",
-      result: {
-        meta: {
-          durationMs: 1,
-          executionTrace: { runner: "cli" },
-          agentMeta: {
-            sessionId,
-            provider: "claude-cli",
-            model: "claude-opus-4-7",
-            contextTokens: 100_000,
-          },
-        },
-      } as never,
-    });
-
-    const ensureContextEnginesInitialized = vi.fn();
-    const resolveContextEngine = vi.fn(async () => buildContextEngine({ compactCalls: [] }));
-    const compactAgentHarnessSession = vi.fn();
-    const recordCliCompactionInStore = vi.fn();
-    setCliCompactionTestDeps({
-      ensureContextEnginesInitialized,
-      resolveContextEngine,
-      maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
-      resolveCliBackendConfig: () => ({
-        id: "claude-cli",
-        modelProvider: "anthropic",
-        config: { command: "claude" },
-        bundleMcp: true,
-        ownsNativeCompaction: true,
-      }),
-      createPreparedEmbeddedAgentSettingsManager: async () => ({
-        getCompactionReserveTokens: () => 10_000,
-        getCompactionKeepRecentTokens: () => 0,
-        applyOverrides: () => {},
-      }),
-      shouldPreemptivelyCompactBeforePrompt: (params) => ({
-        route: "fits",
-        shouldCompact: false,
-        estimatedPromptTokens: 90_000,
-        promptBudgetBeforeReserve: Math.floor(params.contextTokenBudget * 0.8),
-        overflowTokens: Math.max(0, 90_000 - Math.floor(params.contextTokenBudget * 0.8)),
-        toolResultReducibleChars: 0,
-        effectiveReserveTokens: 10_000,
-      }),
-      resolveLiveToolResultMaxChars: () => 20_000,
-      recordCliCompactionInStore,
-    });
-
-    const ordinarySessionEntry = sessionStore[sessionKey];
-    const updatedEntry = await runCliTurnCompactionLifecycle({
-      cfg,
-      sessionId,
-      sessionKey,
-      sessionEntry: ordinarySessionEntry,
-      sessionStore,
-      storePath,
-      sessionAgentId: "main",
-      workspaceDir: tmpDir,
-      agentDir: tmpDir,
-      provider: "claude-cli",
-      model: "claude-opus-4-7",
-    });
-
-    expect(ordinarySessionEntry?.contextTokens).toBe(100_000);
-    expect(ordinarySessionEntry?.agentHarnessId).toBeUndefined();
-    expect(updatedEntry).toBe(ordinarySessionEntry);
-    expect(ensureContextEnginesInitialized).not.toHaveBeenCalled();
-    expect(resolveContextEngine).not.toHaveBeenCalled();
-    expect(compactAgentHarnessSession).not.toHaveBeenCalled();
-    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
   it("treats below-target CLI transcript compaction as a no-op", async () => {

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -308,7 +308,7 @@ describe("runCliTurnCompactionLifecycle", () => {
     );
   });
 
-  it("compacts claude-cli native harness sessions using the persisted Anthropic configured budget", async () => {
+  it("persists the configured Anthropic budget before ordinary claude-cli compaction defers to its backend", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -358,26 +358,18 @@ describe("runCliTurnCompactionLifecycle", () => {
             sessionId,
             provider: "claude-cli",
             model: "claude-opus-4-7",
-            agentHarnessId: "claude-cli",
           },
         },
       } as never,
     });
 
-    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
-    const compactAgentHarnessSession = vi.fn(async () => ({
-      ok: true,
-      compacted: true,
-      result: { tokensBefore: 90_000, tokensAfter: 10_000 },
-    }));
-    const recordCliCompactionInStore = vi.fn(async () => ({
-      ...sessionStore[sessionKey],
-      compactionCount: 1,
-    }));
+    const ensureContextEnginesInitialized = vi.fn();
+    const resolveContextEngine = vi.fn(async () => buildContextEngine({ compactCalls: [] }));
+    const compactAgentHarnessSession = vi.fn();
+    const recordCliCompactionInStore = vi.fn();
     setCliCompactionTestDeps({
-      ensureContextEnginesInitialized: vi.fn(),
-      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
-      ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+      ensureContextEnginesInitialized,
+      resolveContextEngine,
       maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
       resolveCliBackendConfig: () => ({
         id: "claude-cli",
@@ -391,7 +383,6 @@ describe("runCliTurnCompactionLifecycle", () => {
         getCompactionKeepRecentTokens: () => 0,
         applyOverrides: () => {},
       }),
-      applyAgentAutoCompactionGuard: vi.fn(async () => undefined),
       shouldPreemptivelyCompactBeforePrompt: (params) => ({
         route: "fits",
         shouldCompact: false,
@@ -405,11 +396,12 @@ describe("runCliTurnCompactionLifecycle", () => {
       recordCliCompactionInStore,
     });
 
+    const ordinarySessionEntry = sessionStore[sessionKey];
     const updatedEntry = await runCliTurnCompactionLifecycle({
       cfg,
       sessionId,
       sessionKey,
-      sessionEntry: sessionStore[sessionKey],
+      sessionEntry: ordinarySessionEntry,
       sessionStore,
       storePath,
       sessionAgentId: "main",
@@ -419,21 +411,13 @@ describe("runCliTurnCompactionLifecycle", () => {
       model: "claude-opus-4-7",
     });
 
-    expect(sessionStore[sessionKey]?.contextTokens).toBe(100_000);
-    expect(sessionStore[sessionKey]?.agentHarnessId).toBe("claude-cli");
-    expect(compactAgentHarnessSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        agentHarnessId: "claude-cli",
-        contextTokenBudget: 100_000,
-        currentTokenCount: 90_000,
-        force: true,
-        provider: "claude-cli",
-        model: "claude-opus-4-7",
-      }),
-    );
-    expect(compactCalls).toHaveLength(0);
-    expect(recordCliCompactionInStore).toHaveBeenCalledTimes(1);
-    expect(updatedEntry?.compactionCount).toBe(1);
+    expect(ordinarySessionEntry?.contextTokens).toBe(100_000);
+    expect(ordinarySessionEntry?.agentHarnessId).toBeUndefined();
+    expect(updatedEntry).toBe(ordinarySessionEntry);
+    expect(ensureContextEnginesInitialized).not.toHaveBeenCalled();
+    expect(resolveContextEngine).not.toHaveBeenCalled();
+    expect(compactAgentHarnessSession).not.toHaveBeenCalled();
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
   });
 
   it("treats below-target CLI transcript compaction as a no-op", async () => {

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -13,6 +13,7 @@ import {
   runCliTurnCompactionLifecycle,
   setCliCompactionTestDeps,
 } from "./cli-compaction.js";
+import { updateSessionStoreAfterAgentRun } from "./session-store.js";
 
 function buildContextEngine(params: {
   compactCalls: Array<Parameters<ContextEngine["compact"]>[0]>;
@@ -305,6 +306,102 @@ describe("runCliTurnCompactionLifecycle", () => {
         tokensAfter: 100,
       }),
     );
+  });
+
+  it("compacts claude-cli transcripts using the persisted Anthropic configured budget", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": { command: "claude" },
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: "claude-opus-4-7", contextTokens: 100_000 }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const sessionKey = "agent:main:cli-configured-budget";
+    const sessionId = "session-cli-configured-budget";
+    const sessionFile = path.join(tmpDir, "session-configured-budget.jsonl");
+    const storePath = path.join(tmpDir, "sessions-configured-budget.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        sessionFile,
+        totalTokens: 90_000,
+        totalTokensFresh: true,
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    await updateSessionStoreAfterAgentRun({
+      cfg,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore,
+      defaultProvider: "claude-cli",
+      defaultModel: "claude-opus-4-7",
+      result: {
+        meta: {
+          durationMs: 1,
+          executionTrace: { runner: "cli" },
+          agentMeta: {
+            sessionId,
+            provider: "claude-cli",
+            model: "claude-opus-4-7",
+          },
+        },
+      } as never,
+    });
+
+    const compactCalls: Array<Parameters<ContextEngine["compact"]>[0]> = [];
+    const maintenance = vi.fn(async () => ({ changed: false, bytesFreed: 0, rewrittenEntries: 0 }));
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => buildContextEngine({ compactCalls }),
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 10_000,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: (params) => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 90_000,
+        promptBudgetBeforeReserve: Math.floor(params.contextTokenBudget * 0.8),
+        overflowTokens: Math.max(0, 90_000 - Math.floor(params.contextTokenBudget * 0.8)),
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 10_000,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: maintenance,
+    });
+
+    const updatedEntry = await runCliTurnCompactionLifecycle({
+      cfg,
+      sessionId,
+      sessionKey,
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+    });
+
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0]?.tokenBudget).toBe(100_000);
+    expect(updatedEntry?.compactionCount).toBe(1);
   });
 
   it("treats below-target CLI transcript compaction as a no-op", async () => {

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -493,6 +493,60 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("persists Anthropic configured contextTokens for claude-cli runtime sessions", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: {
+              models: [{ id: "claude-opus-4-7", contextTokens: 100_000 }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-claude-cli-configured-context";
+      const sessionId = "test-claude-cli-configured-context-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "claude-cli",
+        defaultModel: "claude-opus-4-7",
+        result: {
+          meta: {
+            durationMs: 1,
+            executionTrace: { runner: "cli" },
+            agentMeta: {
+              sessionId,
+              provider: "claude-cli",
+              model: "claude-opus-4-7",
+            },
+          },
+        } as EmbeddedAgentRunResult,
+      });
+
+      expect(sessionStore[sessionKey]?.contextTokens).toBe(100_000);
+      expect(loadSessionStore(storePath)[sessionKey]?.contextTokens).toBe(100_000);
+    });
+  });
+
   it("clears the embedded harness pin after a CLI run", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -519,7 +519,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
           updatedAt: 1,
         },
       };
-      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+      await seedSessionStore(storePath, sessionStore);
 
       await updateSessionStoreAfterAgentRun({
         cfg,
@@ -543,7 +543,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       });
 
       expect(sessionStore[sessionKey]?.contextTokens).toBe(100_000);
-      expect(loadSessionStore(storePath)[sessionKey]?.contextTokens).toBe(100_000);
+      expect(loadPersistedSessionEntry(storePath, sessionKey)?.contextTokens).toBe(100_000);
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -493,7 +493,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("persists Anthropic configured contextTokens for claude-cli runtime sessions", async () => {
+  it("reconciles an existing claude-cli session to its prepared context budget", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {
         agents: {
@@ -517,6 +517,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         [sessionKey]: {
           sessionId,
           updatedAt: 1,
+          contextTokens: 1_048_576,
         },
       };
       await seedSessionStore(storePath, sessionStore);
@@ -537,6 +538,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
               sessionId,
               provider: "claude-cli",
               model: "claude-opus-4-7",
+              contextTokens: 100_000,
             },
           },
         } as EmbeddedAgentRunResult,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -493,20 +493,13 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("reconciles an existing claude-cli session to its prepared context budget", async () => {
+  it("persists the prepared claude-cli context budget", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {
         agents: {
           defaults: {
             cliBackends: {
               "claude-cli": { command: "claude" },
-            },
-          },
-        },
-        models: {
-          providers: {
-            anthropic: {
-              models: [{ id: "claude-opus-4-7", contextTokens: 100_000 }],
             },
           },
         },

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -23,7 +23,7 @@ export type ContextTokenResolutionParams = {
   cfg?: OpenClawConfig;
   sourceCfg?: OpenClawConfig | null;
   provider?: string;
-  configuredProvider?: string;
+  modelProvider?: string;
   model?: string;
   contextTokensOverride?: number;
   fallbackContextTokens?: number;
@@ -154,14 +154,14 @@ function resolveProviderQualifiedModel(provider: string, model: string): string 
 function resolveConfiguredRuntimeContextTokens(
   cfg: OpenClawConfig | null | undefined,
   provider: string,
-  configuredProvider: string | undefined,
+  modelProvider: string | undefined,
   model: string,
 ): ConfiguredContextTokens | undefined {
   const explicitResult = resolveConfiguredProviderContextTokens(cfg, provider, model);
   if (explicitResult) {
     return explicitResult;
   }
-  const canonicalProvider = configuredProvider?.trim();
+  const canonicalProvider = modelProvider?.trim();
   if (
     !canonicalProvider ||
     normalizeProviderId(canonicalProvider) === normalizeProviderId(provider)
@@ -234,14 +234,14 @@ export function resolveContextTokensForModelFromCache(
     const configuredWindow = resolveConfiguredRuntimeContextTokens(
       params.cfg,
       explicitProvider,
-      params.configuredProvider,
+      params.modelProvider,
       ref.model,
     );
     const sourceConfig = params.sourceCfg === undefined ? params.cfg : params.sourceCfg;
     const sourceConfiguredWindow = resolveConfiguredRuntimeContextTokens(
       sourceConfig,
       explicitProvider,
-      params.configuredProvider,
+      params.modelProvider,
       ref.model,
     );
     const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model);

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -140,6 +140,46 @@ function resolveConfiguredProviderContextTokens(
   return findContextTokens((id) => normalizeProviderId(id) === normalizedProvider);
 }
 
+function resolveProviderQualifiedModel(provider: string, model: string): string | undefined {
+  const slash = model.indexOf("/");
+  if (slash <= 0) {
+    return undefined;
+  }
+  const prefixedProvider = normalizeProviderId(model.slice(0, slash));
+  const bareModel = model.slice(slash + 1).trim();
+  return prefixedProvider === normalizeProviderId(provider) && bareModel ? bareModel : undefined;
+}
+
+function resolveKnownRuntimeCanonicalProvider(provider: string): string | undefined {
+  return normalizeProviderId(provider) === "claude-cli" ? "anthropic" : undefined;
+}
+
+function resolveConfiguredRuntimeContextTokens(
+  cfg: OpenClawConfig | null | undefined,
+  provider: string,
+  model: string,
+): ConfiguredContextTokens | undefined {
+  const explicitResult = resolveConfiguredProviderContextTokens(cfg, provider, model);
+  if (explicitResult) {
+    return explicitResult;
+  }
+  const canonicalProvider = resolveKnownRuntimeCanonicalProvider(provider);
+  if (
+    !canonicalProvider ||
+    normalizeProviderId(canonicalProvider) === normalizeProviderId(provider)
+  ) {
+    return undefined;
+  }
+  const canonicalResult = resolveConfiguredProviderContextTokens(cfg, canonicalProvider, model);
+  if (canonicalResult) {
+    return canonicalResult;
+  }
+  const canonicalModel = resolveProviderQualifiedModel(canonicalProvider, model);
+  return canonicalModel
+    ? resolveConfiguredProviderContextTokens(cfg, canonicalProvider, canonicalModel)
+    : undefined;
+}
+
 function resolveModelFamilyId(modelId: string): string {
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   return normalized.includes("/") ? (normalized.split("/").at(-1) ?? normalized) : normalized;
@@ -193,13 +233,13 @@ export function resolveContextTokensForModelFromCache(
   const explicitProvider = params.provider?.trim();
 
   if (ref && explicitProvider) {
-    const configuredWindow = resolveConfiguredProviderContextTokens(
+    const configuredWindow = resolveConfiguredRuntimeContextTokens(
       params.cfg,
       explicitProvider,
       ref.model,
     );
     const sourceConfig = params.sourceCfg === undefined ? params.cfg : params.sourceCfg;
-    const sourceConfiguredWindow = resolveConfiguredProviderContextTokens(
+    const sourceConfiguredWindow = resolveConfiguredRuntimeContextTokens(
       sourceConfig,
       explicitProvider,
       ref.model,

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -23,6 +23,7 @@ export type ContextTokenResolutionParams = {
   cfg?: OpenClawConfig;
   sourceCfg?: OpenClawConfig | null;
   provider?: string;
+  configuredProvider?: string;
   model?: string;
   contextTokensOverride?: number;
   fallbackContextTokens?: number;
@@ -150,20 +151,17 @@ function resolveProviderQualifiedModel(provider: string, model: string): string 
   return prefixedProvider === normalizeProviderId(provider) && bareModel ? bareModel : undefined;
 }
 
-function resolveKnownRuntimeCanonicalProvider(provider: string): string | undefined {
-  return normalizeProviderId(provider) === "claude-cli" ? "anthropic" : undefined;
-}
-
 function resolveConfiguredRuntimeContextTokens(
   cfg: OpenClawConfig | null | undefined,
   provider: string,
+  configuredProvider: string | undefined,
   model: string,
 ): ConfiguredContextTokens | undefined {
   const explicitResult = resolveConfiguredProviderContextTokens(cfg, provider, model);
   if (explicitResult) {
     return explicitResult;
   }
-  const canonicalProvider = resolveKnownRuntimeCanonicalProvider(provider);
+  const canonicalProvider = configuredProvider?.trim();
   if (
     !canonicalProvider ||
     normalizeProviderId(canonicalProvider) === normalizeProviderId(provider)
@@ -236,12 +234,14 @@ export function resolveContextTokensForModelFromCache(
     const configuredWindow = resolveConfiguredRuntimeContextTokens(
       params.cfg,
       explicitProvider,
+      params.configuredProvider,
       ref.model,
     );
     const sourceConfig = params.sourceCfg === undefined ? params.cfg : params.sourceCfg;
     const sourceConfiguredWindow = resolveConfiguredRuntimeContextTokens(
       sourceConfig,
       explicitProvider,
+      params.configuredProvider,
       ref.model,
     );
     const fixedContextWindow = resolveAnthropicFixedContextWindow(ref.provider, ref.model);

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -30,6 +30,7 @@ export type ContextTokenResolutionParams = {
   modelContextWindow?: number;
   modelContextTokens?: number;
   allowAsyncLoad?: boolean;
+  allowUnscopedModelLookup?: boolean;
 };
 
 const ANTHROPIC_GA_1M_MODEL_PREFIXES = [
@@ -306,6 +307,10 @@ export function resolveContextTokensForModelFromCache(
     if (fixedContextWindow !== undefined) {
       return capOverride(fixedContextWindow);
     }
+  }
+
+  if (params.allowUnscopedModelLookup === false) {
+    return override ?? params.fallbackContextTokens;
   }
 
   // Model-only calls use the raw discovery key. With an explicit provider,

--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -229,6 +229,23 @@ describe("context-window-guard", () => {
     expect(guard.shouldBlock).toBe(false);
   });
 
+  it("uses the selected agent cap instead of the default", () => {
+    const info = resolveContextWindowInfo({
+      cfg: { agents: { defaults: { contextTokens: 20_000 } } },
+      provider: "anthropic",
+      modelId: "whatever",
+      modelContextWindow: 200_000,
+      agentContextTokens: 40_000,
+      defaultTokens: 200_000,
+    });
+
+    expect(info).toEqual({
+      source: "agentContextTokens",
+      tokens: 40_000,
+      referenceTokens: 200_000,
+    });
+  });
+
   it("does not override when cap exceeds base window", () => {
     const cfg = {
       agents: { defaults: { contextTokens: 128_000 } },

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -57,6 +57,7 @@ export function resolveContextWindowInfo(params: {
   modelId: string;
   modelContextTokens?: number;
   modelContextWindow?: number;
+  agentContextTokens?: number;
   defaultTokens: number;
 }): ContextWindowInfo {
   const fromModelsConfig = (() => {
@@ -88,9 +89,11 @@ export function resolveContextWindowInfo(params: {
       ? { tokens: fromModel, source: "model" as const }
       : { tokens: defaultTokens, source: "default" as const };
 
-  const capTokens = normalizePositiveInt(params.cfg?.agents?.defaults?.contextTokens);
+  const capTokens =
+    normalizePositiveInt(params.agentContextTokens) ??
+    normalizePositiveInt(params.cfg?.agents?.defaults?.contextTokens);
   if (capTokens && capTokens < baseInfo.tokens) {
-    // Agent defaults can intentionally cap a larger model context window.
+    // Agent settings can intentionally cap a larger model context window.
     return { tokens: capTokens, referenceTokens: baseInfo.tokens, source: "agentContextTokens" };
   }
 

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -395,6 +395,32 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
+  it("uses Anthropic configured contextTokens for claude-cli runtime provider", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  ...testModelContextWindow("claude-opus-4-7", 200_000),
+                  contextTokens: 100_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      provider: "claude-cli",
+      model: "claude-opus-4-7",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(100_000);
+  });
+
   it("returns 1M context for GA-capable Anthropic 4.x models even without context1m", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -413,6 +413,34 @@ describe("resolveContextTokensForModel", () => {
         },
       },
       provider: "claude-cli",
+      configuredProvider: "anthropic",
+      model: "claude-opus-4-7",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(100_000);
+  });
+
+  it("uses the caller-supplied configured provider for a CLI runtime", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [
+                {
+                  ...testModelContextWindow("claude-opus-4-7", 200_000),
+                  contextTokens: 100_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      provider: "fixture-cli",
+      configuredProvider: "anthropic",
       model: "claude-opus-4-7",
       fallbackContextTokens: 200_000,
       allowAsyncLoad: false,

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -307,6 +307,34 @@ describe("createSessionManagerRuntimeRegistry", () => {
 });
 
 describe("resolveContextTokensForModel", () => {
+  it("can exclude unscoped cache entries from provider-owned lookup", () => {
+    resetContextWindowCacheForTest();
+    try {
+      applyDiscoveredContextWindows({
+        cache: MODEL_CONTEXT_TOKEN_CACHE,
+        models: [{ id: "large", contextTokens: 32_000 }],
+      });
+
+      expect(
+        resolveContextTokensForModel({
+          provider: "claude-cli",
+          model: "large",
+          allowAsyncLoad: false,
+          allowUnscopedModelLookup: false,
+        }),
+      ).toBeUndefined();
+      expect(
+        resolveContextTokensForModel({
+          provider: "claude-cli",
+          model: "large",
+          allowAsyncLoad: false,
+        }),
+      ).toBe(32_000);
+    } finally {
+      resetContextWindowCacheForTest();
+    }
+  });
+
   it("uses provider-level context defaults when no model-level cap is set", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -395,59 +395,35 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("uses Anthropic configured contextTokens for claude-cli runtime provider", () => {
-    const result = resolveContextTokensForModel({
-      cfg: {
-        models: {
-          providers: {
-            anthropic: {
-              baseUrl: "https://api.anthropic.com",
-              models: [
-                {
-                  ...testModelContextWindow("claude-opus-4-7", 200_000),
-                  contextTokens: 100_000,
-                },
-              ],
+  it.each(["claude-cli", "fixture-cli"])(
+    "uses the caller-supplied model provider for the %s runtime",
+    (provider) => {
+      const result = resolveContextTokensForModel({
+        cfg: {
+          models: {
+            providers: {
+              anthropic: {
+                baseUrl: "https://api.anthropic.com",
+                models: [
+                  {
+                    ...testModelContextWindow("claude-opus-4-7", 200_000),
+                    contextTokens: 100_000,
+                  },
+                ],
+              },
             },
           },
         },
-      },
-      provider: "claude-cli",
-      configuredProvider: "anthropic",
-      model: "claude-opus-4-7",
-      fallbackContextTokens: 200_000,
-      allowAsyncLoad: false,
-    });
+        provider,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-7",
+        fallbackContextTokens: 200_000,
+        allowAsyncLoad: false,
+      });
 
-    expect(result).toBe(100_000);
-  });
-
-  it("uses the caller-supplied configured provider for a CLI runtime", () => {
-    const result = resolveContextTokensForModel({
-      cfg: {
-        models: {
-          providers: {
-            anthropic: {
-              baseUrl: "https://api.anthropic.com",
-              models: [
-                {
-                  ...testModelContextWindow("claude-opus-4-7", 200_000),
-                  contextTokens: 100_000,
-                },
-              ],
-            },
-          },
-        },
-      },
-      provider: "fixture-cli",
-      configuredProvider: "anthropic",
-      model: "claude-opus-4-7",
-      fallbackContextTokens: 200_000,
-      allowAsyncLoad: false,
-    });
-
-    expect(result).toBe(100_000);
-  });
+      expect(result).toBe(100_000);
+    },
+  );
 
   it("returns 1M context for GA-capable Anthropic 4.x models even without context1m", () => {
     const result = resolveContextTokensForModel({

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -201,6 +201,13 @@ export type CliBackendPlugin = {
    */
   authEpochMode?: CliBackendAuthEpochMode;
   /**
+   * Whether `prepareExecution` may auto-select a configured auth profile.
+   *
+   * Defaults to true for auth bridges. Set false for environment/config-only
+   * hooks that do not consume OpenClaw auth profiles.
+   */
+  autoSelectAuthProfile?: boolean;
+  /**
    * Backend-owned execution bridge.
    *
    * Use this on async run paths when the backend needs a generated auth/config

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -26,6 +26,8 @@ export type CliBackendPrepareExecutionContext = {
   agentDir?: string;
   provider: string;
   modelId: string;
+  /** Effective OpenClaw context budget selected for this run. */
+  contextTokenBudget?: number;
   authProfileId?: string;
   executionMode?: CliBackendExecutionMode;
 };


### PR DESCRIPTION
## What Problem This Solves

Fixes #80933.

`claude-cli` runs could ignore configured model and per-agent `contextTokens` limits. OpenClaw prepared the run under the CLI provider id, so the canonical Anthropic model override was missed; the selected agent cap was not carried into CLI preparation either. Successful sessions could retain a 1M-token window while Claude Code's native auto-compactor used its own default.

## Why This Change Was Made

- Carry the CLI backend's canonical model provider and selected agent cap into context-window resolution while preserving explicit runtime-provider overrides.
- Add an optional, provider-neutral `contextTokenBudget` field to the CLI backend preparation hook.
- Have the Anthropic plugin pass that effective budget through Claude Code's documented `CLAUDE_CODE_AUTO_COMPACT_WINDOW` launch contract.
- Resolve model aliases in both directions without letting provider defaults or unscoped cache collisions overstate the active model's limit.
- Let environment-only preparation hooks opt out of implicit auth-profile selection while preserving existing auth-bridge behavior.
- Persist the same prepared budget after successful `claude-cli` runs.
- Clear inherited host values before injecting the prepared value, so ambient shell state cannot override OpenClaw configuration.

This adds no config or default surface. It keeps one canonical budget across preparation, child launch, native compaction, and session state.

## User Impact

An Anthropic model configured with `contextTokens: 100000` now gives `claude-cli` the same 100k budget, records 100k in session state, and lets Claude Code derive its native 80k auto-compaction threshold from that value. A smaller selected-agent cap wins consistently at all three boundaries.

## Evidence

- Blacksmith Testbox on the maintained branch: focused agent tests 289/289; Anthropic plugin tests 37/37; corrected child-launch test 1/1; full build green.
- Narrow fallback while Blacksmith checkout was rate-limited: agent/context/backend tests 168/168 and Anthropic plugin tests 37/37.
- Final code tree on Blacksmith Testbox run [29235613053](https://github.com/openclaw/openclaw/actions/runs/29235613053): full test typecheck green and focused preparation regressions 75/75.
- Live Claude Code 2.1.204: a 100k launch budget reported an 80k effective native window; 120k reported 100k. An over-threshold print-mode probe entered Claude's reactive auto-compaction path with the environment-backed threshold.
- Fresh incremental and full-branch autoreviews after the maintainer refactor: no actionable findings.

Plugin SDK metric: two additive optional CLI-backend fields (`contextTokenBudget` and `autoSelectAuthProfile`); zero config/default additions or removals.
