### PR TITLE
fix(status): avoid stale session context windows

### DIFF
--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -24,6 +24,7 @@ export type ResolvedAgentConfig = {
   verboseDefault?: AgentDefaultsConfig["verboseDefault"];
   reasoningDefault?: AgentEntry["reasoningDefault"];
   fastModeDefault?: AgentEntry["fastModeDefault"];
+  contextTokens?: AgentEntry["contextTokens"];
   contextInjection?: AgentEntry["contextInjection"];
   bootstrapMaxChars?: AgentEntry["bootstrapMaxChars"];
   bootstrapTotalMaxChars?: AgentEntry["bootstrapTotalMaxChars"];
@@ -131,6 +132,7 @@ export function resolveAgentConfig(
     verboseDefault: entry.verboseDefault ?? agentDefaults?.verboseDefault,
     reasoningDefault: entry.reasoningDefault,
     fastModeDefault: entry.fastModeDefault,
+    contextTokens: entry.contextTokens ?? agentDefaults?.contextTokens,
     contextInjection: entry.contextInjection,
     bootstrapMaxChars: entry.bootstrapMaxChars,
     bootstrapTotalMaxChars: entry.bootstrapTotalMaxChars,

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -604,6 +604,69 @@ describe("buildStatusReply subagent summary", () => {
     });
   });
 
