### PR TITLE
fix(memory): fall back to keyword search without sqlite

### DIFF
--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -368,6 +368,77 @@ describe("getMemorySearchManager caching", () => {
     expect(searchResults).toHaveLength(1);
   });
 
+  it("returns file keyword fallback when builtin sqlite is unavailable", async () => {
+    const fixtureRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-memory-keyword-fallback-"),
+    );
+    try {
+      const workspace = path.join(fixtureRoot, "workspace");
+      await fs.mkdir(path.join(workspace, "memory"), { recursive: true });
+      await fs.writeFile(
+        path.join(workspace, "MEMORY.md"),
+        "# Root Memory\nThe orbit launch window is morning.\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(workspace, "memory", "preferences.md"),
+        "# Preferences\nFavorite ramen is shoyu.\nThe orbit codename is ORBIT-22.\n",
+        "utf8",
+      );
+      const cfg = {
+        agents: {
+          list: [{ id: "main", default: true, workspace }],
+        },
+      } as OpenClawConfig;
+      mockMemoryIndexGet.mockRejectedValueOnce(
+        new Error(
+          "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite",
+        ),
+      );
+      const debug: unknown[] = [];
+
+      const result = await getMemorySearchManager({ cfg, agentId: "main" });
+      const manager = requireManager(result);
+      const results = await manager.search("orbit ramen", {
+        maxResults: 1,
+        minScore: 0,
+        onDebug: (entry) => debug.push(entry),
+      });
+
+      expect(results).toEqual([
+        expect.objectContaining({
+          path: "memory/preferences.md",
+          startLine: 1,
+          endLine: 4,
+          snippet: expect.stringContaining("ORBIT-22"),
+          source: "memory",
+        }),
+      ]);
+      expect(debug).toEqual([
+        {
+          backend: "builtin",
+          effectiveMode: "keyword-fallback",
+          fallback: "node-sqlite-unavailable",
+        },
+      ]);
+      expect(manager.status()).toEqual(
+        expect.objectContaining({
+          backend: "builtin",
+          provider: "keyword-fallback",
+          requestedProvider: "keyword-fallback",
+          fallback: {
+            from: "builtin-sqlite",
+            reason:
+              "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite",
+          },
+        }),
+      );
+      expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+    } finally {
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("returns the qmd startup failure when builtin fallback is unavailable", async () => {
     const cfg = createQmdCfg("missing-qmd-no-builtin");
     checkQmdBinaryAvailability.mockResolvedValueOnce({

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -396,44 +396,49 @@ describe("getMemorySearchManager caching", () => {
         ),
       );
       const debug: unknown[] = [];
+      const directReadSpy = vi.spyOn(fs, "readFile");
+      try {
+        const result = await getMemorySearchManager({ cfg, agentId: "main" });
+        const manager = requireManager(result);
+        const results = await manager.search("orbit ramen", {
+          maxResults: 1,
+          minScore: 0,
+          onDebug: (entry) => debug.push(entry),
+        });
 
-      const result = await getMemorySearchManager({ cfg, agentId: "main" });
-      const manager = requireManager(result);
-      const results = await manager.search("orbit ramen", {
-        maxResults: 1,
-        minScore: 0,
-        onDebug: (entry) => debug.push(entry),
-      });
-
-      expect(results).toEqual([
-        expect.objectContaining({
-          path: "memory/preferences.md",
-          startLine: 1,
-          endLine: 4,
-          snippet: expect.stringContaining("ORBIT-22"),
-          source: "memory",
-        }),
-      ]);
-      expect(debug).toEqual([
-        {
-          backend: "builtin",
-          effectiveMode: "keyword-fallback",
-          fallback: "node-sqlite-unavailable",
-        },
-      ]);
-      expect(manager.status()).toEqual(
-        expect.objectContaining({
-          backend: "builtin",
-          provider: "keyword-fallback",
-          requestedProvider: "keyword-fallback",
-          fallback: {
-            from: "builtin-sqlite",
-            reason:
-              "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite",
+        expect(results).toEqual([
+          expect.objectContaining({
+            path: "memory/preferences.md",
+            startLine: 1,
+            endLine: 4,
+            snippet: expect.stringContaining("ORBIT-22"),
+            source: "memory",
+          }),
+        ]);
+        expect(debug).toEqual([
+          {
+            backend: "builtin",
+            effectiveMode: "keyword-fallback",
+            fallback: "node-sqlite-unavailable",
           },
-        }),
-      );
-      expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+        ]);
+        expect(manager.status()).toEqual(
+          expect.objectContaining({
+            backend: "builtin",
+            provider: "keyword-fallback",
+            requestedProvider: "keyword-fallback",
+            fallback: {
+              from: "builtin-sqlite",
+              reason:
+                "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite",
+            },
+          }),
+        );
+        expect(directReadSpy).not.toHaveBeenCalled();
+        expect(mockMemoryIndexGet).toHaveBeenCalledTimes(1);
+      } finally {
+        directReadSpy.mockRestore();
+      }
     } finally {
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -465,15 +465,21 @@ class KeywordFallbackMemoryManager implements MemorySearchManager {
       if (opts?.signal?.aborted) {
         throw opts.signal.reason instanceof Error ? opts.signal.reason : new Error("aborted");
       }
-      let content: string;
+      let readResult: MemoryReadResult;
       try {
-        content = await fs.readFile(filePath, "utf8");
+        readResult = await readMemoryFile({
+          workspaceDir: this.params.workspaceDir,
+          extraPaths: this.params.extraPaths,
+          relPath: filePath,
+          lines: Number.MAX_SAFE_INTEGER,
+          maxChars: Number.MAX_SAFE_INTEGER,
+        });
       } catch {
         continue;
       }
-      const relPath = path.relative(this.params.workspaceDir, filePath).replace(/\\/g, "/");
+      const relPath = readResult.path;
       const pathMatches = countKeywordFallbackMatches(relPath, tokens);
-      for (const chunk of chunkMarkdown(content, this.params.chunking)) {
+      for (const chunk of chunkMarkdown(readResult.text, this.params.chunking)) {
         const textMatches = countKeywordFallbackMatches(chunk.text, tokens);
         const matchCount = textMatches + pathMatches;
         if (matchCount === 0) {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -1,12 +1,15 @@
 // Memory Core plugin module implements search manager behavior.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createSubsystemLogger,
   resolveAgentContextLimits,
   resolveAgentWorkspaceDir,
   resolveGlobalSingleton,
+  resolveMemorySearchConfig,
   resolveMemorySearchSyncConfig,
+  truncateUtf16Safe,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
@@ -14,9 +17,15 @@ import {
   resolveQmdBinaryUnavailableReason,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
+  chunkMarkdown,
+  listMemoryFiles,
+  readMemoryFile,
   resolveMemoryBackendConfig,
   type MemoryEmbeddingProbeResult,
+  type MemoryProviderStatus,
+  type MemoryReadResult,
   type MemorySearchManager,
+  type MemorySearchResult,
   type MemorySearchRuntimeDebug,
   type MemorySource,
   type MemorySyncProgressUpdate,
@@ -348,7 +357,204 @@ async function getBuiltinMemorySearchManager(params: {
     return { manager };
   } catch (err) {
     const message = formatErrorMessage(err);
+    if (isNodeSqliteUnavailableError(message)) {
+      const manager = createKeywordFallbackMemoryManager({
+        cfg: params.cfg,
+        agentId: params.agentId,
+        reason: message,
+      });
+      if (manager) {
+        return { manager };
+      }
+    }
     return { manager: null, error: message };
+  }
+}
+
+function isNodeSqliteUnavailableError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("missing node:sqlite") ||
+    normalized.includes("no such built-in module: node:sqlite") ||
+    normalized.includes("sqlite support is unavailable in this node runtime")
+  );
+}
+
+function createKeywordFallbackMemoryManager(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  reason: string;
+}): MemorySearchManager | null {
+  const settings = resolveMemorySearchConfig(params.cfg, params.agentId);
+  if (!settings || !settings.sources.includes("memory")) {
+    return null;
+  }
+  return new KeywordFallbackMemoryManager({
+    workspaceDir: resolveAgentWorkspaceDir(params.cfg, params.agentId),
+    extraPaths: settings.extraPaths,
+    chunking: settings.chunking,
+    maxResults: settings.query.maxResults,
+    minScore: settings.query.minScore,
+    reason: params.reason,
+  });
+}
+
+type KeywordFallbackCandidate = MemorySearchResult & { matchCount: number };
+
+const KEYWORD_FALLBACK_TOKEN_RE = /[\p{L}\p{N}_]+/gu;
+const KEYWORD_FALLBACK_SNIPPET_MAX_CHARS = 700;
+
+function tokenizeKeywordFallbackQuery(query: string): string[] {
+  return Array.from(
+    new Set(
+      (query.match(KEYWORD_FALLBACK_TOKEN_RE) ?? [])
+        .map((token) => token.toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function countKeywordFallbackMatches(text: string, tokens: string[]): number {
+  const normalized = text.toLowerCase();
+  return tokens.filter((token) => normalized.includes(token)).length;
+}
+
+class KeywordFallbackMemoryManager implements MemorySearchManager {
+  constructor(
+    private readonly params: {
+      workspaceDir: string;
+      extraPaths: string[];
+      chunking: { tokens: number; overlap: number };
+      maxResults: number;
+      minScore: number;
+      reason: string;
+    },
+  ) {}
+
+  async search(
+    query: string,
+    opts?: {
+      maxResults?: number;
+      minScore?: number;
+      sessionKey?: string;
+      qmdSearchModeOverride?: "query" | "search" | "vsearch";
+      onDebug?: (debug: MemorySearchRuntimeDebug) => void;
+      sources?: MemorySource[];
+      signal?: AbortSignal;
+    },
+  ): Promise<MemorySearchResult[]> {
+    opts?.onDebug?.({
+      backend: "builtin",
+      effectiveMode: "keyword-fallback",
+      fallback: "node-sqlite-unavailable",
+    });
+    if (opts?.sources && !opts.sources.includes("memory")) {
+      return [];
+    }
+    const tokens = tokenizeKeywordFallbackQuery(query);
+    if (tokens.length === 0) {
+      return [];
+    }
+    const maxResults = Math.max(1, opts?.maxResults ?? this.params.maxResults ?? 10);
+    const minScore = opts?.minScore ?? this.params.minScore ?? 0;
+    const files = (await listMemoryFiles(this.params.workspaceDir, this.params.extraPaths)).filter(
+      (filePath) => filePath.endsWith(".md"),
+    );
+    const candidates: KeywordFallbackCandidate[] = [];
+    for (const filePath of files) {
+      if (opts?.signal?.aborted) {
+        throw opts.signal.reason instanceof Error ? opts.signal.reason : new Error("aborted");
+      }
+      let content: string;
+      try {
+        content = await fs.readFile(filePath, "utf8");
+      } catch {
+        continue;
+      }
+      const relPath = path.relative(this.params.workspaceDir, filePath).replace(/\\/g, "/");
+      const pathMatches = countKeywordFallbackMatches(relPath, tokens);
+      for (const chunk of chunkMarkdown(content, this.params.chunking)) {
+        const textMatches = countKeywordFallbackMatches(chunk.text, tokens);
+        const matchCount = textMatches + pathMatches;
+        if (matchCount === 0) {
+          continue;
+        }
+        const score = Math.min(1, matchCount / tokens.length + Math.min(textMatches, 1) * 0.1);
+        if (score < minScore) {
+          continue;
+        }
+        candidates.push({
+          path: relPath,
+          startLine: chunk.startLine,
+          endLine: chunk.endLine,
+          score,
+          textScore: score,
+          snippet: truncateUtf16Safe(chunk.text, KEYWORD_FALLBACK_SNIPPET_MAX_CHARS),
+          source: "memory",
+          matchCount,
+        });
+      }
+    }
+    return candidates
+      .toSorted((left, right) => {
+        if (left.score !== right.score) {
+          return right.score - left.score;
+        }
+        if (left.matchCount !== right.matchCount) {
+          return right.matchCount - left.matchCount;
+        }
+        const pathOrder = left.path.localeCompare(right.path);
+        if (pathOrder !== 0) {
+          return pathOrder;
+        }
+        return left.startLine - right.startLine;
+      })
+      .slice(0, maxResults)
+      .map(({ matchCount, ...result }) => result);
+  }
+
+  async readFile(params: {
+    relPath: string;
+    from?: number;
+    lines?: number;
+  }): Promise<MemoryReadResult> {
+    return await readMemoryFile({
+      workspaceDir: this.params.workspaceDir,
+      extraPaths: this.params.extraPaths,
+      relPath: params.relPath,
+      from: params.from,
+      lines: params.lines,
+    });
+  }
+
+  status(): MemoryProviderStatus {
+    return {
+      backend: "builtin",
+      provider: "keyword-fallback",
+      requestedProvider: "keyword-fallback",
+      workspaceDir: this.params.workspaceDir,
+      sources: ["memory"],
+      fallback: {
+        from: "builtin-sqlite",
+        reason: this.params.reason,
+      },
+      custom: {
+        fallback: {
+          mode: "keyword",
+          reason: this.params.reason,
+        },
+      },
+    };
+  }
+
+  async sync(): Promise<void> {}
+
+  async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
+    return { ok: false, error: this.params.reason };
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    return false;
   }
 }
 

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -1,6 +1,5 @@
 // Memory Core plugin module implements search manager behavior.
 import fs from "node:fs/promises";
-import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createSubsystemLogger,
@@ -516,7 +515,17 @@ class KeywordFallbackMemoryManager implements MemorySearchManager {
         return left.startLine - right.startLine;
       })
       .slice(0, maxResults)
-      .map(({ matchCount, ...result }) => result);
+      .map(
+        (candidate): MemorySearchResult => ({
+          path: candidate.path,
+          startLine: candidate.startLine,
+          endLine: candidate.endLine,
+          score: candidate.score,
+          textScore: candidate.textScore,
+          snippet: candidate.snippet,
+          source: candidate.source,
+        }),
+      );
   }
 
   async readFile(params: {


### PR DESCRIPTION
## Summary

- Problem: On Node runtimes where the builtin `node:sqlite` module is unavailable, `memory_search` previously lost the builtin indexed manager even though durable markdown memory files were still readable.
- Solution: Keep SQLite/vector search as the canonical path when available, and only for the explicit missing-`node:sqlite` failure seam return a degraded keyword fallback manager over `MEMORY.md`, `memory/*.md`, and configured memory `extraPaths`.
- What changed: The fallback returns bounded markdown keyword results with file paths, line ranges, truncated snippets, and debug/status metadata marking `keyword-fallback` / `node-sqlite-unavailable`.
- What did not change: SQLite/vector indexing, QMD behavior, embeddings, provider selection, sync, runtime service APIs, tool schemas, SDK exports, config shape, migrations, and file formats are unchanged.
- Why it matters / User impact: Users on Node builds without `node:sqlite` get a basic local memory recall path instead of an unavailable manager response for a runtime capability gap outside their control.
- Fixes #93150

## Real behavior proof

- **Behavior addressed:** `memory_search` returns degraded markdown keyword results when the current OpenClaw CLI process cannot load `node:sqlite`, instead of returning unavailable manager metadata. This exercises the production CLI path through `node scripts/run-node.mjs memory ...`, `loadMemoryCommandConfig`, `withMemoryManagerForAgent`, `getMemorySearchManager`, and the PR's `KeywordFallbackMemoryManager`.
- **Real environment tested:** Local #93260 worktree at commit `96d9ef309aead772a74e68e9aaece8021f94f7e2`; git status clean; isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and workspace under `/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence`; local markdown corpus containing `MEMORY.md` and `memory/preferences.md`; scoped preload that makes `node:sqlite` unavailable only for the memory index storage loader.
- **Exact steps or command run after this patch:**

```bash
cd "/media/vdb/code/ai/aispace/openclaw-worktrees/pr-93260" && \
  env NODE_OPTIONS="--require /media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/block-node-sqlite.cjs" \
    OPENCLAW_HOME="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-home" \
    OPENCLAW_STATE_DIR="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-state" \
    OPENCLAW_CONFIG_PATH="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-openclaw.json" \
    OPENCLAW_TEST_FAST=1 \
    NO_COLOR=1 \
    node scripts/run-node.mjs memory status --agent main --json \
      > "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-status.json" \
      2> "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-status.stderr" && \
  env NODE_OPTIONS="--require /media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/block-node-sqlite.cjs" \
    OPENCLAW_HOME="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-home" \
    OPENCLAW_STATE_DIR="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-state" \
    OPENCLAW_CONFIG_PATH="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-openclaw.json" \
    OPENCLAW_TEST_FAST=1 \
    NO_COLOR=1 \
    node scripts/run-node.mjs memory search "orbit ramen" --agent main --max-results 1 --json \
      > "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search.json" \
      2> "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search.stderr" && \
  env NODE_OPTIONS="--require /media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/block-node-sqlite.cjs" \
    OPENCLAW_HOME="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-home" \
    OPENCLAW_STATE_DIR="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-state" \
    OPENCLAW_CONFIG_PATH="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-openclaw.json" \
    OPENCLAW_TEST_FAST=1 \
    NO_COLOR=1 \
    node scripts/run-node.mjs memory search "notpresent" --agent main --json \
      > "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search-empty.json" \
      2> "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search-empty.stderr"
```

The verification was recorded with daily-fix against the same head and evidence files:

```bash
DAILY_FIX="/home/0668001029/.claude/skills/daily-fix/scripts/daily_fix.sh" \
DAILY_FIX_CONTEXT="/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/context.env" \
"$DAILY_FIX" record-verification \
  "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-status.json" \
  "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search.json" \
  "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search-empty.json"
```

- **Evidence after fix:**

`memory status --agent main --json` returned fallback status for the actual CLI manager:

```json
[
  {
    "agentId": "main",
    "status": {
      "backend": "builtin",
      "provider": "keyword-fallback",
      "requestedProvider": "keyword-fallback",
      "workspaceDir": "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-workspace",
      "sources": ["memory"],
      "fallback": {
        "from": "builtin-sqlite",
        "reason": "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite | No such built-in module: node:sqlite | ERR_UNKNOWN_BUILTIN_MODULE"
      },
      "custom": {
        "fallback": {
          "mode": "keyword",
          "reason": "SQLite support is unavailable in this Node runtime (missing node:sqlite). No such built-in module: node:sqlite | No such built-in module: node:sqlite | ERR_UNKNOWN_BUILTIN_MODULE"
        }
      }
    },
    "scan": {
      "sources": [
        {
          "source": "memory",
          "totalFiles": 2,
          "issues": []
        }
      ],
      "totalFiles": 2,
      "issues": []
    }
  }
]
```

`memory search "orbit ramen" --agent main --max-results 1 --json` returned a markdown memory result:

```json
{
  "results": [
    {
      "path": "memory/preferences.md",
      "startLine": 1,
      "endLine": 4,
      "score": 1,
      "textScore": 1,
      "snippet": "# Preferences\nFavorite ramen is shoyu.\nThe orbit codename is ORBIT-22.\n",
      "source": "memory"
    }
  ]
}
```

A no-match probe stayed empty instead of producing unrelated fallback hits:

```json
{
  "results": []
}
```

The daily-fix verification marker binds those files to the current PR head:

```json
{
  "head": "96d9ef309aead772a74e68e9aaece8021f94f7e2",
  "pending_diff_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
  "evidence_files": [
    "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-status.json",
    "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search.json",
    "/media/vdb/code/ai/aispace/openclaw-pr-93260-evidence/verify-search-empty.json"
  ]
}
```

- **Observed result after fix:** The OpenClaw CLI process reached the memory-core manager resolution path, classified the simulated `node:sqlite` load failure as `node-sqlite-unavailable`, returned a builtin `keyword-fallback` manager, scanned the isolated markdown memory corpus, returned `memory/preferences.md` with the `ORBIT-22` snippet for `orbit ramen`, and returned no rows for `notpresent`.
- **What was not tested:** Full gateway/UI behavior, semantic/vector ranking parity, indexed SQLite performance, session transcript search, QMD, embeddings, provider calls, live service APIs, and a separate physical Node build without `node:sqlite` were not tested. The proof instead uses a scoped preload to make `node:sqlite` unavailable at the memory index loader seam while preserving the rest of OpenClaw state startup, so the real CLI command can exercise this PR's production fallback path.
- **Fix classification:** Root cause fix

## Review findings addressed

- **RF-001:** Fixed for contributor-readiness purposes. ClawSweeper did not complete because of a Codex infrastructure/structured-output failure, so it produced no source-level author finding to patch. The PR now includes current-head real CLI behavior proof showing the no-`node:sqlite` path returns a degraded keyword fallback manager and markdown search results. A fresh ClawSweeper review or maintainer policy decision is still appropriate before merge because the prior bot review did not complete.

## Regression Test Plan

- **Target test file:** `extensions/memory-core/src/memory/search-manager.test.ts`
- **Scenario locked in:** The regression forces `MemoryIndexManager.get()` to throw the wrapped missing-`node:sqlite` error, then verifies `getMemorySearchManager()` returns a keyword fallback manager, searches a real `MEMORY.md` / `memory/*.md` fixture, emits fallback debug metadata, preserves path/line/snippet metadata, and avoids a direct `fs.readFile` fallback corpus path.
- **Why this is the smallest reliable guardrail:** The bug is at the memory-core manager-resolution seam, not in provider calls or gateway transport. The test isolates the exact SQLite initialization failure classification and the safe memory-file read boundary without requiring a live embedding provider or vector index.
- **Current-head CI:** GitHub checks are aligned to `96d9ef309aead772a74e68e9aaece8021f94f7e2`; CI, CodeQL Critical Quality, Dependency Guard, Real behavior proof, Workflow Sanity, OpenGrep PR Diff, iOS Periphery Dead Code, Labeler, Auto response, and ClawSweeper Dispatch are reported successful in the collected current-head checkout context.
- **New proof verification:** The no-`node:sqlite` CLI proof above was recorded against HEAD `96d9ef309aead772a74e68e9aaece8021f94f7e2` with clean git status and no pending source diff.

## Patch quality notes

- **Patch quality notes:** The fallback wording in the diff is intentional and narrow: it names a degraded manager that only activates for errors classified as missing `node:sqlite`; other builtin manager setup failures still surface unavailable metadata instead of being hidden.
- **Default returns:** Empty-result returns are limited to normal no-match/no-memory-source cases inside the degraded fallback search. They do not swallow SQLite initialization failures outside the explicit missing-`node:sqlite` classifier.
- **Filesystem boundary:** Fallback corpus reads go through `readMemoryFile`, preserving the existing memory host boundary for workspace paths, configured `extraPaths`, regular-file checks, line limits, and character limits.
- **Scope boundary:** This PR only changes `extensions/memory-core/src/memory/search-manager.ts` and its focused regression test. It does not alter provider routing, embedding calls, QMD, gateway transport, public tool schemas, public config schema, storage format, migrations, or runtime service APIs.
- **Architecture / source-of-truth check:** SQLite/vector indexing remains the source-of-truth search path when available. The keyword manager is a compatibility fallback for a known runtime capability gap and delegates allowed corpus access to existing memory host helpers.
- **Out-of-scope boundary:** Semantic/vector ranking parity, session transcript search, new public config, new schema fields, SDK export changes, migrations, provider/embedding behavior, QMD behavior, gateway/UI behavior, and live service APIs are intentionally out of scope.

## Merge risk

- **Risk labels considered:** `merge-risk: compatibility`, `merge-risk: availability`, and the local memory-file/source boundary.
- **Risk explanation:** The compatibility risk is the intentional response-shape change for the explicit missing-`node:sqlite` path: callers now see `provider: "keyword-fallback"` and markdown result rows instead of unavailable-manager metadata. The availability risk is that fallback searches scan configured markdown memory files on each search. The boundary risk is local memory-file access and memory result sourcing.
- **Why acceptable:** The changed behavior is limited to the explicit missing-`node:sqlite` runtime capability gap; runtimes with SQLite keep the existing indexed path. Fallback reads use `readMemoryFile`, results are source-scoped to memory files, bounded by `maxResults`, snippet-truncated, and marked with fallback debug/status metadata so callers can distinguish degraded keyword results from vector-backed search.

## Root Cause

- **Root cause:** The builtin memory search manager treated the missing `node:sqlite` runtime capability as a generic terminal setup failure, even though the invariant for durable memory is that readable markdown memory should remain available through the memory host file boundary when the indexed backend is unavailable for a known runtime capability gap.
- **Why this is root-cause fix:** The manager-resolution seam now classifies the explicit missing-`node:sqlite` failure at its source and returns a degraded keyword fallback manager for that runtime capability gap, while leaving unrelated manager setup failures as unavailable errors. The fallback corpus is read through existing memory-file helpers and reports degraded mode in runtime debug/status metadata, so the fix changes the source manager selection behavior rather than masking one downstream call site.
- **Maintainer-ready confidence:** Medium-high after the current-head no-`node:sqlite` CLI proof. The remaining decision is policy acceptance of degraded keyword fallback semantics and its compatibility/availability tradeoff.
- **Source-of-truth boundary:** SQLite/vector search remains canonical whenever `node:sqlite` is available. The fallback is not a new canonical ranking engine; it is a bounded compatibility path for markdown memory recall when the builtin SQLite dependency cannot load.
- **Compatibility / default behavior:** Runtimes where `node:sqlite` is available keep the existing SQLite/vector search behavior. Only the explicit missing-`node:sqlite` path changes response shape from unavailable metadata to `keyword-fallback` status and markdown result rows.
- **Availability tradeoff:** The fallback favors bounded local availability over semantic/vector quality and indexed performance when SQLite is absent; maintainers should explicitly accept that degraded behavior before merge.
- **Fix classification:** Root cause fix
- **Out-of-scope boundary:** Semantic/vector ranking parity, new public config, new schema fields, runtime service API changes, SDK export changes, migrations, provider/embedding behavior, QMD behavior, and session transcript search.
