### PR TITLE
fix(mattermost): backfill thread history from server when in-memory window is empty

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -275,10 +275,21 @@ export type MattermostThread = {
 export async function fetchMattermostThread(
   client: MattermostClient,
   threadRootId: string,
+  timeoutMs = 5000,
 ): Promise<MattermostThread> {
-  return await client.request<MattermostThread>(
-    `/posts/${encodeURIComponent(threadRootId)}/thread`,
-  );
+  // Bound the recovery fetch so a slow/unresponsive server cannot stall the
+  // inbound reply: abort after `timeoutMs` and let the caller proceed without
+  // backfilled history.
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), resolveTimerTimeoutMs(timeoutMs, 5000));
+  try {
+    return await client.request<MattermostThread>(
+      `/posts/${encodeURIComponent(threadRootId)}/thread`,
+      { signal: controller.signal },
+    );
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 export async function sendMattermostTyping(

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -266,6 +266,21 @@ export async function fetchMattermostChannelByName(
   );
 }
 
+/** Response shape of `GET /posts/{id}/thread`: ordered ids plus a post map. */
+export type MattermostThread = {
+  order: string[];
+  posts: Record<string, MattermostPost>;
+};
+
+export async function fetchMattermostThread(
+  client: MattermostClient,
+  threadRootId: string,
+): Promise<MattermostThread> {
+  return await client.request<MattermostThread>(
+    `/posts/${encodeURIComponent(threadRootId)}/thread`,
+  );
+}
+
 export async function sendMattermostTyping(
   client: MattermostClient,
   params: { channelId: string; parentId?: string },

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1187,6 +1187,43 @@ describe("backfillMattermostThreadHistory", () => {
     expect(client.request).toHaveBeenCalledTimes(1);
   });
 
+  it("resolves usernames only for the retained historyLimit posts on a long thread", async () => {
+    const channelHistories = new Map();
+    const order = Array.from({ length: 50 }, (_, i) => `p${i}`);
+    const posts = Object.fromEntries(
+      order.map((id, i) => [id, { id, user_id: `u${i}`, message: `m${i}`, create_at: i }]),
+    );
+    const client = threadClientMock({ order, posts });
+    const boundedResolveUserInfo = vi.fn(
+      async (userId: string): Promise<MattermostUser | null> => ({
+        id: userId,
+        username: `user-${userId}`,
+      }),
+    );
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 5,
+      resolveUserInfo: boundedResolveUserInfo,
+      backfilledSessionIds: new Map(),
+    });
+
+    // Only the last historyLimit posts are seeded...
+    const seeded = channelHistories.get("channel:chan-1");
+    expect(seeded?.map((e: { messageId?: string }) => e.messageId)).toStrictEqual([
+      "p45",
+      "p46",
+      "p47",
+      "p48",
+      "p49",
+    ]);
+    // ...and username resolution is bounded to those retained posts, not all 50.
+    expect(boundedResolveUserInfo).toHaveBeenCalledTimes(5);
+  });
+
   it("skips the server fetch when the thread session was already backfilled (active thread)", async () => {
     const channelHistories = new Map();
     const client = threadClientMock({ order: ["p1"], posts: { p1: { id: "p1", message: "x" } } });

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1073,6 +1073,7 @@ describe("backfillMattermostThreadHistory", () => {
       historyLimit: 10,
       currentPostId: "p3",
       resolveUserInfo,
+      backfilledSessionIds: new Map(),
     });
 
     expect(client.request).toHaveBeenCalledWith("/posts/root-1/thread");
@@ -1101,6 +1102,7 @@ describe("backfillMattermostThreadHistory", () => {
       historyLimit: 1,
       currentPostId: "p3",
       resolveUserInfo,
+      backfilledSessionIds: new Map(),
     });
 
     const seeded = channelHistories.get("channel:chan-1");
@@ -1119,6 +1121,7 @@ describe("backfillMattermostThreadHistory", () => {
       channelHistories,
       historyLimit: 10,
       resolveUserInfo,
+      backfilledSessionIds: new Map(),
     });
 
     expect(client.request).not.toHaveBeenCalled();
@@ -1142,11 +1145,85 @@ describe("backfillMattermostThreadHistory", () => {
       channelHistories,
       historyLimit: 10,
       resolveUserInfo,
+      backfilledSessionIds: new Map(),
       log,
     });
 
     expect(channelHistories.has("channel:chan-1")).toBe(false);
     expect(log).toHaveBeenCalledTimes(1);
     expect(String(log.mock.calls[0]?.[0])).toContain("boom");
+  });
+
+  it("skips the server fetch when the thread session was already backfilled (active thread)", async () => {
+    const channelHistories = new Map();
+    const client = threadClientMock({ order: ["p1"], posts: { p1: { id: "p1", message: "x" } } });
+    const backfilledSessionIds = new Map([["channel:chan-1", "session-1"]]);
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      currentPostId: "p2",
+      resolveUserInfo,
+      sessionId: "session-1",
+      backfilledSessionIds,
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
+    expect(channelHistories.has("channel:chan-1")).toBe(false);
+  });
+
+  it("backfills again when the session id rotated (e.g. after /new)", async () => {
+    const channelHistories = new Map();
+    const client = threadClientMock({
+      order: ["p1", "p2"],
+      posts: {
+        p1: { id: "p1", user_id: "u1", message: "first", create_at: 100 },
+        p2: { id: "p2", user_id: "u2", message: "second", create_at: 200 },
+      },
+    });
+    const backfilledSessionIds = new Map([["channel:chan-1", "session-1"]]);
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      currentPostId: "p3",
+      resolveUserInfo,
+      sessionId: "session-2",
+      backfilledSessionIds,
+    });
+
+    expect(client.request).toHaveBeenCalledWith("/posts/root-1/thread");
+    expect(channelHistories.get("channel:chan-1")).toHaveLength(2);
+    expect(backfilledSessionIds.get("channel:chan-1")).toBe("session-2");
+  });
+
+  it("records the session id after seeding so the same session is not refetched", async () => {
+    const channelHistories = new Map();
+    const client = threadClientMock({
+      order: ["p1"],
+      posts: { p1: { id: "p1", user_id: "u1", message: "first", create_at: 100 } },
+    });
+    const backfilledSessionIds = new Map();
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      currentPostId: "p2",
+      resolveUserInfo,
+      sessionId: "session-1",
+      backfilledSessionIds,
+    });
+
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(backfilledSessionIds.get("channel:chan-1")).toBe("session-1");
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1226,4 +1226,47 @@ describe("backfillMattermostThreadHistory", () => {
     expect(client.request).toHaveBeenCalledTimes(1);
     expect(backfilledSessionIds.get("channel:chan-1")).toBe("session-1");
   });
