### PR TITLE
fix(mattermost): wake agent on bare @bot mention [AI]

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.test.ts
@@ -1,6 +1,6 @@
 // Mattermost tests cover monitor helpers plugin behavior.
 import { describe, expect, it } from "vitest";
-import { normalizeMention } from "./monitor-helpers.js";
+import { normalizeMention, shouldDropEmptyNormalizedMattermostBody } from "./monitor-helpers.js";
 
 describe("normalizeMention", () => {
   it("returns trimmed text when no mention provided", () => {
@@ -79,5 +79,65 @@ describe("normalizeMention", () => {
     const input = "@echobot\n    code line 1\n    code line 2";
     const result = normalizeMention(input, "echobot");
     expect(result).toBe("    code line 1\n    code line 2");
+  });
+});
+
+describe("shouldDropEmptyNormalizedMattermostBody", () => {
+  it("drops truly empty posts with no bot mention", () => {
+    expect(
+      shouldDropEmptyNormalizedMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "   ",
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps group bare bot mentions after normalization clears the body", () => {
+    const rawText = "@openclaw";
+    expect(normalizeMention(rawText, "openclaw")).toBe("");
+    expect(
+      shouldDropEmptyNormalizedMattermostBody({
+        bodyText: "",
+        wasMentioned: true,
+        rawText,
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps direct bare bot mentions when wasMentioned is false", () => {
+    const rawText = "@openclaw";
+    expect(
+      shouldDropEmptyNormalizedMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText,
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
+  });
+
+  it("drops empty posts that mention someone else but not the bot", () => {
+    expect(
+      shouldDropEmptyNormalizedMattermostBody({
+        bodyText: "",
+        wasMentioned: false,
+        rawText: "@alice",
+        botUsername: "openclaw",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not drop when normalized body still has text", () => {
+    expect(
+      shouldDropEmptyNormalizedMattermostBody({
+        bodyText: "hello",
+        wasMentioned: false,
+        rawText: "@openclaw hello",
+        botUsername: "openclaw",
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor-helpers.ts
+++ b/extensions/mattermost/src/mattermost/monitor-helpers.ts
@@ -53,3 +53,25 @@ export function normalizeMention(text: string, mention: string | undefined): str
 
   return normalizedLines.map((line) => line.text).join("\n");
 }
+
+/** True when an inbound post should be dropped after mention normalization left no body text. */
+export function shouldDropEmptyNormalizedMattermostBody(params: {
+  bodyText: string;
+  wasMentioned: boolean;
+  rawText: string;
+  botUsername?: string;
+}): boolean {
+  if (params.bodyText.trim()) {
+    return false;
+  }
+  if (params.wasMentioned) {
+    return false;
+  }
+  const botUsername = params.botUsername?.trim();
+  if (!botUsername) {
+    return true;
+  }
+  const normalizedRaw = params.rawText.toLowerCase();
+  const normalizedBot = botUsername.toLowerCase();
+  return !normalizedRaw.includes(`@${normalizedBot}`);
+}

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -445,6 +445,52 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.Provider).toBe("mattermost");
   });
 
+  it("dispatches bare bot mentions with empty normalized body as wake events", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-bare-mention",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "@openclaw",
+          create_at: 1_714_000_000_001,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.BodyForAgent).toBe("");
+    expect(ctx?.MessageSid).toBe("post-bare-mention");
+  });
+
   it("merges Mattermost progress preview updates by line identity", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -69,6 +69,7 @@ import {
   formatInboundFromLabel,
   normalizeMention,
   resolveThreadSessionKeys,
+  shouldDropEmptyNormalizedMattermostBody,
 } from "./monitor-helpers.js";
 import { resolveOncharPrefixes, stripOncharPrefix } from "./monitor-onchar.js";
 import { createMattermostMonitorResources, type MattermostMediaInfo } from "./monitor-resources.js";
@@ -1526,9 +1527,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
         const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();
         const bodyText = normalizeMention(baseText, botUsername);
-        if (!bodyText) {
+        if (
+          shouldDropEmptyNormalizedMattermostBody({
+            bodyText,
+            wasMentioned,
+            rawText,
+            botUsername,
+          })
+        ) {
           logVerboseMessage(
-            `mattermost: drop group message (empty body after normalization channel=${channelId} sender=${senderId})`,
+            `mattermost: drop message (empty body after normalization channel=${channelId} sender=${senderId} wasMentioned=${wasMentioned})`,
           );
           return;
         }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Mattermost posts whose only content is a bare `@bot` mention were silently dropped after `normalizeMention` stripped the mention and left an empty body.

Why does this matter now?

- Issue #93205: users naturally send `@openclaw` alone to wake a stalled bot, but the empty-body guard returned before dispatch.

What is the intended outcome?

- Bare bot mentions wake the agent with an empty prompt; truly empty unmentioned posts still drop.

What is intentionally out of scope?

- No changes to `post_edited` mention handling (#71930), thread mention policy (#57846), or thread-history backfill (#93204).
- No new config flags or core dispatch changes.

What does success look like?

- Group and DM inbound posts containing only `@botUsername` reach `dispatchReplyFromConfig`; whitespace-only posts without a bot mention still drop.

What should reviewers focus on?

- `extensions/mattermost/src/mattermost/monitor-helpers.ts` (`shouldDropEmptyNormalizedMattermostBody`)
- `extensions/mattermost/src/mattermost/monitor.ts` empty-body guard
- Regression tests in `monitor-helpers.test.ts` and `monitor.inbound-system-event.test.ts`

## Linked context

Which issue does this close?

Closes #93205

Which issues, PRs, or discussions are related?

Related #65729

Was this requested by a maintainer or owner?

- ClawSweeper marked queueable-fix / fix-shape-clear / source-repro with focused extension vitest acceptance criteria.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: bare `@openclaw` Mattermost posts no longer hit the empty-body early return when the user intentionally mentioned the bot.
- Real environment tested: local OpenClaw checkout on branch `fix/issue-93205-bare-mention`, Mattermost extension vitest harness with mocked WebSocket inbound posts.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-helpers.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts extensions/mattermost/src/mattermost/monitor.test.ts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "proof": "mattermost-bare-mention-wake",
  "test": "dispatches bare bot mentions with empty normalized body as wake events",
  "inputMessage": "@openclaw",
  "dispatchCalled": true,
  "bodyForAgent": "",
  "messageSid": "post-bare-mention"
}
```

- Observed result after fix: inbound harness dispatches once for `@openclaw` with `BodyForAgent === ""`; helper tests confirm empty unmentioned posts still drop.
- What was not tested: live Mattermost workspace / real WebSocket gateway session.
- Proof limitations or environment constraints: L2 extension vitest only; no live Mattermost server proof.
- Before evidence (optional but encouraged): prior guard used `if (!bodyText) return`, so mention-only posts never reached dispatch.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor-helpers.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts extensions/mattermost/src/mattermost/monitor.test.ts` — 86 passed
- `pnpm exec oxfmt --check extensions/mattermost/src/mattermost/monitor-helpers.ts extensions/mattermost/src/mattermost/monitor-helpers.test.ts extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts` — passed
- `pnpm check:test-types` — passed (via pre-push gate)

What regression coverage was added or updated?

- `shouldDropEmptyNormalizedMattermostBody` unit cases (group mention, DM raw @bot, unrelated @user, non-empty body)
- Inbound integration test: WebSocket `@openclaw` post dispatches with empty `BodyForAgent`

What failed before this fix, if known?

- `shouldDropEmptyNormalizedMattermostBody is not a function` during RED; after fix all 86 extension tests pass.

If no test was added, why not?

- N/A — tests added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — bare bot mentions now wake the agent instead of being silently dropped.

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

- Accidentally dispatching on empty posts that should remain dropped (no bot mention).

How is that risk mitigated?

- Helper requires `wasMentioned` or raw text containing `@botUsername`; unrelated empty posts and `@otheruser`-only posts still drop; regression tests cover both paths.

## Current review state

What is the next action?

- **阻塞**：需要真实 Mattermost 环境证明（ClawSweeper 要求）
- **下一步**：添加真实 Mattermost 证据，显示裸机器人提及能唤醒代理，而空白或不相关的空帖子仍然被丢弃

What is still waiting on author, maintainer, CI, or external proof?

- **作者**：需要提供真实 Mattermost 环境证明
- **维护者**：等待审查和合并
- **CI**：全部通过
- **外部证明**：需要真实 Mattermost 服务器证明

Which bot or reviewer comments were addressed?

- Implements ClawSweeper #93205 acceptance criteria (extension vitest files listed in issue review).
- **ClawSweeper 反馈**：需要真实行为证明 before merge
- **评级**：🦪 silver shellfish（薄信号；证据、验证或实现需要改进）
- **合并风险**：🚨 message-delivery（更改了空规范化 Mattermost 帖子的分发逻辑，且缺少实时传输证明）

## 补充证明信息

### 证明限制说明

由于环境限制，无法提供真实 Mattermost 服务器证明。当前证明级别为 **L2（helper + extension vitest）**。

### 代码变更分析

1. **monitor-helpers.ts**：
   - 新增 `shouldDropEmptyNormalizedMattermostBody` 函数
   - 逻辑：如果 `wasMentioned` 为 true，或者原始文本包含 `@botUsername`，则不丢弃
   - 保持对真正空消息的丢弃行为

2. **monitor.ts**：
   - 替换原来的 `if (!bodyText) return` 为 `shouldDropEmptyNormalizedMattermostBody` 调用
   - 保持相同的分发逻辑，仅改变空消息判断

### 测试覆盖

1. **单元测试**（monitor-helpers.test.ts）：
   - 群组裸 `@echobot` → 不丢弃
   - DM 裸 `@echobot` → 不丢弃
   - `@otheruser` 无 bot mention → 丢弃
   - 空字符串、仅空白 → 丢弃
   - 非空消息 → 不丢弃

2. **集成测试**（monitor.inbound-system-event.test.ts）：
   - WebSocket `@openclaw` 帖子 → 分发，`BodyForAgent === ""`

### 建议验证方案

**维护者验证步骤**：
1. 在 Mattermost 中创建测试频道
2. 仅发送 `@botUsername`（无其他内容）
3. 验证 bot 被唤醒并响应
4. 发送空白消息或仅空格的消息
5. 验证 bot 不响应

**替代证明方案**：
- 提供 Mattermost WebSocket 日志片段（如可访问）
- 提供 OpenClaw 运行时日志片段（如可访问）
- 维护者在本地环境验证

### 风险缓解

1. **误分发空消息**：
   - 辅助函数要求 `wasMentioned` 或原始文本包含 `@botUsername`
   - 不相关的空帖子和 `@otheruser` 帖子仍被丢弃
   - 回归测试覆盖两条路径

2. **向后兼容性**：
   - 仅改变空消息判断逻辑
   - 不影响其他消息处理流程
   - 不改变配置或核心分发逻辑