### PR TITLE
fix(doctor): skip top-level allowlist scan when active per-account scopes exist

### DIFF
--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -32,7 +32,6 @@ describe("doctor empty allowlist policy scan", () => {
     );
 
     expect(warnings).toEqual([
-      '- channels.signal.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to channels.signal.allowFrom, or run "openclaw doctor --fix" to auto-migrate from pairing store when entries exist.',
       '- channels.signal.accounts.work.dmPolicy is "allowlist" but allowFrom is empty — all DMs will be blocked. Add sender IDs to channels.signal.accounts.work.allowFrom, or run "openclaw doctor --fix" to auto-migrate from pairing store when entries exist.',
     ]);
   });
@@ -57,6 +56,33 @@ describe("doctor empty allowlist policy scan", () => {
       '- channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.telegram.groupAllowFrom or channels.telegram.allowFrom, or set groupPolicy to "open".',
       "extra:channels.telegram",
     ]);
+  });
+
+  it("does not warn top-level empty groupAllowFrom when active accounts have their own lists", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            // top-level empty — should not warn because accounts have own lists
+            accounts: {
+              work: {
+                groupAllowFrom: ["+15551234567"],
+                dmPolicy: "open",
+              },
+              personal: {
+                groupAllowFrom: ["+15557654321"],
+                dmPolicy: "open",
+              },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    // No warnings: top-level parent skipped, accounts have non-empty groupAllowFrom
+    expect(warnings).toEqual([]);
   });
 
   it("skips disabled channel and account entries", () => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -88,12 +88,12 @@ export function scanEmptyAllowlistPolicyWarnings(
     if (isDisabledRecord(channelConfig)) {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, channelName);
-
     const accounts = asObjectRecord(channelConfig.accounts);
     if (!accounts) {
+      checkAccount(channelConfig, `channels.${channelName}`, channelName);
       continue;
     }
+    let hasActiveAccount = false;
     for (const [accountId, account] of Object.entries(accounts)) {
       if (!account || typeof account !== "object") {
         continue;
@@ -101,12 +101,20 @@ export function scanEmptyAllowlistPolicyWarnings(
       if (isDisabledRecord(account)) {
         continue;
       }
+      hasActiveAccount = true;
       checkAccount(
         account as DoctorAccountRecord,
         `channels.${channelName}.accounts.${accountId}`,
         channelName,
         channelConfig,
       );
+    }
+    // When active per-account scopes exist, the top-level channel config acts only
+    // as a parent fallback for allowlist resolution, not as its own standalone record.
+    // Avoid false "empty allowlist" warnings for the parent when every active account
+    // supplies its own populated list.
+    if (!hasActiveAccount) {
+      checkAccount(channelConfig, `channels.${channelName}`, channelName);
     }
   }
 


### PR DESCRIPTION
## Summary

The empty-allowlist doctor scanner treated the top-level channel config as its own standalone account, producing false 'empty allowlist' warnings when every active account under that channel supplied its own populated `groupAllowFrom` or `allowFrom`.

## Behavior addressed

When a channel has `groupPolicy: "allowlist"` with an empty top-level `groupAllowFrom`, but every active account carries its own populated list, `openclaw doctor` incorrectly warns that inbound group messages will be dropped. Runtime resolves per-account (`account ?? parent`), and since every account has its own list, the top-level scope is never read — inbound routing works correctly.

Closes #92684

## Fix

- Only run the top-level channel config check when there are no active (non-disabled) account entries, matching runtime resolution semantics.
- When accounts exist, the top-level config acts only as a parent fallback for allowlist resolution.

## Change Type

- [x] Bug fix

## Scope

- [x] Doctor / diagnostics

## Evidence

### Source-level reproduction path (from ClawSweeper review, issue #92684):
- Current scanner calls `checkAccount(channelConfig, ...)` before iterating accounts (`src/commands/doctor/shared/empty-allowlist-scan.ts:91`)
- Warning builder treats empty top-level `groupAllowFrom` as drop risk (`src/commands/doctor/shared/empty-allowlist-policy.ts:61`)
- Runtime account config overrides parent allowlists (e.g. `extensions/telegram/src/account-config.ts:94`)

### Test coverage:
- **Added**: `does not warn top-level empty groupAllowFrom when active accounts have their own lists` — verifies the core fix scenario
- **Updated**: existing test adjusted to reflect that top-level with active accounts no longer produces standalone warnings

```
Test Files  1 passed (1)
      Tests  4 passed (4)
```

@clawsweeper review