### PR TITLE
fix(agents): classify Zhipu GLM overload as overloaded for failover

### DIFF
--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -103,12 +103,10 @@ describe("Z.ai vendor error codes (#48988)", () => {
   });
 });
 
-describe("Zhipu (GLM) overload error (#93211)", () => {
-  // Zhipu returns HTTP 200 with the error in the body, so failover keys on the
-  // message phrase rather than a status code.
+describe("Chinese provider overload messages", () => {
   const ZHIPU_OVERLOAD = "[1305][该模型当前访问量过大，请您稍后再试]";
 
-  it("classifies the GLM overload body as overloaded so failover triggers", () => {
+  it("classifies the Zhipu GLM overload body as overloaded", () => {
     expect(isOverloadedErrorMessage(ZHIPU_OVERLOAD)).toBe(true);
   });
 

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -103,6 +103,21 @@ describe("Z.ai vendor error codes (#48988)", () => {
   });
 });
 
+describe("Zhipu (GLM) overload error (#93211)", () => {
+  // Zhipu returns HTTP 200 with the error in the body, so failover keys on the
+  // message phrase rather than a status code.
+  const ZHIPU_OVERLOAD = "[1305][该模型当前访问量过大，请您稍后再试]";
+
+  it("classifies the GLM overload body as overloaded so failover triggers", () => {
+    expect(isOverloadedErrorMessage(ZHIPU_OVERLOAD)).toBe(true);
+  });
+
+  it("does not misclassify the GLM overload body as rate limit or auth", () => {
+    expect(isRateLimitErrorMessage(ZHIPU_OVERLOAD)).toBe(false);
+    expect(isAuthErrorMessage(ZHIPU_OVERLOAD)).toBe(false);
+  });
+});
+
 describe("Volcengine Coding Plan subscription errors", () => {
   it("classifies InvalidSubscription JSON body as billing", () => {
     const raw =

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -107,9 +107,6 @@ const ERROR_PATTERNS = {
     // Chinese provider overloaded messages
     "服务过载",
     "当前负载过高",
-    // Zhipu (GLM) overload contract: code 1305 ships a 200 body
-    // "该模型当前访问量过大，请您稍后再试" (model traffic too high); the
-    // distinctive phrase is the overload signal failover keys on (#93211).
     "访问量过大",
   ],
   serverError: [

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -107,6 +107,10 @@ const ERROR_PATTERNS = {
     // Chinese provider overloaded messages
     "服务过载",
     "当前负载过高",
+    // Zhipu (GLM) overload contract: code 1305 ships a 200 body
+    // "该模型当前访问量过大，请您稍后再试" (model traffic too high); the
+    // distinctive phrase is the overload signal failover keys on (#93211).
+    "访问量过大",
   ],
   serverError: [
     "an error occurred while processing",

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -746,11 +746,8 @@ describe("runWithModelFallback", () => {
     expect(result.attempts[0].reason).toBe("unknown");
   });
 
-  it("falls back on a Zhipu (GLM) 1305 overload body and classifies it as overloaded (#93211)", async () => {
+  it("falls back on a Zhipu GLM 1305 overload body and classifies it as overloaded", async () => {
     const cfg = makeCfg();
-    // Zhipu (GLM) signals overload as a 200 body "[1305][该模型当前访问量过大，请您稍后再试]";
-    // the runtime surfaces it as a thrown error. Without the overload pattern it
-    // classifies as "unknown"; with it, failover keys the recovery on "overloaded".
     const glmOverload = new Error("[1305][该模型当前访问量过大，请您稍后再试]");
     const run = vi.fn().mockRejectedValueOnce(glmOverload).mockResolvedValueOnce("ok");
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -746,6 +746,27 @@ describe("runWithModelFallback", () => {
     expect(result.attempts[0].reason).toBe("unknown");
   });
 
+  it("falls back on a Zhipu (GLM) 1305 overload body and classifies it as overloaded (#93211)", async () => {
+    const cfg = makeCfg();
+    // Zhipu (GLM) signals overload as a 200 body "[1305][该模型当前访问量过大，请您稍后再试]";
+    // the runtime surfaces it as a thrown error. Without the overload pattern it
+    // classifies as "unknown"; with it, failover keys the recovery on "overloaded".
+    const glmOverload = new Error("[1305][该模型当前访问量过大，请您稍后再试]");
+    const run = vi.fn().mockRejectedValueOnce(glmOverload).mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "glm",
+      model: "GLM-5.2",
+      run,
+    });
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(requireMockCall(run, 1, "fallback run")).toEqual(["anthropic", "claude-haiku-3-5"]);
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0].reason).toBe("overloaded");
+  });
+
   it("does not prepare agent harness plugins for forced OpenClaw candidates", async () => {
     const cfg = makeCfg({
       models: {


### PR DESCRIPTION
## Summary

Model fallback (`agents.defaults.model.fallbacks`) did not recover correctly when Zhipu (GLM) returned its overload error. Zhipu signals overload as **HTTP 200** with the error in the body:

```
[1305][该模型当前访问量过大，请您稍后再试]
```

The Anthropic-compatible client surfaces that body as a thrown error, which `runWithModelFallback` normalizes via `coerceToFailoverError` → `isOverloadedErrorMessage`. There was no pattern for this phrase, so the overload was not recognized as a failover reason.

This adds the distinctive overload phrase `访问量过大` ("traffic too high") to `ERROR_PATTERNS.overloaded`, next to the existing Chinese overload markers (`服务过载`, `当前负载过高`). The error now classifies as `overloaded` — the failover reason the issue asks for — so the configured fallback is reached with the correct, overload-specific recovery semantics.

Closes #93211

## Verification

### Real behavior proof

- **Behavior addressed:** Zhipu/GLM overload body `[1305][该模型当前访问量过大，请您稍后再试]` was not recognized as `overloaded`, so failover did not key on the provider-overload contract.
- **Real environment tested:** drove the real `runWithModelFallback` orchestrator (the function the issue names as mishandling the error) in this checkout, before and after the patch, injecting the exact reported error at the throw point the Anthropic-compatible client surfaces it. No live Zhipu endpoint was available (no API key), so the `[1305]` body is reproduced at that runtime boundary rather than over the wire.
- **Exact steps or command run after this patch:**

```
# orchestrator-level (real runWithModelFallback):
node scripts/run-vitest.mjs src/agents/model-fallback.test.ts -t "Zhipu"
# matcher-level:
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/failover-matches.test.ts
```

- **Evidence after fix:** ran the orchestrator test with the overload pattern removed, then restored:

```
# BEFORE (pattern removed) — runWithModelFallback with the GLM body:
result.attempts[0].reason === "unknown"     # not recognized as overload

# AFTER (this patch):
result.attempts[0].reason === "overloaded"  # recognized; recovery keyed on overload
run called twice; fallback run === ["anthropic", "claude-haiku-3-5"]
```

- **Observed result after fix:** with the patch the GLM overload error resolves to `overloaded` inside `runWithModelFallback` and the configured fallback model is attempted. For full honesty about current `main`: an unrecognized error already falls back generically with reason `unknown` when candidates remain, so the symptom from the 2026.6.5 report (no fallback at all) is partly masked on `main`; this patch supplies the *correct* classification (`overloaded`), which is what the issue requests and what carries the proper provider-overload retry/cooldown handling rather than the generic `unknown` path.
- **What was not tested:** end-to-end delivery against the live Zhipu Anthropic-compatible endpoint (`https://open.bigmodel.cn/api/anthropic`) — no credentials. The orchestrator classification + fallback decision is the failover decision point, exercised above.

Coverage: `failover-matches.test.ts` → 25 passed (GLM body pinned as `overloaded`, not rate-limit/auth); `model-fallback.test.ts` → 80 passed (new orchestrator case asserts the GLM overload reaches the configured fallback keyed on `overloaded`).
