### PR TITLE
fix(session-memory): skip delivery-mirror entries and dedup consecutive identical assistant messages (#92563)

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -813,7 +813,38 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Only message 2");
   });
 
-  it("skips delivery-mirror assistant messages (#92563)", async () => {
+  it("preserves standalone delivery-mirror replies with different text (#92563)", async () => {
+    const sessionContent = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "A reply" }],
+        },
+      }),
+      // Standalone delivery-mirror with different visible text — should be preserved
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "A different reply" }],
+          provider: "openclaw",
+          model: "delivery-mirror",
+        },
+      }),
+    ].join("\n");
+    const memoryContent = await readSessionTranscript({ sessionContent });
+
+    expect(memoryContent).toContain("assistant: A reply");
+    expect(memoryContent).toContain("assistant: A different reply");
+  });
+
+  it("dedupes delivery-mirror that duplicates preceding assistant text (#92563)", async () => {
+    // Same text as previous assistant → should be deduped.
     const sessionContent = [
       JSON.stringify({
         type: "message",
@@ -826,7 +857,7 @@ describe("session-memory hook", () => {
           content: [{ type: "text", text: "Hi there" }],
         },
       }),
-      // delivery-mirror duplicates the visible text and should be skipped
+      // delivery-mirror with the same visible text → deduped
       JSON.stringify({
         type: "message",
         message: {
@@ -841,7 +872,6 @@ describe("session-memory hook", () => {
 
     expect(memoryContent).toContain("user: Hello");
     expect(memoryContent).toContain("assistant: Hi there");
-    // Should appear exactly once
     const matches = (memoryContent?.match(/assistant: Hi there/g) ?? []).length;
     expect(matches).toBe(1);
   });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -924,4 +924,21 @@ describe("session-memory hook", () => {
     const assistantLines = (memoryContent?.match(/^assistant:/gm) ?? []).length;
     expect(assistantLines).toBe(2);
   });
+
+  it("keeps repeated assistant reply after an intervening visible user message (#92563)", async () => {
+    // Same assistant text across different turns should NOT be deduped.
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Question A" },
+      { role: "assistant", content: "OK" },
+      { role: "user", content: "Question B" },
+      { role: "assistant", content: "OK" },
+    ]);
+    const memoryContent = await readSessionTranscript({ sessionContent });
+
+    expect(memoryContent).toContain("user: Question A");
+    expect(memoryContent).toContain("assistant: OK");
+    expect(memoryContent).toContain("user: Question B");
+    const okCount = (memoryContent?.match(/assistant: OK/g) ?? []).length;
+    expect(okCount).toBe(2);
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -812,4 +812,86 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
   });
+
+  it("skips delivery-mirror assistant messages (#92563)", async () => {
+    const sessionContent = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hi there" }],
+        },
+      }),
+      // delivery-mirror duplicates the visible text and should be skipped
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hi there" }],
+          provider: "openclaw",
+          model: "delivery-mirror",
+        },
+      }),
+    ].join("\n");
+    const memoryContent = await readSessionTranscript({ sessionContent });
+
+    expect(memoryContent).toContain("user: Hello");
+    expect(memoryContent).toContain("assistant: Hi there");
+    // Should appear exactly once
+    const matches = (memoryContent?.match(/assistant: Hi there/g) ?? []).length;
+    expect(matches).toBe(1);
+  });
+
+  it("dedupes consecutive identical assistant messages (#92563)", async () => {
+    const sessionContent = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "question" },
+      }),
+      // Raw thinking message
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Let me think..." },
+            { type: "text", text: "Here is the answer" },
+          ],
+        },
+      }),
+      // Cleaned copy (same visible text)
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Here is the answer" }],
+        },
+      }),
+    ].join("\n");
+    const memoryContent = await readSessionTranscript({ sessionContent });
+
+    expect(memoryContent).toContain("user: question");
+    expect(memoryContent).toContain("assistant: Here is the answer");
+    const matches = (memoryContent?.match(/assistant: Here is the answer/g) ?? []).length;
+    expect(matches).toBe(1);
+  });
+
+  it("keeps consecutive assistant messages with different text", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "Reply A" },
+      { role: "user", content: "second" },
+      { role: "assistant", content: "Reply B" },
+    ]);
+    const memoryContent = await readSessionTranscript({ sessionContent });
+
+    expect(memoryContent).toContain("assistant: Reply A");
+    expect(memoryContent).toContain("assistant: Reply B");
+    const assistantLines = (memoryContent?.match(/^assistant:/gm) ?? []).length;
+    expect(assistantLines).toBe(2);
+  });
 });

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -40,26 +40,18 @@ export async function getRecentSessionContent(
             role?: unknown;
             content?: unknown;
             provenance?: unknown;
-            provider?: unknown;
-            model?: unknown;
           };
           const role = msg.role;
           if ((role === "user" || role === "assistant") && "content" in msg && msg.content) {
-            // Delivery-mirror entries duplicate the visible text of the preceding
-            // assistant message and should not appear in session memory summaries.
-            if (
-              role === "assistant" &&
-              msg.provider === "openclaw" &&
-              msg.model === "delivery-mirror"
-            ) {
-              continue;
-            }
             if (role === "user" && hasInterSessionUserProvenance(msg)) {
               continue;
             }
             const text = extractTextMessageContent(msg.content);
             if (text && !text.startsWith("/")) {
               // Dedupe consecutive assistant messages with identical text.
+              // Thinking-enabled models produce raw (thinking + text) and
+              // cleaned (text-only) copies in the same turn; delivery mirrors
+              // can also repeat the visible text of the preceding assistant.
               if (role === "assistant" && text === lastAssistantText) {
                 continue;
               }

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -47,17 +47,18 @@ export async function getRecentSessionContent(
               continue;
             }
             const text = extractTextMessageContent(msg.content);
+            // Only dedupe consecutive assistant rows so a reply from a different
+            // turn that happens to repeat the same text is still included.
             if (text && !text.startsWith("/")) {
-              // Dedupe consecutive assistant messages with identical text.
-              // Thinking-enabled models produce raw (thinking + text) and
-              // cleaned (text-only) copies in the same turn; delivery mirrors
-              // can also repeat the visible text of the preceding assistant.
-              if (role === "assistant" && text === lastAssistantText) {
-                continue;
-              }
-              allMessages.push(`${role}: ${text}`);
               if (role === "assistant") {
+                if (text === lastAssistantText) {
+                  continue;
+                }
+                allMessages.push(`assistant: ${text}`);
                 lastAssistantText = text;
+              } else {
+                allMessages.push(`${role}: ${text}`);
+                lastAssistantText = undefined;
               }
             }
           }

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -31,6 +31,7 @@ export async function getRecentSessionContent(
     const lines = content.trim().split("\n");
 
     const allMessages: string[] = [];
+    let lastAssistantText: string | undefined;
     for (const line of lines) {
       try {
         const entry = JSON.parse(line);
@@ -39,15 +40,33 @@ export async function getRecentSessionContent(
             role?: unknown;
             content?: unknown;
             provenance?: unknown;
+            provider?: unknown;
+            model?: unknown;
           };
           const role = msg.role;
           if ((role === "user" || role === "assistant") && "content" in msg && msg.content) {
+            // Delivery-mirror entries duplicate the visible text of the preceding
+            // assistant message and should not appear in session memory summaries.
+            if (
+              role === "assistant" &&
+              msg.provider === "openclaw" &&
+              msg.model === "delivery-mirror"
+            ) {
+              continue;
+            }
             if (role === "user" && hasInterSessionUserProvenance(msg)) {
               continue;
             }
             const text = extractTextMessageContent(msg.content);
             if (text && !text.startsWith("/")) {
+              // Dedupe consecutive assistant messages with identical text.
+              if (role === "assistant" && text === lastAssistantText) {
+                continue;
+              }
               allMessages.push(`${role}: ${text}`);
+              if (role === "assistant") {
+                lastAssistantText = text;
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

`getRecentSessionContent` 未对 consecutive assistant 消息做去重，导致
thinking 模型的 raw(thinking+text) 和 cleaned(text-only) 消息在 session
memory 中产生重复行。

**修复：** 连续相同文本的 assistant 消息仅保留第一条，遇到 user 消息重置状态。

Fixes #92563

## Verification

### vitest: 28/28 通过

```
 ✓ preserves standalone delivery-mirror replies with different text (#92563)
 ✓ dedupes delivery-mirror that duplicates preceding assistant text (#92563)
 ✓ dedupes consecutive identical assistant messages (#92563)
 ✓ keeps repeated assistant reply after an intervening visible user message (#92563)
```

### 修复前 vs 修复后对比

```
修复前（无去重）                          修复后（有去重）
user: 帮我看看今天天气                    user: 帮我看看今天天气
assistant: 请告诉我你所在的城市... ←raw    assistant: 请告诉我你所在的城市...  ← 一条
assistant: 请告诉我你所在的城市... ←重复   user: 上海
user: 上海                                assistant: 上海今天多云...
assistant: 上海今天多云...

"请告诉我你所在的城市" 出现: 2 次 ❌        "请告诉我你所在的城市" 出现: 1 次 ✅
assistant 行数: 3                          assistant 行数: 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)