### PR TITLE
feat: add session stream mode command

### DIFF
--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -184,6 +184,15 @@ top-level boolean/string spellings are rewritten by `openclaw doctor --fix`).
 | `block`    | Preview updates in chunked/appended steps                             |
 | `progress` | Progress/status preview during generation, final answer at completion |
 
+Authorized senders can use `/stream status|off|partial|block|progress|default`
+on Telegram, Discord, and Slack to set a preview mode for the current session.
+The session override wins over channel config until `/stream default` removes
+it. `off` disables preview updates for the session; normal final delivery and
+channel block-delivery fallbacks are unchanged. `/streaming` is an alias, and
+text commands also accept `final` as a compatibility alias for `off`. Other
+channels report that the text command is unsupported and do not save an
+override; native command menus hide it unless the channel opts in.
+
 `streaming.mode: "block"` is a preview-streaming mode for edit-capable
 channels such as Discord and Telegram; it does not by itself enable channel
 block delivery there. Use `streaming.block.enabled` for normal block replies.

--- a/docs/plugins/sdk-channel-plugins/message-adapter.md
+++ b/docs/plugins/sdk-channel-plugins/message-adapter.md
@@ -136,6 +136,19 @@ operation accepts visible final text and enforces its transport's caption and
 overflow rules. Core then holds final-mode streamed text for that operation and
 falls back to text when the voice payload is proven unsent.
 
+### Session preview-streaming overrides
+
+A channel that honors the persisted `/stream` session preference opts in with
+`plugin.streaming.sessionModeDefault`. Set it to the channel-owned mode used
+when `channels.<id>.streaming.mode` is unset, and implement the typed
+`resolveSessionMode({ account, sessionMode })` adapter beside it. Core passes
+the plugin's opaque resolved account back to that adapter, so it never assumes
+an account config shape. The channel's delivery path must read
+`SessionEntry.streamingMode` and apply it ahead of account configuration. Omit
+the fields when the channel cannot honor all four canonical modes (`off`,
+`partial`, `block`, and `progress`). Contract tests should prove the declared
+default, a configured account override, and a session override.
+
 The legacy `dispatchInboundReplyWithBase` helper remains available from the
 deprecated `openclaw/plugin-sdk/inbound-reply-dispatch` compatibility shim.
 Do not use it for new channel code; start with the `message` adapter, receipts,

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -237,6 +237,7 @@ plugins, and installed skills.
     | `/verbose on\|off\|full` | Toggle verbose output. Alias: `/v` |
     | `/trace on\|off` | Toggle plugin trace output for the current session |
     | `/fast [status\|auto\|on\|off\|default]` | Show, set, or clear fast mode |
