### PR TITLE
fix(agents): replace prose terminal classifiers

### DIFF
--- a/docs/plugins/adding-capabilities.md
+++ b/docs/plugins/adding-capabilities.md
@@ -71,7 +71,7 @@ If the work is vendor-only and no shared contract exists yet, stop and define th
 
 Use **provider hooks** when the behavior belongs to the model provider contract rather than the generic agent loop. Examples include provider-specific request params after transport selection, auth-profile preference, prompt overlays, and follow-up fallback routing after model/profile failover.
 
-Use **agent harness hooks** when the behavior belongs to the runtime that is executing a turn. Harnesses can classify successful-but-unusable attempt results such as empty, reasoning-only, or planning-only responses so the outer model fallback policy can make the retry decision.
+Use **agent harness hooks** when the behavior belongs to the runtime that is executing a turn. Harnesses can classify explicit protocol outcomes such as empty output, reasoning without visible output, or a structured plan without a final answer so the outer model fallback policy can make the retry decision.
 
 Keep both seams narrow:
 

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -180,8 +180,10 @@ Native harnesses that own their own protocol projection can use
 `openclaw/plugin-sdk/agent-harness-runtime` when a completed turn produced no
 visible assistant text. The helper returns `empty`, `reasoning-only`, or
 `planning-only` so OpenClaw's fallback policy can decide whether to retry on a
-different model. It intentionally leaves prompt errors, in-flight turns, and
-intentional silent replies such as `NO_REPLY` unclassified.
+different model. `planning-only` requires the harness's explicit `planText`
+field; OpenClaw does not infer it from assistant prose. The helper intentionally
+leaves prompt errors, in-flight turns, and intentional silent replies such as
+`NO_REPLY` unclassified.
 
 ### Native Codex harness mode
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1040,10 +1040,11 @@ the Server-side compaction accordion below.
     ```
 
     With `strict-agentic`, OpenClaw:
-    - No longer treats a plan-only turn as successful progress when a tool action is available
-    - Retries the turn with an act-now steer
     - Auto-enables `update_plan` for substantial work
-    - Surfaces an explicit blocked state if the model keeps planning without acting
+    - Retries structurally empty or reasoning-only turns with a visible-answer continuation
+    - Uses explicit harness plan events when the selected harness provides them
+
+    OpenClaw does not classify assistant prose to decide whether a turn is a plan, progress update, or final answer.
 
     <Note>
     Scoped to OpenAI and Codex GPT-5-family runs only. Other providers and older model families keep default behavior.

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import {
   embeddedAgentLog,
+  isToolWrappedWithBeforeToolCallHook,
   type EmbeddedRunAttemptParams,
+  wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -579,6 +581,46 @@ describe("Codex app-server dynamic tool build", () => {
       currentChannelId: "D123",
       currentMessagingTarget: "user:U123",
     });
+  });
+
+  it("forwards the tool outcome observer into Codex dynamic tools", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const onToolOutcome = vi.fn();
+    params.disableTools = false;
+    params.onToolOutcome = onToolOutcome;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const factoryOptions: unknown[] = [];
+    setOpenClawCodingToolsFactoryForTests((options) => {
+      factoryOptions.push(options);
+      return [];
+    });
+
+    await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
+
+    expect(factoryOptions[0]).toMatchObject({ onToolOutcome });
+  });
+
+  it("preserves before-tool wrapping through Codex runtime normalization", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    const runtimePlan = createCodexRuntimePlanFixture();
+    runtimePlan.tools.normalize = (tools) => tools.map((tool) => ({ ...tool }));
+    params.runtimePlan = runtimePlan;
+    const wrappedTool = wrapToolWithBeforeToolCallHook(createRuntimeDynamicTool("web_fetch"), {
+      agentId: "main",
+      sessionId: params.sessionId,
+    });
+    setOpenClawCodingToolsFactoryForTests(() => [wrappedTool]);
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).not.toBe(wrappedTool);
+    expect(isToolWrappedWithBeforeToolCallHook(tools[0])).toBe(true);
   });
 
   it("passes runtime config into Codex exec dynamic tool construction", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -290,6 +290,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     recordToolPrepStage: (name) => {
       toolBuildStages.mark(name);
     },
+    onToolOutcome: params.onToolOutcome,
   });
   toolBuildStages.mark("create-openclaw-coding-tools");
   const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -6,6 +6,7 @@ import {
   embeddedAgentLog,
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createTerminalPresentationContractTool } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import {
   onInternalDiagnosticEvent,
   waitForDiagnosticEventsDrained,
@@ -224,6 +225,7 @@ describe("createCodexDynamicToolBridge", () => {
   it("can register a durable tool schema while denying execution for the current turn", async () => {
     const heartbeatExecute = vi.fn(async () => textToolResult("heartbeat recorded"));
     const onAgentToolResult = vi.fn();
+    const onToolOutcome = vi.fn();
     const bridge = createCodexDynamicToolBridge({
       tools: [createTool({ name: "message" })],
       registeredTools: [
@@ -231,6 +233,7 @@ describe("createCodexDynamicToolBridge", () => {
         createTool({ name: HEARTBEAT_RESPONSE_TOOL_NAME, execute: heartbeatExecute }),
       ],
       signal: new AbortController().signal,
+      hookContext: { runId: "run-unavailable", onToolOutcome },
     });
 
     expect(bridge.availableSpecs.map((tool) => tool.name)).toEqual(["message"]);
@@ -276,6 +279,13 @@ describe("createCodexDynamicToolBridge", () => {
         },
       },
       isError: true,
+    });
+    expect(onToolOutcome).toHaveBeenLastCalledWith({
+      toolName: HEARTBEAT_RESPONSE_TOOL_NAME,
+      argsHash: "",
+      resultHash: "",
+      terminalPresentation: undefined,
+      presentationOnly: true,
     });
   });
 
@@ -795,6 +805,53 @@ describe("createCodexDynamicToolBridge", () => {
         threadId: "thread-ts-1",
         text: "hello from Codex",
         mediaUrls: ["/tmp/reply.png"],
+      },
+    ]);
+  });
+
+  it("records hook-adjusted message arguments as delivery telemetry", async () => {
+    const beforeToolCall = vi.fn(async () => ({
+      params: {
+        action: "send",
+        text: "rewritten delivery",
+        mediaUrl: "/tmp/rewritten.png",
+        provider: "telegram",
+        to: "chat-rewritten",
+      },
+    }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const execute = vi.fn(async () => textToolResult("Sent."));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "message", execute })],
+      signal: new AbortController().signal,
+    });
+
+    await handleMessageToolCall(bridge, { action: "status" });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        action: "send",
+        text: "rewritten delivery",
+        mediaUrl: "/tmp/rewritten.png",
+        provider: "telegram",
+        to: "chat-rewritten",
+      },
+      expect.any(AbortSignal),
+      undefined,
+    );
+    expect(bridge.telemetry.messagingToolSentTexts).toEqual(["rewritten delivery"]);
+    expect(bridge.telemetry.messagingToolSentMediaUrls).toEqual(["/tmp/rewritten.png"]);
+    expect(bridge.telemetry.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "telegram",
+        to: "chat-rewritten",
+        threadId: undefined,
+        text: "rewritten delivery",
+        mediaUrls: ["/tmp/rewritten.png"],
       },
     ]);
   });
@@ -1351,6 +1408,32 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
+  it("keeps thrown read-only dynamic tool failures replay-safe", async () => {
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "web_fetch",
+          execute: vi.fn(async () => {
+            throw new Error("backend unavailable");
+          }),
+        }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "web_fetch",
+      arguments: { url: "https://example.com" },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.sideEffectEvidence).toBeUndefined();
+  });
+
   it("preserves terminal async tool results without marking them as errors", async () => {
     const bridge = createBridgeWithToolResult("image_generate", {
       content: [{ type: "text", text: "Background task started." }],
@@ -1384,32 +1467,47 @@ describe("createCodexDynamicToolBridge", () => {
       callId: "call-1",
       namespace: null,
       tool: "exec",
-      arguments: { command: "pwd" },
+      arguments: { command: "touch /tmp/openclaw-replay-test" },
     });
 
     expect(result).toEqual(expectInputText("done"));
     expect(result.sideEffectEvidence).toBe(true);
   });
 
-  it("keeps audited core read-only dynamic tools replay-safe", async () => {
-    const bridge = createBridgeWithToolResult("search", textToolResult("no matches"));
+  it("omits side-effect evidence for explicitly replay-safe terminal tools", async () => {
+    const bridge = createBridgeWithToolResult("web_fetch", textToolResult("done"));
 
     const result = await bridge.handleToolCall({
       threadId: "thread-1",
       turnId: "turn-1",
       callId: "call-1",
       namespace: null,
-      tool: "search",
-      arguments: { query: "scheduler" },
+      tool: "web_fetch",
+      arguments: { url: "https://example.com/private" },
     });
 
-    expect(result).toEqual(expectInputText("no matches"));
+    expect(result).toEqual(expectInputText("done"));
+    expect(result.sideEffectEvidence).toBeUndefined();
+  });
+
+  it("shares replay-safe classification with OpenClaw for read-only dynamic tools", async () => {
+    const bridge = createBridgeWithToolResult("web_search", textToolResult("done"));
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-web-search",
+      namespace: null,
+      tool: "web_search",
+      arguments: { query: "current weather" },
+    });
+
     expect(result.sideEffectEvidence).toBeUndefined();
   });
 
   it("keeps async-started read-only tools replay-unsafe", async () => {
     const bridge = createBridgeWithToolResult(
-      "search",
+      "web_search",
       textToolResult("Background task started.", {
         async: true,
         status: "started",
@@ -1420,9 +1518,9 @@ describe("createCodexDynamicToolBridge", () => {
     const result = await bridge.handleToolCall({
       threadId: "thread-1",
       turnId: "turn-1",
-      callId: "call-1",
+      callId: "call-async-search",
       namespace: null,
-      tool: "search",
+      tool: "web_search",
       arguments: { query: "scheduler" },
     });
 
@@ -1430,8 +1528,131 @@ describe("createCodexDynamicToolBridge", () => {
     expect(result.sideEffectEvidence).toBe(true);
   });
 
+  it("keeps terminal tools replay-unsafe when before_tool_call can rewrite arguments", async () => {
+    const beforeToolCall = vi.fn(async () => ({ params: { action: "add" } }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: beforeToolCall }]),
+    );
+    const execute = vi.fn(async () => textToolResult("done"));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "cron", execute })],
+      signal: new AbortController().signal,
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "cron",
+      arguments: { action: "status" },
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-1",
+      { action: "add" },
+      expect.any(AbortSignal),
+      undefined,
+    );
+    expect(result.sideEffectEvidence).toBe(true);
+  });
+
+  it("keeps executed mutations replay-unsafe when middleware rewrites the result as blocked", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(async () => ({
+      result: textToolResult("blocked by middleware", {
+        status: "blocked",
+        deniedReason: "plugin-before-tool-call",
+      }),
+    }));
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "redactor",
+      pluginName: "Redactor",
+      rawHandler: handler,
+      handler,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const execute = vi.fn(async () => textToolResult("added", { id: "job-1" }));
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "cron", execute })],
+      signal: new AbortController().signal,
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-cron-rewritten-blocked",
+      namespace: null,
+      tool: "cron",
+      arguments: { action: "add", job: { name: "reminder" } },
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(result.diagnosticTerminalType).toBe("blocked");
+    expect(result.sideEffectEvidence).toBe(true);
+  });
+
+  it("snapshots executed arguments before result middleware can mutate them", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(
+      async (event: { args: Record<string, unknown>; result: AgentToolResult<unknown> }) => {
+        event.args.action = "status";
+        return { result: event.result };
+      },
+    );
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "mutator",
+      pluginName: "Mutator",
+      rawHandler: handler,
+      handler,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const bridge = createBridgeWithToolResult("cron", textToolResult("added", { id: "job-1" }));
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-cron-mutable-args",
+      namespace: null,
+      tool: "cron",
+      arguments: { action: "add", job: { name: "reminder" } },
+    });
+
+    expect(result.sideEffectEvidence).toBe(true);
+    expect(bridge.telemetry.successfulCronAdds).toBe(1);
+  });
+
+  it("snapshots executed arguments before after_tool_call hooks can mutate them", async () => {
+    const afterToolCall = vi.fn((event: unknown) => {
+      const eventRecord = requireRecord(event, "after_tool_call event");
+      const paramsRecord = requireRecord(eventRecord.params, "after_tool_call params");
+      paramsRecord.action = "status";
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
+    );
+    const bridge = createBridgeWithToolResult("cron", textToolResult("added", { id: "job-1" }));
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "cron",
+      arguments: { action: "add", job: { name: "reminder" } },
+    });
+
+    expect(result.sideEffectEvidence).toBe(true);
+    expect(bridge.telemetry.successfulCronAdds).toBe(1);
+  });
+
   it("does not mark pre-execution argument failures as side-effect evidence", async () => {
     const execute = vi.fn(async () => textToolResult("should not run"));
+    const onToolOutcome = vi.fn();
     const bridge = createCodexDynamicToolBridge({
       tools: [
         createTool({
@@ -1445,6 +1666,7 @@ describe("createCodexDynamicToolBridge", () => {
         }),
       ],
       signal: new AbortController().signal,
+      hookContext: { runId: "run-invalid-arguments", onToolOutcome },
     });
 
     const result = await bridge.handleToolCall({
@@ -1462,6 +1684,13 @@ describe("createCodexDynamicToolBridge", () => {
     });
     expect(result.sideEffectEvidence).toBeUndefined();
     expect(execute).not.toHaveBeenCalled();
+    expect(onToolOutcome).toHaveBeenLastCalledWith({
+      toolName: "exec",
+      argsHash: "",
+      resultHash: "",
+      terminalPresentation: undefined,
+      presentationOnly: true,
+    });
   });
 
   it("uses raw tool provenance for media trust after middleware rewrites details", async () => {
@@ -1837,7 +2066,7 @@ describe("createCodexDynamicToolBridge", () => {
     const handler = vi.fn(
       async (event: { args: Record<string, unknown>; result: AgentToolResult<unknown> }) => {
         events.push("middleware");
-        expect(event.args).toEqual({ command: "status" });
+        expect(event.args).toEqual({ command: "status", mode: "safe" });
         return {
           result: {
             ...event.result,
@@ -1879,6 +2108,118 @@ describe("createCodexDynamicToolBridge", () => {
     await vi.waitFor(() => {
       expect(events).toEqual(["before_tool_call", "execute", "middleware", "after_tool_call"]);
     });
+  });
+
+  it("builds terminal presentation from the post-middleware result", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(async () => ({
+      result: textToolResult("redacted output", {
+        origin: "redacted.example",
+        status: 200,
+      }),
+    }));
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "redactor",
+      pluginName: "Redactor",
+      rawHandler: handler,
+      handler,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const onToolOutcome = vi.fn();
+    const tool = createTerminalPresentationContractTool({
+      name: "web_fetch",
+      result: textToolResult("raw output", {
+        origin: "private.example",
+        status: 200,
+      }),
+      format: (_params, result) => {
+        const details = requireRecord(result.details, "terminal presentation details");
+        return `Origin: ${String(details.origin)}\nStatus: ${String(details.status)}`;
+      },
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+      hookContext: {
+        runId: "run-terminal-middleware",
+        sessionId: "session-terminal-middleware",
+        onToolOutcome,
+      },
+    });
+
+    await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-terminal-middleware",
+      namespace: null,
+      tool: "web_fetch",
+      arguments: { url: "https://private.example" },
+    });
+
+    expect(onToolOutcome).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        presentationOnly: true,
+        terminalPresentation: "Origin: redacted.example\nStatus: 200",
+      }),
+    );
+  });
+
+  it("clears raw terminal presentation when middleware returns an error", async () => {
+    const registry = createEmptyPluginRegistry();
+    const handler = vi.fn(async () => ({
+      result: textToolResult("output blocked by middleware", {
+        status: "error",
+        middlewareError: true,
+      }),
+    }));
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "redactor",
+      pluginName: "Redactor",
+      rawHandler: handler,
+      handler,
+      runtimes: ["codex"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const onToolOutcome = vi.fn();
+    const tool = createTerminalPresentationContractTool({
+      name: "web_fetch",
+      result: textToolResult("raw output", {
+        origin: "private.example",
+        status: 200,
+      }),
+      format: (_params, result) => {
+        const details = requireRecord(result.details, "terminal presentation details");
+        return `Origin: ${String(details.origin)}`;
+      },
+    });
+    const bridge = createCodexDynamicToolBridge({
+      tools: [tool],
+      signal: new AbortController().signal,
+      hookContext: {
+        runId: "run-terminal-middleware-error",
+        sessionId: "session-terminal-middleware-error",
+        onToolOutcome,
+      },
+    });
+
+    await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-terminal-middleware-error",
+      namespace: null,
+      tool: "web_fetch",
+      arguments: { url: "https://private.example" },
+    });
+
+    expect(onToolOutcome).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        presentationOnly: true,
+        terminalPresentation: undefined,
+      }),
+    );
   });
 
   it("reports dynamic tool execution errors through after_tool_call without stranding the turn", async () => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -4,18 +4,21 @@
  */
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import {
+  consumeAdjustedParamsForToolCall,
+  consumePreExecutionBlockedToolCall,
   createAgentToolResultMiddlewareRunner,
   createCodexAppServerToolResultExtensionRunner,
   extractMessagingToolSend,
   extractMessagingToolSendResult,
   extractToolResultMediaArtifact,
   filterToolResultMediaUrls,
+  finalizeToolTerminalPresentation,
   HEARTBEAT_RESPONSE_TOOL_NAME,
   embeddedAgentLog,
   getChannelAgentToolMeta,
   getPluginToolMeta,
   type EmbeddedRunAttemptParams,
-  isAgentToolReplaySafe,
+  isReplaySafeToolCall,
   isToolWrappedWithBeforeToolCallHook,
   isToolResultError,
   isMessagingTool,
@@ -62,6 +65,7 @@ type CodexDynamicToolHookContext = {
   currentThreadId?: string;
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
+  onToolOutcome?: EmbeddedRunAttemptParams["onToolOutcome"];
 };
 
 type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
@@ -181,16 +185,13 @@ export function createCodexDynamicToolBridge(params: {
     runtime: "codex",
     ...toolResultHookContext,
   });
-  const isReplaySafeTool = (tool: AnyAgentTool) =>
-    isAgentToolReplaySafe(tool, {
-      declaredReplaySafe: (candidate) => {
-        const pluginMeta = getPluginToolMeta(candidate as AnyAgentTool);
-        if (pluginMeta) {
-          return pluginMeta.replaySafe === true;
-        }
-        return getChannelAgentToolMeta(candidate as never) ? false : undefined;
-      },
-    });
+  const isReplaySafeToolInstance = (tool: AnyAgentTool): boolean => {
+    const pluginMeta = getPluginToolMeta(tool);
+    if (pluginMeta) {
+      return pluginMeta.replaySafe === true;
+    }
+    return getChannelAgentToolMeta(tool as never) === undefined;
+  };
   const legacyExtensionRunner =
     createCodexAppServerToolResultExtensionRunner(toolResultHookContext);
   const directToolNames = new Set([
@@ -219,6 +220,14 @@ export function createCodexDynamicToolBridge(params: {
         const message = registeredToolNames.has(call.tool)
           ? `OpenClaw tool is not available for this turn: ${call.tool}`
           : `Unknown OpenClaw tool: ${call.tool}`;
+        finalizeToolTerminalPresentation({
+          toolCallId: call.callId,
+          runId: toolResultHookContext.runId,
+          result: failedToolResult(message),
+          isError: true,
+          observer: params.hookContext?.onToolOutcome,
+          toolName: call.tool,
+        });
         notifyAgentToolResult(
           options?.onAgentToolResult,
           call.tool,
@@ -246,40 +255,45 @@ export function createCodexDynamicToolBridge(params: {
       const startedAt = Date.now();
       const signal = composeAbortSignals(params.signal, options?.signal);
       let didStartExecution = false;
+      let executionPrevented = false;
+      let executedArgs = structuredClone(args);
       try {
         // Prepare before marking side-effect evidence; argument preparation can
         // fail without the target tool actually starting.
         const preparedArgs = tool.prepareArguments ? tool.prepareArguments(args) : args;
         const telemetryArgs = isRecord(preparedArgs) ? preparedArgs : args;
-        const messagingTelemetryArgs = applyCurrentMessageProvider(
-          toolName,
-          telemetryArgs,
-          params.hookContext?.currentChannelProvider,
-        );
-        const messagingTarget =
-          isMessagingTool(toolName) && isMessagingToolSendAction(toolName, telemetryArgs)
-            ? extractMessagingToolSend(toolName, messagingTelemetryArgs, {
-                config: params.hookContext?.config,
-                currentChannelId: params.hookContext?.currentChannelId,
-                currentMessagingTarget: params.hookContext?.currentMessagingTarget,
-                currentThreadId: params.hookContext?.currentThreadId,
-                replyToMode: params.hookContext?.replyToMode,
-                hasRepliedRef: params.hookContext?.hasRepliedRef,
-              })
-            : undefined;
+        executedArgs = structuredClone(telemetryArgs);
+        const messagingContext = {
+          config: params.hookContext?.config,
+          currentChannelId: params.hookContext?.currentChannelId,
+          currentMessagingTarget: params.hookContext?.currentMessagingTarget,
+          currentThreadId: params.hookContext?.currentThreadId,
+          replyToMode: params.hookContext?.replyToMode,
+          hasRepliedRef: params.hookContext?.hasRepliedRef
+            ? { value: params.hookContext.hasRepliedRef.value }
+            : undefined,
+        };
         didStartExecution = true;
         const rawResult = await tool.execute(call.callId, preparedArgs, signal);
+        const adjustedExecutedArgs = consumeAdjustedParamsForToolCall(
+          call.callId,
+          toolResultHookContext.runId,
+        );
+        if (isRecord(adjustedExecutedArgs)) {
+          executedArgs = structuredClone(adjustedExecutedArgs);
+        }
+        executionPrevented = consumePreExecutionBlockedToolCall(
+          call.callId,
+          toolResultHookContext.runId,
+        );
+        const telemetryRawResult = sanitizeToolResult(rawResult);
         const rawIsError = isCodexToolResultError(rawResult);
-        const confirmedMessagingTarget =
-          !rawIsError && messagingTarget
-            ? extractMessagingToolSendResult(messagingTarget, rawResult)
-            : messagingTarget;
         const middlewareResult = await middlewareRunner.applyToolResultMiddleware({
           threadId: call.threadId,
           turnId: call.turnId,
           toolCallId: call.callId,
           toolName,
-          args,
+          args: structuredClone(executedArgs),
           isError: rawIsError,
           result: rawResult,
         });
@@ -288,20 +302,11 @@ export function createCodexDynamicToolBridge(params: {
           turnId: call.turnId,
           toolCallId: call.callId,
           toolName,
-          args,
+          args: structuredClone(executedArgs),
           result: middlewareResult,
         });
         const resultIsError = rawIsError || isCodexToolResultError(result);
         notifyAgentToolResult(options?.onAgentToolResult, toolName, result, resultIsError);
-        collectToolTelemetry({
-          toolName,
-          args: telemetryArgs,
-          result,
-          mediaTrustResult: rawResult,
-          telemetry,
-          isError: resultIsError,
-          messagingTarget: confirmedMessagingTarget,
-        });
         void runAgentHarnessAfterToolCallHook({
           toolName,
           toolCallId: call.callId,
@@ -310,9 +315,39 @@ export function createCodexDynamicToolBridge(params: {
           sessionId: toolResultHookContext.sessionId,
           sessionKey: toolResultHookContext.sessionKey,
           channelId: toolResultHookContext.channelId,
-          startArgs: args,
+          startArgs: executedArgs,
           result,
           startedAt,
+        });
+        finalizeToolTerminalPresentation({
+          toolCallId: call.callId,
+          runId: toolResultHookContext.runId,
+          result,
+          isError: resultIsError,
+          observer: params.hookContext?.onToolOutcome,
+          toolName,
+        });
+        const messagingTelemetryArgs = applyCurrentMessageProvider(
+          toolName,
+          executedArgs,
+          params.hookContext?.currentChannelProvider,
+        );
+        const messagingTarget =
+          isMessagingTool(toolName) && isMessagingToolSendAction(toolName, executedArgs)
+            ? extractMessagingToolSend(toolName, messagingTelemetryArgs, messagingContext)
+            : undefined;
+        const confirmedMessagingTarget =
+          !rawIsError && messagingTarget
+            ? extractMessagingToolSendResult(messagingTarget, telemetryRawResult)
+            : messagingTarget;
+        collectToolTelemetry({
+          toolName,
+          args: executedArgs,
+          result,
+          mediaTrustResult: telemetryRawResult,
+          telemetry,
+          isError: resultIsError,
+          messagingTarget: confirmedMessagingTarget,
         });
         const terminalType = inferToolResultDiagnosticTerminalType(result, resultIsError);
         const response = withDiagnosticTerminalType(
@@ -332,21 +367,37 @@ export function createCodexDynamicToolBridge(params: {
         const asyncStarted =
           isAsyncStartedToolResult(rawResult) || isAsyncStartedToolResult(result);
         withDynamicToolAsyncStarted(response, asyncStarted);
-        return withSideEffectEvidence(
-          response,
-          asyncStarted || (terminalType !== "blocked" && !isReplaySafeTool(toolEntry.tool)),
-        );
+        const replaySafe =
+          executionPrevented ||
+          (!asyncStarted &&
+            isReplaySafeToolInstance(toolEntry.tool) &&
+            isReplaySafeToolCall(toolName, executedArgs));
+        return withSideEffectEvidence(response, !replaySafe);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        notifyAgentToolResult(
-          options?.onAgentToolResult,
-          toolName,
-          failedToolResult(errorMessage),
-          true,
+        const adjustedExecutedArgs = consumeAdjustedParamsForToolCall(
+          call.callId,
+          toolResultHookContext.runId,
         );
+        if (isRecord(adjustedExecutedArgs)) {
+          executedArgs = structuredClone(adjustedExecutedArgs);
+        }
+        executionPrevented =
+          executionPrevented ||
+          consumePreExecutionBlockedToolCall(call.callId, toolResultHookContext.runId);
+        const failedResult = failedToolResult(errorMessage);
+        finalizeToolTerminalPresentation({
+          toolCallId: call.callId,
+          runId: toolResultHookContext.runId,
+          result: failedResult,
+          isError: true,
+          observer: params.hookContext?.onToolOutcome,
+          toolName,
+        });
+        notifyAgentToolResult(options?.onAgentToolResult, toolName, failedResult, true);
         collectToolTelemetry({
           toolName,
-          args,
+          args: executedArgs,
           result: undefined,
           telemetry,
           isError: true,
@@ -359,10 +410,15 @@ export function createCodexDynamicToolBridge(params: {
           sessionId: toolResultHookContext.sessionId,
           sessionKey: toolResultHookContext.sessionKey,
           channelId: toolResultHookContext.channelId,
-          startArgs: args,
+          startArgs: executedArgs,
           error: errorMessage,
           startedAt,
         });
+        const replaySafe =
+          !didStartExecution ||
+          executionPrevented ||
+          (isReplaySafeToolInstance(toolEntry.tool) &&
+            isReplaySafeToolCall(toolName, executedArgs));
         return withSideEffectEvidence(
           withDiagnosticTerminalType(
             {
@@ -376,7 +432,7 @@ export function createCodexDynamicToolBridge(params: {
             },
             "error",
           ),
-          didStartExecution && !isReplaySafeTool(toolEntry.tool),
+          didStartExecution && !replaySafe,
         );
       }
     },
@@ -689,7 +745,7 @@ function collectToolTelemetry(params: {
   toolName: string;
   args: Record<string, unknown>;
   result: AgentToolResult<unknown> | undefined;
-  mediaTrustResult?: AgentToolResult<unknown>;
+  mediaTrustResult?: unknown;
   telemetry: CodexDynamicToolBridge["telemetry"];
   isError: boolean;
   messagingTarget?: MessagingToolSend;

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2708,7 +2708,7 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
   });
 
-  it("retains blocked dynamic tool outcomes until the same tool recovers", async () => {
+  it("clears a blocked dynamic tool outcome after the next successful tool", async () => {
     const projector = await createProjector();
 
     projector.recordDynamicToolResult({
@@ -2725,11 +2725,11 @@ describe("CodexAppServerEventProjector", () => {
     });
 
     projector.recordDynamicToolResult({
-      callId: "call-cron-recovered",
-      tool: "cron",
+      callId: "call-web-fetch-recovered",
+      tool: "web_fetch",
       success: true,
       terminalType: "completed",
-      contentItems: [{ type: "inputText", text: "status ok" }],
+      contentItems: [{ type: "inputText", text: "fetch ok" }],
     });
 
     expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toBeUndefined();

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2708,7 +2708,152 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
   });
 
-  it("does not mark blocked dynamic tools as side-effecting", async () => {
+  it("retains blocked dynamic tool outcomes until the same tool recovers", async () => {
+    const projector = await createProjector();
+
+    projector.recordDynamicToolResult({
+      callId: "call-cron-blocked",
+      tool: "cron",
+      success: false,
+      terminalType: "blocked",
+      contentItems: [{ type: "inputText", text: "blocked by policy" }],
+    });
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "cron",
+      error: "blocked by policy",
+    });
+
+    projector.recordDynamicToolResult({
+      callId: "call-cron-recovered",
+      tool: "cron",
+      success: true,
+      terminalType: "completed",
+      contentItems: [{ type: "inputText", text: "status ok" }],
+    });
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toBeUndefined();
+  });
+
+  it.each([
+    {
+      command: "/bin/zsh -lc 'rg -n TODO src'",
+      commandActions: [{ type: "search", command: "rg -n TODO src", query: "TODO", path: "src" }],
+    },
+    {
+      command: "/bin/zsh -lc 'cat package.json'",
+      commandActions: [
+        { type: "read", command: "cat package.json", name: "cat", path: "/workspace/package.json" },
+      ],
+    },
+    {
+      command: "/bin/zsh -lc 'touch changed.txt'",
+      commandActions: [{ type: "unknown", command: "touch changed.txt" }],
+    },
+  ])(
+    "treats native command actions as replay-unsafe: $command",
+    async ({ command, commandActions }) => {
+      const projector = await createProjector();
+
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "commandExecution",
+            id: "command-native",
+            command,
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "completed",
+            commandActions,
+            aggregatedOutput: "",
+            exitCode: 0,
+            durationMs: 1,
+          },
+        }),
+      );
+
+      expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
+        hadPotentialSideEffects: true,
+        replaySafe: false,
+      });
+    },
+  );
+
+  it("clears a prior terminal presentation after a native tool completes", async () => {
+    let terminalPresentation: string | undefined = "stale web fetch";
+    const projector = await createProjector({
+      ...(await createParams()),
+      onToolOutcome: (observation) => {
+        terminalPresentation = observation.terminalPresentation;
+      },
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "command-clear-presentation",
+          command: "git status --short",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [{ type: "unknown", command: "git status --short" }],
+          aggregatedOutput: "",
+          exitCode: 0,
+          durationMs: 1,
+        },
+      }),
+    );
+
+    expect(terminalPresentation).toBeUndefined();
+  });
+
+  it("clears a prior terminal presentation after an unprojected native tool completes", async () => {
+    let terminalPresentation: string | undefined = "stale web fetch";
+    const projector = await createProjector({
+      ...(await createParams()),
+      onToolOutcome: (observation) => {
+        terminalPresentation = observation.terminalPresentation;
+      },
+    });
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "imageView",
+          id: "image-view-clear-presentation",
+          path: "/workspace/reference.png",
+        },
+      ]),
+    );
+
+    expect(terminalPresentation).toBeUndefined();
+  });
+
+  it("treats native image generation without a saved path as side-effect evidence", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "imageGeneration",
+          id: "image-generation-side-effect",
+          status: "completed",
+          revisedPrompt: null,
+          result: "generated-image-result",
+        },
+      ]),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).replayMetadata).toEqual({
+      hadPotentialSideEffects: true,
+      replaySafe: false,
+    });
+  });
+
+  it("keeps executed dynamic tools side-effecting when their result is rewritten as blocked", async () => {
     const projector = await createProjector();
 
     projector.recordDynamicToolCall({
@@ -2727,7 +2872,7 @@ describe("CodexAppServerEventProjector", () => {
 
     const result = projector.buildResult(buildEmptyToolTelemetry());
 
-    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
   });
 
   it("treats completed native MCP tool calls as side-effect evidence", async () => {
@@ -2745,6 +2890,34 @@ describe("CodexAppServerEventProjector", () => {
           tool: "create_issue",
           status: "completed",
           arguments: { title: "check replay safety" },
+        },
+      },
+    });
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
+  });
+
+  it("treats native collaboration calls as side-effect evidence", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "collab-1",
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "completed",
+          senderThreadId: "thread-1",
+          receiverThreadIds: ["child-thread-1"],
+          prompt: "Inspect the replay path",
+          model: null,
+          reasoningEffort: null,
+          agentsStates: {},
         },
       },
     });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -457,7 +457,7 @@ export class CodexAppServerEventProjector {
       };
     } else if (
       params.success &&
-      this.lastNativeToolError?.toolName === params.tool &&
+      this.lastNativeToolError &&
       !this.lastNativeToolError.mutatingAction
     ) {
       this.lastNativeToolError = undefined;

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -170,6 +170,7 @@ export class CodexAppServerEventProjector {
     string,
     { toolName: string; meta?: string; asyncStarted?: boolean }
   >();
+  private readonly terminalPresentationClearedItemIds = new Set<string>();
   private readonly sideEffectingToolItemIds = new Set<string>();
   private readonly sideEffectingDynamicToolCallIds = new Set<string>();
   private readonly toolTranscriptMessages: AgentMessage[] = [];
@@ -434,6 +435,7 @@ export class CodexAppServerEventProjector {
     sideEffectEvidence?: boolean;
     contentItems: CodexDynamicToolCallOutputContentItem[];
   }): void {
+    const resultText = collectDynamicToolContentText(params.contentItems);
     if (params.asyncStarted === true) {
       const existing = this.toolMetas.get(params.callId);
       this.toolMetas.set(params.callId, {
@@ -445,11 +447,22 @@ export class CodexAppServerEventProjector {
     this.recordToolTranscriptResult({
       id: params.callId,
       name: params.tool,
-      text: collectDynamicToolContentText(params.contentItems),
+      text: resultText,
       isError: !params.success,
     });
-    const terminalType = params.terminalType ?? (params.success ? "completed" : "error");
-    if (terminalType !== "blocked" && params.sideEffectEvidence === true) {
+    if (!params.success && params.terminalType === "blocked") {
+      this.lastNativeToolError = {
+        toolName: params.tool,
+        error: resultText || "codex dynamic tool blocked",
+      };
+    } else if (
+      params.success &&
+      this.lastNativeToolError?.toolName === params.tool &&
+      !this.lastNativeToolError.mutatingAction
+    ) {
+      this.lastNativeToolError = undefined;
+    }
+    if (params.sideEffectEvidence === true) {
       this.sideEffectingDynamicToolCallIds.add(params.callId);
     }
   }
@@ -610,6 +623,7 @@ export class CodexAppServerEventProjector {
 
   private async handleItemCompleted(params: JsonObject): Promise<void> {
     const item = readItem(params.item);
+    this.clearTerminalPresentationForNativeItem(item);
     const itemId = item?.id ?? readString(params, "itemId") ?? readString(params, "id");
     if (itemId) {
       this.activeItemIds.delete(itemId);
@@ -753,6 +767,7 @@ export class CodexAppServerEventProjector {
       this.promptErrorSource = "prompt";
     }
     for (const item of turn.items ?? []) {
+      this.clearTerminalPresentationForNativeItem(item);
       this.rememberAssistantPhase(item);
       if (item.type === "agentMessage" && typeof item.text === "string") {
         this.rememberAssistantItem(item.id);
@@ -1109,6 +1124,24 @@ export class CodexAppServerEventProjector {
     }
   }
 
+  private clearTerminalPresentationForNativeItem(item: CodexThreadItem | undefined): void {
+    if (
+      !item ||
+      this.terminalPresentationClearedItemIds.has(item.id) ||
+      !shouldClearTerminalPresentationForNativeItem(item)
+    ) {
+      return;
+    }
+    this.terminalPresentationClearedItemIds.add(item.id);
+    this.params.onToolOutcome?.({
+      toolName: itemName(item) ?? item.type,
+      argsHash: "",
+      resultHash: "",
+      terminalPresentation: undefined,
+      presentationOnly: true,
+    });
+  }
+
   private recordNativeToolError(params: {
     item: CodexThreadItem;
     name: string;
@@ -1373,6 +1406,11 @@ export class CodexAppServerEventProjector {
     if (!item) {
       return;
     }
+    if (isSideEffectingNativeToolItem(item)) {
+      this.sideEffectingToolItemIds.add(item.id);
+    } else {
+      this.sideEffectingToolItemIds.delete(item.id);
+    }
     const toolName = itemName(item);
     if (!toolName) {
       return;
@@ -1384,11 +1422,6 @@ export class CodexAppServerEventProjector {
       ...(meta ? { meta } : {}),
       ...(existing?.asyncStarted ? { asyncStarted: true } : {}),
     });
-    if (isSideEffectingNativeToolItem(item)) {
-      this.sideEffectingToolItemIds.add(item.id);
-    } else {
-      this.sideEffectingToolItemIds.delete(item.id);
-    }
   }
 
   private recordNativeToolTranscriptCall(item: CodexThreadItem | undefined): void {
@@ -2168,7 +2201,31 @@ function shouldRecordNativeToolTranscript(item: CodexThreadItem): boolean {
 }
 
 function isMutatingNativeToolItem(item: CodexThreadItem): boolean {
-  return item.type === "commandExecution" || item.type === "fileChange";
+  if (item.type === "commandExecution") {
+    // Codex commandActions describe presentation, not safety. Upstream may
+    // classify mutating commands as read/search, so native commands fail closed.
+    return true;
+  }
+  return (
+    item.type === "fileChange" ||
+    item.type === "collabAgentToolCall" ||
+    item.type === "imageGeneration"
+  );
+}
+
+function shouldClearTerminalPresentationForNativeItem(item: CodexThreadItem): boolean {
+  switch (item.type) {
+    case "collabAgentToolCall":
+    case "commandExecution":
+    case "fileChange":
+    case "imageGeneration":
+    case "imageView":
+    case "mcpToolCall":
+    case "webSearch":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function nativeToolActionFingerprint(item: CodexThreadItem): string | undefined {

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
@@ -9,7 +10,8 @@ import {
   OUTCOME_FALLBACK_RUNTIME_CONTRACT,
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import {
   CodexAppServerEventProjector,
   type CodexAppServerToolTelemetry,
@@ -95,6 +97,7 @@ function readMirrorIdentity(message: unknown): string | undefined {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   for (const tempDir of tempDirs) {
     await fs.rm(tempDir, { recursive: true, force: true });
   }
@@ -402,4 +405,60 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
     expect(result.agentHarnessResultClassification).toBeUndefined();
     expect(classifyProjectedAttemptResult(result)).toBeNull();
   });
+
+  it.each([
+    { action: "status", replaySafe: true },
+    { action: "add", replaySafe: false },
+  ])(
+    "classifies an empty Codex turn after cron.$action from structured replay safety",
+    async ({ action, replaySafe }) => {
+      const toolResult: AgentToolResult<unknown> = {
+        content: [{ type: "text", text: "cron complete" }],
+        details: { ok: true },
+      };
+      const bridge = createCodexDynamicToolBridge({
+        tools: [
+          {
+            name: "cron",
+            description: "Cron",
+            parameters: { type: "object", properties: {} },
+            execute: vi.fn(async () => toolResult),
+          } as never,
+        ],
+        signal: new AbortController().signal,
+      });
+      const projector = await createProjector();
+      const call = {
+        threadId: THREAD_ID,
+        turnId: TURN_ID,
+        callId: `call-cron-${action}`,
+        namespace: null,
+        tool: "cron",
+        arguments: { action },
+      };
+      projector.recordDynamicToolCall(call);
+      const response = await bridge.handleToolCall(call);
+      projector.recordDynamicToolResult({
+        callId: call.callId,
+        tool: call.tool,
+        success: response.success,
+        terminalType: response.diagnosticTerminalType,
+        sideEffectEvidence: response.sideEffectEvidence === true,
+        contentItems: response.contentItems,
+      });
+      await projector.handleNotification(
+        forCurrentTurn("turn/completed", {
+          turn: { id: TURN_ID, status: "completed", items: [] },
+        }),
+      );
+
+      const result = projector.buildResult(bridge.telemetry);
+
+      expect(result.replayMetadata).toEqual({
+        hadPotentialSideEffects: !replaySafe,
+        replaySafe,
+      });
+      expect(classifyProjectedAttemptResult(result) !== null).toBe(replaySafe);
+    },
+  );
 });

--- a/extensions/codex/src/app-server/run-attempt.hooks.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.hooks.test.ts
@@ -41,6 +41,64 @@ function flushDiagnosticEvents() {
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt hooks and model diagnostics", () => {
+  it.each([
+    { label: "completed", status: "completed" as const, error: undefined, legacy: false },
+    { label: "failed", status: "failed" as const, error: "codex exploded", legacy: false },
+    {
+      label: "completed legacy alias",
+      status: "completed" as const,
+      error: undefined,
+      legacy: true,
+    },
+  ])("defers $label lifecycle terminal ownership", async ({ status, error, legacy }) => {
+    const onRunAgentEvent = vi.fn();
+    const sessionFile = path.join(tempDir, `deferred-${status}.jsonl`);
+    const workspaceDir = path.join(tempDir, `workspace-${status}`);
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    if (legacy) {
+      params.deferTerminalLifecycleEnd = true;
+    } else {
+      params.deferTerminalLifecycle = true;
+    }
+    params.onAgentEvent = onRunAgentEvent;
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    if (status === "completed") {
+      await harness.notify({
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "msg-1",
+          delta: "hello back",
+        },
+      });
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    } else {
+      await harness.notify({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status,
+            error: { message: error },
+          },
+        },
+      });
+    }
+    await run;
+
+    const lifecycleEvents = onRunAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents.map((event) => event.data.phase)).toEqual(["start", "finishing"]);
+    expect(lifecycleEvents[1]?.data.error).toBe(error);
+  });
+
   it("fires llm_input, llm_output, and agent_end hooks for codex turns", async () => {
     const llmInput = vi.fn();
     const llmOutput = vi.fn();

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1513,6 +1513,9 @@ export async function runCodexAppServerAttempt(
         startedAt: attemptStartedAt,
         endedAt: Date.now(),
         ...data,
+        ...((params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd)
+          ? { phase: "finishing" }
+          : {}),
       },
     });
     lifecycleTerminalEmitted = true;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -732,6 +732,7 @@ export async function runCodexAppServerAttempt(
       currentThreadId: params.currentThreadTs,
       replyToMode: params.replyToMode,
       hasRepliedRef: params.hasRepliedRef,
+      onToolOutcome: params.onToolOutcome,
     },
   });
   const hadSessionFile = await pathExists(activeSessionFile);

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -221,7 +221,11 @@ describe("runAgentLoop deferred tool hydration", () => {
                 stopReason: "stop" as const,
                 timestamp: Date.now(),
               };
-        stream.push({ type: "done", reason: message.stopReason, message });
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
       });
       return stream;
     };
@@ -289,7 +293,11 @@ describe("runAgentLoop deferred tool hydration", () => {
                 stopReason: "stop" as const,
                 timestamp: Date.now(),
               };
-        stream.push({ type: "done", reason: message.stopReason, message });
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
       });
       return stream;
     };
@@ -656,7 +664,63 @@ describe("agentLoop tool termination", () => {
     expect(turn).toBe(3);
     expect(executed).toEqual(["message", "exec"]);
     expect(events.filter((event) => event.type === "tool_execution_start")).toHaveLength(2);
+    expect(
+      events
+        .filter(
+          (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+            event.type === "tool_execution_end",
+        )
+        .map((event) => event.executionStarted),
+    ).toEqual([true, true]);
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
+  });
+
+  it("marks policy-blocked tool calls as not executed", async () => {
+    const executed: string[] = [];
+    let turn = 0;
+    const streamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantMessage([
+                { type: "toolCall", id: "call-cron", name: "cron", arguments: {} },
+              ])
+            : makeAssistantMessage([{ type: "text", text: "done" }]);
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const stream = agentLoop(
+      [{ role: "user", content: "hello", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("cron", executed)],
+      },
+      {
+        ...config,
+        beforeToolCall: async () => ({ block: true, reason: "blocked" }),
+      },
+      undefined,
+      streamFn,
+    );
+
+    const events = await collectEvents(stream);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+
+    expect(executed).toEqual([]);
+    expect(endEvent?.executionStarted).toBe(false);
   });
 
   it("stops after a tool result only when the finalized result explicitly terminates", async () => {

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -588,6 +588,7 @@ async function executeToolCallsSequential(
         toolCall,
         result: preparation.result,
         isError: preparation.isError,
+        executionStarted: false,
       };
     } else {
       const executed = await executePreparedToolCall(preparation, signal, emit);
@@ -650,6 +651,7 @@ async function executeToolCallsParallel(
         toolCall,
         result: preparation.result,
         isError: preparation.isError,
+        executionStarted: false,
       } satisfies FinalizedToolCallOutcome;
       await emitToolExecutionEnd(finalized, emit);
       finalizedCalls.push(finalized);
@@ -715,6 +717,7 @@ type FinalizedToolCallOutcome = {
   toolCall: AgentToolCall;
   result: AgentToolResult<unknown>;
   isError: boolean;
+  executionStarted: boolean;
 };
 
 type FinalizedToolCallEntry = FinalizedToolCallOutcome | (() => Promise<FinalizedToolCallOutcome>);
@@ -951,6 +954,7 @@ async function finalizeExecutedToolCall(
     toolCall: prepared.toolCall,
     result,
     isError,
+    executionStarted: true,
   };
 }
 
@@ -971,6 +975,7 @@ async function emitToolExecutionEnd(
     toolName: finalized.toolCall.name,
     result: finalized.result,
     isError: finalized.isError,
+    executionStarted: finalized.executionStarted,
   });
 }
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -528,4 +528,6 @@ export type AgentEvent =
       toolName: string;
       result: unknown;
       isError: boolean;
+      /** False when resolution, argument preparation, validation, or policy blocked execution. */
+      executionStarted?: boolean;
     };

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1120,7 +1120,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     );
     expect(lifecycleFinishingCalls.length).toBeGreaterThanOrEqual(1);
     expectRecordFields(mockCallArg(state.runAgentAttemptMock), {
-      deferTerminalLifecycleEnd: true,
+      deferTerminalLifecycle: true,
     });
     const firstFinishingIndex = state.emitAgentEventMock.mock.calls.findIndex((call: unknown[]) => {
       const arg = call[0] as { stream?: string; data?: { phase?: string } };
@@ -3052,6 +3052,136 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       model: "claude",
       reason: "format",
     });
+  });
+
+  it("emits a failure lifecycle after delivering a preserved exhausted result", async () => {
+    const exhaustedResult = {
+      payloads: [{ text: "Terminal tool summary", isError: true }],
+      meta: {
+        durationMs: 100,
+        aborted: false,
+        stopReason: "end_turn",
+        error: {
+          kind: "incomplete_turn",
+          message: "All fallback candidates ended incomplete",
+          fallbackSafe: true,
+          terminalPresentation: true,
+        },
+        agentMeta: { provider: "anthropic", model: "claude" },
+      },
+    };
+    state.runAgentAttemptMock.mockImplementationOnce(async (attemptParams: unknown) => {
+      const params = attemptParams as {
+        deferTerminalLifecycle?: boolean;
+        onAgentEvent?: (event: { stream: string; data: Record<string, unknown> }) => void;
+      };
+      expect(params.deferTerminalLifecycle).toBe(true);
+      params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "finishing",
+          error: "All fallback candidates ended incomplete",
+        },
+      });
+      return exhaustedResult;
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "exhausted",
+      result: await params.run("anthropic", "claude"),
+      provider: "anthropic",
+      model: "claude",
+      attempts: [
+        {
+          provider: "anthropic",
+          model: "claude",
+          error: "All fallback candidates ended incomplete",
+          reason: "format",
+        },
+      ],
+    }));
+
+    await runBasicAgentCommand();
+
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledTimes(1);
+    const lifecycleEvents = state.emitAgentEventMock.mock.calls
+      .map((call) => call[0] as { stream?: string; data?: Record<string, unknown> })
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents.some((event) => event.data?.phase === "finishing")).toBe(false);
+    expect(lifecycleEvents.some((event) => event.data?.phase === "end")).toBe(false);
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            error: "All fallback candidates ended incomplete",
+            fallbackExhaustedFailure: true,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("emits a failure lifecycle for completed non-fallbackable error results", async () => {
+    const terminalErrorResult = {
+      payloads: [{ text: "Command may have changed state", isError: true }],
+      meta: {
+        durationMs: 100,
+        aborted: false,
+        stopReason: "end_turn",
+        replayInvalid: true,
+        error: {
+          kind: "incomplete_turn",
+          message: "raw provider detail should stay private",
+          fallbackSafe: false,
+        },
+        agentMeta: { provider: "anthropic", model: "claude" },
+      },
+    };
+    state.runAgentAttemptMock.mockImplementationOnce(async (attemptParams: unknown) => {
+      const params = attemptParams as {
+        onAgentEvent?: (event: { stream: string; data: Record<string, unknown> }) => void;
+      };
+      params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "finishing",
+          error: "Command may have changed state",
+          replayInvalid: true,
+        },
+      });
+      return terminalErrorResult;
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "completed",
+      result: await params.run("anthropic", "claude"),
+      provider: "anthropic",
+      model: "claude",
+      attempts: [],
+    }));
+
+    await runBasicAgentCommand();
+
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledTimes(1);
+    const lifecycleEvents = state.emitAgentEventMock.mock.calls
+      .map((call) => call[0] as { stream?: string; data?: Record<string, unknown> })
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            error: "Command may have changed state",
+            replayInvalid: true,
+          }),
+        }),
+      ]),
+    );
+    expect(
+      lifecycleEvents.some(
+        (event) => event.data?.phase === "end" || event.data?.fallbackExhaustedFailure === true,
+      ),
+    ).toBe(false);
+    expect(JSON.stringify(lifecycleEvents)).not.toContain("raw provider detail");
   });
 
   it("updates hasSessionModelOverride for fallback resolution after switch", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -97,7 +97,10 @@ import { resolveAgentRunContext } from "./command/run-context.js";
 import { resolveSession } from "./command/session.js";
 import type { AgentCommandIngressOpts, AgentCommandOpts } from "./command/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
-import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "./embedded-agent-runner/result-fallback-classifier.js";
 import { resolveFastModeState } from "./fast-mode.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
 import { resolveAvailableAgentHarnessPolicy } from "./harness/selection.js";
@@ -1733,6 +1736,7 @@ async function agentCommandInternal(
     let result: AgentAttemptResult;
     let fallbackProvider = provider;
     let fallbackModel = model;
+    let fallbackExhausted = false;
     const MAX_LIVE_SWITCH_RETRIES = 5;
     let liveSwitchRetries = 0;
     let autoFallbackPrimaryProbeInterruptedByLiveSwitch = false;
@@ -1798,6 +1802,7 @@ async function agentCommandInternal(
               model: modelLocal,
               result: resultLocal,
             }),
+          mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           abortSignal: opts.abortSignal,
           run: async (providerOverride, modelOverride, runOptions) => {
             const isAutoFallbackPrimaryProbeCandidate =
@@ -1883,7 +1888,9 @@ async function agentCommandInternal(
         }
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
+        fallbackExhausted = fallbackResult.outcome === "exhausted";
         if (
+          !fallbackExhausted &&
           autoFallbackPrimaryProbe &&
           !autoFallbackPrimaryProbeInterruptedByLiveSwitch &&
           sessionEntry &&
@@ -2078,7 +2085,9 @@ async function agentCommandInternal(
             opts.bootstrapContextRunKind !== "heartbeat" &&
             !opts.internalEvents?.length,
           preserveRuntimeModel:
-            opts.bootstrapContextRunKind === "heartbeat" || preserveUserFacingSessionModelState,
+            fallbackExhausted ||
+            opts.bootstrapContextRunKind === "heartbeat" ||
+            preserveUserFacingSessionModelState,
           preserveUserFacingSessionModelState,
         });
         sessionEntry = sessionStore[sessionKey] ?? sessionEntry;

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -86,7 +86,10 @@ import {
 import { isStoredCredentialCompatibleWithAuthProvider } from "./auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
-import { createAgentAttemptLifecycleCallbacks } from "./command/attempt-callbacks.js";
+import {
+  createAgentAttemptLifecycleCallbacks,
+  type AgentAttemptLifecycleState,
+} from "./command/attempt-callbacks.js";
 import {
   persistSessionEntry as persistSessionEntryBase,
   prependInternalEventContext,
@@ -1655,7 +1658,7 @@ async function agentCommandInternal(
       : sessionFile;
 
     const startedAt = Date.now();
-    const attemptLifecycleState = {
+    const attemptLifecycleState: AgentAttemptLifecycleState = {
       currentTurnUserMessagePersisted: false,
       lifecycleFinishing: false,
       lifecycleEnded: false,
@@ -1706,6 +1709,52 @@ async function agentCommandInternal(
           aborted: runResult.meta.aborted ?? false,
           stopReason,
           ...resolveAgentRunAbortLifecycleFields(opts.abortSignal),
+        },
+      });
+    };
+    const resolveLifecycleResultError = (
+      runResult: AgentAttemptResult,
+      includeErrorPayload: boolean,
+    ) =>
+      attemptLifecycleState.lifecycleError ??
+      (includeErrorPayload
+        ? runResult.payloads?.find(
+            (payload) => payload.isError === true && typeof payload.text === "string",
+          )?.text
+        : undefined) ??
+      (runResult.meta.error ? "Agent run failed" : undefined);
+    const emitLifecycleResultError = (
+      runResult: AgentAttemptResult,
+      fallbackExhausted: boolean,
+    ) => {
+      if (attemptLifecycleState.lifecycleEnded) {
+        return;
+      }
+      attemptLifecycleState.lifecycleEnded = true;
+      const error =
+        resolveLifecycleResultError(runResult, fallbackExhausted) ??
+        (fallbackExhausted ? "All model fallback candidates failed" : "Agent run failed");
+      emitAgentEvent({
+        runId,
+        lifecycleGeneration,
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          startedAt,
+          endedAt: Date.now(),
+          error,
+          ...(runResult.meta.stopReason ? { stopReason: runResult.meta.stopReason } : {}),
+          ...(runResult.meta.livenessState ? { livenessState: runResult.meta.livenessState } : {}),
+          ...(runResult.meta.timeoutPhase ? { timeoutPhase: runResult.meta.timeoutPhase } : {}),
+          ...(typeof runResult.meta.providerStarted === "boolean"
+            ? { providerStarted: runResult.meta.providerStarted }
+            : {}),
+          ...(typeof runResult.meta.aborted === "boolean"
+            ? { aborted: runResult.meta.aborted }
+            : {}),
+          ...(runResult.meta.replayInvalid === true ? { replayInvalid: true } : {}),
+          ...(runResult.meta.yielded === true ? { yielded: true } : {}),
+          ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
         },
       });
     };
@@ -1805,6 +1854,9 @@ async function agentCommandInternal(
           mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           abortSignal: opts.abortSignal,
           run: async (providerOverride, modelOverride, runOptions) => {
+            attemptLifecycleState.lifecycleError = undefined;
+            attemptLifecycleState.lifecycleFinishing = false;
+            attemptLifecycleState.lifecycleEnded = false;
             const isAutoFallbackPrimaryProbeCandidate =
               autoFallbackPrimaryProbe &&
               providerOverride === autoFallbackPrimaryProbe.provider &&
@@ -1878,7 +1930,7 @@ async function agentCommandInternal(
                 lifecycleGeneration = nextLifecycleGeneration;
               },
               onAgentEvent: attemptLifecycleCallbacks.onAgentEvent,
-              deferTerminalLifecycleEnd: true,
+              deferTerminalLifecycle: true,
             });
           },
         });
@@ -1947,7 +1999,9 @@ async function agentCommandInternal(
             },
           };
         }
-        emitLifecycleFinishing(result);
+        if (!fallbackExhausted) {
+          emitLifecycleFinishing(result);
+        }
         break;
       } catch (err) {
         if (err instanceof LiveSessionModelSwitchError) {
@@ -2269,7 +2323,11 @@ async function agentCommandInternal(
         }
       }
 
-      emitLifecycleEnd(result);
+      if (fallbackExhausted || resolveLifecycleResultError(result, false)) {
+        emitLifecycleResultError(result, fallbackExhausted);
+      } else {
+        emitLifecycleEnd(result);
+      }
       return deliveryResult;
     } catch (error) {
       emitLifecyclePostTurnError(error);

--- a/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -31,6 +31,7 @@ const beforeToolCallMocks = vi.hoisted(() => ({
   },
   consumeAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
   recordAdjustedParamsForToolCall: vi.fn(),
+  recordStructuredReplayTrustForToolCall: vi.fn(),
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
@@ -97,6 +98,11 @@ async function loadFreshAfterToolCallModulesForTest() {
     emitAgentEvent: vi.fn(),
     emitAgentItemEvent: vi.fn(),
   }));
+  vi.doMock("./agent-tools.before-tool-call.state.js", () => ({
+    consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    consumePreExecutionBlockedToolCall: vi.fn(() => false),
+    consumeStructuredReplaySafeToolCall: vi.fn(() => false),
+  }));
   vi.doMock("./agent-tools.before-tool-call.js", () => ({
     BeforeToolCallBlockedError: beforeToolCallMocks.BeforeToolCallBlockedError,
     buildBlockedToolResult: ({ reason }: { reason: string }) => ({
@@ -104,7 +110,10 @@ async function loadFreshAfterToolCallModulesForTest() {
       details: { status: "blocked", deniedReason: "plugin-before-tool-call", reason },
     }),
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    consumePreExecutionBlockedToolCall: vi.fn(() => false),
     recordAdjustedParamsForToolCall: beforeToolCallMocks.recordAdjustedParamsForToolCall,
+    recordStructuredReplayTrustForToolCall:
+      beforeToolCallMocks.recordStructuredReplayTrustForToolCall,
     isBeforeToolCallBlockedError: (error: unknown) =>
       error instanceof beforeToolCallMocks.BeforeToolCallBlockedError,
     isToolWrappedWithBeforeToolCallHook: beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook,

--- a/src/agents/agent-tool-definition-adapter.after-tool-call.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.test.ts
@@ -25,6 +25,7 @@ const hookMocks = vi.hoisted(() => ({
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   consumeAdjustedParamsForToolCall: vi.fn((_: string) => undefined as unknown),
   recordAdjustedParamsForToolCall: vi.fn(),
+  recordStructuredReplayTrustForToolCall: vi.fn(),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
     params,
@@ -43,6 +44,7 @@ vi.mock("./agent-tools.before-tool-call.js", () => ({
   }),
   consumeAdjustedParamsForToolCall: hookMocks.consumeAdjustedParamsForToolCall,
   recordAdjustedParamsForToolCall: hookMocks.recordAdjustedParamsForToolCall,
+  recordStructuredReplayTrustForToolCall: hookMocks.recordStructuredReplayTrustForToolCall,
   isBeforeToolCallBlockedError: (error: unknown) =>
     error instanceof hookMocks.BeforeToolCallBlockedError,
   isToolWrappedWithBeforeToolCallHook: hookMocks.isToolWrappedWithBeforeToolCallHook,
@@ -72,6 +74,7 @@ describe("agent tool definition adapter after_tool_call", () => {
     hookMocks.consumeAdjustedParamsForToolCall.mockClear();
     hookMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
     hookMocks.recordAdjustedParamsForToolCall.mockClear();
+    hookMocks.recordStructuredReplayTrustForToolCall.mockClear();
     hookMocks.runBeforeToolCallHook.mockClear();
     hookMocks.runBeforeToolCallHook.mockImplementation(async ({ params }) => ({
       blocked: false,

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -402,6 +402,8 @@ export function toToolDefinitions(
                 return buildBlockedToolResult({
                   reason: hookOutcome.reason,
                   deniedReason: hookOutcome.deniedReason,
+                  toolCallId,
+                  runId: hookContext?.runId,
                 });
               }
               throw new Error(hookOutcome.reason);
@@ -433,6 +435,8 @@ export function toToolDefinitions(
             logDebug(`tools: ${normalizedName} blocked by before_tool_call: ${err.reason}`);
             return buildBlockedToolResult({
               reason: err.reason,
+              toolCallId,
+              runId: hookContext?.runId,
             });
           }
           const described = describeToolExecutionError(err);
@@ -522,6 +526,8 @@ export function toClientToolDefinitions(
               return buildBlockedToolResult({
                 reason: outcome.reason,
                 deniedReason: outcome.deniedReason,
+                toolCallId,
+                runId: hookContext?.runId,
               });
             }
             throw new Error(outcome.reason);

--- a/src/agents/agent-tool-definition-adapter.ts
+++ b/src/agents/agent-tool-definition-adapter.ts
@@ -13,6 +13,7 @@ import {
   isToolWrappedWithBeforeToolCallHook,
   isBeforeToolCallBlockedError,
   recordAdjustedParamsForToolCall,
+  recordStructuredReplayTrustForToolCall,
   runBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import {
@@ -372,6 +373,7 @@ export function toToolDefinitions(
       executionMode: tool.executionMode,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
+        recordStructuredReplayTrustForToolCall(toolCallId, tool, hookContext?.runId);
         let executeParams = params;
         try {
           if (!beforeHookWrapped) {

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -977,15 +977,33 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     );
   });
 
-  it("clears a parallel terminal presentation when a later finalized tool has none", async () => {
-    let terminalPresentation: string | undefined;
-    const onToolOutcome = vi.fn((outcome: { terminalPresentation?: string }) => {
-      terminalPresentation = outcome.terminalPresentation;
+  it("keeps the later model-ordered result when parallel tools finish out of order", async () => {
+    type ToolResult = { content: []; details: { ok?: boolean; status?: number } };
+    let resolvePresentation!: (result: ToolResult) => void;
+    let resolvePlain!: (result: ToolResult) => void;
+    const presentationExecution = new Promise<ToolResult>((resolve) => {
+      resolvePresentation = resolve;
     });
+    const plainExecution = new Promise<ToolResult>((resolve) => {
+      resolvePlain = resolve;
+    });
+    let terminalPresentation: string | undefined;
+    let latestOrdinal = -1;
+    const onToolOutcome = vi.fn(
+      (outcome: { toolCallOrdinal?: number; terminalPresentation?: string }) => {
+        const ordinal = outcome.toolCallOrdinal ?? latestOrdinal + 1;
+        if (ordinal >= latestOrdinal) {
+          latestOrdinal = ordinal;
+          terminalPresentation = outcome.terminalPresentation;
+        }
+      },
+    );
+    let nextToolOutcomeOrdinal = 0;
     const hookContext = {
       runId: "run-parallel-terminal-presentation",
       sessionId: "session-parallel-terminal-presentation",
       onToolOutcome,
+      allocateToolOutcomeOrdinal: () => nextToolOutcomeOrdinal++,
     };
     const presentationTool = wrapToolWithBeforeToolCallHook(
       setToolTerminalPresentation(
@@ -993,10 +1011,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
           name: "web_fetch",
           description: "fetch",
           parameters: {},
-          execute: vi.fn().mockResolvedValue({
-            content: [],
-            details: { status: 200 },
-          }),
+          execute: vi.fn(() => presentationExecution),
         } as any,
         () => ({ text: "Fetched with status 200" }),
       ),
@@ -1007,24 +1022,16 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         name: "read_file",
         description: "read",
         parameters: {},
-        execute: vi.fn().mockResolvedValue({
-          content: [],
-          details: { ok: true },
-        }),
+        execute: vi.fn(() => plainExecution),
       } as any,
       hookContext,
     );
 
-    const presentationResult = await presentationTool.execute("call-presentation", {});
-    const plainResult = await plainTool.execute("call-plain", {});
-    finalizeToolTerminalPresentation({
-      toolCallId: "call-presentation",
-      runId: hookContext.runId,
-      result: presentationResult,
-      isError: false,
-    });
-    expect(terminalPresentation).toBe("Fetched with status 200");
+    const presentationResultPromise = presentationTool.execute("call-presentation", {});
+    const plainResultPromise = plainTool.execute("call-plain", {});
 
+    resolvePlain({ content: [], details: { ok: true } });
+    const plainResult = await plainResultPromise;
     finalizeToolTerminalPresentation({
       toolCallId: "call-plain",
       runId: hookContext.runId,
@@ -1032,10 +1039,24 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       isError: false,
     });
     expect(terminalPresentation).toBeUndefined();
+
+    resolvePresentation({ content: [], details: { status: 200 } });
+    const presentationResult = await presentationResultPromise;
+    finalizeToolTerminalPresentation({
+      toolCallId: "call-presentation",
+      runId: hookContext.runId,
+      result: presentationResult,
+      isError: false,
+    });
+
+    expect(terminalPresentation).toBeUndefined();
+    expect(onToolOutcome.mock.calls.map(([outcome]) => outcome.toolCallOrdinal)).toEqual([
+      1, 1, 0, 0,
+    ]);
     expect(onToolOutcome).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        presentationOnly: true,
-        terminalPresentation: undefined,
+        toolCallOrdinal: 0,
+        terminalPresentation: "Fetched with status 200",
       }),
     );
   });

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -23,12 +23,15 @@ import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import {
   testing as beforeToolCallTesting,
   consumeAdjustedParamsForToolCall,
+  finalizeToolTerminalPresentation,
   isToolWrappedWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
+import { normalizeToolParameters } from "./agent-tools.schema.js";
 import { markCodeModeControlTool } from "./code-mode-control-tools.js";
 import { CODE_MODE_EXEC_TOOL_NAME, createCodeModeTools } from "./code-mode.js";
 import { splitSdkTools } from "./embedded-agent-runner.js";
+import { setToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
 type BeforeToolCallHandlerMock = ReturnType<typeof vi.fn>;
 
@@ -937,6 +940,104 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     );
 
     expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits a tool-authored terminal presentation with the recorded outcome", async () => {
+    const onToolOutcome = vi.fn();
+    const sourceTool = setToolTerminalPresentation(
+      {
+        name: "web_fetch",
+        description: "fetch",
+        parameters: {},
+        execute: vi.fn().mockResolvedValue({
+          content: [],
+          details: { status: 200 },
+        }),
+      } as any,
+      (_params, result) => ({
+        text: `Fetched with status ${(result.details as { status: number }).status}`,
+      }),
+    );
+    const tool = wrapToolWithBeforeToolCallHook(
+      normalizeToolParameters(sourceTool, { modelProvider: "openai" }),
+      {
+        sessionId: "session-terminal-presentation",
+        onToolOutcome,
+      },
+    );
+    await tool.execute("call-terminal-presentation", {
+      url: "https://example.com",
+    });
+
+    expect(onToolOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "web_fetch",
+        terminalPresentation: "Fetched with status 200",
+      }),
+    );
+  });
+
+  it("clears a parallel terminal presentation when a later finalized tool has none", async () => {
+    let terminalPresentation: string | undefined;
+    const onToolOutcome = vi.fn((outcome: { terminalPresentation?: string }) => {
+      terminalPresentation = outcome.terminalPresentation;
+    });
+    const hookContext = {
+      runId: "run-parallel-terminal-presentation",
+      sessionId: "session-parallel-terminal-presentation",
+      onToolOutcome,
+    };
+    const presentationTool = wrapToolWithBeforeToolCallHook(
+      setToolTerminalPresentation(
+        {
+          name: "web_fetch",
+          description: "fetch",
+          parameters: {},
+          execute: vi.fn().mockResolvedValue({
+            content: [],
+            details: { status: 200 },
+          }),
+        } as any,
+        () => ({ text: "Fetched with status 200" }),
+      ),
+      hookContext,
+    );
+    const plainTool = wrapToolWithBeforeToolCallHook(
+      {
+        name: "read_file",
+        description: "read",
+        parameters: {},
+        execute: vi.fn().mockResolvedValue({
+          content: [],
+          details: { ok: true },
+        }),
+      } as any,
+      hookContext,
+    );
+
+    const presentationResult = await presentationTool.execute("call-presentation", {});
+    const plainResult = await plainTool.execute("call-plain", {});
+    finalizeToolTerminalPresentation({
+      toolCallId: "call-presentation",
+      runId: hookContext.runId,
+      result: presentationResult,
+      isError: false,
+    });
+    expect(terminalPresentation).toBe("Fetched with status 200");
+
+    finalizeToolTerminalPresentation({
+      toolCallId: "call-plain",
+      runId: hookContext.runId,
+      result: plainResult,
+      isError: false,
+    });
+    expect(terminalPresentation).toBeUndefined();
+    expect(onToolOutcome).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        presentationOnly: true,
+        terminalPresentation: undefined,
+      }),
+    );
   });
 
   it("passes hook context for unwrapped tool definitions", async () => {

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -17,6 +17,7 @@ import { addTestHook, createMockPluginRegistry } from "../plugins/hooks.test-hel
 import { patchPluginSessionExtension } from "../plugins/host-hook-state.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { setPluginToolMeta } from "../plugins/tools.js";
 import type { PluginHookRegistration } from "../plugins/types.js";
 import { toClientToolDefinitions, toToolDefinitions } from "./agent-tool-definition-adapter.js";
 import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
@@ -31,6 +32,7 @@ import { normalizeToolParameters } from "./agent-tools.schema.js";
 import { markCodeModeControlTool } from "./code-mode-control-tools.js";
 import { CODE_MODE_EXEC_TOOL_NAME, createCodeModeTools } from "./code-mode.js";
 import { splitSdkTools } from "./embedded-agent-runner.js";
+import type { ExtensionContext } from "./sessions/index.js";
 import { setToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
 type BeforeToolCallHandlerMock = ReturnType<typeof vi.fn>;
@@ -92,6 +94,7 @@ describe("before_tool_call hook integration", () => {
     resetGlobalHookRunner();
     resetDiagnosticSessionStateForTest();
     beforeToolCallTesting.adjustedParamsByToolCallId.clear();
+    beforeToolCallTesting.structuredReplaySafeToolCallIds.clear();
     beforeToolCallHook = installBeforeToolCallHook();
   });
 
@@ -113,6 +116,54 @@ describe("before_tool_call hook integration", () => {
       undefined,
       extensionContext,
     );
+  });
+
+  it("records structured replay trust only for concrete core-owned tools", async () => {
+    beforeToolCallHook = installBeforeToolCallHook({ enabled: false });
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const coreTool = wrapToolWithBeforeToolCallHook({ name: "search", execute } as any, {
+      runId: "run-core",
+    });
+    const pluginSource = { name: "search", execute } as any;
+    setPluginToolMeta(pluginSource, { pluginId: "example", optional: false });
+    const pluginTool = wrapToolWithBeforeToolCallHook(pluginSource, {
+      runId: "run-plugin",
+    });
+
+    const [coreDefinition] = toToolDefinitions([coreTool], { runId: "run-core" });
+    const [pluginDefinition] = toToolDefinitions([pluginTool], { runId: "run-plugin" });
+    const extensionContext = {} as ExtensionContext;
+    await coreDefinition?.execute(
+      "call-core",
+      { query: "core" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    await pluginDefinition?.execute(
+      "call-plugin",
+      { query: "plugin" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(
+      beforeToolCallTesting.structuredReplaySafeToolCallIds.has(
+        beforeToolCallTesting.buildAdjustedParamsKey({
+          runId: "run-core",
+          toolCallId: "call-core",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      beforeToolCallTesting.structuredReplaySafeToolCallIds.has(
+        beforeToolCallTesting.buildAdjustedParamsKey({
+          runId: "run-plugin",
+          toolCallId: "call-plugin",
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("allows hook to modify parameters", async () => {

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -4,8 +4,10 @@
  * normalized payload selected by hook processing.
  */
 export const adjustedParamsByToolCallId = new Map<string, unknown>();
+export const preExecutionBlockedToolCallIds = new Set<string>();
 
 /** Clear adjusted tool parameters between isolated tests. */
 export function resetAdjustedParamsByToolCallIdForTests(): void {
   adjustedParamsByToolCallId.clear();
+  preExecutionBlockedToolCallIds.clear();
 }

--- a/src/agents/agent-tools.before-tool-call.state.ts
+++ b/src/agents/agent-tools.before-tool-call.state.ts
@@ -5,9 +5,52 @@
  */
 export const adjustedParamsByToolCallId = new Map<string, unknown>();
 export const preExecutionBlockedToolCallIds = new Set<string>();
+export const structuredReplaySafeToolCallIds = new Set<string>();
+
+export function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }): string {
+  if (params.runId && params.runId.trim()) {
+    return `${params.runId}:${params.toolCallId}`;
+  }
+  return params.toolCallId;
+}
+
+/** Consume and remove hook-adjusted params for a completed tool call. */
+export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  const params = adjustedParamsByToolCallId.get(key);
+  adjustedParamsByToolCallId.delete(key);
+  return params;
+}
+
+/** Snapshot hook-adjusted params without consuming later outcome bookkeeping. */
+export function peekAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  const params = adjustedParamsByToolCallId.get(key);
+  return params === undefined ? undefined : structuredClone(params);
+}
+
+/** Consume whether policy prevented the target tool from starting. */
+export function consumePreExecutionBlockedToolCall(toolCallId: string, runId?: string): boolean {
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  const blocked = preExecutionBlockedToolCallIds.has(key);
+  preExecutionBlockedToolCallIds.delete(key);
+  return blocked;
+}
+
+export function recordStructuredReplaySafeToolCall(toolCallId: string, runId?: string): void {
+  structuredReplaySafeToolCallIds.add(buildAdjustedParamsKey({ runId, toolCallId }));
+}
+
+export function consumeStructuredReplaySafeToolCall(toolCallId: string, runId?: string): boolean {
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  const replaySafe = structuredReplaySafeToolCallIds.has(key);
+  structuredReplaySafeToolCallIds.delete(key);
+  return replaySafe;
+}
 
 /** Clear adjusted tool parameters between isolated tests. */
 export function resetAdjustedParamsByToolCallIdForTests(): void {
   adjustedParamsByToolCallId.clear();
   preExecutionBlockedToolCallIds.clear();
+  structuredReplaySafeToolCallIds.clear();
 }

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -61,7 +61,15 @@ import { resolveSkillWorkshopToolApproval } from "../skills/workshop/policy.js";
 import { isPlainObject, truncateUtf16Safe } from "../utils.js";
 import {
   adjustedParamsByToolCallId,
+  buildAdjustedParamsKey,
   preExecutionBlockedToolCallIds,
+  recordStructuredReplaySafeToolCall,
+  structuredReplaySafeToolCallIds,
+} from "./agent-tools.before-tool-call.state.js";
+export {
+  consumeAdjustedParamsForToolCall,
+  consumePreExecutionBlockedToolCall,
+  peekAdjustedParamsForToolCall,
 } from "./agent-tools.before-tool-call.state.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
@@ -352,6 +360,25 @@ export function recordAdjustedParamsForToolCall(
   }
 }
 
+/** Record that one concrete core-owned tool call may use structured replay classification. */
+export function recordStructuredReplayTrustForToolCall(
+  toolCallId: string | undefined,
+  tool: AnyAgentTool,
+  runId?: string,
+): void {
+  if (!toolCallId || getPluginToolMeta(tool) || getChannelAgentToolMeta(tool as never)) {
+    return;
+  }
+  recordStructuredReplaySafeToolCall(toolCallId, runId);
+  while (structuredReplaySafeToolCallIds.size > MAX_TRACKED_ADJUSTED_PARAMS) {
+    const oldest = structuredReplaySafeToolCallIds.values().next().value;
+    if (!oldest) {
+      break;
+    }
+    structuredReplaySafeToolCallIds.delete(oldest);
+  }
+}
+
 /**
  * Returns true when an error represents an intentional before_tool_call veto.
  */
@@ -363,13 +390,6 @@ const loadBeforeToolCallRuntime = createLazyRuntimeSurface(
   () => import("./agent-tools.before-tool-call.runtime.js"),
   ({ beforeToolCallRuntime }) => beforeToolCallRuntime,
 );
-
-function buildAdjustedParamsKey(params: { runId?: string; toolCallId: string }): string {
-  if (params.runId && params.runId.trim()) {
-    return `${params.runId}:${params.toolCallId}`;
-  }
-  return params.toolCallId;
-}
 
 function mergeParamsWithApprovalOverrides(
   originalParams: unknown,
@@ -1538,29 +1558,6 @@ export function copyBeforeToolCallHookMarker(source: AnyAgentTool, target: AnyAg
   });
 }
 
-/** Consume and remove hook-adjusted params for a completed tool call. */
-export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
-  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
-  const params = adjustedParamsByToolCallId.get(adjustedParamsKey);
-  adjustedParamsByToolCallId.delete(adjustedParamsKey);
-  return params;
-}
-
-/** Snapshot hook-adjusted params without consuming later outcome bookkeeping. */
-export function peekAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
-  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
-  const params = adjustedParamsByToolCallId.get(adjustedParamsKey);
-  return params === undefined ? undefined : structuredClone(params);
-}
-
-/** Consume whether policy prevented the target tool from starting. */
-export function consumePreExecutionBlockedToolCall(toolCallId: string, runId?: string): boolean {
-  const key = buildAdjustedParamsKey({ runId, toolCallId });
-  const blocked = preExecutionBlockedToolCallIds.has(key);
-  preExecutionBlockedToolCallIds.delete(key);
-  return blocked;
-}
-
 function recordPreExecutionBlockedToolCall(toolCallId?: string, runId?: string): void {
   if (!toolCallId) {
     return;
@@ -1584,6 +1581,7 @@ export const testing = {
   buildAdjustedParamsKey,
   adjustedParamsByToolCallId,
   preExecutionBlockedToolCallIds,
+  structuredReplaySafeToolCallIds,
   runBeforeToolCallHook,
   mergeParamsWithApprovalOverrides,
   isPlainObject,

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -34,6 +34,7 @@ import {
   MAX_PLUGIN_APPROVAL_TIMEOUT_MS,
 } from "../infra/plugin-approvals.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
+import { redactToolDetail } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { deriveToolParams } from "../plugins/host-tool-param-parsers.js";
@@ -57,8 +58,11 @@ import {
 } from "../skills/loading/source.js";
 import type { SkillSnapshot, SkillTelemetrySource } from "../skills/types.js";
 import { resolveSkillWorkshopToolApproval } from "../skills/workshop/policy.js";
-import { isPlainObject } from "../utils.js";
-import { adjustedParamsByToolCallId } from "./agent-tools.before-tool-call.state.js";
+import { isPlainObject, truncateUtf16Safe } from "../utils.js";
+import {
+  adjustedParamsByToolCallId,
+  preExecutionBlockedToolCallIds,
+} from "./agent-tools.before-tool-call.state.js";
 import { copyChannelAgentToolMeta, getChannelAgentToolMeta } from "./channel-tools.js";
 import {
   getCodeModeExecBeforeHookMetadata,
@@ -69,6 +73,7 @@ import {
 } from "./code-mode-control-tools.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { normalizeToolName } from "./tool-policy.js";
+import { getToolTerminalPresentation } from "./tool-terminal-presentation.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
@@ -76,6 +81,8 @@ export type ToolOutcomeObservation = {
   toolName: string;
   argsHash: string;
   resultHash: string;
+  terminalPresentation?: string;
+  presentationOnly?: boolean;
 };
 
 export type ToolOutcomeObserver = (observation: ToolOutcomeObservation) => void;
@@ -207,8 +214,107 @@ const BEFORE_TOOL_CALL_HOOK_CONTEXT = Symbol("beforeToolCallHookContext");
 const BEFORE_TOOL_CALL_HOOK_FAILURE_REASON =
   "Tool call blocked because before_tool_call hook failed";
 const MAX_TRACKED_ADJUSTED_PARAMS = 1024;
+const MAX_PENDING_TERMINAL_PRESENTATIONS = 1024;
 const LOOP_WARNING_BUCKET_SIZE = 10;
 const MAX_LOOP_WARNING_KEYS = 256;
+const MAX_TERMINAL_PRESENTATION_CHARS = 2_000;
+const pendingTerminalPresentationByToolCall = new Map<
+  string,
+  {
+    observer: ToolOutcomeObserver;
+    tool: AnyAgentTool;
+    toolParams: unknown;
+  }
+>();
+
+export function resolveToolTerminalPresentation(params: {
+  tool: AnyAgentTool;
+  toolParams: unknown;
+  result: Awaited<ReturnType<AnyAgentTool["execute"]>>;
+}): string | undefined {
+  try {
+    const taggedTool = params.tool as unknown as Record<symbol, unknown>;
+    const sourceTool = taggedTool[BEFORE_TOOL_CALL_SOURCE_TOOL];
+    const presentationTool =
+      sourceTool && typeof sourceTool === "object" ? (sourceTool as AnyAgentTool) : params.tool;
+    const text = getToolTerminalPresentation(presentationTool)?.(
+      params.toolParams,
+      params.result,
+    )?.text.trim();
+    if (!text) {
+      return undefined;
+    }
+    return truncateUtf16Safe(redactToolDetail(text), MAX_TERMINAL_PRESENTATION_CHARS);
+  } catch (err) {
+    log.warn(
+      `terminal tool presentation failed: tool=${params.tool.name || "tool"} error=${String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+function rememberPendingTerminalPresentation(params: {
+  ctx?: HookContext;
+  tool: AnyAgentTool;
+  toolParams: unknown;
+  toolCallId?: string;
+}): void {
+  if (!params.toolCallId || !params.ctx?.onToolOutcome) {
+    return;
+  }
+  const key = buildAdjustedParamsKey({
+    runId: params.ctx.runId,
+    toolCallId: params.toolCallId,
+  });
+  pendingTerminalPresentationByToolCall.set(key, {
+    observer: params.ctx.onToolOutcome,
+    tool: params.tool,
+    toolParams: structuredClone(params.toolParams),
+  });
+  while (pendingTerminalPresentationByToolCall.size > MAX_PENDING_TERMINAL_PRESENTATIONS) {
+    const oldestKey = pendingTerminalPresentationByToolCall.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    pendingTerminalPresentationByToolCall.delete(oldestKey);
+  }
+}
+
+/** Finalizes a trusted terminal summary after harness result middleware. */
+export function finalizeToolTerminalPresentation(params: {
+  toolCallId: string;
+  runId?: string;
+  result: Awaited<ReturnType<AnyAgentTool["execute"]>>;
+  isError: boolean;
+  observer?: ToolOutcomeObserver;
+  toolName?: string;
+}): void {
+  const key = buildAdjustedParamsKey({
+    runId: params.runId,
+    toolCallId: params.toolCallId,
+  });
+  const pending = pendingTerminalPresentationByToolCall.get(key);
+  pendingTerminalPresentationByToolCall.delete(key);
+  const observer = pending?.observer ?? params.observer;
+  if (!observer) {
+    return;
+  }
+  observer({
+    toolName: pending?.tool.name || params.toolName || "tool",
+    argsHash: "",
+    resultHash: "",
+    terminalPresentation: params.isError
+      ? undefined
+      : pending
+        ? resolveToolTerminalPresentation({
+            tool: pending.tool,
+            toolParams: pending.toolParams,
+            result: params.result,
+          })
+        : undefined,
+    presentationOnly: true,
+  });
+}
 
 /**
  * Error used when before_tool_call intentionally vetoes a tool call.
@@ -230,7 +336,7 @@ export function recordAdjustedParamsForToolCall(
     return;
   }
   const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
-  adjustedParamsByToolCallId.set(adjustedParamsKey, params);
+  adjustedParamsByToolCallId.set(adjustedParamsKey, structuredClone(params));
   if (adjustedParamsByToolCallId.size > MAX_TRACKED_ADJUSTED_PARAMS) {
     const oldest = adjustedParamsByToolCallId.keys().next().value;
     if (oldest) {
@@ -696,7 +802,10 @@ async function resolveSkillWorkshopApprovalForFinalParams(params: {
 export function buildBlockedToolResult(params: {
   reason: string;
   deniedReason?: HookBlockedReason;
+  toolCallId?: string;
+  runId?: string;
 }) {
+  recordPreExecutionBlockedToolCall(params.toolCallId, params.runId);
   return {
     content: [{ type: "text" as const, text: params.reason }],
     details: {
@@ -778,6 +887,7 @@ async function recordLoopOutcome(args: {
   toolCallId?: string;
   result?: unknown;
   error?: unknown;
+  terminalPresentation?: string;
 }): Promise<void> {
   if (!args.ctx?.sessionKey && !args.ctx?.sessionId) {
     return;
@@ -803,6 +913,7 @@ async function recordLoopOutcome(args: {
         toolName: record.toolName,
         argsHash: record.argsHash,
         resultHash: record.resultHash,
+        ...(args.terminalPresentation ? { terminalPresentation: args.terminalPresentation } : {}),
       };
     }
   } catch (err) {
@@ -1198,6 +1309,8 @@ export function wrapToolWithBeforeToolCallHook(
         const blockedResult = buildBlockedToolResult({
           reason: outcome.reason,
           deniedReason: outcome.deniedReason ?? "plugin-before-tool-call",
+          toolCallId,
+          runId: ctx?.runId,
         });
         await recordLoopOutcome({
           ctx,
@@ -1244,12 +1357,24 @@ export function wrapToolWithBeforeToolCallHook(
       try {
         const result = await execute(toolCallId, executeParams, signal, onUpdate);
         const durationMs = Date.now() - startedAt;
+        const terminalPresentation = resolveToolTerminalPresentation({
+          tool,
+          toolParams: executeParams,
+          result,
+        });
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
           toolParams: executeParams,
           toolCallId,
           result,
+          terminalPresentation,
+        });
+        rememberPendingTerminalPresentation({
+          ctx,
+          tool,
+          toolParams: executeParams,
+          toolCallId,
         });
         const skillMatch = findSkillUsageMatch({
           toolName: normalizedToolName,
@@ -1405,6 +1530,35 @@ export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: str
   return params;
 }
 
+/** Snapshot hook-adjusted params without consuming later outcome bookkeeping. */
+export function peekAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
+  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
+  const params = adjustedParamsByToolCallId.get(adjustedParamsKey);
+  return params === undefined ? undefined : structuredClone(params);
+}
+
+/** Consume whether policy prevented the target tool from starting. */
+export function consumePreExecutionBlockedToolCall(toolCallId: string, runId?: string): boolean {
+  const key = buildAdjustedParamsKey({ runId, toolCallId });
+  const blocked = preExecutionBlockedToolCallIds.has(key);
+  preExecutionBlockedToolCallIds.delete(key);
+  return blocked;
+}
+
+function recordPreExecutionBlockedToolCall(toolCallId?: string, runId?: string): void {
+  if (!toolCallId) {
+    return;
+  }
+  preExecutionBlockedToolCallIds.add(buildAdjustedParamsKey({ runId, toolCallId }));
+  while (preExecutionBlockedToolCallIds.size > MAX_TRACKED_ADJUSTED_PARAMS) {
+    const oldest = preExecutionBlockedToolCallIds.values().next().value;
+    if (!oldest) {
+      break;
+    }
+    preExecutionBlockedToolCallIds.delete(oldest);
+  }
+}
+
 /** Test-only access to before_tool_call internals. */
 export const testing = {
   BEFORE_TOOL_CALL_DIAGNOSTIC_OPTIONS,
@@ -1413,6 +1567,7 @@ export const testing = {
   BEFORE_TOOL_CALL_WRAPPED,
   buildAdjustedParamsKey,
   adjustedParamsByToolCallId,
+  preExecutionBlockedToolCallIds,
   runBeforeToolCallHook,
   mergeParamsWithApprovalOverrides,
   isPlainObject,

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -81,6 +81,8 @@ export type ToolOutcomeObservation = {
   toolName: string;
   argsHash: string;
   resultHash: string;
+  /** Monotonic model-call order within the owning embedded run. */
+  toolCallOrdinal?: number;
   terminalPresentation?: string;
   presentationOnly?: boolean;
 };
@@ -116,6 +118,7 @@ export type HookContext = {
   channelId?: string;
   loopDetection?: ToolLoopDetectionConfig;
   onToolOutcome?: ToolOutcomeObserver;
+  allocateToolOutcomeOrdinal?: () => number;
   skillsSnapshot?: SkillSnapshot;
   skillCommand?: {
     commandName: string;
@@ -224,6 +227,7 @@ const pendingTerminalPresentationByToolCall = new Map<
     observer: ToolOutcomeObserver;
     tool: AnyAgentTool;
     toolParams: unknown;
+    toolCallOrdinal?: number;
   }
 >();
 
@@ -258,6 +262,7 @@ function rememberPendingTerminalPresentation(params: {
   tool: AnyAgentTool;
   toolParams: unknown;
   toolCallId?: string;
+  toolCallOrdinal?: number;
 }): void {
   if (!params.toolCallId || !params.ctx?.onToolOutcome) {
     return;
@@ -270,6 +275,7 @@ function rememberPendingTerminalPresentation(params: {
     observer: params.ctx.onToolOutcome,
     tool: params.tool,
     toolParams: structuredClone(params.toolParams),
+    toolCallOrdinal: params.toolCallOrdinal,
   });
   while (pendingTerminalPresentationByToolCall.size > MAX_PENDING_TERMINAL_PRESENTATIONS) {
     const oldestKey = pendingTerminalPresentationByToolCall.keys().next().value;
@@ -303,6 +309,7 @@ export function finalizeToolTerminalPresentation(params: {
     toolName: pending?.tool.name || params.toolName || "tool",
     argsHash: "",
     resultHash: "",
+    ...(pending?.toolCallOrdinal !== undefined ? { toolCallOrdinal: pending.toolCallOrdinal } : {}),
     terminalPresentation: params.isError
       ? undefined
       : pending
@@ -887,6 +894,7 @@ async function recordLoopOutcome(args: {
   toolCallId?: string;
   result?: unknown;
   error?: unknown;
+  toolCallOrdinal?: number;
   terminalPresentation?: string;
 }): Promise<void> {
   if (!args.ctx?.sessionKey && !args.ctx?.sessionId) {
@@ -913,6 +921,7 @@ async function recordLoopOutcome(args: {
         toolName: record.toolName,
         argsHash: record.argsHash,
         resultHash: record.resultHash,
+        ...(args.toolCallOrdinal !== undefined ? { toolCallOrdinal: args.toolCallOrdinal } : {}),
         ...(args.terminalPresentation ? { terminalPresentation: args.terminalPresentation } : {}),
       };
     }
@@ -1261,6 +1270,9 @@ export function wrapToolWithBeforeToolCallHook(
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
+      // Allocate before any async preparation so parallel completions retain
+      // the assistant message's tool-call order.
+      const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.();
       const prepare = (tool as BeforeToolCallPreparingTool).prepareBeforeToolCallParams;
       const preparedParams = prepare
         ? await prepare(params, {
@@ -1318,6 +1330,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: outcome.params ?? hookParams,
           toolCallId,
           result: blockedResult,
+          toolCallOrdinal,
         });
         return blockedResult;
       }
@@ -1368,6 +1381,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: executeParams,
           toolCallId,
           result,
+          toolCallOrdinal,
           terminalPresentation,
         });
         rememberPendingTerminalPresentation({
@@ -1375,6 +1389,7 @@ export function wrapToolWithBeforeToolCallHook(
           tool,
           toolParams: executeParams,
           toolCallId,
+          toolCallOrdinal,
         });
         const skillMatch = findSkillUsageMatch({
           toolName: normalizedToolName,
@@ -1428,6 +1443,7 @@ export function wrapToolWithBeforeToolCallHook(
           toolParams: executeParams,
           toolCallId,
           error: err,
+          toolCallOrdinal,
         });
         throw err;
       }

--- a/src/agents/agent-tools.deferred-followup-guidance.test.ts
+++ b/src/agents/agent-tools.deferred-followup-guidance.test.ts
@@ -3,8 +3,10 @@
  * Protects the model-facing text selected after tool filtering.
  */
 import { describe, expect, it } from "vitest";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
 import { applyDeferredFollowupToolDescriptions } from "./agent-tools.deferred-followup.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
+import { getChannelAgentToolMeta, setChannelAgentToolMeta } from "./channel-tool-metadata.js";
 
 function findToolDescription(toolName: string, includeCron: boolean) {
   const tools = applyDeferredFollowupToolDescriptions([
@@ -44,5 +46,22 @@ describe("createOpenClawCodingTools deferred follow-up guidance", () => {
     expect(process.description).toBe(
       "Manage running exec sessions for commands already started: list, poll, log, write, send-keys, submit, paste, kill. Use poll/log when you need status, logs, quiet-success confirmation, or completion confirmation when automatic completion wake is unavailable. Use poll/log also for input-wait hints. Use write/send-keys/submit/paste/kill for input or intervention.",
     );
+  });
+
+  it("preserves ownership metadata when replacing process descriptions", () => {
+    const processTool = {
+      name: "process",
+      description: "plugin process",
+    } as AnyAgentTool;
+    setPluginToolMeta(processTool, { pluginId: "example", optional: false });
+    setChannelAgentToolMeta(processTool as never, { channelId: "example-channel" });
+
+    const [updated] = applyDeferredFollowupToolDescriptions([processTool]);
+
+    expect(updated).not.toBe(processTool);
+    expect(getPluginToolMeta(updated)).toEqual({ pluginId: "example", optional: false });
+    expect(getChannelAgentToolMeta(updated as never)).toEqual({
+      channelId: "example-channel",
+    });
   });
 });

--- a/src/agents/agent-tools.deferred-followup.ts
+++ b/src/agents/agent-tools.deferred-followup.ts
@@ -1,3 +1,5 @@
+import { copyPluginToolMeta } from "../plugins/tools.js";
+import { copyBeforeToolCallHookMarker } from "./agent-tools.before-tool-call.js";
 /**
  * Adjusts exec/process tool descriptions for long-running follow-up behavior.
  * Cron-aware runs can point models at scheduled follow-ups; cronless runs keep
@@ -5,6 +7,17 @@
  */
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { describeExecTool, describeProcessTool } from "./bash-tools.descriptions.js";
+import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
+
+function replaceDescription(tool: AnyAgentTool, description: string): AnyAgentTool {
+  const updated = { ...tool, description };
+  copyPluginToolMeta(tool, updated);
+  copyChannelAgentToolMeta(tool as never, updated as never);
+  copyBeforeToolCallHookMarker(tool, updated);
+  copyToolTerminalPresentation(tool, updated);
+  return updated;
+}
 
 /** Return tools with exec/process descriptions adjusted for cron availability. */
 export function applyDeferredFollowupToolDescriptions(
@@ -14,16 +27,10 @@ export function applyDeferredFollowupToolDescriptions(
   const hasCronTool = tools.some((tool) => tool.name === "cron");
   return tools.map((tool) => {
     if (tool.name === "exec") {
-      return {
-        ...tool,
-        description: describeExecTool({ agentId: params?.agentId, hasCronTool }),
-      };
+      return replaceDescription(tool, describeExecTool({ agentId: params?.agentId, hasCronTool }));
     }
     if (tool.name === "process") {
-      return {
-        ...tool,
-        description: describeProcessTool({ hasCronTool }),
-      };
+      return replaceDescription(tool, describeProcessTool({ hasCronTool }));
     }
     return tool;
   });

--- a/src/agents/agent-tools.schema.ts
+++ b/src/agents/agent-tools.schema.ts
@@ -11,6 +11,7 @@ import {
 import { copyBeforeToolCallHookMarker } from "./agent-tools.before-tool-call.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
 export { normalizeToolParameterSchema };
 
@@ -74,6 +75,7 @@ export function normalizeToolParameters(
     copyPluginToolMeta(tool, target);
     copyChannelAgentToolMeta(tool as never, target as never);
     copyBeforeToolCallHookMarker(tool, target);
+    copyToolTerminalPresentation(tool, target);
     return target;
   }
   const schema =

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -553,6 +553,8 @@ export function createOpenClawCodingTools(options?: {
   toolPolicyAuditLogLevel?: "info" | "debug";
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
+  /** Supplies run-global model-call ordering for parallel tool outcomes. */
+  allocateToolOutcomeOrdinal?: () => number;
   /** Runtime-only resolved skill paths that the read tool may load under workspaceOnly. */
   skillsSnapshot?: SkillSnapshot;
 }): AnyAgentTool[] {
@@ -1191,6 +1193,7 @@ export function createOpenClawCodingTools(options?: {
     ...(options?.trace ? { trace: options.trace } : {}),
     loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
     onToolOutcome: options?.onToolOutcome,
+    allocateToolOutcomeOrdinal: options?.allocateToolOutcomeOrdinal,
   };
   const hookOptions = { emitDiagnostics: options?.emitBeforeToolCallDiagnostics };
   const withHooks = normalized.map((tool) =>

--- a/src/agents/command/attempt-callbacks.test.ts
+++ b/src/agents/command/attempt-callbacks.test.ts
@@ -1,10 +1,13 @@
 // Verifies the small lifecycle callback adapter used during agent attempts.
 import { describe, expect, it } from "vitest";
-import { createAgentAttemptLifecycleCallbacks } from "./attempt-callbacks.js";
+import {
+  createAgentAttemptLifecycleCallbacks,
+  type AgentAttemptLifecycleState,
+} from "./attempt-callbacks.js";
 
 describe("createAgentAttemptLifecycleCallbacks", () => {
   it("tracks user-message persistence without closing over the agent command scope", () => {
-    const state = {
+    const state: AgentAttemptLifecycleState = {
       currentTurnUserMessagePersisted: false,
       lifecycleFinishing: false,
       lifecycleEnded: false,
@@ -36,5 +39,23 @@ describe("createAgentAttemptLifecycleCallbacks", () => {
 
     callbacks.onAgentEvent({ stream: "lifecycle", data: { phase: "end" } });
     expect(state.lifecycleEnded).toBe(true);
+  });
+
+  it("retains deferred lifecycle errors without marking the attempt terminal", () => {
+    const state: AgentAttemptLifecycleState = {
+      currentTurnUserMessagePersisted: false,
+      lifecycleFinishing: false,
+      lifecycleEnded: false,
+    };
+    const callbacks = createAgentAttemptLifecycleCallbacks(state);
+
+    callbacks.onAgentEvent({
+      stream: "lifecycle",
+      data: { phase: "finishing", error: "provider failed" },
+    });
+
+    expect(state.lifecycleError).toBe("provider failed");
+    expect(state.lifecycleFinishing).toBe(true);
+    expect(state.lifecycleEnded).toBe(false);
   });
 });

--- a/src/agents/command/attempt-callbacks.ts
+++ b/src/agents/command/attempt-callbacks.ts
@@ -6,6 +6,7 @@ import type { AgentMessage } from "../runtime/index.js";
 /** Mutable lifecycle flags observed while a single agent attempt runs. */
 export type AgentAttemptLifecycleState = {
   currentTurnUserMessagePersisted: boolean;
+  lifecycleError?: string;
   lifecycleFinishing: boolean;
   lifecycleEnded: boolean;
 };
@@ -29,6 +30,9 @@ export function createAgentAttemptLifecycleCallbacks(state: AgentAttemptLifecycl
     onAgentEvent: (evt) => {
       if (evt.stream !== "lifecycle" || typeof evt.data?.phase !== "string") {
         return;
+      }
+      if (typeof evt.data.error === "string" && evt.data.error.trim()) {
+        state.lifecycleError = evt.data.error;
       }
       // Finishing means output ended but transcript/session persistence may still
       // need to run; end/error means the runtime lifecycle is complete.

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -460,6 +460,8 @@ export function runAgentAttempt(params: {
     data?: Record<string, unknown>;
     sessionKey?: string;
   }) => void;
+  deferTerminalLifecycle?: boolean;
+  /** @deprecated Use deferTerminalLifecycle. */
   deferTerminalLifecycleEnd?: boolean;
   authProfileProvider: string;
   sessionStore?: Record<string, SessionEntry>;
@@ -757,6 +759,7 @@ export function runAgentAttempt(params: {
     promptMode: params.opts.promptMode,
     disableTools: params.opts.modelRun === true,
     onAgentEvent: params.onAgentEvent,
+    deferTerminalLifecycle: params.deferTerminalLifecycle,
     deferTerminalLifecycleEnd: params.deferTerminalLifecycleEnd,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
     onUserMessagePersisted: params.onUserMessagePersisted,

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1642,7 +1642,15 @@ describe("updateSessionStoreAfterAgentRun", () => {
           updatedAt: 1,
           modelProvider: "anthropic",
           model: "claude-opus-4-6",
+          agentHarnessId: "openclaw",
           contextTokens: 1_000_000,
+          cliSessionBindings: {
+            "claude-cli": { sessionId: "existing-cli-session" },
+          },
+          cliSessionIds: {
+            "claude-cli": "existing-cli-session",
+          },
+          claudeCliSessionId: "existing-cli-session",
           contextBudgetStatus: {
             schemaVersion: 1,
             source: "pre-prompt-estimate",
@@ -1672,9 +1680,11 @@ describe("updateSessionStoreAfterAgentRun", () => {
           durationMs: 500,
           agentMeta: {
             sessionId,
-            provider: "ollama",
-            model: "llama3.2:1b",
+            provider: "claude-cli",
+            model: "claude-sonnet-4-6",
+            agentHarnessId: "codex",
             contextTokens: 128_000,
+            cliSessionBinding: { sessionId: "heartbeat-cli-session" },
             contextBudgetStatus: {
               schemaVersion: 1,
               source: "pre-prompt-estimate",
@@ -1713,16 +1723,24 @@ describe("updateSessionStoreAfterAgentRun", () => {
       // Runtime model and contextTokens should be preserved from the original entry
       expect(sessionStore[sessionKey]?.model).toBe("claude-opus-4-6");
       expect(sessionStore[sessionKey]?.modelProvider).toBe("anthropic");
+      expect(sessionStore[sessionKey]?.agentHarnessId).toBe("openclaw");
       expect(sessionStore[sessionKey]?.contextTokens).toBe(1_000_000);
       expect(sessionStore[sessionKey]?.contextBudgetStatus?.provider).toBe("anthropic");
       expect(sessionStore[sessionKey]?.contextBudgetStatus?.estimatedPromptTokens).toBe(640_000);
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
+        sessionId: "existing-cli-session",
+      });
 
       const persisted = loadSessionStore(storePath);
       expect(persisted[sessionKey]?.model).toBe("claude-opus-4-6");
       expect(persisted[sessionKey]?.modelProvider).toBe("anthropic");
+      expect(persisted[sessionKey]?.agentHarnessId).toBe("openclaw");
       expect(persisted[sessionKey]?.contextTokens).toBe(1_000_000);
       expect(persisted[sessionKey]?.contextBudgetStatus?.provider).toBe("anthropic");
       expect(persisted[sessionKey]?.contextBudgetStatus?.estimatedPromptTokens).toBe(640_000);
+      expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toEqual({
+        sessionId: "existing-cli-session",
+      });
     });
   });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -185,12 +185,14 @@ export async function updateSessionStoreAfterAgentRun(params: {
     });
   }
   if (!preserveUserFacingRunState) {
-    if (agentHarnessId) {
-      next.agentHarnessId = agentHarnessId;
-    } else if (result.meta.executionTrace?.runner === "cli") {
-      next.agentHarnessId = undefined;
+    if (!preserveRuntimeModel) {
+      if (agentHarnessId) {
+        next.agentHarnessId = agentHarnessId;
+      } else if (result.meta.executionTrace?.runner === "cli") {
+        next.agentHarnessId = undefined;
+      }
     }
-    if (isCliProvider(providerUsed, cfg)) {
+    if (!preserveRuntimeModel && isCliProvider(providerUsed, cfg)) {
       const cliSessionBinding = result.meta.agentMeta?.cliSessionBinding;
       if (result.meta.agentMeta?.clearCliSessionBinding === true) {
         clearCliSession(next, providerUsed);

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -817,39 +817,26 @@ describe("runEmbeddedAgent", () => {
     expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledWith("session:test");
   });
 
-  it("retries a planning-only GPT turn once with an act-now steer", async () => {
+  it("returns visible assistant prose without semantic retry classification", async () => {
     const sessionFile = nextSessionFile();
     const cfg = createEmbeddedAgentRunnerOpenAiConfig(["gpt-5.4"]);
     const sessionKey = nextSessionKey();
 
-    runEmbeddedAttemptMock
-      .mockImplementationOnce(async (params: unknown) => {
-        expect((params as { prompt?: string }).prompt).toMatch(/^ship it(?:\n\n|$)/);
-        return makeEmbeddedRunnerAttempt({
-          assistantTexts: ["I'll inspect the files, make the change, and run the checks."],
-          lastAssistant: buildEmbeddedRunnerAssistant({
-            model: "gpt-5.4",
-            content: [
-              {
-                type: "text",
-                text: "I'll inspect the files, make the change, and run the checks.",
-              },
-            ],
-          }),
-        });
-      })
-      .mockImplementationOnce(async (params: unknown) => {
-        expect((params as { prompt?: string }).prompt).toContain(
-          "Do not restate the plan. Act now",
-        );
-        return makeEmbeddedRunnerAttempt({
-          assistantTexts: ["done"],
-          lastAssistant: buildEmbeddedRunnerAssistant({
-            model: "gpt-5.4",
-            content: [{ type: "text", text: "done" }],
-          }),
-        });
+    runEmbeddedAttemptMock.mockImplementationOnce(async (params: unknown) => {
+      expect((params as { prompt?: string }).prompt).toMatch(/^ship it(?:\n\n|$)/);
+      return makeEmbeddedRunnerAttempt({
+        assistantTexts: ["I'll inspect the files, make the change, and run the checks."],
+        lastAssistant: buildEmbeddedRunnerAssistant({
+          model: "gpt-5.4",
+          content: [
+            {
+              type: "text",
+              text: "I'll inspect the files, make the change, and run the checks.",
+            },
+          ],
+        }),
       });
+    });
 
     const result = await runEmbeddedAgent({
       sessionId: "session:test",
@@ -862,12 +849,14 @@ describe("runEmbeddedAgent", () => {
       model: "gpt-5.4",
       timeoutMs: 5_000,
       agentDir,
-      runId: nextRunId("planning-only-retry"),
+      runId: nextRunId("visible-prose"),
       enqueue: immediateEnqueue,
     });
 
-    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
-    expect(result.payloads?.[0]?.text).toBe("done");
+    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.text).toBe(
+      "I'll inspect the files, make the change, and run the checks.",
+    );
   });
 
   it("handles prompt error paths without dropping user state", async () => {

--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -1,8 +1,17 @@
+import { wrapToolWithBeforeToolCallHook } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  createTerminalPresentationContractTool,
+  textToolResult,
+} from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 // Covers embedded runner extension factories and tool-result middleware bridge.
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  consumeAdjustedParamsForToolCall,
+  recordAdjustedParamsForToolCall,
+} from "./agent-tools.before-tool-call.js";
 import { buildEmbeddedExtensionFactories } from "./embedded-agent-runner/extensions.js";
 import { consumeEmbeddedToolSendReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
 import { cleanupTempPluginTestEnvironment } from "./test-helpers/temp-plugin-extension-fixtures.js";
@@ -72,6 +81,169 @@ describe("buildEmbeddedExtensionFactories", () => {
     expect(seenToolCallIds[0]).toMatch(/^openclaw-/);
     expect(seenToolCallIds[1]).toMatch(/^openclaw-/);
     expect(seenToolCallIds[0]).not.toBe(seenToolCallIds[1]);
+  });
+
+  it("finalizes terminal presentation from the post-middleware result", async () => {
+    const registry = createEmptyPluginRegistry();
+    const seenMiddlewareArgs: unknown[] = [];
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "redactor",
+      pluginName: "redactor",
+      rawHandler: () => undefined,
+      handler: (event) => {
+        seenMiddlewareArgs.push(structuredClone(event.args));
+        (event.args as { url?: string }).url = "https://mutated.example";
+        return {
+          result: textToolResult("redacted output", {
+            origin: "redacted.example",
+            status: 200,
+          }),
+        };
+      },
+      runtimes: ["openclaw"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const onToolOutcome = vi.fn();
+    const tool = wrapToolWithBeforeToolCallHook(
+      createTerminalPresentationContractTool({
+        name: "web_fetch",
+        result: textToolResult("raw output", {
+          origin: "private.example",
+          status: 200,
+        }),
+        format: (params, result) => {
+          const input = params as { url?: string };
+          const details = result.details as { origin?: string; status?: number };
+          return `URL: ${String(input.url)}\nOrigin: ${String(details.origin)}\nStatus: ${String(details.status)}`;
+        },
+      }),
+      {
+        runId: "run-terminal-middleware",
+        sessionId: "session-terminal-middleware",
+        onToolOutcome,
+      },
+    );
+    const rawResult = await tool.execute(
+      "call-terminal-middleware",
+      { url: "https://private.example" },
+      undefined,
+      undefined,
+    );
+    recordAdjustedParamsForToolCall(
+      "call-terminal-middleware",
+      { url: "https://approved.example" },
+      "run-terminal-middleware",
+    );
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+      runId: "run-terminal-middleware",
+    });
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+
+    await handlers.get("tool_result")?.(
+      {
+        toolName: "web_fetch",
+        toolCallId: "call-terminal-middleware",
+        input: { url: "https://private.example" },
+        content: rawResult.content,
+        details: rawResult.details,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(onToolOutcome).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        presentationOnly: true,
+        terminalPresentation: "URL: https://private.example\nOrigin: redacted.example\nStatus: 200",
+      }),
+    );
+    expect(seenMiddlewareArgs).toEqual([{ url: "https://approved.example" }]);
+    expect(
+      consumeAdjustedParamsForToolCall("call-terminal-middleware", "run-terminal-middleware"),
+    ).toEqual({ url: "https://approved.example" });
+  });
+
+  it("clears terminal presentation when middleware blocks the result", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.agentToolResultMiddlewares.push({
+      pluginId: "blocker",
+      pluginName: "Blocker",
+      rawHandler: () => undefined,
+      handler: () => ({
+        result: textToolResult("blocked by middleware", {
+          status: "blocked",
+          reason: "policy denied",
+        }),
+      }),
+      runtimes: ["openclaw"],
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+    const onToolOutcome = vi.fn();
+    const tool = wrapToolWithBeforeToolCallHook(
+      createTerminalPresentationContractTool({
+        name: "web_fetch",
+        result: textToolResult("raw output", {
+          origin: "private.example",
+          status: 200,
+        }),
+        format: () => "Origin: private.example",
+      }),
+      {
+        runId: "run-terminal-blocked",
+        sessionId: "session-terminal-blocked",
+        onToolOutcome,
+      },
+    );
+    const rawResult = await tool.execute(
+      "call-terminal-blocked",
+      { url: "https://private.example" },
+      undefined,
+      undefined,
+    );
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: SessionManager.inMemory(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+      runId: "run-terminal-blocked",
+    });
+    const handlers = new Map<string, Function>();
+    await factories[0]?.({
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+    } as never);
+
+    const result = await handlers.get("tool_result")?.(
+      {
+        toolName: "web_fetch",
+        toolCallId: "call-terminal-blocked",
+        input: { url: "https://private.example" },
+        content: rawResult.content,
+        details: rawResult.details,
+      },
+      { cwd: "/tmp" },
+    );
+
+    expect(result).toMatchObject({ isError: true });
+    expect(onToolOutcome).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        presentationOnly: true,
+        terminalPresentation: undefined,
+      }),
+    );
   });
 
   it("marks status-error tool results as model-visible failures", async () => {

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -213,13 +213,20 @@ export function hasCommittedMessagingToolDeliveryEvidence(
   );
 }
 
-/** Returns whether any outbound side effect makes a retry unsafe. */
-export function hasOutboundDeliveryEvidence(result: AgentDeliveryEvidence): boolean {
+/** Returns whether committed outbound evidence makes replay unsafe. */
+export function hasCommittedOutboundDeliveryEvidence(result: AgentDeliveryEvidence): boolean {
   return (
     hasMessagingToolDeliveryEvidence(result) ||
     (Array.isArray(result.acceptedSessionSpawns) &&
       hasAcceptedSessionSpawn(result.acceptedSessionSpawns)) ||
-    hasPositiveNumber(result.successfulCronAdds) ||
+    hasPositiveNumber(result.successfulCronAdds)
+  );
+}
+
+/** Returns whether any tool progress or outbound side effect makes a retry unsafe. */
+export function hasOutboundDeliveryEvidence(result: AgentDeliveryEvidence): boolean {
+  return (
+    hasCommittedOutboundDeliveryEvidence(result) ||
     hasPositiveNumber(result.meta?.toolSummary?.calls)
   );
 }

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -2,7 +2,6 @@
  * Builds extension factories available to embedded-agent runtime sessions.
  */
 import { randomUUID } from "node:crypto";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { setCompactionSafeguardRuntime } from "../agent-hooks/compaction-safeguard-runtime.js";
@@ -15,11 +14,16 @@ import {
   ensureAgentCompactionReserveTokens,
   resolveEffectiveCompactionMode,
 } from "../agent-settings.js";
+import {
+  finalizeToolTerminalPresentation,
+  peekAdjustedParamsForToolCall,
+} from "../agent-tools.before-tool-call.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { createAgentToolResultMiddlewareRunner } from "../harness/tool-result-middleware.js";
 import type { AgentToolResult } from "../runtime/index.js";
 import type { ExtensionFactory, SessionManager } from "../sessions/index.js";
+import { isToolResultError } from "../tool-result-error.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
 import { recordEmbeddedToolSendReceipt } from "./tool-send-receipts.js";
@@ -41,16 +45,6 @@ function recordFromUnknown(value: unknown): Record<string, unknown> {
     : {};
 }
 
-// Only checks "error" and "timeout" — the status values emitted by the
-// adapter's buildToolExecutionErrorResult. The subscribe-side classifier
-// (isErrorLikeStatus) uses a broader regex because it handles arbitrary
-// external tool results; this bridge only elevates adapter-produced statuses.
-function hasErrorToolResultStatus(result: AgentToolResult<unknown>): boolean {
-  const details = recordFromUnknown(result.details);
-  const status = normalizeOptionalLowercaseString(details.status);
-  return status === "error" || status === "timeout";
-}
-
 function snapshotToolSendReceipt(details: unknown): unknown {
   const toolSend = recordFromUnknown(details).toolSend;
   return toolSend && typeof toolSend === "object" && !Array.isArray(toolSend)
@@ -58,7 +52,10 @@ function snapshotToolSendReceipt(details: unknown): unknown {
     : toolSend;
 }
 
-function buildAgentToolResultMiddlewareFactory(sessionManager: SessionManager): ExtensionFactory {
+function buildAgentToolResultMiddlewareFactory(
+  sessionManager: SessionManager,
+  runId?: string,
+): ExtensionFactory {
   const runner = createAgentToolResultMiddlewareRunner({ runtime: "openclaw" });
   return (agent) => {
     agent.on("tool_result", async (rawEvent: unknown, ctx: { cwd?: string }) => {
@@ -81,19 +78,29 @@ function buildAgentToolResultMiddlewareFactory(sessionManager: SessionManager): 
         // Routing evidence stays private so middleware may fully replace result details.
         recordEmbeddedToolSendReceipt(sessionManager, eventToolCallId, rawToolSend);
       }
-      const inputHadErrorStatus = hasErrorToolResultStatus(current);
+      const inputHadErrorStatus = isToolResultError(current);
+      const adjustedInput = eventToolCallId
+        ? peekAdjustedParamsForToolCall(eventToolCallId, runId)
+        : undefined;
       const result = await runner.applyToolResultMiddleware({
         threadId: event.threadId,
         turnId: event.turnId,
         toolCallId,
         toolName: event.toolName,
-        args: recordFromUnknown(event.input),
+        args: recordFromUnknown(adjustedInput ?? event.input),
         cwd: ctx.cwd,
         isError: event.isError,
         result: current,
       });
-      const isError =
-        event.isError === true || inputHadErrorStatus || hasErrorToolResultStatus(result);
+      const isError = event.isError === true || inputHadErrorStatus || isToolResultError(result);
+      if (eventToolCallId) {
+        finalizeToolTerminalPresentation({
+          toolCallId: eventToolCallId,
+          runId,
+          result,
+          isError,
+        });
+      }
       return {
         content: result.content,
         details: result.details,
@@ -165,6 +172,7 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  runId?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveEffectiveCompactionMode(params.cfg) === "safeguard") {
@@ -198,7 +206,7 @@ export function buildEmbeddedExtensionFactories(params: {
   if (pruningFactory) {
     factories.push(pruningFactory);
   }
-  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager));
+  factories.push(buildAgentToolResultMiddlewareFactory(params.sessionManager, params.runId));
   return factories;
 }
 

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -156,4 +156,107 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
 
     expect(result).toBeNull();
   });
+
+  it("keeps tool-authored incomplete summaries fallback-eligible", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text:
+              "Web fetch completed.\nOrigin: https://example.com\nStatus: 200\n\n" +
+              "⚠️ Agent couldn't generate a response. Please try again.",
+          },
+        ],
+        meta: {
+          durationMs: 42,
+          replayInvalid: true,
+          agentHarnessResultClassification: "empty",
+          toolSummary: {
+            calls: 1,
+          },
+          error: {
+            kind: "incomplete_turn",
+            message: "Agent couldn't generate a response.",
+            fallbackSafe: true,
+            terminalPresentation: true,
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message:
+        "Web fetch completed.\nOrigin: https://example.com\nStatus: 200\n\n" +
+        "⚠️ Agent couldn't generate a response. Please try again.",
+      reason: "format",
+      code: "incomplete_result",
+      preserveResultOnExhaustion: true,
+      preserveResultPriority: 1,
+    });
+  });
+
+  it("does not fallback after structured replay state records potential side effects", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [],
+        meta: {
+          durationMs: 42,
+          replayInvalid: true,
+          agentHarnessResultClassification: "reasoning-only",
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps side-effecting incomplete tool turns out of fallback before harness classification", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [{ isError: true, text: "Agent couldn't generate a response." }],
+        meta: {
+          durationMs: 42,
+          agentHarnessResultClassification: "empty",
+          toolSummary: {
+            calls: 1,
+          },
+          error: {
+            kind: "incomplete_turn",
+            message: "Agent couldn't generate a response.",
+            fallbackSafe: false,
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not trust fallback-safe metadata over concrete outbound delivery evidence", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "openai",
+      model: "gpt-5.5",
+      result: {
+        payloads: [{ isError: true, text: "Agent couldn't generate a response." }],
+        messagingToolSentTexts: ["already delivered"],
+        meta: {
+          durationMs: 42,
+          error: {
+            kind: "incomplete_turn",
+            message: "Agent couldn't generate a response.",
+            fallbackSafe: true,
+          },
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
 });

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -6,7 +6,10 @@ import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
 import { isGpt5ModelId } from "../gpt5-prompt-overlay.js";
 import type { ModelFallbackResultClassification } from "../model-fallback.js";
-import { hasOutboundDeliveryEvidence, hasVisibleAgentPayload } from "./delivery-evidence.js";
+import {
+  hasCommittedOutboundDeliveryEvidence,
+  hasVisibleAgentPayload,
+} from "./delivery-evidence.js";
 import type { EmbeddedAgentRunResult } from "./types.js";
 
 /**
@@ -15,9 +18,6 @@ import type { EmbeddedAgentRunResult } from "./types.js";
  * The classifier only flags failed invisible outcomes; delivered messages, deliberate silent
  * replies, hook blocks, and aborts must not trigger another model attempt.
  */
-const EMPTY_TERMINAL_REPLY_RE = /Agent couldn't generate a response/i;
-const PLAN_ONLY_TERMINAL_REPLY_RE = /Agent stopped after repeated plan-only turns/i;
-
 function isEmbeddedAgentRunResult(value: unknown): value is EmbeddedAgentRunResult {
   return Boolean(
     value &&
@@ -26,6 +26,43 @@ function isEmbeddedAgentRunResult(value: unknown): value is EmbeddedAgentRunResu
     (value as { meta?: unknown }).meta &&
     typeof (value as { meta?: unknown }).meta === "object",
   );
+}
+
+/** Keeps final-candidate bookkeeping while surfacing the best trusted terminal payload. */
+export function mergeEmbeddedAgentRunResultForModelFallbackExhaustion(params: {
+  latestResult: EmbeddedAgentRunResult;
+  preferredResult: EmbeddedAgentRunResult;
+}): EmbeddedAgentRunResult {
+  const executionTrace = params.latestResult.meta.executionTrace;
+  const filteredAttempts = executionTrace?.attempts?.filter(
+    (attempt) => attempt.result !== "success",
+  );
+  const traceNeedsNormalization =
+    executionTrace !== undefined &&
+    (executionTrace.winnerProvider !== undefined ||
+      executionTrace.winnerModel !== undefined ||
+      filteredAttempts?.length !== executionTrace.attempts?.length);
+  if (params.latestResult === params.preferredResult && !traceNeedsNormalization) {
+    return params.latestResult;
+  }
+  return {
+    ...params.latestResult,
+    payloads: params.preferredResult.payloads,
+    meta: {
+      ...params.latestResult.meta,
+      error: params.preferredResult.meta.error,
+      ...(traceNeedsNormalization
+        ? {
+            executionTrace: {
+              ...executionTrace,
+              winnerProvider: undefined,
+              winnerModel: undefined,
+              attempts: filteredAttempts?.length ? filteredAttempts : undefined,
+            },
+          }
+        : {}),
+    },
+  };
 }
 
 function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boolean {
@@ -57,7 +94,7 @@ function classifyHarnessResult(params: {
       };
     case "planning-only":
       return {
-        message: `${params.provider}/${params.model} exhausted plan-only retries without taking action`,
+        message: `${params.provider}/${params.model} ended with a structured plan but no final answer`,
         reason: "format",
         code: "planning_only_result",
       };
@@ -107,7 +144,15 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
   ) {
     return null;
   }
-  if (hasOutboundDeliveryEvidence(params.result)) {
+  const incompleteTurn = params.result.meta.error?.kind === "incomplete_turn";
+  if (incompleteTurn && params.result.meta.error?.fallbackSafe !== true) {
+    return null;
+  }
+  const fallbackSafeIncompleteTurn = incompleteTurn;
+  if (params.result.meta.replayInvalid === true && !fallbackSafeIncompleteTurn) {
+    return null;
+  }
+  if (hasCommittedOutboundDeliveryEvidence(params.result)) {
     return null;
   }
   if (params.result.meta.error?.kind === "hook_block") {
@@ -115,7 +160,22 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     // bypass a policy decision rather than recover a malformed model result.
     return null;
   }
+  const payloads = params.result.payloads ?? [];
 
+  if (fallbackSafeIncompleteTurn) {
+    const terminalErrorText = payloads.find(
+      (payload) => payload.isError === true && typeof payload.text === "string",
+    )?.text;
+    return {
+      message:
+        terminalErrorText ??
+        `${params.provider}/${params.model} ended with an incomplete terminal response`,
+      reason: "format",
+      code: "incomplete_result",
+      preserveResultOnExhaustion: true,
+      preserveResultPriority: params.result.meta.error?.terminalPresentation === true ? 1 : 0,
+    };
+  }
   const harnessClassification = classifyHarnessResult({
     provider: params.provider,
     model: params.model,
@@ -125,18 +185,10 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     return harnessClassification;
   }
 
-  const payloads = params.result.payloads ?? [];
   const errorText = payloads
     .filter((payload) => payload?.isError === true)
     .map((payload) => (typeof payload.text === "string" ? payload.text : ""))
     .join("\n");
-  if (EMPTY_TERMINAL_REPLY_RE.test(errorText)) {
-    return {
-      message: `${params.provider}/${params.model} ended with an incomplete terminal response`,
-      reason: "format",
-      code: "incomplete_result",
-    };
-  }
   const failoverReason = classifyBusinessDenialErrorPayloadReason(errorText, params.provider);
   if (failoverReason) {
     return {
@@ -169,20 +221,5 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     };
   }
 
-  if (PLAN_ONLY_TERMINAL_REPLY_RE.test(errorText)) {
-    return {
-      message: `${params.provider}/${params.model} exhausted plan-only retries without taking action`,
-      reason: "format",
-      code: "planning_only_result",
-    };
-  }
-  if (!EMPTY_TERMINAL_REPLY_RE.test(errorText)) {
-    return null;
-  }
-
-  return {
-    message: `${params.provider}/${params.model} ended with an incomplete terminal response`,
-    reason: "format",
-    code: "incomplete_result",
-  };
+  return null;
 }

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -354,4 +354,36 @@ describe("runEmbeddedAgent silent-error retry", () => {
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("does not mark incomplete turns fallback-safe after a terminal heartbeat response", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        ...emptyErrorAttempt("anthropic", "claude-opus-4-8", 1120, [
+          {
+            type: "thinking",
+            thinking: "internal reasoning before provider error",
+            thinkingSignature: JSON.stringify({ id: "rs_heartbeat_error", type: "reasoning" }),
+          },
+        ]),
+        heartbeatToolResponse: {
+          outcome: "progress",
+          notify: false,
+          summary: "Still working",
+        },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      runId: "run-terminal-heartbeat-not-fallback-safe",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.meta.error).toMatchObject({
+      kind: "incomplete_turn",
+      fallbackSafe: false,
+    });
+  });
 });

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -447,7 +447,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ]);
   });
 
-  it("does not reuse a presentation after a later tool outcome", async () => {
+  it("keeps model-call order when parallel tool outcomes finish out of order", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
       const onToolOutcome = (
@@ -456,20 +456,23 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
             toolName: string;
             argsHash: string;
             resultHash: string;
+            toolCallOrdinal?: number;
             terminalPresentation?: string;
           }) => void;
         }
       ).onToolOutcome;
       onToolOutcome?.({
-        toolName: "web_fetch",
-        argsHash: "fetch-args",
-        resultHash: "fetch-result",
-        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
-      });
-      onToolOutcome?.({
         toolName: "exec",
         argsHash: "exec-args",
         resultHash: "exec-result",
+        toolCallOrdinal: 1,
+      });
+      onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "fetch-args",
+        resultHash: "fetch-result",
+        toolCallOrdinal: 0,
+        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
       });
       return makeAttemptResult({
         assistantTexts: [],

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2993,7 +2993,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("treats post-tool exact NO_REPLY assistant turns as intentional silence", () => {
     const attempt = makeAttemptResult({
       assistantTexts: ["NO_REPLY"],
-      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+      toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
       lastAssistant: {
         role: "assistant",
         stopReason: "stop",
@@ -3049,7 +3049,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
     const postToolEmptyAttempt = makeAttemptResult({
       assistantTexts: [],
-      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+      toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
       lastAssistant: {
         role: "assistant",
         api: "openai-completions",
@@ -3189,7 +3189,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
-        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+        toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
         lastAssistant: {
           role: "assistant",
           api: "openai-completions",
@@ -3248,7 +3248,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["NO_REPLY"],
-        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+        toolMetas: [{ toolName: "process.poll", meta: "pid=123", replaySafe: true }],
         lastAssistant: {
           role: "assistant",
           api: "openai-completions",

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -1,7 +1,6 @@
 // Coverage for incomplete-turn safety, retry instructions, and liveness states.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { isCoreToolNameReplaySafe } from "../tool-replay-safety.js";
 import {
   hasCommittedMessagingToolDeliveryEvidence,
   hasOutboundDeliveryEvidence,
@@ -21,23 +20,15 @@ import {
   resetRunOverflowCompactionHarnessMocks,
 } from "./run.overflow-compaction.harness.js";
 import {
-  ACK_EXECUTION_FAST_PATH_INSTRUCTION,
   buildAttemptReplayMetadata,
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   EMPTY_RESPONSE_RETRY_INSTRUCTION,
-  extractPlanningOnlyPlanDetails,
-  isLikelyExecutionAckPrompt,
-  PLANNING_ONLY_RETRY_INSTRUCTION,
   REASONING_ONLY_RETRY_INSTRUCTION,
-  resolveAckExecutionFastPathInstruction,
   resolveEmptyResponseRetryInstruction,
-  resolvePlanningOnlyRetryLimit,
-  resolvePlanningOnlyRetryInstruction,
   isIncompleteTerminalAssistantTurn,
   resolveIncompleteTurnPayloadText as resolveIncompleteTurnPayloadTextCore,
   resolveReasoningOnlyRetryInstruction,
-  STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
@@ -288,89 +279,270 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectNoWarnMessageWith("incomplete turn detected");
   });
 
-  it("uses explicit agentId without a session key before surfacing the strict-agentic blocked state", async () => {
+  it("surfaces the latest tool-authored presentation after a structured incomplete turn", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValue(
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      (
+        attemptParams as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "args",
+        resultHash: "result",
+        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
+      });
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "web_fetch" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-structured-terminal-presentation",
+    });
+
+    expect(result.payloads).toEqual([
+      {
+        text:
+          "Web fetch completed.\nOrigin: https://example.com\nStatus: 200\n\n" +
+          "⚠️ Agent couldn't generate a response. Please try again.",
+        isError: true,
+      },
+    ]);
+    expect(result.meta.replayInvalid).toBe(true);
+    expect(result.meta.livenessState).toBe("abandoned");
+    expect(result.meta.error?.fallbackSafe).toBe(true);
+    expect(result.meta.error?.terminalPresentation).toBe(true);
+    expectWarnMessageWith("surfacing tool-authored terminal presentation");
+  });
+
+  it("surfaces read-only cron presentation after a structured incomplete turn", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      (
+        attemptParams as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome?.({
+        toolName: "cron",
+        argsHash: "args",
+        resultHash: "result",
+        terminalPresentation: "Cron scheduler status.\nEnabled: yes",
+      });
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "cron" }],
+        replayMetadata: {
+          hadPotentialSideEffects: false,
+          replaySafe: true,
+        },
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-read-only-cron-terminal-presentation",
+    });
+
+    expect(result.payloads).toEqual([
+      {
+        text:
+          "Cron scheduler status.\nEnabled: yes\n\n" +
+          "⚠️ Agent couldn't generate a response. Please try again.",
+        isError: true,
+      },
+    ]);
+    expect(result.meta.error?.fallbackSafe).toBe(true);
+    expect(result.meta.error?.terminalPresentation).toBe(true);
+  });
+
+  it("preserves a terminal tool presentation across an empty-response retry", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      (
+        attemptParams as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "args",
+        resultHash: "result",
+        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
+      });
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "web_fetch" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
       }),
     );
 
     const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      sessionKey: undefined,
-      agentId: "research",
       provider: "openai",
       model: "gpt-5.4",
-      runId: "run-strict-agentic-explicit-agent",
-      config: {
-        agents: {
-          defaults: {
-            embeddedAgent: {
-              executionContract: "default",
-            },
-          },
-          list: [
-            { id: "main" },
-            {
-              id: "research",
-              embeddedAgent: {
-                executionContract: "strict-agentic",
-              },
-            },
-          ],
-        },
-      } as OpenClawConfig,
+      runId: "run-preserved-terminal-presentation",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toEqual([
       {
-        text: STRICT_AGENTIC_BLOCKED_TEXT,
+        text:
+          "Web fetch completed.\nOrigin: https://example.com\nStatus: 200\n\n" +
+          "⚠️ Agent couldn't generate a response. Please try again.",
         isError: true,
       },
     ]);
   });
 
-  it("emits explicit replayInvalid + blocked liveness state at the strict-agentic blocked exit", async () => {
-    // Criterion 4 of the GPT-5.4 parity gate requires every terminal exit path
-    // to emit explicit replayInvalid + livenessState. The strict-agentic
-    // blocked exit is the exact place where strict-agentic is supposed to be
-    // loudest; it must not fall through to "silent disappearance".
+  it("does not reuse a presentation after a later tool outcome", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValue(
-      makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    );
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      const onToolOutcome = (
+        attemptParams as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome;
+      onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "fetch-args",
+        resultHash: "fetch-result",
+        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
+      });
+      onToolOutcome?.({
+        toolName: "exec",
+        argsHash: "exec-args",
+        resultHash: "exec-result",
+      });
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "web_fetch" }, { toolName: "exec" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
 
     const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
       provider: "openai",
       model: "gpt-5.4",
-      runId: "run-strict-agentic-blocked-liveness",
-      config: {
-        agents: {
-          defaults: {
-            embeddedAgent: {
-              executionContract: "strict-agentic",
-            },
-          },
-          list: [{ id: "main" }],
-        },
-      } as OpenClawConfig,
+      runId: "run-stale-terminal-presentation",
     });
 
-    expect(result.payloads).toEqual([
-      {
-        text: STRICT_AGENTIC_BLOCKED_TEXT,
-        isError: true,
-      },
-    ]);
-    expect(result.meta.livenessState).toBe("blocked");
-    expect(result.meta.replayInvalid).toBe(false);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
+    expect(result.meta.error?.fallbackSafe).toBe(false);
+  });
+
+  it("does not surface a read-only presentation after a sibling side effect", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      const onToolOutcome = (
+        attemptParams as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome;
+      onToolOutcome?.({
+        toolName: "exec",
+        argsHash: "exec-args",
+        resultHash: "exec-result",
+      });
+      onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "fetch-args",
+        resultHash: "fetch-result",
+        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
+      });
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }, { toolName: "web_fetch" }],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "toolUse",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    });
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      runId: "run-side-effect-terminal-presentation",
+    });
+
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
+    expect(result.meta.error?.fallbackSafe).toBe(false);
   });
 
   it("promotes successful final assistant text when a prompt timeout races completion", async () => {
@@ -476,104 +648,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         stage: "assistant",
       },
     ]);
-  });
-
-  it("auto-activates strict-agentic for unconfigured GPT-5 openai runs and surfaces the blocked state", async () => {
-    // Criterion 1 of the GPT-5.4 parity gate ("no stalls after planning") must
-    // cover out-of-the-box installs, not only users who opted in. An
-    // unconfigured GPT-5.4 openai run should receive the strict-agentic retry
-    // + blocked-state treatment automatically.
-    mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValue(
-      makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    );
-
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-strict-agentic-auto-activated",
-      config: {
-        agents: {
-          list: [{ id: "main" }],
-        },
-      } as OpenClawConfig,
-    });
-
-    // Two retries (strict-agentic retry cap) plus the original attempt = 3 calls.
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
-    expect(result.payloads).toEqual([
-      {
-        text: STRICT_AGENTIC_BLOCKED_TEXT,
-        isError: true,
-      },
-    ]);
-    expect(result.meta.livenessState).toBe("blocked");
-    expect(warnMessages().join("\n")).toContain(
-      "strict-agentic execution contract triggered: runId=run-strict-agentic-auto-activated",
-    );
-    expect(warnMessages().join("\n")).toContain(
-      "provider=openai/gpt-5.4 harness=codex contract=strict-agentic configured=unspecified",
-    );
-    expect(mockedLog.info.mock.calls.map(([message]) => String(message)).join("\n")).not.toContain(
-      "strict-agentic execution contract active",
-    );
-  });
-
-  it("respects explicit default contract opt-out on GPT-5 openai runs", async () => {
-    // Users who explicitly set executionContract: "default" opt out of
-    // auto-activated strict-agentic. They keep the old pre-parity-program
-    // behavior (1 retry, then fall through to the normal completion path).
-    mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedRunEmbeddedAttempt.mockResolvedValue(
-      makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    );
-
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      provider: "openai",
-      model: "gpt-5.4",
-      runId: "run-strict-agentic-explicit-default-optout",
-      config: {
-        agents: {
-          defaults: {
-            embeddedAgent: {
-              executionContract: "default",
-            },
-          },
-          list: [{ id: "main" }],
-        },
-      } as OpenClawConfig,
-    });
-
-    // Default contract: 1 retry then falls through. Should NOT surface the
-    // strict-agentic blocked payload.
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    const payloadTexts = (result.payloads ?? []).map((payload) => payload.text ?? "");
-    for (const text of payloadTexts) {
-      expect(text).not.toContain("plan-only turns");
-    }
-  });
-
-  it("detects replay-safe planning-only GPT turns", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    });
-
-    expect(retryInstruction).toContain("Do not restate the plan");
   });
 
   it("retries reasoning-only GPT turns with a visible-answer continuation instruction", async () => {
@@ -1172,190 +1246,65 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("reasoning-only retries exhausted");
   });
 
-  it("detects structured bullet-only plans with intent cues as planning-only GPT turns", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+  it("preserves a terminal tool presentation after reasoning-only retries are exhausted", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    const reasoningOnlyAttempt = async () =>
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: JSON.stringify({
+                id: "rs_reasoning_terminal_presentation",
+                type: "reasoning",
+              }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      });
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams: unknown) => {
+      (
+        attemptParams as {
+          onToolOutcome?: (observation: {
+            toolName: string;
+            argsHash: string;
+            resultHash: string;
+            terminalPresentation?: string;
+          }) => void;
+        }
+      ).onToolOutcome?.({
+        toolName: "web_fetch",
+        argsHash: "args",
+        resultHash: "result",
+        terminalPresentation: "Web fetch completed.\nOrigin: https://example.com\nStatus: 200",
+      });
+      return reasoningOnlyAttempt();
+    });
+    mockedRunEmbeddedAttempt.mockImplementation(reasoningOnlyAttempt);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
       provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [
-          "Plan:\n1. I'll inspect the code\n2. I'll patch the issue\n3. I'll run the tests",
-        ],
-      }),
+      model: "gpt-5.4",
+      reasoningLevel: "on",
+      runId: "run-reasoning-terminal-presentation",
     });
 
-    expect(retryInstruction).toContain("Do not restate the plan");
-  });
-
-  it("does not misclassify ordinary bullet summaries as planning-only", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["1. Parser refactor\n2. Regression coverage\n3. Docs cleanup"],
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("does not treat a bare plan heading as planning-only without an intent cue", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Plan:\n1. Parser refactor\n2. Regression coverage\n3. Docs cleanup"],
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("does not retry planning-only detection after tool activity", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-        toolMetas: [
-          { toolName: "read", meta: "path=src/index.ts" },
-          { toolName: "search", meta: "pattern=runEmbeddedAgent" },
-        ],
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("does not retry planning-only detection after an item has started", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-        itemLifecycle: {
-          startedCount: 1,
-          completedCount: 0,
-          activeCount: 1,
-        },
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("treats update_plan as non-progress for planning-only retry detection", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll capture the steps, then take the first tool action."],
-        toolMetas: [{ toolName: "update_plan", meta: "status=updated" }],
-        itemLifecycle: {
-          startedCount: 1,
-          completedCount: 1,
-          activeCount: 0,
-        },
-      }),
-    });
-
-    expect(retryInstruction).toContain("Act now");
-  });
-
-  it("allows one retry by default and two retries for strict-agentic runs", () => {
-    expect(resolvePlanningOnlyRetryLimit("default")).toBe(1);
-    expect(resolvePlanningOnlyRetryLimit("strict-agentic")).toBe(2);
-    expect(STRICT_AGENTIC_BLOCKED_TEXT).toContain("plan-only turns");
-    expect(STRICT_AGENTIC_BLOCKED_TEXT).toContain("advanced the task");
-  });
-
-  it("detects short execution approval prompts", () => {
-    expect(isLikelyExecutionAckPrompt("ok do it")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("go ahead")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("Can you do it?")).toBe(false);
-  });
-
-  it("detects short execution approvals across requested locales", () => {
-    expect(isLikelyExecutionAckPrompt("نفذها")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("mach es")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("進めて")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("fais-le")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("adelante")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("vai em frente")).toBe(true);
-    expect(isLikelyExecutionAckPrompt("진행해")).toBe(true);
-  });
-
-  it("adds an ack-turn fast-path instruction for GPT action turns", () => {
-    const instruction = resolveAckExecutionFastPathInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "go ahead",
-    });
-
-    expect(instruction).toContain("Do not recap or restate the plan");
-  });
-
-  it("applies the planning-only retry guard to prefixed GPT-5 ids", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "  openai/gpt-5.4  ",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    });
-
-    expect(retryInstruction).toContain("Do not restate the plan");
-  });
-
-  it("applies the ack-turn fast path to broadened GPT-5-family ids", () => {
-    const instruction = resolveAckExecutionFastPathInstruction({
-      provider: "openai",
-      modelId: "gpt-5o-mini",
-      prompt: "go ahead",
-    });
-
-    expect(instruction).toContain("Do not recap or restate the plan");
-  });
-
-  it("applies the ack-turn fast path to Gemini action turns", () => {
-    const instruction = resolveAckExecutionFastPathInstruction({
-      provider: "google",
-      modelId: "gemini-3.1-pro",
-      prompt: "go ahead",
-    });
-
-    expect(instruction).toBe(ACK_EXECUTION_FAST_PATH_INSTRUCTION);
-  });
-
-  it("extracts structured steps from planning-only narration", () => {
-    expect(
-      extractPlanningOnlyPlanDetails(
-        "I'll inspect the code. Then I'll patch the issue. Finally I'll run tests.",
-      ),
-    ).toEqual({
-      explanation: "I'll inspect the code. Then I'll patch the issue. Finally I'll run tests.",
-      steps: ["I'll inspect the code.", "Then I'll patch the issue.", "Finally I'll run tests."],
-    });
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(result.payloads).toEqual([
+      {
+        text:
+          "Web fetch completed.\nOrigin: https://example.com\nStatus: 200\n\n" +
+          "⚠️ Agent couldn't generate a response. Please try again.",
+        isError: true,
+      },
+    ]);
   });
 
   it("marks incomplete-turn retries as replay-invalid abandoned runs", () => {
@@ -1806,27 +1755,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
-  it("does not apply planning-only or ack fast paths to Ollama runs", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    });
-    const ackInstruction = resolveAckExecutionFastPathInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      prompt: "go ahead",
-    });
-
-    expect(retryInstruction).toBeNull();
-    expect(ackInstruction).toBeNull();
-  });
-
   it("retries signed reasoning-only Ollama turns with a visible-answer continuation instruction", () => {
     const retryInstruction = resolveReasoningOnlyRetryInstruction({
       provider: "ollama",
@@ -2077,232 +2005,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-  });
-
-  it.each(["search", "web_search", "x_search", "memory_get", "tool_describe"])(
-    "retries post-tool empty final turns after known read-only %s calls",
-    (toolName) => {
-      const finalAssistant = {
-        role: "assistant",
-        stopReason: "stop",
-        provider: "ollama",
-        model: "gemma4:31b",
-        content: [],
-      } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-      const retryInstruction = resolveEmptyResponseRetryInstruction({
-        provider: "ollama",
-        modelId: "gemma4:31b",
-        payloadCount: 1,
-        aborted: false,
-        timedOut: false,
-        attempt: makeAttemptResult({
-          assistantTexts: ["Checking the scheduler now."],
-          toolMetas: [{ toolName }],
-          currentAttemptAssistant: finalAssistant,
-          lastAssistant: finalAssistant,
-        }),
-      });
-
-      expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-    },
-  );
-
-  it("does not retry post-tool empty final turns after memory_search recall tracking", () => {
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "ollama",
-      model: "gemma4:31b",
-      content: [],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "ollama",
-      modelId: "gemma4:31b",
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Checking memory now."],
-        toolMetas: [{ toolName: "memory_search" }],
-        currentAttemptAssistant: finalAssistant,
-        lastAssistant: finalAssistant,
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("retries post-tool reasoning-only final turns after earlier narration", () => {
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "openai",
-      model: "gpt-5.4",
-      content: [
-        {
-          type: "thinking",
-          thinking: "internal reasoning",
-          thinkingSignature: JSON.stringify({ id: "rs_post_tool", type: "reasoning" }),
-        },
-      ],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "search" }],
-        currentAttemptAssistant: finalAssistant,
-        lastAssistant: finalAssistant,
-      }),
-    });
-
-    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-  });
-
-  it("uses lastAssistant for legacy harness results that omit currentAttemptAssistant", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "search" }],
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-      }),
-    });
-
-    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
-  });
-
-  it("does not reuse historical lastAssistant when the current assistant is explicitly absent", () => {
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "search" }],
-        currentAttemptAssistant: undefined,
-        lastAssistant: {
-          role: "assistant",
-          stopReason: "stop",
-          provider: "openai",
-          model: "gpt-5.4",
-          content: [],
-        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("does not retry post-tool empty final turns after unclassified tools", () => {
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "custom",
-      model: "composer-2.5",
-      content: [],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    const attempt = makeAttemptResult({
-      assistantTexts: ["Checking the scheduler now."],
-      toolMetas: [{ toolName: "search" }, { toolName: "vendor_widget" }],
-      currentAttemptAssistant: finalAssistant,
-      lastAssistant: finalAssistant,
-    });
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "custom",
-      modelId: "composer-2.5",
-      modelApi: "custom-api",
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt,
-    });
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt,
-    });
-
-    expect(attempt.replayMetadata).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-    expect(retryInstruction).toBeNull();
-    expect(incompleteTurnText).toContain("tool actions may have already been executed");
-  });
-
-  it("does not retry post-tool turns with a visible final assistant answer", () => {
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "custom",
-      model: "composer-2.5",
-      content: [{ type: "text", text: "There are zero matches." }],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    const retryInstruction = resolveEmptyResponseRetryInstruction({
-      provider: "custom",
-      modelId: "composer-2.5",
-      modelApi: "custom-api",
-      payloadCount: 2,
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now.", "There are zero matches."],
-        toolMetas: [{ toolName: "search" }],
-        currentAttemptAssistant: finalAssistant,
-        lastAssistant: finalAssistant,
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("surfaces exhausted post-tool empty final turns without replacing terminal output", () => {
-    const finalAssistant = {
-      role: "assistant",
-      stopReason: "stop",
-      provider: "custom",
-      model: "composer-2.5",
-      content: [],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    const attempt = makeAttemptResult({
-      assistantTexts: ["Checking the scheduler now."],
-      toolMetas: [{ toolName: "search" }],
-      currentAttemptAssistant: finalAssistant,
-      lastAssistant: finalAssistant,
-    });
-    const incompleteTurnText = resolveIncompleteTurnPayloadText({
-      payloadCount: 1,
-      aborted: false,
-      timedOut: false,
-      attempt,
-    });
-
-    expect(incompleteTurnText).toContain("couldn't generate a response");
-    expect(
-      resolveEmptyResponseRetryInstruction({
-        provider: "openai",
-        modelId: "gpt-5.4",
-        payloadCount: 1,
-        aborted: false,
-        timedOut: false,
-        attempt: { ...attempt, toolMediaUrls: ["file:///tmp/render.png"] },
-      }),
-    ).toBeNull();
   });
 
   it("does not retry clean zero-token Ollama stop turns", () => {
@@ -2610,17 +2312,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(
       buildAttemptReplayMetadata({
         toolMetas: [{ toolName: "image_generate", asyncStarted: true }],
-        didSendViaMessagingTool: false,
-        messagingToolSentTexts: [],
-        messagingToolSentMediaUrls: [],
-      }),
-    ).toEqual({ hadPotentialSideEffects: true, replaySafe: false });
-  });
-
-  it("treats unclassified tools as replay-invalid potential side effects", () => {
-    expect(
-      buildAttemptReplayMetadata({
-        toolMetas: [{ toolName: "vendor_widget" }],
         didSendViaMessagingTool: false,
         messagingToolSentTexts: [],
         messagingToolSentMediaUrls: [],
@@ -3299,7 +2990,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
   it("treats post-tool exact NO_REPLY assistant turns as intentional silence", () => {
     const attempt = makeAttemptResult({
       assistantTexts: ["NO_REPLY"],
-      toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
+      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
       lastAssistant: {
         role: "assistant",
         stopReason: "stop",
@@ -3355,7 +3046,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
     const postToolEmptyAttempt = makeAttemptResult({
       assistantTexts: [],
-      toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
+      toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
       lastAssistant: {
         role: "assistant",
         api: "openai-completions",
@@ -3477,7 +3168,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.livenessState).toBe("working");
   });
 
-  it("retries post-tool empty final turns after pre-tool narration even when silence is allowed", async () => {
+  it("retries post-tool openai-compatible empty stop turns even when empty silence is allowed", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedResolveModelAsync.mockResolvedValue({
       model: {
@@ -3492,20 +3183,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       },
       modelRegistry: {},
     });
-    const finalAssistant = {
-      role: "assistant",
-      api: "openai-completions",
-      stopReason: "stop",
-      provider: "stepfun",
-      model: "step-router-v1",
-      content: [],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
-        currentAttemptAssistant: finalAssistant,
-        lastAssistant: finalAssistant,
+        assistantTexts: [],
+        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
+        lastAssistant: {
+          role: "assistant",
+          api: "openai-completions",
+          stopReason: "stop",
+          provider: "stepfun",
+          model: "step-router-v1",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
       }),
     );
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
@@ -3538,57 +3227,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expectWarnMessageWith("empty response detected");
   });
 
-  it("does not retry post-tool empty final turns after unclassified tools", async () => {
-    mockedClassifyFailoverReason.mockReturnValue(null);
-    mockedResolveModelAsync.mockResolvedValue({
-      model: {
-        id: "step-router-v1",
-        provider: "stepfun",
-        contextWindow: 200000,
-        api: "openai-completions",
-      },
-      error: null,
-      authStorage: {
-        setRuntimeApiKey: vi.fn(),
-      },
-      modelRegistry: {},
-    });
-    const finalAssistant = {
-      role: "assistant",
-      api: "openai-completions",
-      stopReason: "stop",
-      provider: "stepfun",
-      model: "step-router-v1",
-      content: [],
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    mockedRunEmbeddedAttempt.mockResolvedValue(
-      makeAttemptResult({
-        assistantTexts: ["Checking the scheduler now."],
-        toolMetas: [{ toolName: "vendor_widget" }],
-        currentAttemptAssistant: finalAssistant,
-        lastAssistant: finalAssistant,
-      }),
-    );
-
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      allowEmptyAssistantReplyAsSilent: true,
-      provider: "stepfun",
-      model: "step-router-v1",
-      runId: "run-post-tool-unclassified-empty-stop",
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    expectNoWarnMessageWith("empty response detected");
-    expect(result.payloads).toEqual([
-      {
-        text: "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying.",
-        isError: true,
-      },
-    ]);
-    expect(result.meta.livenessState).toBe("abandoned");
-  });
-
   it("returns NO_REPLY without retrying post-tool exact silent assistant replies", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedResolveModelAsync.mockResolvedValue({
@@ -3607,7 +3245,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: ["NO_REPLY"],
-        toolMetas: [{ toolName: "search", meta: "query=scheduler" }],
+        toolMetas: [{ toolName: "process.poll", meta: "pid=123" }],
         lastAssistant: {
           role: "assistant",
           api: "openai-completions",
@@ -3726,7 +3364,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe("paused");
   });
 
-  it("does not strict-agentic retry casual Discord status chatter", async () => {
+  it("does not classify visible assistant prose for retry", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
@@ -3742,7 +3380,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         "made a bunch of improvements to the student's source code (openclaw) this weekend, along with a few other maintainers. hopefully he will be more proactive now",
       provider: "openai",
       model: "gpt-5.4",
-      runId: "run-strict-agentic-casual-discord-status",
+      runId: "run-visible-prose-no-classifier",
       config: {
         agents: {
           list: [{ id: "main" }],
@@ -3753,233 +3391,6 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads).toBeUndefined();
     expect(result.meta.livenessState).toBe("working");
-  });
-
-  it("detects replay-safe planning-only Gemini turns", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "google-gemini-cli",
-      modelId: "gemini-3.1-pro",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    });
-
-    expect(retryInstruction).toContain("Do not restate the plan");
-  });
-
-  it("does not enable incomplete-turn recovery for non-Gemini Google models", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "google",
-      modelId: "gemma-4-26b-a4b-it",
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["I'll inspect the code, make the change, and run the checks."],
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-
-  it("does not misclassify a direct answer that says 'i'm not going to' as planning-only", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      provider: "openai",
-      modelId: "gpt-5.4",
-      prompt: "What do you think lobstar should do to help the chart?",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: [
-          "I'm not going to give token-pumping instructions for a chart. Best answer: build trust and let the market do what it will.",
-        ],
-      }),
-    });
-
-    expect(retryInstruction).toBeNull();
-  });
-});
-
-describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {
-  const openaiParams = { provider: "openai", modelId: "gpt-5.4" } as const;
-
-  function makeAttemptWithTools(
-    toolNames: string[],
-    assistantText: string,
-  ): Parameters<typeof resolvePlanningOnlyRetryInstruction>[0]["attempt"] {
-    const toolMetas = toolNames.map((toolName) => ({
-      toolName,
-      replaySafe: isCoreToolNameReplaySafe(toolName),
-    }));
-    return {
-      toolMetas,
-      assistantTexts: [assistantText],
-      lastAssistant: { stopReason: "stop" },
-      itemLifecycle: { startedCount: toolNames.length },
-      replayMetadata: buildAttemptReplayMetadata({
-        toolMetas,
-        didSendViaMessagingTool: false,
-        messagingToolSentTexts: [],
-        messagingToolSentMediaUrls: [],
-      }),
-      clientToolCalls: undefined,
-      yieldDetected: false,
-      didSendDeterministicApprovalPrompt: false,
-      didSendViaMessagingTool: false,
-      lastToolError: null,
-    } as unknown as Parameters<typeof resolvePlanningOnlyRetryInstruction>[0]["attempt"];
-  }
-
-  it("retries when exactly 1 non-plan tool call plus 'i can do that' prose is detected", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "I can do that next."),
-    });
-
-    expect(result).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
-  });
-
-  it("retries when exactly 1 non-plan tool call plus planning prose is detected", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "I'll analyze the structure next."),
-    });
-
-    expect(result).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
-  });
-
-  it("does not retry when 2+ non-plan tool calls are present", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read", "search"], "I'll verify the output."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when 1 tool call plus completion language is present", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "Done. The file looks correct."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when 1 tool call plus 'let me know' handoff is present", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "Let me know if you need anything else."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when 1 tool call plus an answer-style summary is present", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(
-        ["read"],
-        "I'll summarize the root cause: the provider auth scope is missing.",
-      ),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when 1 tool call plus a future-tense description is present", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(
-        ["read"],
-        "I'll describe the issue: the provider auth scope is missing.",
-      ),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when 1 safe tool call is followed by answer prose joined with 'and'", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "I'll explain and recommend a fix."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when 1 tool call plus a bare 'i can do that' reply is present", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "I can do that."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when the lone tool call already had side effects", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["sessions_spawn"], "I'll continue from there next."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry when the lone tool call is unclassified", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "Please inspect the code, make the change, and run the checks.",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["vendor_widget"], "I'll continue from there next."),
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("does not retry single-action narration on casual non-task chat", () => {
-    const result = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "i haven't restarted you on latest main yet @The Student - get ready though",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptWithTools(["read"], "I'll check that next."),
-    });
-
-    expect(result).toBeNull();
+    expectNoWarnMessageWith("planning");
   });
 });

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -112,6 +112,53 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("keeps fallback unsafe when an overflow retry follows a mutating attempt", async () => {
+    const overflowError = makeOverflowError();
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: overflowError,
+          toolMetas: [{ toolName: "exec" }],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "web_fetch" }],
+          replayMetadata: {
+            hadPotentialSideEffects: false,
+            replaySafe: true,
+          },
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "toolUse",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      );
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        tokensBefore: 150000,
+      }),
+    );
+
+    const result = await runEmbeddedAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(requireMockCallArg(mockedRunEmbeddedAttempt, 1).initialReplayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+    expect(result.meta.error?.fallbackSafe).toBe(false);
+  });
+
   it("uses provider thinking policy for configless embedded MiniMax-M3 runs", async () => {
     mockedResolveModelAsync.mockResolvedValueOnce({
       model: {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1341,11 +1341,21 @@ async function runEmbeddedAgentInternal(
       );
       let postCompactionAbortController: AbortController | undefined;
       let postCompactionAbortError: PostCompactionLoopPersistedError | undefined;
-      const attemptTerminalToolPresentation = { value: undefined as string | undefined };
+      const attemptTerminalToolPresentation = {
+        ordinal: -1,
+        value: undefined as string | undefined,
+      };
+      let nextToolOutcomeOrdinal = 0;
+      const allocateToolOutcomeOrdinal = (): number => nextToolOutcomeOrdinal++;
       const readAttemptTerminalToolPresentation = (): string | undefined =>
         attemptTerminalToolPresentation.value;
       const observeToolOutcome = (observation: ToolOutcomeObservation): void => {
-        attemptTerminalToolPresentation.value = observation.terminalPresentation;
+        const observationOrdinal =
+          observation.toolCallOrdinal ?? attemptTerminalToolPresentation.ordinal + 1;
+        if (observationOrdinal >= attemptTerminalToolPresentation.ordinal) {
+          attemptTerminalToolPresentation.ordinal = observationOrdinal;
+          attemptTerminalToolPresentation.value = observation.terminalPresentation;
+        }
         if (observation.presentationOnly) {
           return;
         }
@@ -1811,6 +1821,7 @@ async function runEmbeddedAgentInternal(
             beforeAgentStartResult,
             thinkLevel,
             onToolOutcome: observeToolOutcome,
+            allocateToolOutcomeOrdinal,
             onRunProgress: notifyRunProgress,
             fastMode: params.fastMode,
             verboseLevel: params.verboseLevel,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3343,15 +3343,13 @@ async function runEmbeddedAgentInternal(
                 ? [silentToolResultReplyPayload]
                 : payloadsWithToolMedia;
           const payloadCount = payloadsForTerminalPath?.length ?? 0;
-          const emptyAssistantReplyIsSilent =
-            Boolean(silentToolResultReplyPayload) ||
-            shouldTreatEmptyAssistantReplyAsSilent({
-              allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
-              payloadCount,
-              aborted,
-              timedOut,
-              attempt,
-            });
+          const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
+            allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
+            payloadCount,
+            aborted,
+            timedOut,
+            attempt,
+          });
           const nextReasoningOnlyRetryInstruction = emptyAssistantReplyIsSilent
             ? null
             : resolveReasoningOnlyRetryInstruction({

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -18,7 +18,6 @@ import {
   assertAgentRunLifecycleGenerationCurrent,
   captureAgentRunLifecycleGeneration,
   claimAgentRunContext,
-  emitAgentPlanEvent,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
   registerAgentRunContext,
@@ -40,11 +39,11 @@ import {
   retireSessionMcpRuntimeForSessionKey,
 } from "../agent-bundle-mcp-tools.js";
 import {
-  resolveAgentExecutionContract,
   resolveAgentDir,
   resolveSessionAgentIds,
   resolveAgentWorkspaceDir,
 } from "../agent-scope.js";
+import type { ToolOutcomeObservation } from "../agent-tools.before-tool-call.js";
 import { resolveProcessToolScopeKey } from "../agent-tools.js";
 import {
   type AuthProfileFailureReason,
@@ -136,7 +135,6 @@ import { resolveModelAsync } from "./model.js";
 import {
   createPostCompactionLoopGuard,
   PostCompactionLoopPersistedError,
-  type PostCompactionGuardObservation,
 } from "./post-compaction-loop-guard.js";
 import { createEmbeddedRunReplayState, observeReplayMetadata } from "./replay-state.js";
 import {
@@ -184,16 +182,12 @@ import {
 import {
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
-  resolveAckExecutionFastPathInstruction,
+  hasAttemptTerminalState,
   resolveAttemptReplayMetadata,
-  extractPlanningOnlyPlanDetails,
   resolveEmptyResponseRetryInstruction,
   resolveIncompleteTurnPayloadText,
-  resolvePlanningOnlyRetryLimit,
-  resolvePlanningOnlyRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
   resolveSilentToolResultReplyPayload,
-  STRICT_AGENTIC_BLOCKED_TEXT,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
   shouldRetryMissingAssistantTurn,
@@ -219,7 +213,6 @@ import type {
   EmbeddedAgentRunResult,
   TraceAttempt,
   ToolSummaryTrace,
-  EmbeddedRunLivenessState,
 } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
 
@@ -1292,10 +1285,6 @@ async function runEmbeddedAgentInternal(
         config: params.config,
         agentId: params.agentId,
       });
-      const configuredExecutionContract = resolveAgentExecutionContract(
-        params.config,
-        sessionAgentId,
-      );
       const strictAgenticActive = isStrictAgenticExecutionContractActive({
         config: params.config,
         sessionKey: params.sessionKey,
@@ -1304,8 +1293,6 @@ async function runEmbeddedAgentInternal(
         modelId,
       });
       const executionContract = strictAgenticActive ? "strict-agentic" : "default";
-      const configuredExecutionContractForLog = configuredExecutionContract ?? "unspecified";
-      const maxPlanningOnlyRetryAttempts = resolvePlanningOnlyRetryLimit(executionContract);
       const maxReasoningOnlyRetryAttempts = DEFAULT_REASONING_ONLY_RETRY_LIMIT;
       const maxEmptyResponseRetryAttempts = DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT;
 
@@ -1329,7 +1316,6 @@ async function runEmbeddedAgentInternal(
       let runLoopIterations = 0;
       let overloadProfileRotations = 0;
       let consecutiveSameModelRateLimitRetries = 0;
-      let planningOnlyRetryAttempts = 0;
       let reasoningOnlyRetryAttempts = 0;
       let emptyResponseRetryAttempts = 0;
       let compactionContinuationRetryAttempts = 0;
@@ -1355,9 +1341,14 @@ async function runEmbeddedAgentInternal(
       );
       let postCompactionAbortController: AbortController | undefined;
       let postCompactionAbortError: PostCompactionLoopPersistedError | undefined;
-      const observePostCompactionToolOutcome = (
-        observation: PostCompactionGuardObservation,
-      ): void => {
+      const attemptTerminalToolPresentation = { value: undefined as string | undefined };
+      const readAttemptTerminalToolPresentation = (): string | undefined =>
+        attemptTerminalToolPresentation.value;
+      const observeToolOutcome = (observation: ToolOutcomeObservation): void => {
+        attemptTerminalToolPresentation.value = observation.terminalPresentation;
+        if (observation.presentationOnly) {
+          return;
+        }
         const verdict = postCompactionGuard.observe(observation);
         if (verdict.shouldAbort) {
           postCompactionAbortError ??= PostCompactionLoopPersistedError.fromVerdict(verdict);
@@ -1365,16 +1356,10 @@ async function runEmbeddedAgentInternal(
         }
       };
       let lastRetryFailoverReason: FailoverReason | null = null;
-      let planningOnlyRetryInstruction: string | null = null;
       let reasoningOnlyRetryInstruction: string | null = null;
       let emptyResponseRetryInstruction: string | null = null;
       let compactionContinuationRetryInstruction: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
-      const ackExecutionFastPathInstruction = resolveAckExecutionFastPathInstruction({
-        provider,
-        modelId,
-        prompt: params.prompt,
-      });
       let rateLimitProfileRotations = 0;
       let timeoutCompactionAttempts = 0;
       let codexAppServerRecoveryRetries = 0;
@@ -1675,8 +1660,6 @@ async function runEmbeddedAgentInternal(
             (provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt);
           nextAttemptPromptOverride = null;
           const promptAdditions = [
-            ackExecutionFastPathInstruction,
-            planningOnlyRetryInstruction,
             reasoningOnlyRetryInstruction,
             emptyResponseRetryInstruction,
             compactionContinuationRetryInstruction,
@@ -1827,7 +1810,7 @@ async function runEmbeddedAgentInternal(
             agentId: workspaceResolution.agentId,
             beforeAgentStartResult,
             thinkLevel,
-            onToolOutcome: observePostCompactionToolOutcome,
+            onToolOutcome: observeToolOutcome,
             onRunProgress: notifyRunProgress,
             fastMode: params.fastMode,
             verboseLevel: params.verboseLevel,
@@ -3354,17 +3337,6 @@ async function runEmbeddedAgentInternal(
               timedOut,
               attempt,
             });
-          const nextPlanningOnlyRetryInstruction = emptyAssistantReplyIsSilent
-            ? null
-            : resolvePlanningOnlyRetryInstruction({
-                provider,
-                modelId,
-                executionContract,
-                prompt: params.prompt,
-                aborted,
-                timedOut,
-                attempt,
-              });
           const nextReasoningOnlyRetryInstruction = emptyAssistantReplyIsSilent
             ? null
             : resolveReasoningOnlyRetryInstruction({
@@ -3389,50 +3361,6 @@ async function runEmbeddedAgentInternal(
                 attempt,
               });
           if (
-            nextPlanningOnlyRetryInstruction &&
-            planningOnlyRetryAttempts < maxPlanningOnlyRetryAttempts
-          ) {
-            const planningOnlyText = (attempt.assistantTexts ?? []).join("\n\n").trim();
-            const planDetails = extractPlanningOnlyPlanDetails(planningOnlyText);
-            if (planDetails) {
-              emitAgentPlanEvent({
-                runId: params.runId,
-                ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-                data: {
-                  phase: "update",
-                  title: "Assistant proposed a plan",
-                  explanation: planDetails.explanation,
-                  steps: planDetails.steps,
-                  source: "planning_only_retry",
-                },
-              });
-              void params.onAgentEvent?.({
-                stream: "plan",
-                data: {
-                  phase: "update",
-                  title: "Assistant proposed a plan",
-                  explanation: planDetails.explanation,
-                  steps: planDetails.steps,
-                  source: "planning_only_retry",
-                },
-              });
-            }
-            planningOnlyRetryAttempts += 1;
-            planningOnlyRetryInstruction = nextPlanningOnlyRetryInstruction;
-            const planningOnlyRetryLogPrefix =
-              executionContract === "strict-agentic"
-                ? "strict-agentic execution contract triggered"
-                : "planning-only turn detected";
-            log.warn(
-              `${planningOnlyRetryLogPrefix}: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${provider}/${modelId} harness=${sanitizeForLog(agentHarness.id)} ` +
-                `contract=${executionContract} configured=${configuredExecutionContractForLog} — retrying ` +
-                `${planningOnlyRetryAttempts}/${maxPlanningOnlyRetryAttempts} with act-now steer`,
-            );
-            continue;
-          }
-          if (
-            !nextPlanningOnlyRetryInstruction &&
             nextReasoningOnlyRetryInstruction &&
             reasoningOnlyRetryAttempts < maxReasoningOnlyRetryAttempts
           ) {
@@ -3446,7 +3374,6 @@ async function runEmbeddedAgentInternal(
             continue;
           }
           const reasoningOnlyRetriesExhausted =
-            !nextPlanningOnlyRetryInstruction &&
             nextReasoningOnlyRetryInstruction &&
             reasoningOnlyRetryAttempts >= maxReasoningOnlyRetryAttempts;
           if (
@@ -3468,7 +3395,6 @@ async function runEmbeddedAgentInternal(
             continue;
           }
           if (
-            !nextPlanningOnlyRetryInstruction &&
             !nextReasoningOnlyRetryInstruction &&
             nextEmptyResponseRetryInstruction &&
             emptyResponseRetryAttempts < maxEmptyResponseRetryAttempts
@@ -3491,6 +3417,18 @@ async function runEmbeddedAgentInternal(
                 timedOut,
                 attempt,
               });
+          const incompleteTurnFallbackSafe = Boolean(
+            incompleteTurnText &&
+            !aborted &&
+            !timedOut &&
+            !promptError &&
+            !attempt.lastToolError &&
+            !hasAttemptTerminalState(attempt) &&
+            !accumulatedReplayState.hadPotentialSideEffects,
+          );
+          const terminalToolPresentation = incompleteTurnFallbackSafe
+            ? readAttemptTerminalToolPresentation()
+            : undefined;
           if (
             !emptyAssistantReplyIsSilent &&
             attemptCompactionCount > 0 &&
@@ -3502,7 +3440,7 @@ async function runEmbeddedAgentInternal(
             !attempt.yieldDetected &&
             !attempt.didSendDeterministicApprovalPrompt &&
             !attempt.lastToolError &&
-            !resolveAttemptReplayMetadata(attempt).hadPotentialSideEffects &&
+            !accumulatedReplayState.hadPotentialSideEffects &&
             compactionContinuationRetryAttempts < 1
           ) {
             compactionContinuationRetryAttempts += 1;
@@ -3521,73 +3459,20 @@ async function runEmbeddedAgentInternal(
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} attempts=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} — surfacing incomplete-turn error`,
             );
           }
-          if (!incompleteTurnText && nextPlanningOnlyRetryInstruction && strictAgenticActive) {
-            log.warn(
-              `strict-agentic run exhausted planning-only retries: runId=${params.runId} sessionId=${params.sessionId} ` +
-                `provider=${provider}/${modelId} configured=${configuredExecutionContractForLog} — surfacing blocked state`,
-            );
-            // Criterion 4 of the GPT-5.4 parity gate requires every terminal
-            // exit path to emit an explicit livenessState + replayInvalid so
-            // downstream observers never see "silent disappearance". Every
-            // other hard-error terminal branch in this file uses "blocked"
-            // for its livenessState (role ordering, image size, schema
-            // error, compaction timeout, aborted-with-no-payloads). Match
-            // that convention here so lifecycle consumers treat an
-            // isError:true strict-agentic-blocked payload the same way they
-            // treat any other error-terminal payload. Replay validity is
-            // delegated to the shared resolver because the plan-only
-            // transcript itself is replay-safe even though the run is
-            // terminal.
-            const replayInvalid = resolveReplayInvalidForAttempt(null);
-            const livenessState: EmbeddedRunLivenessState = "blocked";
-            setTerminalLifecycleMeta({
-              replayInvalid,
-              livenessState,
-            });
-            return {
-              payloads: [
-                {
-                  text: STRICT_AGENTIC_BLOCKED_TEXT,
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
-                finalPromptText: attempt.finalPromptText,
-                finalAssistantVisibleText,
-                finalAssistantRawText,
-                replayInvalid,
-                livenessState,
-                toolSummary: attemptToolSummary,
-                ...(failureSignal ? { failureSignal } : {}),
-                agentHarnessResultClassification: attempt.agentHarnessResultClassification,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didDeliverSourceReplyViaMessageTool:
-                attempt.didDeliverSourceReplyViaMessageTool === true,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              messagingToolSourceReplyPayloads: attempt.messagingToolSourceReplyPayloads,
-              heartbeatToolResponse: attempt.heartbeatToolResponse,
-              successfulCronAdds: attempt.successfulCronAdds,
-              acceptedSessionSpawns: attempt.acceptedSessionSpawns,
-            };
-          }
           if (reasoningOnlyRetriesExhausted && !finalAssistantVisibleText) {
-            const replayInvalid = resolveReplayInvalidForAttempt(
-              "⚠️ Agent couldn't generate a response. Please try again.",
-            );
+            const incompletePayloadText = terminalToolPresentation
+              ? terminalToolPresentation.concat(
+                  "\n\n",
+                  "⚠️ Agent couldn't generate a response. Please try again.",
+                )
+              : "⚠️ Agent couldn't generate a response. Please try again.";
+            const replayInvalid = resolveReplayInvalidForAttempt(incompletePayloadText);
             const livenessState = resolveRunLivenessState({
               payloadCount: 0,
               aborted,
               timedOut,
               attempt,
-              incompleteTurnText: "⚠️ Agent couldn't generate a response. Please try again.",
+              incompleteTurnText: incompletePayloadText,
             });
             setTerminalLifecycleMeta({
               replayInvalid,
@@ -3603,7 +3488,7 @@ async function runEmbeddedAgentInternal(
             return {
               payloads: [
                 {
-                  text: "⚠️ Agent couldn't generate a response. Please try again.",
+                  text: incompletePayloadText,
                   isError: true,
                 },
               ],
@@ -3617,6 +3502,12 @@ async function runEmbeddedAgentInternal(
                 finalAssistantRawText,
                 replayInvalid,
                 livenessState,
+                error: {
+                  kind: "incomplete_turn",
+                  message: "Agent couldn't generate a response.",
+                  fallbackSafe: incompleteTurnFallbackSafe,
+                  terminalPresentation: terminalToolPresentation !== undefined,
+                },
                 toolSummary: attemptToolSummary,
                 ...(failureSignal ? { failureSignal } : {}),
                 agentHarnessResultClassification: attempt.agentHarnessResultClassification,
@@ -3635,7 +3526,6 @@ async function runEmbeddedAgentInternal(
             };
           }
           if (
-            !nextPlanningOnlyRetryInstruction &&
             !nextReasoningOnlyRetryInstruction &&
             nextEmptyResponseRetryInstruction &&
             emptyResponseRetryAttempts >= maxEmptyResponseRetryAttempts
@@ -3666,10 +3556,12 @@ async function runEmbeddedAgentInternal(
                 `stopReason=${incompleteStopReason ?? "missing"} hasLastAssistant=${attempt.lastAssistant ? "yes" : "no"} ` +
                 `hasCurrentAttemptAssistant=${attempt.currentAttemptAssistant ? "yes" : "no"} payloads=${payloadCount} ` +
                 `tools=${attempt.toolMetas?.length ?? 0} replaySafe=${replayMetadata.replaySafe ? "yes" : "no"} ` +
-                `compactions=${attemptCompactionCount} planningRetries=${planningOnlyRetryAttempts}/${maxPlanningOnlyRetryAttempts} ` +
-                `reasoningRetries=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
+                `compactions=${attemptCompactionCount} reasoningRetries=${reasoningOnlyRetryAttempts}/${maxReasoningOnlyRetryAttempts} ` +
                 `emptyRetries=${emptyResponseRetryAttempts}/${maxEmptyResponseRetryAttempts} ` +
-                `missingAssistantRetries=${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} — surfacing error to user`,
+                `missingAssistantRetries=${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} — ` +
+                (terminalToolPresentation
+                  ? "surfacing tool-authored terminal presentation"
+                  : "surfacing error to user"),
             );
 
             // Mark the failing profile for cooldown so multi-profile setups
@@ -3685,7 +3577,9 @@ async function runEmbeddedAgentInternal(
             return {
               payloads: [
                 {
-                  text: incompleteTurnText,
+                  text: terminalToolPresentation
+                    ? terminalToolPresentation.concat("\n\n", incompleteTurnText)
+                    : incompleteTurnText,
                   isError: true,
                 },
               ],
@@ -3699,6 +3593,12 @@ async function runEmbeddedAgentInternal(
                 finalAssistantRawText,
                 replayInvalid,
                 livenessState,
+                error: {
+                  kind: "incomplete_turn",
+                  message: "Agent couldn't generate a response.",
+                  fallbackSafe: incompleteTurnFallbackSafe,
+                  terminalPresentation: terminalToolPresentation !== undefined,
+                },
                 toolSummary: attemptToolSummary,
                 ...(failureSignal ? { failureSignal } : {}),
                 agentHarnessResultClassification: attempt.agentHarnessResultClassification,
@@ -3731,7 +3631,6 @@ async function runEmbeddedAgentInternal(
               beforeAgentFinalizeRevisionReason,
             );
             suppressNextUserMessagePersistence = true;
-            planningOnlyRetryInstruction = null;
             reasoningOnlyRetryInstruction = null;
             emptyResponseRetryInstruction = null;
             compactionContinuationRetryInstruction = null;

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1838,6 +1838,10 @@ async function runEmbeddedAgentInternal(
             onToolResult: params.onToolResult,
             onAgentToolResult: params.onAgentToolResult,
             onAgentEvent: params.onAgentEvent,
+            deferTerminalLifecycle:
+              params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
+            deferTerminalLifecycleEnd:
+              params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
             onExecutionPhase: params.onExecutionPhase,
             extraSystemPrompt: params.extraSystemPrompt,
             sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1310,6 +1310,7 @@ export async function runEmbeddedAttempt(
             authProfileStore: params.authProfileStore,
             recordToolPrepStage: (name) => corePluginToolStages.mark(name),
             onToolOutcome: params.onToolOutcome,
+            allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
             skillsSnapshot: skillsSnapshotForRun,
             onYield: (message) => {
               yieldDetected = true;
@@ -1626,6 +1627,7 @@ export async function runEmbeddedAttempt(
         agentId: sessionAgentId,
       }),
       onToolOutcome: params.onToolOutcome,
+      allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
     };
     const codeModeTools = codeModeControlsEnabledForRun
       ? createCodeModeTools({
@@ -2339,6 +2341,7 @@ export async function runEmbeddedAttempt(
               runId: params.runId,
               loopDetection: clientToolLoopDetection,
               onToolOutcome: params.onToolOutcome,
+              allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
             },
           )
         : [];

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -99,6 +99,7 @@ import {
   toClientToolDefinitions,
   toToolDefinitions,
 } from "../../agent-tool-definition-adapter.js";
+import { recordStructuredReplayTrustForToolCall } from "../../agent-tools.before-tool-call.js";
 import {
   createOpenClawCodingTools,
   resolveProcessToolScopeKey,
@@ -2414,7 +2415,9 @@ export async function runEmbeddedAttempt(
                   toolCall.name,
                 );
                 // Catalog entries already own before_tool_call wrapping.
-                const definition = tool ? toToolDefinitions([tool])[0] : undefined;
+                const definition = tool
+                  ? toToolDefinitions([tool], catalogToolHookContext)[0]
+                  : undefined;
                 const hydratedTool = definition ? wrapToolDefinition(definition) : undefined;
                 if (hydratedTool) {
                   log.info(`tool-search: hydrated deferred directory tool ${toolCall.name}`);
@@ -3535,6 +3538,13 @@ export async function runEmbeddedAttempt(
       isCompactionInFlightForExternalSignal = () => activeSession.isCompacting;
       toolSearchCatalogExecutor = async (toolParams) => {
         try {
+          if (toolParams.source === "openclaw" && toolParams.sourceName === "core") {
+            recordStructuredReplayTrustForToolCall(
+              toolParams.toolCallId,
+              toolParams.tool as never,
+              params.runId,
+            );
+          }
           const result = await runToolLifecycle({
             toolName: toolParams.toolName,
             toolCallId: toolParams.toolCallId,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3453,7 +3453,10 @@ export async function runEmbeddedAttempt(
           onAssistantMessageStart: params.onAssistantMessageStart,
           onExecutionPhase: params.onExecutionPhase,
           onAgentEvent: params.onAgentEvent,
-          terminalLifecyclePhase: params.deferTerminalLifecycleEnd ? "finishing" : "end",
+          terminalLifecyclePhase:
+            (params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd)
+              ? "finishing"
+              : "end",
           isTerminalAborted: () => aborted,
           resolveTerminalStopReason: () =>
             isAgentRunRestartAbortReason(runAbortController.signal.reason)

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2199,6 +2199,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        runId: params.runId,
       });
       const resourceLoader = createEmbeddedAgentResourceLoader({
         cwd: effectiveCwd,
@@ -5241,7 +5242,9 @@ export async function runEmbeddedAttempt(
 
       const acceptedSessionSpawns = getAcceptedSessionSpawns();
       const observedReplayMetadata = buildAttemptReplayMetadata({
-        toolMetas: toolMetasNormalized,
+        // Structured start arguments already updated replayState for mutations and async work.
+        // Reclassifying by tool name would incorrectly mark read-only cron actions as unsafe.
+        toolMetas: [],
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -3,16 +3,13 @@
  */
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
   isSilentReplyPayloadText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
 } from "../../../auto-reply/tokens.js";
-import type { EmbeddedAgentExecutionContract } from "../../../config/types.agent-defaults.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
-import { extractAssistantVisibleText } from "../../embedded-agent-utils.js";
 import {
   isStrictAgenticSupportedProviderModel,
   stripProviderPrefix,
@@ -66,23 +63,6 @@ type IncompleteTurnAttempt = Pick<
 > &
   Partial<Pick<EmbeddedRunAttemptResult, "acceptedSessionSpawns">>;
 
-type PlanningOnlyAttempt = Pick<
-  EmbeddedRunAttemptResult,
-  | "assistantTexts"
-  | "clientToolCalls"
-  | "yieldDetected"
-  | "didSendDeterministicApprovalPrompt"
-  | "didSendViaMessagingTool"
-  | "lastToolError"
-  | "lastAssistant"
-  | "itemLifecycle"
-  | "replayMetadata"
-  | "messagingToolSentTexts"
-  | "messagingToolSentMediaUrls"
-  | "messagingToolSentTargets"
-  | "toolMetas"
->;
-
 function hasPositiveOutputTokenUsage(message: AgentMessage | null): boolean {
   if (!message || typeof message !== "object") {
     return false;
@@ -126,29 +106,6 @@ export function isIncompleteTerminalAssistantTurn(params: {
   return stopReason === "toolUse" || (stopReason === "length" && !params.hasTerminalOutput);
 }
 
-const PLANNING_ONLY_PROMISE_RE =
-  /\b(?:i(?:'ll| will)|let me|i(?:'m| am)\s+going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|i can do that)\b/i;
-const PLANNING_ONLY_COMPLETION_RE =
-  /\b(?:done|finished|implemented|updated|fixed|changed|ran|verified|found|here(?:'s| is) what|blocked by|the blocker is)\b/i;
-const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
-const PLANNING_ONLY_BULLET_RE = /^(?:[-*•]\s+|\d+[.)]\s+)/u;
-const PLANNING_ONLY_MAX_VISIBLE_TEXT = 700;
-const PLANNING_ONLY_ACTION_VERB_RE =
-  /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship)\b/i;
-const SINGLE_ACTION_EXPLICIT_CONTINUATION_RE =
-  /\b(?:going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|then[, ]+i(?:'ll| will)|i can do that next|let me (?!know\b)\w+(?:\s+\w+){0,3}\s+(?:next|then|first)\b)/i;
-const SINGLE_ACTION_MULTI_STEP_PROMISE_RE =
-  /\bi(?:'ll| will)\b(?=[^.!?]{0,160}\b(?:next|then|after(?:wards)?|once)\b)/i;
-const SINGLE_ACTION_RESULT_STYLE_RE =
-  /\b(?:i(?:'ll| will)\s+(?:summarize|explain|share|show|report|describe|clarify|answer|recap)(?:\s+\w+){0,4}\s*:|(?:here(?:'s| is)|summary|result|answer|findings?|root cause)\s*:)/i;
-const SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES = new Set([
-  "read",
-  "search",
-  "find",
-  "grep",
-  "glob",
-  "ls",
-]);
 const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
   "google",
   "google-vertex",
@@ -156,8 +113,7 @@ const GEMINI_INCOMPLETE_TURN_PROVIDER_IDS = new Set([
   "google-gemini-cli",
 ]);
 const GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN = /^gemini(?:[.-]|$)/;
-// Ollama native `/api/chat` can finish with only thinking/internal blocks when
-// constrained, but it should not inherit the stricter planning-only/ack prompts.
+// Ollama native `/api/chat` can finish with only thinking/internal blocks when constrained.
 const OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN = /^ollama(?:-|$)/;
 // Model APIs eligible for the non-visible turn retry guard.  OpenAI Responses
 // family can produce reasoning-only turns where usage.output > 0 but no visible
@@ -172,73 +128,14 @@ const RETRY_GUARD_MODEL_APIS = new Set([
   "openclaw-openai-responses-transport",
   "openclaw-azure-openai-responses-transport",
 ]);
-const DEFAULT_PLANNING_ONLY_RETRY_LIMIT = 1;
-const STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2;
 // Allow one immediate continuation plus one follow-up continuation before
 // surfacing the existing incomplete-turn error path.
 export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2;
 export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = 1;
-const ACK_EXECUTION_NORMALIZED_SET = new Set([
-  "ok",
-  "okay",
-  "ok do it",
-  "okay do it",
-  "do it",
-  "go ahead",
-  "please do",
-  "sounds good",
-  "sounds good do it",
-  "ship it",
-  "fix it",
-  "make it so",
-  "yes do it",
-  "yep do it",
-  "تمام",
-  "حسنا",
-  "حسنًا",
-  "امض قدما",
-  "نفذها",
-  "mach es",
-  "leg los",
-  "los geht s",
-  "weiter",
-  "やって",
-  "進めて",
-  "そのまま進めて",
-  "allez y",
-  "vas y",
-  "fais le",
-  "continue",
-  "hazlo",
-  "adelante",
-  "sigue",
-  "faz isso",
-  "vai em frente",
-  "pode fazer",
-  "해줘",
-  "진행해",
-  "계속해",
-]);
-const ACTIONABLE_PROMPT_DIRECTIVE_RE =
-  /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare)\b/i;
-const ACTIONABLE_PROMPT_REQUEST_RE =
-  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
-
-export const PLANNING_ONLY_RETRY_INSTRUCTION =
-  "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
 export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
-export const ACK_EXECUTION_FAST_PATH_INSTRUCTION =
-  "The latest user message is a short approval to proceed. Do not recap or restate the plan. Start with the first concrete tool action immediately. Keep any user-facing follow-up brief and natural.";
-export const STRICT_AGENTIC_BLOCKED_TEXT =
-  "Agent stopped after repeated plan-only turns without taking a concrete action. No concrete tool action or external side effect advanced the task.";
-
-export type PlanningOnlyPlanDetails = {
-  explanation: string;
-  steps: string[];
-};
 
 /**
  * Marks whether retrying the attempt can safely replay the prompt. Concrete
@@ -355,17 +252,9 @@ export function resolveIncompleteTurnPayloadText(params: {
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
     !hasTerminalOutput &&
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
-  const emptyResponseAssistant = isEmptyResponseAssistantTurn({
-    payloadCount: params.payloadCount,
-    attempt: params.attempt,
-  });
 
   if (
-    (params.payloadCount !== 0 &&
-      !toolUseTerminal &&
-      !lengthTerminal &&
-      !thinkingOnlyTerminal &&
-      !emptyResponseAssistant) ||
+    (params.payloadCount !== 0 && !toolUseTerminal && !lengthTerminal && !thinkingOnlyTerminal) ||
     (params.aborted && params.externalAbort) ||
     params.timedOut ||
     params.attempt.clientToolCalls ||
@@ -399,6 +288,10 @@ export function resolveIncompleteTurnPayloadText(params: {
     lastAssistant: params.attempt.lastAssistant,
   });
   const reasoningOnlyAssistant = isReasoningOnlyAssistantTurn(assistant);
+  const emptyResponseAssistant = isEmptyResponseAssistantTurn({
+    payloadCount: params.payloadCount,
+    attempt: params.attempt,
+  });
   if (
     !incompleteTerminalAssistant &&
     !lengthTerminal &&
@@ -614,20 +507,6 @@ function isReasoningOnlyAssistantTurn(message: unknown): boolean {
   return assessLastAssistantMessage(message as AgentMessage) === "incomplete-text";
 }
 
-function hasEmptyPostToolFinalAssistantTurn(attempt: IncompleteTurnAttempt): boolean {
-  // assistantTexts aggregates earlier narration. After tools, the latest typed
-  // assistant message is the final-delivery contract and must carry the answer.
-  const currentAssistant = Object.hasOwn(attempt, "currentAttemptAssistant")
-    ? attempt.currentAttemptAssistant
-    : attempt.lastAssistant;
-  return Boolean(
-    attempt.toolMetas.length > 0 &&
-    !hasAttemptTerminalState(attempt) &&
-    currentAssistant &&
-    extractAssistantVisibleText(currentAssistant).trim().length === 0,
-  );
-}
-
 // Unsigned thinking blocks have no cryptographic signature; assessLastAssistantMessage
 // returns "incomplete-thinking" for them. Empty content also returns "incomplete-thinking",
 // so the content.length > 0 guard is required to distinguish the two cases.
@@ -688,16 +567,15 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
 
 function isEmptyResponseAssistantTurn(params: {
   payloadCount: number;
-  attempt: IncompleteTurnAttempt;
+  attempt: Pick<
+    IncompleteTurnAttempt,
+    "assistantTexts" | "currentAttemptAssistant" | "lastAssistant"
+  >;
 }): boolean {
-  const emptyPostToolFinalAssistant = hasEmptyPostToolFinalAssistantTurn(params.attempt);
-  if (params.payloadCount !== 0 && !emptyPostToolFinalAssistant) {
+  if (params.payloadCount !== 0) {
     return false;
   }
-  if (
-    joinAssistantTexts(params.attempt.assistantTexts).length > 0 &&
-    !emptyPostToolFinalAssistant
-  ) {
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
     return false;
   }
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
@@ -712,7 +590,7 @@ function isEmptyResponseAssistantTurn(params: {
       hasAssistantVisibleText: false,
       lastAssistant: assistant,
     }) ||
-    (isReasoningOnlyAssistantTurn(assistant) && !emptyPostToolFinalAssistant)
+    isReasoningOnlyAssistantTurn(assistant)
   ) {
     return false;
   }
@@ -721,7 +599,10 @@ function isEmptyResponseAssistantTurn(params: {
 
 function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   payloadCount: number;
-  attempt: IncompleteTurnAttempt;
+  attempt: Pick<
+    IncompleteTurnAttempt,
+    "assistantTexts" | "currentAttemptAssistant" | "lastAssistant"
+  >;
 }): boolean {
   if (isEmptyResponseAssistantTurn(params)) {
     return true;
@@ -747,7 +628,7 @@ function isNonVisibleAssistantTurnEligibleForSilentReply(params: {
   return isReasoningOnlyAssistantTurn(assistant);
 }
 
-function shouldSkipPlanningOnlyRetry(params: {
+function shouldSkipNonVisibleTurnRetry(params: {
   aborted: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
@@ -772,7 +653,7 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): boolean {
-  if (!params.allowEmptyAssistantReplyAsSilent || shouldSkipPlanningOnlyRetry(params)) {
+  if (!params.allowEmptyAssistantReplyAsSilent || shouldSkipNonVisibleTurnRetry(params)) {
     return false;
   }
   if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
@@ -816,7 +697,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
-  if (shouldSkipPlanningOnlyRetry(params)) {
+  if (shouldSkipNonVisibleTurnRetry(params)) {
     return null;
   }
 
@@ -859,7 +740,7 @@ export function resolveEmptyResponseRetryInstruction(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
-  if (shouldSkipPlanningOnlyRetry(params)) {
+  if (shouldSkipNonVisibleTurnRetry(params)) {
     return null;
   }
 
@@ -873,14 +754,12 @@ export function resolveEmptyResponseRetryInstruction(params: {
   }
 
   const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant ?? null;
-  const emptyPostToolFinalAssistant = hasEmptyPostToolFinalAssistantTurn(params.attempt);
   if (
     assistant?.stopReason === "stop" &&
     OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN.test(
       normalizeLowercaseStringOrEmpty(params.provider ?? ""),
     ) &&
-    !hasPositiveOutputTokenUsage(assistant) &&
-    !emptyPostToolFinalAssistant
+    !hasPositiveOutputTokenUsage(assistant)
   ) {
     return null;
   }
@@ -892,7 +771,6 @@ export function resolveEmptyResponseRetryInstruction(params: {
       modelApi: params.modelApi,
       executionContract: params.executionContract,
     }) ||
-    emptyPostToolFinalAssistant ||
     // Keep the generic zero-usage stop retry for providers that expose a
     // provider-neutral "nothing was generated" signal, even outside the
     // provider allowlist above.
@@ -904,36 +782,25 @@ export function resolveEmptyResponseRetryInstruction(params: {
   return null;
 }
 
-function shouldApplyPlanningOnlyRetryGuard(params: {
-  provider?: string;
-  modelId?: string;
-  executionContract?: string;
-}): boolean {
-  if (params.executionContract === "strict-agentic") {
-    return true;
-  }
-  return isIncompleteTurnRecoverySupportedProviderModel({
-    provider: params.provider,
-    modelId: params.modelId,
-  });
-}
-
 function shouldApplyNonVisibleTurnRetryGuard(params: {
   provider?: string;
   modelId?: string;
   modelApi?: string;
   executionContract?: string;
 }): boolean {
-  if (shouldApplyPlanningOnlyRetryGuard(params)) {
+  if (
+    params.executionContract === "strict-agentic" ||
+    isIncompleteTurnRecoverySupportedProviderModel({
+      provider: params.provider,
+      modelId: params.modelId,
+    })
+  ) {
     return true;
   }
   if (RETRY_GUARD_MODEL_APIS.has(normalizeLowercaseStringOrEmpty(params.modelApi ?? ""))) {
     return true;
   }
-  // Non-visible final turns are narrower than planning-only turns: there is no
-  // user text to classify, just a replay-safe empty/thinking-only result. Ollama
-  // gets this continuation guard without getting the planning-only or ack
-  // fast-path wording, which would be too opinionated for local models.
+  // This path uses provider output structure only: no user or assistant prose classification.
   return OLLAMA_INCOMPLETE_TURN_PROVIDER_ID_PATTERN.test(
     normalizeLowercaseStringOrEmpty(params.provider ?? ""),
   );
@@ -957,222 +824,4 @@ function isIncompleteTurnRecoverySupportedProviderModel(params: {
   }
   const modelId = typeof params.modelId === "string" ? params.modelId : "";
   return GEMINI_INCOMPLETE_TURN_MODEL_ID_PATTERN.test(stripProviderPrefix(modelId));
-}
-
-function normalizeAckPrompt(text: string): string {
-  const normalized = text
-    .normalize("NFKC")
-    .trim()
-    .replace(/[\p{P}\p{S}]+/gu, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return normalizeLowercaseStringOrEmpty(normalized);
-}
-
-/** Detects short multilingual approval prompts that should continue execution immediately. */
-export function isLikelyExecutionAckPrompt(text: string): boolean {
-  const trimmed = text.trim();
-  if (!trimmed || trimmed.length > 80 || trimmed.includes("\n") || trimmed.includes("?")) {
-    return false;
-  }
-  return ACK_EXECUTION_NORMALIZED_SET.has(normalizeAckPrompt(trimmed));
-}
-
-function isLikelyActionableUserPrompt(text: string): boolean {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return false;
-  }
-  if (isLikelyExecutionAckPrompt(trimmed) || trimmed.includes("?")) {
-    return true;
-  }
-  return ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) || ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed);
-}
-
-/** Builds the fast-path execution instruction for short approval prompts like "go ahead". */
-export function resolveAckExecutionFastPathInstruction(params: {
-  provider?: string;
-  modelId?: string;
-  prompt: string;
-}): string | null {
-  if (
-    !shouldApplyPlanningOnlyRetryGuard({
-      provider: params.provider,
-      modelId: params.modelId,
-    }) ||
-    !isLikelyExecutionAckPrompt(params.prompt)
-  ) {
-    return null;
-  }
-  return ACK_EXECUTION_FAST_PATH_INSTRUCTION;
-}
-
-function extractPlanningOnlySteps(text: string): string[] {
-  const lines = normalizeStringEntries(text.split(/\r?\n/));
-  const bulletLines = normalizeStringEntries(
-    lines.map((line) => line.replace(/^[-*•]\s+|^\d+[.)]\s+/u, "")),
-  );
-  if (bulletLines.length >= 2) {
-    return bulletLines.slice(0, 4);
-  }
-  return normalizeStringEntries(text.split(/(?<=[.!?])\s+/u)).slice(0, 4);
-}
-
-function hasStructuredPlanningOnlyFormat(text: string): boolean {
-  const lines = normalizeStringEntries(text.split(/\r?\n/));
-  if (lines.length === 0) {
-    return false;
-  }
-  const bulletLineCount = lines.filter((line) => PLANNING_ONLY_BULLET_RE.test(line)).length;
-  const hasPlanningCueLine = lines.some((line) => PLANNING_ONLY_PROMISE_RE.test(line));
-  const hasPlanningHeading = PLANNING_ONLY_HEADING_RE.test(lines[0] ?? "");
-  return (hasPlanningHeading && hasPlanningCueLine) || (bulletLineCount >= 2 && hasPlanningCueLine);
-}
-
-/** Extracts the visible plan text and normalized step list from a plan-only reply. */
-export function extractPlanningOnlyPlanDetails(text: string): PlanningOnlyPlanDetails | null {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const steps = extractPlanningOnlySteps(trimmed);
-  return {
-    explanation: trimmed,
-    steps,
-  };
-}
-
-function normalizePlanningToolMetas(
-  toolMetas?: PlanningOnlyAttempt["toolMetas"],
-): PlanningOnlyAttempt["toolMetas"] {
-  return toolMetas ?? [];
-}
-
-function countPlanOnlyToolMetas(toolMetas?: PlanningOnlyAttempt["toolMetas"]): number {
-  return normalizePlanningToolMetas(toolMetas).filter((entry) => entry.toolName === "update_plan")
-    .length;
-}
-
-function countNonPlanToolCalls(toolMetas?: PlanningOnlyAttempt["toolMetas"]): number {
-  return normalizePlanningToolMetas(toolMetas).filter((entry) => entry.toolName !== "update_plan")
-    .length;
-}
-
-function hasNonPlanToolActivity(toolMetas?: PlanningOnlyAttempt["toolMetas"]): boolean {
-  return normalizePlanningToolMetas(toolMetas).some((entry) => entry.toolName !== "update_plan");
-}
-
-function hasSingleRetrySafeNonPlanTool(toolMetas?: PlanningOnlyAttempt["toolMetas"]): boolean {
-  const nonPlanToolNames = normalizePlanningToolMetas(toolMetas)
-    .map((entry) => normalizeLowercaseStringOrEmpty(entry.toolName))
-    .filter((toolName) => toolName && toolName !== "update_plan");
-  return (
-    nonPlanToolNames.length === 1 &&
-    SINGLE_ACTION_RETRY_SAFE_TOOL_NAMES.has(nonPlanToolNames[0] ?? "")
-  );
-}
-
-/**
- * Treat a turn with exactly one non-plan tool call plus visible "I'll do X
- * next" prose as effectively planning-only from the user's perspective. This
- * closes the one-action-then-narrative loophole without changing the 2+ tool
- * call path, which still counts as real multi-step progress.
- */
-function isSingleActionThenNarrativePattern(params: {
-  toolMetas?: PlanningOnlyAttempt["toolMetas"];
-  assistantTexts?: readonly string[];
-}): boolean {
-  const nonPlanCount = countNonPlanToolCalls(params.toolMetas);
-  if (nonPlanCount !== 1) {
-    return false;
-  }
-  const text = (params.assistantTexts ?? []).join("\n\n").trim();
-  if (!text || text.length > PLANNING_ONLY_MAX_VISIBLE_TEXT) {
-    return false;
-  }
-  if (SINGLE_ACTION_RESULT_STYLE_RE.test(text)) {
-    return false;
-  }
-  return (
-    SINGLE_ACTION_EXPLICIT_CONTINUATION_RE.test(text) ||
-    SINGLE_ACTION_MULTI_STEP_PROMISE_RE.test(text)
-  );
-}
-
-/** Retry budget for plan-only recovery, higher for strict-agentic models. */
-export function resolvePlanningOnlyRetryLimit(
-  executionContract?: EmbeddedAgentExecutionContract,
-): number {
-  return executionContract === "strict-agentic"
-    ? STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT
-    : DEFAULT_PLANNING_ONLY_RETRY_LIMIT;
-}
-
-/**
- * Builds the retry instruction for assistant turns that only promised a plan
- * instead of taking concrete action. The guard excludes real side effects,
- * non-actionable prompts, explicit completions, and multi-tool progress.
- */
-export function resolvePlanningOnlyRetryInstruction(params: {
-  provider?: string;
-  modelId?: string;
-  executionContract?: string;
-  prompt?: string;
-  aborted: boolean;
-  timedOut: boolean;
-  attempt: PlanningOnlyAttempt;
-}): string | null {
-  const planOnlyToolMetaCount = countPlanOnlyToolMetas(params.attempt.toolMetas);
-  const singleActionNarrative = isSingleActionThenNarrativePattern({
-    toolMetas: params.attempt.toolMetas,
-    assistantTexts: params.attempt.assistantTexts,
-  });
-  const allowSingleActionRetryBypass =
-    singleActionNarrative && hasSingleRetrySafeNonPlanTool(params.attempt.toolMetas);
-  if (
-    !shouldApplyPlanningOnlyRetryGuard({
-      provider: params.provider,
-      modelId: params.modelId,
-      executionContract: params.executionContract,
-    }) ||
-    (typeof params.prompt === "string" && !isLikelyActionableUserPrompt(params.prompt)) ||
-    params.aborted ||
-    params.timedOut ||
-    params.attempt.clientToolCalls ||
-    params.attempt.yieldDetected ||
-    params.attempt.didSendDeterministicApprovalPrompt ||
-    hasMessagingToolDeliveryEvidence(params.attempt) ||
-    params.attempt.lastToolError ||
-    (hasNonPlanToolActivity(params.attempt.toolMetas) && !allowSingleActionRetryBypass) ||
-    ((params.attempt.itemLifecycle?.startedCount ?? 0) > planOnlyToolMetaCount &&
-      !allowSingleActionRetryBypass) ||
-    resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects
-  ) {
-    return null;
-  }
-
-  const stopReason = params.attempt.lastAssistant?.stopReason;
-  if (stopReason && stopReason !== "stop") {
-    return null;
-  }
-
-  const text = (params.attempt.assistantTexts ?? []).join("\n\n").trim();
-  if (!text || text.length > PLANNING_ONLY_MAX_VISIBLE_TEXT || text.includes("```")) {
-    return null;
-  }
-  const hasStructuredPlanningFormat = hasStructuredPlanningOnlyFormat(text);
-  if (!PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat) {
-    return null;
-  }
-  if (
-    !hasStructuredPlanningFormat &&
-    !singleActionNarrative &&
-    !PLANNING_ONLY_ACTION_VERB_RE.test(text)
-  ) {
-    return null;
-  }
-  if (PLANNING_ONLY_COMPLETION_RE.test(text)) {
-    return null;
-  }
-  return PLANNING_ONLY_RETRY_INSTRUCTION;
 }

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -221,9 +221,11 @@ export type RunEmbeddedAgentParams = {
     sessionKey?: string;
   }) => void | Promise<void>;
   /**
-   * Emit lifecycle "finishing" when the model turn ends; the caller owns the
-   * final lifecycle "end" after durable post-turn maintenance completes.
+   * Emit lifecycle "finishing" when the attempt ends; the caller owns the
+   * final lifecycle "end" or "error" after fallback and post-turn work settle.
    */
+  deferTerminalLifecycle?: boolean;
+  /** @deprecated Use deferTerminalLifecycle. */
   deferTerminalLifecycleEnd?: boolean;
   lane?: string;
   enqueue?: CommandQueueEnqueueFn;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -65,6 +65,8 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   agentHarnessTaskRuntimeScope?: AgentHarnessTaskRuntimeScope;
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
+  /** Supplies run-global model-call ordering for parallel tool outcomes. */
+  allocateToolOutcomeOrdinal?: () => number;
   model: Model;
   authStorage: AuthStorage;
   /** Auth profile store already resolved during startup for this attempt. */

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -160,8 +160,13 @@ export type EmbeddedAgentRunMeta = {
       | "role_ordering"
       | "image_size"
       | "retry_limit"
+      | "incomplete_turn"
       | "hook_block";
     message: string;
+    /** True only when model fallback can retry this terminal error without repeating side effects. */
+    fallbackSafe?: boolean;
+    /** True when the payload includes a trusted structured terminal tool summary. */
+    terminalPresentation?: boolean;
   };
   failureSignal?: EmbeddedRunFailureSignal;
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -184,38 +184,9 @@ export function handleAgentEnd(
         : {}),
       ...(typeof terminalAborted === "boolean" ? { aborted: terminalAborted } : {}),
     };
-    if (isError) {
-      emitAgentEvent({
-        runId: ctx.params.runId,
-        ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-        ...(ctx.params.sessionId ? { sessionId: ctx.params.sessionId } : {}),
-        ...(ctx.params.agentId ? { agentId: ctx.params.agentId } : {}),
-        ...(ctx.params.lifecycleGeneration
-          ? { lifecycleGeneration: ctx.params.lifecycleGeneration }
-          : {}),
-        stream: "lifecycle",
-        data: {
-          phase: "error",
-          error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
-          ...terminalMeta,
-          ...(livenessState ? { livenessState } : {}),
-          ...(replayInvalid ? { replayInvalid } : {}),
-          endedAt: Date.now(),
-        },
-      });
-      void ctx.params.onAgentEvent?.({
-        stream: "lifecycle",
-        data: {
-          phase: "error",
-          error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT,
-          ...terminalMeta,
-          ...(livenessState ? { livenessState } : {}),
-          ...(replayInvalid ? { replayInvalid } : {}),
-        },
-      });
-      return;
-    }
-    const successPhase = ctx.params.terminalLifecyclePhase ?? "end";
+    const phase =
+      ctx.params.terminalLifecyclePhase === "finishing" ? "finishing" : isError ? "error" : "end";
+    const errorData = isError ? { error: lifecycleErrorText ?? GENERIC_ASSISTANT_ERROR_TEXT } : {};
     emitAgentEvent({
       runId: ctx.params.runId,
       ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
@@ -226,7 +197,8 @@ export function handleAgentEnd(
         : {}),
       stream: "lifecycle",
       data: {
-        phase: successPhase,
+        phase,
+        ...errorData,
         ...terminalMeta,
         ...(livenessState ? { livenessState } : {}),
         ...(replayInvalid ? { replayInvalid } : {}),
@@ -236,7 +208,8 @@ export function handleAgentEnd(
     void ctx.params.onAgentEvent?.({
       stream: "lifecycle",
       data: {
-        phase: successPhase,
+        phase,
+        ...errorData,
         ...terminalMeta,
         ...(livenessState ? { livenessState } : {}),
         ...(replayInvalid ? { replayInvalid } : {}),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -8,6 +8,11 @@ import {
 } from "../infra/agent-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import {
+  buildBlockedToolResult,
+  recordAdjustedParamsForToolCall,
+  testing as beforeToolCallTesting,
+} from "./agent-tools.before-tool-call.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
 import {
   handleToolExecutionEnd,
@@ -330,7 +335,7 @@ describe("handleToolExecutionStart read path checks", () => {
   });
 });
 
-describe("handleToolExecutionEnd cron.add commitment tracking", () => {
+describe("handleToolExecutionEnd cron mutation tracking", () => {
   it("increments successfulCronAdds when cron add succeeds", async () => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(
@@ -355,6 +360,7 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     );
 
     expect(ctx.state.successfulCronAdds).toBe(1);
+    expect(ctx.state.replayState.hadPotentialSideEffects).toBe(true);
   });
 
   it("does not increment successfulCronAdds when cron add fails", async () => {
@@ -383,6 +389,136 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     expect(ctx.state.successfulCronAdds).toBe(0);
     expect(ctx.state.itemCompletedCount).toBe(1);
     expect(ctx.state.itemActiveIds.size).toBe(0);
+  });
+
+  it("keeps pre-execution cron failures replay-safe", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId: "tool-cron-invalid",
+        args: { action: "add" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId: "tool-cron-invalid",
+        isError: true,
+        executionStarted: false,
+        result: { details: { status: "error", error: "job required" } },
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: false,
+      hadPotentialSideEffects: false,
+    });
+    expect(ctx.state.lastToolError?.mutatingAction).toBe(false);
+  });
+
+  it("keeps a policy-blocked cron mutation replay-safe", async () => {
+    const { ctx } = createTestContext();
+    const toolCallId = "tool-cron-blocked";
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId,
+        args: { action: "add", job: { name: "reminder" } },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId,
+        isError: false,
+        result: buildBlockedToolResult({
+          reason: "blocked by policy",
+          toolCallId,
+          runId: "run-test",
+        }),
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: false,
+      hadPotentialSideEffects: false,
+    });
+    expect(ctx.state.lastToolError?.mutatingAction).toBe(false);
+  });
+
+  it("keeps executed mutations replay-unsafe when middleware rewrites the result as blocked", async () => {
+    const { ctx } = createTestContext();
+    const toolCallId = "tool-cron-rewritten-blocked";
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId,
+        args: { action: "add", job: { name: "reminder" } },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId,
+        isError: true,
+        result: {
+          content: [{ type: "text", text: "blocked by middleware" }],
+          details: {
+            status: "blocked",
+            deniedReason: "plugin-before-tool-call",
+            reason: "blocked by middleware",
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+    expect(ctx.state.lastToolError?.mutatingAction).toBe(true);
+  });
+
+  it("records cron status as read-only", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId: "tool-cron-status",
+        args: { action: "status" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId: "tool-cron-status",
+        isError: false,
+        result: { details: { enabled: true } },
+      } as never,
+    );
+
+    expect(ctx.state.replayState.hadPotentialSideEffects).toBe(false);
   });
 });
 
@@ -620,6 +756,223 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
       replayInvalid: true,
       hadPotentialSideEffects: true,
     });
+  });
+
+  it("keeps failed mutating tool attempts replay-invalid", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-partial-failure",
+        args: { command: "printf changed > /tmp/demo.txt && false" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-partial-failure",
+        isError: true,
+        result: { error: "Command exited with code 1" },
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+  });
+
+  it("keeps unclassified interactive tool calls replay-invalid", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "browser",
+        toolCallId: "tool-browser-click",
+        args: { action: "act", kind: "click", ref: "e12" },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "browser",
+        toolCallId: "tool-browser-click",
+        isError: false,
+        result: { details: { ok: true } },
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+  });
+
+  it("uses hook-adjusted args for replay safety", async () => {
+    const { ctx } = createTestContext();
+    const toolCallId = "tool-cron-hook-rewrite";
+    const adjustedParamsKey = beforeToolCallTesting.buildAdjustedParamsKey({
+      runId: "run-test",
+      toolCallId,
+    });
+    beforeToolCallTesting.adjustedParamsByToolCallId.set(adjustedParamsKey, {
+      action: "add",
+      job: { name: "rewritten mutation" },
+    });
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId,
+        args: { action: "status" },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId,
+        isError: false,
+        result: { ok: true },
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+    expect(ctx.state.successfulCronAdds).toBe(1);
+    expect(beforeToolCallTesting.adjustedParamsByToolCallId.has(adjustedParamsKey)).toBe(false);
+  });
+
+  it("snapshots hook-adjusted args before result middleware can mutate them", async () => {
+    const { ctx } = createTestContext();
+    const toolCallId = "tool-cron-mutable-adjusted-args";
+    const executedArgs = {
+      action: "add",
+      job: { name: "rewritten mutation" },
+    };
+    recordAdjustedParamsForToolCall(toolCallId, executedArgs, "run-test");
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId,
+        args: { action: "status" },
+      } as never,
+    );
+    executedArgs.action = "status";
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId,
+        isError: false,
+        result: { ok: true },
+      } as never,
+    );
+
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("uses hook-adjusted message arguments for delivery telemetry", async () => {
+    const { ctx } = createTestContext();
+    const toolCallId = "tool-message-hook-rewrite";
+    const adjustedParamsKey = beforeToolCallTesting.buildAdjustedParamsKey({
+      runId: "run-test",
+      toolCallId,
+    });
+    beforeToolCallTesting.adjustedParamsByToolCallId.set(adjustedParamsKey, {
+      action: "send",
+      provider: "telegram",
+      to: "chat-rewritten",
+      text: "rewritten delivery",
+      mediaUrl: "/tmp/rewritten.png",
+    });
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "message",
+        toolCallId,
+        args: { action: "status" },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "message",
+        toolCallId,
+        isError: false,
+        result: { details: { messageId: "message-rewritten" } },
+      } as never,
+    );
+
+    expect(ctx.state.messagingToolSentTexts).toEqual(["rewritten delivery"]);
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["/tmp/rewritten.png"]);
+    expect(ctx.state.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "telegram",
+        to: "chat-rewritten",
+        threadId: undefined,
+        text: "rewritten delivery",
+        mediaUrls: ["/tmp/rewritten.png"],
+      },
+    ]);
+  });
+
+  it("does not treat text or media arguments on non-messaging tools as delivery", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "cron",
+        toolCallId: "tool-cron-wake",
+        args: {
+          action: "wake",
+          text: "not an outbound message",
+          mediaUrl: "/tmp/not-an-outbound-message.png",
+        },
+      } as never,
+    );
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "cron",
+        toolCallId: "tool-cron-wake",
+        isError: false,
+        result: { details: { status: "ok" } },
+      } as never,
+    );
+
+    expect(ctx.state.messagingToolSentTexts).toEqual([]);
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual([]);
+    expect(ctx.state.messagingToolSentTargets).toEqual([]);
   });
 
   it("marks successful legacy subagents control actions as replay-invalid", async () => {
@@ -1608,6 +1961,69 @@ describe("messaging tool media URL tracking", () => {
       to: "user:u1",
       threadId: "171.222",
       threadImplicit: true,
+    });
+  });
+
+  it("preserves the pre-send reply state when committing implicit thread evidence", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "slack" }),
+            messaging: { normalizeTarget: (raw: string) => raw.trim().toLowerCase() },
+            threading: {
+              resolveAutoThreadId: ({
+                toolContext,
+              }: {
+                toolContext?: {
+                  currentThreadTs?: string;
+                  replyToMode?: "off" | "first" | "all" | "batched";
+                  hasRepliedRef?: { value: boolean };
+                };
+              }) =>
+                toolContext?.replyToMode === "first" && !toolContext.hasRepliedRef?.value
+                  ? toolContext.currentThreadTs
+                  : undefined,
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    const { ctx } = createTestContext();
+    ctx.params.currentChannelId = "D1";
+    ctx.params.currentMessagingTarget = "user:u1";
+    ctx.params.currentThreadId = "171.222";
+    ctx.params.replyToMode = "first";
+    ctx.params.hasRepliedRef = { value: false };
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-first-threaded-message",
+      args: {
+        action: "send",
+        provider: "slack",
+        to: "user:U1",
+        content: "hi",
+      },
+    });
+    ctx.params.hasRepliedRef.value = true;
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-first-threaded-message",
+      isError: false,
+      result: { details: { messageId: "message-1" } },
+    });
+
+    expectRecordFields(requireSingleMessagingTarget(ctx), "messaging target", {
+      provider: "slack",
+      to: "user:u1",
+      threadId: "171.222",
+      threadImplicit: true,
+      text: "hi",
     });
   });
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -11,6 +11,7 @@ import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/c
 import {
   buildBlockedToolResult,
   recordAdjustedParamsForToolCall,
+  recordStructuredReplayTrustForToolCall,
   testing as beforeToolCallTesting,
 } from "./agent-tools.before-tool-call.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
@@ -495,30 +496,72 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     expect(ctx.state.lastToolError?.mutatingAction).toBe(true);
   });
 
-  it("records cron status as read-only", async () => {
+  it("records structured core read actions as replay-safe", async () => {
+    for (const [toolName, action] of [
+      ["cron", "status"],
+      ["gateway", "config.get"],
+      ["gateway", "config.schema.lookup"],
+      ["nodes", "status"],
+      ["nodes", "describe"],
+      ["nodes", "pending"],
+    ] as const) {
+      const { ctx } = createTestContext();
+      const toolCallId = `tool-${toolName}-${action}`;
+      recordStructuredReplayTrustForToolCall(
+        toolCallId,
+        { name: toolName, execute: vi.fn() } as never,
+        "run-test",
+      );
+      await handleToolExecutionStart(
+        ctx as never,
+        {
+          type: "tool_execution_start",
+          toolName,
+          toolCallId,
+          args: { action },
+        } as never,
+      );
+      await handleToolExecutionEnd(
+        ctx as never,
+        {
+          type: "tool_execution_end",
+          toolName,
+          toolCallId,
+          isError: false,
+          result: { details: { ok: true } },
+        } as never,
+      );
+
+      expect(ctx.state.replayState.hadPotentialSideEffects, `${toolName}.${action}`).toBe(false);
+    }
+  });
+
+  it("does not trust replay-safe names without concrete instance provenance", async () => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(
       ctx as never,
       {
         type: "tool_execution_start",
-        toolName: "cron",
-        toolCallId: "tool-cron-status",
-        args: { action: "status" },
+        toolName: "search",
+        toolCallId: "tool-shadowed-search",
+        args: { query: "scheduler" },
       } as never,
     );
-
     await handleToolExecutionEnd(
       ctx as never,
       {
         type: "tool_execution_end",
-        toolName: "cron",
-        toolCallId: "tool-cron-status",
+        toolName: "search",
+        toolCallId: "tool-shadowed-search",
         isError: false,
-        result: { details: { enabled: true } },
+        result: { matches: [] },
       } as never,
     );
 
-    expect(ctx.state.replayState.hadPotentialSideEffects).toBe(false);
+    expect(ctx.state.replayState).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
   });
 });
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -199,6 +199,7 @@ const TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS = TOOL_START_WARNING_PREVIEW_MAX_
 type ToolStartRecord = {
   startTime: number;
   args: unknown;
+  hasRepliedRef?: { value: boolean };
 };
 
 /** Track tool execution start data for after_tool_call hook. */
@@ -232,13 +233,14 @@ function buildToolCallSummary(
   toolName: string,
   args: unknown,
   meta: string | undefined,
-  replaySafe: boolean,
+  instanceReplaySafe: boolean,
 ): ToolCallSummary {
   const mutation = buildToolMutationState(toolName, args, meta);
   return {
     meta,
-    replaySafe: replaySafe && !mutation.mutatingAction,
+    instanceReplaySafe,
     mutatingAction: mutation.mutatingAction,
+    replaySafe: instanceReplaySafe && mutation.replaySafe,
     actionFingerprint: mutation.actionFingerprint,
     fileTarget: mutation.fileTarget,
   };
@@ -554,6 +556,16 @@ function collectMessagingMediaUrlsFromRecord(record: Record<string, unknown>): s
   }
 
   return urls;
+}
+
+function readMessagingText(record: Record<string, unknown>): string | undefined {
+  for (const key of ["content", "message", "text", "body"]) {
+    const value = readStringValue(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function collectMessagingMediaUrlsFromToolResult(result: unknown): string[] {
@@ -894,12 +906,7 @@ async function emitToolResultOutput(params: {
 /** Handles a tool-execution start event and emits UI/telemetry start state. */
 export function handleToolExecutionStart(
   ctx: ToolHandlerContext,
-  evt: AgentEvent & {
-    toolName: string;
-    toolCallId: string;
-    args: unknown;
-    replaySafe?: boolean;
-  },
+  evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
 ): void | Promise<void> {
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
     const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
@@ -928,7 +935,13 @@ export function handleToolExecutionStart(
 
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();
-    toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
+    toolStartData.set(buildToolStartKey(runId, toolCallId), {
+      startTime: startedAt,
+      args,
+      ...(ctx.params.hasRepliedRef
+        ? { hasRepliedRef: { value: ctx.params.hasRepliedRef.value } }
+        : {}),
+    });
     traceToolExecutionStart({ ctx, toolName, toolCallId, args });
 
     if (toolName === "read") {
@@ -995,11 +1008,14 @@ export function handleToolExecutionStart(
         detailMode: ctx.params.toolProgressDetail ?? "explain",
       }),
     );
-    const replaySafe =
+    const instanceReplaySafe =
       evt.replaySafe === true ||
       ctx.params.replaySafeToolNames?.has(rawToolName) === true ||
       ctx.params.replaySafeToolNames?.has(toolName) === true;
-    ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta, replaySafe));
+    ctx.state.toolMetaById.set(
+      toolCallId,
+      buildToolCallSummary(toolName, args, meta, instanceReplaySafe),
+    );
     ctx.log.debug(
       `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
     );
@@ -1097,9 +1113,8 @@ export function handleToolExecutionStart(
         if (sendTarget) {
           ctx.state.pendingMessagingTargets.set(toolCallId, sendTarget);
         }
-        // Field names vary by tool: Discord/Slack use "content", sessions_send uses "message"
-        const text = (argsRecord.content as string) ?? (argsRecord.message as string);
-        if (text && typeof text === "string") {
+        const text = readMessagingText(argsRecord);
+        if (text) {
           ctx.state.pendingMessagingTexts.set(toolCallId, text);
           ctx.log.debug(`Tracking pending messaging text: tool=${toolName} len=${text.length}`);
         }
@@ -1215,12 +1230,7 @@ export function handleToolExecutionUpdate(
 /** Handles a tool-execution result and commits replay, media, hook, and error state. */
 export async function handleToolExecutionEnd(
   ctx: ToolHandlerContext,
-  evt: AgentEvent & {
-    toolName: string;
-    toolCallId: string;
-    isError: boolean;
-    result?: unknown;
-  },
+  evt: Extract<AgentEvent, { type: "tool_execution_end" }>,
 ) {
   const rawToolName = evt.toolName;
   const toolName = normalizeToolName(rawToolName);
@@ -1251,15 +1261,37 @@ export async function handleToolExecutionEnd(
   const startData = toolStartData.get(toolStartKey);
   toolStartData.delete(toolStartKey);
   ctx.state.execLiveUpdateStateById?.delete(toolCallId);
-  const callSummary = ctx.state.toolMetaById.get(toolCallId);
-  const completedReplayUnsafeAction = !isToolError && callSummary?.replaySafe !== true;
-  const meta = callSummary?.meta;
+  const initialCallSummary = ctx.state.toolMetaById.get(toolCallId);
+  const initialArgs =
+    startData?.args && typeof startData.args === "object"
+      ? (startData.args as Record<string, unknown>)
+      : {};
+  const { consumeAdjustedParamsForToolCall, consumePreExecutionBlockedToolCall } =
+    await loadBeforeToolCall();
+  const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
+  const executionPrevented = consumePreExecutionBlockedToolCall(toolCallId, runId);
+  const startArgs =
+    adjustedArgs && typeof adjustedArgs === "object"
+      ? (adjustedArgs as Record<string, unknown>)
+      : initialArgs;
+  const callSummary = buildToolCallSummary(
+    toolName,
+    startArgs,
+    initialCallSummary?.meta,
+    initialCallSummary?.instanceReplaySafe === true,
+  );
+  // Older/custom event producers omit executionStarted. Treat omission as
+  // executed; only an explicit false can prove preparation stopped the call.
+  const executionStarted = evt.executionStarted !== false && !executionPrevented;
+  const attemptedMutatingAction = callSummary.mutatingAction && executionStarted;
+  const attemptedPotentialSideEffect = !callSummary.replaySafe && executionStarted;
+  const meta = callSummary.meta;
   const asyncStarted = !isToolError && isAsyncStartedToolResult(sanitizedResult);
   const asyncTaskIds = asyncStarted ? readAsyncStartedTaskIds(sanitizedResult) : {};
   ctx.state.toolMetas.push({
     toolName,
     meta,
-    replaySafe: callSummary?.replaySafe === true,
+    replaySafe: callSummary.replaySafe,
     ...(asyncStarted ? { asyncStarted: true, ...asyncTaskIds } : {}),
   });
   const acceptedSessionSpawn =
@@ -1281,9 +1313,9 @@ export async function handleToolExecutionEnd(
       error: errorMessage,
       timedOut: isToolResultTimedOut(sanitizedResult) || undefined,
       middlewareError: isMiddlewareToolResultError(sanitizedResult) || undefined,
-      mutatingAction: callSummary?.mutatingAction,
-      actionFingerprint: callSummary?.actionFingerprint,
-      fileTarget: callSummary?.fileTarget,
+      mutatingAction: attemptedMutatingAction,
+      actionFingerprint: attemptedMutatingAction ? callSummary.actionFingerprint : undefined,
+      fileTarget: attemptedMutatingAction ? callSummary.fileTarget : undefined,
     };
   } else if (ctx.state.lastToolError) {
     // Keep unresolved mutating failures until the same action succeeds.
@@ -1305,7 +1337,7 @@ export async function handleToolExecutionEnd(
   if (asyncStarted) {
     ctx.state.hadDeterministicSideEffect = true;
   }
-  if (completedReplayUnsafeAction || acceptedSessionSpawn || asyncStarted) {
+  if (attemptedPotentialSideEffect || acceptedSessionSpawn || asyncStarted) {
     ctx.state.replayState = mergeEmbeddedRunReplayState(ctx.state.replayState, {
       replayInvalid: true,
       hadPotentialSideEffects: true,
@@ -1313,43 +1345,46 @@ export async function handleToolExecutionEnd(
   }
 
   // Commit messaging tool evidence on success, discard on error.
-  const pendingText = ctx.state.pendingMessagingTexts.get(toolCallId);
-  const pendingTarget = ctx.state.pendingMessagingTargets.get(toolCallId);
-  const pendingMediaUrls = ctx.state.pendingMessagingMediaUrls.get(toolCallId) ?? [];
-  const startArgs =
-    startData?.args && typeof startData.args === "object"
-      ? (startData.args as Record<string, unknown>)
-      : {};
+  const messagingArgs = applyCurrentMessageProvider(toolName, startArgs, ctx.params.messageChannel);
   const isMessagingSend =
-    pendingMediaUrls.length > 0 ||
-    (isMessagingTool(toolName) && isMessagingToolSendAction(toolName, startArgs));
+    isMessagingTool(toolName) && isMessagingToolSendAction(toolName, startArgs);
+  const messageText = isMessagingSend ? readMessagingText(startArgs) : undefined;
+  const argumentMediaUrls = isMessagingSend ? collectMessagingMediaUrlsFromRecord(startArgs) : [];
+  const messageTarget = isMessagingSend
+    ? extractMessagingToolSend(toolName, messagingArgs, {
+        config: ctx.params.config,
+        currentChannelId: ctx.params.currentChannelId,
+        currentMessagingTarget: ctx.params.currentMessagingTarget,
+        currentThreadId:
+          ctx.params.currentThreadId ?? parseSessionThreadInfoFast(ctx.params.sessionKey).threadId,
+        currentMessageId: ctx.params.currentMessageId,
+        replyToMode: ctx.params.replyToMode,
+        hasRepliedRef: startData?.hasRepliedRef,
+      })
+    : undefined;
   const committedMediaUrls =
     !isToolError && isMessagingSend
-      ? [...pendingMediaUrls, ...collectMessagingMediaUrlsFromToolResult(result)]
+      ? [...argumentMediaUrls, ...collectMessagingMediaUrlsFromToolResult(result)]
       : [];
-  if (pendingText) {
-    ctx.state.pendingMessagingTexts.delete(toolCallId);
-    if (!isToolError) {
-      ctx.state.messagingToolSentTexts.push(pendingText);
-      ctx.state.messagingToolSentTextsNormalized.push(normalizeTextForComparison(pendingText));
-      ctx.log.debug(`Committed messaging text: tool=${toolName} len=${pendingText.length}`);
-      ctx.trimMessagingToolSent();
-    }
-  }
-  if (pendingTarget) {
-    ctx.state.pendingMessagingTargets.delete(toolCallId);
-    if (!isToolError) {
-      const extractionResult = applyToolSendReceiptForExtraction(result, toolSendReceiptResult);
-      const confirmedTarget = extractMessagingToolSendResult(pendingTarget, extractionResult);
-      ctx.state.messagingToolSentTargets.push({
-        ...confirmedTarget,
-        ...(pendingText ? { text: pendingText } : {}),
-        ...(committedMediaUrls.length > 0 ? { mediaUrls: committedMediaUrls.slice() } : {}),
-      });
-      ctx.trimMessagingToolSent();
-    }
-  }
+  ctx.state.pendingMessagingTexts.delete(toolCallId);
+  ctx.state.pendingMessagingTargets.delete(toolCallId);
   ctx.state.pendingMessagingMediaUrls.delete(toolCallId);
+  if (!isToolError && messageText) {
+    ctx.state.messagingToolSentTexts.push(messageText);
+    ctx.state.messagingToolSentTextsNormalized.push(normalizeTextForComparison(messageText));
+    ctx.log.debug(`Committed messaging text: tool=${toolName} len=${messageText.length}`);
+    ctx.trimMessagingToolSent();
+  }
+  if (!isToolError && messageTarget) {
+    const extractionResult = applyToolSendReceiptForExtraction(result, toolSendReceiptResult);
+    const confirmedTarget = extractMessagingToolSendResult(messageTarget, extractionResult);
+    ctx.state.messagingToolSentTargets.push({
+      ...confirmedTarget,
+      ...(messageText ? { text: messageText } : {}),
+      ...(committedMediaUrls.length > 0 ? { mediaUrls: committedMediaUrls.slice() } : {}),
+    });
+    ctx.trimMessagingToolSent();
+  }
   if (!isToolError && isMessagingSend) {
     if (committedMediaUrls.length > 0) {
       ctx.state.messagingToolSentMediaUrls.push(...committedMediaUrls);
@@ -1374,7 +1409,7 @@ export async function handleToolExecutionEnd(
   }
 
   // Track committed reminders only when cron.add completed successfully.
-  if (!isToolError && toolName === "cron" && isCronAddAction(startData?.args)) {
+  if (!isToolError && toolName === "cron" && isCronAddAction(startArgs)) {
     ctx.state.successfulCronAdds += 1;
   }
   if (!isToolError && toolName === HEARTBEAT_RESPONSE_TOOL_NAME) {
@@ -1629,16 +1664,10 @@ export async function handleToolExecutionEnd(
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? (await loadHookRunnerGlobal()).getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
-    const { consumeAdjustedParamsForToolCall } = await loadBeforeToolCall();
-    const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
-    const afterToolCallArgs =
-      adjustedArgs && typeof adjustedArgs === "object"
-        ? (adjustedArgs as Record<string, unknown>)
-        : startArgs;
     const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
     const hookEvent: PluginHookAfterToolCallEvent = {
       toolName,
-      params: afterToolCallArgs,
+      params: startArgs,
       runId,
       toolCallId,
       result: sanitizedResult,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -35,6 +35,11 @@ import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
+import {
+  consumeAdjustedParamsForToolCall,
+  consumePreExecutionBlockedToolCall,
+  consumeStructuredReplaySafeToolCall,
+} from "./agent-tools.before-tool-call.state.js";
 import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
 import type { ApplyPatchSummary } from "./apply-patch.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
@@ -70,7 +75,6 @@ import { normalizeToolName } from "./tool-policy.js";
 
 type ExecApprovalReplyModule = typeof import("../infra/exec-approval-reply.js");
 type HookRunnerGlobalModule = typeof import("../plugins/hook-runner-global.js");
-type BeforeToolCallModule = typeof import("./agent-tools.before-tool-call.js");
 type ChannelToolProgress = {
   text: string;
 };
@@ -80,9 +84,6 @@ const execApprovalReplyModuleLoader = createLazyImportLoader<ExecApprovalReplyMo
 );
 const hookRunnerGlobalModuleLoader = createLazyImportLoader<HookRunnerGlobalModule>(
   () => import("../plugins/hook-runner-global.js"),
-);
-const beforeToolCallModuleLoader = createLazyImportLoader<BeforeToolCallModule>(
-  () => import("./agent-tools.before-tool-call.js"),
 );
 const LIVE_EXEC_OUTPUT_MAX_CHARS = 8000;
 const LIVE_EXEC_UPDATE_MIN_INTERVAL_MS = 250;
@@ -111,10 +112,6 @@ function loadExecApprovalReply(): Promise<ExecApprovalReplyModule> {
 
 function loadHookRunnerGlobal(): Promise<HookRunnerGlobalModule> {
   return hookRunnerGlobalModuleLoader.load();
-}
-
-function loadBeforeToolCall(): Promise<BeforeToolCallModule> {
-  return beforeToolCallModuleLoader.load();
 }
 
 function getRequiredParamGroupsForTool(
@@ -234,13 +231,16 @@ function buildToolCallSummary(
   args: unknown,
   meta: string | undefined,
   instanceReplaySafe: boolean,
+  structuredReplaySafe: boolean,
 ): ToolCallSummary {
   const mutation = buildToolMutationState(toolName, args, meta);
   return {
     meta,
     instanceReplaySafe,
     mutatingAction: mutation.mutatingAction,
-    replaySafe: instanceReplaySafe && mutation.replaySafe,
+    replaySafe:
+      (instanceReplaySafe && !mutation.mutatingAction) ||
+      (structuredReplaySafe && mutation.replaySafe),
     actionFingerprint: mutation.actionFingerprint,
     fileTarget: mutation.fileTarget,
   };
@@ -1019,7 +1019,7 @@ export function handleToolExecutionStart(
       ctx.params.replaySafeToolNames?.has(toolName) === true;
     ctx.state.toolMetaById.set(
       toolCallId,
-      buildToolCallSummary(toolName, args, meta, instanceReplaySafe),
+      buildToolCallSummary(toolName, args, meta, instanceReplaySafe, false),
     );
     ctx.log.debug(
       `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
@@ -1271,10 +1271,9 @@ export async function handleToolExecutionEnd(
     startData?.args && typeof startData.args === "object"
       ? (startData.args as Record<string, unknown>)
       : {};
-  const { consumeAdjustedParamsForToolCall, consumePreExecutionBlockedToolCall } =
-    await loadBeforeToolCall();
   const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
   const executionPrevented = consumePreExecutionBlockedToolCall(toolCallId, runId);
+  const structuredReplaySafe = consumeStructuredReplaySafeToolCall(toolCallId, runId);
   const startArgs =
     adjustedArgs && typeof adjustedArgs === "object"
       ? (adjustedArgs as Record<string, unknown>)
@@ -1284,6 +1283,7 @@ export async function handleToolExecutionEnd(
     startArgs,
     initialCallSummary?.meta,
     initialCallSummary?.instanceReplaySafe === true,
+    structuredReplaySafe,
   );
   // Older/custom event producers omit executionStarted. Treat omission as
   // executed; only an explicit false can prove preparation stopped the call.

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -906,7 +906,12 @@ async function emitToolResultOutput(params: {
 /** Handles a tool-execution start event and emits UI/telemetry start state. */
 export function handleToolExecutionStart(
   ctx: ToolHandlerContext,
-  evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
+  evt: AgentEvent & {
+    toolName: string;
+    toolCallId: string;
+    args: unknown;
+    replaySafe?: boolean;
+  },
 ): void | Promise<void> {
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
     const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -43,6 +43,7 @@ type EmbeddedSubscribeLogger = {
 /** Per-tool metadata tracked between tool start/update/end events. */
 export type ToolCallSummary = {
   meta?: string;
+  instanceReplaySafe: boolean;
   replaySafe: boolean;
   mutatingAction: boolean;
   actionFingerprint?: string;

--- a/src/agents/embedded-agent-subscribe.lifecycle-billing-error.test.ts
+++ b/src/agents/embedded-agent-subscribe.lifecycle-billing-error.test.ts
@@ -38,4 +38,32 @@ describe("subscribeEmbeddedAgentSession lifecycle billing errors", () => {
     expect(lifecycleError?.data?.phase).toBe("error");
     expect(lifecycleError?.data?.error).toContain("Anthropic (claude-3-5-sonnet)");
   });
+
+  it("defers error terminal ownership while preserving diagnostics", () => {
+    const onAgentEvent = vi.fn();
+    const { emit } = createSubscribedSessionHarness({
+      runId: "run-deferred-error",
+      onAgentEvent,
+      terminalLifecyclePhase: "finishing",
+    });
+
+    emitAssistantLifecycleErrorAndEnd({
+      emit,
+      errorMessage: "insufficient credits",
+      provider: "Anthropic",
+      model: "claude-3-5-sonnet",
+    });
+
+    const lifecycleEvents = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "lifecycle");
+    expect(lifecycleEvents).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          phase: "finishing",
+          error: expect.stringContaining("Anthropic (claude-3-5-sonnet)"),
+        }),
+      }),
+    ]);
+  });
 });

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -18,6 +18,9 @@ import { collectTextContentBlocks } from "./content-blocks.js";
 import { isMessageToolSendActionName } from "./embedded-agent-messaging.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
 import { normalizeToolName } from "./tool-policy.js";
+import { readToolResultDetails, readToolResultStatus } from "./tool-result-error.js";
+
+export { isToolResultError } from "./tool-result-error.js";
 
 const TOOL_RESULT_MAX_CHARS = 8000;
 const TOOL_ERROR_MAX_CHARS = 400;
@@ -318,21 +321,6 @@ export function isCoreToolResultMediaTrustedName(toolName?: string): boolean {
   return TRUSTED_TOOL_RESULT_MEDIA.has(normalizeToolName(toolName));
 }
 
-function readToolResultDetails(result: unknown): Record<string, unknown> | undefined {
-  if (!result || typeof result !== "object") {
-    return undefined;
-  }
-  const record = result as Record<string, unknown>;
-  return record.details && typeof record.details === "object" && !Array.isArray(record.details)
-    ? (record.details as Record<string, unknown>)
-    : undefined;
-}
-
-function readToolResultStatus(result: unknown): string | undefined {
-  const status = readToolResultDetails(result)?.status;
-  return normalizeOptionalLowercaseString(status);
-}
-
 function isExternalToolResult(result: unknown): boolean {
   const details = readToolResultDetails(result);
   if (!details) {
@@ -540,40 +528,6 @@ export function extractToolResultMediaArtifact(
 
 export function extractToolResultMediaPaths(result: unknown): string[] {
   return extractToolResultMediaArtifact(result)?.mediaUrls ?? [];
-}
-
-export function isToolResultError(result: unknown): boolean {
-  const details = readToolResultDetails(result);
-  const normalized = readToolResultStatus(result);
-  const explicitlySuccessful = details?.ok === true || details?.success === true;
-  if (details?.ok === false || details?.success === false) {
-    return true;
-  }
-  const hasFailureStatus =
-    normalized === "error" ||
-    normalized === "failed" ||
-    normalized === "failure" ||
-    normalized === "timeout" ||
-    normalized === "timed_out" ||
-    normalized === "blocked" ||
-    normalized === "denied" ||
-    normalized === "forbidden" ||
-    normalized === "unavailable" ||
-    normalized === "approval-unavailable" ||
-    normalized === "disabled" ||
-    normalized === "aborted" ||
-    normalized === "cancelled" ||
-    normalized === "canceled" ||
-    normalized === "killed" ||
-    normalized === "invalid";
-  if (hasFailureStatus && !explicitlySuccessful) {
-    return true;
-  }
-  if (details?.timedOut === true || Boolean(details?.error)) {
-    return true;
-  }
-  const exitCode = details?.exitCode;
-  return typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0;
 }
 
 export function extractToolErrorCode(result: unknown): string | undefined {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1353,6 +1353,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           toolName: toolParams.toolName,
           toolCallId: toolParams.toolCallId,
           isError: false,
+          executionStarted: true,
           result,
         } as never);
         return result;
@@ -1362,6 +1363,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           toolName: toolParams.toolName,
           toolCallId: toolParams.toolCallId,
           isError: true,
+          executionStarted: true,
           result: buildToolLifecycleErrorResult(error),
         } as never);
         throw error;

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -73,6 +73,7 @@ export type SubscribeEmbeddedAgentSessionParams = {
     sessionKey?: string;
   }) => void | Promise<void>;
   onHeartbeatToolResponse?: (response: HeartbeatToolResponse) => void | Promise<void>;
+  /** "finishing" defers both success and error terminal ownership to the caller. */
   terminalLifecyclePhase?: "end" | "finishing";
   /** Read immediately before terminal lifecycle emission. */
   isTerminalAborted?: () => boolean | undefined;

--- a/src/agents/execution-contract.ts
+++ b/src/agents/execution-contract.ts
@@ -72,17 +72,16 @@ export function isStrictAgenticSupportedProviderModel(params: {
  * - Supported provider/model + explicit `"default"` in config ⇒ `"default"`
  *   (opt-out honored).
  * - Supported provider/model + unspecified ⇒ `"strict-agentic"` so the
- *   no-stall completion-gate criterion applies to out-of-the-box GPT-5 runs
- *   without requiring every user to set the flag.
+ *   structured plan tool and non-visible turn recovery apply to out-of-the-box
+ *   GPT-5 runs without requiring every user to set the flag.
  * - Unsupported provider/model (anything that is not openai
  *   with a gpt-5-family model id) ⇒ `"default"`, even when the config
- *   explicitly sets `"strict-agentic"`. The retry guard and blocked-exit
- *   helpers all check this lane again, so an explicit `"strict-agentic"`
- *   on an unsupported lane is a no-op rather than a hard failure.
+ *   explicitly sets `"strict-agentic"`. The structured guards check this lane
+ *   again, so an explicit `"strict-agentic"` on an unsupported lane is a no-op
+ *   rather than a hard failure.
  *
- * This means explicit opt-out still works, but the gate criterion
- * "GPT-5.4 no longer stalls after planning" now covers unconfigured
- * installations, not only users who opted in manually.
+ * Explicit opt-out still works. Assistant prose is never classified to decide
+ * whether a turn represents planning, progress, or completion.
  */
 export function resolveEffectiveExecutionContract(params: {
   config?: OpenClawConfig;

--- a/src/agents/harness/hook-helpers.ts
+++ b/src/agents/harness/hook-helpers.ts
@@ -25,16 +25,17 @@ export async function runAgentHarnessAfterToolCallHook(params: {
   error?: string;
   startedAt?: number;
 }): Promise<void> {
+  const adjustedArgs = consumeAdjustedParamsForToolCall(params.toolCallId, params.runId);
+  // Hooks should see adjusted tool params when before_tool_call rewrote them.
+  const resolvedArgs =
+    adjustedArgs && typeof adjustedArgs === "object"
+      ? (adjustedArgs as Record<string, unknown>)
+      : params.startArgs;
+  const eventArgs = structuredClone(resolvedArgs);
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("after_tool_call")) {
     return;
   }
-  const adjustedArgs = consumeAdjustedParamsForToolCall(params.toolCallId, params.runId);
-  // Hooks should see adjusted tool params when before_tool_call rewrote them.
-  const eventArgs =
-    adjustedArgs && typeof adjustedArgs === "object"
-      ? (adjustedArgs as Record<string, unknown>)
-      : params.startArgs;
   try {
     await hookRunner.runAfterToolCall(
       {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1492,6 +1492,7 @@ describe("runWithModelFallback", () => {
       payloads: [],
       meta: {
         durationMs: 1,
+        replayInvalid: true,
         toolSummary: {
           calls: 1,
           tools: ["mcp_write"],
@@ -1574,6 +1575,11 @@ describe("runWithModelFallback", () => {
       ],
       meta: {
         durationMs: 1,
+        error: {
+          kind: "incomplete_turn",
+          message: "Agent couldn't generate a response.",
+          fallbackSafe: true,
+        },
       },
     };
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -268,6 +268,8 @@ export type ModelFallbackResultClassification =
       status?: number;
       code?: string;
       rawError?: string;
+      preserveResultOnExhaustion?: boolean;
+      preserveResultPriority?: number;
     }
   | {
       error: unknown;
@@ -284,11 +286,23 @@ type ModelFallbackResultClassifier<T> = (attempt: {
 }) => ModelFallbackResultClassification | Promise<ModelFallbackResultClassification>;
 
 type ModelFallbackRunResult<T> = {
+  outcome: "completed" | "exhausted";
   result: T;
   provider: string;
   model: string;
   attempts: FallbackAttempt[];
 };
+
+type ModelFallbackExhaustionResult<T> = Pick<
+  ModelFallbackRunResult<T>,
+  "result" | "provider" | "model"
+> & {
+  priority: number;
+};
+type ModelFallbackClassifiedResult<T> = Pick<
+  ModelFallbackRunResult<T>,
+  "result" | "provider" | "model"
+>;
 
 type ModelFallbackAuthRuntime = typeof import("./model-fallback-auth.runtime.js");
 
@@ -309,6 +323,7 @@ function buildFallbackSuccess<T>(params: {
   attempts: FallbackAttempt[];
 }): ModelFallbackRunResult<T> {
   return {
+    outcome: "completed",
     result: params.result,
     provider: params.provider,
     model: params.model,
@@ -368,7 +383,14 @@ async function runFallbackAttempt<T>(params: {
   total: number;
   attribution?: FailoverAttribution;
   abortSignal?: AbortSignal;
-}): Promise<{ success: ModelFallbackRunResult<T> } | { error: unknown }> {
+}): Promise<
+  | { success: ModelFallbackRunResult<T> }
+  | {
+      error: unknown;
+      classifiedResult?: ModelFallbackClassifiedResult<T>;
+      exhaustionResult?: ModelFallbackExhaustionResult<T>;
+    }
+> {
   const runResult = await runFallbackCandidate({
     run: params.run,
     provider: params.provider,
@@ -394,7 +416,32 @@ async function runFallbackAttempt<T>(params: {
       if (isTerminalAbort(params.abortSignal)) {
         throw toLintErrorObject(classifiedError, "Non-Error thrown");
       }
-      return { error: classifiedError };
+      const preserveResultOnExhaustion =
+        classification &&
+        "preserveResultOnExhaustion" in classification &&
+        classification.preserveResultOnExhaustion === true;
+      return {
+        error: classifiedError,
+        classifiedResult: {
+          result: runResult.result,
+          provider: params.provider,
+          model: params.model,
+        },
+        ...(preserveResultOnExhaustion
+          ? {
+              exhaustionResult: {
+                result: runResult.result,
+                provider: params.provider,
+                model: params.model,
+                priority:
+                  typeof classification.preserveResultPriority === "number" &&
+                  Number.isFinite(classification.preserveResultPriority)
+                    ? classification.preserveResultPriority
+                    : 0,
+              },
+            }
+          : {}),
+      };
     }
     return {
       success: buildFallbackSuccess({
@@ -1232,6 +1279,7 @@ export async function runWithModelFallback<T>(
     onError?: ModelFallbackErrorHandler;
     onFallbackStep?: ModelFallbackStepHandler;
     classifyResult?: ModelFallbackResultClassifier<T>;
+    mergeExhaustedResult?: (params: { latestResult: T; preferredResult: T }) => T;
     skipAuthProfileRuntime?: boolean;
     abortSignal?: AbortSignal;
   } & ModelManifestNormalizationContext,
@@ -1257,6 +1305,8 @@ export async function runWithModelFallback<T>(
     : null;
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
+  let latestClassifiedResult: ModelFallbackClassifiedResult<T> | undefined;
+  let exhaustionResult: ModelFallbackExhaustionResult<T> | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
   const observeDecision = async (decision: ModelFallbackDecisionParams) => {
     if (!params.onFallbackStep && !isModelFallbackDecisionLogEnabled()) {
@@ -1558,6 +1608,15 @@ export async function runWithModelFallback<T>(
       return attemptRun.success;
     }
     const err = attemptRun.error;
+    if (attemptRun.classifiedResult) {
+      latestClassifiedResult = attemptRun.classifiedResult;
+    }
+    if (
+      attemptRun.exhaustionResult &&
+      (!exhaustionResult || attemptRun.exhaustionResult.priority >= exhaustionResult.priority)
+    ) {
+      exhaustionResult = attemptRun.exhaustionResult;
+    }
     {
       // Local runtime coordination errors (session write-lock timeout, embedded
       // attempt session takeover) are not provider/model failures. Aborting
@@ -1686,6 +1745,28 @@ export async function runWithModelFallback<T>(
         total: candidates.length,
       });
     }
+  }
+
+  if (exhaustionResult) {
+    if (latestClassifiedResult && params.mergeExhaustedResult) {
+      return {
+        outcome: "exhausted",
+        result: params.mergeExhaustedResult({
+          latestResult: latestClassifiedResult.result,
+          preferredResult: exhaustionResult.result,
+        }),
+        provider: latestClassifiedResult.provider,
+        model: latestClassifiedResult.model,
+        attempts,
+      };
+    }
+    return {
+      outcome: "exhausted",
+      result: exhaustionResult.result,
+      provider: exhaustionResult.provider,
+      model: exhaustionResult.model,
+      attempts,
+    };
   }
 
   return throwFallbackFailureSummary({

--- a/src/agents/openclaw-tools.update-plan.test.ts
+++ b/src/agents/openclaw-tools.update-plan.test.ts
@@ -229,11 +229,8 @@ describe("openclaw-tools update_plan gating", () => {
   });
 
   it("auto-enables update_plan for unconfigured GPT-5 openai runs", () => {
-    // Criterion 1 of the GPT-5.4 parity gate ("no stalls after planning") is
-    // universal, not opt-in. Unspecified executionContract on a supported
-    // provider/model auto-activates strict-agentic so unconfigured installs
-    // get the same behavior as explicit opt-in. Explicit "default" still
-    // opts out (see "respects explicit default contract opt-out" below).
+    // Unspecified executionContract on a supported provider/model enables the
+    // structured plan tool by default. Explicit "default" still opts out.
     const cfg = {
       agents: {
         list: [{ id: "main" }],

--- a/src/agents/outcome-fallback-runtime-contract.test.ts
+++ b/src/agents/outcome-fallback-runtime-contract.test.ts
@@ -4,7 +4,10 @@ import {
   OUTCOME_FALLBACK_RUNTIME_CONTRACT,
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "./embedded-agent-runner/result-fallback-classifier.js";
 import { runWithModelFallback } from "./model-fallback.js";
 
 vi.mock("./auth-profiles/source-check.js", () => ({
@@ -68,6 +71,107 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
     });
     const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
 
+    const result = await runWithModelFallback<ReturnType<typeof createContractRunResult>>({
+      cfg: undefined,
+      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      fallbacksOverride: contractFallbackOverride,
+      run,
+      classifyResult: ({ provider, model, result: resultValue }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result: resultValue,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+      skipAuthProfileRuntime: true,
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(result.result).toBe(fallback);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls.at(1)).toEqual([
+      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
+      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
+    ]);
+    expect(result.attempts[0]?.provider).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider);
+    expect(result.attempts[0]?.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel);
+    expect(result.attempts[0]?.reason).toBe("format");
+    expect(result.attempts[0]?.code).toBe("empty_result");
+  });
+
+  it("preserves a tool-authored summary when fallback candidates are exhausted", async () => {
+    const terminalSummary =
+      "Web fetch completed.\nOrigin: https://example.com\nStatus: 200\n\n" +
+      "Agent couldn't generate a response.";
+    const incomplete = createContractRunResult({
+      payloads: [{ text: terminalSummary, isError: true }],
+      meta: {
+        durationMs: 1,
+        toolSummary: { calls: 1, tools: ["web_fetch"] },
+        error: {
+          kind: "incomplete_turn",
+          message: "Agent couldn't generate a response.",
+          fallbackSafe: true,
+          terminalPresentation: true,
+        },
+      },
+    });
+
+    const result = await runWithModelFallback<ReturnType<typeof createContractRunResult>>({
+      cfg: undefined,
+      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      fallbacksOverride: [],
+      run: vi.fn().mockResolvedValue(incomplete),
+      classifyResult: ({ provider, model, result: resultValue }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result: resultValue,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+      skipAuthProfileRuntime: true,
+    });
+
+    expect(result.outcome).toBe("exhausted");
+    expect(result.result).toBe(incomplete);
+    expect(result.result.payloads).toEqual([{ text: terminalSummary, isError: true }]);
+    expect(result.attempts).toMatchObject([
+      {
+        provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+        model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+        reason: "format",
+        code: "incomplete_result",
+      },
+    ]);
+  });
+
+  it("preserves the latest structured summary after all fallback candidates are exhausted", async () => {
+    const primary = createContractRunResult({
+      payloads: [{ text: "Primary terminal summary", isError: true }],
+      meta: {
+        durationMs: 1,
+        error: {
+          kind: "incomplete_turn",
+          message: "Primary incomplete",
+          fallbackSafe: true,
+        },
+      },
+    });
+    const fallback = createContractRunResult({
+      payloads: [{ text: "Fallback terminal summary", isError: true }],
+      meta: {
+        durationMs: 1,
+        error: {
+          kind: "incomplete_turn",
+          message: "Fallback incomplete",
+          fallbackSafe: true,
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
+
     const result = await runWithModelFallback({
       cfg: undefined,
       provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
@@ -80,19 +184,132 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
           model,
           result: resultValue,
         }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       skipAuthProfileRuntime: true,
     });
 
+    expect(result.outcome).toBe("exhausted");
     expect(result.result).toBe(fallback);
+    expect(result.provider).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider);
+    expect(result.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel);
+    expect(result.attempts).toHaveLength(2);
+  });
+
+  it("keeps a richer terminal presentation over a later generic incomplete result", async () => {
+    const primary = createContractRunResult({
+      payloads: [{ text: "Primary terminal summary", isError: true }],
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "primary-session",
+          sessionFile: "/tmp/primary.jsonl",
+          provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+          model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+        },
+        error: {
+          kind: "incomplete_turn",
+          message: "Primary incomplete",
+          fallbackSafe: true,
+          terminalPresentation: true,
+        },
+      },
+    });
+    const fallback = createContractRunResult({
+      payloads: [{ text: "Generic fallback incomplete", isError: true }],
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "fallback-session",
+          sessionFile: "/tmp/fallback.jsonl",
+          provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
+          model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
+        },
+        executionTrace: {
+          winnerProvider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
+          winnerModel: OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
+          fallbackUsed: true,
+          runner: "embedded",
+          attempts: [
+            {
+              provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
+              model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
+              result: "success",
+            },
+          ],
+        },
+        error: {
+          kind: "incomplete_turn",
+          message: "Fallback incomplete",
+          fallbackSafe: true,
+        },
+      },
+    });
+    const run = vi.fn().mockResolvedValueOnce(primary).mockResolvedValueOnce(fallback);
+
+    const result = await runWithModelFallback<ReturnType<typeof createContractRunResult>>({
+      cfg: undefined,
+      provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+      model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+      fallbacksOverride: contractFallbackOverride,
+      run,
+      classifyResult: ({ provider, model, result: resultValue }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result: resultValue,
+        }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+      skipAuthProfileRuntime: true,
+    });
+
+    expect(result.outcome).toBe("exhausted");
+    expect(result.result.payloads).toBe(primary.payloads);
+    expect(result.result.meta.error).toBe(primary.meta.error);
+    expect(result.result.meta.agentMeta).toBe(fallback.meta.agentMeta);
+    expect(result.result.meta.executionTrace).toEqual({
+      winnerProvider: undefined,
+      winnerModel: undefined,
+      fallbackUsed: true,
+      runner: "embedded",
+      attempts: undefined,
+    });
+    expect(result.provider).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider);
+    expect(result.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel);
+    expect(result.attempts).toHaveLength(2);
+  });
+
+  it("rethrows an unrecognized final failure instead of hiding it behind an earlier summary", async () => {
+    const primary = createContractRunResult({
+      payloads: [{ text: "Primary terminal summary", isError: true }],
+      meta: {
+        durationMs: 1,
+        error: {
+          kind: "incomplete_turn",
+          message: "Primary incomplete",
+          fallbackSafe: true,
+        },
+      },
+    });
+    const finalError = new Error("fallback runtime crashed");
+    const run = vi.fn().mockResolvedValueOnce(primary).mockRejectedValueOnce(finalError);
+
+    await expect(
+      runWithModelFallback<ReturnType<typeof createContractRunResult>>({
+        cfg: undefined,
+        provider: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider,
+        model: OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel,
+        fallbacksOverride: contractFallbackOverride,
+        run,
+        classifyResult: ({ provider, model, result: resultValue }) =>
+          classifyEmbeddedAgentRunResultForModelFallback({
+            provider,
+            model,
+            result: resultValue,
+          }),
+        skipAuthProfileRuntime: true,
+      }),
+    ).rejects.toBe(finalError);
     expect(run).toHaveBeenCalledTimes(2);
-    expect(run.mock.calls.at(1)).toEqual([
-      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackProvider,
-      OUTCOME_FALLBACK_RUNTIME_CONTRACT.fallbackModel,
-    ]);
-    expect(result.attempts[0]?.provider).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryProvider);
-    expect(result.attempts[0]?.model).toBe(OUTCOME_FALLBACK_RUNTIME_CONTRACT.primaryModel);
-    expect(result.attempts[0]?.reason).toBe("format");
-    expect(result.attempts[0]?.code).toBe("empty_result");
   });
 
   const nonFallbackCases = [
@@ -116,9 +333,13 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
       }),
     },
     {
-      name: "tool summary side effect",
+      name: "structured replay side effect",
       result: createContractRunResult({
-        meta: { durationMs: 1, toolSummary: { calls: 1, tools: ["message"] } },
+        meta: {
+          durationMs: 1,
+          replayInvalid: true,
+          toolSummary: { calls: 1, tools: ["message"] },
+        },
       }),
     },
     {
@@ -200,6 +421,7 @@ describe("Outcome/fallback runtime contract - embedded runtime fallback classifi
       skipAuthProfileRuntime: true,
     });
 
+    expect(result.outcome).toBe("completed");
     expect(result.result).toBe(contractCase.result);
     expect(result.attempts).toStrictEqual([]);
     expect(run).toHaveBeenCalledTimes(1);

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -8,7 +8,15 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tools.js";
+import {
+  isToolWrappedWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "../agent-tools.before-tool-call.js";
 import type { RuntimeToolSchemaDiagnostic } from "../tool-schema-projection.js";
+import {
+  getToolTerminalPresentation,
+  setToolTerminalPresentation,
+} from "../tool-terminal-presentation.js";
 import { logAgentRuntimeToolDiagnostics, normalizeAgentRuntimeTools } from "./tools.js";
 import type { AgentRuntimePlan } from "./types.js";
 
@@ -226,6 +234,36 @@ describe("AgentRuntimePlan tool policy helpers", () => {
         toolName: "lookup_note",
       },
     });
+  });
+
+  it("preserves private execution metadata when provider normalization clones tools", () => {
+    const formatter = vi.fn(() => ({ text: "Terminal summary" }));
+    const tool = {
+      ...createParameterFreeTool("web_fetch"),
+      label: "Web fetch",
+      execute: vi.fn(),
+    } as AgentTool;
+    const source = setToolTerminalPresentation(
+      wrapToolWithBeforeToolCallHook(tool, {
+        agentId: "main",
+        sessionId: "session-runtime-normalization",
+      }),
+      formatter,
+    );
+    const normalized = {
+      ...source,
+      parameters: normalizedParameterFreeSchema(),
+    };
+    mocks.normalizeProviderToolSchemas.mockReturnValueOnce([normalized]);
+
+    const result = normalizeAgentRuntimeTools({
+      tools: [source],
+      provider: "openai",
+    });
+
+    expect(result[0]).toBe(normalized);
+    expect(isToolWrappedWithBeforeToolCallHook(result[0])).toBe(true);
+    expect(getToolTerminalPresentation(result[0])).toBe(formatter);
   });
 
   it("does not reread quarantined tools while preserving normalized metadata", () => {

--- a/src/agents/runtime-plan/tools.ts
+++ b/src/agents/runtime-plan/tools.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimePluginHandle } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { copyPluginToolMeta } from "../../plugins/tools.js";
+import { copyBeforeToolCallHookMarker } from "../agent-tools.before-tool-call.js";
 import { copyChannelAgentToolMeta } from "../channel-tools.js";
 import {
   logProviderToolSchemaDiagnostics,
@@ -18,6 +19,7 @@ import {
   filterProviderNormalizableTools,
   type RuntimeToolSchemaDiagnostic,
 } from "../tool-schema-projection.js";
+import { copyToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import type { AgentRuntimePlan } from "./types.js";
 
 type AgentRuntimeToolPolicyParams<TSchemaType extends TSchema = TSchema, TResult = unknown> = {
@@ -51,14 +53,16 @@ function runtimePlanToolContext(params: {
   };
 }
 
-// Normalizers may return cloned tool definitions. Copy plugin/channel metadata
-// so downstream inventory, delivery, and attribution still know the owner.
+// Normalizers may return cloned tool definitions. Preserve owner and private
+// execution metadata so downstream dispatch keeps the same policy and result contract.
 function copyRuntimeToolMetadata(source: AgentTool, target: AgentTool): void {
   if (source === target) {
     return;
   }
   copyPluginToolMeta(source as never, target as never);
   copyChannelAgentToolMeta(source as never, target as never);
+  copyBeforeToolCallHookMarker(source as never, target as never);
+  copyToolTerminalPresentation(source as never, target as never);
 }
 
 // Duplicate names cannot be matched by map lookup alone, so same-index matches

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -164,6 +164,14 @@ describe("tool mutation helpers", () => {
     }
     expect(buildToolMutationState("message", {}).mutatingAction).toBe(true);
     expect(buildToolMutationState("cron", { action: "runs" }).mutatingAction).toBe(false);
+    for (const action of ["config.get", "config.schema.lookup"]) {
+      expect(buildToolMutationState("gateway", { action }).mutatingAction, action).toBe(false);
+    }
+    for (const action of ["status", "describe", "pending"]) {
+      expect(buildToolMutationState("nodes", { action }).mutatingAction, action).toBe(false);
+    }
+    expect(buildToolMutationState("gateway", { action: "config.patch" }).mutatingAction).toBe(true);
+    expect(buildToolMutationState("nodes", { action: "approve" }).mutatingAction).toBe(true);
     expect(buildToolMutationState("get_goal", { sessionKey: "agent:main" }).mutatingAction).toBe(
       false,
     );
@@ -195,6 +203,13 @@ describe("tool mutation helpers", () => {
       }),
     ).toBe(true);
     expect(isReplaySafeToolCall("cron", { action: "status" })).toBe(true);
+    expect(isReplaySafeToolCall("gateway", { action: "config.get" })).toBe(true);
+    expect(isReplaySafeToolCall("gateway", { action: "config.schema.lookup" })).toBe(true);
+    expect(isReplaySafeToolCall("gateway", { action: "config.patch" })).toBe(false);
+    expect(isReplaySafeToolCall("nodes", { action: "status" })).toBe(true);
+    expect(isReplaySafeToolCall("nodes", { action: "describe" })).toBe(true);
+    expect(isReplaySafeToolCall("nodes", { action: "pending" })).toBe(true);
+    expect(isReplaySafeToolCall("nodes", { action: "approve" })).toBe(false);
     expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(false);
     expect(isReplaySafeToolCall("process", { action: "list" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "log", sessionId: "run-1" })).toBe(true);
@@ -209,6 +224,9 @@ describe("tool mutation helpers", () => {
     expect(isReplaySafeToolCall("skill_workshop", { action: "create" })).toBe(false);
     expect(isReplaySafeToolCall("transcripts", { action: "status" })).toBe(true);
     expect(isReplaySafeToolCall("transcripts", { action: "import" })).toBe(false);
+    expect(isReplaySafeToolCall("subagents", {})).toBe(true);
+    expect(isReplaySafeToolCall("subagents", { action: "list" })).toBe(true);
+    expect(isReplaySafeToolCall("subagents", { action: "kill" })).toBe(false);
     expect(isReplaySafeToolCall("tool_call", { id: "sessions_list" })).toBe(false);
     expect(isReplaySafeToolCall("tool_search_code", { code: "return 1" })).toBe(false);
     expect(isReplaySafeToolCall("unknown_plugin_tool", { action: "list" })).toBe(false);

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -6,6 +6,7 @@ import {
   buildToolMutationState,
   isLikelyMutatingToolName,
   isMutatingToolCall,
+  isReplaySafeToolCall,
   isSameToolMutationAction,
 } from "./tool-mutation.js";
 
@@ -43,8 +44,6 @@ describe("tool mutation helpers", () => {
     ["exec", "sed -n '1,220p' src/agents/tool-mutation.ts"],
     ["bash", "cat package.json"],
     ["exec", "rg -n tool-mutation src/agents"],
-    ["bash", "git status --short"],
-    ["exec", "git diff -- src/agents/tool-mutation.ts"],
     ["exec", "gh search prs --repo openclaw/openclaw tool-mutation --json number,title,state"],
     ["bash", "gh pr view 123 --repo openclaw/openclaw --json title,state"],
   ])("treats read-only shell command as non-mutating: %s %s", (toolName, command) => {
@@ -61,14 +60,30 @@ describe("tool mutation helpers", () => {
     ["bash", "cat package.json > /tmp/package.json"],
     ["bash", "rg foo src | wc -l"],
     ["bash", "rg --pre touch pattern file"],
+    ["bash", "rg --pre=touch pattern file"],
+    ["bash", "rg --hostname-bin /tmp/helper pattern file"],
+    ["bash", "rg --hostname-bin=/tmp/helper pattern file"],
+    ["bash", "rg --search-zip pattern archive.zip"],
+    ["bash", "rg -z pattern archive.zip"],
+    ["bash", "rg pattern {--pre=sh,script.sh}"],
+    ["exec", "file --compile -m custom.magic"],
     ["exec", "python3 <<'PY'\nprint('hello')\nPY"],
     ["exec", "npm start"],
+    ["exec", "zsh -lc 'rg TODO src'"],
+    ["exec", "./zsh -lc 'rg TODO src'"],
+    ["exec", "/tmp/zsh -lc 'rg TODO src'"],
+    ["exec", "/bin/zsh -lc 'rg TODO src'"],
+    ["bash", "git status --short"],
+    ["exec", "git diff -- src/agents/tool-mutation.ts"],
     ["exec", "git checkout feature-branch"],
     ["exec", "git branch -D old-branch"],
     ["exec", "git diff --output=/tmp/patch.diff"],
     ["exec", "git diff --ext-diff"],
+    ["exec", "git show --textconv HEAD:file.txt"],
+    ["exec", "git log --exec=/tmp/helper"],
     ["exec", "git grep -O pattern"],
     ["exec", "git grep -Ovim pattern"],
+    ["exec", "git grep --ext-grep pattern"],
     ["exec", "git grep --open-files-in-pager=vim pattern"],
     ["exec", "gh pr create --title fix --body body"],
     ["exec", "gh pr view 123 --web"],
@@ -119,6 +134,36 @@ describe("tool mutation helpers", () => {
       buildToolMutationState("subagents", { action: "steer", target: "worker-1" }).mutatingAction,
     ).toBe(true);
     expect(buildToolMutationState("subagents", { action: "list" }).mutatingAction).toBe(false);
+    expect(
+      buildToolMutationState("sessions_spawn", { task: "inspect the failure" }).mutatingAction,
+    ).toBe(true);
+    expect(buildToolMutationState("process", { action: "clear" }).mutatingAction).toBe(true);
+    expect(buildToolMutationState("process", { action: "remove" }).mutatingAction).toBe(true);
+    expect(
+      buildToolMutationState("message", { action: "sendAttachment", path: "/tmp/report.pdf" })
+        .mutatingAction,
+    ).toBe(true);
+    expect(
+      buildToolMutationState("message", { action: "upload-file", path: "/tmp/report.pdf" })
+        .mutatingAction,
+    ).toBe(true);
+    for (const action of ["poll", "topic-create", "role-add", "ban", "future-action"]) {
+      expect(buildToolMutationState("message", { action }).mutatingAction, action).toBe(true);
+    }
+    for (const action of [
+      "read",
+      "reactions",
+      "list-pins",
+      "thread-list",
+      "member-info",
+      "channel-list",
+      "voice-status",
+      "event-list",
+    ]) {
+      expect(buildToolMutationState("message", { action }).mutatingAction, action).toBe(false);
+    }
+    expect(buildToolMutationState("message", {}).mutatingAction).toBe(true);
+    expect(buildToolMutationState("cron", { action: "runs" }).mutatingAction).toBe(false);
     expect(buildToolMutationState("get_goal", { sessionKey: "agent:main" }).mutatingAction).toBe(
       false,
     );
@@ -129,6 +174,46 @@ describe("tool mutation helpers", () => {
       buildToolMutationState("update_goal", { sessionKey: "agent:main", status: "complete" })
         .mutatingAction,
     ).toBe(true);
+  });
+
+  it("fails closed for replay unless the structured tool contract is read-only", () => {
+    for (const toolName of [
+      "agents_list",
+      "image",
+      "pdf",
+      "read",
+      "sessions_history",
+      "sessions_list",
+      "tool_describe",
+      "tool_search",
+    ]) {
+      expect(isReplaySafeToolCall(toolName, {}), toolName).toBe(true);
+    }
+    expect(
+      isReplaySafeToolCall("update_plan", {
+        plan: [{ step: "Inspect", status: "in_progress" }],
+      }),
+    ).toBe(true);
+    expect(isReplaySafeToolCall("cron", { action: "status" })).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(false);
+    expect(isReplaySafeToolCall("process", { action: "list" })).toBe(true);
+    expect(isReplaySafeToolCall("process", { action: "log", sessionId: "run-1" })).toBe(true);
+    expect(isReplaySafeToolCall("process", { action: "poll", sessionId: "run-1" })).toBe(false);
+    expect(isReplaySafeToolCall("browser", { action: "tabs" })).toBe(true);
+    expect(isReplaySafeToolCall("browser", { action: "act", kind: "click" })).toBe(false);
+    expect(isReplaySafeToolCall("browser", { action: "open", url: "https://example.com" })).toBe(
+      false,
+    );
+    expect(isReplaySafeToolCall("skill_workshop", { action: "list" })).toBe(true);
+    expect(isReplaySafeToolCall("skill_workshop", { action: "inspect" })).toBe(true);
+    expect(isReplaySafeToolCall("skill_workshop", { action: "create" })).toBe(false);
+    expect(isReplaySafeToolCall("transcripts", { action: "status" })).toBe(true);
+    expect(isReplaySafeToolCall("transcripts", { action: "import" })).toBe(false);
+    expect(isReplaySafeToolCall("tool_call", { id: "sessions_list" })).toBe(false);
+    expect(isReplaySafeToolCall("tool_search_code", { code: "return 1" })).toBe(false);
+    expect(isReplaySafeToolCall("unknown_plugin_tool", { action: "list" })).toBe(false);
+    expect(isReplaySafeToolCall("survey_actions", { action: "list" })).toBe(false);
+    expect(isReplaySafeToolCall("survey_actions", { action: "poll" })).toBe(false);
   });
 
   it("matches tool actions by fingerprint and fails closed on asymmetric data", () => {

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -58,25 +58,65 @@ const READ_ONLY_ACTIONS = new Set([
   "inspect",
   "check",
   "probe",
+  "runs",
 ]);
 
-const PROCESS_MUTATING_ACTIONS = new Set(["write", "send_keys", "submit", "paste", "kill"]);
-
-const MESSAGE_MUTATING_ACTIONS = new Set([
-  "send",
-  "reply",
-  "thread_reply",
-  "threadreply",
-  "edit",
-  "delete",
-  "react",
-  "pin",
-  "unpin",
+const PROCESS_MUTATING_ACTIONS = new Set([
+  "write",
+  "send_keys",
+  "submit",
+  "paste",
+  "kill",
+  "clear",
+  "remove",
 ]);
+
+const PROCESS_REPLAY_SAFE_ACTIONS = new Set(["list", "log"]);
+
+const MESSAGE_READ_ONLY_ACTIONS = new Set([
+  "reactions",
+  "read",
+  "list_pins",
+  "permissions",
+  "thread_list",
+  "search",
+  "sticker_search",
+  "member_info",
+  "role_info",
+  "emoji_list",
+  "channel_info",
+  "channel_list",
+  "voice_status",
+  "event_list",
+]);
+
+const REPLAY_SAFE_TOOL_NAMES = new Set([
+  "agents_list",
+  "find",
+  "get_goal",
+  "glob",
+  "grep",
+  "image",
+  "ls",
+  "memory_get",
+  "memory_search",
+  "pdf",
+  "read",
+  "search",
+  "sessions_history",
+  "sessions_list",
+  "tool_describe",
+  "tool_search",
+  "update_plan",
+  "web_fetch",
+  "web_search",
+  "x_search",
+]);
+
+const BROWSER_READ_ONLY_ACTIONS = new Set(["console", "profiles", "snapshot", "status", "tabs"]);
 
 const READ_ONLY_SHELL_COMMANDS = new Set([
   "cat",
-  "file",
   "grep",
   "head",
   "ls",
@@ -87,21 +127,12 @@ const READ_ONLY_SHELL_COMMANDS = new Set([
   "wc",
 ]);
 
-const READ_ONLY_GIT_SUBCOMMANDS = new Set([
-  "diff",
-  "grep",
-  "log",
-  "ls-files",
-  "rev-parse",
-  "show",
-  "status",
-]);
-
 const READ_ONLY_GH_PR_SUBCOMMANDS = new Set(["checks", "diff", "list", "status", "view"]);
 const READ_ONLY_GH_ISSUE_SUBCOMMANDS = new Set(["list", "status", "view"]);
 
-const UNSAFE_RG_FLAGS = new Set(["--pre", "--pre-glob"]);
-const UNSAFE_GIT_FLAGS = new Set(["--ext-diff", "--output", "-o", "--open-files-in-pager"]);
+const UNSAFE_RG_FLAGS = new Set(["--hostname-bin", "--pre", "--pre-glob", "--search-zip", "-z"]);
+const UNSAFE_RG_VALUE_FLAGS = ["--hostname-bin", "--pre", "--pre-glob"] as const;
+const SHELL_EXPANSION_CHARS = new Set(["$", "*", "?", "[", "]", "{", "}", "~"]);
 
 // Structured file-target identity for cross-tool same-target recovery.
 // Carried alongside `actionFingerprint` so comparison does not have to
@@ -116,6 +147,7 @@ export type FileTarget = {
 
 type ToolMutationState = {
   mutatingAction: boolean;
+  replaySafe: boolean;
   actionFingerprint?: string;
   fileTarget?: FileTarget;
 };
@@ -142,8 +174,13 @@ function readShellCommand(record: Record<string, unknown> | undefined): string |
 }
 
 function tokenizeSimpleShellCommand(command: string): string[] | undefined {
-  if (/[;&|<>\n\r`]/.test(command) || command.includes("$(") || command.includes("\\")) {
+  if (/[;&|<>\n\r`]/.test(command) || command.includes("\\")) {
     return undefined;
+  }
+  for (const char of SHELL_EXPANSION_CHARS) {
+    if (command.includes(char)) {
+      return undefined;
+    }
   }
   const tokens: string[] = [];
   let current = "";
@@ -222,33 +259,9 @@ function hasUnsafeRipgrepFlag(tokens: readonly string[]): boolean {
     const normalized = normalizeLowercaseStringOrEmpty(token);
     return (
       UNSAFE_RG_FLAGS.has(normalized) ||
-      normalized.startsWith("--pre=") ||
-      normalized.startsWith("--pre-glob=")
+      UNSAFE_RG_VALUE_FLAGS.some((flag) => normalized.startsWith(`${flag}=`))
     );
   });
-}
-
-function hasUnsafeGitFlag(tokens: readonly string[]): boolean {
-  return tokens.some((token) => {
-    const normalized = normalizeLowercaseStringOrEmpty(token);
-    return (
-      UNSAFE_GIT_FLAGS.has(normalized) ||
-      token.startsWith("-O") ||
-      normalized.startsWith("--output=") ||
-      normalized.startsWith("--open-files-in-pager=")
-    );
-  });
-}
-
-function isReadOnlyGitCommand(tokens: readonly string[]): boolean {
-  const subcommand = normalizeLowercaseStringOrEmpty(tokens[1]);
-  if (hasUnsafeGitFlag(tokens)) {
-    return false;
-  }
-  if (READ_ONLY_GIT_SUBCOMMANDS.has(subcommand)) {
-    return true;
-  }
-  return subcommand === "remote" && tokens.length === 3 && tokens[2] === "-v";
 }
 
 function isReadOnlyGhCommand(tokens: readonly string[]): boolean {
@@ -295,9 +308,6 @@ function isPlainReadOnlyShellCommand(command: string | undefined): boolean {
   }
   if (executable === "sed") {
     return isReadOnlySedCommand(tokens);
-  }
-  if (executable === "git") {
-    return isReadOnlyGitCommand(tokens);
   }
   if (executable === "gh") {
     return isReadOnlyGhCommand(tokens);
@@ -355,6 +365,7 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "write":
     case "edit":
     case "apply_patch":
+    case "sessions_spawn":
     case "sessions_send":
     case "create_goal":
     case "update_goal":
@@ -365,11 +376,9 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "process":
       return action != null && PROCESS_MUTATING_ACTIONS.has(action);
     case "message":
-      return (
-        (action != null && MESSAGE_MUTATING_ACTIONS.has(action)) ||
-        typeof record?.content === "string" ||
-        typeof record?.message === "string"
-      );
+      // Message actions are an extensible plugin surface. Only known lookup
+      // actions are replay-safe; missing and future actions fail closed.
+      return action == null || !MESSAGE_READ_ONLY_ACTIONS.has(action);
     case "subagents":
       return action === "kill" || action === "steer";
     case "session_status":
@@ -386,6 +395,44 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
       }
       if (normalized.startsWith("message_") || normalized.includes("send")) {
         return true;
+      }
+      return false;
+    }
+  }
+}
+
+/** Return true only for tool calls whose structured contract proves replay safety. */
+export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(toolName);
+  const record = asRecord(args);
+  const action = normalizeActionName(record?.action);
+  if (REPLAY_SAFE_TOOL_NAMES.has(normalized)) {
+    return true;
+  }
+  switch (normalized) {
+    case "exec":
+    case "bash":
+      return false;
+    case "process":
+      return action != null && PROCESS_REPLAY_SAFE_ACTIONS.has(action);
+    case "message":
+      return action != null && MESSAGE_READ_ONLY_ACTIONS.has(action);
+    case "subagents":
+      return action === "list";
+    case "session_status":
+      return !isMutatingToolCall(normalized, args);
+    case "browser":
+      return action != null && BROWSER_READ_ONLY_ACTIONS.has(action);
+    case "skill_workshop":
+      return action === "list" || action === "inspect";
+    case "transcripts":
+      return action === "status";
+    default: {
+      if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
+        return action != null && READ_ONLY_ACTIONS.has(action);
+      }
+      if (normalized === "nodes") {
+        return action === "list";
       }
       return false;
     }
@@ -491,6 +538,7 @@ export function buildToolMutationState(
   const fileTarget = extractFileTarget(toolName, args);
   return {
     mutatingAction: actionFingerprint != null,
+    replaySafe: isReplaySafeToolCall(toolName, args),
     actionFingerprint,
     ...(fileTarget !== undefined ? { fileTarget } : {}),
   };

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -114,6 +114,8 @@ const REPLAY_SAFE_TOOL_NAMES = new Set([
 ]);
 
 const BROWSER_READ_ONLY_ACTIONS = new Set(["console", "profiles", "snapshot", "status", "tabs"]);
+const GATEWAY_REPLAY_SAFE_ACTIONS = new Set(["config.get", "config.schema.lookup"]);
+const NODES_REPLAY_SAFE_ACTIONS = new Set(["status", "describe", "pending"]);
 
 const READ_ONLY_SHELL_COMMANDS = new Set([
   "cat",
@@ -383,12 +385,13 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
       return action === "kill" || action === "steer";
     case "session_status":
       return typeof record?.model === "string" && record.model.trim().length > 0;
+    case "gateway":
+      return action == null || !GATEWAY_REPLAY_SAFE_ACTIONS.has(action);
+    case "nodes":
+      return action == null || !NODES_REPLAY_SAFE_ACTIONS.has(action);
     default: {
-      if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
+      if (normalized === "cron" || normalized === "canvas") {
         return action == null || !READ_ONLY_ACTIONS.has(action);
-      }
-      if (normalized === "nodes") {
-        return action == null || action !== "list";
       }
       if (normalized.endsWith("_actions")) {
         return action == null || !READ_ONLY_ACTIONS.has(action);
@@ -418,7 +421,7 @@ export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
     case "message":
       return action != null && MESSAGE_READ_ONLY_ACTIONS.has(action);
     case "subagents":
-      return action === "list";
+      return action == null || action === "list";
     case "session_status":
       return !isMutatingToolCall(normalized, args);
     case "browser":
@@ -427,12 +430,13 @@ export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
       return action === "list" || action === "inspect";
     case "transcripts":
       return action === "status";
+    case "gateway":
+      return action != null && GATEWAY_REPLAY_SAFE_ACTIONS.has(action);
+    case "nodes":
+      return action != null && NODES_REPLAY_SAFE_ACTIONS.has(action);
     default: {
-      if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
+      if (normalized === "cron" || normalized === "canvas") {
         return action != null && READ_ONLY_ACTIONS.has(action);
-      }
-      if (normalized === "nodes") {
-        return action === "list";
       }
       return false;
     }

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -1,0 +1,49 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+
+export function readToolResultDetails(result: unknown): Record<string, unknown> | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const record = result as Record<string, unknown>;
+  return record.details && typeof record.details === "object" && !Array.isArray(record.details)
+    ? (record.details as Record<string, unknown>)
+    : undefined;
+}
+
+export function readToolResultStatus(result: unknown): string | undefined {
+  return normalizeOptionalLowercaseString(readToolResultDetails(result)?.status);
+}
+
+export function isToolResultError(result: unknown): boolean {
+  const details = readToolResultDetails(result);
+  const normalized = readToolResultStatus(result);
+  const explicitlySuccessful = details?.ok === true || details?.success === true;
+  if (details?.ok === false || details?.success === false) {
+    return true;
+  }
+  const hasFailureStatus =
+    normalized === "error" ||
+    normalized === "failed" ||
+    normalized === "failure" ||
+    normalized === "timeout" ||
+    normalized === "timed_out" ||
+    normalized === "blocked" ||
+    normalized === "denied" ||
+    normalized === "forbidden" ||
+    normalized === "unavailable" ||
+    normalized === "approval-unavailable" ||
+    normalized === "disabled" ||
+    normalized === "aborted" ||
+    normalized === "cancelled" ||
+    normalized === "canceled" ||
+    normalized === "killed" ||
+    normalized === "invalid";
+  if (hasFailureStatus && !explicitlySuccessful) {
+    return true;
+  }
+  if (details?.timedOut === true || Boolean(details?.error)) {
+    return true;
+  }
+  const exitCode = details?.exitCode;
+  return typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0;
+}

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -829,7 +829,7 @@ describe("Tool Search", () => {
     expect(compacted.catalogToolCount).toBe(0);
   });
 
-  it("moves client tools into the same catalog when a session catalog exists", () => {
+  it("moves client tools into the same catalog and preserves client execution provenance", async () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
     const config = {
       tools: {
@@ -855,6 +855,23 @@ describe("Tool Search", () => {
       .get("session:session-client")
       ?.entries.find((entry) => entry.id === "client:client:client_pick_file");
     expect(clientEntry?.source).toBe("client");
+
+    const executeTool = vi.fn(async () => jsonResult({ status: "ok" }));
+    const runtimeTools = createToolSearchTools({
+      sessionId: "session-client",
+      config: {},
+      executeTool,
+    });
+    await runtimeTools[3]?.execute("call-client", {
+      id: "client:client:client_pick_file",
+      args: { path: "/tmp/file" },
+    });
+
+    expect(mockCall(executeTool)[0]).toMatchObject({
+      source: "client",
+      sourceName: "client",
+      toolName: "client_pick_file",
+    });
   });
 
   it("keeps client tools visible in directory mode", () => {
@@ -1033,6 +1050,8 @@ describe("Tool Search", () => {
     const firstExecuteInput = mockCall(executeTool)[0] as {
       tool?: { name?: string };
       toolName?: string;
+      source?: string;
+      sourceName?: string;
       toolCallId?: string;
       parentToolCallId?: string;
       input?: unknown;
@@ -1041,6 +1060,8 @@ describe("Tool Search", () => {
     };
     expect(firstExecuteInput.tool?.name).toBe("fake_lifecycle");
     expect(firstExecuteInput.toolName).toBe("fake_lifecycle");
+    expect(firstExecuteInput.source).toBe("openclaw");
+    expect(firstExecuteInput.sourceName).toBe("fake-catalog");
     expect(firstExecuteInput.toolCallId).toBe("tool_search_code:call-lifecycle:fake_lifecycle:1");
     expect(firstExecuteInput.parentToolCallId).toBe("call-lifecycle");
     expect(firstExecuteInput.input).toEqual({ value: "ok" });
@@ -1061,6 +1082,8 @@ describe("Tool Search", () => {
     const secondExecuteInput = mockCall(executeTool, 1)[0] as {
       tool?: { name?: string };
       toolName?: string;
+      source?: string;
+      sourceName?: string;
       toolCallId?: string;
       parentToolCallId?: string;
       input?: unknown;
@@ -1069,6 +1092,8 @@ describe("Tool Search", () => {
     };
     expect(secondExecuteInput.tool?.name).toBe("fake_lifecycle");
     expect(secondExecuteInput.toolName).toBe("fake_lifecycle");
+    expect(secondExecuteInput.source).toBe("openclaw");
+    expect(secondExecuteInput.sourceName).toBe("fake-catalog");
     expect(secondExecuteInput.toolCallId).toBe(
       "tool_search_code:call-lifecycle-structured:fake_lifecycle:1",
     );

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -64,6 +64,8 @@ type ReusableCatalogSnapshot = {
 export type ToolSearchCatalogToolExecutor = (params: {
   tool: CatalogTool;
   toolName: string;
+  source: CatalogSource;
+  sourceName?: string;
   toolCallId: string;
   parentToolCallId?: string;
   input: unknown;
@@ -1728,6 +1730,8 @@ export class ToolSearchRuntime {
     const result = await executeTool({
       tool: entry.tool,
       toolName: entry.name,
+      source: entry.source,
+      sourceName: entry.sourceName,
       toolCallId,
       parentToolCallId: options?.parentToolCallId,
       input: input ?? {},

--- a/src/agents/tool-terminal-presentation.ts
+++ b/src/agents/tool-terminal-presentation.ts
@@ -1,0 +1,35 @@
+/**
+ * Internal opt-in for deterministic terminal summaries from trusted built-in tools.
+ * This is intentionally absent from the public AgentTool and Plugin SDK contracts.
+ */
+import type { AgentToolResult } from "./runtime/index.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+export type TerminalToolPresentation = { text: string };
+export type TerminalToolPresentationFormatter = (
+  params: unknown,
+  result: AgentToolResult<unknown>,
+) => TerminalToolPresentation | undefined;
+
+const terminalPresentationByTool = new WeakMap<object, TerminalToolPresentationFormatter>();
+
+export function setToolTerminalPresentation<T extends AnyAgentTool>(
+  tool: T,
+  formatter: TerminalToolPresentationFormatter,
+): T {
+  terminalPresentationByTool.set(tool, formatter);
+  return tool;
+}
+
+export function getToolTerminalPresentation(
+  tool: AnyAgentTool,
+): TerminalToolPresentationFormatter | undefined {
+  return terminalPresentationByTool.get(tool);
+}
+
+export function copyToolTerminalPresentation(source: AnyAgentTool, target: AnyAgentTool): void {
+  const formatter = terminalPresentationByTool.get(source);
+  if (formatter) {
+    terminalPresentationByTool.set(target, formatter);
+  }
+}

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -10,6 +10,7 @@ vi.mock("../agent-scope.js", () => ({
   resolveSessionAgentId: () => "agent-123",
 }));
 
+import { getToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import { createCronTool } from "./cron-tool.js";
 
 describe("cron tool flat-params", () => {
@@ -25,6 +26,48 @@ describe("cron tool flat-params", () => {
     }
     return call as [string, unknown, TParams];
   }
+
+  it("presents read-only cron metadata without job content", () => {
+    const tool = createCronTool();
+    const terminalPresentation = getToolTerminalPresentation(tool);
+    if (!terminalPresentation) {
+      throw new Error("expected cron terminal presentation");
+    }
+
+    expect(
+      terminalPresentation(
+        { action: "list" },
+        {
+          content: [],
+          details: {
+            total: 2,
+            jobs: [
+              { id: "one", name: "private reminder", payload: { text: "secret" } },
+              { id: "two", name: "another reminder" },
+            ],
+          },
+        },
+      ),
+    ).toEqual({ text: "Cron jobs listed.\nCount: 2" });
+    expect(
+      terminalPresentation(
+        { action: "list" },
+        {
+          content: [],
+          details: {
+            total: 250,
+            jobs: [{ id: "one" }, { id: "two" }],
+          },
+        },
+      ),
+    ).toEqual({ text: "Cron jobs listed.\nCount: 250" });
+    expect(
+      terminalPresentation(
+        { action: "add" },
+        { content: [], details: { id: "three", name: "private reminder" } },
+      ),
+    ).toBeUndefined();
+  });
 
   it("preserves explicit top-level sessionKey during flat-params recovery", async () => {
     const tool = createCronTool(

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -24,6 +24,7 @@ import {
   stringEnum,
 } from "../schema/typebox.js";
 import { CRON_TOOL_DISPLAY_SUMMARY } from "../tool-description-presets.js";
+import { setToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import {
   type AnyAgentTool,
   jsonResult,
@@ -438,6 +439,46 @@ function filterCronStatusResultForSelfScope(result: unknown): unknown {
   return { enabled: isRecord(result) && result.enabled === true };
 }
 
+function formatCronTerminalPresentation(
+  params: unknown,
+  result: unknown,
+): { text: string } | undefined {
+  if (!isRecord(params) || !isRecord(result) || !isRecord(result.details)) {
+    return undefined;
+  }
+  switch (params.action) {
+    case "status": {
+      const enabled = result.details.enabled === true ? "yes" : "no";
+      return { text: `Cron scheduler status.\nEnabled: ${enabled}` };
+    }
+    case "list": {
+      const total =
+        typeof result.details.total === "number" &&
+        Number.isFinite(result.details.total) &&
+        result.details.total >= 0
+          ? Math.floor(result.details.total)
+          : undefined;
+      const count =
+        total ?? (Array.isArray(result.details.jobs) ? result.details.jobs.length : undefined);
+      return count === undefined
+        ? { text: "Cron jobs listed." }
+        : { text: `Cron jobs listed.\nCount: ${count}` };
+    }
+    case "get":
+      return { text: "Cron job loaded." };
+    case "runs": {
+      const entries = Array.isArray(result.details.entries)
+        ? result.details.entries.length
+        : undefined;
+      return entries === undefined
+        ? { text: "Cron run history loaded." }
+        : { text: `Cron run history loaded.\nCount: ${entries}` };
+    }
+    default:
+      return undefined;
+  }
+}
+
 function cronListResultHasJob(result: unknown, jobId: string): boolean {
   return (
     isRecord(result) &&
@@ -520,7 +561,7 @@ async function buildReminderContextLines(params: {
 
 export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): AnyAgentTool {
   const callGateway = deps?.callGatewayTool ?? callGatewayTool;
-  return {
+  const tool: AnyAgentTool = {
     label: "Cron",
     name: "cron",
     displaySummary: CRON_TOOL_DISPLAY_SUMMARY,
@@ -912,4 +953,5 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
       }
     },
   };
+  return setToolTerminalPresentation(tool, formatCronTerminalPresentation);
 }

--- a/src/agents/tools/web-fetch.test.ts
+++ b/src/agents/tools/web-fetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeWebFetchUrl } from "./web-fetch.js";
+import { getToolTerminalPresentation } from "../tool-terminal-presentation.js";
+import { createWebFetchTool, sanitizeWebFetchUrl } from "./web-fetch.js";
 
 describe("sanitizeWebFetchUrl", () => {
   it("removes whitespace between scheme and authority (reported bug)", () => {
@@ -58,5 +59,43 @@ describe("sanitizeWebFetchUrl", () => {
 
   it("handles https:// with tab after scheme", () => {
     expect(sanitizeWebFetchUrl("https://\texample.com")).toBe("https://example.com");
+  });
+});
+
+describe("web_fetch terminal presentation", () => {
+  it("uses response metadata without page content or URL secrets", () => {
+    const tool = createWebFetchTool();
+    const terminalPresentation = tool ? getToolTerminalPresentation(tool) : undefined;
+    if (!terminalPresentation) {
+      throw new Error("expected web_fetch terminal presentation");
+    }
+
+    const result = {
+      content: [],
+      details: {
+        url: "https://user:pass@example.com/report?token=secret#section",
+        finalUrl: "https://example.com/final?token=secret#section",
+        status: 200,
+        contentType: "text/html",
+        rawLength: 1200,
+        truncated: true,
+        title: "untrusted title",
+        text: "untrusted page content",
+      },
+    };
+    const presentation = terminalPresentation({}, result);
+
+    expect(presentation?.text).toBe(
+      [
+        "Web fetch completed.",
+        "Origin: https://example.com",
+        "Status: 200",
+        "Content type: text/html",
+        "Content length: 1200 characters",
+        "Truncated: yes",
+      ].join("\n"),
+    );
+    expect(presentation?.text).not.toContain("secret");
+    expect(presentation?.text).not.toContain("untrusted");
   });
 });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -19,6 +19,7 @@ import { isRecord } from "../../utils.js";
 import { extractReadableContent } from "../../web-fetch/content-extractors.runtime.js";
 import { resolveWebProviderConfig } from "../../web/provider-runtime-shared.js";
 import { stringEnum } from "../schema/string-enum.js";
+import { setToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   jsonResult,
@@ -211,6 +212,42 @@ const WEB_FETCH_WRAPPER_NO_WARNING_OVERHEAD = wrapExternalContent("", {
   source: "web_fetch",
   includeWarning: false,
 }).length;
+
+function formatTerminalWebFetchOrigin(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatWebFetchTerminalPresentation(result: unknown): { text: string } | undefined {
+  if (!isRecord(result) || !isRecord(result.details)) {
+    return undefined;
+  }
+  const details = result.details;
+  const origin =
+    formatTerminalWebFetchOrigin(details.finalUrl) ?? formatTerminalWebFetchOrigin(details.url);
+  const status = typeof details.status === "number" ? details.status : undefined;
+  if (!origin || status === undefined) {
+    return undefined;
+  }
+  const lines = [`Web fetch completed.`, `Origin: ${origin}`, `Status: ${status}`];
+  if (typeof details.contentType === "string" && details.contentType.trim()) {
+    lines.push(`Content type: ${details.contentType.trim()}`);
+  }
+  if (typeof details.rawLength === "number" && Number.isFinite(details.rawLength)) {
+    lines.push(`Content length: ${Math.max(0, Math.floor(details.rawLength))} characters`);
+  }
+  if (details.truncated === true) {
+    lines.push("Truncated: yes");
+  }
+  return { text: lines.join("\n") };
+}
 
 function wrapWebFetchContent(
   value: string,
@@ -673,7 +710,7 @@ export function createWebFetchTool(options?: {
   if (!resolveFetchEnabled({ fetch, sandboxed: options?.sandboxed })) {
     return null;
   }
-  return {
+  const tool: AnyAgentTool = {
     label: "Web Fetch",
     name: "web_fetch",
     description:
@@ -770,4 +807,7 @@ export function createWebFetchTool(options?: {
       }
     },
   };
+  return setToolTerminalPresentation(tool, (_params, result) =>
+    formatWebFetchTerminalPresentation(result),
+  );
 }

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -1,0 +1,121 @@
+import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+
+export type AgentLifecycleTerminalBackstop = {
+  emit: (
+    phase: "end" | "error",
+    resultOrError: unknown,
+    extraData?: Record<string, unknown>,
+  ) => void;
+  getDeferredError: () => string | undefined;
+  note: (evt: { stream: string; data: Record<string, unknown> }) => void;
+};
+
+const DEFERRED_TERMINAL_METADATA_KEYS = [
+  "stopReason",
+  "yielded",
+  "timeoutPhase",
+  "providerStarted",
+  "aborted",
+  "livenessState",
+  "replayInvalid",
+] as const;
+
+export function resolveAgentLifecycleTerminalMetadata(meta: unknown): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  if (!meta || typeof meta !== "object") {
+    return metadata;
+  }
+  const record = meta as Record<string, unknown>;
+  for (const key of DEFERRED_TERMINAL_METADATA_KEYS) {
+    if (Object.hasOwn(record, key)) {
+      metadata[key] = record[key];
+    }
+  }
+  return metadata;
+}
+
+export function createAgentLifecycleTerminalBackstop(params: {
+  runId: string;
+  sessionKey?: string;
+  startedAt?: number;
+  getLifecycleGeneration: () => string;
+  resolveAbortLifecycleFields: () => {
+    aborted?: true;
+    stopReason?: string;
+  };
+}): AgentLifecycleTerminalBackstop {
+  let terminalEmitted = false;
+  let startedAt = params.startedAt;
+  let deferredError: string | undefined;
+  const deferredTerminalMetadata: Record<string, unknown> = {};
+
+  const note = (evt: { stream: string; data: Record<string, unknown> }) => {
+    if (evt.stream !== "lifecycle") {
+      return;
+    }
+    const phase = readStringValue(evt.data.phase);
+    if (phase === "start" && typeof evt.data.startedAt === "number") {
+      startedAt = evt.data.startedAt;
+    }
+    if (phase === "finishing") {
+      deferredError = readStringValue(evt.data.error) ?? deferredError;
+      Object.assign(deferredTerminalMetadata, resolveAgentLifecycleTerminalMetadata(evt.data));
+    }
+    if (phase === "end" || phase === "error") {
+      terminalEmitted = true;
+    }
+  };
+
+  const emit: AgentLifecycleTerminalBackstop["emit"] = (phase, resultOrError, extraData) => {
+    if (terminalEmitted) {
+      return;
+    }
+    terminalEmitted = true;
+    const abortLifecycleFields = params.resolveAbortLifecycleFields();
+    const restartAbort = abortLifecycleFields.stopReason === AGENT_RUN_RESTART_ABORT_STOP_REASON;
+    const data: Record<string, unknown> = {
+      ...deferredTerminalMetadata,
+      phase: restartAbort ? "end" : phase,
+      endedAt: Date.now(),
+      ...(startedAt !== undefined ? { startedAt } : {}),
+    };
+    if (restartAbort) {
+      data.aborted = true;
+      data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
+    } else if (phase === "error") {
+      data.error = formatErrorMessage(resultOrError);
+      Object.assign(data, abortLifecycleFields);
+    } else {
+      const meta =
+        resultOrError && typeof resultOrError === "object" && "meta" in resultOrError
+          ? (resultOrError as { meta?: Record<string, unknown> }).meta
+          : undefined;
+      Object.assign(data, resolveAgentLifecycleTerminalMetadata(meta));
+      if (abortLifecycleFields.aborted === true) {
+        data.aborted = true;
+      }
+      if (abortLifecycleFields.stopReason && !readStringValue(data.stopReason)) {
+        data.stopReason = abortLifecycleFields.stopReason;
+      }
+    }
+    if (extraData) {
+      Object.assign(data, extraData);
+    }
+    emitAgentEvent({
+      runId: params.runId,
+      lifecycleGeneration: params.getLifecycleGeneration(),
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      stream: "lifecycle",
+      data,
+    });
+  };
+
+  return {
+    emit,
+    getDeferredError: () => deferredError,
+    note,
+  };
+}

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1610,6 +1610,80 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("does not clear an auto-fallback pin for an exhausted preserved result", async () => {
+    const probe = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      fallbackProvider: "google",
+      fallbackModel: "gemini-3-pro",
+      fallbackAuthProfileId: "google:fallback",
+      fallbackAuthProfileIdSource: "auto" as const,
+    };
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = probe.provider;
+    followupRun.run.model = probe.model;
+    followupRun.run.autoFallbackPrimaryProbe = probe;
+    const sessionKey = "exhausted-primary-probe";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: 1,
+      providerOverride: probe.fallbackProvider,
+      modelOverride: probe.fallbackModel,
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: probe.provider,
+      modelOverrideFallbackOriginModel: probe.model,
+      authProfileOverride: probe.fallbackAuthProfileId,
+      authProfileOverrideSource: "auto",
+    };
+    const activeSessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    state.runWithModelFallbackMock.mockResolvedValueOnce({
+      outcome: "exhausted",
+      result: {
+        payloads: [{ text: "Terminal tool summary", isError: true }],
+        meta: {
+          error: {
+            kind: "incomplete_turn",
+            message: "All fallback candidates ended incomplete",
+            fallbackSafe: true,
+            terminalPresentation: true,
+          },
+        },
+      },
+      provider: probe.provider,
+      model: probe.model,
+      attempts: [
+        { provider: probe.provider, model: probe.model, error: "incomplete" },
+        {
+          provider: probe.fallbackProvider,
+          model: probe.fallbackModel,
+          error: "incomplete",
+        },
+      ],
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun }),
+      sessionKey,
+      activeSessionStore,
+      getActiveSessionEntry: () => activeSessionStore[sessionKey],
+    });
+
+    expect(result).toMatchObject({
+      kind: "success",
+      fallbackExhausted: true,
+      fallbackProvider: probe.provider,
+      fallbackModel: probe.model,
+    });
+    expect(activeSessionStore[sessionKey]).toMatchObject({
+      providerOverride: probe.fallbackProvider,
+      modelOverride: probe.fallbackModel,
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: probe.provider,
+      modelOverrideFallbackOriginModel: probe.model,
+    });
+  });
+
   it("keeps fallback auth available for later same-provider fallback models", async () => {
     const probe = {
       provider: "anthropic",
@@ -3384,18 +3458,15 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
-  it("classifies GPT-5 plan-only terminal results as fallback-eligible", async () => {
+  it("classifies structured harness plan-only terminal results as fallback-eligible", async () => {
     const followupRun = createFollowupRun();
     followupRun.run.provider = "openai";
     followupRun.run.model = "gpt-5.4";
     state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [
-        {
-          text: "agent stopped after repeated plan-only turns without taking a concrete action.",
-          isError: true,
-        },
-      ],
-      meta: {},
+      payloads: [],
+      meta: {
+        agentHarnessResultClassification: "planning-only",
+      },
     });
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       const first = (await params.run("openai", "gpt-5.4")) as {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -391,12 +391,15 @@ function createTestUserTurnRecorder(message: PersistedUserTurnMessage) {
 function createMockReplyOperation(): {
   replyOperation: ReplyOperation;
   failMock: ReturnType<typeof vi.fn>;
+  retainFailureUntilCompleteMock: ReturnType<typeof vi.fn>;
   updateSessionIdMock: ReturnType<typeof vi.fn>;
 } {
   const failMock = vi.fn();
+  const retainFailureUntilCompleteMock = vi.fn();
   const updateSessionIdMock = vi.fn();
   return {
     failMock,
+    retainFailureUntilCompleteMock,
     updateSessionIdMock,
     replyOperation: {
       key: "main",
@@ -409,7 +412,7 @@ function createMockReplyOperation(): {
       updateSessionId: updateSessionIdMock,
       attachBackend: vi.fn(),
       detachBackend: vi.fn(),
-      retainFailureUntilComplete: vi.fn(),
+      retainFailureUntilComplete: retainFailureUntilCompleteMock,
       complete: vi.fn(),
       completeThen: vi.fn((afterClear: () => void) => afterClear()),
       completeWithAfterClearBarrier: vi.fn(),
@@ -495,6 +498,7 @@ function expectBlockReplyCall(
 function createMinimalRunAgentTurnParams(overrides?: {
   followupRun?: FollowupRun;
   opts?: GetReplyOptions;
+  replyOperation?: ReplyOperation;
   sessionCtx?: TemplateContext;
 }) {
   return {
@@ -507,6 +511,7 @@ function createMinimalRunAgentTurnParams(overrides?: {
         MessageSid: "msg",
       } as unknown as TemplateContext),
     opts: overrides?.opts ?? ({} satisfies GetReplyOptions),
+    replyOperation: overrides?.replyOperation,
     typingSignals: createMockTypingSignaler(),
     blockReplyPipeline: null,
     blockStreamingEnabled: false,
@@ -1636,19 +1641,34 @@ describe("runAgentTurnWithFallback", () => {
       authProfileOverrideSource: "auto",
     };
     const activeSessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
-    state.runWithModelFallbackMock.mockResolvedValueOnce({
-      outcome: "exhausted",
-      result: {
-        payloads: [{ text: "Terminal tool summary", isError: true }],
-        meta: {
-          error: {
-            kind: "incomplete_turn",
-            message: "All fallback candidates ended incomplete",
-            fallbackSafe: true,
-            terminalPresentation: true,
-          },
+    const exhaustedResult = {
+      payloads: [{ text: "Terminal tool summary", isError: true }],
+      meta: {
+        error: {
+          kind: "incomplete_turn",
+          message: "All fallback candidates ended incomplete",
+          fallbackSafe: true,
+          terminalPresentation: true,
         },
       },
+    };
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "finishing",
+          error: "All fallback candidates ended incomplete",
+          livenessState: "blocked",
+          providerStarted: true,
+          replayInvalid: true,
+          timeoutPhase: "provider",
+        },
+      });
+      return exhaustedResult;
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "exhausted",
+      result: await params.run(probe.provider, probe.model),
       provider: probe.provider,
       model: probe.model,
       attempts: [
@@ -1659,11 +1679,13 @@ describe("runAgentTurnWithFallback", () => {
           error: "incomplete",
         },
       ],
-    });
+    }));
+    const { replyOperation, failMock, retainFailureUntilCompleteMock } = createMockReplyOperation();
+    const emitAgentEvent = vi.mocked((await import("../../infra/agent-events.js")).emitAgentEvent);
 
     const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
     const result = await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams({ followupRun }),
+      ...createMinimalRunAgentTurnParams({ followupRun, replyOperation }),
       sessionKey,
       activeSessionStore,
       getActiveSessionEntry: () => activeSessionStore[sessionKey],
@@ -1682,6 +1704,147 @@ describe("runAgentTurnWithFallback", () => {
       modelOverrideFallbackOriginProvider: probe.provider,
       modelOverrideFallbackOriginModel: probe.model,
     });
+    expect(retainFailureUntilCompleteMock).toHaveBeenCalledTimes(1);
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(Error));
+    expect(
+      emitAgentEvent.mock.calls
+        .map((call) => call[0])
+        .find(
+          (event) =>
+            event.stream === "lifecycle" &&
+            event.data.phase === "error" &&
+            event.data.fallbackExhaustedFailure === true &&
+            event.data.livenessState === "blocked" &&
+            event.data.providerStarted === true &&
+            event.data.replayInvalid === true &&
+            event.data.timeoutPhase === "provider",
+        ),
+    ).toBeDefined();
+  });
+
+  it("reports a completed non-fallbackable error result as a failure terminal", async () => {
+    const terminalErrorResult = {
+      payloads: [{ text: "Command may have changed state", isError: true }],
+      meta: {
+        replayInvalid: true,
+        error: {
+          kind: "incomplete_turn",
+          message: "raw provider detail should stay private",
+          fallbackSafe: false,
+        },
+      },
+    };
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: {
+          phase: "finishing",
+          error: "Command may have changed state",
+          replayInvalid: true,
+        },
+      });
+      return terminalErrorResult;
+    });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "completed",
+      result: await params.run("anthropic", "claude"),
+      provider: "anthropic",
+      model: "claude",
+      attempts: [],
+    }));
+    const { replyOperation, failMock, retainFailureUntilCompleteMock } = createMockReplyOperation();
+    const emitAgentEvent = vi.mocked((await import("../../infra/agent-events.js")).emitAgentEvent);
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        replyOperation,
+        opts: { runId: "run-non-fallbackable-error" },
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    expect(retainFailureUntilCompleteMock).toHaveBeenCalledTimes(1);
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(Error));
+    const lifecycleEvents = emitAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (event) => event.runId === "run-non-fallbackable-error" && event.stream === "lifecycle",
+      );
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            error: "Command may have changed state",
+            replayInvalid: true,
+          }),
+        }),
+      ]),
+    );
+    expect(
+      lifecycleEvents.some(
+        (event) => event.data.phase === "end" || event.data.fallbackExhaustedFailure === true,
+      ),
+    ).toBe(false);
+    expect(JSON.stringify(lifecycleEvents)).not.toContain("raw provider detail");
+  });
+
+  it("reports exhausted CLI results without a success lifecycle terminal", async () => {
+    state.isCliProviderMock.mockReturnValue(true);
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      outcome: "exhausted",
+      result: await params.run("codex-cli", "gpt-5.4"),
+      provider: "codex-cli",
+      model: "gpt-5.4",
+      attempts: [{ provider: "codex-cli", model: "gpt-5.4", error: "incomplete" }],
+    }));
+    state.runCliAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "Terminal tool summary", isError: true }],
+      meta: {
+        error: {
+          kind: "incomplete_turn",
+          message: "CLI turn ended incomplete",
+        },
+      },
+    });
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "codex-cli";
+    followupRun.run.model = "gpt-5.4";
+    const { replyOperation, failMock, retainFailureUntilCompleteMock } = createMockReplyOperation();
+    const emitAgentEvent = vi.mocked((await import("../../infra/agent-events.js")).emitAgentEvent);
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        replyOperation,
+        opts: { runId: "run-cli-exhausted" },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "success",
+      fallbackExhausted: true,
+      fallbackProvider: "codex-cli",
+      fallbackModel: "gpt-5.4",
+    });
+    expect(retainFailureUntilCompleteMock).toHaveBeenCalledTimes(1);
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(Error));
+    const lifecycleEvents = emitAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.runId === "run-cli-exhausted" && event.stream === "lifecycle");
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            fallbackExhaustedFailure: true,
+          }),
+        }),
+      ]),
+    );
+    expect(lifecycleEvents.some((event) => event.data.phase === "end")).toBe(false);
   });
 
   it("keeps fallback auth available for later same-provider fallback models", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -105,6 +105,11 @@ import {
   stripLeadingSilentToken,
 } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import {
+  createAgentLifecycleTerminalBackstop,
+  resolveAgentLifecycleTerminalMetadata,
+  type AgentLifecycleTerminalBackstop,
+} from "./agent-lifecycle-terminal.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
   clearDroppedCliSessionBinding,
@@ -1323,88 +1328,6 @@ function isReplyOperationRestartAbort(replyOperation?: ReplyOperation): boolean 
   );
 }
 
-function createEmbeddedLifecycleTerminalBackstop(params: {
-  runId: string;
-  sessionKey?: string;
-  getLifecycleGeneration: () => string;
-  resolveAbortLifecycleFields: () => {
-    aborted?: true;
-    stopReason?: string;
-  };
-}) {
-  let terminalEmitted = false;
-  let startedAt: number | undefined;
-
-  const note = (evt: { stream: string; data: Record<string, unknown> }) => {
-    if (evt.stream !== "lifecycle") {
-      return;
-    }
-    const phase = readStringValue(evt.data.phase);
-    if (phase === "start" && typeof evt.data.startedAt === "number") {
-      startedAt = evt.data.startedAt;
-    }
-    if (phase === "end" || phase === "error") {
-      terminalEmitted = true;
-    }
-  };
-
-  const emit = (phase: "end" | "error", resultOrError: unknown) => {
-    if (terminalEmitted) {
-      return;
-    }
-    terminalEmitted = true;
-    const abortLifecycleFields = params.resolveAbortLifecycleFields();
-    const restartAbort = abortLifecycleFields.stopReason === AGENT_RUN_RESTART_ABORT_STOP_REASON;
-    const terminalPhase = restartAbort ? "end" : phase;
-    const data: Record<string, unknown> = {
-      phase: terminalPhase,
-      endedAt: Date.now(),
-      ...(startedAt !== undefined ? { startedAt } : {}),
-    };
-    if (restartAbort) {
-      data.aborted = true;
-      data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
-    } else if (phase === "error") {
-      data.error = formatErrorMessage(resultOrError);
-      Object.assign(data, abortLifecycleFields);
-    } else {
-      const meta =
-        resultOrError && typeof resultOrError === "object" && "meta" in resultOrError
-          ? (resultOrError as { meta?: Record<string, unknown> }).meta
-          : undefined;
-      if (meta?.aborted === true) {
-        data.aborted = true;
-      }
-      const stopReason = readStringValue(meta?.stopReason);
-      if (stopReason) {
-        data.stopReason = stopReason;
-      }
-      const livenessState = readStringValue(meta?.livenessState);
-      if (livenessState) {
-        data.livenessState = livenessState;
-      }
-      if (meta?.replayInvalid === true) {
-        data.replayInvalid = true;
-      }
-      if (abortLifecycleFields.aborted === true) {
-        data.aborted = true;
-      }
-      if (abortLifecycleFields.stopReason && !readStringValue(data.stopReason)) {
-        data.stopReason = abortLifecycleFields.stopReason;
-      }
-    }
-    emitAgentEvent({
-      runId: params.runId,
-      lifecycleGeneration: params.getLifecycleGeneration(),
-      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-      stream: "lifecycle",
-      data,
-    });
-  };
-
-  return { emit, note };
-}
-
 function emitModelFallbackStepLifecycle(params: {
   runId: string;
   sessionKey?: string;
@@ -1724,6 +1647,18 @@ export async function runAgentTurnWithFallback(params: {
   let attemptedRuntimeModel = fallbackModel;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let fallbackExhausted = false;
+  let pendingLifecycleTerminal:
+    | {
+        provider: string;
+        model: string;
+        backstop: AgentLifecycleTerminalBackstop;
+      }
+    | undefined;
+  const takePendingLifecycleTerminal = () => {
+    const terminal = pendingLifecycleTerminal?.backstop;
+    pendingLifecycleTerminal = undefined;
+    return terminal;
+  };
   let transientHttpRetriesRemaining = 1;
   const consumeTransientHttpRetry = () => transientHttpRetriesRemaining-- > 0;
   let liveModelSwitchRetries = 0;
@@ -2146,6 +2081,23 @@ export async function runAgentTurnWithFallback(params: {
                 params.getActiveSessionEntry(),
                 cliExecutionProvider,
               );
+              const cliLifecycleStartedAt = Date.now();
+              const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
+                runId,
+                sessionKey: params.sessionKey,
+                startedAt: cliLifecycleStartedAt,
+                getLifecycleGeneration: () => lifecycleGeneration,
+                resolveAbortLifecycleFields: () => ({
+                  ...resolveAgentRunAbortLifecycleFields(runAbortSignal),
+                  ...(isReplyOperationRestartAbort(params.replyOperation)
+                    ? {
+                        aborted: true as const,
+                        stopReason: AGENT_RUN_RESTART_ABORT_STOP_REASON,
+                      }
+                    : {}),
+                }),
+              });
+              pendingLifecycleTerminal = { provider, model, backstop: lifecycleBackstop };
               const authProfile = resolveRunAuthProfile(candidateRun, cliExecutionProvider, {
                 config: runtimeConfig,
               });
@@ -2175,6 +2127,8 @@ export async function runAgentTurnWithFallback(params: {
                   runId,
                   lifecycleGeneration,
                   provider: cliExecutionProvider,
+                  startedAt: cliLifecycleStartedAt,
+                  emitLifecycleTerminal: false,
                   onAgentRunStart: notifyAgentRunStart,
                   suppressAssistantBridge: params.followupRun.run.silentExpected,
                   onAssistantText: async (text) => {
@@ -2353,7 +2307,7 @@ export async function runAgentTurnWithFallback(params: {
                 : undefined);
             return (async () => {
               let attemptCompactionCount = 0;
-              const lifecycleBackstop = createEmbeddedLifecycleTerminalBackstop({
+              const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
                 runId,
                 sessionKey: params.sessionKey,
                 getLifecycleGeneration: () => lifecycleGeneration,
@@ -2367,6 +2321,7 @@ export async function runAgentTurnWithFallback(params: {
                     : {}),
                 }),
               });
+              pendingLifecycleTerminal = { provider, model, backstop: lifecycleBackstop };
               try {
                 // Profiler-only milestone: it exposes time spent before Codex
                 // dispatch while leaving the regular embedded run path inert.
@@ -2436,6 +2391,7 @@ export async function runAgentTurnWithFallback(params: {
                     imageOrder: currentTurnImages.imageOrder,
                     abortSignal: runAbortSignal,
                     replyOperation: params.replyOperation,
+                    deferTerminalLifecycle: true,
                     onExecutionStarted: (info) => {
                       if (info?.lifecycleGeneration) {
                         lifecycleGeneration = info.lifecycleGeneration;
@@ -2735,7 +2691,6 @@ export async function runAgentTurnWithFallback(params: {
                 bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                   result.meta?.systemPromptReport,
                 );
-                lifecycleBackstop.emit("end", result);
                 const resultCompactionCount = Math.max(
                   0,
                   result.meta?.agentMeta?.compactionCount ?? 0,
@@ -2753,7 +2708,6 @@ export async function runAgentTurnWithFallback(params: {
                     );
                   }
                 }
-                lifecycleBackstop.emit("error", err);
                 throw err;
               } finally {
                 autoCompactionCount += attemptCompactionCount;
@@ -2768,16 +2722,23 @@ export async function runAgentTurnWithFallback(params: {
         sessionKey: params.sessionKey,
         outcome: "completed",
       });
-      const restartAbortReason = runAbortSignal?.reason;
-      if (isReplyOperationRestartAbort(params.replyOperation)) {
-        throw isAgentRunRestartAbortReason(restartAbortReason)
-          ? restartAbortReason
-          : createAgentRunRestartAbortError();
-      }
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
       fallbackExhausted = fallbackResult.outcome === "exhausted";
+      const settledLifecycleTerminal =
+        pendingLifecycleTerminal?.provider === fallbackProvider &&
+        pendingLifecycleTerminal.model === fallbackModel
+          ? pendingLifecycleTerminal.backstop
+          : undefined;
+      pendingLifecycleTerminal = undefined;
+      const restartAbortReason = runAbortSignal?.reason;
+      if (isReplyOperationRestartAbort(params.replyOperation)) {
+        settledLifecycleTerminal?.emit("end", runResult);
+        throw isAgentRunRestartAbortReason(restartAbortReason)
+          ? restartAbortReason
+          : createAgentRunRestartAbortError();
+      }
       fallbackAttempts = Array.isArray(fallbackResult.attempts)
         ? fallbackResult.attempts.map((attempt) => ({
             provider: attempt.provider,
@@ -2799,7 +2760,34 @@ export async function runAgentTurnWithFallback(params: {
       // Preserve the active session mapping and surface explicit guidance instead
       // of silently rotating the session key to a new session id.
       const embeddedError = runResult.meta?.error;
+      const deferredLifecycleError = settledLifecycleTerminal?.getDeferredError();
+      const userFacingErrorPayload = runResult.payloads?.find(
+        (payload) => payload.isError === true && typeof payload.text === "string",
+      )?.text;
+      const terminalErrorMessage =
+        deferredLifecycleError ??
+        userFacingErrorPayload ??
+        (embeddedError ? "Agent run failed" : undefined);
+      const emitSettledLifecycleError = (error: Error, extraData?: Record<string, unknown>) => {
+        if (settledLifecycleTerminal) {
+          settledLifecycleTerminal.emit("error", error, extraData);
+          return;
+        }
+        emitAgentEvent({
+          runId,
+          lifecycleGeneration,
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          stream: "lifecycle",
+          data: {
+            phase: "error",
+            error: error.message,
+            endedAt: Date.now(),
+            ...extraData,
+          },
+        });
+      };
       if (embeddedError && isContextOverflowError(embeddedError.message)) {
+        emitSettledLifecycleError(new Error(terminalErrorMessage ?? "Agent run failed"));
         defaultRuntime.error(
           `Auto-compaction failed (${embeddedError.message}). Preserving existing session mapping for ${params.sessionKey ?? params.followupRun.run.sessionId}.`,
         );
@@ -2821,6 +2809,7 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
       if (embeddedError?.kind === "role_ordering") {
+        emitSettledLifecycleError(new Error(terminalErrorMessage ?? "Agent run failed"));
         const providerRequestError = classifyProviderRequestError(embeddedError);
         params.replyOperation?.fail("run_failed", embeddedError);
         const embeddedErrorText = formatErrorMessage(embeddedError).replace(/\.\s*$/, "");
@@ -2835,6 +2824,25 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
+      const terminalMetadata = resolveAgentLifecycleTerminalMetadata(runResult.meta);
+      if (fallbackExhausted) {
+        const exhaustionError = new Error(
+          terminalErrorMessage ?? "All model fallback candidates failed",
+        );
+        emitSettledLifecycleError(exhaustionError, {
+          ...terminalMetadata,
+          fallbackExhaustedFailure: true,
+        });
+        params.replyOperation?.retainFailureUntilComplete();
+        params.replyOperation?.fail("run_failed", exhaustionError);
+      } else if (deferredLifecycleError || embeddedError) {
+        const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
+        emitSettledLifecycleError(terminalError, terminalMetadata);
+        params.replyOperation?.retainFailureUntilComplete();
+        params.replyOperation?.fail("run_failed", terminalError);
+      } else {
+        settledLifecycleTerminal?.emit("end", runResult);
+      }
       break;
     } catch (err) {
       if (err instanceof LiveSessionModelSwitchError) {
@@ -2849,6 +2857,7 @@ export async function runAgentTurnWithFallback(params: {
             `Live model switch failed after ${MAX_LIVE_SWITCH_RETRIES} retries ` +
               `(${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)}). The requested model may be unavailable.`,
           );
+          takePendingLifecycleTerminal()?.emit("error", err);
           const switchErrorText = shouldSurfaceToControlUi
             ? "⚠️ Agent failed before reply: model switch could not be completed. " +
               "The requested model may be temporarily unavailable.\n" +
@@ -2877,6 +2886,7 @@ export async function runAgentTurnWithFallback(params: {
         if (effectiveRun !== runnableRun && effectiveRun !== params.followupRun.run) {
           applyLiveModelSwitchToRun(effectiveRun, err);
         }
+        pendingLifecycleTerminal = undefined;
         fallbackProvider = err.provider;
         fallbackModel = err.model;
         continue;
@@ -2899,6 +2909,7 @@ export async function runAgentTurnWithFallback(params: {
       const isTransientHttp = isTransientHttpError(message);
 
       if (isReplyOperationRestartAbort(params.replyOperation)) {
+        takePendingLifecycleTerminal()?.emit("end", err);
         return {
           kind: "final",
           payload: markAgentRunFailureReplyPayload({
@@ -2908,6 +2919,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       if (isReplyOperationUserAbort(params.replyOperation)) {
+        takePendingLifecycleTerminal()?.emit("error", err);
         return {
           kind: "final",
           payload: {
@@ -2918,6 +2930,7 @@ export async function runAgentTurnWithFallback(params: {
 
       const restartLifecycleError = resolveRestartLifecycleError(err);
       if (restartLifecycleError instanceof GatewayDrainingError) {
+        takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
         params.replyOperation?.fail("gateway_draining", restartLifecycleError);
         return {
           kind: "final",
@@ -2928,6 +2941,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       if (restartLifecycleError instanceof CommandLaneClearedError) {
+        takePendingLifecycleTerminal()?.emit("error", restartLifecycleError);
         params.replyOperation?.fail("command_lane_cleared", restartLifecycleError);
         return {
           kind: "final",
@@ -2938,6 +2952,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       if (isCompactionFailure) {
+        takePendingLifecycleTerminal()?.emit("error", err);
         defaultRuntime.error(
           `Auto-compaction failed (${message}). Preserving existing session mapping for ${params.sessionKey ?? params.followupRun.run.sessionId}.`,
         );
@@ -2960,6 +2975,7 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
       if (providerRequestError) {
+        takePendingLifecycleTerminal()?.emit("error", err);
         params.replyOperation?.fail("run_failed", err);
         return {
           kind: "final",
@@ -2970,6 +2986,7 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       if (isTransientHttp && consumeTransientHttpRetry()) {
+        pendingLifecycleTerminal = undefined;
         // Retry the full runWithModelFallback() cycle — transient errors
         // (502/521/etc.) typically affect the whole provider, so falling
         // back to an alternate model first would not help. Instead we wait
@@ -3053,19 +3070,26 @@ export async function runAgentTurnWithFallback(params: {
           : {}),
       };
 
-      emitAgentEvent({
-        runId,
-        lifecycleGeneration,
-        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        stream: "lifecycle",
-        data: {
-          phase: "error",
-          error: message,
-          endedAt: Date.now(),
-          ...abortLifecycleFields,
+      const failedLifecycleTerminal = takePendingLifecycleTerminal();
+      if (failedLifecycleTerminal) {
+        failedLifecycleTerminal.emit("error", err, {
           fallbackExhaustedFailure: true,
-        },
-      });
+        });
+      } else {
+        emitAgentEvent({
+          runId,
+          lifecycleGeneration,
+          ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+          stream: "lifecycle",
+          data: {
+            phase: "error",
+            error: message,
+            endedAt: Date.now(),
+            ...abortLifecycleFields,
+            fallbackExhaustedFailure: true,
+          },
+        });
+      }
       params.replyOperation?.fail("run_failed", err);
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -40,6 +40,7 @@ import {
 } from "../../agents/embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging.js";
+import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
 import { isFailoverError } from "../../agents/failover-error.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
@@ -312,6 +313,7 @@ export type AgentRunLoopResult =
       runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
       fallbackProvider?: string;
       fallbackModel?: string;
+      fallbackExhausted?: true;
       fallbackAttempts: RuntimeFallbackAttempt[];
       didLogHeartbeatStrip: boolean;
       autoCompactionCount: number;
@@ -1721,6 +1723,7 @@ export async function runAgentTurnWithFallback(params: {
   let attemptedRuntimeProvider = fallbackProvider;
   let attemptedRuntimeModel = fallbackModel;
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
+  let fallbackExhausted = false;
   let transientHttpRetriesRemaining = 1;
   const consumeTransientHttpRetry = () => transientHttpRetriesRemaining-- > 0;
   let liveModelSwitchRetries = 0;
@@ -2064,6 +2067,7 @@ export async function runAgentTurnWithFallback(params: {
             }
             return classification;
           },
+          mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           run: async (provider, model, runOptions) => {
             attemptedRuntimeProvider = provider;
             attemptedRuntimeModel = model;
@@ -2773,6 +2777,7 @@ export async function runAgentTurnWithFallback(params: {
       runResult = fallbackResult.result;
       fallbackProvider = fallbackResult.provider;
       fallbackModel = fallbackResult.model;
+      fallbackExhausted = fallbackResult.outcome === "exhausted";
       fallbackAttempts = Array.isArray(fallbackResult.attempts)
         ? fallbackResult.attempts.map((attempt) => ({
             provider: attempt.provider,
@@ -2783,10 +2788,12 @@ export async function runAgentTurnWithFallback(params: {
             code: attempt.code || undefined,
           }))
         : [];
-      await clearRecoveredAutoFallbackPrimaryProbe({
-        provider: fallbackProvider,
-        model: fallbackModel,
-      });
+      if (!fallbackExhausted) {
+        await clearRecoveredAutoFallbackPrimaryProbe({
+          provider: fallbackProvider,
+          model: fallbackModel,
+        });
+      }
 
       // Some embedded runs surface context overflow as an error payload instead of throwing.
       // Preserve the active session mapping and surface explicit guidance instead
@@ -3139,6 +3146,7 @@ export async function runAgentTurnWithFallback(params: {
     runResult,
     fallbackProvider,
     fallbackModel,
+    ...(fallbackExhausted ? { fallbackExhausted: true as const } : {}),
     fallbackAttempts,
     didLogHeartbeatStrip,
     autoCompactionCount,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -16,6 +16,7 @@ import {
   type QueueSettings,
 } from "./queue.js";
 import { createReplyOperation, testing as replyRunTesting } from "./reply-run-registry.js";
+import { consumeReplyUsageState } from "./reply-usage-state.js";
 import { createMockTypingController } from "./test-helpers.js";
 
 type AgentRunParams = {
@@ -93,6 +94,7 @@ vi.mock("../../agents/model-fallback.js", () => ({
     model: string;
     run: (provider: string, model: string) => Promise<unknown>;
   }) => ({
+    outcome: "completed" as const,
     result: await run(provider, model),
     provider,
     model,
@@ -1131,6 +1133,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
           fallbackStepFinalOutcome: "succeeded",
         });
         return {
+          outcome: "completed" as const,
           result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
@@ -1174,6 +1177,84 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
+  it("does not report an exhausted fallback candidate as a successful winner", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-exhausted-trace-"));
+    const storePath = join(root, "sessions.json");
+    const sessionFile = join(root, "session.jsonl");
+    const runId = "run-exhausted-trace";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      traceLevel: "raw",
+    };
+    await saveSessionStore(storePath, { main: sessionEntry }, { skipMaintenance: true });
+    try {
+      state.runEmbeddedAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "Terminal tool summary", isError: true }],
+        meta: {
+          error: {
+            kind: "incomplete_turn",
+            message: "Agent ended incomplete",
+            fallbackSafe: true,
+            terminalPresentation: true,
+          },
+          executionTrace: {
+            winnerProvider: "anthropic",
+            winnerModel: "claude",
+            attempts: [{ provider: "anthropic", model: "claude", result: "success" }],
+            fallbackUsed: false,
+            runner: "embedded",
+          },
+          agentMeta: {
+            sessionId: "session",
+            provider: "anthropic",
+            model: "claude",
+            usage: { input: 10, output: 2 },
+          },
+        },
+      });
+      vi.spyOn(modelFallbackModule, "runWithModelFallback").mockImplementationOnce(
+        async (args) => ({
+          outcome: "exhausted",
+          result: await args.run("anthropic", "claude"),
+          provider: "anthropic",
+          model: "claude",
+          attempts: [
+            {
+              provider: "anthropic",
+              model: "claude",
+              error: "Agent ended incomplete",
+              reason: "format",
+            },
+          ],
+        }),
+      );
+
+      const { run } = createMinimalRun({
+        opts: { runId },
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        sessionKey: "main",
+        storePath,
+        runOverrides: {
+          sessionFile,
+          traceAuthorized: true,
+        },
+      });
+      const result = await run();
+      const text = (Array.isArray(result) ? result : [result])
+        .map((payload) => payload?.text ?? "")
+        .join("\n");
+
+      expect(text).not.toContain("winner=anthropic/claude");
+      expect(text).not.toContain("result=success");
+      expect(text).toContain("Summary: fallback=yes attempts=1");
+      expect(consumeReplyUsageState(runId)?.resolvedRef).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not persist active fallback state for internal subagent announce fallback", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -1208,6 +1289,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
           fallbackStepFinalOutcome: "succeeded",
         });
         return {
+          outcome: "completed" as const,
           result: await run("google", "gemini-2.5-flash"),
           provider: "google",
           model: "gemini-2.5-flash",
@@ -1284,6 +1366,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         fallbackStepFinalOutcome: "succeeded",
       });
       return {
+        outcome: "completed" as const,
         result: await run("google", "gemini-2.5-flash"),
         provider: "google",
         model: "gemini-2.5-flash",
@@ -1342,6 +1425,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
@@ -1390,6 +1474,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
@@ -1440,6 +1525,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1487,6 +1573,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1574,6 +1661,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1629,6 +1717,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1679,6 +1768,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1730,6 +1820,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1781,6 +1872,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1828,6 +1920,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementationOnce(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("openai", "gpt-5.5"),
           provider: "openai",
           model: "gpt-5.5",
@@ -1880,6 +1973,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
       .spyOn(modelFallbackModule, "runWithModelFallback")
       .mockImplementation(
         async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          outcome: "completed" as const,
           result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
           provider: "deepinfra",
           model: "moonshotai/Kimi-K2.5",
@@ -1947,6 +2041,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
           callCount += 1;
           if (callCount === 2) {
             return {
+              outcome: "completed" as const,
               result: await run(provider, model),
               provider,
               model,
@@ -1954,6 +2049,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
             };
           }
           return {
+            outcome: "completed" as const,
             result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
             provider: "deepinfra",
             model: "moonshotai/Kimi-K2.5",
@@ -2017,6 +2113,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
           callCount += 1;
           if (callCount === 1) {
             return {
+              outcome: "completed" as const,
               result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
               provider: "deepinfra",
               model: "moonshotai/Kimi-K2.5",
@@ -2031,6 +2128,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
             };
           }
           return {
+            outcome: "completed" as const,
             result: await run(provider, model),
             provider,
             model,
@@ -2097,6 +2195,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
           callCount += 1;
           if (callCount === 1) {
             return {
+              outcome: "completed" as const,
               result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
               provider: "deepinfra",
               model: "moonshotai/Kimi-K2.5",
@@ -2111,6 +2210,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
             };
           }
           return {
+            outcome: "completed" as const,
             result: await run(provider, model),
             provider,
             model,
@@ -2186,6 +2286,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
         .spyOn(modelFallbackModule, "runWithModelFallback")
         .mockImplementation(
           async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+            outcome: "completed" as const,
             result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
             provider: "deepinfra",
             model: "moonshotai/Kimi-K2.5",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -469,7 +469,11 @@ function mergeExecutionTrace(params: {
   provider?: string;
   model?: string;
   runner: "embedded" | "cli";
+  exhausted?: boolean;
 }): TraceExecutionView | undefined {
+  const executionAttempts = params.exhausted
+    ? (params.executionTrace?.attempts ?? []).filter((attempt) => attempt.result !== "success")
+    : (params.executionTrace?.attempts ?? []);
   const attempts: TraceAttemptView[] = [
     ...(params.fallbackAttempts ?? []).map((attempt) =>
       Object.assign(
@@ -482,11 +486,14 @@ function mergeExecutionTrace(params: {
         typeof attempt.status === `number` ? { status: attempt.status } : {},
       ),
     ),
-    ...(params.executionTrace?.attempts ?? []),
+    ...executionAttempts,
   ];
-  const winnerProvider =
-    params.executionTrace?.winnerProvider ?? normalizeOptionalString(params.provider);
-  const winnerModel = params.executionTrace?.winnerModel ?? normalizeOptionalString(params.model);
+  const winnerProvider = params.exhausted
+    ? undefined
+    : (params.executionTrace?.winnerProvider ?? normalizeOptionalString(params.provider));
+  const winnerModel = params.exhausted
+    ? undefined
+    : (params.executionTrace?.winnerModel ?? normalizeOptionalString(params.model));
   if (
     winnerProvider &&
     winnerModel &&
@@ -1713,6 +1720,7 @@ export async function runReplyAgent(params: {
       runResult,
       fallbackProvider,
       fallbackModel,
+      fallbackExhausted,
       fallbackAttempts,
       directlySentBlockKeys,
       directlySentBlockPayloads,
@@ -1772,8 +1780,12 @@ export async function runReplyAgent(params: {
 
     let replyUsageState: PluginHookReplyUsageState | undefined;
     {
-      const winnerProvider = runResult.meta?.executionTrace?.winnerProvider ?? providerUsed;
-      const winnerModel = runResult.meta?.executionTrace?.winnerModel ?? modelUsed;
+      const winnerProvider = fallbackExhausted
+        ? undefined
+        : (runResult.meta?.executionTrace?.winnerProvider ?? providerUsed);
+      const winnerModel = fallbackExhausted
+        ? undefined
+        : (runResult.meta?.executionTrace?.winnerModel ?? modelUsed);
       const ctxTokens = runResult.meta?.agentMeta?.contextTokens;
       const compactions = runResult.meta?.agentMeta?.compactionCount;
       const lastCallUsage = runResult.meta?.agentMeta?.lastCallUsage;
@@ -1861,7 +1873,7 @@ export async function runReplyAgent(params: {
       state: fallbackStateEntry,
       cfg,
     });
-    if (fallbackTransition.stateChanged && !preserveUserFacingSessionState) {
+    if (fallbackTransition.stateChanged && !fallbackExhausted && !preserveUserFacingSessionState) {
       if (fallbackStateEntry) {
         fallbackStateEntry.fallbackNoticeSelectedModel = fallbackTransition.nextState.selectedModel;
         fallbackStateEntry.fallbackNoticeActiveModel = fallbackTransition.nextState.activeModel;
@@ -1923,6 +1935,7 @@ export async function runReplyAgent(params: {
       promptTokens,
       usageIsContextSnapshot: usedCliProvider ? true : undefined,
       isHeartbeat,
+      preserveRuntimeModel: fallbackExhausted,
       preserveUserFacingSessionModelState: preserveUserFacingSessionState,
       modelUsed,
       providerUsed,
@@ -1983,7 +1996,11 @@ export async function runReplyAgent(params: {
     };
 
     const fallbackNoticePayloads: ReplyPayload[] = [];
-    if (!preserveUserFacingSessionState && fallbackTransition.fallbackTransitioned) {
+    if (
+      !fallbackExhausted &&
+      !preserveUserFacingSessionState &&
+      fallbackTransition.fallbackTransitioned
+    ) {
       emitAgentEvent({
         runId,
         sessionKey,
@@ -2016,7 +2033,11 @@ export async function runReplyAgent(params: {
         );
       }
     }
-    if (!preserveUserFacingSessionState && fallbackTransition.fallbackCleared) {
+    if (
+      !fallbackExhausted &&
+      !preserveUserFacingSessionState &&
+      fallbackTransition.fallbackCleared
+    ) {
       emitAgentEvent({
         runId,
         sessionKey,
@@ -2315,6 +2336,7 @@ export async function runReplyAgent(params: {
       provider: providerUsed,
       model: modelUsed,
       runner: isCliProvider(providerUsed, cfg) ? "cli" : "embedded",
+      exhausted: fallbackExhausted,
     });
     const requestShaping = {
       authMode:

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -306,7 +306,9 @@ async function persistRunSessionUsageForFollowupTest(
     return;
   }
   const preserveSessionModelState =
-    params.isHeartbeat === true || params.preserveUserFacingSessionModelState === true;
+    params.isHeartbeat === true ||
+    params.preserveRuntimeModel === true ||
+    params.preserveUserFacingSessionModelState === true;
   const preserveUserFacingRunState = params.preserveUserFacingSessionModelState === true;
   const nextEntry: SessionEntry = {
     ...entry,
@@ -315,7 +317,7 @@ async function persistRunSessionUsageForFollowupTest(
       ? entry.modelProvider
       : (params.providerUsed ?? entry.modelProvider),
     model: preserveSessionModelState ? entry.model : (params.modelUsed ?? entry.model),
-    contextTokens: preserveUserFacingRunState
+    contextTokens: preserveSessionModelState
       ? entry.contextTokens
       : (params.contextTokensUsed ?? entry.contextTokens),
     systemPromptReport: preserveUserFacingRunState

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -40,6 +40,7 @@ let createMockFollowupRun: typeof import("./test-helpers.js").createMockFollowup
 let createMockTypingController: typeof import("./test-helpers.js").createMockTypingController;
 let createReplyOperationForTest: typeof import("./reply-run-registry.js").createReplyOperation;
 let abortActiveReplyRunsForTest: typeof import("./reply-run-registry.js").abortActiveReplyRuns;
+let replyRunRegistryForTest: typeof import("./reply-run-registry.js").replyRunRegistry;
 let replyRunTestingForTest: typeof import("./reply-run-registry.js").testing;
 let cliBackendsTestingForTest: typeof import("../../agents/cli-backends.js").testing;
 let setReplyPayloadMetadataForTest: typeof import("../reply-payload.js").setReplyPayloadMetadata;
@@ -469,6 +470,7 @@ async function loadFreshFollowupRunnerModuleForTest() {
   ({
     abortActiveReplyRuns: abortActiveReplyRunsForTest,
     createReplyOperation: createReplyOperationForTest,
+    replyRunRegistry: replyRunRegistryForTest,
     testing: replyRunTestingForTest,
   } = await import("./reply-run-registry.js"));
   ({ setReplyPayloadMetadata: setReplyPayloadMetadataForTest } =
@@ -1596,22 +1598,38 @@ describe("createFollowupRunner runtime config", () => {
       },
     );
     runCliAgentMock.mockRejectedValueOnce(new Error("cli failed"));
-    runEmbeddedAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
-      realAgentEvents.emitAgentEvent({
-        runId: params.runId,
-        stream: "lifecycle",
-        data: { phase: "start", startedAt: Date.now() },
-      });
-      realAgentEvents.emitAgentEvent({
-        runId: params.runId,
-        stream: "lifecycle",
-        data: { phase: "end", endedAt: Date.now() },
-      });
-      return {
-        payloads: [{ text: "fallback ok" }],
-        meta: {},
-      };
-    });
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: {
+        runId: string;
+        deferTerminalLifecycle?: boolean;
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        expect(params.deferTerminalLifecycle).toBe(true);
+        const startedAt = Date.now();
+        const startEvent = {
+          stream: "lifecycle",
+          data: { phase: "start", startedAt },
+        };
+        realAgentEvents.emitAgentEvent({
+          runId: params.runId,
+          ...startEvent,
+        });
+        await params.onAgentEvent?.(startEvent);
+        const finishingEvent = {
+          stream: "lifecycle",
+          data: { phase: "finishing", endedAt: Date.now() },
+        };
+        realAgentEvents.emitAgentEvent({
+          runId: params.runId,
+          ...finishingEvent,
+        });
+        await params.onAgentEvent?.(finishingEvent);
+        return {
+          payloads: [{ text: "fallback ok" }],
+          meta: {},
+        };
+      },
+    );
 
     const runner = createFollowupRunner({
       typing: createMockTypingController(),
@@ -1641,7 +1659,206 @@ describe("createFollowupRunner runtime config", () => {
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const embeddedCall = requireLastMockCallArg(runEmbeddedAgentMock, "run embedded agent");
     expect(embeddedCall.suppressAssistantErrorPersistence).toBe(false);
-    expect(lifecyclePhases).toEqual(["start", "start", "end"]);
+    expect(lifecyclePhases).toEqual(["start", "start", "finishing", "end"]);
+  });
+
+  it("delivers an exhausted embedded followup as a failed lifecycle", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const unsubscribe = realAgentEvents.onAgentEvent((evt) => {
+      if (evt.stream === "lifecycle") {
+        lifecycleEvents.push(evt.data);
+      }
+    });
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        outcome: "exhausted",
+        result: await params.run("anthropic", "claude-opus-4-7"),
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+    );
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: {
+        deferTerminalLifecycle?: boolean;
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        expect(params.deferTerminalLifecycle).toBe(true);
+        await params.onAgentEvent?.({
+          stream: "lifecycle",
+          data: { phase: "start", startedAt: 1_000 },
+        });
+        await params.onAgentEvent?.({
+          stream: "lifecycle",
+          data: { phase: "finishing", endedAt: 1_500 },
+        });
+        return {
+          payloads: [{ text: "Terminal tool summary", isError: true }],
+          meta: {
+            error: {
+              kind: "incomplete_turn",
+              message: "raw exhausted provider detail should stay private",
+            },
+          },
+        };
+      },
+    );
+    let operationResultDuringCompletion:
+      | import("./reply-run-registry.js").ReplyOperation["result"]
+      | undefined;
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    try {
+      await runner(
+        createQueuedRun({
+          originatingChannel: "telegram",
+          originatingTo: "chat-1",
+          queuedLifecycle: {
+            onComplete: () => {
+              operationResultDuringCompletion = replyRunRegistryForTest.get("main")?.result;
+            },
+          },
+          run: {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            messageProvider: "telegram",
+          },
+        }),
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ text: "Terminal tool summary", isError: true }),
+      }),
+    );
+    expect(operationResultDuringCompletion).toMatchObject({
+      kind: "failed",
+      code: "run_failed",
+    });
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "error",
+          startedAt: 1_000,
+          fallbackExhaustedFailure: true,
+        }),
+      ]),
+    );
+    expect(lifecycleEvents.some((event) => event.phase === "end")).toBe(false);
+    expect(JSON.stringify(lifecycleEvents)).not.toContain("raw exhausted provider detail");
+  });
+
+  it("delivers a completed non-fallbackable error followup as a failed lifecycle", async () => {
+    const realAgentEvents = await vi.importActual<typeof import("../../infra/agent-events.js")>(
+      "../../infra/agent-events.js",
+    );
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const unsubscribe = realAgentEvents.onAgentEvent((evt) => {
+      if (evt.stream === "lifecycle") {
+        lifecycleEvents.push(evt.data);
+      }
+    });
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        outcome: "completed",
+        result: await params.run("anthropic", "claude-opus-4-7"),
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      }),
+    );
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: {
+        onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => Promise<void>;
+      }) => {
+        await params.onAgentEvent?.({
+          stream: "lifecycle",
+          data: {
+            phase: "finishing",
+            error: "Command may have changed state",
+            replayInvalid: true,
+          },
+        });
+        return {
+          payloads: [{ text: "Command may have changed state", isError: true }],
+          meta: {
+            replayInvalid: true,
+            error: {
+              kind: "incomplete_turn",
+              message: "raw provider detail should stay private",
+              fallbackSafe: false,
+            },
+          },
+        };
+      },
+    );
+    let operationResultDuringCompletion:
+      | import("./reply-run-registry.js").ReplyOperation["result"]
+      | undefined;
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionKey: "main",
+      defaultModel: "anthropic/claude-opus-4-7",
+    });
+
+    try {
+      await runner(
+        createQueuedRun({
+          originatingChannel: "telegram",
+          originatingTo: "chat-1",
+          queuedLifecycle: {
+            onComplete: () => {
+              operationResultDuringCompletion = replyRunRegistryForTest.get("main")?.result;
+            },
+          },
+          run: {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            messageProvider: "telegram",
+          },
+        }),
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          text: "Command may have changed state",
+          isError: true,
+        }),
+      }),
+    );
+    expect(operationResultDuringCompletion).toMatchObject({
+      kind: "failed",
+      code: "run_failed",
+    });
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "error",
+          error: "Command may have changed state",
+          replayInvalid: true,
+        }),
+      ]),
+    );
+    expect(
+      lifecycleEvents.some(
+        (event) => event.phase === "end" || event.fallbackExhaustedFailure === true,
+      ),
+    ).toBe(false);
+    expect(JSON.stringify(lifecycleEvents)).not.toContain("raw provider detail");
   });
 
   it("suppresses deferred CLI success after restart cancellation", async () => {
@@ -1715,7 +1932,7 @@ describe("createFollowupRunner runtime config", () => {
     expect(lifecycleEvents).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          phase: "error",
+          phase: "end",
           aborted: true,
           stopReason: "restart",
         }),

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -46,6 +46,11 @@ import {
 } from "../reply-payload.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  createAgentLifecycleTerminalBackstop,
+  resolveAgentLifecycleTerminalMetadata,
+  type AgentLifecycleTerminalBackstop,
+} from "./agent-lifecycle-terminal.js";
+import {
   clearDroppedCliSessionBinding,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
@@ -785,11 +790,11 @@ export function createFollowupRunner(params: {
       fallbackModel = run.model;
       replyOperation.setPhase("running");
       const runAbortSignal = replyOperation.abortSignal;
-      let pendingDeferredCliTerminal:
+      let pendingLifecycleTerminal:
         | {
             provider: string;
             model: string;
-            startedAt: number;
+            backstop: AgentLifecycleTerminalBackstop;
           }
         | undefined;
       let queuedUserMessagePersistedAcrossFallback = false;
@@ -892,12 +897,16 @@ export function createFollowupRunner(params: {
                   cliExecutionProvider,
                 );
                 const cliLifecycleStartedAt = Date.now();
-                let droppedCliSessionReplacement = false;
-                pendingDeferredCliTerminal = {
-                  provider,
-                  model,
+                const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
+                  runId,
+                  sessionKey: replySessionKey,
                   startedAt: cliLifecycleStartedAt,
-                };
+                  getLifecycleGeneration: () => lifecycleGeneration,
+                  resolveAbortLifecycleFields: () =>
+                    resolveAgentRunAbortLifecycleFields(runAbortSignal),
+                });
+                let droppedCliSessionReplacement = false;
+                pendingLifecycleTerminal = { provider, model, backstop: lifecycleBackstop };
                 const followupCurrentMessageId = resolveFollowupCurrentMessageId();
                 const cliToolSummaryTracker = createCliToolSummaryTracker({
                   detailMode: toolProgressDetail,
@@ -1032,7 +1041,14 @@ export function createFollowupRunner(params: {
                 );
                 return result;
               }
-              pendingDeferredCliTerminal = undefined;
+              const lifecycleBackstop = createAgentLifecycleTerminalBackstop({
+                runId,
+                sessionKey: replySessionKey,
+                getLifecycleGeneration: () => lifecycleGeneration,
+                resolveAbortLifecycleFields: () =>
+                  resolveAgentRunAbortLifecycleFields(runAbortSignal),
+              });
+              pendingLifecycleTerminal = { provider, model, backstop: lifecycleBackstop };
               const followupCurrentMessageId = resolveFollowupCurrentMessageId();
               const result = await runEmbeddedAgent({
                 allowGatewaySubagentBinding: true,
@@ -1101,6 +1117,7 @@ export function createFollowupRunner(params: {
                 runTimeoutOverrideMs: run.runTimeoutOverrideMs,
                 runId,
                 abortSignal: runAbortSignal,
+                deferTerminalLifecycle: true,
                 onExecutionStarted: (info) => {
                   if (info?.lifecycleGeneration) {
                     lifecycleGeneration = info.lifecycleGeneration;
@@ -1119,8 +1136,9 @@ export function createFollowupRunner(params: {
                 shouldEmitToolResult: shouldEmitToolResultProgress,
                 shouldEmitToolOutput: shouldEmitToolOutputProgress,
                 onToolResult: deliverFollowupToolSummary,
-                onAgentEvent: (evt) =>
-                  enqueueProgressDelivery(async () => {
+                onAgentEvent: (evt) => {
+                  lifecycleBackstop.note(evt);
+                  return enqueueProgressDelivery(async () => {
                     await forwardFollowupProgressEvent({
                       evt,
                       opts,
@@ -1140,7 +1158,8 @@ export function createFollowupRunner(params: {
                     ) {
                       markVisibleToolErrorProgress();
                     }
-                  }),
+                  });
+                },
               });
               bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                 result.meta?.systemPromptReport,
@@ -1160,27 +1179,61 @@ export function createFollowupRunner(params: {
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
         fallbackExhausted = fallbackResult.outcome === "exhausted";
+        const settledLifecycleTerminal =
+          pendingLifecycleTerminal?.provider === fallbackProvider &&
+          pendingLifecycleTerminal.model === fallbackModel
+            ? pendingLifecycleTerminal.backstop
+            : undefined;
+        pendingLifecycleTerminal = undefined;
         if (isAgentRunRestartAbortReason(runAbortSignal.reason)) {
+          settledLifecycleTerminal?.emit("end", runResult);
           throw runAbortSignal.reason;
         }
-        if (
-          pendingDeferredCliTerminal &&
-          pendingDeferredCliTerminal.provider === fallbackProvider &&
-          pendingDeferredCliTerminal.model === fallbackModel
-        ) {
+        const emitSettledLifecycleError = (error: Error, extraData?: Record<string, unknown>) => {
+          if (settledLifecycleTerminal) {
+            settledLifecycleTerminal.emit("error", error, extraData);
+            return;
+          }
           emitAgentEvent({
             runId,
             lifecycleGeneration,
+            ...(replySessionKey ? { sessionKey: replySessionKey } : {}),
             stream: "lifecycle",
             data: {
-              phase: "end",
-              startedAt: pendingDeferredCliTerminal.startedAt,
+              phase: "error",
+              error: error.message,
               endedAt: Date.now(),
-              ...resolveAgentRunAbortLifecycleFields(runAbortSignal),
+              ...extraData,
             },
           });
+        };
+        const deferredLifecycleError = settledLifecycleTerminal?.getDeferredError();
+        const userFacingErrorPayload = runResult.payloads?.find(
+          (payload) => payload.isError === true && typeof payload.text === "string",
+        )?.text;
+        const terminalErrorMessage =
+          deferredLifecycleError ??
+          userFacingErrorPayload ??
+          (runResult.meta?.error ? "Agent run failed" : undefined);
+        const terminalMetadata = resolveAgentLifecycleTerminalMetadata(runResult.meta);
+        if (fallbackExhausted) {
+          const exhaustionError = new Error(
+            terminalErrorMessage ?? "All model fallback candidates failed",
+          );
+          emitSettledLifecycleError(exhaustionError, {
+            ...terminalMetadata,
+            fallbackExhaustedFailure: true,
+          });
+          replyOperation.retainFailureUntilComplete();
+          replyOperation.fail("run_failed", exhaustionError);
+        } else if (deferredLifecycleError || runResult.meta?.error) {
+          const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
+          emitSettledLifecycleError(terminalError, terminalMetadata);
+          replyOperation.retainFailureUntilComplete();
+          replyOperation.fail("run_failed", terminalError);
+        } else {
+          settledLifecycleTerminal?.emit("end", runResult);
         }
-        pendingDeferredCliTerminal = undefined;
         if (!fallbackExhausted) {
           await clearRecoveredAutoFallbackPrimaryProbe({
             provider: fallbackProvider,
@@ -1190,21 +1243,8 @@ export function createFollowupRunner(params: {
       } catch (err) {
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);
-        if (pendingDeferredCliTerminal) {
-          emitAgentEvent({
-            runId,
-            lifecycleGeneration,
-            stream: "lifecycle",
-            data: {
-              phase: "error",
-              startedAt: pendingDeferredCliTerminal.startedAt,
-              endedAt: Date.now(),
-              error: message,
-              ...resolveAgentRunAbortLifecycleFields(runAbortSignal),
-            },
-          });
-          pendingDeferredCliTerminal = undefined;
-        }
+        pendingLifecycleTerminal?.backstop.emit("error", err);
+        pendingLifecycleTerminal = undefined;
         if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
           clearAgentRunContext(runId, lifecycleGeneration);
         }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -11,6 +11,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -605,6 +606,7 @@ export function createFollowupRunner(params: {
       let runResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
+      let fallbackExhausted = false;
       const resolveFollowupCurrentMessageId = () =>
         run.inputProvenance?.kind === "internal_system" &&
         run.inputProvenance.sourceTool === "restart-sentinel"
@@ -819,6 +821,7 @@ export function createFollowupRunner(params: {
           },
           classifyResult: ({ result, provider, model }) =>
             outcomePlan.classifyRunResult({ result, provider, model }),
+          mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           run: async (provider, model, runOptions) => {
             const suppressQueuedUserPersistenceForCandidate =
               (run.suppressNextUserMessagePersistence ?? false) ||
@@ -1156,6 +1159,7 @@ export function createFollowupRunner(params: {
         runResult = fallbackResult.result;
         fallbackProvider = fallbackResult.provider;
         fallbackModel = fallbackResult.model;
+        fallbackExhausted = fallbackResult.outcome === "exhausted";
         if (isAgentRunRestartAbortReason(runAbortSignal.reason)) {
           throw runAbortSignal.reason;
         }
@@ -1177,10 +1181,12 @@ export function createFollowupRunner(params: {
           });
         }
         pendingDeferredCliTerminal = undefined;
-        await clearRecoveredAutoFallbackPrimaryProbe({
-          provider: fallbackProvider,
-          model: fallbackModel,
-        });
+        if (!fallbackExhausted) {
+          await clearRecoveredAutoFallbackPrimaryProbe({
+            provider: fallbackProvider,
+            model: fallbackModel,
+          });
+        }
       } catch (err) {
         const message = formatErrorMessage(err);
         replyOperation.fail("run_failed", err);
@@ -1235,6 +1241,7 @@ export function createFollowupRunner(params: {
           compactionTokensAfter: runResult.meta?.agentMeta?.compactionTokensAfter,
           promptTokens,
           isHeartbeat: opts?.isHeartbeat === true,
+          preserveRuntimeModel: fallbackExhausted,
           preserveUserFacingSessionModelState: preserveUserFacingSessionState,
           modelUsed,
           providerUsed,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -118,6 +118,7 @@ export async function persistSessionUsageUpdate(params: {
   clearCliSessionBinding?: boolean;
   compactionTokensAfter?: number;
   preserveFreshTotalTokensOnStaleUsage?: boolean;
+  preserveRuntimeModel?: boolean;
   preserveUserFacingSessionModelState?: boolean;
   logLabel?: string;
 }): Promise<void> {
@@ -148,9 +149,11 @@ export async function persistSessionUsageUpdate(params: {
         update: async (entry) => {
           const updatedAt = Date.now();
           const preserveSessionModelState =
-            params.isHeartbeat === true || params.preserveUserFacingSessionModelState === true;
+            params.isHeartbeat === true ||
+            params.preserveRuntimeModel === true ||
+            params.preserveUserFacingSessionModelState === true;
           const preserveUserFacingRunState = params.preserveUserFacingSessionModelState === true;
-          const resolvedContextTokens = preserveUserFacingRunState
+          const resolvedContextTokens = preserveSessionModelState
             ? entry.contextTokens
             : (params.contextTokensUsed ?? entry.contextTokens);
           // Use last-call usage for totalTokens when available. The accumulated
@@ -234,7 +237,7 @@ export async function persistSessionUsageUpdate(params: {
           ) {
             patch.totalTokensFresh = false;
           }
-          return preserveUserFacingRunState
+          return preserveSessionModelState
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },
@@ -254,9 +257,11 @@ export async function persistSessionUsageUpdate(params: {
         takeCacheOwnership: true,
         update: async (entry) => {
           const preserveSessionModelState =
-            params.isHeartbeat === true || params.preserveUserFacingSessionModelState === true;
+            params.isHeartbeat === true ||
+            params.preserveRuntimeModel === true ||
+            params.preserveUserFacingSessionModelState === true;
           const preserveUserFacingRunState = params.preserveUserFacingSessionModelState === true;
-          const contextTokens = preserveUserFacingRunState
+          const contextTokens = preserveSessionModelState
             ? entry.contextTokens
             : (params.contextTokensUsed ?? entry.contextTokens);
           const patch: Partial<SessionEntry> = {
@@ -270,7 +275,7 @@ export async function persistSessionUsageUpdate(params: {
               : (params.systemPromptReport ?? entry.systemPromptReport),
             updatedAt: Date.now(),
           };
-          return preserveUserFacingRunState
+          return preserveSessionModelState
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3479,6 +3479,59 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].outputTokens).toBe(10_000);
   });
 
+  it("accounts exhausted-run usage without committing its model", async () => {
+    const storePath = await createStorePath("openclaw-usage-exhausted-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "google",
+        model: "gemini-3-pro",
+        contextTokens: 1_000_000,
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "existing-cli-session" },
+        },
+        cliSessionIds: {
+          "claude-cli": "existing-cli-session",
+        },
+        claudeCliSessionId: "existing-cli-session",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 120, output: 8, total: 128 },
+      lastCallUsage: { input: 100, output: 8, total: 108 },
+      providerUsed: "claude-cli",
+      modelUsed: "claude-sonnet-4-6",
+      contextTokensUsed: 200_000,
+      cliSessionBinding: { sessionId: "exhausted-cli-session" },
+      preserveRuntimeModel: true,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey]).toMatchObject({
+      modelProvider: "google",
+      model: "gemini-3-pro",
+      contextTokens: 1_000_000,
+      inputTokens: 120,
+      outputTokens: 8,
+      totalTokens: 100,
+      totalTokensFresh: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "existing-cli-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "existing-cli-session",
+      },
+      claudeCliSessionId: "existing-cli-session",
+    });
+  });
+
   it("accounts goal usage when fresh token snapshots are persisted", async () => {
     const storePath = await createStorePath("openclaw-usage-goal-");
     const sessionKey = "main";

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1541,11 +1541,11 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.embeddedAgent.projectSettingsPolicy":
     'How embedded OpenClaw handles workspace-local `.openclaw/settings.json`: "sanitize" (default) strips shellPath/shellCommandPrefix, "ignore" disables project settings entirely, and "trusted" applies project settings as-is.',
   "agents.defaults.embeddedAgent.executionContract":
-    'Embedded OpenClaw execution contract: "default" keeps the standard runner behavior, while "strict-agentic" keeps OpenAI/OpenAI Codex GPT-5-family runs acting until they hit a real blocker instead of stopping at plans or filler.',
+    'Embedded OpenClaw execution contract: "default" keeps the standard runner behavior, while "strict-agentic" enables structured plan tracking and non-visible turn recovery for supported OpenAI/OpenAI Codex GPT-5-family runs.',
   "agents.list[].embeddedAgent":
     "Optional per-agent embedded OpenClaw overrides. Use this to opt specific agents into stricter GPT-5 execution behavior without changing the global default.",
   "agents.list[].embeddedAgent.executionContract":
-    'Optional per-agent embedded OpenClaw execution contract override. Set "strict-agentic" to keep that agent acting through plan-only turns on OpenAI/OpenAI Codex GPT-5-family runs, or "default" to inherit the standard runner behavior.',
+    'Optional per-agent embedded OpenClaw execution contract override. Set "strict-agentic" to enable structured plan tracking and non-visible turn recovery for that agent on supported OpenAI/OpenAI Codex GPT-5-family runs, or "default" to inherit the standard runner behavior.',
   "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
   "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
   "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -342,7 +342,7 @@ export type AgentDefaultsConfig = {
     /**
      * Embedded OpenClaw execution contract:
      * - default: keep the standard runner behavior
-     * - strict-agentic: on OpenAI/OpenAI Codex GPT-5-family runs, keep acting until hitting a real blocker
+     * - strict-agentic: enable structured plan tracking and non-visible turn recovery on supported GPT-5 runs
      */
     executionContract?: EmbeddedAgentExecutionContract;
   };

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -268,6 +268,9 @@ export {
 export { appendSessionTranscriptMessage } from "../config/sessions/transcript-append.js";
 export { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 export {
+  consumeAdjustedParamsForToolCall,
+  consumePreExecutionBlockedToolCall,
+  finalizeToolTerminalPresentation,
   getBeforeToolCallPolicyDiagnosticState,
   hasBeforeToolCallPolicy,
   isToolWrappedWithBeforeToolCallHook,
@@ -278,6 +281,7 @@ export {
   type BeforeToolCallPolicyDiagnosticState,
   type DeferredPluginToolApproval,
 } from "../agents/agent-tools.before-tool-call.js";
+export { isReplaySafeToolCall } from "../agents/tool-mutation.js";
 export {
   resolveAgentHarnessBeforePromptBuildResult,
   runAgentHarnessAfterCompactionHook,

--- a/src/plugin-sdk/agent-runtime-test-contracts.ts
+++ b/src/plugin-sdk/agent-runtime-test-contracts.ts
@@ -7,6 +7,7 @@ export {
 } from "./test-helpers/agents/auth-profile-runtime-contract.js";
 export { DELIVERY_NO_REPLY_RUNTIME_CONTRACT } from "./test-helpers/agents/delivery-no-reply-runtime-contract.js";
 export {
+  createTerminalPresentationContractTool,
   installCodexToolResultMiddleware,
   installOpenClawOwnedToolHooks,
   mediaToolResult,

--- a/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -2,6 +2,8 @@
 import { vi } from "vitest";
 import { resetAdjustedParamsByToolCallIdForTests } from "../../../agents/agent-tools.before-tool-call.state.js";
 import type { AgentToolResult } from "../../../agents/runtime/index.js";
+import { setToolTerminalPresentation } from "../../../agents/tool-terminal-presentation.js";
+import type { AnyAgentTool } from "../../../agents/tools/common.js";
 import type {
   CodexAppServerExtensionFactory,
   CodexAppServerToolResultEvent,
@@ -38,6 +40,26 @@ export function mediaToolResult(
       ...(audioAsVoice ? { audioAsVoice } : {}),
     },
   });
+}
+
+export function createTerminalPresentationContractTool(params: {
+  name: string;
+  result: AgentToolResult<unknown>;
+  format: (params: unknown, result: AgentToolResult<unknown>) => string | undefined;
+}): AnyAgentTool {
+  return setToolTerminalPresentation(
+    {
+      name: params.name,
+      label: `${params.name} contract tool`,
+      description: `${params.name} contract tool`,
+      parameters: {},
+      execute: vi.fn(async () => params.result),
+    } as AnyAgentTool,
+    (toolParams, result) => {
+      const text = params.format(toolParams, result);
+      return text ? { text } : undefined;
+    },
+  );
 }
 
 export function installOpenClawOwnedToolHooks(params?: {

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -9106,9 +9106,6 @@ surfaces:
           - name: Incomplete-turn recovery
             coverageIds: [incomplete-turn-recovery]
             description: Covers Incomplete-turn recovery across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
-          - name: Planning-only turn recovery
-            coverageIds: [planning-only-turn-recovery]
-            description: Covers Planning-only turn recovery across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
         docs:
           - docs/providers/google.md
           - docs/concepts/model-providers.md
@@ -9123,7 +9120,6 @@ surfaces:
           - Thinking-level mapping
           - Tool turn ordering
           - Incomplete-turn recovery
-          - Planning-only turn recovery
         category_note: direct-gemini-api-transport-streaming-and-multimodal-payloads.md
         human_lts_override: false
       - name: Media, Search, and Realtime


### PR DESCRIPTION
## Summary

- remove language-specific assistant-prose classification and use explicit harness/protocol terminal states
- preserve trusted post-middleware terminal summaries for structured replay-safe tools, with fail-closed mutation and replay evidence
- keep exhausted and non-fallbackable failures non-winning and failure-terminal across lifecycle, session, and model bookkeeping
- align OpenClaw and Codex tool semantics; supersedes #90872 while preserving @fuller-stack-dev's original intent and commit credit

Release note: prevents silent agent turns without parsing natural-language progress text and avoids replaying side effects during model fallback.

## Verification

- focused matrix: 698 tests across unit-fast, auto-reply, agents, E2E, and Codex-extension shards
- `pnpm tsgo:core`
- `pnpm check:test-types`
- `pnpm build`
- clean Codex branch autoreview
- Azure Linux `check:changed`: `run_2a378f6aa965` ([proof](https://crabbox.openclaw.ai/portal/runs/run_2a378f6aa965))

## Source Study

- OpenCode: structured tool/runtime completion behavior
- Codex: app-server plan items, command actions, dynamic tools, collaboration items, and shell safety
- Cline: explicit task/tool lifecycle handling
