### PR TITLE
fix(auto-reply): clear pending-final state before honoring post-send abort (#89115)

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -225,6 +225,56 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
   });
 
+  it("clears pending final delivery when abort fires after a successful final send (#89115)", async () => {
+    // Regression for #89115: an abort that lands after the final reply has
+    // shipped (here, during sendFinalReply) must still clear the pending-final
+    // bookkeeping — otherwise pendingFinalDelivery stays true and the get-reply
+    // redelivery short-circuit silently blocks every later inbound.
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    sessionStoreMocks.currentEntry = {
+      sessionKey: "agent:test:session",
+      pendingFinalDelivery: true,
+      pendingFinalDeliveryText: "durable reply",
+      pendingFinalDeliveryCreatedAt: 1,
+      pendingFinalDeliveryLastAttemptAt: 2,
+      pendingFinalDeliveryAttemptCount: 3,
+      pendingFinalDeliveryLastError: "previous failure",
+      pendingFinalDeliveryContext: { source: "heartbeat" },
+      pendingFinalDeliveryIntentId: "intent-89115",
+    };
+    sessionStoreMocks.resolveSessionStoreEntry.mockReturnValue({
+      existing: sessionStoreMocks.currentEntry,
+    });
+    const abortController = new AbortController();
+    const dispatcher = createDispatcher();
+    vi.mocked(dispatcher.sendFinalReply).mockImplementation(() => {
+      abortController.abort();
+      return true;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { abortSignal: abortController.signal },
+      replyResolver: async () => ({ text: "durable reply" }),
+    });
+
+    // Abort landed after delivery: the run is still surfaced as aborted
+    // (queuedFinal:false), but the pending-final state is fully cleared.
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+    expect(result.queuedFinal).toBe(false);
+    expect(sessionStoreMocks.updateSessionStoreEntry).toHaveBeenCalledOnce();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryContext).toBeUndefined();
+    expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryIntentId).toBeUndefined();
+  });
+
   it("preserves pending final delivery when final dispatch fails", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(false);
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -753,6 +753,7 @@ async function clearPendingFinalDeliveryAfterSuccess(params: {
         pendingFinalDeliveryAttemptCount: undefined,
         pendingFinalDeliveryLastError: undefined,
         pendingFinalDeliveryContext: undefined,
+        pendingFinalDeliveryIntentId: undefined,
         updatedAt: Date.now(),
       };
     },
@@ -3297,11 +3298,15 @@ export async function dispatchReplyFromConfig(
     }
 
     if (attemptedFinalDelivery && !finalDeliveryFailed) {
-      throwIfDispatchOperationAborted();
+      // The final reply already shipped, so clear the durable pending-final
+      // bookkeeping before honoring a late abort. A stuck-session recovery abort
+      // racing this window (#89115) otherwise strands pendingFinalDelivery=true,
+      // and the get-reply redelivery short-circuit then silently blocks all inbound.
       await clearPendingFinalDeliveryAfterSuccess({
         storePath: sessionStoreEntry.storePath,
         sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
       });
+      throwIfDispatchOperationAborted();
     }
 
     if (!suppressDelivery) {


### PR DESCRIPTION
## Summary

Fixes #89115 — agent "goes silent" after a delivered final reply.

In `dispatchReplyFromConfig`, the user-message success branch called
`throwIfDispatchOperationAborted()` **before** `clearPendingFinalDeliveryAfterSuccess()`:

```ts
if (attemptedFinalDelivery && !finalDeliveryFailed) {
  throwIfDispatchOperationAborted();          // ← aborts here…
  await clearPendingFinalDeliveryAfterSuccess({ ... });  // …so this never runs
}
```

If stuck-session recovery aborts the embedded run in the narrow window between
the final reply shipping and the clear, the message **is** delivered but
`pendingFinalDelivery` stays `true` forever. The get-reply redelivery
short-circuit then keys off that flag and silently blocks every future inbound —
the agent appears to go silent until the session is manually reset.

## The fix

1. **Reorder** — clear the durable pending-final bookkeeping first, *then* honor
   the abort. The reply already shipped, so the clear must run; the abort is still
   surfaced afterwards (the dispatch routes through `finishReplyOperationAbortedDispatch()`
   and reports `queuedFinal: false`), so cancellation reporting is preserved.
2. **Completeness** — also clear the stranded `pendingFinalDeliveryIntentId`
   field. `agent-command.ts` already clears it on its path; the success helper
   did not, leaving stale state behind.

This is intentionally narrow: it does **not** change delivery-success detection,
add idle-wait calls, or touch the dispatcher outcome counts.

## Why this supersedes #90229 and #89130

Both prior PRs had the right instinct; this one keeps the correct parts and drops
the risk:

- **#89130** *deleted* the abort check instead of moving it after the clear,
  dropping the post-delivery cancellation reporting the codebase expects; it also
  missed `pendingFinalDeliveryIntentId` and its test was mock-only.
- **#90229** had the correct reorder + the `intentId` cleanup, but bundled
  unrelated changes onto a P1 hot path (`waitForReplyDispatcherIdle`, a
  `completedFinalDeliveryAttempt`/final-outcome-counts rework whose synchronous
  failed-count check is unreliable for async dispatchers) and had drifted from
  `main` (the `sendFinalPayload` transcript-mirror helpers were renamed), so it
  no longer applied cleanly.

## Real behavior proof

- **Behavior or issue addressed:** #89115 — delivered final reply leaves
  `pendingFinalDelivery: true`, silently blocking subsequent inbound messages.
- **Real environment tested:** Not run against a live gateway in this change set.
- **Exact steps or command run after this patch:**
  `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- **Evidence after fix:** New regression test
  `clears pending final delivery when abort fires after a successful final send (#89115)`
  drives the real `dispatchReplyFromConfig` control flow (abort fired from inside
  the dispatcher's `sendFinalReply`, in the post-send window). Result: the clear
  runs, every `pendingFinalDelivery*` field (including `pendingFinalDeliveryIntentId`)
  is cleared, and the run is still surfaced as aborted (`queuedFinal: false`).
- **Observed result after fix:** 7/7 in the file pass; full reply-dispatch suite,
  `sessions.test.ts` (44) and `agent-command.live-model-switch.test.ts` (62) pass.
- **Before evidence:** Reverting only the source change makes the new test fail —
  `updateSessionStoreEntry` is called **0 times** (the abort threw before the
  clear), i.e. the pending state is stranded exactly as reported.
- **What was not tested:** A full live OpenClaw gateway repro with a real channel
  and real stuck-session recovery timing.
- **Proof limitations or environment constraints:** Validation here is the
  deterministic regression test (fails on `main`, passes with the fix) plus
  typecheck/lint/format; no live multi-process gateway run was performed in this
  environment.

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts` — 7/7
- `node scripts/run-vitest.mjs src/config/sessions/sessions.test.ts src/agents/agent-command.live-model-switch.test.ts` — 44 + 62
- `pnpm tsgo:core` and `pnpm tsgo:test:src` — clean
- `oxfmt --check` + `oxlint` on the changed files — clean

Regression coverage added: a test that fails before the fix (clear skipped,
state stranded) and passes after.

## Risk checklist

- Did user-visible behavior change? **Yes** — a delivered-then-aborted final no
  longer strands the session; subsequent inbound messages are processed.
- Did config, environment, or migration behavior change? **No.**
