### PR TITLE
fix(mattermost): keep bare @mention with empty body instead of dropping it

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -143,16 +143,19 @@ describe("shouldDropEmptyMattermostBody", () => {
     ).toBe(true);
   });
 
-  it.each(["@openclaw @openclaw", "@openclaw\n@openclaw"])(
-    "drops a repeated mention-only post: %j",
-    (rawText) => {
-      expect(
-        shouldDropEmptyMattermostBody({
-          bodyText: "",
-          rawText,
-          botUsername: "openclaw",
-        }),
-      ).toBe(true);
-    },
-  );
+  it.each([
+    "@openclaw @openclaw",
+    "@openclaw\n@openclaw",
+    "@openclaw\n",
+    "\n@openclaw",
+    "@openclaw\r\n",
+  ])("drops a repeated mention-only post: %j", (rawText) => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        rawText,
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
 });

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -151,7 +151,8 @@ describe("shouldDropEmptyMattermostBody", () => {
     "@openclaw\r\n",
     "@openclaw\u2028",
     "@openclaw\u2029",
-  ])("drops a repeated mention-only post: %j", (rawText) => {
+    "\v@openclaw\f",
+  ])("drops an invalid empty-body candidate: %j", (rawText) => {
     expect(
       shouldDropEmptyMattermostBody({
         bodyText: "",

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -87,7 +87,6 @@ describe("shouldDropEmptyMattermostBody", () => {
     expect(
       shouldDropEmptyMattermostBody({
         bodyText: "",
-        wasMentioned: false,
         rawText: "   ",
         botUsername: "openclaw",
       }),
@@ -98,7 +97,6 @@ describe("shouldDropEmptyMattermostBody", () => {
     expect(
       shouldDropEmptyMattermostBody({
         bodyText: "hello",
-        wasMentioned: false,
         rawText: "hello",
         botUsername: "openclaw",
       }),
@@ -109,7 +107,6 @@ describe("shouldDropEmptyMattermostBody", () => {
     expect(
       shouldDropEmptyMattermostBody({
         bodyText: "",
-        wasMentioned: true,
         rawText: "@openclaw",
         botUsername: "openclaw",
       }),
@@ -120,7 +117,6 @@ describe("shouldDropEmptyMattermostBody", () => {
     expect(
       shouldDropEmptyMattermostBody({
         bodyText: "",
-        wasMentioned: false,
         rawText: "@OpenClaw",
         botUsername: "openclaw",
       }),
@@ -131,9 +127,18 @@ describe("shouldDropEmptyMattermostBody", () => {
     expect(
       shouldDropEmptyMattermostBody({
         bodyText: "",
-        wasMentioned: false,
         rawText: "@someoneelse",
         botUsername: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("drops a blank post even when a generic mention pattern matched it", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        rawText: "",
+        botUsername: "openclaw",
       }),
     ).toBe(true);
   });

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -1,6 +1,6 @@
 // Mattermost tests cover monitor helpers plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeMention } from "./monitor-helpers.js";
+import { normalizeMention, shouldDropEmptyMattermostBody } from "./monitor-helpers.js";
 
 describe("normalizeMention", () => {
   it("returns trimmed text when no mention provided", () => {
@@ -79,5 +79,62 @@ describe("normalizeMention", () => {
     const input = "@echobot\n    code line 1\n    code line 2";
     const result = normalizeMention(input, "echobot");
     expect(result).toBe("    code line 1\n    code line 2");
+  });
+});
+
+describe("shouldDropEmptyMattermostBody", () => {
+  it("drops a non-mention message that normalizes to an empty body", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "   ",
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a message that still has body text", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "hello",
+        wasMentioned: false,
+        rawText: "hello",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a bare mention in a group", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: true,
+        rawText: "@openclaw",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a bare mention in a direct message", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "@OpenClaw",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("drops an empty body when the bot username is unknown", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "@someoneelse",
+        botUsername: undefined,
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -152,6 +152,8 @@ describe("shouldDropEmptyMattermostBody", () => {
     "@openclaw\u2028",
     "@openclaw\u2029",
     "\v@openclaw\f",
+    "@openclaw\u00a0",
+    "\u2003@openclaw",
   ])("drops an invalid empty-body candidate: %j", (rawText) => {
     expect(
       shouldDropEmptyMattermostBody({

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -149,6 +149,8 @@ describe("shouldDropEmptyMattermostBody", () => {
     "@openclaw\n",
     "\n@openclaw",
     "@openclaw\r\n",
+    "@openclaw\u2028",
+    "@openclaw\u2029",
   ])("drops a repeated mention-only post: %j", (rawText) => {
     expect(
       shouldDropEmptyMattermostBody({

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -142,4 +142,17 @@ describe("shouldDropEmptyMattermostBody", () => {
       }),
     ).toBe(true);
   });
+
+  it.each(["@openclaw @openclaw", "@openclaw\n@openclaw"])(
+    "drops a repeated mention-only post: %j",
+    (rawText) => {
+      expect(
+        shouldDropEmptyMattermostBody({
+          bodyText: "",
+          rawText,
+          botUsername: "openclaw",
+        }),
+      ).toBe(true);
+    },
+  );
 });

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -153,6 +153,16 @@ describe("shouldDropEmptyMattermostBody", () => {
     ).toBe(true);
   });
 
+  it("drops a bot mention with only a combining-mark residual", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "\ufe0f",
+        rawText: "@openclaw\ufe0f",
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
+
   it.each([
     "@openclaw @openclaw",
     "@openclaw\n@openclaw",

--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -143,6 +143,16 @@ describe("shouldDropEmptyMattermostBody", () => {
     ).toBe(true);
   });
 
+  it("drops a bot mention with only a Unicode control residual", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "\u0085",
+        rawText: "@openclaw\u0085",
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
+
   it.each([
     "@openclaw @openclaw",
     "@openclaw\n@openclaw",

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -63,9 +63,7 @@ export function shouldDropEmptyMattermostBody(params: {
   if (params.bodyText) {
     return false;
   }
-  if (/[\r\n\u2028\u2029]/u.test(params.rawText)) {
-    return true;
-  }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
-  return !botUsername || normalizeLowercaseStringOrEmpty(params.rawText) !== `@${botUsername}`;
+  const bareMention = params.rawText.match(/^[ \t]*(@[^ \t\r\n\v\f\u2028\u2029]+)[ \t]*$/u)?.[1];
+  return !botUsername || normalizeLowercaseStringOrEmpty(bareMention ?? "") !== `@${botUsername}`;
 }

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -64,7 +64,5 @@ export function shouldDropEmptyMattermostBody(params: {
     return false;
   }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
-  return (
-    !botUsername || !normalizeLowercaseStringOrEmpty(params.rawText).includes(`@${botUsername}`)
-  );
+  return !botUsername || normalizeLowercaseStringOrEmpty(params.rawText) !== `@${botUsername}`;
 }

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -63,7 +63,7 @@ export function shouldDropEmptyMattermostBody(params: {
   if (params.bodyText) {
     return false;
   }
-  if (/[\r\n]/u.test(params.rawText)) {
+  if (/[\r\n\u2028\u2029]/u.test(params.rawText)) {
     return true;
   }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -60,7 +60,7 @@ export function shouldDropEmptyMattermostBody(params: {
   rawText: string;
   botUsername?: string | null;
 }): boolean {
-  if (params.bodyText) {
+  if (/[^\p{White_Space}\p{Cc}\p{Cf}]/u.test(params.bodyText)) {
     return false;
   }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -64,6 +64,6 @@ export function shouldDropEmptyMattermostBody(params: {
     return false;
   }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
-  const bareMention = params.rawText.match(/^[ \t]*(@[^ \t\r\n\v\f\u2028\u2029]+)[ \t]*$/u)?.[1];
+  const bareMention = params.rawText.match(/^[ \t]*(@\S+)[ \t]*$/u)?.[1];
   return !botUsername || normalizeLowercaseStringOrEmpty(bareMention ?? "") !== `@${botUsername}`;
 }

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -60,7 +60,7 @@ export function shouldDropEmptyMattermostBody(params: {
   rawText: string;
   botUsername?: string | null;
 }): boolean {
-  if (/[^\p{White_Space}\p{Cc}\p{Cf}]/u.test(params.bodyText)) {
+  if (/[^\p{White_Space}\p{Cc}\p{Cf}\p{M}]/u.test(params.bodyText)) {
     return false;
   }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -1,6 +1,7 @@
 // Mattermost helper module supports monitor helpers behavior.
 import { formatInboundFromLabel as formatInboundFromLabelShared } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveThreadSessionKeys as resolveThreadSessionKeysShared } from "openclaw/plugin-sdk/routing";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 
 export { rawDataToString };
@@ -52,4 +53,19 @@ export function normalizeMention(text: string, mention: string | undefined): str
   }
 
   return normalizedLines.map((line) => line.text).join("\n");
+}
+
+export function shouldDropEmptyMattermostBody(params: {
+  bodyText: string;
+  wasMentioned: boolean;
+  rawText: string;
+  botUsername?: string | null;
+}): boolean {
+  if (params.bodyText || params.wasMentioned) {
+    return false;
+  }
+  const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
+  return (
+    !botUsername || !normalizeLowercaseStringOrEmpty(params.rawText).includes(`@${botUsername}`)
+  );
 }

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -63,6 +63,9 @@ export function shouldDropEmptyMattermostBody(params: {
   if (params.bodyText) {
     return false;
   }
+  if (/[\r\n]/u.test(params.rawText)) {
+    return true;
+  }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
   return !botUsername || normalizeLowercaseStringOrEmpty(params.rawText) !== `@${botUsername}`;
 }

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -57,11 +57,10 @@ export function normalizeMention(text: string, mention: string | undefined): str
 
 export function shouldDropEmptyMattermostBody(params: {
   bodyText: string;
-  wasMentioned: boolean;
   rawText: string;
   botUsername?: string | null;
 }): boolean {
-  if (params.bodyText || params.wasMentioned) {
+  if (params.bodyText) {
     return false;
   }
   const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -445,6 +445,54 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.Provider).toBe("mattermost");
   });
 
+  it("dispatches a bare bot mention whose body is empty after normalization as a wake event", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-bare-mention",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "@openclaw",
+          create_at: 1_714_000_000_001,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.BodyForAgent).toBe("");
+    expect(ctx?.MessageSid).toBe("post-bare-mention");
+    expect(ctx?.OriginatingChannel).toBe("mattermost");
+    expect(ctx?.Provider).toBe("mattermost");
+  });
+
   it("merges Mattermost progress preview updates and clears after message-tool delivery", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -487,7 +487,7 @@ describe("mattermost inbound user posts", () => {
 
     expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
     const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
-    expect(ctx?.BodyForAgent).toBe("");
+    expect(ctx?.BodyForAgent).toBe("@openclaw");
     expect(ctx?.MessageSid).toBe("post-bare-mention");
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -17,6 +17,7 @@ import {
   resolveMattermostEffectiveReplyToId,
   resolveMattermostReplyRootId,
   resolveMattermostThreadSessionContext,
+  shouldDropEmptyMattermostBody,
   shouldFinalizeMattermostPreviewAfterDispatch,
   shouldClearMattermostDraftPreview,
   shouldSuppressMattermostDefaultToolProgressMessages,
@@ -1065,5 +1066,62 @@ describe("resolveMattermostReactionChannelId", () => {
 
   it("returns undefined when neither payload location includes channel_id", () => {
     expect(resolveMattermostReactionChannelId({})).toBeUndefined();
+  });
+});
+
+describe("shouldDropEmptyMattermostBody", () => {
+  it("drops a non-mention message that normalizes to an empty body", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "   ",
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a message that still has body text", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "hello",
+        wasMentioned: false,
+        rawText: "hello",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a bare mention in a group (wasMentioned)", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: true,
+        rawText: "@openclaw",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps a bare mention when raw text contains the bot @username (covers DMs)", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "@OpenClaw",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("still drops an empty body when the bot username is unknown", () => {
+    expect(
+      shouldDropEmptyMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "@someoneelse",
+        botUsername: undefined,
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -17,7 +17,6 @@ import {
   resolveMattermostEffectiveReplyToId,
   resolveMattermostReplyRootId,
   resolveMattermostThreadSessionContext,
-  shouldDropEmptyMattermostBody,
   shouldFinalizeMattermostPreviewAfterDispatch,
   shouldClearMattermostDraftPreview,
   shouldSuppressMattermostDefaultToolProgressMessages,
@@ -1066,62 +1065,5 @@ describe("resolveMattermostReactionChannelId", () => {
 
   it("returns undefined when neither payload location includes channel_id", () => {
     expect(resolveMattermostReactionChannelId({})).toBeUndefined();
-  });
-});
-
-describe("shouldDropEmptyMattermostBody", () => {
-  it("drops a non-mention message that normalizes to an empty body", () => {
-    expect(
-      shouldDropEmptyMattermostBody({
-        bodyText: "",
-        wasMentioned: false,
-        rawText: "   ",
-        botUsername: "openclaw",
-      }),
-    ).toBe(true);
-  });
-
-  it("keeps a message that still has body text", () => {
-    expect(
-      shouldDropEmptyMattermostBody({
-        bodyText: "hello",
-        wasMentioned: false,
-        rawText: "hello",
-        botUsername: "openclaw",
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps a bare mention in a group (wasMentioned)", () => {
-    expect(
-      shouldDropEmptyMattermostBody({
-        bodyText: "",
-        wasMentioned: true,
-        rawText: "@openclaw",
-        botUsername: "openclaw",
-      }),
-    ).toBe(false);
-  });
-
-  it("keeps a bare mention when raw text contains the bot @username (covers DMs)", () => {
-    expect(
-      shouldDropEmptyMattermostBody({
-        bodyText: "",
-        wasMentioned: false,
-        rawText: "@OpenClaw",
-        botUsername: "openclaw",
-      }),
-    ).toBe(false);
-  });
-
-  it("still drops an empty body when the bot username is unknown", () => {
-    expect(
-      shouldDropEmptyMattermostBody({
-        bodyText: "",
-        wasMentioned: false,
-        rawText: "@someoneelse",
-        botUsername: undefined,
-      }),
-    ).toBe(true);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1333,7 +1333,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           normalizeOptionalString(payload.data?.sender_name) ??
           normalizeOptionalString((await resolveUserInfo(senderId))?.username) ??
           senderId;
-        const rawText = normalizeOptionalString(post.message) ?? "";
+        const rawPostText = typeof post.message === "string" ? post.message : "";
+        const rawText = normalizeOptionalString(rawPostText) ?? "";
         const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
           cfg,
           surface: "mattermost",
@@ -1527,7 +1528,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
         const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();
         const bodyText = normalizeMention(baseText, botUsername);
-        if (shouldDropEmptyMattermostBody({ bodyText, rawText, botUsername })) {
+        if (shouldDropEmptyMattermostBody({ bodyText, rawText: rawPostText, botUsername })) {
           logVerboseMessage(
             `mattermost: drop message (empty body after normalization channel=${channelId} sender=${senderId} wasMentioned=${wasMentioned})`,
           );

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -492,6 +492,33 @@ export function resolveMattermostReactionChannelId(
   );
 }
 
+/**
+ * Decide whether an inbound Mattermost message whose body is empty after mention
+ * normalization should be dropped. A bare mention of the bot (just `@bot` with no
+ * other text) normalizes to an empty body but is a deliberate wake signal, so it
+ * must not be dropped. It is kept when the message was mentioned (group gate) or
+ * its raw text still contains the bot's `@username` (covers groups and DMs, where
+ * `wasMentioned` is not evaluated).
+ */
+export function shouldDropEmptyMattermostBody(params: {
+  bodyText: string;
+  wasMentioned: boolean;
+  rawText: string;
+  botUsername?: string | null;
+}): boolean {
+  if (params.bodyText) {
+    return false;
+  }
+  if (params.wasMentioned) {
+    return false;
+  }
+  const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
+  if (botUsername && normalizeLowercaseStringOrEmpty(params.rawText).includes(`@${botUsername}`)) {
+    return false;
+  }
+  return true;
+}
+
 function buildMattermostAttachmentPlaceholder(mediaList: MattermostMediaInfo[]): string {
   if (mediaList.length === 0) {
     return "";
@@ -1526,7 +1553,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
         const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();
         const bodyText = normalizeMention(baseText, botUsername);
-        if (!bodyText) {
+        if (shouldDropEmptyMattermostBody({ bodyText, wasMentioned, rawText, botUsername })) {
           logVerboseMessage(
             `mattermost: drop group message (empty body after normalization channel=${channelId} sender=${senderId})`,
           );

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1527,7 +1527,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
         const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();
         const bodyText = normalizeMention(baseText, botUsername);
-        if (shouldDropEmptyMattermostBody({ bodyText, wasMentioned, rawText, botUsername })) {
+        if (shouldDropEmptyMattermostBody({ bodyText, rawText, botUsername })) {
           logVerboseMessage(
             `mattermost: drop message (empty body after normalization channel=${channelId} sender=${senderId} wasMentioned=${wasMentioned})`,
           );

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -69,6 +69,7 @@ import {
   formatInboundFromLabel,
   normalizeMention,
   resolveThreadSessionKeys,
+  shouldDropEmptyMattermostBody,
 } from "./monitor-helpers.js";
 import { resolveOncharPrefixes, stripOncharPrefix } from "./monitor-onchar.js";
 import { createMattermostMonitorResources, type MattermostMediaInfo } from "./monitor-resources.js";
@@ -490,33 +491,6 @@ export function resolveMattermostReactionChannelId(
     normalizeOptionalString(payload.broadcast?.channel_id) ??
     normalizeOptionalString(payload.data?.channel_id)
   );
-}
-
-/**
- * Decide whether an inbound Mattermost message whose body is empty after mention
- * normalization should be dropped. A bare mention of the bot (just `@bot` with no
- * other text) normalizes to an empty body but is a deliberate wake signal, so it
- * must not be dropped. It is kept when the message was mentioned (group gate) or
- * its raw text still contains the bot's `@username` (covers groups and DMs, where
- * `wasMentioned` is not evaluated).
- */
-export function shouldDropEmptyMattermostBody(params: {
-  bodyText: string;
-  wasMentioned: boolean;
-  rawText: string;
-  botUsername?: string | null;
-}): boolean {
-  if (params.bodyText) {
-    return false;
-  }
-  if (params.wasMentioned) {
-    return false;
-  }
-  const botUsername = normalizeLowercaseStringOrEmpty(params.botUsername ?? "");
-  if (botUsername && normalizeLowercaseStringOrEmpty(params.rawText).includes(`@${botUsername}`)) {
-    return false;
-  }
-  return true;
 }
 
 function buildMattermostAttachmentPlaceholder(mediaList: MattermostMediaInfo[]): string {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1555,7 +1555,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const bodyText = normalizeMention(baseText, botUsername);
         if (shouldDropEmptyMattermostBody({ bodyText, wasMentioned, rawText, botUsername })) {
           logVerboseMessage(
-            `mattermost: drop group message (empty body after normalization channel=${channelId} sender=${senderId})`,
+            `mattermost: drop message (empty body after normalization channel=${channelId} sender=${senderId} wasMentioned=${wasMentioned})`,
           );
           return;
         }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1533,6 +1533,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           );
           return;
         }
+        // Mention-only turns need non-empty agent text; the shared reply runner rejects empty
+        // bodies before model invocation. The guard above ensures this fallback is a bot mention.
+        const bodyForAgent = bodyText || rawText.trim();
 
         core.channel.activity.record({
           channel: "mattermost",
@@ -1591,7 +1594,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             : undefined;
         const ctxPayload = core.channel.reply.finalizeInboundContext({
           Body: combinedBody,
-          BodyForAgent: bodyText,
+          BodyForAgent: bodyForAgent,
           InboundHistory: inboundHistory,
           RawBody: bodyText,
           CommandBody: commandBody,


### PR DESCRIPTION
## Summary
- A Mattermost message whose only content is a mention of the bot (e.g. just `@bot`) normalizes to an empty body and is then dropped by the empty-body guard, so a bare mention never wakes the agent.
- Extract `shouldDropEmptyMattermostBody` and use it for that guard: keep the message when it was mentioned (group gate) or when the raw text still contains the bot's `@username` (covers both groups and DMs, where `wasMentioned` is not evaluated). A genuinely empty, non-mention message is still dropped.
- Add unit coverage for the helper and a monitor-level inbound dispatch regression test.

Fixes #93205. Part of the #65729 umbrella split.

## Behavior
- Before: `normalizeMention` strips `@bot`, `bodyText` is empty, and the message is dropped (`drop group message (empty body after normalization)`).
- After: a bare mention is kept and wakes the agent — the mention itself is the trigger.

## Real behavior proof
- **Behavior or issue addressed:** A Mattermost post whose only content is a bare bot mention (`@openclaw`) normalizes to an empty body and is dropped by the empty-body guard, so the mention never wakes the agent (#93205).
- **Real environment tested:** Self-hosted OpenClaw deployment on base image `ghcr.io/openclaw/openclaw:2026.6.5` running the equivalent change, connected to a live Mattermost server, bot user `@openclaw`.
- **Exact steps or command run after this patch:** Posted a message whose only content was `@openclaw` (no other text) in a Mattermost channel where the bot is a member.
- **Observed result after fix:** The agent woke and replied (`openclaw: 在。怎麼了?`). Before this change the same post was silently dropped with `mattermost: drop ... (empty body after normalization)`.
- **Evidence after fix:** ![bare @mention wakes the bot](https://github.com/iloveleon19/openclaw/releases/download/pr93242-proof/pr93242-proof-1.png)
- **What was not tested:** The DM bare-mention path was not separately screenshotted here (it is covered by the helper unit tests and the new inbound dispatch regression test); onchar-prefix mode was not exercised.

## Tests
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts` — 63 passed
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` — 10 passed
- `corepack pnpm format:check extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts`
