### PR TITLE
feat(agents): add configurable bootstrap file list per agent

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -306,9 +306,11 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+  const agentConfig =
+    params.agentId && params.config ? resolveAgentConfig(params.config, params.agentId) : undefined;
   const bootstrapFiles = applyContextModeFilter({
     files: filterCompletedWorkspaceBootstrapFile(
-      filterBootstrapFilesForSession(rawFiles, sessionKey),
+      filterBootstrapFilesForSession(rawFiles, sessionKey, agentConfig?.bootstrap),
       workspaceSetupCompleted,
       params.workspaceDir,
     ),

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1093,12 +1093,17 @@ const CRON_BOOTSTRAP_ALLOWLIST = new Set([
 export function filterBootstrapFilesForSession(
   files: WorkspaceBootstrapFile[],
   sessionKey?: string,
+  agentBootstrapList?: string[],
 ): WorkspaceBootstrapFile[] {
   if (!sessionKey) {
     return files;
   }
   if (isSubagentSessionKey(sessionKey)) {
-    return files.filter((file) => SUBAGENT_BOOTSTRAP_ALLOWLIST.has(file.name));
+    // Use agent-specific bootstrap list if provided, otherwise use default allowlist
+    const allowlist = agentBootstrapList
+      ? new Set(agentBootstrapList)
+      : SUBAGENT_BOOTSTRAP_ALLOWLIST;
+    return files.filter((file) => allowlist.has(file.name));
   }
   if (isCronSessionKey(sessionKey)) {
     return files.filter((file) => CRON_BOOTSTRAP_ALLOWLIST.has(file.name));

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -111,6 +111,8 @@ export type AgentConfig = {
   bootstrapMaxChars?: AgentDefaultsConfig["bootstrapMaxChars"];
   /** Optional per-agent max total chars across injected bootstrap files. */
   bootstrapTotalMaxChars?: AgentDefaultsConfig["bootstrapTotalMaxChars"];
+  /** Optional per-agent list of bootstrap files to load (e.g., ["AGENTS.md", "SOUL.md", "TOOLS.md", "MEMORY.md"]). Defaults to AGENTS.md and TOOLS.md for subagents. */
+  bootstrap?: string[];
   /** Optional per-agent experimental flags. Omitted fields inherit agents.defaults.experimental. */
   experimental?: AgentDefaultsConfig["experimental"];
   /** Optional allowlist of skills for this agent; omitting it inherits agents.defaults.skills when set, and an explicit list replaces defaults instead of merging. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1060,6 +1060,7 @@ export const AgentEntrySchema = z
       .optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
+    bootstrap: z.array(z.string()).optional(),
     experimental: z
       .object({
         localModelLean: z.boolean().optional(),


### PR DESCRIPTION
Allow agents to customize which bootstrap files (AGENTS.md, SOUL.md, TOOLS.md, MEMORY.md, etc) are loaded via a per-agent "bootstrap" config option. Defaults to AGENTS.md and TOOLS.md for subagents, but can be overridden in agents.list with a custom list.

Example config:
{
  "agents": {
    "list": [
      {
        "id": "main",
        "bootstrap": ["AGENTS.md", "SOUL.md", "TOOLS.md", "MEMORY.md"]
      }
    ]
  }
}

Changes:
- Add bootstrap?: string[] field to AgentConfig type
- Add bootstrap array validation to Zod schema
- Update filterBootstrapFilesForSession to accept optional agent bootstrap list
- Pass agent config's bootstrap list to file filtering in resolveBootstrapFilesForRun

## Summary

What problem does this PR solve?

Why does this matter now?

What is the intended outcome?

What is intentionally out of scope?

What does success look like?

What should reviewers focus on?

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
- Real environment tested:
- Exact steps or command run after this patch:
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
- Observed result after fix:
- What was not tested:
- Proof limitations or environment constraints:
- Before evidence (optional but encouraged):

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

What regression coverage was added or updated?

What failed before this fix, if known?

If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Did config, environment, or migration behavior change? (`Yes/No`)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

What is the highest-risk area?

How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

What is still waiting on author, maintainer, CI, or external proof?

Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
