### PR TITLE
fix(cli): restart gateway for missing auth channel

### DIFF
--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -245,6 +245,36 @@ describe("channel-auth", () => {
     );
   });
 
+  it("requests a gateway restart when local login saves auth for a channel missing from the running gateway", async () => {
+    const weixinPlugin = {
+      ...plugin,
+      id: "openclaw-weixin",
+    };
+    const cfg = { channels: { "openclaw-weixin": {} } };
+    mocks.normalizeChannelId.mockReturnValue("openclaw-weixin");
+    mocks.getChannelPlugin.mockReturnValue(weixinPlugin);
+    mocks.listChannelPlugins.mockReturnValue([weixinPlugin]);
+    mocks.loadConfig.mockReturnValue(cfg);
+    mocks.callGateway
+      .mockRejectedValueOnce(new Error("invalid channels.start channel"))
+      .mockResolvedValueOnce({ ok: true, status: "scheduled" });
+
+    await expect(
+      runChannelLogin({ channel: "weixin", account: "acct-1" }, runtime),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(2, {
+      config: cfg,
+      method: "gateway.restart.request",
+      params: {
+        reason: "channel openclaw-weixin auth saved for a channel missing from the running gateway",
+      },
+      mode: "backend",
+      clientName: "gateway-client",
+      deviceIdentity: null,
+    });
+  });
+
   it("auto-picks the single configured channel that supports login when opts are empty", async () => {
     await runChannelLogin({}, runtime);
 

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -146,6 +146,32 @@ function resolveAccountContext(
   return { accountId };
 }
 
+function shouldRestartGatewayForMissingRuntimeChannel(error: unknown, channelId: string): boolean {
+  const message = formatErrorMessage(error).toLowerCase();
+  const channel = channelId.toLowerCase();
+  return (
+    message.includes("invalid channels.start channel") ||
+    message.includes(`unknown channel: ${channel}`) ||
+    message.includes(`unknown channel ${channel}`)
+  );
+}
+
+async function requestGatewayRestartForMissingRuntimeChannel(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+}) {
+  await callGateway({
+    config: params.cfg,
+    method: "gateway.restart.request",
+    params: {
+      reason: `channel ${params.channelId} auth saved for a channel missing from the running gateway`,
+    },
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    deviceIdentity: null,
+  });
+}
+
 async function reconcileGatewayRuntimeAfterLocalLogin(params: {
   cfg: OpenClawConfig;
   plugin: ChannelPlugin;
@@ -176,8 +202,25 @@ async function reconcileGatewayRuntimeAfterLocalLogin(params: {
       deviceIdentity: null,
     });
   } catch (error) {
+    const message = formatErrorMessage(error);
+    if (shouldRestartGatewayForMissingRuntimeChannel(error, params.channelId)) {
+      try {
+        await requestGatewayRestartForMissingRuntimeChannel({
+          cfg: params.cfg,
+          channelId: params.channelId,
+        });
+        params.runtime.log(
+          `Local login saved auth for ${params.channelId}/${params.accountId}, and requested a gateway restart because the running gateway did not know the channel: ${message}`,
+        );
+      } catch (restartError) {
+        params.runtime.log(
+          `Local login saved auth for ${params.channelId}/${params.accountId}, but the running gateway did not restart it: ${message}; gateway restart request failed: ${formatErrorMessage(restartError)}`,
+        );
+      }
+      return;
+    }
     params.runtime.log(
-      `Local login saved auth for ${params.channelId}/${params.accountId}, but the running gateway did not restart it: ${formatErrorMessage(error)}`,
+      `Local login saved auth for ${params.channelId}/${params.accountId}, but the running gateway did not restart it: ${message}`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes #91932.

- Requests the existing safe gateway restart RPC when local channel login saves auth but the running gateway rejects `channels.start` because it does not know that channel yet.
- Keeps the existing warning-only behavior for unrelated local gateway reconcile failures, and leaves remote gateway mode unchanged.
- Adds a regression test for an `openclaw-weixin`-style plugin where saved auth is followed by `invalid channels.start channel` from the running gateway.

## Why it matters / User impact

When a user reconfigures or logs in to an external channel such as `openclaw-weixin`, the credentials can be saved locally while the already-running gateway still uses an older plugin registry snapshot. In that state the user sees login complete, but the channel stays offline because the gateway refuses `channels.start`; requesting the existing safe restart turns that durable saved-auth state into a recoverable reconnect instead of requiring another manual reconfiguration.

## Scope and contract boundary

- **Scope boundary:** This PR only changes the local CLI post-login reconcile path after auth has already succeeded. It does not change channel setup, plugin install mode, config persistence format, gateway channel start semantics, or any Weixin plugin implementation.
- **Source-of-truth / contract boundary:** The gateway remains the owner of loaded channel runtime metadata. The CLI does not mutate the gateway registry; it asks the gateway's existing `gateway.restart.request` handler to refresh through the normal safe restart lifecycle.
- **Compatibility / public contract boundary:** No protocol schema, public config shape, channel ID normalization rule, or `channels.start` request contract changes. The existing `channels.start` failure remains visible in the CLI log, and the new restart RPC is only attempted for missing-runtime-channel signals.
- **Related PR scan:** The daily-fix issue initialization did not find a current linked open PR for #91932. This patch intentionally avoids the broader installer fallback suggested in the issue because existing install-target rejection is a separate public behavior.
- **Out of scope:** Live Weixin QR auth, real Weixin message delivery, plugin installer fallback/update semantics, and ad hoc gateway registry refresh APIs.

## Real behavior proof
- **Behavior or issue addressed:** Local login for an external auth-capable channel can save credentials successfully, then fail to start the channel in the already-running gateway when that gateway still has an old channel registry. Before this patch, that path only logged the `channels.start` failure and left the channel offline until manual intervention. After this patch, that exact missing-runtime-channel failure requests `gateway.restart.request` so the gateway can reload plugin metadata and use the saved auth.
- **Real environment tested:** Local OpenClaw repository checkout on Linux, using the repo Vitest runner against the production `runChannelLogin` flow in `src/cli/channel-auth.ts` with gateway RPC calls mocked at the process boundary.
- **Exact steps or command run after this patch:**
```bash
node scripts/run-vitest.mjs src/cli/channel-auth.test.ts -- --reporter=verbose -t "requests a gateway restart when local login saves auth for a channel missing from the running gateway"
node scripts/run-vitest.mjs src/cli/channel-auth.test.ts -- --reporter=verbose
git diff --check
```
- **Evidence after fix:**
```text
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > requests a gateway restart when local login saves auth for a channel missing from the running gateway

Test Files  1 passed (1)
Tests  1 passed | 18 skipped (19)

✓ |cli| src/cli/channel-auth.test.ts > channel-auth > runs login with explicit trimmed account and verbose flag
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > skips gateway runtime reconcile in remote mode and warns without failing login
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > keeps login successful when local gateway runtime reconcile fails
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > requests a gateway restart when local login saves auth for a channel missing from the running gateway
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > auto-picks the single configured channel that supports login when opts are empty
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > does not auto-pick enabled-only channel stubs when channel is omitted
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > auto-picks the single auth-capable channel from the auto-enabled config snapshot
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > persists auto-enabled config during logout auto-pick too
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > ignores configured channels that do not support login when channel is omitted
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > propagates auth-channel ambiguity when multiple configured channels support login
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > ignores plugins with prototype-chain IDs like __proto__
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > throws for unsupported channel aliases
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > throws when channel does not support login
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > installs a catalog-backed channel plugin on demand for login
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > strips pending install records before persisting install-on-demand login config
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > resolves explicit channel login through the catalog when registry normalize misses
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > runs logout through the live gateway with resolved account and explicit account id
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > falls back to local auth cleanup when a local gateway logout is unreachable
✓ |cli| src/cli/channel-auth.test.ts > channel-auth > throws when channel does not support logout

Test Files  1 passed (1)
Tests  19 passed (19)
```
- **Observed result after fix:** The regression now proves that `runChannelLogin` first attempts `channels.start`, observes `invalid channels.start channel`, and then sends `gateway.restart.request` with reason `channel openclaw-weixin auth saved for a channel missing from the running gateway`. The full `channel-auth` test file remains green, including the pre-existing generic gateway failure case that must continue to only warn.
- **What was not tested:** I did not run a live QR-authenticated Weixin login or real Weixin message transport in this environment. The proof covers the local CLI/gateway-reconcile decision point and discloses that maintainers with live Weixin credentials may still want to replay the full channel setup flow.

## Regression Test Plan

- **Target test file:** `src/cli/channel-auth.test.ts`
- **Regression scenario:** `runChannelLogin` resolves an `openclaw-weixin`-style plugin, saves auth, receives `invalid channels.start channel` from the local gateway reconcile call, and then sends `gateway.restart.request` with the saved channel ID in the restart reason.
- **Test guardrail rationale:** The same file also keeps the existing generic gateway failure test green, proving that unrelated local gateway failures still only log a warning and do not restart the gateway.
- **Commands run:**
```bash
node scripts/run-vitest.mjs src/cli/channel-auth.test.ts -- --reporter=verbose -t "requests a gateway restart when local login saves auth for a channel missing from the running gateway"
node scripts/run-vitest.mjs src/cli/channel-auth.test.ts -- --reporter=verbose
git diff --check
```

## Merge risk

- **Risk labels considered:** auth-provider, availability, compatibility, message-delivery
- **Risk explanation:** This is an auth/channel availability path because it can request a local gateway restart after credentials are saved. It is also compatibility-sensitive because it reacts to a `channels.start` error string, but it does not change protocol schemas, config formats, plugin install records, or channel normalization.
- **Why acceptable:** The restart request is limited to local mode, only after successful auth, only for a plugin that already declares `gateway.startAccount`, and only when the failed `channels.start` response indicates the running gateway is missing that channel. Remote gateway mode and generic gateway failures keep the previous behavior.

## Root Cause
- **Root cause:** After CLI local login saved auth for an external channel, `reconcileGatewayRuntimeAfterLocalLogin` treated every local `channels.start` failure the same way. When the running gateway rejected the channel because its registry had not loaded the newly installed external channel, the CLI only logged a warning and never asked the gateway to reload/restart, leaving the saved channel offline.
- **Why this is root-cause fix:** The repository already has a safe `gateway.restart.request` path and plugin install/config reload planning treats plugin install metadata changes as restart-requiring. This patch wires the CLI auth reconcile path into that existing restart mechanism only for the missing-runtime-channel failure that matches the issue, instead of changing plugin installer semantics or broadening channel validation.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High for the local CLI/gateway reconcile path; live Weixin transport proof remains untested and is disclosed above.
- **Patch quality notes:** Diff is limited to `src/cli/channel-auth.ts` and `src/cli/channel-auth.test.ts`; it does not change plugin install mode, channel protocol schema, or gateway channel registry ownership.
- **Architecture / source-of-truth check:** The fix preserves gateway plugin metadata as runtime-owned and restart-refreshed. It uses the existing gateway restart RPC instead of adding a private registry refresh path or special-casing Weixin plugin installation.
