### PR TITLE
fix(plugins): run message_sending on all channel agent-reply deliveries (#92374)

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1016,6 +1016,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       messageId: 17,
       textSnapshot: "first page",
       retain: true,
+      reason: "final-overflow",
     });
     expect(bot.api["deleteMessage"]).not.toHaveBeenCalled();
 
@@ -1643,6 +1644,28 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(bot.api["deleteMessage"]).toHaveBeenCalledWith(123, 2001);
     // Cancelled: skip message_sent emission, prompt-context recording, and mirroring.
+    expect(emitInternalMessageSentHook).not.toHaveBeenCalled();
+    expect(recordOutboundMessageForPromptContext).not.toHaveBeenCalled();
+  });
+
+  it("deletes the streamed reply when message_sending rewrites it to empty text", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    installMessageSendingHook(async () => ({ content: "   " }));
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Secret answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    const bot = createBot();
+
+    await dispatchWithContext({ context, bot });
+
+    expect(bot.api["deleteMessage"]).toHaveBeenCalledWith(123, 2001);
+    expect(editMessageTelegram).not.toHaveBeenCalled();
     expect(emitInternalMessageSentHook).not.toHaveBeenCalled();
     expect(recordOutboundMessageForPromptContext).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1678,6 +1678,31 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   });
 
+  it("keeps streamed reply records unchanged when a message_sending rewrite edit fails", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    installMessageSendingHook(async () => ({ content: "Redacted answer" }));
+    editMessageTelegram.mockRejectedValueOnce(new Error("edit failed"));
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Original answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context });
+
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(emitInternalMessageSentHook).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "Original answer", messageId: 2001 }),
+    );
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext, 0), {
+      text: "Original answer",
+    });
+  });
+
   it("does not gate streamed replies when no message_sending hook is registered", async () => {
     setupDraftStreams({ answerMessageId: 2001 });
     const runMessageSending = vi.fn(async () => ({ cancel: true }));
@@ -2786,6 +2811,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(followUpTexts.join("")).toContain("one");
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("runs message_sending before sending long streamed final follow-up chunks", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const longText = "one ".repeat(80);
+    const runMessageSending = installMessageSendingHook(async () => ({ cancel: true }));
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: longText }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    const bot = createBot();
+
+    await dispatchWithContext({ context: createContext(), bot, textLimit: 80 });
+
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(runMessageSending, 0, 0), {
+      content: longText,
+      to: "123",
+    });
+    expect(bot.api.deleteMessage).toHaveBeenCalledWith(123, 2001);
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(emitInternalMessageSentHook).not.toHaveBeenCalled();
+    expect(recordOutboundMessageForPromptContext).not.toHaveBeenCalled();
   });
 
   it("keeps streamed final text in place when late media arrives", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -106,10 +106,19 @@ const resolveSessionStoreEntry = vi.hoisted(() =>
   })),
 );
 const updateSessionStoreEntry = vi.hoisted(() => vi.fn(async () => null));
+const getGlobalHookRunner = vi.hoisted(() => vi.fn((): unknown => undefined));
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream,
 }));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner,
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-outbound")>();
@@ -243,6 +252,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     resetPluginStateStoreForTests({ closeDatabase: false });
     installTelegramStateRuntimeForTest();
     resetTelegramReplyFenceForTests();
+    getGlobalHookRunner.mockReset();
+    getGlobalHookRunner.mockReturnValue(undefined);
     createTelegramDraftStream.mockReset();
     dispatchReplyWithBufferedBlockDispatcher.mockReset();
     deliverReplies.mockReset();
@@ -495,6 +506,20 @@ describe("dispatchTelegramMessage draft streaming", () => {
         editForumTopic: vi.fn().mockResolvedValue(true),
       },
     } as unknown as Bot;
