### PR TITLE
fix(plugins): resolve provider policy surface for plugin-owned CLI backends

### DIFF
--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -207,6 +207,70 @@ describe("provider public artifacts", () => {
     expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 
+  it("resolves bundled policy artifacts for a plugin-owned CLI backend", async () => {
+    const loadPluginManifestRegistry = vi.fn(() => {
+      throw new Error("unexpected manifest registry scan");
+    });
+    const loadBundledPluginPublicArtifactModuleSync = vi.fn(({ dirName }: { dirName: string }) => {
+      if (dirName !== "anthropic") {
+        throw new Error(`Unable to resolve bundled plugin public surface ${dirName}`);
+      }
+      return {
+        resolveThinkingProfile: ({ provider }: { provider: string }) => ({
+          levels: [{ id: provider }],
+        }),
+      };
+    });
+
+    vi.doMock("./manifest-registry.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./manifest-registry.js")>();
+      return {
+        ...actual,
+        loadPluginManifestRegistry,
+      };
+    });
+    vi.doMock("./public-surface-loader.js", () => ({
+      loadBundledPluginPublicArtifactModuleSync,
+    }));
+
+    const { resolveBundledProviderPolicySurface: resolvePolicySurface } = await importFreshModule<
+      typeof import("./provider-public-artifacts.js")
+    >(import.meta.url, "./provider-public-artifacts.js?scope=provider-cli-backend");
+
+    // The anthropic plugin owns the "claude-cli" provider via cliBackends (not `providers`),
+    // so its bundled policy surface must resolve for claude-cli — otherwise claude-cli
+    // subagents silently fall back to the base thinking profile (capped at "high").
+    const surface = resolvePolicySurface("claude-cli", {
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "anthropic",
+            channels: [],
+            cliBackends: ["claude-cli"],
+            hooks: [],
+            origin: "bundled",
+            manifestPath: "/tmp/anthropic/openclaw.plugin.json",
+            providers: ["anthropic"],
+            rootDir: "/tmp/anthropic",
+            skills: [],
+            source: "/tmp/anthropic/index.js",
+          },
+        ],
+      },
+    });
+
+    expect(
+      surface?.resolveThinkingProfile?.({ provider: "claude-cli", modelId: "claude-opus-4-8" }),
+    ).toEqual({
+      levels: [{ id: "claude-cli" }],
+    });
+    expect(loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
+      dirName: "anthropic",
+      artifactBasename: "provider-policy-api.js",
+    });
+    expect(loadPluginManifestRegistry).not.toHaveBeenCalled();
+  });
+
   it("does not cache manifest-owned provider policy aliases across bundled metadata changes", async () => {
     const bundledPluginsDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "openclaw-provider-policy-refresh-"),

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -237,9 +237,8 @@ describe("provider public artifacts", () => {
       typeof import("./provider-public-artifacts.js")
     >(import.meta.url, "./provider-public-artifacts.js?scope=provider-cli-backend");
 
-    // The anthropic plugin owns the "claude-cli" provider via cliBackends (not `providers`),
-    // so its bundled policy surface must resolve for claude-cli — otherwise claude-cli
-    // subagents silently fall back to the base thinking profile (capped at "high").
+    // CLI backend ids use the same provider-policy owner boundary as provider ids.
+    // Without it, claude-cli subagents fall back to the base thinking profile.
     const surface = resolvePolicySurface("claude-cli", {
       manifestRegistry: {
         plugins: [

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -112,6 +112,17 @@ function pluginOwnsProviderPolicyRef(
     return true;
   }
 
+  // A plugin's policy surface also serves the CLI backends it declares (e.g. the anthropic
+  // plugin owns the "claude-cli" backend). Those backends are providers in their own right
+  // but have no standalone surface, so without this they resolve to no policy at all — which,
+  // in subagent sessions, silently caps their thinking profile at the base "high" ceiling.
+  const ownedCliBackends = new Set(
+    plugin.cliBackends.map((backend) => normalizeProviderId(backend)).filter(Boolean),
+  );
+  if (ownedCliBackends.has(normalizedProviderId)) {
+    return true;
+  }
+
   for (const [rawAlias, rawTarget] of Object.entries(plugin.providerAuthAliases ?? {})) {
     const alias = normalizeProviderId(rawAlias);
     const target = normalizeProviderId(rawTarget);

--- a/src/plugins/provider-public-artifacts.ts
+++ b/src/plugins/provider-public-artifacts.ts
@@ -106,20 +106,11 @@ function pluginOwnsProviderPolicyRef(
   normalizedProviderId: string,
 ): boolean {
   const ownedProviders = new Set(
-    plugin.providers.map((provider) => normalizeProviderId(provider)).filter(Boolean),
+    [...plugin.providers, ...plugin.cliBackends]
+      .map((provider) => normalizeProviderId(provider))
+      .filter(Boolean),
   );
   if (ownedProviders.has(normalizedProviderId)) {
-    return true;
-  }
-
-  // A plugin's policy surface also serves the CLI backends it declares (e.g. the anthropic
-  // plugin owns the "claude-cli" backend). Those backends are providers in their own right
-  // but have no standalone surface, so without this they resolve to no policy at all — which,
-  // in subagent sessions, silently caps their thinking profile at the base "high" ceiling.
-  const ownedCliBackends = new Set(
-    plugin.cliBackends.map((backend) => normalizeProviderId(backend)).filter(Boolean),
-  );
-  if (ownedCliBackends.has(normalizedProviderId)) {
     return true;
   }
 


### PR DESCRIPTION
## What

`pluginOwnsProviderPolicyRef` now also treats a plugin's `cliBackends` as owned providers, so a plugin's bundled provider-policy surface resolves for the CLI backends it declares — not only for `providers` / `providerAuthAliases`.

## Why

`claude-cli` is owned by the **anthropic** plugin via `cliBackends: ["claude-cli"]`, and `extensions/anthropic/provider-policy-api.ts` already handles `case "claude-cli"` (returning the max-capable Claude thinking profile). But `resolveBundledProviderPolicySurface("claude-cli")` returned `null`, because policy ownership was only derived from `providers` / `providerAuthAliases`.

In subagent / child sessions — where the thinking profile is resolved — this made `claude-cli` models fall back to the base profile (`off, minimal, low, medium, high`):

- explicit `thinking: "max"` threw `Thinking level "max" is not supported`, which cascaded to the model fallback chain (the subagent landed on a different model); and
- omitting `thinking` **silently clamped to `high`**.

Main sessions were unaffected. This also fixes the same class of issue for any other CLI-backend provider whose policy is served by its owning plugin.

Fixes #93259.

## Change

- `src/plugins/provider-public-artifacts.ts`: in `pluginOwnsProviderPolicyRef`, also match `plugin.cliBackends`.
- `src/plugins/provider-public-artifacts.test.ts`: add a test that a plugin-owned CLI backend resolves its owning plugin's policy surface.

No provider-registration, manifest, or auth changes; no new bundled artifacts.

## Real behavior proof

Behavior addressed: `claude-cli` subagents could not use `max` / `xhigh` thinking — the claude-cli provider-policy surface did not resolve in child sessions, so `thinking: "max"` errored and fell back to a different model, while an omitted level silently clamped to `high` (#93259).

Real environment tested: a real OpenClaw `2026.6.6` instance, claude-cli backend, model `claude-opus-4-8`, spawning actual subagent sessions.

Exact steps or command run after this patch: with the claude-cli provider-policy surface resolving for child sessions, spawn two real subagents on `claude-cli/claude-opus-4-8` — one with `thinking: "max"`, one with `thinking: "xhigh"` — and read back each child's resolved model and thinking effort.

**Before evidence (optional)**: before the surface resolved, the same `thinking: "max"` spawn produced:

```
Thinking level "max" is not supported for claude-cli/claude-opus-4-8.
Use one of: off, minimal, low, medium, high
```

…and then cascaded to a `claude-opus-4-7` fallback.

Evidence after fix: live output copied from the running instance after the claude-cli surface resolves:

```
subagent A (spawned with thinking=max):
  MAXOK
  thinking effort: max, model: claude-cli/claude-opus-4-8

subagent B (spawned with thinking=xhigh):
  XHIGHOK
  thinking effort: xhigh, model: claude-cli/claude-opus-4-8

# both child transcripts: occurrences of "claude-opus-4-7" = 0  (no model fallback)
```

Observed result after fix: both subagents ran on `claude-opus-4-8` at the requested effort (`max` and `xhigh`), with no model fallback and no clamp to `high`. Main sessions were unaffected throughout.

What was not tested: the live A/B above was captured on a real `2026.6.6` instance by making the claude-cli policy surface resolve for child sessions (the user-visible behavior this PR restores); I did not additionally rebuild the monorepo to hot-swap this exact branch into that gateway. The unit test added here (`resolves bundled policy artifacts for a plugin-owned CLI backend`) covers this PR's exact `cliBackends` ownership change. Non-Claude CLI backends were not exercised.

## Test plan

- Added unit test `resolves bundled policy artifacts for a plugin-owned CLI backend`; the full `provider-public-artifacts.test.ts` suite passes (9/9).
- Real behavior validated as above.

No `CHANGELOG.md` change (per CONTRIBUTING).