+    | `/stream [status\|off\|partial\|block\|progress\|default]` | Show, set, or clear the current session's preview streaming mode on Telegram, Discord, and Slack. Alias: `/streaming` |
     | `/reasoning [on\|off\|stream]` | Toggle reasoning visibility. Alias: `/reason` |
     | `/elevated [on\|off\|ask\|full]` | Toggle elevated mode. Alias: `/elev` |
     | `/exec host=<auto\|sandbox\|gateway\|node> security=<deny\|allowlist\|full> ask=<off\|on-miss\|always> node=<id>` | Show resolved exec defaults; persist host/node placement, apply security/ask to this message only. See [Session permission modes](/gateway/permission-modes) |

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -29,6 +29,7 @@ type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 export function createDiscordDraftPreviewController(params: {
   cfg: OpenClawConfig;
   discordConfig: DiscordConfig;
+  sessionStreamingMode?: unknown;
   accountId: string;
   sourceRepliesAreToolOnly: boolean;
   textLimit: number;
@@ -40,7 +41,10 @@ export function createDiscordDraftPreviewController(params: {
   chunkMode: Parameters<typeof chunkDiscordTextWithMode>[1]["chunkMode"];
   log: (message: string) => void;
 }) {
-  const discordStreamMode = resolveDiscordPreviewStreamMode(params.discordConfig);
+  const discordStreamMode = resolveDiscordPreviewStreamMode({
+    ...params.discordConfig,
+    sessionStreamingMode: params.sessionStreamingMode,
+  });
   // Provider drafts are visible before outbound modifiers run. Keep them off whenever a hook
   // can rewrite or cancel so the original payload cannot flash before durable delivery.
   const hookRunner = getGlobalHookRunner();
@@ -58,6 +62,7 @@ export function createDiscordDraftPreviewController(params: {
   const accountBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.discordConfig, {
     previewAvailable,
     blockStreamingDefault: params.cfg.agents?.defaults?.blockStreamingDefault,
+    sessionStreamingMode: params.sessionStreamingMode,
   });
   const canStreamDraft = previewAvailable && !accountBlockStreamingEnabled;
   const draftStream = canStreamDraft
@@ -346,7 +351,7 @@ export function createDiscordDraftPreviewController(params: {
       // Queued/followup turns need a fresh progress draft after the primary final.
       return beginNewProgressTurn();
     },
-    resetReasoningProgress: progressDraft.resetReasoningProgress,
+    resetReasoningProgress: () => progressDraft.resetReasoningProgress(),
     handleQueuedFollowupAdmitted() {
       return beginNewProgressTurn({ force: true });
     },

--- a/extensions/discord/src/monitor/message-handler.process-reply-runtime.ts
+++ b/extensions/discord/src/monitor/message-handler.process-reply-runtime.ts
@@ -190,9 +190,24 @@ export function createDiscordMessageReplyRuntime(params: {
   const deliverChannelId = deliverTarget.startsWith("channel:")
     ? deliverTarget.slice("channel:".length)
     : messageChannelId;
+  let sessionStreamingMode: unknown;
+  if (ctxPayload.SessionKey) {
+    try {
+      const storePath = resolveStorePath(cfg.session?.store, { agentId: route.agentId });
+      sessionStreamingMode = getSessionEntry({
+        agentId: route.agentId,
+        readConsistency: "latest",
+        sessionKey: ctxPayload.SessionKey,
+        storePath,
+      })?.streamingMode;
+    } catch (err) {
+      logVerbose(`discord stream mode session lookup failed: ${String(err)}`);
+    }
+  }
   const draftPreview = createDiscordDraftPreviewController({
     cfg,
     discordConfig,
+    sessionStreamingMode,
     accountId,
     sourceRepliesAreToolOnly: params.sourceRepliesAreToolOnly,
     textLimit,

--- a/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
@@ -39,7 +39,7 @@ function registerHooks(...hooks: string[]) {
   });
 }
 
-async function runHookSafetyFinalReply(mode: (typeof PREVIEW_MODES)[number]) {
+async function runHookSafetyFinalReply(mode: "off" | (typeof PREVIEW_MODES)[number]) {
   dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
     await params?.dispatcher.sendFinalReply({ text: "final answer" });
     await params?.dispatcher.waitForIdle();
@@ -95,6 +95,23 @@ describe("processDiscordMessage provider preview hook safety", () => {
     await runProcessDiscordMessage(ctx);
 
     expect(createDiscordDraftStream).not.toHaveBeenCalled();
+  });
+
+  it("uses a session preview override ahead of Discord account config", async () => {
+    getSessionEntry.mockReturnValue({ streamingMode: "partial" });
+
+    await runHookSafetyFinalReply("off");
+
+    expect(createDiscordDraftStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a session turn Discord previews off without changing final delivery", async () => {
+    getSessionEntry.mockReturnValue({ streamingMode: "off" });
+
+    await runHookSafetyFinalReply("partial");
+
+    expect(createDiscordDraftStream).not.toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
   });
 
   it("uses an explicit partial preview despite inherited block delivery", async () => {

--- a/extensions/discord/src/preview-streaming.test.ts
+++ b/extensions/discord/src/preview-streaming.test.ts
@@ -1,0 +1,19 @@
+// Discord tests cover preview streaming mode resolution.
+import { describe, expect, it } from "vitest";
+import { resolveDiscordPreviewStreamMode } from "./preview-streaming.js";
+
+describe("resolveDiscordPreviewStreamMode", () => {
+  it("prefers a session streaming override before account config", () => {
+    expect(
+      resolveDiscordPreviewStreamMode({
+        streaming: { mode: "partial" },
+        sessionStreamingMode: "block",
+      }),
+    ).toBe("block");
+  });
+
+  it("keeps Discord streaming off when no config or session override is set", () => {
+    expect(resolveDiscordPreviewStreamMode()).toBe("off");
+    expect(resolveDiscordPreviewStreamMode({ sessionStreamingMode: "bogus" })).toBe("off");
+  });
+});

--- a/extensions/discord/src/preview-streaming.ts
+++ b/extensions/discord/src/preview-streaming.ts
@@ -7,7 +7,10 @@ import {
 export function resolveDiscordPreviewStreamMode(
   params: {
     streaming?: unknown;
+    sessionStreamingMode?: unknown;
   } = {},
 ): StreamingMode {
-  return resolveChannelPreviewStreamMode(params, "off");
+  return resolveChannelPreviewStreamMode(params, "off", {
+    sessionMode: params.sessionStreamingMode,
+  });
 }

--- a/extensions/discord/src/shared.test.ts
+++ b/extensions/discord/src/shared.test.ts
@@ -39,6 +39,29 @@ describe("createDiscordPluginBase", () => {
     expect(plugin.security?.collectAuditFindings).toBeTypeOf("function");
   });
 
+  it("declares the inherited preview-streaming mode so /stream is supported", () => {
+    const plugin = createDiscordPluginBase({ setupContract: {} as never });
+    const account = plugin.config.resolveAccount(
+      { channels: { discord: { streaming: { mode: "partial" } } } } as OpenClawConfig,
+      "default",
+    );
+    const defaultAccount = plugin.config.resolveAccount({} as OpenClawConfig, "default");
+
+    expect(plugin.streaming?.sessionModeDefault).toBe("off");
+    expect(plugin.streaming?.resolveSessionMode?.({ account: defaultAccount })).toEqual({
+      mode: "off",
+      source: "channel default",
+    });
+    expect(plugin.streaming?.resolveSessionMode?.({ account })).toEqual({
+      mode: "partial",
+      source: "channel config",
+    });
+    expect(plugin.streaming?.resolveSessionMode?.({ account, sessionMode: "block" })).toEqual({
+      mode: "block",
+      source: "session",
+    });
+  });
+
   it("hydrates announce delivery targets from stored session routing", () => {
     const plugin = createDiscordPluginBase({ setupContract: {} as never });
 

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -149,6 +149,16 @@ export function createDiscordPluginBase(params: {
     doctor: discordDoctor,
     streaming: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+      sessionModeDefault: "off",
+      resolveSessionMode: ({ account, sessionMode }) => {
+        if (sessionMode) {
+          return { mode: sessionMode, source: "session" };
+        }
+        const mode = account.config.streaming?.mode;
+        return mode
+          ? { mode, source: "channel config" }
+          : { mode: "off", source: "channel default" };
+      },
     },
     reload: {
       configPrefixes: ["channels.discord"],

--- a/extensions/slack/src/channel.setup.ts
+++ b/extensions/slack/src/channel.setup.ts
@@ -5,6 +5,7 @@ import { slackBaseConfigAdapter } from "./config-adapter.js";
 import { SlackChannelConfigSchema } from "./config-schema.js";
 import { slackSetupContract, createSlackSetupWizardProxy } from "./setup-core.js";
 import { describeSlackSetupAccount, SLACK_CHANNEL } from "./setup-shared.js";
+import { resolveSlackStreamingMode } from "./streaming-compat.js";
 
 const slackSetupWizard = createSlackSetupWizardProxy(async () => ({
   slackSetupWizard: (await import("./setup-surface.js")).slackSetupWizard,
@@ -40,6 +41,19 @@ export const slackSetupPlugin: ChannelPlugin<ResolvedSlackAccount> = {
   },
   streaming: {
     blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
+    sessionModeDefault: "progress",
+    resolveSessionMode: ({ account, sessionMode }) => {
+      const streaming = account.config.streaming;
+      const mode = resolveSlackStreamingMode({ streaming, sessionStreamingMode: sessionMode });
+      if (sessionMode) {
+        return { mode, source: "session" };
+      }
+      return streaming?.mode !== undefined ||
+        typeof streaming === "boolean" ||
+        typeof streaming === "string"
+        ? { mode, source: "channel config" }
+        : { mode: "progress", source: "channel default" };
+    },
   },
   reload: {
     configPrefixes: ["channels.slack"],

--- a/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-setup.ts
@@ -14,6 +14,7 @@ import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { formatSlackError } from "../../errors.js";
@@ -252,7 +253,24 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     },
   });
 
-  const slackStreaming = resolveSlackStreamingConfig({ streaming: account.config.streaming });
+  let sessionStreamingMode: unknown;
+  const streamSessionKey = prepared.ctxPayload.SessionKey ?? route.sessionKey;
+  if (streamSessionKey) {
+    try {
+      sessionStreamingMode = getSessionEntry({
+        agentId: route.agentId,
+        readConsistency: "latest",
+        storePath: prepared.turn.storePath,
+        sessionKey: streamSessionKey,
+      })?.streamingMode;
+    } catch (err) {
+      logVerbose(`slack stream mode session lookup failed: ${String(err)}`);
+    }
+  }
+  const slackStreaming = resolveSlackStreamingConfig({
+    streaming: account.config.streaming,
+    sessionStreamingMode,
+  });
   const streamThreadHint =
     forcedReplyThreadTs ??
     resolveSlackStreamingThreadHint({
@@ -286,7 +304,11 @@ export async function createSlackDispatchSetup(prepared: PreparedSlackMessage) {
     threadTs: streamThreadHint,
   });
   const shouldUseDraftStream = previewStreamingEnabled && !useStreaming;
-  const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(account.config);
+  const blockStreamingEnabled = resolveChannelStreamingBlockEnabled(account.config, {
+    previewAvailable: useStreaming || shouldUseDraftStream,
+    blockStreamingDefault: cfg.agents?.defaults?.blockStreamingDefault,
+    sessionStreamingMode,
+  });
   const disableBlockStreaming = sourceRepliesAreToolOnly
     ? true
     : resolveSlackDisableBlockStreaming({

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -20,6 +20,7 @@ const STREAM_MESSAGE_TS = "171234.567";
 const SAME_TEXT = "same reply";
 
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
+const getSessionEntryMock = vi.hoisted(() => vi.fn());
 const createSlackDraftStreamMock = vi.fn();
 const deliverRepliesMock = vi.fn(
   async (_params: { replies: ReplyPayload[] }) =>
@@ -56,6 +57,8 @@ class TestSlackStreamNotDeliveredError extends Error {
 }
 let mockedNativeStreaming = false;
 let mockedBlockStreamingEnabled: boolean | undefined = false;
+let resolveBlockStreamingFromPreviewAvailability = false;
+let capturedPreviewAvailable: boolean | undefined;
 let mockedSlackStreamingMode: "off" | "partial" | "block" | "progress" = "partial";
 let mockedSlackDraftMode: "replace" | "status_final" | "append" = "append";
 let mockedPinnedMainDmOwner: string | undefined;
@@ -788,7 +791,16 @@ vi.mock("openclaw/plugin-sdk/channel-outbound", async (importOriginal) => {
       const previousText = typeof previous === "string" ? previous.trim() : previous?.text.trim();
       return previousText === normalized ? lines : [...lines, line].slice(-params.maxLines);
     },
-    resolveChannelStreamingBlockEnabled: () => mockedBlockStreamingEnabled,
+    resolveChannelStreamingBlockEnabled: (
+      _entry: unknown,
+      previewPolicy?: { previewAvailable?: boolean },
+    ) => {
+      capturedPreviewAvailable = previewPolicy?.previewAvailable;
+      if (resolveBlockStreamingFromPreviewAvailability) {
+        return previewPolicy?.previewAvailable !== true;
+      }
+      return mockedBlockStreamingEnabled;
+    },
     resolveChannelStreamingNativeTransport: () => mockedNativeStreaming,
     resolveChannelStreamingSuppressDefaultToolProgressMessages: (
       entry?: {
@@ -901,6 +913,10 @@ vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
   resolvePinnedMainDmOwnerFromAllowlist: () => mockedPinnedMainDmOwner,
 }));
 
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => ({
+  getSessionEntry: getSessionEntryMock,
+}));
+
 vi.mock("openclaw/plugin-sdk/string-coerce-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/string-coerce-runtime")>();
   const normalizeMockLowercaseString = (value?: string) => value?.toLowerCase();
@@ -938,14 +954,12 @@ vi.mock("../../sent-thread-cache.js", () => ({
   recordSlackThreadParticipation: recordSlackThreadParticipationMock,
 }));
 
-vi.mock("../../stream-mode.js", () => ({
-  applyAppendOnlyStreamUpdate: ({ incoming }: { incoming: string }) => ({
-    changed: true,
-    rendered: incoming,
-    source: incoming,
-  }),
-  resolveSlackStreamingConfig: () => ({
-    mode: mockedSlackStreamingMode,
+vi.mock("../../stream-mode.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../stream-mode.js")>()),
+  resolveSlackStreamingConfig: (params?: {
+    sessionStreamingMode?: typeof mockedSlackStreamingMode;
+  }) => ({
+    mode: params?.sessionStreamingMode ?? mockedSlackStreamingMode,
     nativeStreaming: mockedNativeStreaming,
     draftMode: mockedSlackDraftMode,
   }),
@@ -1180,11 +1194,14 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     removeSlackReactionMock.mockReset();
     logVerboseMock.mockReset();
     getGlobalHookRunnerMock.mockReset().mockReturnValue(undefined);
+    getSessionEntryMock.mockReset().mockReturnValue(undefined);
     for (const value of Object.values(statusReactionControllerMock)) {
       value.mockClear();
     }
     mockedNativeStreaming = false;
     mockedBlockStreamingEnabled = false;
+    resolveBlockStreamingFromPreviewAvailability = false;
+    capturedPreviewAvailable = undefined;
     mockedSlackStreamingMode = "partial";
     mockedSlackDraftMode = "append";
     mockedPinnedMainDmOwner = undefined;
@@ -1411,6 +1428,31 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(startSlackStreamMock).toHaveBeenCalledTimes(1);
     expect(stopSlackStreamMock).toHaveBeenCalledTimes(1);
     expect(deliverRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps inherited blocks when no Slack preview transport can target the turn", async () => {
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((hookName: string) => hookName === "reply_payload_sending"),
+    });
+    mockedNativeStreaming = true;
+    mockedSlackStreamingMode = "partial";
+    mockedSlackIsThreadReply = false;
+    mockedReplyThreadTs = undefined;
+    resolveBlockStreamingFromPreviewAvailability = true;
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        message: { ts: undefined, event_ts: undefined, thread_ts: undefined },
+        ctxPayload: { MessageThreadId: undefined },
+        replyToMode: "off",
+      }),
+    );
+
+    expect(capturedPreviewAvailable).toBe(false);
+    expect(capturedReplyOptions?.disableBlockStreaming).toBe(false);
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(startSlackStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to normal delivery when preview finalize fails", async () => {
@@ -2100,6 +2142,25 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
       ]);
     },
   );
+
+  it("uses a session preview override ahead of Slack account config", async () => {
+    mockedSlackStreamingMode = "off";
+    getSessionEntryMock.mockReturnValue({ streamingMode: "partial" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(createSlackDraftStreamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a session turn Slack previews off without suppressing final delivery", async () => {
+    mockedSlackStreamingMode = "partial";
+    getSessionEntryMock.mockReturnValue({ streamingMode: "off" });
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(createSlackDraftStreamMock).not.toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+  });
 
   it("does not restart Slack session status once the turn has visible output", async () => {
     const setSlackSessionStatus = vi.fn(async () => undefined);

--- a/extensions/slack/src/shared.test.ts
+++ b/extensions/slack/src/shared.test.ts
@@ -42,6 +42,52 @@ describe("createSlackPluginBase", () => {
     expect(plugin.security?.collectWarnings).toBeTypeOf("function");
     expect(plugin.security?.collectAuditFindings).toBeTypeOf("function");
   });
+
+  it("declares the inherited preview-streaming mode so /stream is supported", () => {
+    const plugin = createSlackPluginBase({
+      setupContract: {} as never,
+      setupWizard: {} as never,
+    });
+    const account = plugin.config.resolveAccount(
+      { channels: { slack: { streaming: { mode: "partial" } } } } as OpenClawConfig,
+      "default",
+    );
+    const defaultAccount = plugin.config.resolveAccount({} as OpenClawConfig, "default");
+
+    expect(plugin.streaming?.sessionModeDefault).toBe("progress");
+    expect(plugin.streaming?.resolveSessionMode?.({ account: defaultAccount })).toEqual({
+      mode: "progress",
+      source: "channel default",
+    });
+    expect(plugin.streaming?.resolveSessionMode?.({ account })).toEqual({
+      mode: "partial",
+      source: "channel config",
+    });
+    expect(plugin.streaming?.resolveSessionMode?.({ account, sessionMode: "block" })).toEqual({
+      mode: "block",
+      source: "session",
+    });
+  });
+
+  it.each([
+    [false, "off"],
+    [true, "partial"],
+    ["block", "block"],
+  ] as const)("inherits legacy streaming value %s for /stream", (streaming, mode) => {
+    const plugin = createSlackPluginBase({
+      setupContract: {} as never,
+      setupWizard: {} as never,
+    });
+    const account = plugin.config.resolveAccount(
+      { channels: { slack: { streaming } } } as unknown as OpenClawConfig,
+      "default",
+    );
+
+    expect(plugin.streaming?.resolveSessionMode?.({ account })).toEqual({
+      mode,
+      source: "channel config",
+    });
+  });
 });
 
 describe("setSlackChannelAllowlist", () => {

--- a/extensions/slack/src/stream-mode.test.ts
+++ b/extensions/slack/src/stream-mode.test.ts
@@ -49,6 +49,18 @@ describe("resolveSlackStreamingConfig", () => {
       nativeStreaming: true,
     });
   });
+
+  it("prefers a session streaming override before account config", () => {
+    expect(
+      resolveSlackStreamingConfig({
+        streaming: { mode: "partial" },
+        sessionStreamingMode: "progress",
+      }),
+    ).toEqual({
+      mode: "progress",
+      nativeStreaming: true,
+    });
+  });
 });
 
 describe("applyAppendOnlyStreamUpdate", () => {

--- a/extensions/slack/src/stream-mode.ts
+++ b/extensions/slack/src/stream-mode.ts
@@ -11,6 +11,7 @@ export function resolveSlackStreamingConfig(params: {
   streaming?: unknown;
   streamMode?: unknown;
   nativeStreaming?: unknown;
+  sessionStreamingMode?: unknown;
 }): {
   mode: SlackStreamingMode;
   nativeStreaming: boolean;

--- a/extensions/slack/src/streaming-compat.ts
+++ b/extensions/slack/src/streaming-compat.ts
@@ -58,8 +58,13 @@ export function resolveSlackStreamingMode(
   params: {
     streamMode?: unknown;
     streaming?: unknown;
+    sessionStreamingMode?: unknown;
   } = {},
 ): StreamingMode {
+  const sessionMode = parseStreamingMode(params.sessionStreamingMode);
+  if (sessionMode) {
+    return sessionMode;
+  }
   const parsedStreaming = parseStreamingMode(
     getChannelStreamingConfigObject(params)?.mode ?? params.streaming,
   );

--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -66,6 +66,7 @@ export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
   const accountBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.telegramCfg, {
     previewAvailable,
     blockStreamingDefault: params.cfg.agents?.defaults?.blockStreamingDefault,
+    sessionStreamingMode: params.sessionStreamingMode,
   });
   const canStreamAnswerDraft = previewAvailable && !accountBlockStreamingEnabled;
   const streamReasoningDraft = params.resolvedReasoningLevel === "stream";
@@ -171,7 +172,7 @@ export function createDraftState(params: TurnConfig): TelegramDraftStateSlice {
     reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
   };
   const resolvedBlockStreamingEnabled = resolveChannelStreamingBlockEnabled(params.telegramCfg);
-  const disableBlockStreaming = !streamDeliveryEnabled
+  const disableBlockStreaming = isRoomEvent
     ? true
     : forceBlockStreamingForReasoning
       ? false

--- a/extensions/telegram/src/bot-message-dispatch.preview-hook-safety.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.preview-hook-safety.test.ts
@@ -1,12 +1,16 @@
 import { expect, it, vi } from "vitest";
 import {
   createContext,
+  createDirectSessionPayload,
   createReasoningStreamContext,
   createTelegramDraftStream,
+  deliverReplies,
   describeTelegramDispatch,
+  dispatchReplyWithBufferedBlockDispatcher,
   dispatchWithContext,
   expectDispatchParams,
   getGlobalHookRunner,
+  loadSessionStore,
 } from "./bot-message-dispatch.test-harness.js";
 
 function registerHooks(...hooks: string[]) {
@@ -63,6 +67,59 @@ describeTelegramDispatch("Telegram provider preview hook safety", () => {
     expectDispatchParams({
       replyOptions: expect.objectContaining({ disableBlockStreaming: true }),
     });
+  });
+
+  it("inherits the global block default when Telegram only supplies its preview default", async () => {
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      cfg: { agents: { defaults: { blockStreamingDefault: "on" } } },
+    });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expectDispatchParams({
+      replyOptions: expect.objectContaining({
+        onPartialReply: undefined,
+        disableBlockStreaming: undefined,
+      }),
+    });
+  });
+
+  it("uses a session preview override ahead of Telegram account config", async () => {
+    const ctxPayload = createDirectSessionPayload();
+    loadSessionStore.mockReturnValue({ [ctxPayload.SessionKey]: { streamingMode: "partial" } });
+
+    await dispatchWithContext({
+      context: createContext({ ctxPayload }),
+      streamMode: "off",
+      cfg: { agents: { defaults: { blockStreamingDefault: "on" } } },
+      telegramCfg: { streaming: { mode: "off" } },
+    });
+
+    expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a session turn Telegram previews off without suppressing the turn", async () => {
+    const ctxPayload = createDirectSessionPayload();
+    loadSessionStore.mockReturnValue({ [ctxPayload.SessionKey]: { streamingMode: "off" } });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({ ctxPayload }),
+      streamMode: "partial",
+    });
+
+    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    expectDispatchParams({
+      replyOptions: expect.objectContaining({
+        onPartialReply: undefined,
+        disableBlockStreaming: undefined,
+      }),
+    });
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
   });
 
   it("preserves answer previews for observer-only hooks", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -46,6 +46,7 @@ import {
   buildTelegramNativeQuoteCandidate,
   type TelegramNativeQuoteCandidateByMessageId,
 } from "./bot/native-quote.js";
+import { resolveTelegramPreviewStreamMode } from "./preview-streaming.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
@@ -285,6 +286,7 @@ export const dispatchTelegramMessage = async (
     cfg,
     runtime,
     replyToMode,
+    streamMode,
     telegramCfg,
     telegramDeps: injectedTelegramDeps,
     retryDispatchErrors = false,
@@ -296,6 +298,20 @@ export const dispatchTelegramMessage = async (
   const telegramDeps =
     injectedTelegramDeps ?? (await import("./bot-deps.js")).defaultTelegramBotDeps;
   const loadFreshSessionEntry = createFreshTelegramSessionEntryLoader({ cfg, telegramDeps });
+  let sessionStreamingMode: unknown;
+  const streamSessionKey = dispatchContext.ctxPayload.SessionKey;
+  if (streamSessionKey) {
+    try {
+      sessionStreamingMode = loadFreshSessionEntry(dispatchContext.route.agentId, streamSessionKey)
+        .entry?.streamingMode;
+    } catch (err) {
+      logVerbose(`telegram stream mode session lookup failed: ${String(err)}`);
+    }
+  }
+  const effectiveStreamMode = resolveTelegramPreviewStreamMode({
+    streaming: { mode: streamMode },
+    sessionStreamingMode,
+  });
   const isRoomEvent = dispatchContext.ctxPayload.InboundEventKind === "room_event";
   const status = createTelegramDispatchStatus({ context: dispatchContext });
   const tableMode = resolveMarkdownTableMode({
@@ -335,7 +351,9 @@ export const dispatchTelegramMessage = async (
     replyQuotePosition: quote.replyQuotePosition,
     replyQuoteText: quote.replyQuoteText,
     resolvedReasoningLevel,
+    sessionStreamingMode,
     statusReactionController: status.controller,
+    streamMode: effectiveStreamMode,
     tableMode,
     telegramDeps,
   };

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -98,6 +98,7 @@ export type TelegramDispatchTurnConfig = Omit<
   replyQuotePosition?: number;
   replyQuoteText?: string;
   resolvedReasoningLevel: TelegramReasoningLevel;
+  sessionStreamingMode: unknown;
   statusReactionController: TelegramMessageContext["statusReactionController"];
   tableMode: Parameters<
     NonNullable<import("./bot-deps.js").TelegramBotDeps["deliverReplies"]>

--- a/extensions/telegram/src/preview-streaming.test.ts
+++ b/extensions/telegram/src/preview-streaming.test.ts
@@ -1,0 +1,18 @@
+// Telegram tests cover preview streaming mode resolution.
+import { describe, expect, it } from "vitest";
+import { resolveTelegramPreviewStreamMode } from "./preview-streaming.js";
+
+describe("resolveTelegramPreviewStreamMode", () => {
+  it("prefers a session streaming override before account config", () => {
+    expect(
+      resolveTelegramPreviewStreamMode({
+        streaming: { mode: "partial" },
+        sessionStreamingMode: "progress",
+      }),
+    ).toBe("progress");
+  });
+
+  it("keeps the Telegram default when no config or session override is set", () => {
+    expect(resolveTelegramPreviewStreamMode()).toBe("progress");
+  });
+});

--- a/extensions/telegram/src/preview-streaming.ts
+++ b/extensions/telegram/src/preview-streaming.ts
@@ -7,10 +7,13 @@ import {
 export function resolveTelegramPreviewStreamMode(
   params: {
     streaming?: unknown;
+    sessionStreamingMode?: unknown;
   } = {},
 ): StreamingMode {
   // Telegram defaults to the progress draft: on tool-heavy turns a status draft
   // answers "is it working?", which streamed answer text cannot.
   // Operators who prefer streamed answer text set `streaming.mode: "partial"`.
-  return resolveChannelPreviewStreamMode(params, "progress");
+  return resolveChannelPreviewStreamMode(params, "progress", {
+    sessionMode: params.sessionStreamingMode,
+  });
 }

--- a/extensions/telegram/src/setup-plugin.ts
+++ b/extensions/telegram/src/setup-plugin.ts
@@ -19,6 +19,7 @@ export function createTelegramSetupPluginBase(params: {
   | "reload"
   | "configSchema"
   | "config"
+  | "streaming"
   | "setupContract"
   | "secrets"
 > {
@@ -44,6 +45,18 @@ export function createTelegramSetupPluginBase(params: {
       polls: true,
       nativeCommands: true,
       blockStreaming: true,
+    },
+    streaming: {
+      sessionModeDefault: "progress",
+      resolveSessionMode: ({ account, sessionMode }) => {
+        if (sessionMode) {
+          return { mode: sessionMode, source: "session" };
+        }
+        const mode = account.config.streaming?.mode;
+        return mode
+          ? { mode, source: "channel config" }
+          : { mode: "progress", source: "channel default" };
+      },
     },
     reload: {
       configPrefixes: ["channels.telegram"],

--- a/extensions/telegram/src/shared.test.ts
+++ b/extensions/telegram/src/shared.test.ts
@@ -29,6 +29,31 @@ function resolveAccount(cfg: OpenClawConfig, accountId: string): ResolvedTelegra
   return telegramPluginBase.config.resolveAccount(cfg, accountId);
 }
 
+describe("createTelegramPluginBase streaming", () => {
+  it("declares the inherited preview-streaming mode so /stream is supported", () => {
+    const account = telegramPluginBase.config.resolveAccount(
+      { channels: { telegram: { streaming: { mode: "partial" } } } } as OpenClawConfig,
+      "default",
+    );
+    const defaultAccount = telegramPluginBase.config.resolveAccount(
+      {} as OpenClawConfig,
+      "default",
+    );
+
+    expect(telegramPluginBase.streaming?.sessionModeDefault).toBe("progress");
+    expect(telegramPluginBase.streaming?.resolveSessionMode?.({ account: defaultAccount })).toEqual(
+      { mode: "progress", source: "channel default" },
+    );
+    expect(telegramPluginBase.streaming?.resolveSessionMode?.({ account })).toEqual({
+      mode: "partial",
+      source: "channel config",
+    });
+    expect(
+      telegramPluginBase.streaming?.resolveSessionMode?.({ account, sessionMode: "block" }),
+    ).toEqual({ mode: "block", source: "session" });
+  });
+});
+
 describe("createTelegramPluginBase config duplicate token guard", () => {
   it.each(["buildModelsMenuChannelData", "buildModelsProviderChannelData"] as const)(
     "%s renders providers and preserves the empty fallback",

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -27,6 +27,7 @@ export function createTelegramPluginBase(params: {
   | "reload"
   | "configSchema"
   | "config"
+  | "streaming"
   | "setupContract"
   | "secrets"
 > {

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -123,6 +123,7 @@ function defineBuiltinCommand(
     nativeProviders: options.nativeProviders
       ? normalizeStringEntries(options.nativeProviders)
       : undefined,
+    nativeChannelCapability: options.nativeChannelCapability,
     description,
     ...(options.descriptionLocalizations
       ? { descriptionLocalizations: options.descriptionLocalizations }
@@ -545,6 +546,17 @@ export function buildBuiltinChatCommands(
             "default",
             "status",
           ],
+        }),
+      ],
+      argsMenu: "auto",
+    }),
+    defineBuiltinCommand("stream", "Set chat preview streaming mode.", "options", "standard", {
+      nativeAliases: ["streaming"],
+      nativeChannelCapability: "sessionStreaming",
+      textAliases: ["/stream", "/streaming"],
+      args: [
+        defineCommandArgument("mode", "Preview streaming mode", {
+          choices: ["status", "off", "partial", "block", "progress", "default"],
         }),
       ],
       argsMenu: "auto",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -589,6 +589,61 @@ describe("commands registry", () => {
     expect(model.description).toBe("Show or set the model; use -s, -a, or -g to choose scope.");
   });
 
+  it("registers stream mode as a first-class options command", () => {
+    const stream = requireChatCommand("stream");
+    expect(stream.nativeName).toBe("stream");
+    expect(stream.nativeAliases).toEqual(["streaming"]);
+    expect(stream.nativeChannelCapability).toBe("sessionStreaming");
+    expect(stream.textAliases).toEqual(["/stream", "/streaming"]);
+    expect(stream.category).toBe("options");
+    const modeArg = requireCommandArg(stream, "mode");
+    expect(modeArg.choices).toEqual(["status", "off", "partial", "block", "progress", "default"]);
+  });
+
+  it("publishes stream natively only for channels with session streaming support", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "discord",
+              capabilities: { nativeCommands: true, chatTypes: ["direct"] },
+            }),
+            streaming: {
+              sessionModeDefault: "off",
+              resolveSessionMode: () => ({ mode: "off", source: "channel default" }),
+            },
+          },
+          source: "test",
+        },
+        {
+          pluginId: "clickclack",
+          plugin: createChannelTestPluginBase({
+            id: "clickclack",
+            capabilities: { nativeCommands: true, chatTypes: ["direct"] },
+          }),
+          source: "test",
+        },
+      ]),
+    );
+
+    expect(
+      nativeNameSet(
+        listNativeCommandSpecsForConfig({ commands: { native: true } }, { provider: "discord" }),
+      ).has("stream"),
+    ).toBe(true);
+    expect(
+      nativeNameSet(
+        listNativeCommandSpecsForConfig({ commands: { native: true } }, { provider: "clickclack" }),
+      ).has("stream"),
+    ).toBe(false);
+    expect(findCommandByNativeName("stream", "discord")?.key).toBe("stream");
+    expect(findCommandByNativeName("streaming", "discord")?.key).toBe("stream");
+    expect(findCommandByNativeName("stream", "clickclack")).toBeUndefined();
+    expect(findCommandByNativeName("streaming", "clickclack")).toBeUndefined();
+  });
+
   it("detects known text commands", () => {
     const detection = getCommandDetection();
     expect(detection.exact.has("/commands")).toBe(true);

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -7,7 +7,11 @@ import {
   buildConfiguredModelCatalog,
   resolveConfiguredModelRef,
 } from "../agents/model-selection.js";
-import { getChannelPlugin, getLoadedChannelPlugin } from "../channels/plugins/index.js";
+import {
+  getChannelPlugin,
+  getLoadedChannelPlugin,
+  type ChannelPlugin,
+} from "../channels/plugins/index.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -59,17 +63,21 @@ type NativeCommandProviderLookupOptions = {
   includeBundledChannelFallback?: boolean;
 };
 
-function createNativeCommandNameMapper(
-  provider?: string,
+function resolveNativeChannelPlugin(
+  provider: string | undefined,
   options?: NativeCommandProviderLookupOptions,
+) {
+  if (!provider) {
+    return undefined;
+  }
+  return options?.includeBundledChannelFallback === false
+    ? getLoadedChannelPlugin(provider)
+    : getChannelPlugin(provider);
+}
+
+function createNativeCommandNameMapper(
+  resolveNativeCommandName?: NonNullable<ChannelPlugin["commands"]>["resolveNativeCommandName"],
 ): (command: ChatCommandDefinition) => Array<{ name: string; normalizedName?: string }> {
-  // Registry state is lifecycle-owned, so resolve the adapter once per list or lookup operation.
-  const resolveNativeCommandName = !provider
-    ? undefined
-    : (options?.includeBundledChannelFallback === false
-        ? getLoadedChannelPlugin(provider)
-        : getChannelPlugin(provider)
-      )?.commands?.resolveNativeCommandName;
   return (command) => {
     const primary = command.nativeName
       ? (resolveNativeCommandName?.({
@@ -83,17 +91,30 @@ function createNativeCommandNameMapper(
   };
 }
 
-function supportsNativeProvider(command: ChatCommandDefinition, provider?: string): boolean {
-  if (!command.nativeProviders?.length) {
-    return true;
-  }
+function supportsNativeProvider(
+  command: ChatCommandDefinition,
+  provider?: string,
+  plugin?: ChannelPlugin,
+): boolean {
   const normalizedProvider = normalizeOptionalLowercaseString(provider);
-  if (!normalizedProvider) {
+  if (
+    command.nativeProviders?.length &&
+    (!normalizedProvider ||
+      !command.nativeProviders.some(
+        (candidate) => normalizeOptionalLowercaseString(candidate) === normalizedProvider,
+      ))
+  ) {
     return false;
   }
-  return command.nativeProviders.some(
-    (candidate) => normalizeOptionalLowercaseString(candidate) === normalizedProvider,
-  );
+  if (command.nativeChannelCapability === "sessionStreaming") {
+    // The default opts in; the resolver proves core can query the typed account
+    // contract before a native user can select a session override.
+    return (
+      plugin?.streaming?.sessionModeDefault !== undefined &&
+      plugin.streaming.resolveSessionMode !== undefined
+    );
+  }
+  return true;
 }
 
 function listNativeSpecsFromCommands(
@@ -101,11 +122,17 @@ function listNativeSpecsFromCommands(
   provider?: string,
   options?: NativeCommandProviderLookupOptions,
 ): NativeCommandSpec[] {
-  const mapNativeCommandNames = createNativeCommandNameMapper(provider, options);
+  // Registry state is lifecycle-owned, so resolve the adapter once per list operation.
+  const plugin = resolveNativeChannelPlugin(provider, options);
+  const mapNativeCommandNames = createNativeCommandNameMapper(
+    plugin?.commands?.resolveNativeCommandName,
+  );
   return commands
     .filter(
       (command) =>
-        command.scope !== "text" && command.nativeName && supportsNativeProvider(command, provider),
+        command.scope !== "text" &&
+        command.nativeName &&
+        supportsNativeProvider(command, provider, plugin),
     )
     .flatMap((command) => {
       return mapNativeCommandNames(command).map(({ name }, index) => {
@@ -198,11 +225,15 @@ export function findCommandByNativeName(
   if (!normalized) {
     return undefined;
   }
-  const mapNativeCommandNames = createNativeCommandNameMapper(provider, options);
+  // Registry state is lifecycle-owned, so resolve the adapter once per lookup operation.
+  const plugin = resolveNativeChannelPlugin(provider, options);
+  const mapNativeCommandNames = createNativeCommandNameMapper(
+    plugin?.commands?.resolveNativeCommandName,
+  );
   return getChatCommands().find(
     (command) =>
       command.scope !== "text" &&
-      supportsNativeProvider(command, provider) &&
+      supportsNativeProvider(command, provider, plugin) &&
       mapNativeCommandNames(command).some(({ normalizedName }) => normalizedName === normalized),
   );
 }

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -69,6 +69,8 @@ export type ChatCommandDefinition = {
   nativeName?: string;
   nativeAliases?: string[];
   nativeProviders?: string[];
+  /** Channel-owned feature required before this command is advertised natively. */
+  nativeChannelCapability?: "sessionStreaming";
   description: string;
   /** Localized descriptions for native command surfaces that support them. */
   descriptionLocalizations?: Record<string, string>;

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -27,6 +27,7 @@ import { handleModelsCommand } from "./commands-models.js";
 import { handleNameCommand } from "./commands-name.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
+import { handleStreamCommand } from "./commands-session-stream.js";
 import {
   handleAbortTrigger,
   handleActivationCommand,
@@ -56,6 +57,7 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleActivationCommand,
     handleSendPolicyCommand,
     handleFastCommand,
+    handleStreamCommand,
     handleUsageCommand,
     handleSessionCommand,
     handleRestartCommand,

--- a/src/auto-reply/reply/commands-session-stream.ts
+++ b/src/auto-reply/reply/commands-session-stream.ts
@@ -1,0 +1,152 @@
+// Implements the session-scoped preview streaming command.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import type { StreamingMode } from "../../config/types.base.js";
+import { isSessionDefaultDirectiveValue } from "../thinking.js";
+import { resolveChannelAccountId, resolveCommandSurfaceChannel } from "./channel-context.js";
+import { commandReply, defineAuthorizedTextCommand, matchCommandPrefix } from "./command-gates.js";
+import {
+  persistCommandSession,
+  sessionEntryPersistenceConflictReply,
+} from "./commands-session-store.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+const STREAM_COMMAND_PREFIXES = ["/stream", "/streaming"] as const;
+
+type StreamCommandContract = {
+  plugin: NonNullable<ReturnType<typeof getChannelPlugin>>;
+  resolveSessionMode: NonNullable<
+    NonNullable<NonNullable<ReturnType<typeof getChannelPlugin>>["streaming"]>["resolveSessionMode"]
+  >;
+};
+
+function matchStreamCommand(normalized: string): string | null {
+  for (const prefix of STREAM_COMMAND_PREFIXES) {
+    const args = matchCommandPrefix(normalized, prefix);
+    if (args !== null) {
+      return args;
+    }
+  }
+  return null;
+}
+
+function normalizeStreamCommandMode(raw: string): StreamingMode | undefined {
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  if (normalized === "final") {
+    return "off";
+  }
+  return parseStreamCommandMode(normalized);
+}
+
+function parseStreamCommandMode(value: unknown): StreamingMode | undefined {
+  const normalized = typeof value === "string" ? normalizeLowercaseStringOrEmpty(value) : "";
+  if (
+    normalized === "off" ||
+    normalized === "partial" ||
+    normalized === "block" ||
+    normalized === "progress"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function formatStreamModeLabel(mode: StreamingMode): string {
+  return mode === "off" ? "off (preview disabled)" : mode;
+}
+
+function resolveStreamCommandContract(params: HandleCommandsParams): StreamCommandContract | null {
+  const channelId = normalizeChannelId(
+    params.command.channelId ?? resolveCommandSurfaceChannel(params),
+  );
+  if (!channelId) {
+    return null;
+  }
+  const plugin = getChannelPlugin(channelId);
+  const streaming = plugin?.streaming;
+  if (!plugin || !streaming?.sessionModeDefault || !streaming.resolveSessionMode) {
+    return null;
+  }
+  return { plugin, resolveSessionMode: streaming.resolveSessionMode };
+}
+
+function resolveStreamCommandMode(
+  params: HandleCommandsParams,
+  contract: StreamCommandContract,
+  sessionMode?: unknown,
+) {
+  const account = contract.plugin.config.resolveAccount(
+    params.cfg,
+    params.command.accountId ?? resolveChannelAccountId(params),
+  );
+  return contract.resolveSessionMode({
+    account,
+    sessionMode: parseStreamCommandMode(sessionMode) ?? undefined,
+  });
+}
+
+export const handleStreamCommand = defineAuthorizedTextCommand(
+  {
+    label: "/stream",
+    match: matchStreamCommand,
+    silentUnauthorized: true,
+  },
+  async (params, rawArgs) => {
+    const contract = resolveStreamCommandContract(params);
+    if (!contract) {
+      return commandReply("⚙️ /stream isn't supported on this channel yet.");
+    }
+
+    const rawMode = normalizeLowercaseStringOrEmpty(rawArgs);
+    const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+    if (!rawMode || rawMode === "status") {
+      const resolved = resolveStreamCommandMode(
+        params,
+        contract,
+        targetSessionEntry?.streamingMode,
+      );
+      return commandReply(
+        `⚙️ Current stream mode: ${formatStreamModeLabel(resolved.mode)} (${resolved.source}).`,
+      );
+    }
+
+    const resetsToDefault = isSessionDefaultDirectiveValue(rawMode);
+    const nextMode = resetsToDefault ? undefined : normalizeStreamCommandMode(rawMode);
+    if (nextMode === undefined) {
+      if (resetsToDefault) {
+        if (targetSessionEntry && params.sessionStore && params.sessionKey) {
+          delete targetSessionEntry.streamingMode;
+          if (
+            !(await persistCommandSession({
+              ...params,
+              sessionEntry: targetSessionEntry,
+              touchedFields: ["streamingMode"],
+            }))
+          ) {
+            return sessionEntryPersistenceConflictReply();
+          }
+        }
+        const inherited = resolveStreamCommandMode(params, contract);
+        return commandReply(
+          `⚙️ Stream mode reset to ${formatStreamModeLabel(inherited.mode)} (${inherited.source}).`,
+        );
+      }
+      return commandReply("⚙️ Usage: /stream status|off|partial|block|progress|default");
+    }
+
+    if (targetSessionEntry && params.sessionStore && params.sessionKey) {
+      targetSessionEntry.streamingMode = nextMode;
+      if (
+        !(await persistCommandSession({
+          ...params,
+          sessionEntry: targetSessionEntry,
+          touchedFields: ["streamingMode"],
+        }))
+      ) {
+        return sessionEntryPersistenceConflictReply();
+      }
+    }
+
+    return commandReply(`⚙️ Stream mode set to ${formatStreamModeLabel(nextMode)}.`);
+  },
+);

--- a/src/auto-reply/reply/commands-session.stream.test.ts
+++ b/src/auto-reply/reply/commands-session.stream.test.ts
@@ -1,0 +1,199 @@
+// Tests selection, status, and persistence for the per-session preview streaming command.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/index.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { handleStreamCommand } from "./commands-session-stream.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+import { buildCommandTestParams } from "./commands.test-harness.js";
+
+const persistCommandSessionMock = vi.hoisted(() => vi.fn(async () => true));
+const resolvedAccount = { accountId: "opaque-account" };
+type ResolveSessionMode = NonNullable<
+  NonNullable<ChannelPlugin<typeof resolvedAccount>["streaming"]>["resolveSessionMode"]
+>;
+const resolveSessionModeMock = vi.hoisted(() =>
+  vi.fn<ResolveSessionMode>((params) => {
+    const sessionMode = params.sessionMode;
+    if (
+      sessionMode === "off" ||
+      sessionMode === "partial" ||
+      sessionMode === "block" ||
+      sessionMode === "progress"
+    ) {
+      return { mode: sessionMode, source: "session" as const };
+    }
+    return { mode: "progress" as const, source: "channel default" as const };
+  }),
+);
+const getChannelPluginMock = vi.hoisted(() =>
+  vi.fn<
+    () => {
+      streaming: {
+        sessionModeDefault?: "off" | "partial" | "block" | "progress";
+        resolveSessionMode?: typeof resolveSessionModeMock;
+      };
+      config: { resolveAccount: () => typeof resolvedAccount };
+    }
+  >(() => ({
+    streaming: { sessionModeDefault: "progress", resolveSessionMode: resolveSessionModeMock },
+    config: { resolveAccount: () => resolvedAccount },
+  })),
+);
+const persistenceConflictReply = vi.hoisted(() => ({
+  shouldContinue: false,
+  reply: { text: "retry stream command" },
+}));
+
+vi.mock("./commands-session-store.js", () => ({
+  persistCommandSession: persistCommandSessionMock,
+  sessionEntryPersistenceConflictReply: () => persistenceConflictReply,
+}));
+
+vi.mock("../../channels/plugins/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../../channels/plugins/index.js")>(
+    "../../channels/plugins/index.js",
+  );
+  return { ...actual, getChannelPlugin: getChannelPluginMock };
+});
+
+function buildStreamParams(commandBodyNormalized: string): HandleCommandsParams {
+  const sessionEntry = { sessionId: "session-1", updatedAt: 1, streamingMode: "block" as const };
+  const params = buildCommandTestParams(
+    commandBodyNormalized,
+    { commands: { text: true } } as OpenClawConfig,
+    { Provider: "telegram", Surface: "telegram" },
+  );
+  return {
+    ...params,
+    sessionKey: "telegram:dm:owner",
+    sessionEntry,
+    sessionStore: { "telegram:dm:owner": sessionEntry },
+  };
+}
+
+describe("handleStreamCommand", () => {
+  beforeEach(() => {
+    persistCommandSessionMock.mockReset().mockResolvedValue(true);
+    resolveSessionModeMock.mockClear();
+    getChannelPluginMock.mockReset().mockReturnValue({
+      streaming: { sessionModeDefault: "progress", resolveSessionMode: resolveSessionModeMock },
+      config: { resolveAccount: () => resolvedAccount },
+    });
+  });
+
+  it("persists only the target session store entry's streaming mode field", async () => {
+    const params = buildStreamParams("/stream progress");
+    const wrapperEntry = params.sessionEntry;
+    const targetEntry = { sessionId: "session-target", updatedAt: 2 };
+    params.sessionStore = { [params.sessionKey]: targetEntry };
+
+    await expect(handleStreamCommand(params, true)).resolves.toMatchObject({
+      reply: { text: "⚙️ Stream mode set to progress." },
+    });
+    expect(wrapperEntry?.streamingMode).toBe("block");
+    expect(targetEntry).toMatchObject({ streamingMode: "progress" });
+    expect(persistCommandSessionMock).toHaveBeenCalledWith({
+      ...params,
+      sessionEntry: targetEntry,
+      touchedFields: ["streamingMode"],
+    });
+  });
+
+  it("reports a concurrent session change instead of acknowledging a reset", async () => {
+    const params = buildStreamParams("/stream default");
+    persistCommandSessionMock.mockResolvedValueOnce(false);
+
+    await expect(handleStreamCommand(params, true)).resolves.toEqual(persistenceConflictReply);
+    expect(persistCommandSessionMock).toHaveBeenCalledWith({
+      ...params,
+      sessionEntry: params.sessionEntry,
+      touchedFields: ["streamingMode"],
+    });
+  });
+
+  it.each([
+    ["/streaming block", "block", "⚙️ Stream mode set to block."],
+    ["/stream final", "off", "⚙️ Stream mode set to off (preview disabled)."],
+  ] as const)("accepts %s", async (command, expectedMode, expectedText) => {
+    const params = buildStreamParams(command);
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(params.sessionEntry?.streamingMode).toBe(expectedMode);
+    expect(result?.reply?.text).toBe(expectedText);
+  });
+
+  it("reports the persisted session override", async () => {
+    const params = buildStreamParams("/stream status");
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(result?.reply?.text).toBe("⚙️ Current stream mode: block (session).");
+    expect(resolveSessionModeMock).toHaveBeenCalledWith({
+      account: resolvedAccount,
+      sessionMode: "block",
+    });
+    expect(persistCommandSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a configured preview mode when the session has no override", async () => {
+    const params = buildStreamParams("/stream status");
+    delete params.sessionEntry?.streamingMode;
+    resolveSessionModeMock.mockReturnValueOnce({ mode: "partial", source: "channel config" });
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(result?.reply?.text).toBe("⚙️ Current stream mode: partial (channel config).");
+    expect(resolveSessionModeMock).toHaveBeenCalledWith({
+      account: resolvedAccount,
+      sessionMode: undefined,
+    });
+  });
+
+  it("reports the channel default when only unrelated streaming config exists", async () => {
+    const params = buildStreamParams("/stream status");
+    delete params.sessionEntry?.streamingMode;
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(result?.reply?.text).toBe("⚙️ Current stream mode: progress (channel default).");
+  });
+
+  it("clears the override and reports the newly inherited mode", async () => {
+    const params = buildStreamParams("/stream default");
+    resolveSessionModeMock.mockReturnValueOnce({ mode: "partial", source: "channel config" });
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(params.sessionEntry?.streamingMode).toBeUndefined();
+    expect(result?.reply?.text).toBe("⚙️ Stream mode reset to partial (channel config).");
+    expect(resolveSessionModeMock).toHaveBeenCalledWith({
+      account: resolvedAccount,
+      sessionMode: undefined,
+    });
+  });
+
+  it("rejects invalid selections without changing the session", async () => {
+    const params = buildStreamParams("/stream sometimes");
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(params.sessionEntry?.streamingMode).toBe("block");
+    expect(result?.reply?.text).toBe("⚙️ Usage: /stream status|off|partial|block|progress|default");
+    expect(persistCommandSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not save overrides for channels without the delivery capability", async () => {
+    getChannelPluginMock.mockReturnValue({
+      streaming: { sessionModeDefault: "progress" },
+      config: { resolveAccount: () => resolvedAccount },
+    });
+    const params = buildStreamParams("/stream partial");
+
+    const result = await handleStreamCommand(params, true);
+
+    expect(params.sessionEntry?.streamingMode).toBe("block");
+    expect(result?.reply?.text).toBe("⚙️ /stream isn't supported on this channel yet.");
+    expect(persistCommandSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -205,6 +205,7 @@ export function initFastReplySessionState(params: {
     reasoningLevel: existingEntry?.reasoningLevel,
     ttsAuto: existingEntry?.ttsAuto,
     responseUsage: existingEntry?.responseUsage,
+    streamingMode: existingEntry?.streamingMode,
     ...(normalizedChatType ? { chatType: normalizedChatType } : {}),
     ...(normalizeOptionalString(ctx.Provider)
       ? { channel: normalizeOptionalString(ctx.Provider) }

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -818,6 +818,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
         sessionId: "existing-fast-reset-usage",
         updatedAt: Date.now(),
         responseUsage: "full",
+        streamingMode: "block",
       },
     });
 
@@ -835,7 +836,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     });
 
     expect(result.resetTriggered).toBe(true);
-    expect(result.sessionEntry.responseUsage).toBe("full");
+    expect(result.sessionEntry).toMatchObject({ responseUsage: "full", streamingMode: "block" });
   });
 
   it("preserves the exact multiline reset payload during fast bootstrap", () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2178,6 +2178,7 @@ describe("initSessionState RawBody", () => {
         traceLevel: "high",
         reasoningLevel: "low",
         ttsAuto: "always",
+        streamingMode: "block",
         pinnedAt: 123,
       },
       expected: {
@@ -2186,8 +2187,17 @@ describe("initSessionState RawBody", () => {
         traceLevel: "high",
         reasoningLevel: "low",
         ttsAuto: "always",
+        streamingMode: "block",
         pinnedAt: 123,
       },
+      persisted: true,
+    },
+    {
+      name: "preserves the session stream mode across an implicit idle rollover",
+      slug: "stream-idle",
+      entry: { streamingMode: "partial" as const },
+      expected: { streamingMode: "partial" },
+      reset: { mode: "idle" as const, idleMinutes: 1 },
       persisted: true,
     },
     {
@@ -2264,7 +2274,10 @@ describe("initSessionState RawBody", () => {
         SessionKey: sessionKey,
       },
       cfg: {
-        session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
+        session: {
+          store: storePath,
+          reset: "reset" in scenario ? scenario.reset : ({ mode: "daily", atHour: 4 } as const),
+        },
       } as OpenClawConfig,
     });
 
@@ -4140,6 +4153,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       verboseLevel: "on",
       thinkingLevel: "high",
       reasoningLevel: "low",
+      streamingMode: "progress",
       label: "telegram-priority",
     } as const;
     const cases = await runExplicitResetCases({

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -426,6 +426,7 @@ function resolveReplySessionRolloverState(
     reasoningLevel: entry.reasoningLevel,
     ttsAuto: entry.ttsAuto,
     responseUsage: entry.responseUsage,
+    streamingMode: entry.streamingMode,
     ...selectSessionModelOverride(preservedSelection),
     authProfileOverride: preservedSelection.authProfileOverride,
     authProfileOverrideSource: preservedSelection.authProfileOverrideSource,

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -11,7 +11,7 @@ import type {
 import type { AgentTool, AgentToolResult } from "../../agents/runtime/index.js";
 import type { ReplyDeliveryContext, ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import type { MarkdownTableMode } from "../../config/types.base.js";
+import type { MarkdownTableMode, StreamingMode } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { MessagePresentation } from "../../interactive/payload.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
@@ -341,10 +341,21 @@ export type ChannelMentionAdapter = {
   }) => string;
 };
 
-export type ChannelStreamingAdapter = {
+export type ChannelStreamingAdapter<ResolvedAccount = unknown> = {
   blockStreamingCoalesceDefaults?: {
     minChars: number;
     idleMs: number;
+  };
+  /**
+   * Opts the channel into `/stream` and declares the inherited mode used when
+   * neither account config nor a session override selects one. The channel's
+   * delivery path must honor `SessionEntry.streamingMode` when this is set.
+   */
+  sessionModeDefault?: StreamingMode;
+  /** Resolves the effective session mode without exposing the plugin's account shape to core. */
+  resolveSessionMode?: (params: { account: ResolvedAccount; sessionMode?: StreamingMode }) => {
+    mode: StreamingMode;
+    source: "session" | "channel config" | "channel default";
   };
 };
 

--- a/src/channels/plugins/types.plugin.ts
+++ b/src/channels/plugins/types.plugin.ts
@@ -105,7 +105,7 @@ export type ChannelPlugin<ResolvedAccount = any, Probe = unknown, Audit = unknow
   doctor?: ChannelDoctorAdapter;
   bindings?: ChannelConfiguredBindingProvider;
   conversationBindings?: ChannelConversationBindingSupport;
-  streaming?: ChannelStreamingAdapter;
+  streaming?: ChannelStreamingAdapter<ResolvedAccount>;
   threading?: ChannelThreadingAdapter;
   message?: ChannelMessageAdapterShape;
   messaging?: ChannelMessagingAdapter;

--- a/src/channels/streaming.lifecycle.test.ts
+++ b/src/channels/streaming.lifecycle.test.ts
@@ -129,6 +129,37 @@ describe("channel-streaming", () => {
     );
   });
 
+  it("prefers session preview mode overrides before channel config", () => {
+    expect(
+      resolveChannelPreviewStreamMode({ streaming: { mode: "partial" } }, "off", {
+        sessionMode: "progress",
+      }),
+    ).toBe("progress");
+    expect(
+      resolveChannelPreviewStreamMode({ streaming: { mode: "partial" } }, "off", {
+        sessionMode: "bogus",
+      }),
+    ).toBe("partial");
+  });
+
+  it("uses one resolved mode for progress policy", () => {
+    const entry = {
+      streaming: {
+        mode: "partial" as const,
+        progress: { commentary: true, toolProgress: false },
+      },
+    };
+
+    expect(resolveChannelStreamingPreviewToolProgress(entry, true, "progress")).toBe(false);
+    expect(resolveChannelStreamingProgressCommentary(entry, false, "progress")).toBe(true);
+    expect(
+      resolveChannelStreamingSuppressDefaultToolProgressMessages(entry, {
+        draftStreamActive: true,
+        mode: "off",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps block preview mode separate from block delivery", () => {
     expect(resolveChannelStreamingBlockEnabled({ streaming: { mode: "block" } })).toBeUndefined();
     expect(

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -358,6 +358,19 @@ describe("streaming config resolution", () => {
     },
   );
 
+  it("lets an available session preview mode override the inherited block default", () => {
+    expect(
+      resolveChannelStreamingBlockEnabled(
+        {},
+        {
+          previewAvailable: true,
+          blockStreamingDefault: "on",
+          sessionStreamingMode: "partial",
+        },
+      ),
+    ).toBe(false);
+  });
+
   it("keeps the inherited block default for off or invalid preview modes", () => {
     expect(
       resolveChannelStreamingBlockEnabled(

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -815,6 +815,7 @@ export function resolveChannelStreamingBlockEnabled(
   previewPolicy: {
     previewAvailable: boolean;
     blockStreamingDefault?: "off" | "on";
+    sessionStreamingMode?: unknown;
   },
 ): boolean;
 export function resolveChannelStreamingBlockEnabled(
@@ -822,6 +823,7 @@ export function resolveChannelStreamingBlockEnabled(
   previewPolicy?: {
     previewAvailable: boolean;
     blockStreamingDefault?: "off" | "on";
+    sessionStreamingMode?: unknown;
   },
 ): boolean | undefined {
   const explicitBlockStreaming = asBoolean(getChannelStreamingConfigObject(entry)?.block?.enabled);
@@ -830,9 +832,9 @@ export function resolveChannelStreamingBlockEnabled(
   }
   // Explicit channel choices beat the inherited agent default. Keep availability
   // in the decision so a turn that cannot render a preview may still use blocks.
-  const explicitPreviewMode = parsePreviewStreamingMode(
-    getChannelStreamingConfigObject(entry)?.mode,
-  );
+  const sessionPreviewMode = parsePreviewStreamingMode(previewPolicy.sessionStreamingMode);
+  const explicitPreviewMode =
+    sessionPreviewMode ?? parsePreviewStreamingMode(getChannelStreamingConfigObject(entry)?.mode);
   if (
     previewPolicy.previewAvailable &&
     explicitPreviewMode !== null &&
@@ -956,7 +958,12 @@ export function resolveChannelStreamingSuppressDefaultToolProgressMessages(
 export function resolveChannelPreviewStreamMode(
   entry: StreamingCompatEntry | null | undefined,
   defaultMode: StreamingMode,
+  options?: { sessionMode?: unknown },
 ): StreamingMode {
+  const sessionMode = parsePreviewStreamingMode(options?.sessionMode);
+  if (sessionMode) {
+    return sessionMode;
+  }
   return parsePreviewStreamingMode(getChannelStreamingConfigObject(entry)?.mode) ?? defaultMode;
 }
 

--- a/src/config/sessions/session-entry-selection.test.ts
+++ b/src/config/sessions/session-entry-selection.test.ts
@@ -10,11 +10,13 @@ describe("inheritSessionSelection", () => {
         updatedAt: 1,
         authProfileOverride: "openai:work",
         thinkingLevel: "ultra",
+        streamingMode: "progress",
       }),
     ).toMatchObject({
       authProfileOverride: "openai:work",
       authProfileOverrideSource: "user",
       thinkingLevel: "ultra",
+      streamingMode: "progress",
     });
 
     const automatic = inheritSessionSelection({

--- a/src/config/sessions/session-entry-selection.ts
+++ b/src/config/sessions/session-entry-selection.ts
@@ -92,6 +92,7 @@ export function inheritSessionSelection(
     ...(parentEntry.traceLevel ? { traceLevel: parentEntry.traceLevel } : {}),
     ...(parentEntry.reasoningLevel ? { reasoningLevel: parentEntry.reasoningLevel } : {}),
     ...(parentEntry.elevatedLevel ? { elevatedLevel: parentEntry.elevatedLevel } : {}),
+    ...(parentEntry.streamingMode ? { streamingMode: parentEntry.streamingMode } : {}),
     ...(inheritAuthProfile && authProfileOverrideSource && parentEntry.authProfileOverride
       ? { authProfileOverride: parentEntry.authProfileOverride }
       : {}),

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -26,6 +26,7 @@ import type {
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import type { SessionBoardFace } from "../../shared/session-types.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import type { StreamingMode } from "../types.base.js";
 import type { TtsAutoMode } from "../types.tts.js";
 import type { MainRestartRecoveryState } from "./main-session-recovery.types.js";
 import type {
@@ -482,6 +483,8 @@ type SessionEntryCore = SessionRestartRecoveryState &
     };
     fastMode?: FastMode;
     toolOverrides?: SessionToolOverrides;
+    /** Per-session preview streaming override for supported channels. */
+    streamingMode?: StreamingMode;
     /** Swarm group for collector-mode child sessions. */
     swarmGroupId?: string;
     /** Marks non-interactive collector-mode child sessions. */

--- a/src/gateway/server.sessions.recover.test.ts
+++ b/src/gateway/server.sessions.recover.test.ts
@@ -534,6 +534,7 @@ test("sessions.recover rolls over one tombstone and returns its continuation out
         agentRuntimeOverride: "codex",
         providerOverride: "openai",
         modelOverride: "gpt-5.6-sol",
+        streamingMode: "block",
         modelSelectionLocked: true,
         pinnedAt: 1,
         sandbox: "required",
@@ -597,6 +598,7 @@ test("sessions.recover rolls over one tombstone and returns its continuation out
     modelOverride: "gpt-5.6-sol",
     previousSessionId: sourceSessionId,
     providerOverride: "openai",
+    streamingMode: "block",
     sandbox: "required",
     spawnedCwd: "/tmp/recovered-worktree",
   });

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -1041,6 +1041,7 @@ test("sessions.reset preserves explicit session preferences across session rollo
   await writeSingleLineSession(dir, "sess-main", "hello");
   const preferences = {
     responseUsage: "tokens",
+    streamingMode: "partial",
     pinnedAt: 123,
     label: "Operator session",
     category: "Operator group",

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1695,6 +1695,7 @@ export async function performGatewaySessionReset(params: {
             reasoningLevel: currentEntry?.reasoningLevel,
             elevatedLevel: currentEntry?.elevatedLevel,
             ttsAuto: currentEntry?.ttsAuto,
+            streamingMode: currentEntry?.streamingMode,
             execHost: params.execNode
               ? "node"
               : params.clearExecBinding

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -89,6 +89,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "cronRunContinuation",
   "fastMode",
   "toolOverrides",
+  "streamingMode",
   "verboseLevel",
   "traceLevel",
   "reasoningLevel",


### PR DESCRIPTION
Implements the session-scoped streaming control discussed in #74077 (closed automatically for inactivity).

Related: #80989

> AI-assisted with OpenAI Codex; the resulting code and tests were reviewed and validated locally.

## What Problem This Solves

Preview streaming is configured globally per channel, so users cannot switch one active chat between off, partial, block, and progress behavior without editing config. This adds a session-scoped control that preserves channel configuration as the fallback.

## User-Facing Behavior

Authorized Telegram, Discord, and Slack users can run:

```text
/stream status
/stream off
/stream partial
/stream block
/stream progress
/stream default
```

`/streaming` is an alias. Text commands also accept `final` as a compatibility alias for canonical `off`.

The selected mode is persisted only for the current session. `/stream default` removes the override and reports the inherited channel mode. `off` disables previews without suppressing normal final delivery or an inherited block-delivery fallback.

## Implementation

- Adds optional `SessionEntry.streamingMode` state and preserves it across the same lifecycle boundaries as adjacent session preferences.
- Lets supporting channel plugins declare their inherited streaming mode and resolve account config without core assuming a plugin-specific config shape.
- Applies the session override before Telegram, Discord, and Slack account configuration in both preview selection and block arbitration.
- Capability-gates native command registration. ClickClack and other non-participating plugins do not advertise `/stream`; unsupported text invocation returns a clear response and does not persist state.
- Uses conflict-aware session persistence with `touchedFields: ["streamingMode"]` so a concurrent lifecycle change returns the standard retry response instead of acknowledging a lost write.

## Maintainer Decision Requested

This PR intentionally introduces one optional public channel-plugin contract: `plugin.streaming.sessionModeDefault` plus `resolveSessionMode({ account, sessionMode })`.

The contract keeps defaults and account-shape knowledge inside each channel plugin and makes native registration capability-aware. Please confirm whether this is the preferred long-term opt-in boundary for session-scoped streaming controls. The feature should not merge without that API sponsorship.

## Evidence

Exact candidate head: `7b98d15970f59dd3441bf4de782f67880f9c38da`  
Feature base: `d09401295626bebd53aa84492b91e7909e22487f`

- Production-focused matrix on the immediately preceding, production-identical head `9f8a86c87baf7a1528a85f6ac2638e0ec2b5c4d2`: 16 files / 699 assertions passed, covering command selection/persistence, lifecycle carry-forward, capability gating, stream/block resolution, and Telegram/Discord/Slack preview plus final-delivery behavior. A diff-caused duplicate Slack stream-mode mock was reproduced at 205/207 and repaired to 207/207.
- Exact-head boundary repair: the prior hosted `check-additional-boundaries` correctly found that a new standalone Gateway test root raised `gateway-root` from 720 to 721. That regression assertion now lives in the existing `sessions.recover` production-path test; the standalone root is removed. The exact-head recovery file passes 29/29, the repository boundary guard passes at the 720-root cap, and formatting/type-aware Oxlint/`git diff --check` pass.
- Clean merge simulation against live `openclaw/main` `89a1abd12ff92d78e0a5d2cf22641968dce828ea`: passed (tree `23fbae78977fb69774005b763f246b9b21dcdbdb`), with no paths changed on both sides since the feature base.
- Current repair gates: lower-level exact build, 49-file current-format check, direct type-aware Oxlint, `git diff --check`, and docs format/MDX/internal-link/config-example/glossary checks pass. Full wrapper `check:changed` remains delegated to hosted clean-install CI because local shared dependencies were intentionally not reconciled.
- Conflict-marker, coercion/deprecation, boundary, dead-export, dependency-pin, Plugin SDK export-sync, surface-budget, subpath-export, and wildcard-re-export guards pass.
- Fresh independent `gpt-5.6-sol` Max review found no actionable P0-P2 issue.
- A prior clean-install hosted core type shard passes after the test fixture was typed from the public resolver contract; no production behavior changed. A prior compact declaration-tooling failure also passed on rerun and was not diff-caused.
- Hosted exact-head run `34457781315` is terminal with **171 successes, 39 skips, and five failures** including the derivative `openclaw/ci-gate`. The four primary failures are outside this PR's changed paths: the current-main UI max-lines violation, runner-native tsgo `ETXTBSY`, a database-preflight artifact timeout, and a real-heartbeat cron timeout.

Current-head credentialed Telegram proof is `blocked_external`. The official Test Server doctor cannot load the OpenClaw QA broker because this host has no authenticated Convex broker access; no private credentials or local setup were used. A maintainer-run proof still needs to exercise `status`, `off`, `partial`, `progress`, `default`, and normal final delivery on this exact head.

## Scope and Compatibility

- No dependency, lockfile, workflow, permission, secret, or generated bundle changes.
- The optional persisted field is backward-compatible: absent or invalid values fall back to channel config/defaults.
- Only Telegram, Discord, and Slack opt in. ClickClack, Mattermost, Microsoft Teams, Matrix, and other channels remain unchanged.
- The narrower tool-progress toggle discussed in #80989 remains out of scope.