+
+  it("marks a non-empty first sighting serviced so a later same-session empty window does not refetch", async () => {
+    // Active-thread steady state: the first sighting has non-empty pending history (no fetch
+    // needed), then the turn kernel clears the window. The non-empty return must still record the
+    // session, otherwise the next same-session turn mis-reads the empty window as a cold start and
+    // refetches the whole server thread on an ordinary follow-up.
+    const channelHistories = new Map([["channel:chan-1", [{ sender: "@existing", body: "kept" }]]]);
+    const client = threadClientMock({ order: ["p1"], posts: { p1: { id: "p1", message: "x" } } });
+    const backfilledSessionIds = new Map();
+
+    // First sighting: non-empty window -> no fetch, but the session is recorded as serviced.
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      currentPostId: "p2",
+      resolveUserInfo,
+      sessionId: "session-1",
+      backfilledSessionIds,
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
+    expect(backfilledSessionIds.get("channel:chan-1")).toBe("session-1");
+
+    // The turn kernel clears the window; the next same-session follow-up must NOT refetch.
+    channelHistories.delete("channel:chan-1");
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      currentPostId: "p3",
+      resolveUserInfo,
+      sessionId: "session-1",
+      backfilledSessionIds,
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
+    expect(channelHistories.has("channel:chan-1")).toBe(false);
+  });
 });

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1076,7 +1076,10 @@ describe("backfillMattermostThreadHistory", () => {
       backfilledSessionIds: new Map(),
     });
 
