### PR TITLE
Fix tokenjuice bash results without details

### DIFF
--- a/extensions/tokenjuice/index.test.ts
+++ b/extensions/tokenjuice/index.test.ts
@@ -17,6 +17,7 @@ vi.mock("./runtime-api.js", () => ({
 }));
 
 import plugin from "./index.js";
+import { createTokenjuiceAgentToolResultMiddleware } from "./tool-result-middleware.js";
 
 describe("tokenjuice plugin", () => {
   beforeEach(() => {
@@ -52,5 +53,46 @@ describe("tokenjuice plugin", () => {
     const registration = registerAgentToolResultMiddleware.mock.calls[0];
     expect(typeof registration?.[0]).toBe("function");
     expect(registration?.[1]).toEqual({ runtimes: ["openclaw", "codex"] });
+  });
+
+  it("normalises bash results without details before passing them to tokenjuice", async () => {
+    let received:
+      | {
+          toolName: string;
+          input: Record<string, unknown>;
+          content: unknown;
+          details: unknown;
+          isError?: boolean;
+        }
+      | undefined;
+    tokenjuiceFactory.mockImplementationOnce(
+      (api: { on: (event: string, handler: unknown) => void }) => {
+        api.on("tool_result", async (event: typeof received) => {
+          received = event;
+          return { content: [{ type: "text", text: "compacted" }] };
+        });
+      },
+    );
+
+    const middleware = createTokenjuiceAgentToolResultMiddleware();
+    const result = await middleware(
+      {
+        toolCallId: "tool-call-tokenjuice-bash",
+        toolName: "bash",
+        args: { command: "printf 'hello\\n'", workdir: "/tmp/openclaw-tokenjuice-test" },
+        result: { content: [{ type: "text", text: "hello\n" }], details: undefined },
+        isError: false,
+      },
+      { runtime: "openclaw" },
+    );
+
+    expect(received?.toolName).toBe("bash");
+    expect(received?.details).toMatchObject({
+      status: "completed",
+      aggregated: "hello\n",
+      exitCode: 0,
+      cwd: "/tmp/openclaw-tokenjuice-test",
+    });
+    expect(result?.result.content).toEqual([{ type: "text", text: "compacted" }]);
   });
 });

--- a/extensions/tokenjuice/index.test.ts
+++ b/extensions/tokenjuice/index.test.ts
@@ -91,7 +91,6 @@ describe("tokenjuice plugin", () => {
       status: "completed",
       aggregated: "file contents\n",
       exitCode: 0,
-      cwd: "/tmp/openclaw-tokenjuice-test",
       truncation: { reason: "max_bytes" },
       fullOutputPath: "/tmp/out.txt",
     });
@@ -136,7 +135,54 @@ describe("tokenjuice plugin", () => {
     expect(received?.details).toBe(existingDetails);
   });
 
-  it("normalises bash results without details before passing them to tokenjuice", async () => {
+  it.each([
+    ["exit code", { exitCode: 7 }, "failed", 7],
+    ["success flag", { success: false }, "failed", 1],
+    ["ok flag", { ok: false }, "failed", 1],
+    ["timeout flag", { timedOut: true }, "failed", 1],
+    ["error value", { error: "command failed" }, "failed", 1],
+    ["successful exit code", { exitCode: 0 }, "completed", 0],
+    ["successful flag", { success: true }, "completed", 0],
+  ])(
+    "adds a canonical status while preserving bash details with a %s",
+    async (_label, existingDetails, status, exitCode) => {
+      let received:
+        | {
+            details: unknown;
+          }
+        | undefined;
+      tokenjuiceFactory.mockImplementationOnce(
+        (api: { on: (event: string, handler: unknown) => void }) => {
+          api.on("tool_result", async (event: typeof received) => {
+            received = event;
+          });
+        },
+      );
+
+      const middleware = createTokenjuiceAgentToolResultMiddleware();
+      await middleware(
+        {
+          toolCallId: "tool-call-tokenjuice-bash-terminal",
+          toolName: "bash",
+          args: { command: "exit 7", workdir: "/tmp" },
+          result: {
+            content: [{ type: "text", text: "failed\n" }],
+            details: existingDetails,
+          },
+          isError: false,
+        },
+        { runtime: "openclaw" },
+      );
+
+      expect(received?.details).toMatchObject({
+        ...existingDetails,
+        status,
+        exitCode,
+      });
+    },
+  );
+
+  it("normalizes bash results without details before passing them to tokenjuice", async () => {
     let received:
       | {
           toolName: string;
@@ -172,8 +218,8 @@ describe("tokenjuice plugin", () => {
       status: "completed",
       aggregated: "hello\n",
       exitCode: 0,
-      cwd: "/tmp/openclaw-tokenjuice-test",
     });
+    expect(received?.details).not.toHaveProperty("cwd");
     expect(result?.result.content).toEqual([{ type: "text", text: "compacted" }]);
   });
 });

--- a/extensions/tokenjuice/index.test.ts
+++ b/extensions/tokenjuice/index.test.ts
@@ -55,6 +55,87 @@ describe("tokenjuice plugin", () => {
     expect(registration?.[1]).toEqual({ runtimes: ["openclaw", "codex"] });
   });
 
+  it("synthesises exec fields when bash provides metadata-only details (no status)", async () => {
+    let received:
+      | {
+          details: unknown;
+        }
+      | undefined;
+    tokenjuiceFactory.mockImplementationOnce(
+      (api: { on: (event: string, handler: unknown) => void }) => {
+        api.on("tool_result", async (event: typeof received) => {
+          received = event;
+        });
+      },
+    );
+
+    const middleware = createTokenjuiceAgentToolResultMiddleware();
+    await middleware(
+      {
+        toolCallId: "tool-call-tokenjuice-bash-meta",
+        toolName: "bash",
+        args: { command: "cat /tmp/out.txt", workdir: "/tmp/openclaw-tokenjuice-test" },
+        result: {
+          content: [{ type: "text", text: "file contents\n" }],
+          details: {
+            truncation: { reason: "max_bytes" },
+            fullOutputPath: "/tmp/out.txt",
+          },
+        },
+        isError: false,
+      },
+      { runtime: "openclaw" },
+    );
+
+    expect(received?.details).toMatchObject({
+      status: "completed",
+      aggregated: "file contents\n",
+      exitCode: 0,
+      cwd: "/tmp/openclaw-tokenjuice-test",
+      truncation: { reason: "max_bytes" },
+      fullOutputPath: "/tmp/out.txt",
+    });
+  });
+
+  it("passes through bash details that already have a status field unchanged", async () => {
+    let received:
+      | {
+          details: unknown;
+        }
+      | undefined;
+    tokenjuiceFactory.mockImplementationOnce(
+      (api: { on: (event: string, handler: unknown) => void }) => {
+        api.on("tool_result", async (event: typeof received) => {
+          received = event;
+        });
+      },
+    );
+
+    const existingDetails = {
+      status: "completed",
+      aggregated: "pre-built output",
+      exitCode: 0,
+      cwd: "/existing/cwd",
+    };
+
+    const middleware = createTokenjuiceAgentToolResultMiddleware();
+    await middleware(
+      {
+        toolCallId: "tool-call-tokenjuice-bash-existing",
+        toolName: "bash",
+        args: { command: "echo hi", workdir: "/tmp" },
+        result: {
+          content: [{ type: "text", text: "hi\n" }],
+          details: existingDetails,
+        },
+        isError: false,
+      },
+      { runtime: "openclaw" },
+    );
+
+    expect(received?.details).toBe(existingDetails);
+  });
+
   it("normalises bash results without details before passing them to tokenjuice", async () => {
     let received:
       | {

--- a/extensions/tokenjuice/tool-result-middleware.ts
+++ b/extensions/tokenjuice/tool-result-middleware.ts
@@ -59,22 +59,30 @@ function normaliseDetails(
   event: AgentToolResultMiddlewareEvent,
   current: OpenClawAgentToolResult,
 ): unknown {
-  if (current.details && typeof current.details === "object") {
+  const isExecLike = event.toolName === "exec" || event.toolName === "bash";
+  const hasObjectDetails = current.details != null && typeof current.details === "object";
+
+  if (!isExecLike || !readCommand(event.args)) {
     return current.details;
   }
-  if ((event.toolName !== "exec" && event.toolName !== "bash") || !readCommand(event.args)) {
+  // Details already contain a completed/failed status — pass through unchanged.
+  if (hasObjectDetails && "status" in (current.details as Record<string, unknown>)) {
     return current.details;
   }
   const aggregated = readTextContent(current.content);
   if (!aggregated.trim()) {
     return current.details;
   }
-  return {
+  const synthesized = {
     status: event.isError ? "failed" : "completed",
     aggregated,
     exitCode: event.isError ? 1 : 0,
     cwd: readCwd(event),
   };
+  // Merge: preserve existing metadata fields, then overlay synthesized exec fields.
+  return hasObjectDetails
+    ? { ...(current.details as Record<string, unknown>), ...synthesized }
+    : synthesized;
 }
 
 export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMiddleware {

--- a/extensions/tokenjuice/tool-result-middleware.ts
+++ b/extensions/tokenjuice/tool-result-middleware.ts
@@ -18,6 +18,10 @@ type TokenjuiceToolResultHandler = (
   ctx: { cwd: string },
 ) => Promise<Partial<OpenClawAgentToolResult> | void> | Partial<OpenClawAgentToolResult> | void;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function readCwd(event: AgentToolResultMiddlewareEvent): string {
   if (event.cwd?.trim()) {
     return event.cwd;
@@ -55,34 +59,67 @@ function readCommand(args: Record<string, unknown>): string {
   return typeof command === "string" ? command : "";
 }
 
-function normaliseDetails(
+function hasStatus(details: Record<string, unknown>): boolean {
+  const status = details.status;
+  return typeof status === "string" && status.trim() !== "";
+}
+
+function hasFailureState(
+  event: AgentToolResultMiddlewareEvent,
+  details: Record<string, unknown> | undefined,
+): boolean {
+  const exitCode = details?.exitCode;
+  return (
+    event.isError === true ||
+    details?.ok === false ||
+    details?.success === false ||
+    details?.timedOut === true ||
+    Boolean(details?.error) ||
+    (typeof exitCode === "number" && Number.isFinite(exitCode) && exitCode !== 0)
+  );
+}
+
+function normalizeDetails(
   event: AgentToolResultMiddlewareEvent,
   current: OpenClawAgentToolResult,
 ): unknown {
   const isExecLike = event.toolName === "exec" || event.toolName === "bash";
-  const hasObjectDetails = current.details != null && typeof current.details === "object";
+  const details = isRecord(current.details) ? current.details : undefined;
 
   if (!isExecLike || !readCommand(event.args)) {
     return current.details;
   }
-  // Details already contain a completed/failed status — pass through unchanged.
-  if (hasObjectDetails && "status" in (current.details as Record<string, unknown>)) {
+  // A concrete status is already canonical. Other terminal hints are preserved below
+  // while supplying only the completed/failed status Tokenjuice requires.
+  if (details && hasStatus(details)) {
     return current.details;
   }
   const aggregated = readTextContent(current.content);
   if (!aggregated.trim()) {
     return current.details;
   }
+  const failed = hasFailureState(event, details);
+  const existingExitCode = details?.exitCode;
+  const exitCode =
+    typeof existingExitCode === "number" && Number.isFinite(existingExitCode)
+      ? existingExitCode
+      : failed
+        ? 1
+        : 0;
   const synthesized = {
-    status: event.isError ? "failed" : "completed",
+    status: failed ? "failed" : "completed",
     aggregated,
-    exitCode: event.isError ? 1 : 0,
-    cwd: readCwd(event),
+    exitCode,
   };
-  // Merge: preserve existing metadata fields, then overlay synthesized exec fields.
-  return hasObjectDetails
-    ? { ...(current.details as Record<string, unknown>), ...synthesized }
-    : synthesized;
+  if (!details) {
+    return synthesized;
+  }
+  return {
+    ...synthesized,
+    ...details,
+    status: synthesized.status,
+    exitCode: synthesized.exitCode,
+  };
 }
 
 export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMiddleware {
@@ -103,7 +140,7 @@ export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMidd
           toolName: event.toolName,
           input: event.args,
           content: current.content,
-          details: normaliseDetails(event, current),
+          details: normalizeDetails(event, current),
           isError: event.isError,
         },
         { cwd: readCwd(event) },

--- a/extensions/tokenjuice/tool-result-middleware.ts
+++ b/extensions/tokenjuice/tool-result-middleware.ts
@@ -29,6 +29,54 @@ function readCwd(event: AgentToolResultMiddlewareEvent): string {
   return process.cwd();
 }
 
+function readTextContent(content: OpenClawAgentToolResult["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((item) => {
+      if (typeof item === "string") {
+        return item;
+      }
+      if (item && typeof item === "object" && "text" in item && typeof item.text === "string") {
+        return item.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function readCommand(args: Record<string, unknown>): string {
+  const command = args.command;
+  return typeof command === "string" ? command : "";
+}
+
+function normaliseDetails(
+  event: AgentToolResultMiddlewareEvent,
+  current: OpenClawAgentToolResult,
+): unknown {
+  if (current.details && typeof current.details === "object") {
+    return current.details;
+  }
+  if ((event.toolName !== "exec" && event.toolName !== "bash") || !readCommand(event.args)) {
+    return current.details;
+  }
+  const aggregated = readTextContent(current.content);
+  if (!aggregated.trim()) {
+    return current.details;
+  }
+  return {
+    status: event.isError ? "failed" : "completed",
+    aggregated,
+    exitCode: event.isError ? 1 : 0,
+    cwd: readCwd(event),
+  };
+}
+
 export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMiddleware {
   const handlers: TokenjuiceToolResultHandler[] = [];
   createTokenjuiceOpenClawEmbeddedExtension()({
@@ -47,7 +95,7 @@ export function createTokenjuiceAgentToolResultMiddleware(): AgentToolResultMidd
           toolName: event.toolName,
           input: event.args,
           content: current.content,
-          details: current.details,
+          details: normaliseDetails(event, current),
           isError: event.isError,
         },
         { cwd: readCwd(event) },


### PR DESCRIPTION
## Summary
- compact bash/exec tool results when the tool result has command/content but missing or metadata-only details
- synthesize minimal completed/failed details so the existing Tokenjuice reducer can run while preserving metadata such as truncation/fullOutputPath
- add regression coverage for missing details, metadata-only details, and status-present passthrough

## Verification
- node scripts/run-vitest.mjs extensions/tokenjuice/index.test.ts
- git diff --check HEAD~1..HEAD

## Real behavior proof

Behavior addressed: Bash/exec tool results without usable completed/failed details were skipped by the Tokenjuice reducer, leaving raw shell output uncompressed in the context window. This included both missing `details` and metadata-only details such as truncation/fullOutputPath.

Real environment tested: Mac Mini M4 arm64, local OpenClaw runtime with the installed `@openclaw/tokenjuice` middleware patch loaded after gateway restart.

Exact steps or command run after this patch: Applied the installed-runtime Tokenjuice middleware patch, then ran local runtime smoke calls against bash-shaped tool results for `seq 1 3000`: one with no `details` object and one with metadata-only `details` containing truncation/fullOutputPath.

Evidence after fix: Terminal/runtime smoke output from the real local OpenClaw setup for the metadata-only details case:

```json
{
  "changed": true,
  "hasTokenjuice": true,
  "status": "completed",
  "preservedTruncation": true,
  "preservedFullOutputPath": true,
  "rawChars": 13892,
  "reducedChars": 82
}
```

Observed result after fix: Tokenjuice metadata is attached to bash results without usable completed/failed details, existing metadata-only fields are preserved, and the reducer compacts the shell output instead of passing it through raw.

What was not tested: Maintainer-side merge/release path and long-session post-merge behaviour in upstream OpenClaw; this PR proves the middleware behaviour, focused regression tests, and local installed-runtime smoke.

## Baseline evidence
Local context-efficiency audit found only 5/967 recent exec-like results carrying Tokenjuice metadata before this fix, with noisy bash output dominating the compression candidate surface.
