### PR TITLE
fix(plugins): start explicitly enabled external channel plugins at gateway boot (#93219)

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -2360,6 +2360,55 @@ describe("resolveGatewayStartupPluginIds", () => {
     ]);
   });
 
+  it("starts an explicitly enabled external channel plugin without channel config (#93219)", () => {
+    const registry: PluginManifestRegistry = {
+      plugins: [
+        withManifestLoadPaths({
+          id: "openclaw-weixin",
+          channels: ["weixin"],
+          origin: "global",
+          enabledByDefault: undefined,
+          providers: [],
+          cliBackends: [],
+        }),
+        withManifestLoadPaths({
+          id: "external-tool-only",
+          channels: [],
+          origin: "global",
+          enabledByDefault: undefined,
+          providers: [],
+          cliBackends: [],
+        }),
+      ] as PluginManifestRecord[],
+      diagnostics: [],
+    };
+    const index = createInstalledPluginIndexFixture(registry);
+
+    const plan = resolveGatewayStartupPluginPlanFromRegistry({
+      config: {
+        channels: {},
+        plugins: {
+          entries: {
+            "openclaw-weixin": { enabled: true },
+            "external-tool-only": { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      env: createPluginPlanningTestEnv(),
+      index,
+      manifestRegistry: registry,
+    });
+
+    // The channel plugin must load at startup so it can listen, even though no
+    // channels.<id> config block exists — only plugins.entries enablement (#93219).
+    expect(plan.pluginIds).toContain("openclaw-weixin");
+    // Laziness guard: an explicitly enabled external tool plugin (no channels)
+    // must NOT be force-loaded at gateway startup.
+    expect(plan.pluginIds).not.toContain("external-tool-only");
+    // No channels.<id> config => not a deferred configured-channel load.
+    expect(plan.configuredDeferredChannelPluginIds).toStrictEqual([]);
+  });
+
   it("does not treat explicitly disabled stale channel config as deferred startup intent", () => {
     useManifestRegistryFixture(createManifestRegistryFixtureWithWorkspaceDemoChannel());
 

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -206,6 +206,40 @@ function hasConfiguredStartupChannel(params: {
   );
 }
 
+// #93219: an externally-installed channel plugin enabled only via
+// `plugins.entries.<id>.enabled=true` (no `channels.<id>` config block, no
+// `activation.onStartup`) must still load at gateway startup so its channel can
+// listen. Manifest channel ownership scopes this to channel plugins so explicitly
+// enabled tool plugins stay lazy, and bundled channels keep starting from channel
+// config/default rules rather than from a bare plugin entry.
+function hasExplicitlyEnabledExternalStartupChannel(params: {
+  plugin: InstalledPluginIndexRecord;
+  config: OpenClawConfig;
+  pluginsConfig: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+  activationSource: {
+    plugins: ReturnType<typeof normalizePluginsConfigWithRegistry>;
+    rootConfig?: OpenClawConfig;
+  };
+  manifestLookup: ManifestRegistryLookup;
+  platform?: NodeJS.Platform;
+}): boolean {
+  if (params.plugin.origin === "bundled") {
+    return false;
+  }
+  if (listManifestChannelIds(params.manifestLookup, params.plugin.pluginId).length === 0) {
+    return false;
+  }
+  const activationState = resolveEffectivePluginActivationState({
+    id: params.plugin.pluginId,
+    origin: params.plugin.origin,
+    config: params.pluginsConfig,
+    rootConfig: params.config,
+    enabledByDefault: isPluginEnabledByDefaultForPlatform(params.plugin, params.platform),
+    activationSource: params.activationSource,
+  });
+  return activationState.enabled && activationState.explicitlyEnabled;
+}
+
 type ManifestRegistryLookup = ReadonlyMap<string, PluginManifestRecord>;
 
 function createManifestRegistryLookup(
@@ -1926,13 +1960,20 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
   const pluginIds: string[] = [];
   for (const plugin of params.index.plugins) {
     const manifest = findManifestPlugin(manifestLookup, plugin.pluginId);
-    if (
-      hasConfiguredStartupChannel({
-        plugin,
-        manifestLookup,
-        configuredChannelIds,
-      })
-    ) {
+    const hasConfiguredChannel = hasConfiguredStartupChannel({
+      plugin,
+      manifestLookup,
+      configuredChannelIds,
+    });
+    const hasExplicitExternalChannel = hasExplicitlyEnabledExternalStartupChannel({
+      plugin,
+      config: params.config,
+      pluginsConfig,
+      activationSource,
+      manifestLookup,
+      platform: params.platform,
+    });
+    if (hasConfiguredChannel || hasExplicitExternalChannel) {
       const canStartConfiguredChannel = canStartConfiguredChannelPlugin({
         plugin,
         config: params.config,
@@ -1943,7 +1984,9 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
       });
       if (canStartConfiguredChannel) {
         pluginIds.push(plugin.pluginId);
-        if (plugin.startup.deferConfiguredChannelFullLoadUntilAfterListen) {
+        // Deferred configured-channel load applies only when a channels.<id>
+        // config block exists, not to the bare-entry explicit-external path.
+        if (hasConfiguredChannel && plugin.startup.deferConfiguredChannelFullLoadUntilAfterListen) {
           configuredDeferredChannelPluginIds.push(plugin.pluginId);
         }
       }


### PR DESCRIPTION
## Summary

After the runtime/layout migration, the gateway loaded only the bundled stock plugins and never any externally-installed npm plugin (e.g. a third-party WeChat channel plugin enabled via `plugins.entries.openclaw-weixin.enabled=true`). The channel never started, so `openclaw channels login` succeeded on the client side but the running gateway rejected `channels.start` and `openclaw channels list` reported "no configured chat channels". This restores startup loading for externally-installed channel plugins that are explicitly enabled, without a `channels.<id>` config block.

## Root Cause

- `src/plugins/gateway-startup-plugin-ids.ts:resolveGatewayStartupPluginPlanFromRegistry`: for each indexed plugin, the channel-startup branch is only entered when `hasConfiguredStartupChannel` is true. `hasConfiguredStartupChannel` requires one of the plugin's manifest channel ids to be present in `configuredChannelIds`, which is derived from `listPotentialEnabledChannelIds(config, env)` — i.e. from `channels.<id>` config / persisted auth, **not** from `plugins.entries.<id>.enabled`.
- An externally-installed channel plugin whose manifest declares a channel but has no `activation.onStartup`, enabled solely via `plugins.entries.<id>.enabled=true` with no `channels.<id>` block, therefore matches no startup predicate — including the final `shouldConsiderForGatewayStartup` catch-all (which only covers `onStartup` / context-engine slot / memory / dreaming) — and is dropped from the plan.
- Asymmetry confirming the gap: the metadata-snapshot **scope** (`resolveGatewayStartupMetadataPluginIds` via `addPluginConfigEntryIds`) already includes every `plugins.entries.<id>` where `enabled !== false`, so the snapshot index contains the plugin; only the plan loop diverges and excludes it.

This matches clawsweeper's source-level review on #93219 (`clawsweeper:source-repro`, `clawsweeper:fix-shape-clear`, `clawsweeper:queueable-fix`): *"current main still routes gateway runtime loading through a startup plugin-id plan, and that plan does not include an externally installed channel plugin merely because `plugins.entries.<id>.enabled=true`, even though the reported plugin's manifest declares a channel but no `activation.onStartup`."*

## Changes

- `src/plugins/gateway-startup-plugin-ids.ts`: add `hasExplicitlyEnabledExternalStartupChannel(plugin, ...)` — true only for a **non-bundled** plugin whose **manifest declares channels** and whose effective activation is `enabled && explicitlyEnabled`. OR it into the channel-startup branch alongside `hasConfiguredStartupChannel`; the final start decision still goes through the existing `canStartConfiguredChannelPlugin` (so `plugins.enabled=false`, denylist, `entries[id].enabled=false`, and restrictive allowlists still apply). The `configuredDeferredChannelPluginIds` population stays gated on `hasConfiguredStartupChannel` only.
- Manifest-channel ownership scopes the new path to channel plugins, so explicitly-enabled **tool** plugins stay lazy (no eager startup load), bundled channels keep starting from channel-config/default rules, and `shouldConsiderForGatewayStartup` is intentionally left unchanged.

## Reproduction (before fix)

New unit case in `channel-plugin-ids.test.ts` (external channel plugin `openclaw-weixin`, manifest `channels: ["weixin"]`, origin `global`, no `activation.onStartup`; config has `plugins.entries["openclaw-weixin"].enabled = true` and an empty `channels` block) failed:

```text
AssertionError: expected [] to include 'openclaw-weixin'
 ❯ src/plugins/channel-plugin-ids.test.ts:2404
   expect(plan.pluginIds).toContain("openclaw-weixin");
```

(`plan.pluginIds` was `[]` — the plugin was dropped from the startup plan.)

## Verification (after fix)

```text
✓ plugins  src/plugins/channel-plugin-ids.test.ts (145 tests) — 145 passed
✓ "starts an explicitly enabled external channel plugin without channel config (#93219)"
```

The same test now also asserts the laziness guard: an explicitly-enabled external **tool** plugin (no channels) is NOT force-loaded, and `configuredDeferredChannelPluginIds` stays `[]` when there is no channel config.

## Test

- `pnpm test src/plugins/channel-plugin-ids.test.ts` — 145 passed (incl. new #93219 case + laziness/deferred-load regression assertions)
- `pnpm test src/plugins/effective-plugin-ids.test.ts src/plugins/plugin-lookup-table.test.ts` — 21 passed (downstream consumers of the plan)
- `pnpm tsgo:core` — passed
- `pnpm tsgo:core:test` — passed

## Notes

- Scope: single issue; smallest complete fix (≈43 net prod LOC across 1 prod file + 1 test file).
- Metadata snapshot: no change needed — `resolveGatewayStartupMetadataPluginIds` already includes explicitly-enabled entries in scope, so `isMetadataSnapshotScopedForGatewayStartup` stays consistent with the broadened plan.
- Distinct from #93230 (`fix(cli): restart gateway for missing auth channel`, #91932): that patches the `invalid channels.start` symptom via a CLI gateway restart; this fixes the root cause so the channel plugin is in the startup plan in the first place.
- `pnpm build`: compilation and bundling (tsdown, plugin-sdk dts, ui:build) completed; the build only failed at the final `write-cli-startup-metadata` step because the dev machine runs Node v22.14.0 while the CLI requires Node >= 22.19. This is an environment gate unrelated to the change (no new imports were added; the tsdown `[INEFFECTIVE_DYNAMIC_IMPORT]` check passed). The issue is `clawsweeper:source-repro` (not live-repro); proof here is at the source/unit level accordingly.

Closes #93219