-    expect(client.request).toHaveBeenCalledWith("/posts/root-1/thread");
+    expect(client.request).toHaveBeenCalledWith(
+      "/posts/root-1/thread",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
     expect(channelHistories.get("channel:chan-1")).toStrictEqual([
       { sender: "@user-u1", body: "first", timestamp: 100, messageId: "p1" },
       { sender: "@user-u2", body: "second", timestamp: 200, messageId: "p2" },
@@ -1154,6 +1157,36 @@ describe("backfillMattermostThreadHistory", () => {
     expect(String(log.mock.calls[0]?.[0])).toContain("boom");
   });
 
+  it("marks the session serviced on fetch failure so it is fetched at most once per session", async () => {
+    const channelHistories = new Map();
+    const client = createMattermostClientMock();
+    client.request = vi.fn(async () => {
+      throw new Error("timeout");
+    }) as MattermostClient["request"];
+    const backfilledSessionIds = new Map();
+
+    const call = () =>
+      backfillMattermostThreadHistory({
+        client,
+        threadRootId: "root-1",
+        historyKey: "channel:chan-1",
+        channelHistories,
+        historyLimit: 10,
+        resolveUserInfo,
+        sessionId: "session-1",
+        backfilledSessionIds,
+      });
+
+    await call();
+    // The failed attempt still records the session id...
+    expect(backfilledSessionIds.get("channel:chan-1")).toBe("session-1");
+    expect(client.request).toHaveBeenCalledTimes(1);
+
+    // ...so a same-session follow-up does not re-fetch the slow/erroring server.
+    await call();
+    expect(client.request).toHaveBeenCalledTimes(1);
+  });
+
   it("skips the server fetch when the thread session was already backfilled (active thread)", async () => {
     const channelHistories = new Map();
     const client = threadClientMock({ order: ["p1"], posts: { p1: { id: "p1", message: "x" } } });
@@ -1198,7 +1231,10 @@ describe("backfillMattermostThreadHistory", () => {
       backfilledSessionIds,
     });
 
-    expect(client.request).toHaveBeenCalledWith("/posts/root-1/thread");
+    expect(client.request).toHaveBeenCalledWith(
+      "/posts/root-1/thread",
+      expect.objectContaining({ signal: expect.anything() }),
+    );
     expect(channelHistories.get("channel:chan-1")).toHaveLength(2);
     expect(backfilledSessionIds.get("channel:chan-1")).toBe("session-2");
   });

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -4,8 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import * as clientModule from "./client.js";
-import type { MattermostClient } from "./client.js";
+import type { MattermostClient, MattermostUser } from "./client.js";
 import {
+  backfillMattermostThreadHistory,
   buildMattermostModelPickerSelectMessageSid,
   canFinalizeMattermostPreviewInPlace,
   deliverMattermostReplyWithDraftPreview,
@@ -1037,5 +1038,115 @@ describe("resolveMattermostReactionChannelId", () => {
 
   it("returns undefined when neither payload location includes channel_id", () => {
     expect(resolveMattermostReactionChannelId({})).toBeUndefined();
+  });
+});
+
+describe("backfillMattermostThreadHistory", () => {
+  function threadClientMock(response: unknown): MattermostClient {
+    const client = createMattermostClientMock();
+    client.request = vi.fn(async () => response) as MattermostClient["request"];
+    return client;
+  }
+
+  const resolveUserInfo = vi.fn(
+    async (userId: string): Promise<MattermostUser | null> => ({
+      id: userId,
+      username: `user-${userId}`,
+    }),
+  );
+
+  it("seeds an empty history window from the server thread", async () => {
+    const channelHistories = new Map();
+    const client = threadClientMock({
+      order: ["p1", "p2"],
+      posts: {
+        p1: { id: "p1", user_id: "u1", message: "first", create_at: 100 },
+        p2: { id: "p2", user_id: "u2", message: "second", create_at: 200 },
+      },
+    });
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      currentPostId: "p3",
+      resolveUserInfo,
+    });
+
+    expect(client.request).toHaveBeenCalledWith("/posts/root-1/thread");
+    expect(channelHistories.get("channel:chan-1")).toStrictEqual([
+      { sender: "@user-u1", body: "first", timestamp: 100, messageId: "p1" },
+      { sender: "@user-u2", body: "second", timestamp: 200, messageId: "p2" },
+    ]);
+  });
+
+  it("excludes the current post and trims to historyLimit", async () => {
+    const channelHistories = new Map();
+    const client = threadClientMock({
+      order: ["p1", "p2", "p3"],
+      posts: {
+        p1: { id: "p1", user_id: "u1", message: "first" },
+        p2: { id: "p2", user_id: "u2", message: "second" },
+        p3: { id: "p3", user_id: "u3", message: "current" },
+      },
+    });
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 1,
+      currentPostId: "p3",
+      resolveUserInfo,
+    });
+
+    const seeded = channelHistories.get("channel:chan-1");
+    expect(seeded).toHaveLength(1);
+    expect(seeded?.[0]?.messageId).toBe("p2");
+  });
+
+  it("does not overwrite a non-empty history window", async () => {
+    const channelHistories = new Map([["channel:chan-1", [{ sender: "@existing", body: "kept" }]]]);
+    const client = threadClientMock({ order: ["p1"], posts: { p1: { id: "p1", message: "x" } } });
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      resolveUserInfo,
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
+    expect(channelHistories.get("channel:chan-1")).toStrictEqual([
+      { sender: "@existing", body: "kept" },
+    ]);
+  });
+
+  it("swallows fetch errors and logs", async () => {
+    const channelHistories = new Map();
+    const client = createMattermostClientMock();
+    client.request = vi.fn(async () => {
+      throw new Error("boom");
+    }) as MattermostClient["request"];
+    const log = vi.fn();
+
+    await backfillMattermostThreadHistory({
+      client,
+      threadRootId: "root-1",
+      historyKey: "channel:chan-1",
+      channelHistories,
+      historyLimit: 10,
+      resolveUserInfo,
+      log,
+    });
+
+    expect(channelHistories.has("channel:chan-1")).toBe(false);
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(String(log.mock.calls[0]?.[0])).toContain("boom");
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -540,12 +540,15 @@ export async function backfillMattermostThreadHistory(params: {
     const thread = await fetchMattermostThread(params.client, params.threadRootId);
     const order = Array.isArray(thread?.order) ? thread.order : [];
     const posts = thread?.posts ?? {};
+    // Bound the per-post work: select eligible posts and trim to the last
+    // `historyLimit` BEFORE resolving usernames, so a large cold thread cannot
+    // issue an unbounded number of sequential user lookups on the reply path.
+    const eligiblePosts = order
+      .map((postId) => posts[postId])
+      .filter((post): post is MattermostPost => Boolean(post) && post.id !== params.currentPostId)
+      .slice(-params.historyLimit);
     const entries: HistoryEntry[] = [];
-    for (const postId of order) {
-      const threadPost = posts[postId];
-      if (!threadPost || threadPost.id === params.currentPostId) {
-        continue;
-      }
+    for (const threadPost of eligiblePosts) {
       const userId = normalizeOptionalString(threadPost.user_id);
       const username = userId
         ? normalizeOptionalString((await params.resolveUserInfo(userId))?.username)
@@ -558,7 +561,7 @@ export async function backfillMattermostThreadHistory(params: {
       });
     }
     if (entries.length > 0) {
-      params.channelHistories.set(params.historyKey, entries.slice(-params.historyLimit));
+      params.channelHistories.set(params.historyKey, entries);
     }
     // Record even when the server thread had no extra posts, so the same session is not
     // refetched on every follow-up turn within its lifetime.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -509,12 +509,23 @@ export async function backfillMattermostThreadHistory(params: {
   historyLimit: number;
   currentPostId?: string;
   resolveUserInfo: (userId: string) => Promise<MattermostUser | null>;
+  /** Current agent session id for this thread; backfill runs at most once per session id. */
+  sessionId?: string;
+  /** Per-historyKey record of the session id last backfilled (recovery-gate state). */
+  backfilledSessionIds: Map<string, string>;
   log?: (message: string) => void;
 }): Promise<void> {
   if (params.historyLimit <= 0) {
     return;
   }
   if ((params.channelHistories.get(params.historyKey)?.length ?? 0) > 0) {
+    return;
+  }
+  // Recovery gate: the in-memory window is cleared after every turn, so "window empty" also
+  // matches normal active-thread follow-ups. The agent session id only rotates on /new or a
+  // restart — exactly when the thread context is actually missing — so backfill at most once
+  // per session id and skip the server fetch while it is unchanged.
+  if (params.sessionId && params.backfilledSessionIds.get(params.historyKey) === params.sessionId) {
     return;
   }
   try {
@@ -540,6 +551,11 @@ export async function backfillMattermostThreadHistory(params: {
     }
     if (entries.length > 0) {
       params.channelHistories.set(params.historyKey, entries.slice(-params.historyLimit));
+    }
+    // Record even when the server thread had no extra posts, so the same session is not
+    // refetched on every follow-up turn within its lifetime.
+    if (params.sessionId) {
+      params.backfilledSessionIds.set(params.historyKey, params.sessionId);
     }
   } catch (err) {
     params.log?.(
@@ -928,6 +944,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
+  // Tracks the agent session id last backfilled per thread historyKey so thread history is
+  // seeded once per session (on /new or restart) instead of on every active-thread follow-up.
+  const backfilledSessionIds = new Map<string, string>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const { groupPolicy, providerMissingFallbackApplied } =
@@ -1637,6 +1656,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           sender: { name: senderName, id: senderId },
         });
         if (historyKey && threadRootId) {
+          const threadStorePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+            agentId: route.agentId,
+          });
+          const threadSessionId = core.agent.session.getSessionEntry({
+            storePath: threadStorePath,
+            sessionKey: historyKey,
+            agentId: route.agentId,
+          })?.sessionId;
           await backfillMattermostThreadHistory({
             client,
             threadRootId,
@@ -1645,6 +1672,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             historyLimit,
             currentPostId: post.id ?? undefined,
             resolveUserInfo,
+            sessionId: threadSessionId,
+            backfilledSessionIds,
             log: (message) => logVerboseMessage(message),
           });
         }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -33,6 +33,7 @@ import {
 import {
   createMattermostClient,
   fetchMattermostMe,
+  fetchMattermostThread,
   normalizeMattermostBaseUrl,
   updateMattermostPost,
   type MattermostClient,
@@ -489,6 +490,64 @@ export function resolveMattermostReactionChannelId(
     normalizeOptionalString(payload.broadcast?.channel_id) ??
     normalizeOptionalString(payload.data?.channel_id)
   );
+}
+
+/**
+ * Backfill in-memory thread history from the server when the local history window
+ * for a thread is empty (e.g. after a gateway restart or a session clear). Without
+ * this, a user who @mentions the bot inside an existing thread to wake it gets a
+ * reply with no thread context. Fetches the full thread via
+ * `GET /posts/{threadRootId}/thread`, maps posts to history entries (resolving
+ * usernames), and seeds the most recent entries up to `historyLimit`. Failures are
+ * logged and swallowed so inbound handling continues.
+ */
+export async function backfillMattermostThreadHistory(params: {
+  client: MattermostClient;
+  threadRootId: string;
+  historyKey: string;
+  channelHistories: Map<string, HistoryEntry[]>;
+  historyLimit: number;
+  currentPostId?: string;
+  resolveUserInfo: (userId: string) => Promise<MattermostUser | null>;
+  log?: (message: string) => void;
+}): Promise<void> {
+  if (params.historyLimit <= 0) {
+    return;
+  }
+  if ((params.channelHistories.get(params.historyKey)?.length ?? 0) > 0) {
+    return;
+  }
+  try {
+    const thread = await fetchMattermostThread(params.client, params.threadRootId);
+    const order = Array.isArray(thread?.order) ? thread.order : [];
+    const posts = thread?.posts ?? {};
+    const entries: HistoryEntry[] = [];
+    for (const postId of order) {
+      const threadPost = posts[postId];
+      if (!threadPost || threadPost.id === params.currentPostId) {
+        continue;
+      }
+      const userId = normalizeOptionalString(threadPost.user_id);
+      const username = userId
+        ? normalizeOptionalString((await params.resolveUserInfo(userId))?.username)
+        : undefined;
+      entries.push({
+        sender: username ? `@${username}` : (userId ?? "unknown"),
+        body: normalizeOptionalString(threadPost.message) ?? "[attachment]",
+        timestamp: typeof threadPost.create_at === "number" ? threadPost.create_at : undefined,
+        messageId: normalizeOptionalString(threadPost.id),
+      });
+    }
+    if (entries.length > 0) {
+      params.channelHistories.set(params.historyKey, entries.slice(-params.historyLimit));
+    }
+  } catch (err) {
+    params.log?.(
+      `mattermost: thread history backfill failed (thread=${params.threadRootId}): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
 }
 
 function buildMattermostAttachmentPlaceholder(mediaList: MattermostMediaInfo[]): string {
@@ -1577,6 +1636,18 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           chatType,
           sender: { name: senderName, id: senderId },
         });
+        if (historyKey && threadRootId) {
+          await backfillMattermostThreadHistory({
+            client,
+            threadRootId,
+            historyKey,
+            channelHistories,
+            historyLimit,
+            currentPostId: post.id ?? undefined,
+            resolveUserInfo,
+            log: (message) => logVerboseMessage(message),
+          });
+        }
         let combinedBody = body;
         if (historyKey) {
           const channelHistory = createChannelHistoryWindow({ historyMap: channelHistories });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -566,6 +566,13 @@ export async function backfillMattermostThreadHistory(params: {
       params.backfilledSessionIds.set(params.historyKey, params.sessionId);
     }
   } catch (err) {
+    // One attempt per session: record the session even on failure (including a
+    // timeout abort) so a slow or erroring server is not re-fetched on every
+    // follow-up turn within the session's lifetime, which would repeatedly add
+    // an awaited REST call and delay replies.
+    if (params.sessionId) {
+      params.backfilledSessionIds.set(params.historyKey, params.sessionId);
+    }
     params.log?.(
       `mattermost: thread history backfill failed (thread=${params.threadRootId}): ${
         err instanceof Error ? err.message : String(err)

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -519,6 +519,14 @@ export async function backfillMattermostThreadHistory(params: {
     return;
   }
   if ((params.channelHistories.get(params.historyKey)?.length ?? 0) > 0) {
+    // The active thread already has in-memory history, so no server fetch is needed — but mark
+    // this session serviced first. Otherwise a non-empty first sighting returns without recording
+    // the session, and the next same-session follow-up (after the turn kernel clears the window)
+    // mis-reads the empty window as a cold start and refetches the whole server thread on an
+    // ordinary reply, adding an awaited REST call and re-injecting context the session already has.
+    if (params.sessionId) {
+      params.backfilledSessionIds.set(params.historyKey, params.sessionId);
+    }
     return;
   }
   // Recovery gate: the in-memory window is cleared after every turn, so "window empty" also


### PR DESCRIPTION
## Summary
- Thread/conversation history is in-memory only, so after a gateway restart or a session clear the window for a thread is empty. A user who @mentions the bot inside an existing thread to wake it then gets a reply with no thread context — worst exactly when the bot was unresponsive and is being recovered.
- Add `fetchMattermostThread` (`GET /posts/{id}/thread`) and `backfillMattermostThreadHistory`, which seeds the history window from the server thread (resolving usernames, trimmed to `historyLimit`).
- **Recovery-gated:** the in-memory window is cleared after every turn, so "window empty" alone would refetch and re-inject the whole server thread on every active-thread follow-up. The backfill is gated on the agent session id (read via `getSessionEntry`): it only rotates on `/new` or a restart — exactly when the thread context is actually missing — so the server thread is fetched at most once per session id and skipped while it is unchanged.
- Wired into the inbound path for thread messages (`threadRootId` present and a history key); failures are logged and swallowed so inbound handling continues.
- Unit coverage: seed from server, current-post exclusion + trim, no-overwrite when non-empty, error swallow, **plus the recovery gate** (active-thread steady state does not refetch, session-id rotation re-seeds, session id recorded after seeding).

Fixes #93204. Part of the #65729 umbrella split.

## Scope
- Applies to any thread that has a history key. With current behavior DMs have a null history key, so this affects group/channel threads; DM coverage would follow the separate DM-threading track (#93203).
- No new config. With the recovery gate, steady-state active threads do not refetch — the server thread is fetched only on session recovery.

## Availability (review follow-up)

The added inbound thread lookup is bounded so it cannot slow the reply path:

- `fetchMattermostThread` aborts after a **5s timeout** (`AbortController`); on a slow/unresponsive server the reply proceeds without backfilled history.
- `backfillMattermostThreadHistory` records the session id **even when the fetch fails** (including a timeout abort), so a failing/slow server is fetched **at most once per session** rather than retried on every follow-up turn. Combined with the existing session-id recovery gate, backfill runs at most one bounded REST call per session.

## Real behavior proof
- **Behavior or issue addressed:** A thread whose in-memory window is empty after restart/session-clear must re-seed thread context from the server (#93204), AND it must NOT refetch the whole server thread on every normal active-thread follow-up (the window is cleared each turn).
- **Real environment tested:** Self-hosted OpenClaw on base image `ghcr.io/openclaw/openclaw:2026.6.5` running the equivalent change (Codex runtime), connected to a live Mattermost server, bot user `@openclaw`.
- **Exact steps or command run after this patch:** In a Mattermost channel thread, sent several follow-up messages to the bot, then `/new`, then another follow-up — while watching the backfill verbose logs.
- **Observed result after fix:** the server thread was fetched once on first touch, **skipped on the active follow-ups** (no refetch while the session id was unchanged), and **fetched again after `/new`** (session id rotated → context re-seeded); the post-`/new` follow-up was answered from the recovered thread context.
- **Evidence after fix:** redacted runtime logs from the recovery-gated build (session keys truncated), plus a screenshot of context surviving `/new`:
  ```
  thread backfill seeded 2 entries for agent:main:mattermost:group:…:thread:…
  thread backfill skipped: same session for agent:main:mattermost:group:…:thread:…
  thread backfill skipped: same session for agent:main:mattermost:group:…:thread:…
  thread backfill seeded 8 entries for agent:main:mattermost:group:…:thread:…   (after /new)
  ```
  ![thread context survives session clear](https://github.com/iloveleon19/openclaw/releases/download/pr93243-proof/pr93243-proof-1.png)
- **What was not tested:** DM threads (out of scope here — channel-only; DM track is #93203). The exact verbose seed/skip log strings above are from the equivalent dist-patched deployment, not this branch build (this branch keeps the helper's error-only logging); the gate behavior itself is covered deterministically by the added unit tests.

## Tests
- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/client.test.ts` — all passed (incl. 7 `backfillMattermostThreadHistory` tests: 4 prior + 3 recovery-gate)
- `corepack pnpm format:check extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts`

