### PR TITLE
fix(agents): prefer identity.name over agent slot id in Runtime prompt line (fixes #81269)

### DIFF
--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -106,6 +106,61 @@ describe("buildSystemPromptParams", () => {
     expect(runtimeInfo.repoRoot).toBeUndefined();
   });
 
+  it("threads identity.name into runtimeInfo when configured", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+            identity: { name: "Runt", emoji: "⚓" },
+          },
+        ],
+      },
+    };
+
+    const { runtimeInfo } = buildSystemPromptParams({
+      config,
+      agentId: "main",
+      runtime: {
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(runtimeInfo.agentId).toBe("main");
+    expect(runtimeInfo.identityName).toBe("Runt");
+  });
+
+  it("leaves identityName undefined when identity.name is not configured", () => {
+    const config: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "main",
+          },
+        ],
+      },
+    };
+
+    const { runtimeInfo } = buildSystemPromptParams({
+      config,
+      agentId: "main",
+      runtime: {
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(runtimeInfo.agentId).toBe("main");
+    expect(runtimeInfo.identityName).toBeUndefined();
+  });
+
   it("carries session identity into runtime info", () => {
     const { runtimeInfo } = buildSystemPromptParams({
       agentId: "main",

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -9,6 +9,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import type { ChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { findGitRoot } from "../infra/git-root.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import type { ActiveProcessSessionReference } from "./bash-process-references.js";
 import {
   formatUserTime,
@@ -19,6 +20,7 @@ import {
 
 type RuntimeInfoInput = {
   agentId?: string;
+  identityName?: string;
   sessionKey?: string;
   sessionId?: string;
   host: string;
@@ -56,12 +58,16 @@ export function buildSystemPromptParams(params: {
     workspaceDir: params.workspaceDir,
     cwd: params.cwd,
   });
+  const agentConfig =
+    params.config && params.agentId ? resolveAgentConfig(params.config, params.agentId) : undefined;
+  const identityName = agentConfig?.identity?.name || undefined;
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
   const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
   const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
   return {
     runtimeInfo: {
       agentId: params.agentId,
+      identityName,
       ...params.runtime,
       repoRoot,
     },

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1244,6 +1244,34 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("thinking=low");
   });
 
+  it("prefers identityName over agentId in runtime line", () => {
+    const line = buildRuntimeLine({
+      agentId: "main",
+      identityName: "Runt",
+      host: "host",
+      os: "linux",
+      arch: "x64",
+      node: "v22",
+      model: "anthropic/claude",
+    });
+
+    expect(line).toContain("agent=Runt");
+    expect(line).not.toContain("agent=main");
+  });
+
+  it("falls back to agentId when identityName is not set", () => {
+    const line = buildRuntimeLine({
+      agentId: "main",
+      host: "host",
+      os: "linux",
+      arch: "x64",
+      node: "v22",
+      model: "anthropic/claude",
+    });
+
+    expect(line).toContain("agent=main");
+  });
+
   it("renders extra system prompt exactly once", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1272,6 +1272,36 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("agent=main");
   });
 
+  it("strips newline and control characters from identityName in Runtime line", () => {
+    const line = buildRuntimeLine({
+      agentId: "main",
+      identityName: "Evil\nAgent\r\nInjected",
+      host: "host",
+      os: "linux",
+      arch: "x64",
+      node: "v22",
+      model: "anthropic/claude",
+    });
+
+    expect(line).toContain("agent=EvilAgentInjected");
+    expect(line).not.toContain("\n");
+    expect(line).not.toContain("\r");
+  });
+
+  it("trims leading/trailing whitespace from identityName in Runtime line", () => {
+    const line = buildRuntimeLine({
+      agentId: "main",
+      identityName: "  Runt  ",
+      host: "host",
+      os: "linux",
+      arch: "x64",
+      node: "v22",
+      model: "anthropic/claude",
+    });
+
+    expect(line).toContain("agent=Runt");
+  });
+
   it("renders extra system prompt exactly once", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1391,7 +1391,11 @@ export function buildRuntimeLine(
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
   return `Runtime: ${[
     runtimeInfo?.identityName || runtimeInfo?.agentId
-      ? `agent=${runtimeInfo.identityName ?? runtimeInfo.agentId}`
+      ? `agent=${
+          runtimeInfo.identityName
+            ? sanitizeForPromptLiteral(runtimeInfo.identityName.trim())
+            : runtimeInfo.agentId
+        }`
       : "",
     runtimeInfo?.sessionKey ? `session=${sanitizeForPromptLiteral(runtimeInfo.sessionKey)}` : "",
     runtimeInfo?.sessionId ? `sessionId=${sanitizeForPromptLiteral(runtimeInfo.sessionId)}` : "",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -716,6 +716,7 @@ export function buildAgentSystemPrompt(params: {
   nativeCommandGuidanceLines?: string[];
   runtimeInfo?: {
     agentId?: string;
+    identityName?: string;
     sessionKey?: string;
     sessionId?: string;
     host?: string;
@@ -1370,6 +1371,7 @@ function buildActiveProcessSessionReferenceLines(
 export function buildRuntimeLine(
   runtimeInfo?: {
     agentId?: string;
+    identityName?: string;
     sessionKey?: string;
     sessionId?: string;
     host?: string;
@@ -1388,7 +1390,9 @@ export function buildRuntimeLine(
 ): string {
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
   return `Runtime: ${[
-    runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
+    runtimeInfo?.identityName || runtimeInfo?.agentId
+      ? `agent=${runtimeInfo.identityName ?? runtimeInfo.agentId}`
+      : "",
     runtimeInfo?.sessionKey ? `session=${sanitizeForPromptLiteral(runtimeInfo.sessionKey)}` : "",
     runtimeInfo?.sessionId ? `sessionId=${sanitizeForPromptLiteral(runtimeInfo.sessionId)}` : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",


### PR DESCRIPTION
### Summary

- **Problem**: The Runtime line in the system prompt renders `agent=<slotId>` even when a distinct `identity.name` is configured, causing models to identify themselves by the slot id instead of their configured persona
- **Root Cause**: `buildRuntimeLine()` in `src/agents/system-prompt.ts` only reads `runtimeInfo.agentId` (the slot id) and `buildSystemPromptParams()` in `src/agents/system-prompt-params.ts` does not resolve `identity.name` from the agent config. Additionally, when `identity.name` is rendered, it is not sanitized — newline/control characters in the config value could break the Runtime record format.
- **Fix**: (1) Resolve `identity.name` via `resolveAgentConfig()` in `buildSystemPromptParams`, inject it as `identityName` in `runtimeInfo`, and prefer `identityName` over `agentId` when rendering the Runtime line. (2) Apply `sanitizeForPromptLiteral(value.trim())` to `identityName` at the render site, matching the existing sanitization applied to `sessionKey` and `sessionId` in the same Runtime line.
- **What changed**:
  - `src/agents/system-prompt-params.ts` — resolve `identity.name` from agent config and add `identityName` to `runtimeInfo` (+6 lines)
  - `src/agents/system-prompt.ts` — accept `identityName` in `runtimeInfo` types, prefer it over `agentId`, apply `sanitizeForPromptLiteral` + `.trim()` (+6/-1 lines)
  - `src/agents/system-prompt.test.ts` — add 4 test cases: identityName preferred, agentId fallback, newline/control-character stripping, whitespace trimming (+58 lines)
  - `src/agents/system-prompt-params.test.ts` — add 2 test cases: identity.name threading and undefined fallback (+55 lines)
- **What did NOT change (scope boundary)**:
  - No changes to `sessionKey`, `sessionId`, or any other Runtime line field
  - No changes to agent slot routing, session resolution, or identity workspace files
  - No changes to system prompt structure outside the Runtime line

### Reproduction

1. Configure an agent slot with `id: "main"` and `identity: { name: "Runt" }`
2. Start the gateway and send a message
3. **Before this PR**: The Runtime line in the system prompt shows `agent=main`, causing the model to identify as "main" despite IDENTITY.md saying "Runt"
4. **After this PR**: The Runtime line shows `agent=Runt`, matching the configured identity; control characters and surrounding whitespace in the name are stripped

### Real behavior proof

**Behavior or issue addressed (#81269)**: The system prompt Runtime line now prefers a sanitized `identity.name` over the agent slot id (`agentId`), preventing identity drift and prompt injection via unvalidated config strings.

**Real environment tested**: Linux, Node 22.22.0 — direct invocation of `buildRuntimeLine` via `node --import tsx` against the patched source, exercising all four scenarios: slot-only fallback, identity-name preference, control-character stripping, and whitespace trimming.

**Exact steps or command run after this patch**: 
```
node --import tsx -e '
import { buildRuntimeLine } from "./src/agents/system-prompt.ts";
const opts = { host: "testhost", os: "linux", arch: "x64", node: "v22.22.0", model: "anthropic/claude-sonnet-4-6" };
console.log("Before (slot id):", buildRuntimeLine({ agentId: "main", ...opts }));
console.log("After  (identity):", buildRuntimeLine({ agentId: "main", identityName: "Runt", ...opts }));
const bad = "Evil\nAgent\r\nInjected";
console.log("Sanitized:       ", buildRuntimeLine({ agentId: "main", identityName: bad, ...opts }));
console.log("Trimmed:         ", buildRuntimeLine({ agentId: "main", identityName: "  Runt  ", ...opts }));
'
```

**Evidence after fix**:
```text
Before (slot id): Runtime: agent=main | host=testhost | os=linux (x64) | node=v22.22.0 | model=anthropic/claude-sonnet-4-6 | thinking=off
After  (identity): Runtime: agent=Runt | host=testhost | os=linux (x64) | node=v22.22.0 | model=anthropic/claude-sonnet-4-6 | thinking=off
Sanitized:        Runtime: agent=EvilAgentInjected | host=testhost | os=linux (x64) | node=v22.22.0 | model=anthropic/claude-sonnet-4-6 | thinking=off
Trimmed:          Runtime: agent=Runt | host=testhost | os=linux (x64) | node=v22.22.0 | model=anthropic/claude-sonnet-4-6 | thinking=off
```

**Observed result after fix**: `buildRuntimeLine` returns `agent=Runt` when `identityName: "Runt"` is set alongside `agentId: "main"`, and falls back to `agent=main` when only `agentId` is set. A malicious identity name `"Evil\nAgent\r\nInjected"` containing real LF/CR control characters is rendered as `agent=EvilAgentInjected` — all control characters stripped by `sanitizeForPromptLiteral`. Leading/trailing whitespace in `"  Runt  "` is trimmed to `agent=Runt`.

**What was not tested**: Live gateway round-trip with a real channel (Telegram, etc.) was not driven; the fix is validated at the `buildRuntimeLine` function level with direct invocations covering all four scenarios.

**Repro confirmation**: The new test cases "prefers identityName over agentId in runtime line", "strips newline and control characters from identityName", and "trims leading/trailing whitespace from identityName" all pass on the patched branch and fail on origin/main where appropriate.

### Risk / Mitigation

- **Risk**: If `resolveAgentConfig()` returns `undefined` for an agent id that doesn't exist in config, `identityName` will be `undefined` and the Runtime line falls back to `agentId` — identical to current behavior
  **Mitigation**: The fix uses `identityName ?? agentId` with optional chaining throughout; `identityName` is only set when `agentConfig?.identity?.name` is a non-empty string
- **Risk**: `resolveAgentConfig` is already imported and used by `system-prompt-config.ts` in the same call path; this fix adds one additional call per system prompt build
  **Mitigation**: `resolveAgentConfig` is a synchronous config lookup (no I/O); the overhead is negligible
- **Risk**: `identity.name` is now model-facing Runtime metadata (prompt boundary change)
  **Mitigation**: The rendered value is passed through `sanitizeForPromptLiteral(value.trim())` — the same sanitizer already applied to `sessionKey` and `sessionId` in the same Runtime line, which strips Unicode control/category-Cc/Cf characters including newlines, carriage returns, and line separators

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents (system prompt rendering)
- [x] config (identity resolution)

### Regression Test Plan

- `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts` — 92 tests covering Runtime line rendering, identityName preference, sanitization, and fallback
- `node scripts/run-vitest.mjs src/agents/system-prompt-params.test.ts` — 8 tests covering config-to-runtimeInfo plumbing

### Review Findings Addressed

- **[P1] Add redacted real setup proof**: Added direct `node --import tsx` invocation output showing `buildRuntimeLine` with identityName preferred (agent=Runt), slot-id fallback (agent=main), control-character stripping (agent=EvilAgentInjected), and whitespace trimming (agent=Runt). Terminal fenced block with real command and output.
- **[P1] Add `buildSystemPromptParams` regression test**: Added two tests — "threads identity.name into runtimeInfo when configured" and "leaves identityName undefined when identity.name is not configured".
- **[P2] Sanitize identity names before rendering Runtime**: Applied `sanitizeForPromptLiteral(value.trim())` to `identityName` at the render site in `buildRuntimeLine`, matching the existing sanitization pattern for `sessionKey` and `sessionId`. Added regression tests for newline/control-character stripping and whitespace trimming.

### Linked Issue/PR

Fixes #81269
