### PR TITLE
fix(cron): resolve lastRunStatus in cron list/show human output

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -4,11 +4,13 @@ import type { CronJob } from "../../cron/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import {
   coerceCronDeliveryPreviews,
+  enrichCronJsonWithStatus,
   getCronChannelOptions,
   parseAt,
   parseCronToolsAllow,
   parseDurationMs,
   printCronList,
+  printCronShow,
 } from "./shared.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -336,5 +338,38 @@ describe("parseDurationMs", () => {
     expect(parseDurationMs(`1${"0".repeat(302)}d`)).toBeNull();
     // A large-but-finite result is still accepted.
     expect(parseDurationMs(`9${"0".repeat(15)}ms`)).toBe(9_000_000_000_000_000);
+  });
+});
+
+describe("cron status rendering", () => {
+  beforeEach(() => {
+    hoisted.listChannelPluginsMock.mockReset();
+    hoisted.listChannelPluginsMock.mockReturnValue([]);
+  });
+
+  // `lastRunStatus` is the primary execution-status field (`lastStatus` is the
+  // deprecated alias). The human `cron list`/`cron show` output must resolve it
+  // the same way the `--json` status field does, instead of showing "idle".
+  it("renders lastRunStatus (matching the --json status), not idle, when lastStatus is unset", () => {
+    const now = Date.now();
+    const job = createBaseJob({
+      id: "status-job",
+      sessionTarget: "isolated",
+      state: { nextRunAtMs: now + 3_600_000, lastRunStatus: "ok" },
+    });
+
+    const show = createRuntimeLogCapture();
+    printCronShow(job, show.runtime);
+    expectLogsToInclude(show.logs, "status: ok");
+    expect(show.logs.join("\n")).not.toContain("status: idle");
+
+    const list = createRuntimeLogCapture();
+    printCronList([job], list.runtime);
+    const dataLine = list.logs.find((line) => line.includes("status-job")) ?? "";
+    expect(dataLine).toContain("ok");
+    expect(dataLine).not.toContain("idle");
+
+    // The computed --json status must agree with the human render.
+    expect(enrichCronJsonWithStatus(job)).toMatchObject({ status: "ok" });
   });
 });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -182,9 +182,12 @@ export async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
     if (res?.enabled === true) {
       return;
     }
