### PR TITLE
fix(security): respect hook session key prefixes in audit

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -685,13 +685,13 @@ export function collectHooksHardeningFindings(
     });
   }
 
-  if (allowRequestSessionKey) {
+  if (allowRequestSessionKey && allowedPrefixes.length === 0) {
     findings.push({
       checkId: "hooks.request_session_key_enabled",
       severity: remoteExposure ? "critical" : "warn",
       title: "External hook payloads may override sessionKey",
       detail:
-        "hooks.allowRequestSessionKey=true allows `/hooks/agent` callers to choose the session key. Treat hook token holders as full-trust unless you also restrict prefixes.",
+        "hooks.allowRequestSessionKey=true allows `/hooks/agent` callers to choose arbitrary session key shapes because hooks.allowedSessionKeyPrefixes is unset or empty.",
       remediation:
         "Set hooks.allowRequestSessionKey=false (recommended) or constrain hooks.allowedSessionKeyPrefixes.",
     });

--- a/src/security/audit-hooks-routing.test.ts
+++ b/src/security/audit-hooks-routing.test.ts
@@ -121,6 +121,21 @@ describe("security audit hooks ingress findings", () => {
     }
   });
 
+  it("does not warn for request sessionKey overrides constrained by prefixes", () => {
+    const findings = collectHooksHardeningFindings({
+      hooks: {
+        enabled: true,
+        token: "shared-gateway-token-1234567890",
+        defaultSessionKey: "hook:ingress",
+        allowRequestSessionKey: true,
+        allowedSessionKeyPrefixes: ["hook:"],
+      },
+    });
+
+    expect(hasFinding(findings, "hooks.request_session_key_enabled", "warn")).toBe(false);
+    expect(hasFinding(findings, "hooks.request_session_key_prefixes_missing", "warn")).toBe(false);
+  });
+
   it("flags hooks token reuse of gateway password auth as critical", () => {
     const findings = collectHooksHardeningFindings({
       gateway: {


### PR DESCRIPTION
## Summary

- Problem: The security audit always emitted `hooks.request_session_key_enabled` when `hooks.allowRequestSessionKey=true`, even after users configured `hooks.allowedSessionKeyPrefixes` to constrain accepted session key shapes.
- Solution: Treat configured non-empty `hooks.allowedSessionKeyPrefixes` as the canonical mitigation for this finding, and keep the warning only for the unrestricted override case.
- What changed: `collectHooksHardeningFindings()` now reports `hooks.request_session_key_enabled` only when request session key overrides are enabled without prefix restrictions; the finding detail now names the unrestricted session-key-shape risk.
- What did NOT change: Hook request validation, hook runtime routing, gateway auth, token checks, `hooks.request_session_key_prefixes_missing`, public config schema, default config values, and small-model/proxy audit findings are unchanged.
- Why it matters / User impact: Users who already constrained hook session keys stop seeing a stale warning that recommends the mitigation they have already applied, while unrestricted hook payloads still receive the same audit signal.
- Refs #17447; addresses the hook-session-key prefix false-positive portion.

## Real behavior proof

- **Behavior or issue addressed:** When `hooks.allowRequestSessionKey=true` and `hooks.allowedSessionKeyPrefixes` is a non-empty allowlist, the audit no longer reports `hooks.request_session_key_enabled`; when prefixes are absent, the existing warning path remains covered by existing tests.
- **Real environment tested:** Local OpenClaw worktree at commit `90235ba7c95fbd231d8cdcf3ed2cb2a703d13156`, using the repository Vitest runner for focused security audit tests.
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs src/security/audit-hooks-routing.test.ts src/security/audit-extra.sync.test.ts
git diff --check
```

- **Evidence after fix:**

`src/security/audit-hooks-routing.test.ts` and `src/security/audit-extra.sync.test.ts`:

```text
Test Files  2 passed (2)
Tests  28 passed (28)
[test] passed 1 Vitest shard in 16.40s
```

`git diff --check`:

```text
(no output)
```

- **Observed result after fix:** The new regression creates a hook config with `allowRequestSessionKey: true` plus `allowedSessionKeyPrefixes: ["hook:"]` and verifies both `hooks.request_session_key_enabled` and `hooks.request_session_key_prefixes_missing` are absent. Existing table coverage still verifies unrestricted request sessionKey overrides produce the expected warning/critical finding.
- **What was not tested:** A live gateway hook request; the runtime hook validator is unchanged and already enforces prefix constraints outside the audit collector. The small-model MoE heuristic, reverse-proxy warning, and a generic `security.acknowledged` suppression config are intentionally not tested or changed in this PR.

## Regression Test Plan

- **Target test file:** `src/security/audit-hooks-routing.test.ts`
- **Scenario locked in:** `collectHooksHardeningFindings()` receives a hook config where external session key overrides are enabled but constrained to `hook:` prefixes, and the audit must not emit the false-positive request-session-key warning.
- **Why this is the smallest reliable guardrail:** It exercises the security audit collector at the source seam that creates the finding, without mocking the finding result or changing gateway request-handling behavior.

## Merge risk

- **Risk labels considered:** security audit signal, hook session-state routing, public config contract, default behavior, false-negative risk.
- **Risk explanation:** The change narrows one audit finding only when the mitigation named by the existing remediation is present. It does not loosen runtime enforcement: hook payload session keys are still checked by `hooks.allowedSessionKeyPrefixes` before routing.
- **Why acceptable:** Unrestricted overrides still trigger `hooks.request_session_key_enabled` and `hooks.request_session_key_prefixes_missing`; constrained overrides no longer produce a stale warning that says to configure prefixes. The public config surface and default behavior are unchanged.

## Root Cause

- **Root cause:** The source invariant for the hook audit is that `hooks.request_session_key_enabled` should describe unrestricted caller control over session key shape. Before this patch, `collectHooksHardeningFindings()` keyed that finding only on `allowRequestSessionKey` and ignored the already-resolved `allowedPrefixes` state, so the audit reported the unrestricted-risk warning even when the canonical prefix constraint was configured.
- **Why this is root-cause fix:** The fix changes the finding creation condition at the owner source of the audit result, because that is where the collector knows both `allowRequestSessionKey` and the normalized prefix allowlist. It does not hide warnings downstream; it preserves the warning for the actual invariant violation, `allowRequestSessionKey=true` with no prefix restrictions.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High
- **Patch quality notes:** The patch is a focused condition change plus a regression test. It does not add a suppression mechanism, public config field, compatibility shim, schema migration, broad catch, or default-return behavior.
- **Architecture / source-of-truth check:** Runtime hook routing remains the source-of-truth enforcement path for accepted session keys; this patch only aligns the security audit contract with that existing prefix constraint. The config schema and public contract surface are not expanded.
- **Compatibility / default behavior:** Backward compatibility is preserved: no migration, no schema change, no breaking public API change, no new default value, and no upgrade-path requirement. Existing configs with no prefix restrictions keep the same audit warning behavior.
- **Related open PR scan:** The recorded public contract related open PR scan checked same-contract terms including `hooks.allowedSessionKeyPrefixes` and reported `related_open_prs: []` with `scan_error: null`, so this does not compete with a broader canonical PR found by daily-fix.
- **Out of scope:** `security.acknowledged`, `security.trustedModels`, the `models.small_params` MoE heuristic, and `gateway.trusted_proxies_missing` are out of scope and intentionally left unchanged for maintainer/product follow-up.
