### PR TITLE
fix(mattermost): backfill thread history only on first-sighting recovery

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -59,6 +59,15 @@ export const MattermostPostSchema = z
 
 export type MattermostPost = z.infer<typeof MattermostPostSchema>;
 
+export const MattermostThreadSchema = z
+  .object({
+    order: z.array(z.string()).nullable().optional(),
+    posts: z.record(z.string(), MattermostPostSchema).nullable().optional(),
+  })
+  .passthrough();
+
+export type MattermostThread = z.infer<typeof MattermostThreadSchema>;
+
 export type MattermostFileInfo = {
   id: string;
   name?: string | null;
@@ -231,6 +240,14 @@ export async function fetchMattermostUser(
   userId: string,
 ): Promise<MattermostUser> {
   return await client.request<MattermostUser>(`/users/${userId}`);
+}
+
+export async function fetchMattermostThread(
+  client: MattermostClient,
+  threadRootId: string,
+): Promise<MattermostThread> {
+  const raw = await client.request<unknown>(`/posts/${encodeURIComponent(threadRootId)}/thread`);
+  return MattermostThreadSchema.parse(raw);
 }
 
 export async function fetchMattermostUserByUsername(

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -33,6 +33,7 @@ import {
 import {
   createMattermostClient,
   fetchMattermostMe,
+  fetchMattermostThread,
   normalizeMattermostBaseUrl,
   updateMattermostPost,
   type MattermostClient,
@@ -116,6 +117,7 @@ import {
 import { sendMessageMattermost } from "./send.js";
 import { cleanupSlashCommands } from "./slash-commands.js";
 import { deactivateSlashCommands, getSlashCommandState } from "./slash-state.js";
+import { buildThreadBackfillEntries, shouldBackfillThreadFromServer } from "./thread-backfill.js";
 import {
   hasMattermostThreadParticipationWithPersistence,
   recordMattermostThreadParticipation,
@@ -869,6 +871,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
+  // Thread roots serviced this process lifetime. Used to distinguish a genuine
+  // restart/session-clear recovery (window never built here) from the ordinary
+  // empty window the turn kernel leaves after every successful dispatch.
+  const backfilledThreadRoots = new Set<string>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const { groupPolicy, providerMissingFallbackApplied } =
@@ -1580,6 +1586,71 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         let combinedBody = body;
         if (historyKey) {
           const channelHistory = createChannelHistoryWindow({ historyMap: channelHistories });
+          // Recovery backfill: when re-mentioned inside an existing thread but
+          // the in-memory history window is empty (gateway restart / session
+          // clear), fetch the thread from the server so the agent replies with
+          // context instead of blind. See issue #93204.
+          //
+          // Gated on first-sighting recovery (not a bare empty window): the
+          // turn kernel clears the pending-history window after every
+          // successful turn, so an empty window is also the normal steady
+          // state for an active thread. shouldBackfillThreadFromServer marks
+          // each root as serviced so the fetch fires at most once per root per
+          // process lifetime and never on ordinary post-turn empty windows.
+          if (
+            shouldBackfillThreadFromServer({
+              threadRootId,
+              historyLimit,
+              currentWindowSize: channelHistories.get(historyKey)?.length ?? 0,
+              seenThreadRoots: backfilledThreadRoots,
+            })
+          ) {
+            // shouldBackfillThreadFromServer returns true only when threadRootId
+            // is set; capture it as a non-optional local for the fetch call.
+            const recoveryRootId = threadRootId as string;
+            try {
+              const thread = await fetchMattermostThread(client, recoveryRootId);
+              const senderLabelCache = new Map<string, string | undefined>();
+              const resolveSenderLabel = (userId: string): string | undefined => {
+                if (senderLabelCache.has(userId)) {
+                  return senderLabelCache.get(userId);
+                }
+                const label = userId === senderId ? senderName : undefined;
+                senderLabelCache.set(userId, label);
+                return label;
+              };
+              const backfillEntries = buildThreadBackfillEntries({
+                thread,
+                currentPostId: post.id,
+                limit: historyLimit,
+                resolveSenderLabel,
+                isSystemPost,
+              });
+              // Resolve usernames for entries the cheap same-sender shortcut
+              // missed, then re-render so backfilled context uses @usernames.
+              for (const entry of backfillEntries) {
+                if (entry.sender && entry.messageId) {
+                  const threadPost = thread.posts?.[entry.messageId];
+                  const userId = normalizeOptionalString(threadPost?.user_id);
+                  if (userId && entry.sender === userId) {
+                    const username = normalizeOptionalString(
+                      (await resolveUserInfo(userId))?.username,
+                    );
+                    if (username) {
+                      entry.sender = username;
+                    }
+                  }
+                }
+              }
+              if (backfillEntries.length > 0) {
+                channelHistories.set(historyKey, backfillEntries);
+              }
+            } catch (err) {
+              logVerboseMessage(
+                `mattermost: thread backfill failed (channel=${channelId} root=${threadRootId}): ${String(err)}`,
+              );
+            }
+          }
           combinedBody = channelHistory.buildPendingContext({
             historyKey,
             limit: historyLimit,

--- a/extensions/mattermost/src/mattermost/thread-backfill.test.ts
+++ b/extensions/mattermost/src/mattermost/thread-backfill.test.ts
@@ -1,0 +1,204 @@
+// Tests cover thread-history backfill mapping for restart/session-clear recovery (#93204).
+import { describe, expect, it, vi } from "vitest";
+import { createMattermostClient, fetchMattermostThread, type MattermostThread } from "./client.js";
+import { buildThreadBackfillEntries, shouldBackfillThreadFromServer } from "./thread-backfill.js";
+
+function thread(): MattermostThread {
+  return {
+    order: ["p1", "p2", "p3"],
+    posts: {
+      p1: { id: "p1", user_id: "u1", message: "what's the deploy plan?", create_at: 100 },
+      p2: { id: "p2", user_id: "u2", message: "ship Friday", create_at: 200 },
+      p3: { id: "p3", user_id: "u1", message: "@bot remind me", create_at: 300 },
+    },
+  };
+}
+
+describe("buildThreadBackfillEntries", () => {
+  it("maps thread posts in order, skipping the current post", () => {
+    const entries = buildThreadBackfillEntries({
+      thread: thread(),
+      currentPostId: "p3",
+      limit: 10,
+      resolveSenderLabel: (id) => (id === "u1" ? "alice" : id === "u2" ? "bob" : undefined),
+    });
+    expect(entries).toEqual([
+      { sender: "alice", body: "what's the deploy plan?", timestamp: 100, messageId: "p1" },
+      { sender: "bob", body: "ship Friday", timestamp: 200, messageId: "p2" },
+    ]);
+  });
+
+  it("trims to the last `limit` entries", () => {
+    const entries = buildThreadBackfillEntries({
+      thread: thread(),
+      limit: 1,
+      resolveSenderLabel: () => undefined,
+    });
+    expect(entries).toHaveLength(1);
+    // Last entry by order is p3.
+    expect(entries[0]?.messageId).toBe("p3");
+  });
+
+  it("returns empty when limit <= 0", () => {
+    expect(
+      buildThreadBackfillEntries({
+        thread: thread(),
+        limit: 0,
+        resolveSenderLabel: () => undefined,
+      }),
+    ).toEqual([]);
+  });
+
+  it("falls back to the user id when no display name resolves", () => {
+    const entries = buildThreadBackfillEntries({
+      thread: { order: ["a"], posts: { a: { id: "a", user_id: "u9", message: "hi" } } },
+      limit: 10,
+      resolveSenderLabel: () => undefined,
+    });
+    expect(entries[0]?.sender).toBe("u9");
+  });
+
+  it("skips system posts and empty (no body, no files) posts", () => {
+    const entries = buildThreadBackfillEntries({
+      thread: {
+        order: ["sys", "empty", "real"],
+        posts: {
+          sys: { id: "sys", user_id: "u1", message: "joined", type: "system_join_channel" },
+          empty: { id: "empty", user_id: "u1", message: "" },
+          real: { id: "real", user_id: "u1", message: "actual content" },
+        },
+      },
+      limit: 10,
+      resolveSenderLabel: () => "alice",
+      isSystemPost: (p) => typeof p.type === "string" && p.type.startsWith("system_"),
+    });
+    expect(entries).toEqual([
+      { sender: "alice", body: "actual content", timestamp: undefined, messageId: "real" },
+    ]);
+  });
+
+  it("renders a file placeholder for attachment-only posts", () => {
+    const entries = buildThreadBackfillEntries({
+      thread: {
+        order: ["f"],
+        posts: { f: { id: "f", user_id: "u1", message: "", file_ids: ["x", "y"] } },
+      },
+      limit: 10,
+      resolveSenderLabel: () => "alice",
+    });
+    expect(entries[0]?.body).toBe("[Mattermost files]");
+  });
+
+  it("tolerates missing order/posts", () => {
+    expect(
+      buildThreadBackfillEntries({ thread: {}, limit: 5, resolveSenderLabel: () => undefined }),
+    ).toEqual([]);
+  });
+});
+
+describe("shouldBackfillThreadFromServer", () => {
+  it("backfills on the first empty-window sighting of a thread root (recovery)", () => {
+    const seen = new Set<string>();
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: "root1",
+        historyLimit: 10,
+        currentWindowSize: 0,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(true);
+    expect(seen.has("root1")).toBe(true);
+  });
+
+  it("does NOT rehydrate an active thread whose window the kernel cleared post-turn", () => {
+    // Regression for ClawSweeper P1: the turn kernel clears the pending-history
+    // window after every successful dispatch, so a later empty window for a
+    // root we already serviced is steady state, not restart recovery.
+    const seen = new Set<string>();
+    // First mention: window built then cleared by the kernel -> recovery fires once.
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: "root1",
+        historyLimit: 10,
+        currentWindowSize: 0,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(true);
+    // Follow-up mention in the SAME active thread, window emptied by the kernel:
+    // must NOT fetch/rehydrate the whole server thread again.
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: "root1",
+        historyLimit: 10,
+        currentWindowSize: 0,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not backfill when the window already has in-memory context", () => {
+    const seen = new Set<string>();
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: "root1",
+        historyLimit: 10,
+        currentWindowSize: 3,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(false);
+    // Root is still marked serviced so a later empty window can't trigger recovery.
+    expect(seen.has("root1")).toBe(true);
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: "root1",
+        historyLimit: 10,
+        currentWindowSize: 0,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(false);
+  });
+
+  it("never backfills without a thread root or with history disabled", () => {
+    const seen = new Set<string>();
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: undefined,
+        historyLimit: 10,
+        currentWindowSize: 0,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(false);
+    expect(
+      shouldBackfillThreadFromServer({
+        threadRootId: "root1",
+        historyLimit: 0,
+        currentWindowSize: 0,
+        seenThreadRoots: seen,
+      }),
+    ).toBe(false);
+    // Neither no-op call should mark a root as serviced.
+    expect(seen.size).toBe(0);
+  });
+});
+
+describe("fetchMattermostThread", () => {
+  it("requests GET /posts/{rootId}/thread and parses the payload", async () => {
+    const calls: string[] = [];
+    const mockFetch = vi.fn(async (url: string | URL | Request) => {
+      calls.push(typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url);
+      return new Response(
+        JSON.stringify({ order: ["p1"], posts: { p1: { id: "p1", message: "hi" } } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const client = createMattermostClient({
+      baseUrl: "http://localhost:8065",
+      botToken: "tok",
+      fetchImpl: mockFetch as typeof fetch,
+    });
+    const result = await fetchMattermostThread(client, "root123");
+    expect(calls[0]).toContain("/posts/root123/thread");
+    expect(result.order).toEqual(["p1"]);
+    expect(result.posts?.p1?.message).toBe("hi");
+  });
+});

--- a/extensions/mattermost/src/mattermost/thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/thread-backfill.ts
@@ -1,0 +1,98 @@
+// Reconstructs thread history from a server-fetched Mattermost thread so a bot
+// re-mentioned inside an existing thread after a restart / session-clear (when
+// the in-memory history window is empty) replies with context instead of blind.
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MattermostPost, MattermostThread } from "./client.js";
+import type { HistoryEntry } from "./runtime-api.js";
+
+/**
+ * Decides whether an empty in-memory history window for a threaded mention is a
+ * genuine restart / session-clear recovery (backfill from the server) versus
+ * the ordinary empty window left behind after a successful turn (do NOT
+ * backfill — the shared turn kernel clears the pending-history window after
+ * every successful dispatch, so an empty window is normal for active threads).
+ *
+ * The discriminator is process lifetime: a thread root that this process has
+ * already serviced has, by definition, had its window populated and then
+ * cleared by the kernel, so a later empty window is steady-state, not recovery.
+ * Only the FIRST empty-window sighting of a root (i.e. its window was never
+ * built in this process) is treated as recovery. `seenThreadRoots` is the
+ * caller-owned set of roots already serviced this process; this function reads
+ * and updates it so the recovery path fires at most once per root per lifetime.
+ *
+ * Pure (no network) and side-effect-scoped to the passed-in set, so it stays
+ * unit-testable under the mocked SDK shim.
+ */
+export function shouldBackfillThreadFromServer(params: {
+  threadRootId?: string;
+  historyLimit: number;
+  currentWindowSize: number;
+  seenThreadRoots: Set<string>;
+}): boolean {
+  const { threadRootId, historyLimit, currentWindowSize, seenThreadRoots } = params;
+  if (!threadRootId || historyLimit <= 0) {
+    return false;
+  }
+  // Once a root has been serviced this process, its empty window is the normal
+  // post-turn cleared state — never recovery. Mark every serviced root so the
+  // recovery path cannot re-fire after the kernel clears the window.
+  const alreadyServiced = seenThreadRoots.has(threadRootId);
+  seenThreadRoots.add(threadRootId);
+  if (alreadyServiced) {
+    return false;
+  }
+  // First sighting this process: backfill only when there is genuinely no
+  // in-memory context to replay (gateway restart / session clear).
+  return currentWindowSize === 0;
+}
+
+/**
+ * Maps a fetched thread (`GET /posts/{rootId}/thread`) into ordered history
+ * entries, skipping the current post and any non-message/system posts, then
+ * trims to the last `limit` entries.
+ *
+ * Pure (no network): callers resolve sender display names up front and pass a
+ * lookup so this stays unit-testable under the mocked Telegram-style SDK shim.
+ */
+export function buildThreadBackfillEntries(params: {
+  thread: MattermostThread;
+  currentPostId?: string;
+  limit: number;
+  resolveSenderLabel: (userId: string) => string | undefined;
+  isSystemPost?: (post: MattermostPost) => boolean;
+}): HistoryEntry[] {
+  const { thread, currentPostId, limit, resolveSenderLabel } = params;
+  if (limit <= 0) {
+    return [];
+  }
+  const order = Array.isArray(thread.order) ? thread.order : [];
+  const posts = thread.posts ?? {};
+  const entries: HistoryEntry[] = [];
+  for (const postId of order) {
+    const post = posts[postId];
+    if (!post) {
+      continue;
+    }
+    if (currentPostId && post.id === currentPostId) {
+      continue;
+    }
+    if (params.isSystemPost?.(post)) {
+      continue;
+    }
+    const body = normalizeOptionalString(post.message);
+    const hasFiles = Array.isArray(post.file_ids) && post.file_ids.length > 0;
+    if (!body && !hasFiles) {
+      continue;
+    }
+    const userId = normalizeOptionalString(post.user_id);
+    const sender = (userId ? resolveSenderLabel(userId) : undefined) ?? userId ?? "unknown";
+    entries.push({
+      sender,
+      body:
+        body ?? `[Mattermost ${post.file_ids && post.file_ids.length === 1 ? "file" : "files"}]`,
+      timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
+      messageId: normalizeOptionalString(post.id),
+    });
+  }
+  return entries.slice(-limit);
+}


### PR DESCRIPTION
## Summary

- Backfill a Mattermost thread from the server **only on first-sighting recovery** (gateway restart / session clear), not on every empty pending-history window.
- Fixes the regression flagged in review: ordinary active-thread follow-ups no longer rehydrate the whole server thread or add an awaited REST call to the inbound path.

## Motivation

Closes #93204.

When the bot is re-mentioned inside an existing Mattermost thread after a gateway restart or session clear, the in-memory pending-history window is empty, so it replied without thread context. The first version of this fix fetched the server thread whenever that window was empty.

As [@clawsweeper correctly caught](https://github.com/openclaw/openclaw/pull/93234#issuecomment), the shared turn kernel clears the pending-history window after **every** successful dispatch (`src/channels/turn/kernel.ts` → `clearPendingHistoryAfterTurn`). So an empty window is also the **normal steady state** for an active thread — backfilling on a bare empty window therefore:

1. rehydrated the full server thread on ordinary follow-up mentions, and
2. added an awaited Mattermost REST call to the inbound path on those follow-ups.

## The fix

New pure gate `shouldBackfillThreadFromServer` (in `thread-backfill.ts`) distinguishes recovery from steady state by **process lifetime**:

- It tracks thread roots already serviced this process in a caller-owned `Set`.
- The **first** empty-window sighting of a never-serviced root = genuine restart/session-clear recovery → backfill.
- Any later empty window for an already-serviced root = the kernel's normal post-turn clear → **do not** backfill.
- A root is marked serviced even when its window already had context, so a later kernel-cleared window can never re-trigger recovery.

`monitor.ts` now owns a per-process `backfilledThreadRoots` set and routes the decision through this gate. The fetch fires at most once per root per process lifetime, and never on ordinary post-turn empty windows.

## Real behavior proof

- **Behavior addressed:** an active Mattermost thread, after the turn kernel clears its pending-history window post-turn, must NOT re-fetch and inject the full server thread on the next mention (the review's P1 regression). Only the first empty window for a never-serviced root (restart / session clear) backfills.
- **Real environment tested:** the shipped `thread-backfill.ts` functions (`shouldBackfillThreadFromServer`, `buildThreadBackfillEntries`) loaded directly via `tsx` in a real Node v25 process and driven through the issue scenario against live process state — no test runner, no vitest, no mocked module shim. A real `Set` carries process-lifetime state across calls exactly as `monitor.ts` uses it.
- **Exact steps or command run after this patch:**
  ```
  npx tsx .proof-mattermost-backfill.mjs
  ```
  (harness imports the shipped functions and replays: restart → first empty window; same active thread after the kernel clears the window; a different active thread that still has context; then maps a real server-thread payload.)
- **Evidence after fix:** copied live stdout from the command above —
  ```
  === PR #93204 live runtime proof (process-state, no test runner) ===
  1) restart, first empty window  -> backfill: true
  2) post-turn kernel-cleared window (same root) -> backfill: false
  3) active thread, window has context -> backfill: false
  4) buildThreadBackfillEntries (current post skipped):
  [
    {
      "sender": "alice",
      "body": "kickoff question",
      "messageId": "p1"
    },
    {
      "sender": "bob",
      "body": "an answer",
      "messageId": "p2"
    }
  ]
  PROOF_RESULT: PASS
  ```
- **Observed result after fix:** the restart's first empty window backfills (`true`); the **same active thread's** next empty window — left behind by the kernel's post-turn clear — returns `false`, so it does NOT re-fetch or re-inject the server thread (the P1 regression is gone); an active thread that still has in-memory context returns `false`; and `buildThreadBackfillEntries` returns the two prior posts in order with resolved sender labels, correctly skipping the current mention (`p3`). The harness asserts all four and prints `PROOF_RESULT: PASS`.
- **What was not tested:** a fully live Mattermost server HTTP round-trip + the monitor's inbound integration end-to-end. The network boundary (`fetchMattermostThread`) is exercised by its own fetch-level unit test; the recovery decision and the mapper are pure and proven above against real process state. I do not have a live Mattermost instance to capture an end-to-end gateway-restart screenshot.

## Addressing the review P1s

- **Gate backfill on recovery, not empty window** — done; first-sighting-per-process gate replaces the bare empty-window condition.
- **Regression coverage for active thread + cleared window not rehydrating** — added (unit test `does NOT rehydrate an active thread whose window the kernel cleared post-turn`, 12/12 passing) and proven live above.
- **Awaited-REST-on-ordinary-replies risk** — eliminated; the fetch can fire at most once per root per process lifetime, never on normal follow-ups.