+  }
+
+  function installMessageSendingHook(
+    runMessageSending: (
+      payload: unknown,
+      context: unknown,
+    ) => Promise<{ cancel?: boolean; content?: string } | undefined>,
+  ) {
+    const runner = {
+      hasHooks: (name: string) => name === "message_sending",
+      runMessageSending: vi.fn(runMessageSending),
+    };
+    getGlobalHookRunner.mockReturnValue(runner);
+    return runner.runMessageSending;
   }
 
   function createRuntime(): Parameters<typeof dispatchTelegramMessage>[0]["runtime"] {
@@ -1563,6 +1588,121 @@ describe("dispatchTelegramMessage draft streaming", () => {
       sessionKey: "agent:default:telegram:direct:123",
       messageId: "m1",
     });
+  });
+
+  it("runs the message_sending hook on streamed preview-finalized agent replies", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const runMessageSending = installMessageSendingHook(async () => undefined);
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    const bot = createBot();
+
+    await dispatchWithContext({ context, bot });
+
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(runMessageSending, 0, 0), {
+      to: "123",
+      content: "Final answer",
+      threadId: 777,
+    });
+    expectRecordFields(mockCallArg(runMessageSending, 0, 1), {
+      channelId: "telegram",
+      accountId: "default",
+      conversationId: "123",
+    });
+    // Pass-through hook: the committed message is left untouched.
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(bot.api["deleteMessage"]).not.toHaveBeenCalled();
+    expect(emitInternalMessageSentHook).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "Final answer", messageId: 2001, success: true }),
+    );
+  });
+
+  it("deletes the streamed reply when message_sending cancels it", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    installMessageSendingHook(async () => ({ cancel: true }));
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Secret answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    const bot = createBot();
+
+    await dispatchWithContext({ context, bot });
+
+    expect(bot.api["deleteMessage"]).toHaveBeenCalledWith(123, 2001);
+    // Cancelled: skip message_sent emission, prompt-context recording, and mirroring.
+    expect(emitInternalMessageSentHook).not.toHaveBeenCalled();
+    expect(recordOutboundMessageForPromptContext).not.toHaveBeenCalled();
+  });
+
+  it("edits the streamed reply when message_sending rewrites it", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    installMessageSendingHook(async () => ({ content: "Redacted answer" }));
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Original answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    const bot = createBot();
+
+    await dispatchWithContext({ context, bot });
+
+    // Rewrite edits the committed message in place (buttons preserved by omission).
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(mockCallArg(editMessageTelegram, 0, 0)).toBe(123);
+    expect(mockCallArg(editMessageTelegram, 0, 1)).toBe(2001);
+    expect(mockCallArg(editMessageTelegram, 0, 2)).toBe("Redacted answer");
+    expect(bot.api["deleteMessage"]).not.toHaveBeenCalled();
+    // Downstream context/transcript reflect the rewritten content.
+    expect(emitInternalMessageSentHook).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "Redacted answer", messageId: 2001 }),
+    );
+    expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext, 0), {
+      text: "Redacted answer",
+    });
+  });
+
+  it("does not gate streamed replies when no message_sending hook is registered", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const runMessageSending = vi.fn(async () => ({ cancel: true }));
+    getGlobalHookRunner.mockReturnValue({
+      hasHooks: (name: string) => name !== "message_sending",
+      runMessageSending,
+    });
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+    const bot = createBot();
+
+    await dispatchWithContext({ context, bot });
+
+    expect(runMessageSending).not.toHaveBeenCalled();
+    expect(bot.api["deleteMessage"]).not.toHaveBeenCalled();
+    expect(emitInternalMessageSentHook).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "Final answer", messageId: 2001 }),
+    );
   });
 
   it("advances the session marker after mirroring preview-finalized finals", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -982,7 +982,10 @@ export const dispatchTelegramMessage = async ({
           renderText: renderStreamText,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {
-              lanes[laneName].activeChunkIndex += 1;
+              if (superseded.reason === "final-overflow") {
+                lanes[laneName].retainedPreviewMessageIds.push(superseded.messageId);
+                lanes[laneName].activeChunkIndex += 1;
+              }
               return;
             }
             void bot.api.deleteMessage(chatId, superseded.messageId).catch((err: unknown) => {
@@ -1001,6 +1004,7 @@ export const dispatchTelegramMessage = async ({
       hasStreamedMessage: false,
       finalized: false,
       activeChunkIndex: 0,
+      retainedPreviewMessageIds: [],
     };
   };
   const lanes: Record<LaneName, DraftLaneState> = {
@@ -1164,6 +1168,7 @@ export const dispatchTelegramMessage = async ({
     lane.hasStreamedMessage = false;
     lane.finalized = false;
     lane.activeChunkIndex = 0;
+    lane.retainedPreviewMessageIds = [];
     if (lane === answerLane) {
       resetAnswerToolProgressDraft();
       pendingAnswerBlockAssistantMessageIndex = undefined;
@@ -1668,9 +1673,50 @@ export const dispatchTelegramMessage = async ({
     };
     // Streamed previews bypass deliverReplies, so gate them before the final
     // preview is recorded or any continuation chunks are sent.
+    const deleteTelegramStreamMessages = async (
+      messageIds: readonly number[],
+      operation: string,
+    ) => {
+      let firstError: unknown;
+      for (const messageId of messageIds) {
+        try {
+          await bot.api.deleteMessage(chatId, messageId);
+        } catch (err: unknown) {
+          firstError ??= err;
+          logVerbose(
+            `telegram: ${operation} could not delete message ${messageId}: ${formatErrorMessage(
+              err,
+            )}`,
+          );
+        }
+      }
+      if (firstError) {
+        throw firstError;
+      }
+    };
+    const takeRetainedPreviewMessageIds = (lane: DraftLaneState | undefined) => {
+      if (!lane) {
+        return [];
+      }
+      const messageIds = [...new Set(lane.retainedPreviewMessageIds)];
+      lane.retainedPreviewMessageIds = [];
+      lane.activeChunkIndex = 0;
+      return messageIds;
+    };
+    const deleteRetainedPreviewMessages = async (
+      lane: DraftLaneState | undefined,
+      operation: string,
+    ) => {
+      const retainedMessageIds = takeRetainedPreviewMessageIds(lane);
+      if (retainedMessageIds.length === 0) {
+        return;
+      }
+      await deleteTelegramStreamMessages(retainedMessageIds, operation);
+    };
     const runStreamedFinalMessageSending = async (
       content: string,
       messageId: number,
+      lane?: DraftLaneState,
     ): Promise<{ cancel: true } | { content: string }> => {
       const hookRunner = getGlobalHookRunner();
       if (!hookRunner?.hasHooks("message_sending")) {
@@ -1691,17 +1737,23 @@ export const dispatchTelegramMessage = async ({
       );
       if (hookResult?.cancel) {
         try {
-          await bot.api.deleteMessage(chatId, messageId);
-        } catch (err: unknown) {
-          logVerbose(
-            `telegram: message_sending cancel could not delete streamed reply: ${formatErrorMessage(
-              err,
-            )}`,
+          await deleteTelegramStreamMessages(
+            [...takeRetainedPreviewMessageIds(lane), messageId],
+            "message_sending cancel",
           );
-        }
+        } catch {}
         return { cancel: true };
       }
       if (typeof hookResult?.content === "string" && hookResult.content !== content) {
+        if (hookResult.content.trim().length === 0) {
+          try {
+            await deleteTelegramStreamMessages(
+              [...takeRetainedPreviewMessageIds(lane), messageId],
+              "message_sending empty rewrite",
+            );
+          } catch {}
+          return { cancel: true };
+        }
         return { content: hookResult.content };
       }
       return { content };
@@ -1712,6 +1764,7 @@ export const dispatchTelegramMessage = async ({
       const gated = await runStreamedFinalMessageSending(
         result.delivery.content,
         result.delivery.messageId,
+        answerLane,
       );
       if ("cancel" in gated) {
         return { kind: "preview-cancelled" };
@@ -1729,6 +1782,14 @@ export const dispatchTelegramMessage = async ({
               linkPreview: telegramCfg.linkPreview,
             },
           );
+          try {
+            await deleteRetainedPreviewMessages(
+              answerLane,
+              "message_sending rewrite retained cleanup",
+            );
+          } catch {
+            return { kind: "preview-cancelled" };
+          }
           return {
             ...result,
             delivery: {
@@ -1856,9 +1917,15 @@ export const dispatchTelegramMessage = async ({
           buttons,
         });
       },
+      deleteStreamMessages: async ({ messageIds }) => {
+        if (isDispatchSuperseded()) {
+          return;
+        }
+        await deleteTelegramStreamMessages(messageIds, "message_sending retained stream cleanup");
+      },
       resolveFinalTextCandidate: () => resolveCurrentTurnTranscriptFinalText(),
-      beforeFinalizePreviewDelivery: async ({ content, messageId }) =>
-        await runStreamedFinalMessageSending(content, messageId),
+      beforeFinalizePreviewDelivery: async ({ content, messageId, laneName }) =>
+        await runStreamedFinalMessageSending(content, messageId, lanes[laneName]),
       log: logVerbose,
       markDelivered: () => {
         deliveryState.markDelivered();

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -48,7 +48,10 @@ import {
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
-import type { BlockReplyContext } from "openclaw/plugin-sdk/reply-runtime";
+import type {
+  BlockReplyContext,
+  ReplyDispatcherWithTypingOptions,
+} from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   createSubsystemLogger,
@@ -151,6 +154,10 @@ const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-d
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
+
+type TelegramDispatcherOptions = ReplyDispatcherWithTypingOptions & {
+  runsMessageSendingAtDelivery: true;
+};
 
 type DraftPartialTextUpdate = {
   text: string;
@@ -1659,25 +1666,20 @@ export const dispatchTelegramMessage = async ({
       }
       return result.delivered;
     };
-    // Run the plugin `message_sending` hook on streamed/preview-finalized agent replies.
-    // These commit the visible message by editing the live draft, so they never traverse
-    // `deliverReplies` (where Telegram normally runs `message_sending`) and the dispatcher
-    // seam is opted out via runsMessageSendingAtDelivery. This is the one place every
-    // preview-finalized answer funnels through, so it is the canonical gate for them.
-    // The streamed text was already shown incrementally, so cancel deletes the persisted
-    // message and a rewrite edits it in place (buttons are preserved when omitted). See #92374.
+    // Streamed previews bypass deliverReplies, so gate them before the final
+    // preview is recorded or any continuation chunks are sent.
     const runStreamedFinalMessageSending = async (
-      visibleContent: string,
+      content: string,
       messageId: number,
     ): Promise<{ cancel: true } | { content: string }> => {
       const hookRunner = getGlobalHookRunner();
       if (!hookRunner?.hasHooks("message_sending")) {
-        return { content: visibleContent };
+        return { content };
       }
       const hookResult = await hookRunner.runMessageSending(
         {
           to: String(chatId),
-          content: visibleContent,
+          content,
           threadId: threadSpec.id,
           metadata: { channel: "telegram", threadId: threadSpec.id },
         },
@@ -1699,12 +1701,27 @@ export const dispatchTelegramMessage = async ({
         }
         return { cancel: true };
       }
-      if (typeof hookResult?.content === "string" && hookResult.content !== visibleContent) {
+      if (typeof hookResult?.content === "string" && hookResult.content !== content) {
+        return { content: hookResult.content };
+      }
+      return { content };
+    };
+    const gateMaterializedPreviewFinal = async (
+      result: Extract<LaneDeliveryResult, { kind: "preview-finalized" }>,
+    ): Promise<LaneDeliveryResult> => {
+      const gated = await runStreamedFinalMessageSending(
+        result.delivery.content,
+        result.delivery.messageId,
+      );
+      if ("cancel" in gated) {
+        return { kind: "preview-cancelled" };
+      }
+      if (gated.content !== result.delivery.content) {
         try {
           await (telegramDeps.editMessageTelegram ?? editMessageTelegram)(
             chatId,
-            messageId,
-            hookResult.content,
+            result.delivery.messageId,
+            gated.content,
             {
               api: bot.api,
               cfg,
@@ -1712,32 +1729,30 @@ export const dispatchTelegramMessage = async ({
               linkPreview: telegramCfg.linkPreview,
             },
           );
-          return { content: hookResult.content };
+          return {
+            ...result,
+            delivery: {
+              ...result.delivery,
+              content: gated.content,
+              promptContextContent: gated.content,
+            },
+          };
         } catch (err: unknown) {
           logVerbose(
             `telegram: message_sending rewrite could not edit streamed reply: ${formatErrorMessage(
               err,
             )}`,
           );
-          // Fall through with the rewritten content so downstream context stays consistent
-          // with the hook's intent even if the visible edit failed.
-          return { content: hookResult.content };
         }
       }
-      return { content: visibleContent };
+      return result;
     };
     const emitPreviewFinalizedHook = async (result: LaneDeliveryResult) => {
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
         return;
       }
-      const visibleContent = result.delivery.promptContextContent ?? result.delivery.content;
-      const gated = await runStreamedFinalMessageSending(visibleContent, result.delivery.messageId);
-      if ("cancel" in gated) {
-        return;
-      }
-      const finalContent =
-        gated.content === visibleContent ? result.delivery.content : gated.content;
-      const finalPromptContext = gated.content;
+      const finalContent = result.delivery.content;
+      const finalPromptContext = result.delivery.promptContextContent ?? result.delivery.content;
       (telegramDeps.emitInternalMessageSentHook ?? emitInternalMessageSentHook)({
         sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
         chatId: deliveryBaseOptions.chatId,
@@ -1802,16 +1817,18 @@ export const dispatchTelegramMessage = async ({
       }
       answerLane.finalized = true;
       deliveryState.markDelivered();
-      await emitPreviewFinalizedHook({
-        kind: "preview-finalized",
-        delivery: {
-          content,
-          promptContextContent: content,
-          messageId,
-          buttonsAttached: false,
-          receipt: createPreviewMessageReceipt({ id: messageId }),
-        },
-      });
+      await emitPreviewFinalizedHook(
+        await gateMaterializedPreviewFinal({
+          kind: "preview-finalized",
+          delivery: {
+            content,
+            promptContextContent: content,
+            messageId,
+            buttonsAttached: false,
+            receipt: createPreviewMessageReceipt({ id: messageId }),
+          },
+        }),
+      );
     };
     const deliverLaneText = createLaneTextDeliverer({
       lanes,
@@ -1840,6 +1857,8 @@ export const dispatchTelegramMessage = async ({
         });
       },
       resolveFinalTextCandidate: () => resolveCurrentTurnTranscriptFinalText(),
+      beforeFinalizePreviewDelivery: async ({ content, messageId }) =>
+        await runStreamedFinalMessageSending(content, messageId),
       log: logVerbose,
       markDelivered: () => {
         deliveryState.markDelivered();
@@ -1873,15 +1892,17 @@ export const dispatchTelegramMessage = async ({
         await answerLane.stream.stop();
         answerLane.finalized = true;
         deliveryState.markDelivered();
-        await emitPreviewFinalizedHook({
-          kind: "preview-finalized",
-          delivery: {
-            content: text,
-            promptContextContent: deliveredText,
-            messageId,
-            receipt: createPreviewMessageReceipt({ id: messageId }),
-          },
-        });
+        await emitPreviewFinalizedHook(
+          await gateMaterializedPreviewFinal({
+            kind: "preview-finalized",
+            delivery: {
+              content: text,
+              promptContextContent: deliveredText,
+              messageId,
+              receipt: createPreviewMessageReceipt({ id: messageId }),
+            },
+          }),
+        );
         return true;
       }
       const result = await deliverLaneText({
@@ -2338,7 +2359,7 @@ export const dispatchTelegramMessage = async ({
                     deliveryState.markNonSilentFailure();
                     runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
                   },
-                },
+                } as TelegramDispatcherOptions,
                 replyOptions: {
                   skillFilter,
                   disableBlockStreaming,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -41,6 +41,7 @@ import type {
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import {
   isReplyPayloadNonTerminalToolErrorWarning,
@@ -1658,15 +1659,90 @@ export const dispatchTelegramMessage = async ({
       }
       return result.delivered;
     };
+    // Run the plugin `message_sending` hook on streamed/preview-finalized agent replies.
+    // These commit the visible message by editing the live draft, so they never traverse
+    // `deliverReplies` (where Telegram normally runs `message_sending`) and the dispatcher
+    // seam is opted out via runsMessageSendingAtDelivery. This is the one place every
+    // preview-finalized answer funnels through, so it is the canonical gate for them.
+    // The streamed text was already shown incrementally, so cancel deletes the persisted
+    // message and a rewrite edits it in place (buttons are preserved when omitted). See #92374.
+    const runStreamedFinalMessageSending = async (
+      visibleContent: string,
+      messageId: number,
+    ): Promise<{ cancel: true } | { content: string }> => {
+      const hookRunner = getGlobalHookRunner();
+      if (!hookRunner?.hasHooks("message_sending")) {
+        return { content: visibleContent };
+      }
+      const hookResult = await hookRunner.runMessageSending(
+        {
+          to: String(chatId),
+          content: visibleContent,
+          threadId: threadSpec.id,
+          metadata: { channel: "telegram", threadId: threadSpec.id },
+        },
+        {
+          channelId: "telegram",
+          accountId: route.accountId,
+          conversationId: String(chatId),
+        },
+      );
+      if (hookResult?.cancel) {
+        try {
+          await bot.api.deleteMessage(chatId, messageId);
+        } catch (err: unknown) {
+          logVerbose(
+            `telegram: message_sending cancel could not delete streamed reply: ${formatErrorMessage(
+              err,
+            )}`,
+          );
+        }
+        return { cancel: true };
+      }
+      if (typeof hookResult?.content === "string" && hookResult.content !== visibleContent) {
+        try {
+          await (telegramDeps.editMessageTelegram ?? editMessageTelegram)(
+            chatId,
+            messageId,
+            hookResult.content,
+            {
+              api: bot.api,
+              cfg,
+              accountId: route.accountId,
+              linkPreview: telegramCfg.linkPreview,
+            },
+          );
+          return { content: hookResult.content };
+        } catch (err: unknown) {
+          logVerbose(
+            `telegram: message_sending rewrite could not edit streamed reply: ${formatErrorMessage(
+              err,
+            )}`,
+          );
+          // Fall through with the rewritten content so downstream context stays consistent
+          // with the hook's intent even if the visible edit failed.
+          return { content: hookResult.content };
+        }
+      }
+      return { content: visibleContent };
+    };
     const emitPreviewFinalizedHook = async (result: LaneDeliveryResult) => {
       if (isDispatchSuperseded() || result.kind !== "preview-finalized") {
         return;
       }
+      const visibleContent = result.delivery.promptContextContent ?? result.delivery.content;
+      const gated = await runStreamedFinalMessageSending(visibleContent, result.delivery.messageId);
+      if ("cancel" in gated) {
+        return;
+      }
+      const finalContent =
+        gated.content === visibleContent ? result.delivery.content : gated.content;
+      const finalPromptContext = gated.content;
       (telegramDeps.emitInternalMessageSentHook ?? emitInternalMessageSentHook)({
         sessionKeyForInternalHooks: deliveryBaseOptions.sessionKeyForInternalHooks,
         chatId: deliveryBaseOptions.chatId,
         accountId: deliveryBaseOptions.accountId,
-        content: result.delivery.content,
+        content: finalContent,
         success: true,
         messageId: result.delivery.messageId,
         isGroup: deliveryBaseOptions.mirrorIsGroup,
@@ -1682,7 +1758,7 @@ export const dispatchTelegramMessage = async ({
           chatId: deliveryBaseOptions.chatId,
           message: { message_id: result.delivery.messageId },
           messageId: result.delivery.messageId,
-          text: result.delivery.promptContextContent ?? result.delivery.content,
+          text: finalPromptContext,
           ...(threadSpec.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
         });
       } catch (error) {
@@ -1692,14 +1768,12 @@ export const dispatchTelegramMessage = async ({
           )}`,
         );
       }
-      if (deliveryBaseOptions.transcriptMirror && result.delivery.content) {
-        void deliveryBaseOptions
-          .transcriptMirror({ text: result.delivery.content })
-          .catch((err: unknown) => {
-            logVerbose(
-              `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
-            );
-          });
+      if (deliveryBaseOptions.transcriptMirror && finalContent) {
+        void deliveryBaseOptions.transcriptMirror({ text: finalContent }).catch((err: unknown) => {
+          logVerbose(
+            `telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`,
+          );
+        });
       }
     };
     const finalizeSkippedDuplicateAnswerBlockDraft = async () => {
@@ -1916,6 +1990,10 @@ export const dispatchTelegramMessage = async ({
                 cfg,
                 dispatcherOptions: {
                   ...replyPipeline,
+                  // Telegram runs the message_sending plugin hook itself at delivery
+                  // time (deliverReplies + streaming finalizer), so the dispatcher must
+                  // not also compose it into beforeDeliver. See issue #92374.
+                  runsMessageSendingAtDelivery: true,
                   beforeDeliver: async (payload) => payload,
                   onBeforeDeliverCancelled: (payload, info) => {
                     if (info.kind === "block") {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -32,6 +32,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyDispatcherWithTypingOptions } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -111,6 +112,10 @@ export {
 } from "./native-command-callback-data.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
+
+type TelegramDispatcherOptions = ReplyDispatcherWithTypingOptions & {
+  runsMessageSendingAtDelivery: true;
+};
 
 type TelegramNativeCommandContext = Context & { match?: string };
 type TelegramChunkMode = ReturnType<
@@ -1333,7 +1338,7 @@ export const registerTelegramNativeCommands = ({
             onError: (err, info) => {
               runtime.error?.(danger(`telegram slash ${info.kind} reply failed: ${String(err)}`));
             },
-          },
+          } as TelegramDispatcherOptions,
           replyOptions: {
             skillFilter,
             disableBlockStreaming,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1294,6 +1294,9 @@ export const registerTelegramNativeCommands = ({
           cfg: executionCfg,
           dispatcherOptions: {
             ...replyPipeline,
+            // Telegram runs the message_sending plugin hook itself at delivery time
+            // (deliverReplies), so the dispatcher must not also compose it. See #92374.
+            runsMessageSendingAtDelivery: true,
             beforeDeliver: async (payload) => payload,
             deliver: async (payload, _info) => {
               if (

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -388,6 +388,7 @@ describe("createTelegramDraftStream", () => {
       textSnapshot: "Message A partial",
       visibleSinceMs: supersededPreview.visibleSinceMs,
       retain: true,
+      reason: "late-send",
     });
     expect(typeof supersededPreview.visibleSinceMs).toBe("number");
     expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);
@@ -738,6 +739,7 @@ describe("createTelegramDraftStream", () => {
       expect.objectContaining({
         messageId: 17,
         retain: true,
+        reason: "final-overflow",
       }),
     );
   });
@@ -784,6 +786,7 @@ describe("createTelegramDraftStream", () => {
       textSnapshot: "Hello world",
       visibleSinceMs: supersededPreview.visibleSinceMs,
       retain: true,
+      reason: "final-overflow",
     });
     expect(typeof supersededPreview.visibleSinceMs).toBe("number");
     expect(Number.isFinite(supersededPreview.visibleSinceMs)).toBe(true);

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -63,6 +63,7 @@ type SupersededTelegramPreview = {
   textSnapshot: string;
   visibleSinceMs?: number;
   retain?: boolean;
+  reason?: "late-send" | "final-overflow";
 };
 
 function renderTelegramDraftPreview(
@@ -199,6 +200,7 @@ export function createTelegramDraftStream(params: {
         textSnapshot: preview.text,
         visibleSinceMs,
         retain: true,
+        reason: "late-send",
       });
       return true;
     }
@@ -264,6 +266,7 @@ export function createTelegramDraftStream(params: {
             textSnapshot: supersededTextSnapshot,
             visibleSinceMs: supersededVisibleSinceMs,
             retain: true,
+            reason: "final-overflow",
           });
         }
         return await sendOrEditStreamMessage(trimmed);

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -24,6 +24,7 @@ export type DraftLaneState = {
   hasStreamedMessage: boolean;
   finalized: boolean;
   activeChunkIndex: number;
+  retainedPreviewMessageIds: number[];
 };
 
 type LanePreviewFinalizedDelivery = {
@@ -75,6 +76,10 @@ type CreateLaneTextDelivererParams = {
     messageId: number;
     text: string;
     buttons?: TelegramInlineButtons;
+  }) => Promise<void>;
+  deleteStreamMessages?: (params: {
+    laneName: LaneName;
+    messageIds: readonly number[];
   }) => Promise<void>;
   resolveFinalTextCandidate?: (params: {
     finalText: string;
@@ -277,6 +282,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     await params.clearDraftLane(lane);
     lane.lastPartialText = "";
     lane.hasStreamedMessage = false;
+    lane.retainedPreviewMessageIds = [];
+    lane.activeChunkIndex = 0;
   };
 
   const discardUnmaterializedStream = async (lane: DraftLaneState) => {
@@ -288,6 +295,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     lane.lastPartialText = "";
     lane.hasStreamedMessage = false;
     lane.finalized = false;
+    lane.retainedPreviewMessageIds = [];
+    lane.activeChunkIndex = 0;
   };
 
   const rotateFinalizedStream = (lane: DraftLaneState) => {
@@ -298,6 +307,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     lane.lastPartialText = "";
     lane.hasStreamedMessage = false;
     lane.finalized = false;
+    lane.retainedPreviewMessageIds = [];
+    lane.activeChunkIndex = 0;
   };
 
   const streamText = async (
@@ -345,7 +356,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       currentPreviewText: string;
       remainingChunks: readonly string[];
       messageId: number;
-      activeChunkIndex: number;
     }): Promise<
       | { cancel: true }
       | {
@@ -362,48 +372,47 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         messageId: delivery.messageId,
       });
       if (gated && "cancel" in gated) {
+        await deleteRetainedPreviewMessages();
         return { cancel: true };
       }
       let buttonsAttached = false;
-      if (
-        typeof gated?.content === "string" &&
-        gated.content !== delivery.content &&
-        gated.content.trim().length > 0
-      ) {
-        if (delivery.activeChunkIndex > 0) {
-          params.log(
-            `telegram: ${laneName} stream message_sending rewrite skipped after earlier chunks were retained`,
-          );
-        } else {
-          const rewrittenChunks = splitPreviewFinalText(gated.content);
-          const rewrittenCurrentPreviewText = rewrittenChunks[0];
-          if (
-            rewrittenCurrentPreviewText &&
-            rewrittenCurrentPreviewText.length <= params.draftMaxChars
-          ) {
-            try {
-              await params.editStreamMessage({
-                laneName,
-                messageId: delivery.messageId,
-                text: rewrittenCurrentPreviewText,
-                ...(buttons !== undefined ? { buttons } : {}),
-              });
-              return {
-                content: gated.content,
-                promptContextContent: rewrittenCurrentPreviewText,
-                remainingChunks: rewrittenChunks.slice(1),
-                buttonsAttached: buttons !== undefined,
-              };
-            } catch (err) {
-              params.log(
-                `telegram: ${laneName} stream message_sending rewrite edit failed: ${String(err)}`,
-              );
+      if (typeof gated?.content === "string" && gated.content !== delivery.content) {
+        if (gated.content.trim().length === 0) {
+          await deleteCurrentAndRetainedPreviewMessages(delivery.messageId);
+          return { cancel: true };
+        }
+        const rewrittenChunks = splitPreviewFinalText(gated.content);
+        const rewrittenCurrentPreviewText = rewrittenChunks[0];
+        if (
+          rewrittenCurrentPreviewText &&
+          rewrittenCurrentPreviewText.length <= params.draftMaxChars
+        ) {
+          try {
+            await params.editStreamMessage({
+              laneName,
+              messageId: delivery.messageId,
+              text: rewrittenCurrentPreviewText,
+              ...(buttons !== undefined ? { buttons } : {}),
+            });
+            const deletedRetainedPreviews = await deleteRetainedPreviewMessages();
+            if (!deletedRetainedPreviews) {
+              return { cancel: true };
             }
-          } else {
+            return {
+              content: gated.content,
+              promptContextContent: rewrittenCurrentPreviewText,
+              remainingChunks: rewrittenChunks.slice(1),
+              buttonsAttached: buttons !== undefined,
+            };
+          } catch (err) {
             params.log(
-              `telegram: ${laneName} stream message_sending rewrite produced no sendable preview chunk`,
+              `telegram: ${laneName} stream message_sending rewrite edit failed: ${String(err)}`,
             );
           }
+        } else {
+          params.log(
+            `telegram: ${laneName} stream message_sending rewrite produced no sendable preview chunk`,
+          );
         }
       }
       if (buttons) {
@@ -447,6 +456,42 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         buttonsAttached: finalized.buttonsAttached,
       });
 
+    const takeRetainedPreviewMessageIds = () => {
+      const messageIds = lane.retainedPreviewMessageIds;
+      lane.retainedPreviewMessageIds = [];
+      lane.activeChunkIndex = 0;
+      return [...new Set(messageIds)];
+    };
+
+    const deleteStreamMessages = async (messageIds: readonly number[]) => {
+      if (messageIds.length === 0) {
+        return true;
+      }
+      if (!params.deleteStreamMessages) {
+        params.log(
+          `telegram: ${laneName} stream message_sending could not delete retained previews; no delete callback configured`,
+        );
+        return false;
+      }
+      try {
+        await params.deleteStreamMessages({ laneName, messageIds });
+        return true;
+      } catch (err) {
+        params.log(
+          `telegram: ${laneName} stream message_sending retained preview cleanup failed: ${String(err)}`,
+        );
+        return false;
+      }
+    };
+
+    const deleteRetainedPreviewMessages = async () => {
+      return await deleteStreamMessages(takeRetainedPreviewMessageIds());
+    };
+
+    const deleteCurrentAndRetainedPreviewMessages = async (messageId: number) => {
+      return await deleteStreamMessages([...takeRetainedPreviewMessageIds(), messageId]);
+    };
+
     const finalizeDeliveredPrefix = async (
       deliveredStreamText: string,
       messageId: number,
@@ -465,7 +510,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             ? compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])
             : [],
         messageId,
-        activeChunkIndex: Math.max(0, deliveredChunks.length - 1),
       });
       lane.finalized = true;
       params.markDelivered();
@@ -532,7 +576,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         currentPreviewText: previewText,
         remainingChunks,
         messageId,
-        activeChunkIndex,
       });
       lane.finalized = true;
       params.markDelivered();
@@ -618,7 +661,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         currentPreviewText: activeChunkAfterStop,
         remainingChunks: remainingChunksAfterStop,
         messageId,
-        activeChunkIndex: activeChunkIndexAfterStop,
       });
       lane.finalized = true;
       params.markDelivered();

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -38,12 +38,24 @@ type LanePreviewFinalizedDeliveryInput = Omit<LanePreviewFinalizedDelivery, "rec
   receipt?: MessageReceipt;
 };
 
+type LanePreviewFinalizeGateResult = { cancel: true } | { content?: string };
+
+type LanePreviewFinalizeGate = (params: {
+  laneName: LaneName;
+  content: string;
+  promptContextContent: string;
+  messageId: number;
+}) =>
+  | Promise<LanePreviewFinalizeGateResult | undefined>
+  | LanePreviewFinalizeGateResult
+  | undefined;
+
 export type LaneDeliveryResult =
   | {
       kind: "preview-finalized";
       delivery: LanePreviewFinalizedDelivery;
     }
-  | { kind: "preview-retained" | "preview-updated" | "sent" | "skipped" };
+  | { kind: "preview-cancelled" | "preview-retained" | "preview-updated" | "sent" | "skipped" };
 
 type CreateLaneTextDelivererParams = {
   lanes: Record<LaneName, DraftLaneState>;
@@ -68,6 +80,7 @@ type CreateLaneTextDelivererParams = {
     finalText: string;
     laneName: LaneName;
   }) => Promise<string | undefined> | string | undefined;
+  beforeFinalizePreviewDelivery?: LanePreviewFinalizeGate;
   log: (message: string) => void;
   markDelivered: () => void;
 };
@@ -133,6 +146,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     params.applyTextToFollowUpPayload
       ? params.applyTextToFollowUpPayload(payload, text)
       : params.applyTextToPayload(payload, text);
+  const splitPreviewFinalText = (text: string): string[] =>
+    text.length > params.draftMaxChars
+      ? compactChunks(params.splitFinalTextForStream?.(text) ?? [])
+      : [text];
   const textOnlyPayload = (payload: ReplyPayload): ReplyPayload => {
     const {
       mediaUrl: _mediaUrl,
@@ -298,10 +315,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     rotateFinalizedStream(lane);
 
-    const chunks =
-      text.length > params.draftMaxChars
-        ? compactChunks(params.splitFinalTextForStream?.(text) ?? [])
-        : [text];
+    const chunks = splitPreviewFinalText(text);
 
     const clampActiveChunkIndex = () =>
       Math.min(lane.activeChunkIndex, Math.max(0, chunks.length - 1));
@@ -325,46 +339,149 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }) &&
       deliveredStreamTextBeforeUpdate.length > activeChunk.trimEnd().length;
 
-    const finalizeDeliveredPrefix = async (
-      deliveredStreamText: string,
-      messageId: number,
-    ): Promise<LaneDeliveryResult> => {
-      lane.finalized = true;
-      params.markDelivered();
+    const finalizePreviewDelivery = async (delivery: {
+      content: string;
+      promptContextContent: string;
+      currentPreviewText: string;
+      remainingChunks: readonly string[];
+      messageId: number;
+      activeChunkIndex: number;
+    }): Promise<
+      | { cancel: true }
+      | {
+          content: string;
+          promptContextContent: string;
+          remainingChunks: readonly string[];
+          buttonsAttached: boolean;
+        }
+    > => {
+      const gated = await params.beforeFinalizePreviewDelivery?.({
+        laneName,
+        content: delivery.content,
+        promptContextContent: delivery.promptContextContent,
+        messageId: delivery.messageId,
+      });
+      if (gated && "cancel" in gated) {
+        return { cancel: true };
+      }
       let buttonsAttached = false;
+      if (
+        typeof gated?.content === "string" &&
+        gated.content !== delivery.content &&
+        gated.content.trim().length > 0
+      ) {
+        if (delivery.activeChunkIndex > 0) {
+          params.log(
+            `telegram: ${laneName} stream message_sending rewrite skipped after earlier chunks were retained`,
+          );
+        } else {
+          const rewrittenChunks = splitPreviewFinalText(gated.content);
+          const rewrittenCurrentPreviewText = rewrittenChunks[0];
+          if (
+            rewrittenCurrentPreviewText &&
+            rewrittenCurrentPreviewText.length <= params.draftMaxChars
+          ) {
+            try {
+              await params.editStreamMessage({
+                laneName,
+                messageId: delivery.messageId,
+                text: rewrittenCurrentPreviewText,
+                ...(buttons !== undefined ? { buttons } : {}),
+              });
+              return {
+                content: gated.content,
+                promptContextContent: rewrittenCurrentPreviewText,
+                remainingChunks: rewrittenChunks.slice(1),
+                buttonsAttached: buttons !== undefined,
+              };
+            } catch (err) {
+              params.log(
+                `telegram: ${laneName} stream message_sending rewrite edit failed: ${String(err)}`,
+              );
+            }
+          } else {
+            params.log(
+              `telegram: ${laneName} stream message_sending rewrite produced no sendable preview chunk`,
+            );
+          }
+        }
+      }
       if (buttons) {
-        const deliveredChunks = compactChunks(
-          params.splitFinalTextForStream?.(deliveredStreamText) ?? [],
-        );
-        const currentChunk = deliveredChunks.at(-1);
-        if (currentChunk && currentChunk.length <= params.draftMaxChars) {
+        if (delivery.currentPreviewText.length <= params.draftMaxChars) {
           try {
-            await params.editStreamMessage({ laneName, messageId, text: currentChunk, buttons });
+            await params.editStreamMessage({
+              laneName,
+              messageId: delivery.messageId,
+              text: delivery.currentPreviewText,
+              buttons,
+            });
             buttonsAttached = true;
           } catch (err) {
             params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
           }
         }
       }
-      const suffix = activeFullText.slice(deliveredStreamText.length);
-      if (suffix.trim().length > 0) {
-        for (const chunk of compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])) {
-          if (chunk.trim().length === 0) {
-            continue;
-          }
-          await params.sendPayload(followUpPayload(payload, chunk));
+      return {
+        content: delivery.content,
+        promptContextContent: delivery.promptContextContent,
+        remainingChunks: delivery.remainingChunks,
+        buttonsAttached,
+      };
+    };
+    const sendRemainingChunks = async (remainingChunks: readonly string[]) => {
+      for (const chunk of remainingChunks) {
+        if (chunk.trim().length === 0) {
+          continue;
         }
+        await params.sendPayload(followUpPayload(payload, chunk));
       }
-      return result("preview-finalized", {
+    };
+    const finalizedPreviewResult = (
+      finalized: Exclude<Awaited<ReturnType<typeof finalizePreviewDelivery>>, { cancel: true }>,
+      messageId: number,
+    ) =>
+      result("preview-finalized", {
+        content: finalized.content,
+        promptContextContent: finalized.promptContextContent,
+        messageId,
+        buttonsAttached: finalized.buttonsAttached,
+      });
+
+    const finalizeDeliveredPrefix = async (
+      deliveredStreamText: string,
+      messageId: number,
+    ): Promise<LaneDeliveryResult> => {
+      const deliveredChunks = compactChunks(
+        params.splitFinalTextForStream?.(deliveredStreamText) ?? [],
+      );
+      const currentPreviewText = deliveredChunks.at(-1) ?? deliveredStreamText;
+      const suffix = activeFullText.slice(deliveredStreamText.length);
+      const finalized = await finalizePreviewDelivery({
         content: text,
         promptContextContent: deliveredStreamText,
+        currentPreviewText,
+        remainingChunks:
+          suffix.trim().length > 0
+            ? compactChunks(params.splitFinalTextForStream?.(suffix) ?? [])
+            : [],
         messageId,
-        buttonsAttached,
+        activeChunkIndex: Math.max(0, deliveredChunks.length - 1),
       });
+      lane.finalized = true;
+      params.markDelivered();
+      if ("cancel" in finalized) {
+        return result("preview-cancelled");
+      }
+      await sendRemainingChunks(finalized.remainingChunks);
+      return finalizedPreviewResult(finalized, messageId);
     };
 
     const candidateTexts = [stream.lastDeliveredText?.(), lane.lastPartialText];
-    if (useFinalTextRecovery && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)) {
+    if (
+      useFinalTextRecovery &&
+      remainingChunks.length === 0 &&
+      isPotentialTruncatedFinal(activeFullText)
+    ) {
       const resolvedFullCandidate = await params.resolveFinalTextCandidate?.({
         finalText: text,
         laneName,
@@ -379,7 +496,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     const retainedPreview =
-      useFinalTextRecovery && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)
+      useFinalTextRecovery &&
+      remainingChunks.length === 0 &&
+      isPotentialTruncatedFinal(activeFullText)
         ? selectLongerFinalText({
             finalText: activeFullText,
             candidateTexts,
@@ -407,29 +526,21 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       ) {
         return undefined;
       }
-      let buttonsAttached = false;
-      if (buttons) {
-        try {
-          await params.editStreamMessage({ laneName, messageId, text: previewText, buttons });
-          buttonsAttached = true;
-        } catch (err) {
-          params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
-        }
-      }
-      for (const chunk of remainingChunks) {
-        if (chunk.trim().length === 0) {
-          continue;
-        }
-        await params.sendPayload(followUpPayload(payload, chunk));
-      }
-      lane.finalized = true;
-      params.markDelivered();
-      return result("preview-finalized", {
+      const finalized = await finalizePreviewDelivery({
         content: previewText,
         promptContextContent: previewText,
+        currentPreviewText: previewText,
+        remainingChunks,
         messageId,
-        buttonsAttached,
+        activeChunkIndex,
       });
+      lane.finalized = true;
+      params.markDelivered();
+      if ("cancel" in finalized) {
+        return result("preview-cancelled");
+      }
+      await sendRemainingChunks(finalized.remainingChunks);
+      return finalizedPreviewResult(finalized, messageId);
     }
 
     if (!deliveredPrefixBeforeUpdate) {
@@ -443,7 +554,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     } else {
       await params.flushDraftLane(lane);
     }
-    const activeChunkIndexAfterStop = useFinalTextRecovery ? clampActiveChunkIndex() : activeChunkIndex;
+    const activeChunkIndexAfterStop = useFinalTextRecovery
+      ? clampActiveChunkIndex()
+      : activeChunkIndex;
     const activeChunkAfterStop = chunks[activeChunkIndexAfterStop] ?? activeChunk;
     const remainingChunksAfterStop = chunks.slice(activeChunkIndexAfterStop + 1);
 
@@ -485,9 +598,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       return await finalizeDeliveredPrefix(deliveredStreamTextBeforeUpdate, messageId);
     }
 
-    params.markDelivered();
-    let buttonsAttached = false;
-    if (buttons) {
+    if (!finalizePreview && buttons) {
       try {
         await params.editStreamMessage({
           laneName,
@@ -495,28 +606,30 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           text: activeChunkAfterStop,
           buttons,
         });
-        buttonsAttached = true;
       } catch (err) {
         params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
       }
     }
 
     if (finalizePreview) {
-      lane.finalized = true;
-      for (const chunk of remainingChunksAfterStop) {
-        if (chunk.trim().length === 0) {
-          continue;
-        }
-        await params.sendPayload(followUpPayload(payload, chunk));
-      }
-      return result("preview-finalized", {
+      const finalized = await finalizePreviewDelivery({
         content: text,
         promptContextContent: activeChunkAfterStop,
+        currentPreviewText: activeChunkAfterStop,
+        remainingChunks: remainingChunksAfterStop,
         messageId,
-        buttonsAttached,
+        activeChunkIndex: activeChunkIndexAfterStop,
       });
+      lane.finalized = true;
+      params.markDelivered();
+      if ("cancel" in finalized) {
+        return result("preview-cancelled");
+      }
+      await sendRemainingChunks(finalized.remainingChunks);
+      return finalizedPreviewResult(finalized, messageId);
     }
 
+    params.markDelivered();
     return result("preview-updated");
   };
 

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -36,6 +36,7 @@ function createHarness(params?: {
       hasStreamedMessage: false,
       finalized: false,
       activeChunkIndex: 0,
+      retainedPreviewMessageIds: [],
     },
     reasoning: {
       stream: reasoning,
@@ -43,6 +44,7 @@ function createHarness(params?: {
       hasStreamedMessage: false,
       finalized: false,
       activeChunkIndex: 0,
+      retainedPreviewMessageIds: [],
     },
   };
   const sendPayload = vi.fn().mockResolvedValue(true);
@@ -56,6 +58,7 @@ function createHarness(params?: {
     await lane.stream?.clear();
   });
   const editStreamMessage = vi.fn().mockResolvedValue(undefined);
+  const deleteStreamMessages = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
 
@@ -69,6 +72,7 @@ function createHarness(params?: {
     stopDraftLane,
     clearDraftLane,
     editStreamMessage,
+    deleteStreamMessages,
     resolveFinalTextCandidate: params?.resolveFinalTextCandidate,
     beforeFinalizePreviewDelivery: params?.beforeFinalizePreviewDelivery,
     log,
@@ -85,6 +89,7 @@ function createHarness(params?: {
     stopDraftLane,
     clearDraftLane,
     editStreamMessage,
+    deleteStreamMessages,
     log,
     markDelivered,
   };
@@ -970,6 +975,54 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
   });
 
+  it("deletes retained streamed pages when message_sending cancels a long final", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const beforeFinalizePreviewDelivery = vi.fn(async () => ({ cancel: true as const }));
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery,
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 1;
+      harness.lanes.answer.retainedPreviewMessageIds = [998];
+    });
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    expect(result.kind).toBe("preview-cancelled");
+    expect(harness.deleteStreamMessages).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageIds: [998],
+    });
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a streamed final when message_sending rewrites it to empty text", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery: async () => ({ content: "   " }),
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    expect(result.kind).toBe("preview-cancelled");
+    expect(harness.deleteStreamMessages).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageIds: [999],
+    });
+    expect(harness.editStreamMessage).not.toHaveBeenCalled();
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
   it("rewrites a long streamed final before sending suffix chunks", async () => {
     const answer = createTestDraftStream({ messageId: 999 });
     const harness = createHarness({
@@ -993,6 +1046,64 @@ describe("createLaneTextDeliverer", () => {
     });
     expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: " answer" });
     expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " now" });
+  });
+
+  it("deletes retained streamed pages before rewriting a long final", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: (text) =>
+        text === "Clean answer now" ? ["Clean", " answer", " now"] : ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery: async () => ({ content: "Clean answer now" }),
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 1;
+      harness.lanes.answer.retainedPreviewMessageIds = [998];
+    });
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("Clean answer now");
+    expect(delivery.promptContextContent).toBe("Clean");
+    expect(harness.deleteStreamMessages).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageIds: [998],
+    });
+    expect(harness.editStreamMessage).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageId: 999,
+      text: "Clean",
+    });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: " answer" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " now" });
+  });
+
+  it("keeps retained streamed pages when a finalization rewrite edit fails", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: (text) =>
+        text === "Clean answer now" ? ["Clean", " answer", " now"] : ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery: async () => ({ content: "Clean answer now" }),
+    });
+    harness.editStreamMessage.mockRejectedValueOnce(new Error("edit failed"));
+    harness.lanes.answer.hasStreamedMessage = true;
+    answer.stop.mockImplementation(async () => {
+      harness.lanes.answer.activeChunkIndex = 1;
+      harness.lanes.answer.retainedPreviewMessageIds = [998];
+    });
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("Hello world again");
+    expect(delivery.promptContextContent).toBe(" world");
+    expect(harness.deleteStreamMessages).not.toHaveBeenCalled();
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: " again" });
   });
 
   it("keeps original streamed final content when a finalization rewrite edit fails", async () => {

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -20,6 +20,9 @@ function createHarness(params?: {
     finalText: string;
     laneName: LaneName;
   }) => string | undefined;
+  beforeFinalizePreviewDelivery?: Parameters<
+    typeof createLaneTextDeliverer
+  >[0]["beforeFinalizePreviewDelivery"];
 }) {
   const answer =
     params?.answerStream === null
@@ -67,6 +70,7 @@ function createHarness(params?: {
     clearDraftLane,
     editStreamMessage,
     resolveFinalTextCandidate: params?.resolveFinalTextCandidate,
+    beforeFinalizePreviewDelivery: params?.beforeFinalizePreviewDelivery,
     log,
     markDelivered,
   });
@@ -228,10 +232,7 @@ describe("createLaneTextDeliverer", () => {
     expect(answer.update).toHaveBeenCalledWith(previousBlock);
     expect(answer.update).not.toHaveBeenCalledWith(nextAssistantBlock);
     expect(harness.clearDraftLane).toHaveBeenCalledTimes(1);
-    expect(harness.sendPayload).toHaveBeenCalledWith(
-      { text: previousBlock },
-      { durable: false },
-    );
+    expect(harness.sendPayload).toHaveBeenCalledWith({ text: previousBlock }, { durable: false });
     expect(harness.sendPayload).not.toHaveBeenCalledWith(
       { text: nextAssistantBlock },
       expect.anything(),
@@ -943,6 +944,76 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).toHaveBeenCalledWith({ text: " again" });
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the finalization gate before sending long streamed final suffix chunks", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const beforeFinalizePreviewDelivery = vi.fn(async () => ({ cancel: true as const }));
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 5,
+      splitFinalTextForStream: () => ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery,
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    expect(result.kind).toBe("preview-cancelled");
+    expect(beforeFinalizePreviewDelivery).toHaveBeenCalledWith({
+      laneName: "answer",
+      content: "Hello world again",
+      promptContextContent: "Hello",
+      messageId: 999,
+    });
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("rewrites a long streamed final before sending suffix chunks", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: (text) =>
+        text === "Clean answer now" ? ["Clean", " answer", " now"] : ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery: async () => ({ content: "Clean answer now" }),
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("Clean answer now");
+    expect(delivery.promptContextContent).toBe("Clean");
+    expect(harness.editStreamMessage).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageId: 999,
+      text: "Clean",
+    });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: " answer" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " now" });
+  });
+
+  it("keeps original streamed final content when a finalization rewrite edit fails", async () => {
+    const answer = createTestDraftStream({ messageId: 999 });
+    const harness = createHarness({
+      answerStream: answer,
+      draftMaxChars: 6,
+      splitFinalTextForStream: (text) =>
+        text === "Clean answer now" ? ["Clean", " answer", " now"] : ["Hello", " world", " again"],
+      beforeFinalizePreviewDelivery: async () => ({ content: "Clean answer now" }),
+    });
+    harness.editStreamMessage.mockRejectedValueOnce(new Error("edit failed"));
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await deliverFinalAnswer(harness, "Hello world again");
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("Hello world again");
+    expect(delivery.promptContextContent).toBe("Hello");
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(1, { text: " world" });
+    expect(harness.sendPayload).toHaveBeenNthCalledWith(2, { text: " again" });
   });
 
   it("compares retained delivered prefixes against the full final text", async () => {

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "./reply-payload.js";
-import type { ReplyDispatchBeforeDeliver, ReplyDispatcher } from "./reply/reply-dispatcher.js";
+import type {
+  ReplyDispatchBeforeDeliver,
+  ReplyDispatcher,
+  ReplyDispatcherWithTypingOptions,
+} from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 
 type DispatchReplyFromConfigFn =
@@ -15,6 +19,9 @@ type GetGlobalHookRunnerFn = typeof import("../plugins/hook-runner-global.js").g
 type CreateReplyDispatcherFn = typeof import("./reply/reply-dispatcher.js").createReplyDispatcher;
 type CreateReplyDispatcherWithTypingFn =
   typeof import("./reply/reply-dispatcher.js").createReplyDispatcherWithTyping;
+type InternalMessageSendingDeliveryOptions = ReplyDispatcherWithTypingOptions & {
+  runsMessageSendingAtDelivery: true;
+};
 
 const hoisted = vi.hoisted(() => ({
   dispatchReplyFromConfigMock: vi.fn(),
@@ -879,7 +886,7 @@ describe("withReplyDispatcher", () => {
         deliver: async () => undefined,
         beforeDeliver: customBeforeDeliver,
         runsMessageSendingAtDelivery: true,
-      },
+      } as InternalMessageSendingDeliveryOptions,
       replyResolver: async () => ({ text: "ok" }),
     });
 

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -764,7 +764,7 @@ describe("withReplyDispatcher", () => {
     expect(dispatcherOptions.silentReplyContext?.conversationType).toBe("direct");
   });
 
-  it("composes custom beforeDeliver with reply_payload_sending hooks", async () => {
+  it("composes custom beforeDeliver with reply_payload_sending and message_sending hooks", async () => {
     const customBeforeDeliver = vi.fn(async (payload: { text?: string }) => ({
       text: `${payload.text ?? ""} [custom]`,
     }));
@@ -809,7 +809,17 @@ describe("withReplyDispatcher", () => {
 
     expect(customBeforeDeliver).toHaveBeenCalledTimes(2);
     expect(customBeforeDeliver).toHaveBeenCalledWith({ text: "original" }, { kind: "final" });
-    expect(runMessageSending).not.toHaveBeenCalled();
+    // Regression for #92374: a channel-supplied beforeDeliver must NOT shadow the
+    // message_sending gate. It now runs last, after the channel hook + reply_payload_sending.
+    expect(runMessageSending).toHaveBeenCalledTimes(2);
+    expect(runMessageSending).toHaveBeenCalledWith(
+      { content: "original [custom] [plugin]", to: "conv-1" },
+      {
+        accountId: "acct-1",
+        channelId: "threads",
+        conversationId: "conv-1",
+      },
+    );
     expect(runReplyPayloadSending).toHaveBeenCalledTimes(2);
     expect(runReplyPayloadSending).toHaveBeenCalledWith(
       {
@@ -826,10 +836,98 @@ describe("withReplyDispatcher", () => {
         runId: undefined,
       },
     );
-    expect(payload).toEqual({ text: "original [custom] [plugin]" });
+    expect(payload).toEqual({ text: "message hook" });
     expect(payloadWithMetadata ? getReplyPayloadMetadata(payloadWithMetadata) : undefined).toEqual({
       assistantMessageIndex: 5,
     });
+  });
+
+  it("does not compose message_sending when the channel runs it at delivery (runsMessageSendingAtDelivery)", async () => {
+    // Telegram runs message_sending itself (deliverReplies + streaming finalizer), so the
+    // dispatcher must not also compose it — otherwise the hook double-runs and at
+    // per-block instead of per-message granularity. See issue #92374.
+    const customBeforeDeliver = vi.fn(async (payload: { text?: string }) => ({
+      text: `${payload.text ?? ""} [custom]`,
+    }));
+    const runMessageSending = vi.fn(async () => ({ content: "message hook" }));
+    const runReplyPayloadSending = vi.fn(async ({ payload }: { payload: { text?: string } }) => ({
+      payload: {
+        ...payload,
+        text: `${payload.text ?? ""} [plugin]`,
+      },
+    }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(
+        (hookName?: string) =>
+          hookName === "message_sending" || hookName === "reply_payload_sending",
+      ),
+      runMessageSending,
+      runReplyPayloadSending,
+    });
+    hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
+      dispatcher: createDispatcher([]),
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    });
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildTestCtx({ Surface: "telegram", SessionKey: "agent:test:session" }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+        beforeDeliver: customBeforeDeliver,
+        runsMessageSendingAtDelivery: true,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const dispatcherOptions = lastTypingDispatcherOptions();
+    if (!dispatcherOptions?.beforeDeliver) {
+      throw new Error("expected beforeDeliver hook");
+    }
+    const payload = await dispatcherOptions.beforeDeliver({ text: "original" }, { kind: "final" });
+
+    expect(customBeforeDeliver).toHaveBeenCalledTimes(1);
+    expect(runReplyPayloadSending).toHaveBeenCalledTimes(1);
+    // Channel owns the message_sending gate, so the dispatcher must not invoke it.
+    expect(runMessageSending).not.toHaveBeenCalled();
+    expect(payload).toEqual({ text: "original [custom] [plugin]" });
+  });
+
+  it("cancels delivery when message_sending vetoes a reply behind a custom beforeDeliver", async () => {
+    const customBeforeDeliver = vi.fn(async (payload: { text?: string }) => ({
+      text: `${payload.text ?? ""} [custom]`,
+    }));
+    const runMessageSending = vi.fn(async () => ({ cancel: true }));
+    hoisted.getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName?: string) => hookName === "message_sending"),
+      runMessageSending,
+    });
+    hoisted.createReplyDispatcherMock.mockReturnValueOnce(createDispatcher([]));
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithDispatcher({
+      ctx: buildTestCtx({ Surface: "discord", SessionKey: "agent:test:session" }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+        beforeDeliver: customBeforeDeliver,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    const dispatcherOptions = requireReplyDispatcherOptions();
+    if (!dispatcherOptions?.beforeDeliver) {
+      throw new Error("expected beforeDeliver hook");
+    }
+    const payload = await dispatcherOptions.beforeDeliver({ text: "original" }, { kind: "final" });
+
+    // The message_sending veto cancels delivery even though the channel hook ran first.
+    expect(customBeforeDeliver).toHaveBeenCalledTimes(1);
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(payload).toBeNull();
   });
 
   it("does not copy source conversation type onto cross-session native silent-reply targets", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -56,8 +56,18 @@ type ReplyPayloadRunState = {
   runId?: string;
 };
 
+type MessageSendingDeliveryDispatcherOptions = {
+  runsMessageSendingAtDelivery?: boolean;
+};
+
 const foregroundReplyFenceByKey = new Map<string, ForegroundReplyFenceState>();
 const replyPayloadSendingDispatchers = new WeakSet<ReplyDispatcher>();
+
+function runsMessageSendingAtDelivery(
+  options: ReplyDispatcherOptions | ReplyDispatcherWithTypingOptions,
+): boolean {
+  return (options as MessageSendingDeliveryDispatcherOptions).runsMessageSendingAtDelivery === true;
+}
 
 function applyRuntimeToolsAllow(
   replyOptions: Omit<GetReplyOptions, "onBlockReply"> | undefined,
@@ -573,10 +583,9 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     replyPayloadRunState,
   );
   // A channel-supplied beforeDeliver must compose WITH the canonical message_sending
-  // gate, not replace it (issue #92374). Channels that run message_sending themselves
-  // at delivery time opt out via runsMessageSendingAtDelivery so the hook stays
-  // exactly-once and per-message rather than per-streamed-block.
-  const messageSendingBeforeDeliver = params.dispatcherOptions.runsMessageSendingAtDelivery
+  // gate, not replace it. Internal durable delivery paths that run message_sending
+  // at send time opt out so the hook stays exactly-once and per-message.
+  const messageSendingBeforeDeliver = runsMessageSendingAtDelivery(params.dispatcherOptions)
     ? undefined
     : buildMessageSendingBeforeDeliver(finalized);
   const globalBeforeDeliver = combineBeforeDeliverHooks(
@@ -683,9 +692,9 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     replyPayloadRunState,
   );
   // See dispatchInboundMessageWithBufferedDispatcher: compose the channel-supplied
-  // beforeDeliver WITH the canonical message_sending gate (issue #92374), unless the
-  // channel runs message_sending itself at delivery time.
-  const messageSendingBeforeDeliver = params.dispatcherOptions.runsMessageSendingAtDelivery
+  // beforeDeliver WITH the canonical message_sending gate, unless the channel runs
+  // message_sending itself at delivery time.
+  const messageSendingBeforeDeliver = runsMessageSendingAtDelivery(params.dispatcherOptions)
     ? undefined
     : buildMessageSendingBeforeDeliver(params.ctx);
   const globalBeforeDeliver = combineBeforeDeliverHooks(

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -572,12 +572,23 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
     finalized,
     replyPayloadRunState,
   );
+  // A channel-supplied beforeDeliver must compose WITH the canonical message_sending
+  // gate, not replace it (issue #92374). Channels that run message_sending themselves
+  // at delivery time opt out via runsMessageSendingAtDelivery so the hook stays
+  // exactly-once and per-message rather than per-streamed-block.
+  const messageSendingBeforeDeliver = params.dispatcherOptions.runsMessageSendingAtDelivery
+    ? undefined
+    : buildMessageSendingBeforeDeliver(finalized);
   const globalBeforeDeliver = combineBeforeDeliverHooks(
     replyPayloadBeforeDeliver,
-    buildMessageSendingBeforeDeliver(finalized),
+    messageSendingBeforeDeliver,
   );
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        messageSendingBeforeDeliver,
+      )
     : globalBeforeDeliver;
   const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
     foregroundReplyFence || configuredBeforeDeliver
@@ -671,12 +682,22 @@ export async function dispatchInboundMessageWithDispatcher(params: {
     params.ctx,
     replyPayloadRunState,
   );
+  // See dispatchInboundMessageWithBufferedDispatcher: compose the channel-supplied
+  // beforeDeliver WITH the canonical message_sending gate (issue #92374), unless the
+  // channel runs message_sending itself at delivery time.
+  const messageSendingBeforeDeliver = params.dispatcherOptions.runsMessageSendingAtDelivery
+    ? undefined
+    : buildMessageSendingBeforeDeliver(params.ctx);
   const globalBeforeDeliver = combineBeforeDeliverHooks(
     replyPayloadBeforeDeliver,
-    buildMessageSendingBeforeDeliver(params.ctx),
+    messageSendingBeforeDeliver,
   );
   const composedBeforeDeliver = params.dispatcherOptions.beforeDeliver
-    ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
+    ? combineBeforeDeliverHooks(
+        params.dispatcherOptions.beforeDeliver,
+        replyPayloadBeforeDeliver,
+        messageSendingBeforeDeliver,
+      )
     : globalBeforeDeliver;
   const dispatcher = createReplyDispatcher({
     ...params.dispatcherOptions,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -111,14 +111,6 @@ export type ReplyDispatcherOptions = {
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
   beforeDeliver?: ReplyDispatchBeforeDeliver;
-  /**
-   * Set by channels that run the `message_sending` plugin hook themselves at
-   * delivery time (e.g. Telegram's `deliverReplies` + streaming finalizer). When
-   * true the dispatcher must NOT also compose `message_sending` into
-   * `beforeDeliver`, otherwise the hook would run twice (double rewrite/cancel)
-   * and at per-block instead of per-message granularity. See issue #92374.
-   */
-  runsMessageSendingAtDelivery?: boolean;
   onBeforeDeliverCancelled?: ReplyDispatchCancelHandler;
   /** Observe each queued payload settling, including cancellation and delivery failure. */
   onDeliverySettled?: (info: ReplyDispatchRuntimeInfo) => void;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -111,6 +111,14 @@ export type ReplyDispatcherOptions = {
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
   beforeDeliver?: ReplyDispatchBeforeDeliver;
+  /**
+   * Set by channels that run the `message_sending` plugin hook themselves at
+   * delivery time (e.g. Telegram's `deliverReplies` + streaming finalizer). When
+   * true the dispatcher must NOT also compose `message_sending` into
+   * `beforeDeliver`, otherwise the hook would run twice (double rewrite/cancel)
+   * and at per-block instead of per-message granularity. See issue #92374.
+   */
+  runsMessageSendingAtDelivery?: boolean;
   onBeforeDeliverCancelled?: ReplyDispatchCancelHandler;
   /** Observe each queued payload settling, including cancellation and delivery failure. */
   onDeliverySettled?: (info: ReplyDispatchRuntimeInfo) => void;


### PR DESCRIPTION
## Summary

Fixes #92374. The `message_sending` plugin hook was silently **bypassed** whenever a channel supplied its own `dispatcherOptions.beforeDeliver`.

The dispatcher composed the canonical `buildMessageSendingBeforeDeliver` gate only into the **global** `beforeDeliver` path. The **configured** path (used when a channel passes `beforeDeliver`) replaced it entirely:

```ts
// before
const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
  ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver) // <- message_sending dropped
  : globalBeforeDeliver;
```

Consequences on `main`:
- **Discord** (real transform `beforeDeliver`) delivered agent replies without ever running `message_sending`.
- **Telegram** (no-op `beforeDeliver`) likewise never ran it through the seam, and its **streamed "preview-finalized" replies** were never gated at all — they commit by editing the live draft and never traverse `deliverReplies` (where Telegram runs the hook for normal sends).

So plugin authors could not scan / rewrite / cancel agent replies on these channels.

## Why not the obvious one-liner?

Several existing PRs simply add `buildMessageSendingBeforeDeliver` to the configured branch. That cleanly fixes Discord but **double-runs** the hook on Telegram (which already runs `message_sending` in `deliverReplies`), and it still **doesn't gate the streaming path**. Routing Telegram through the dispatcher seam instead would run `message_sending` **per streamed block** rather than per message — a granularity + exactly-once regression, since `beforeDeliver` runs per-kind (tool/block/final).

## The fix (3 parts) — preserves exactly-once + per-message semantics

**Part 1 — dispatcher seam** (`src/auto-reply/dispatch.ts`, `reply-dispatcher.ts`)
Compose `message_sending` into **both** the global and the channel-configured `beforeDeliver` branches. Add a `runsMessageSendingAtDelivery` opt-out flag for channels that own the hook at delivery time, so it never double-runs.

**Part 2 — Telegram opt-out** (`bot-message-dispatch.ts`, `bot-native-commands.ts`)
Telegram sets `runsMessageSendingAtDelivery: true` on both dispatch paths, since it runs `message_sending` itself via `deliverReplies` + the streaming finalizer.

**Part 3 — Telegram streaming finalizer** (`bot-message-dispatch.ts`)
Run `message_sending` in `emitPreviewFinalizedHook` — the single chokepoint every preview-finalized answer funnels through:
- **scan / pass-through** -> hook runs, message untouched
- **cancel** -> delete the already-streamed message
- **rewrite** -> edit the message in place (buttons preserved by omission)

Downstream `message_sent` emit / prompt-context record / transcript mirror use the gated content.

### Net result: `message_sending` runs **exactly once per outbound agent message** on every channel

| Path | Where message_sending runs |
|------|----------------------------|
| Discord / generic configured `beforeDeliver` | dispatcher seam (Part 1) |
| Telegram non-streamed sends | `deliverReplies` (existing) |
| Telegram streamed / preview-finalized | `emitPreviewFinalizedHook` (Part 3) |
| Telegram durable (media/fallback) | durable batch (existing) |

## Known, documented limitations
- Streamed content is shown incrementally before the post-commit gate runs, so a cancel/rewrite visibly *flashes* the original text before it is removed/edited. This is inherent to live streaming.
- A cancel deletes the message after `markDelivered()` has already run; acceptable for streamed replies.

## Tests
- `src/auto-reply/dispatch.test.ts`: `message_sending` now composes with a channel-configured `beforeDeliver`; `runsMessageSendingAtDelivery` opt-out; cancel/veto short-circuit.
- `extensions/telegram/src/bot-message-dispatch.test.ts`: streamed preview-finalized runs the hook with correct context (`to`/`accountId`/`conversationId`/`threadId`); cancel deletes the message; rewrite edits it in place and propagates to downstream context; no-op when no `message_sending` hook is registered.

### Verification
- `tsgo` core + extensions + core-test + extensions-test: clean
- `dispatch.test.ts`: 21 passed
- `bot-message-dispatch.test.ts`: 124 passed (incl. 4 new), `lane-delivery.test.ts` + related: green together

(Pre-existing, unrelated flakes in `bot-message-context.body.test.ts` and `bot.test.ts` reproduce on `main` without these changes.)
