### PR TITLE
fix(agents): isolate invalid plugin model catalogs in ModelRegistry

### DIFF
--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -145,6 +145,36 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("keeps models.json models when a generated plugin catalog shard is invalid", () => {
+    // One stale or invalid plugin shard must not wipe models.json and every
+    // other catalog; the shard error still surfaces via getError().
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: {
+        providers: {
+          custom: {
+            baseUrl: "https://models.example/v1",
+            api: "openai-completions",
+            apiKey: "CUSTOM_API_KEY",
+            models: [{ id: "example-model", name: "Example Model" }],
+          },
+        },
+      },
+      pluginRelativePath: join("plugins", "zai", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: "not-an-object",
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ custom: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+    );
+
+    expect(registry.find("custom", "example-model")?.name).toBe("Example Model");
+    expect(registry.getError()).toContain("Invalid models.json schema");
+  });
+
   it("preserves model params from generated plugin catalog shards", () => {
     const modelsPath = writeModelsJsonWithPluginCatalog({
       root: { providers: {} },

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -21,6 +21,7 @@ import type {
 } from "../../llm/types.js";
 import { registerOAuthProvider, resetOAuthProviders } from "../../llm/utils/oauth/index.js";
 import type { OAuthProviderInterface } from "../../llm/utils/oauth/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentDir } from "../config.js";
 import { resolveModelPluginMetadataSnapshot } from "../model-discovery-context.js";
 import {
@@ -37,6 +38,8 @@ import {
   resolveConfigValueUncached,
   resolveHeadersOrThrow,
 } from "./resolve-config-value.js";
+
+const log = createSubsystemLogger("agents/model-registry");
 
 // Schema for OpenRouter routing preferences
 const PercentileCutoffsSchema = Type.Object({
@@ -371,7 +374,9 @@ export class ModelRegistry {
 
     if (error) {
       this.loadError = error;
-      // Keep the prior empty/default registry shape when models.json failed to load.
+      // Surface the cause here: nothing on the failure path reads getError(),
+      // so without this warn the user only sees "Unknown model" downstream.
+      log.warn(`models.json load error: ${error}`);
     }
 
     let combined = customModels;
@@ -444,6 +449,7 @@ export class ModelRegistry {
       }
 
       const models = this.parseModels(configForUse);
+      const pluginCatalogErrors: string[] = [];
       if (options.includePluginCatalogs !== false) {
         for (const pluginCatalog of listPluginModelCatalogFiles(dirname(modelsJsonPath))) {
           const pluginResult = this.loadCustomModels(pluginCatalog.path, {
@@ -452,13 +458,20 @@ export class ModelRegistry {
             requireGeneratedCatalog: true,
           });
           if (pluginResult.error) {
-            return pluginResult;
+            // One stale or invalid plugin shard must not wipe models.json and
+            // every other catalog; collect the error so it still surfaces via
+            // getError() and skip just this shard.
+            pluginCatalogErrors.push(pluginResult.error);
+            continue;
           }
           models.push(...pluginResult.models);
         }
       }
 
-      return { models, error: undefined };
+      return {
+        models,
+        error: pluginCatalogErrors.length > 0 ? pluginCatalogErrors.join("\n\n") : undefined,
+      };
     } catch (error) {
       if (error instanceof SyntaxError) {
         if (options.requireGeneratedCatalog === true) {


### PR DESCRIPTION
## Summary

- **Problem:** `ModelRegistry.loadCustomModels` aborts the **entire** custom-models load when **any single** generated plugin catalog shard (`agents/<id>/agent/plugins/<plugin>/catalog.json`) fails validation. The plugin-catalog loop did `return pluginResult;` on the first shard error, discarding every model already parsed from `models.json` and other shards — the registry ends up with zero models and tools report every candidate as `Unknown model`.
- **Why now:** Reported with a full source-level root-cause analysis by @pi-oliver-pionizer in #92539; one stale/fossil provider entry (e.g. a legacy `google-vertex` shard missing `"api"`) takes the whole registry down.
- **Intended outcome:** A bad shard is skipped, not fatal — `models.json` and every other valid shard still load. The shard error is still surfaced via `getError()`, and is now also logged at WARN so the real cause is visible instead of hidden behind downstream `Unknown model`.
- **Out of scope (separate surfaces, separate PRs if wanted):** the reporter's optional suggestion (3) generator hygiene — re-validating preserved legacy provider entries in `ensureOpenClawModelsJson`'s merge; and appending `registry.getError()` to the `All <capability> models failed` message in `src/media-generation/runtime-shared.ts`.
- **Reviewer focus:** failure-isolation semantics in the catalog loop (fail-open: skip bad shard, keep the rest) and the new WARN in `loadModels()`.

## Linked context

Closes #92539

Was this requested by a maintainer or owner? No — found via issue triage; credit to reporter @pi-oliver-pionizer for the root-cause analysis.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** one invalid generated plugin catalog shard wipes all custom models (registry empty, `Unknown model` everywhere) and the real cause is unlogged.
- **Real environment tested:** the real `ModelRegistry` via `discoverModels(discoverAuthStorage(agentDir), agentDir)` (`src/agents/agent-model-discovery.ts`) over an on-disk agent dir, run with `tsx` against the actual source — no mocks, no Vitest. Node 22+, macOS.
- **Exact steps or command run after this patch:**
  ```bash
  # agent dir: models.json with one valid custom provider/model, plus an invalid generated shard
  cat /tmp/oc-proof-92539/agent/models.json
  # { "providers": { "custom": { "baseUrl": "...", "api": "openai-completions",
  #   "apiKey": "CUSTOM_API_KEY", "models": [{ "id": "example-model", "name": "Example Model" }] } } }
  cat /tmp/oc-proof-92539/agent/plugins/zai/catalog.json
  # { "generatedBy": "openclaw-plugin-model-catalog-v1", "providers": "not-an-object" }

  # probe.mts: discoverModels(discoverAuthStorage(agentDir), agentDir); print getError()/getAll()/find()
  node --import tsx /tmp/oc-proof-92539/probe.mts
  ```
- **Evidence after fix (copied live output):**
  ```text
  [agents/model-registry] models.json load error: Invalid models.json schema:
    - providers: must be object

  File: /tmp/oc-proof-92539/agent/plugins/zai/catalog.json
  getError(): "Invalid models.json schema:\n  - providers: must be object\n\nFile: .../zai/catalog.json"
  getAll().length: 1
  find(custom,example-model): Example Model
  ```
- **Observed result after fix:** the valid `custom/example-model` from `models.json` loads (`getAll().length: 1`, `find(...)` returns it), the invalid shard is skipped, and the shard error is both returned by `getError()` and logged at WARN.
- **What was not tested:** a live gateway end-to-end image/media generation flow with real provider credentials (the original symptom surface). The bug and fix are entirely in the model-registry load path, which the probe drives directly.
- **Proof limitations or environment constraints:** no live LLM credentials locally; `openclaw models list --all` shows the static bundled catalog rather than the per-agent `models.json` registry, so the probe drives `discoverModels` directly (the exact code path `loadAgentModelRegistry` → `discoverModels` uses at runtime).
- **Before evidence:** same probe, fix reverted (current `main`):
  ```text
  getError(): "Invalid models.json schema:\n  - providers: must be object\n\nFile: .../zai/catalog.json"
  getAll().length: 0
  find(custom,example-model): <undefined>
  ```
  (registry wiped — valid model gone — and no WARN line.)

## Tests and validation

Commands run:
- `node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts` → 8 passed (7 existing + 1 new)
- `pnpm tsgo:core` and `pnpm tsgo:core:test` → no errors
- `node scripts/run-oxlint.mjs <changed files>` → no findings; `git diff --check` clean; oxfmt via pre-commit hook

Regression coverage added: "keeps models.json models when a generated plugin catalog shard is invalid" in `src/agents/sessions/model-registry.test.ts` (reuses the existing `writeModelsJsonWithPluginCatalog` helper). Fails on `main` (`expected undefined to be 'Example Model'`), passes with this fix.

What failed before: that test, plus the real-CLI before/after above.

Note: `codex review` could not run locally (Codex CLI usage limit); substituted with the typecheck/lint checks above plus the real-runtime probe.

## Risk checklist

- **User-visible behavior change?** Yes — agents whose registry was previously wiped by one bad shard now load all valid models, and a WARN line now appears for invalid shards. No change when all shards are valid.
- **Config, environment, or migration behavior change?** No — no new config keys, defaults, or migrations.
- **Security, auth, secrets, network, or tool execution behavior change?** No.
- **Highest-risk area:** the fail-open switch (previously the whole load aborted on a bad shard). 
- **How mitigated:** the error is never swallowed — it is aggregated into the returned `error`, still readable via `getError()`, and now logged at WARN. No existing test asserted the all-or-nothing abort (it was the bug). Valid `models.json` + sibling shards loading is strictly better than zero models.

## Current review state

Next action: maintainer review. Nothing blocking on the author. CI `security-fast` may fail on the pre-existing esbuild advisory (GHSA-gv7w-rqvm-qjhr) in the shared lockfile — this PR touches only `src/agents/sessions/model-registry{,.test}.ts`, no dependency files, so that failure is unrelated and maintainer-owned.