-    const store = typeof res?.sqlitePath === "string" ? res.sqlitePath
-      : typeof res?.storePath === "string" ? res.storePath
-      : "";
+    const store =
+      typeof res?.sqlitePath === "string"
+        ? res.sqlitePath
+        : typeof res?.storePath === "string"
+          ? res.storePath
+          : "";
     defaultRuntime.error(
       [
         "warning: cron scheduler is disabled in the Gateway; jobs are saved but will not run automatically.",
@@ -377,17 +380,6 @@ const formatSchedule = (schedule: CronSchedule | undefined) => {
   return `${base} (stagger ${formatDurationHuman(staggerMs)})`;
 };
 
-const formatStatus = (job: CronJob) => {
-  if (!job.enabled) {
-    return "disabled";
-  }
-  const state = job.state ?? {};
-  if (state.runningAtMs) {
-    return "running";
-  }
-  return state.lastStatus ?? "idle";
-};
-
 export function coerceCronDeliveryPreviews(value: unknown): Map<string, CronDeliveryPreview> {
   const previews =
     value && typeof value === "object"
@@ -450,7 +442,7 @@ export function printCronList(
       CRON_NEXT_PAD,
     );
     const lastLabel = pad(formatRelative(state.lastRunAtMs, now), CRON_LAST_PAD);
-    const statusRaw = formatStatus(job);
+    const statusRaw = computeStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
     const deliveryPreview = opts?.deliveryPreviews?.get(job.id);
@@ -528,6 +520,6 @@ export function printCronShow(
   runtime.log(`delivery: ${preview.label} (${preview.detail})`);
   runtime.log(`next: ${formatRelative(job.state.nextRunAtMs, Date.now())}`);
   runtime.log(`last: ${formatRelative(job.state.lastRunAtMs, Date.now())}`);
-  runtime.log(`status: ${formatStatus(job)}`);
+  runtime.log(`status: ${computeStatus(job)}`);
   runtime.log(`diagnostic: ${job.state.lastDiagnosticSummary ?? "-"}`);
 }


### PR DESCRIPTION
## Summary

`openclaw cron list` and `openclaw cron show` print **`idle`** for a job whose real status is `ok` / `error` / `skipped` whenever the job's state carries only `lastRunStatus` (the primary field) and not the deprecated `lastStatus` alias.

The human-render helper `formatStatus` (`src/cli/cron-cli/shared.ts`) resolved the status as `state.lastStatus ?? "idle"`, **omitting `lastRunStatus`** — while the sibling `computeStatus` (used for the `--json` `status` field) and every other status resolver in the codebase use `state.lastRunStatus ?? state.lastStatus ?? "idle"`. `computeStatus`'s own JSDoc claims it *"mirrors the human-readable status shown by `cron list` / `cron show`"* — but `formatStatus` had diverged from it. `lastRunStatus` is the canonical field; `lastStatus` is `@deprecated` (`src/cron/types.ts`).

## Root cause + fix

`formatStatus` was a near-duplicate of `computeStatus` that was never updated when `lastRunStatus` became the primary field. This change **deletes `formatStatus`** and routes both human-render call sites (the `cron list` Status column and the `cron show` `status:` line) through the single canonical `computeStatus` — one resolver, honoring the documented "mirror" contract. Net **−8 LOC** in source.

## Change Type

- [x] Bug fix (also removes duplicated logic)

## Linked Issue

Source-discovered (no existing issue/PR — verified). The human `cron list`/`cron show` status now matches the `--json` `status` field and the rest of the status-resolution code.

## Evidence

- [x] **Failing before / passing after.** New test `renders lastRunStatus (matching the --json status), not idle, when lastStatus is unset` builds a job with `state: { lastRunStatus: "ok" }` (no `lastStatus`) and asserts `cron show` prints `status: ok` (not `status: idle`), the `cron list` Status column shows `ok`, and `enrichCronJsonWithStatus` agrees (`status: "ok"`). On `main` the human render returns `idle`, so the test fails without this patch. Full file: **29/29 tests pass** (Node 22.22.1). oxlint + oxfmt clean; `tsgo:core` clean.

## Real behavior proof

Behavior addressed: `cron list`/`cron show` human output now shows a job's real run status (`ok`/`error`/`skipped`) when only `lastRunStatus` is set, instead of `idle`, matching the `--json` `status` field.

Real environment tested: local OpenClaw dev gateway (`gateway run --dev --auth none`) on Node 22.22.1 (macOS), isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME`. A real cron job was created, then given a `lastRunStatus`-only state via a `cron.update` state patch (allowed by `CronJobStatePatchSchema`), then rendered by `cron show`/`cron list` on `main` vs this patch.

Exact steps or command run after this patch:

```
$ openclaw cron add --every 1h --session isolated --message hi --name statusbug-proof
# inject lastRunStatus-only state (cron.update patch.state = { lastRunStatus: "ok" }) -> job state becomes {"nextRunAtMs":..., "lastRunStatus":"ok"}  (no lastStatus)
$ openclaw cron show <job-id>
$ openclaw cron list --json
```

Evidence after fix: live gateway terminal output for the same `lastRunStatus`-only job, on `main` vs this patch:

```
# BEFORE (origin/main) — human render diverges from --json:
$ openclaw cron show <job-id>      ->  status: idle
$ openclaw cron list --json        ->  status: ok        (human "idle" vs json "ok" — DIVERGENT)

# AFTER (this patch) — human render matches --json:
$ openclaw cron show <job-id>      ->  status: ok
$ openclaw cron list --json        ->  status: ok        (consistent)
```

Observed result after fix: `cron show`/`cron list` report the real status (`ok`) for the `lastRunStatus`-only job; before the patch they reported `idle` while `--json` reported `ok`. Normal jobs (which dual-write both fields) are unaffected.

What was not tested: a job reaching the `lastRunStatus`-only state purely through the live scheduler (the runtime dual-writes both `lastRunStatus` and `lastStatus`, so the divergence was reproduced by writing the canonical field alone via the supported `cron.update` state patch — exactly the field shape the deprecated-alias migration moves toward).

## Security Impact

None — display/formatting consolidation only. No new permissions, secrets, network calls, or tool-exec surface.

## Compatibility / Migration

Backward compatible. Output is unchanged for every job that has `lastStatus` set (all normally-run jobs); only the previously-wrong `idle` rendering for `lastRunStatus`-only state changes, to the correct status.

## AI assistance

AI-assisted (Claude Code). Verified locally: 29/29 unit tests, oxlint clean, oxfmt clean, `tsgo:core` clean, plus the live before/after gateway proof above. Author understands the change.
