### PR TITLE
docs: add ClickClack to supported channels index

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -27,6 +27,7 @@ Text is supported everywhere; media and reactions vary by channel.
 
 ## Supported channels
 
+- [ClickClack](/channels/clickclack) - Self-hosted ClickClack workspace via bot token (bundled plugin).
 - [Discord](/channels/discord) - Discord Bot API + Gateway; supports servers, channels, and DMs.
 - [Feishu](/channels/feishu) - Feishu/Lark bot via WebSocket (bundled plugin).
 - [Google Chat](/channels/googlechat) - Google Chat API app via HTTP webhook (downloadable plugin).


### PR DESCRIPTION
## Summary

- What problem does this PR solve?
  ClickClack is a fully supported bundled channel with its own docs page, plugin reference, i18n glossary entries, and test coverage, but it was missing from the supported channels list in `docs/channels/index.md`. A user scanning the channel index to check if ClickClack is supported would not find it despite it being included in OpenClaw.

- Why does this matter now?
  Any user consulting the channel index today to evaluate ClickClack as a channel option would incorrectly conclude it is not supported.

- What is the intended outcome?
  ClickClack appears in the supported channels list in the correct alphabetical position (before Discord), consistent with how all other supported channels are listed.

- What is intentionally out of scope?
  No changes to ClickClack functionality, configuration, runtime behavior, or any file other than `docs/channels/index.md`.

- What does success look like?
  ClickClack is discoverable in the channel index alongside all other supported channels.

- What should reviewers focus on?
  Whether the description text and classification (bundled plugin) accurately reflect how ClickClack should be presented relative to the other channel entries.


## Linked context

- Which issue does this close?
  No existing issue — self-discovered gap while reviewing the docs.

- Which issues, PRs, or discussions are related?
  I searched through the open issues and recent PRs but did not come across anything that appeared to be directly related to this gap. If I missed something relevant I would be grateful to be pointed to it.

- Was this requested by a maintainer or owner?
  No.


## Real behavior proof

- Behavior or issue addressed:
  ClickClack absent from `docs/channels/index.md` despite it being a fully functional bundled channel included in OpenClaw.

- Real environment tested:
  Local source checkout, openclaw main as of 7a7165ad22.

- Exact steps or command run after this patch:
  `grep -i "clickclack" docs/channels/index.md` confirms entry is present.

- Evidence after fix:
```bash
$ grep -A1 -B1 "ClickClack" docs/channels/index.md

[ClickClack](/channels/clickclack) - Self-hosted ClickClack workspace via bot token (bundled plugin).
[Discord](/channels/discord) - Discord Bot API + Gateway; supports servers, channels, and DMs.
$
```

- Observed result after fix:
  ClickClack is discoverable in the channel index.

- What was not tested:
  Runtime behavior was not tested. This was due to a broken lockfile on main (`ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` for `@lydell/node-pty`) that prevented the test suite from running locally. I made every reasonable effort to run `pnpm build && pnpm check && pnpm test` and was not able to get past the lockfile error. I recognize this falls short of the stated contribution requirements and sincerely apologize for that. I flagged the lockfile issue separately in the Tests and validation section in case it is not already known. I am happy to run the full suite and update this PR if the lockfile issue is resolved on main, or if there is another approach I should try.

- Proof limitations or environment constraints:
  This is a single markdown line addition with no logic or runtime behavior. I was not able to produce a richer proof than the grep output above, but am happy to provide anything else that would be helpful to reviewers.

- Before evidence:
  (no output — entry was absent)
```bash
$ grep -i "clickclack" docs/channels/index.md
$
```


## Tests and validation

- Which commands did you run?
  Attempted `pnpm build && pnpm check && pnpm test` but encountered a broken lockfile on main (`ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` for `@lydell/node-pty`). Also attempted `pnpm install --no-optional` and `pnpm install --no-frozen-lockfile --no-optional` but both failed with the same underlying error. Flagging this in case it is not already known to the maintainer team.

- What regression coverage was added or updated?
  No regression coverage was added. Given the nature of this change — a single markdown line addition to a docs index file with no logic, config, or runtime code — regression seems unlikely, though I acknowledge I was not able to verify this with a passing test run.

- What failed before this fix, if known?
  No test failure — this is a missing index entry rather than a broken behavior.

- If no test was added, why not?
  I was not sure what the appropriate test coverage would look like for a docs index entry, and would genuinely welcome guidance from maintainers if test coverage is expected for a change of this type.


## Risk checklist

- Did user-visible behavior change?
  No behavior change is expected — this is a single markdown line added to a docs index file with no logic, config, or runtime code touched. I was unable to confirm this with a passing test run due to the lockfile issue described above.

- Did config, environment, or migration behavior change?
  No change is expected for the same reasons above.

- Did security, auth, secrets, network, or tool execution behavior change?
  No change is expected for the same reasons above.

- What is the highest-risk area?
  None apparent to me, though I would defer to maintainer judgment on this.

- How is that risk mitigated?
  Happy to make any changes reviewers feel are needed.


## Current review state

- What is the next action?
  Awaiting maintainer or reviewer feedback.

- What is still waiting on author, maintainer, CI, or external proof?
  If the lockfile issue on main is resolved, I am prepared to run the full test suite and update the PR with results. Any other proof or changes maintainers request I will address promptly.

- Which bot or reviewer comments were addressed?
  No bot or reviewer comments have been received yet.

---

*AI-assisted (Claude). I do not have access to Codex and was therefore unable to run `codex review --base origin/main`. Degree of testing: lightly tested (grep output confirms the entry is present and correctly placed). Prompts and session log available on request. I have reviewed the change and understand what it does.*