+  it("ignores stale live contextTokens when /status displays the current default model", async () => {
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        models: {
+          providers: {
+            "ollama-cloud": {
+              baseUrl: "https://ollama.com",
+              models: [
+                {
+                  id: "deepseek-v4-pro",
+                  name: "DeepSeek V4 Pro",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1_000_000,
+                  maxTokens: 128_000,
+                },
+                {
+                  id: "kimi-k2.7-code",
+                  name: "Kimi K2.7 Code",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 262_144,
+                  maxTokens: 128_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-stale-live-context",
+        updatedAt: 0,
+        modelProvider: "ollama-cloud",
+        model: "kimi-k2.7-code",
+        totalTokens: 0,
+        totalTokensFresh: true,
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      provider: "ollama-cloud",
+      model: "deepseek-v4-pro",
+      contextTokens: 262_144,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: ollama-cloud/deepseek-v4-pro");
+    expect(normalized).toContain("Context: 0/1.0m");
+    expect(normalized).not.toContain("Context: 0/262k");
+  });
+
   it("shows gateway and system uptime in /status output", async () => {
     vi.spyOn(process, "uptime").mockReturnValue(2 * 60 * 60 + 5 * 60);
     vi.spyOn(os, "uptime").mockReturnValue(4 * 24 * 60 * 60 + 3 * 60 * 60);

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -664,6 +664,7 @@ describe("buildStatusReply subagent summary", () => {
     const normalized = normalizeTestText(text);
     expect(normalized).toContain("Model: ollama-cloud/deepseek-v4-pro");
     expect(normalized).toContain("Context: 0/1.0m");
+    expect(normalized).not.toContain("kimi-k2.7-code");
     expect(normalized).not.toContain("Context: 0/262k");
     expect(normalized).not.toContain("/262k");
   });

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -665,6 +665,7 @@ describe("buildStatusReply subagent summary", () => {
     expect(normalized).toContain("Model: ollama-cloud/deepseek-v4-pro");
     expect(normalized).toContain("Context: 0/1.0m");
     expect(normalized).not.toContain("Context: 0/262k");
+    expect(normalized).not.toContain("/262k");
   });
 
   it("shows gateway and system uptime in /status output", async () => {

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -987,6 +987,74 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Context: 1.0k/66k");
   });
 
+  it("ignores stale session contextTokens after the default model changes", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "ollama-cloud/kimi-k2.7-code",
+        contextTokens: 262_144,
+      },
+      explicitConfiguredContextTokens: 262_144,
+      sessionEntry: {
+        sessionId: "default-model-context-window",
+        updatedAt: 0,
+        modelProvider: "ollama-cloud",
+        model: "deepseek-v4-pro",
+        totalTokens: 501,
+        totalTokensFresh: true,
+        contextTokens: 1_000_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: ollama-cloud/kimi-k2.7-code");
+    expect(normalized).toContain("Context: 501/262k");
+    expect(normalized).not.toContain("Context: 501/1.0m");
+  });
+
+  it("uses the selected model window when a stale runtime snapshot is smaller", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "ollama-cloud": {
+              models: [
+                { id: "deepseek-v4-pro", contextWindow: 1_000_000 },
+                { id: "kimi-k2.7-code", contextWindow: 262_144 },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "ollama-cloud/deepseek-v4-pro",
+        contextTokens: 1_000_000,
+      },
+      explicitConfiguredContextTokens: 1_000_000,
+      sessionEntry: {
+        sessionId: "default-model-context-window-larger",
+        updatedAt: 0,
+        modelProvider: "ollama-cloud",
+        model: "kimi-k2.7-code",
+        totalTokens: 0,
+        totalTokensFresh: true,
+        contextTokens: 262_144,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: ollama-cloud/deepseek-v4-pro");
+    expect(normalized).toContain("Context: 0/1.0m");
+    expect(normalized).not.toContain("Context: 0/262k");
+  });
+
   it("recomputes context window from the active fallback model when session contextTokens are stale", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -345,6 +345,28 @@ describe("getStatusSummary", () => {
     });
   });
 
+  it("does not pass stale session contextTokens as status row overrides", async () => {
+    statusSummaryMocks.listSessionEntries.mockReturnValue(
+      toSessionEntrySummaries({
+        "agent:main:main": {
+          sessionId: "stale-context",
+          updatedAt: Date.now(),
+          modelProvider: "openai",
+          model: "gpt-5.4",
+          contextTokens: 1_000_000,
+        },
+      }),
+    );
+
+    await getStatusSummary();
+
+    expect(
+      vi
+        .mocked(statusSummaryRuntime.resolveContextTokensForModel)
+        .mock.calls.some((call) => call[0]?.contextTokensOverride === 1_000_000),
+    ).toBe(false);
+  });
+
   it("uses bundled provider static catalogs for cold status context", async () => {
     vi.mocked(statusSummaryRuntime.resolveConfiguredStatusModelRef).mockReturnValue({
       provider: "google",

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -136,6 +136,38 @@ function hasUserPinnedModelSelection(entry: SessionEntry | undefined): boolean {
   return !hasSessionAutoModelFallbackProvenance(entry);
 }
 
+function normalizeStatusModelPart(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function resolveTrustedSessionContextTokens(params: {
+  entry: SessionEntry | undefined;
+  provider: string | undefined;
+  model: string | null;
+}): number | undefined {
+  const contextTokens =
+    typeof params.entry?.contextTokens === "number" && params.entry.contextTokens > 0
+      ? params.entry.contextTokens
+      : undefined;
+  if (contextTokens === undefined) {
+    return undefined;
+  }
+  if (hasSessionAutoModelFallbackProvenance(params.entry)) {
+    return contextTokens;
+  }
+  const entryProvider = normalizeStatusModelPart(params.entry?.modelProvider);
+  const entryModel = normalizeStatusModelPart(params.entry?.model);
+  const resolvedProvider = normalizeStatusModelPart(params.provider);
+  const resolvedModel = normalizeStatusModelPart(params.model);
+  if (!entryModel || !resolvedModel || entryModel !== resolvedModel) {
+    return undefined;
+  }
+  if (entryProvider && resolvedProvider && entryProvider !== resolvedProvider) {
+    return undefined;
+  }
+  return contextTokens;
+}
+
 type SessionCandidate = {
   key: string;
   entry: SessionEntry;
@@ -361,7 +393,11 @@ export async function getStatusSummary(
             provider: resolvedModel.provider,
             model,
             ...modelContext,
-            contextTokensOverride: entry?.contextTokens,
+            contextTokensOverride: resolveTrustedSessionContextTokens({
+              entry,
+              provider: resolvedModel.provider,
+              model,
+            }),
             fallbackContextTokens: configContextTokens ?? undefined,
             allowAsyncLoad: false,
           }) ?? null;

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -735,10 +735,28 @@ export function buildStatusMessage(args: StatusArgs): string {
     typeof entry?.contextTokens === "number" && entry.contextTokens > 0
       ? entry.contextTokens
       : undefined;
+  const persistedContextMatchesActiveModel = (() => {
+    if (persistedContextTokens === undefined) {
+      return false;
+    }
+    const entryProvider = normalizeLowercaseStringOrEmpty(entry?.modelProvider);
+    const entryModel = normalizeLowercaseStringOrEmpty(entry?.model);
+    const lookupProvider = normalizeLowercaseStringOrEmpty(contextLookupProvider);
+    const lookupModel = normalizeLowercaseStringOrEmpty(contextLookupModel);
+    if (!entryModel || !lookupModel || entryModel !== lookupModel) {
+      return false;
+    }
+    if (entryProvider && lookupProvider && entryProvider !== lookupProvider) {
+      return false;
+    }
+    return !runtimeDiffersFromSelected || initialFallbackState.active;
+  })();
   const cappedPersistedContextTokens =
     typeof persistedContextTokens === "number" && typeof activeContextTokens === "number"
       ? Math.min(persistedContextTokens, activeContextTokens)
-      : persistedContextTokens;
+      : persistedContextMatchesActiveModel
+        ? persistedContextTokens
+        : undefined;
   const agentContextTokens =
     typeof args.agent?.contextTokens === "number" && args.agent.contextTokens > 0
       ? args.agent.contextTokens
@@ -778,17 +796,40 @@ export function buildStatusMessage(args: StatusArgs): string {
   const contextTokens = runtimeDiffersFromSelected
     ? (explicitRuntimeContextTokens ??
       (() => {
-        if (persistedContextTokens !== undefined) {
+        const runtimeSnapshotHasFallbackProvenance =
+          initialFallbackState.active ||
+          hasSessionAutoModelFallbackProvenance(entry) ||
+          areRuntimeModelRefsEquivalent(activeModelLabel, modelRefs.selected.label || "unknown");
+        if (!runtimeSnapshotHasFallbackProvenance) {
+          if (typeof selectedContextTokens === "number") {
+            if (explicitConfiguredContextTokens !== undefined) {
+              return Math.min(explicitConfiguredContextTokens, selectedContextTokens);
+            }
+            if (agentContextTokens !== undefined) {
+              return Math.min(agentContextTokens, selectedContextTokens);
+            }
+            return selectedContextTokens;
+          }
+          if (explicitConfiguredContextTokens !== undefined) {
+            return explicitConfiguredContextTokens;
+          }
+          if (agentContextTokens !== undefined) {
+            return agentContextTokens;
+          }
+          return DEFAULT_CONTEXT_TOKENS;
+        }
+        if (cappedPersistedContextTokens !== undefined) {
+          const trustedPersistedContextTokens = cappedPersistedContextTokens;
           const persistedLooksSelectedWindow =
             typeof selectedContextTokens === "number" &&
-            persistedContextTokens === selectedContextTokens;
+            trustedPersistedContextTokens === selectedContextTokens;
           const activeWindowDiffersFromSelected =
             typeof selectedContextTokens === "number" &&
             typeof activeContextTokens === "number" &&
             activeContextTokens !== selectedContextTokens;
           const explicitConfiguredMatchesPersisted =
             typeof explicitConfiguredContextTokens === "number" &&
-            explicitConfiguredContextTokens === persistedContextTokens;
+            explicitConfiguredContextTokens === trustedPersistedContextTokens;
           if (
             persistedLooksSelectedWindow &&
             activeWindowDiffersFromSelected &&
@@ -797,9 +838,9 @@ export function buildStatusMessage(args: StatusArgs): string {
             return activeContextTokens;
           }
           if (typeof activeContextTokens === "number") {
-            return Math.min(persistedContextTokens, activeContextTokens);
+            return Math.min(trustedPersistedContextTokens, activeContextTokens);
           }
-          return persistedContextTokens;
+          return trustedPersistedContextTokens;
         }
         if (cappedConfiguredContextTokens !== undefined) {
           return cappedConfiguredContextTokens;

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -30,6 +30,7 @@ import { resolveSelectedAndActiveModel } from "../auto-reply/model-runtime.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import { toAgentModelListLike } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import {
@@ -513,11 +514,39 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??
     (agentDefaults.thinkingDefault as ThinkLevel | undefined);
+  const configuredContextTokens =
+    typeof agentConfig?.contextTokens === "number" && agentConfig.contextTokens > 0
+      ? agentConfig.contextTokens
+      : typeof agentDefaults.contextTokens === "number" && agentDefaults.contextTokens > 0
+        ? agentDefaults.contextTokens
+        : undefined;
   const runtimeContextTokens = resolveStatusRuntimeContextTokens({
     cfg,
     provider: activeStatusProvider,
     model: modelRefs.active.model || model,
   });
+  const selectedContextTokens = resolveStatusRuntimeContextTokens({
+    cfg,
+    provider: selectedStatusProvider,
+    model,
+  });
+  const runtimeSnapshotHasFallbackProvenance =
+    !modelRefs.activeDiffers ||
+    hasSessionAutoModelFallbackProvenance(sessionEntry) ||
+    areRuntimeModelRefsEquivalent(modelRefs.active.label, modelRefs.selected.label, {
+      config: cfg,
+    });
+  const statusAgentContextTokens =
+    typeof contextTokens === "number" &&
+    contextTokens > 0 &&
+    (runtimeSnapshotHasFallbackProvenance ||
+      contextTokens === configuredContextTokens ||
+      contextTokens === selectedContextTokens)
+      ? contextTokens
+      : undefined;
+  const statusRuntimeContextTokens = runtimeSnapshotHasFallbackProvenance
+    ? runtimeContextTokens
+    : undefined;
   return buildStatusMessage({
     config: cfg,
     agent: {
@@ -527,7 +556,9 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
         primary: params.primaryModelLabelOverride ?? `${provider}/${model}`,
         ...(agentFallbacksOverride === undefined ? {} : { fallbacks: agentFallbacksOverride }),
       },
-      ...(typeof contextTokens === "number" && contextTokens > 0 ? { contextTokens } : {}),
+      ...(statusAgentContextTokens !== undefined
+        ? { contextTokens: statusAgentContextTokens }
+        : {}),
       thinkingDefault: explicitThinkingDefault,
       verboseDefault: agentDefaults.verboseDefault,
       reasoningDefault: agentConfig?.reasoningDefault ?? agentDefaults.reasoningDefault,
@@ -535,11 +566,8 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     },
     agentId: statusAgentId,
     configuredDefaultModelLabel,
-    explicitConfiguredContextTokens:
-      typeof agentDefaults.contextTokens === "number" && agentDefaults.contextTokens > 0
-        ? agentDefaults.contextTokens
-        : undefined,
-    runtimeContextTokens,
+    explicitConfiguredContextTokens: configuredContextTokens,
+    runtimeContextTokens: statusRuntimeContextTokens,
     sessionEntry,
     sessionKey,
     parentSessionKey,


### PR DESCRIPTION
## Summary

Fix `/status` context-window reporting when persisted session runtime metadata is stale.

The status message can display the currently selected/configured model while still using an old `session.contextTokens` or old runtime-model snapshot to compute the context window. This can produce inconsistent output such as:

```text
Model: ollama-cloud/kimi-k2.7-code
Context: 26/1.0m
```

when the selected model's configured context window is 262k.

This PR keeps the scope narrow: it does not redefine whether an existing session should follow a new default model or keep its previous runtime model. It only prevents status rendering from mixing the selected model display with a stale session context window.

## Changes

- Only trust persisted `session.contextTokens` when it matches the resolved status model or confirmed fallback provenance.
- In `/status` message rendering, when the selected model differs from an unproven runtime snapshot, use the selected/configured model context window instead of the stale runtime window.
- Preserve known runtime alias/fallback behavior, such as CLI runtime aliases.
- Add regression coverage for stale `contextTokens` after default model changes.

## Tests

```bash
env -u OPENCLAW_STATE_DIR OPENCLAW_HOME=/tmp/openclaw-test-home XDG_CONFIG_HOME=/tmp/openclaw-test-home HOME=/tmp/openclaw-test-home OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include.json node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts
```

Result: 3 files, 119 tests passed.