### PR TITLE
Clarify plugin channel config additional-property errors

### DIFF
--- a/src/config/channel-config-metadata.ts
+++ b/src/config/channel-config-metadata.ts
@@ -6,7 +6,12 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import type { ChannelUiMetadata, PluginUiMetadata } from "./schema.js";
 
-type ChannelMetadataRecord = ChannelUiMetadata & {
+export type ChannelSchemaMetadataWithOwnership = ChannelUiMetadata & {
+  schemaPluginId?: string;
+  schemaPluginOrigin?: PluginOrigin;
+};
+
+type ChannelMetadataRecord = ChannelSchemaMetadataWithOwnership & {
   originRank: number;
 };
 
@@ -49,10 +54,10 @@ export function collectPluginSchemaMetadata(registry: PluginManifestRegistry): P
     .map(({ originRank: _originRank, ...record }) => record);
 }
 
-/** Collects per-channel config UI metadata from plugin manifests and channel config blocks. */
-export function collectChannelSchemaMetadata(
+/** Collects per-channel config metadata with the plugin that supplied the selected schema. */
+export function collectChannelSchemaMetadataWithOwnership(
   registry: PluginManifestRegistry,
-): ChannelUiMetadata[] {
+): ChannelSchemaMetadataWithOwnership[] {
   const byChannelId = new Map<string, ChannelMetadataRecord>();
 
   for (const record of registry.plugins) {
@@ -71,6 +76,8 @@ export function collectChannelSchemaMetadata(
           description: rootDescription ?? current?.description,
           configSchema: current?.configSchema,
           configUiHints: current?.configUiHints,
+          schemaPluginId: current?.schemaPluginId,
+          schemaPluginOrigin: current?.schemaPluginOrigin,
           originRank,
         });
       }
@@ -93,6 +100,8 @@ export function collectChannelSchemaMetadata(
         description: channelConfig.description ?? rootDescription ?? current?.description,
         configSchema: channelConfig.schema,
         configUiHints: channelConfig.uiHints as ChannelUiMetadata["configUiHints"],
+        schemaPluginId: channelConfig.schema === undefined ? undefined : record.id,
+        schemaPluginOrigin: channelConfig.schema === undefined ? undefined : record.origin,
         originRank,
       });
     }
@@ -101,4 +110,14 @@ export function collectChannelSchemaMetadata(
   return [...byChannelId.values()]
     .toSorted((left, right) => left.id.localeCompare(right.id))
     .map(({ originRank: _originRank, ...entry }) => entry);
+}
+
+/** Collects public per-channel config UI metadata without internal schema ownership. */
+export function collectChannelSchemaMetadata(
+  registry: PluginManifestRegistry,
+): ChannelUiMetadata[] {
+  return collectChannelSchemaMetadataWithOwnership(registry).map(
+    ({ schemaPluginId: _schemaPluginId, schemaPluginOrigin: _schemaPluginOrigin, ...entry }) =>
+      entry,
+  );
 }

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -276,6 +276,31 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("names the external plugin owner for unsupported channel properties", () => {
+    mockLoadPluginManifestRegistry.mockReturnValue(createExternalFeishuSchemaRegistry());
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        feishu: {
+          appId: "app-id",
+          appSecret: "secret",
+          unsupportedField: true,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.feishu",
+          message:
+            'invalid config for plugin openclaw-lark: must not have additional properties: "unsupportedField"',
+        }),
+      );
+    }
+  });
+
   it("keeps raw channel validation diagnostics plugin-agnostic", () => {
     const result = validateConfigObjectRawWithPlugins({
       channels: {

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -124,6 +124,37 @@ function createExternalFeishuSchemaWithCloserMetadataRegistry(): PluginManifestR
   };
 }
 
+function createExternalFeishuSchemaWithRootOnlyShadowRegistry(): PluginManifestRegistry {
+  const firstSchema = createExternalFeishuSchemaRegistry().plugins[0];
+  return {
+    diagnostics: [],
+    plugins: [
+      firstSchema,
+      createPluginManifestRecord({
+        id: "workspace-channel-labels",
+        origin: "workspace",
+        channels: ["feishu"],
+      }),
+      createPluginManifestRecord({
+        id: "other-global-feishu",
+        origin: "global",
+        channels: ["feishu"],
+        channelConfigs: {
+          feishu: {
+            schema: {
+              type: "object",
+              properties: {
+                otherField: { type: "string" },
+              },
+              additionalProperties: false,
+            },
+          },
+        },
+      }),
+    ],
+  };
+}
+
 function createCompatPluginConfigSchemaRegistry(): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -348,6 +379,67 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
       );
       expect(result.issues.map((issue) => issue.message)).not.toContain(
         'invalid config for plugin workspace-channel-labels: must not have additional properties: "unsupportedField"',
+      );
+    }
+  });
+
+  it("keeps schema ownership coupled when closer root metadata preserves a schema", () => {
+    mockLoadPluginManifestRegistry.mockReturnValue(
+      createExternalFeishuSchemaWithRootOnlyShadowRegistry(),
+    );
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        feishu: {
+          appId: "app-id",
+          appSecret: "secret",
+          unsupportedField: true,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.feishu",
+          message:
+            'invalid config for plugin openclaw-lark: must not have additional properties: "unsupportedField"',
+        }),
+      );
+      expect(result.issues.map((issue) => issue.message)).not.toContain(
+        'invalid config for plugin other-global-feishu: must not have additional properties: "unsupportedField"',
+      );
+    }
+  });
+
+  it("sanitizes the schema owner in validation diagnostics", () => {
+    const unsafeId = `openclaw${String.fromCharCode(10)}${String.fromCharCode(27)}[31m-lark`;
+    const registry = createExternalFeishuSchemaRegistry();
+    registry.plugins[0] = {
+      ...registry.plugins[0],
+      id: unsafeId,
+    };
+    mockLoadPluginManifestRegistry.mockReturnValue(registry);
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        feishu: {
+          appId: "app-id",
+          appSecret: "secret",
+          unsupportedField: true,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.feishu",
+          message:
+            'invalid config for plugin openclaw-lark: must not have additional properties: "unsupportedField"',
+        }),
       );
     }
   });

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -103,6 +103,27 @@ function createExternalFeishuSchemaRegistry(): PluginManifestRegistry {
   };
 }
 
+function createExternalFeishuSchemaWithCloserMetadataRegistry(): PluginManifestRegistry {
+  const registry = createExternalFeishuSchemaRegistry();
+  return {
+    diagnostics: [],
+    plugins: [
+      createPluginManifestRecord({
+        id: "workspace-channel-labels",
+        origin: "workspace",
+        channels: ["feishu"],
+        channelConfigs: {
+          feishu: {
+            schema: undefined as never,
+            label: "Workspace Feishu",
+          },
+        },
+      }),
+      ...registry.plugins,
+    ],
+  };
+}
+
 function createCompatPluginConfigSchemaRegistry(): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -297,6 +318,36 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
           message:
             'invalid config for plugin openclaw-lark: must not have additional properties: "unsupportedField"',
         }),
+      );
+    }
+  });
+
+  it("keeps unsupported property diagnostics assigned to the schema owner", () => {
+    mockLoadPluginManifestRegistry.mockReturnValue(
+      createExternalFeishuSchemaWithCloserMetadataRegistry(),
+    );
+
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        feishu: {
+          appId: "app-id",
+          appSecret: "secret",
+          unsupportedField: true,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.feishu",
+          message:
+            'invalid config for plugin openclaw-lark: must not have additional properties: "unsupportedField"',
+        }),
+      );
+      expect(result.issues.map((issue) => issue.message)).not.toContain(
+        'invalid config for plugin workspace-channel-labels: must not have additional properties: "unsupportedField"',
       );
     }
   });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1236,7 +1236,10 @@ function validateConfigObjectWithPluginsBase(
       const originRank: Record<string, number> = { config: 0, workspace: 1, global: 2, bundled: 3 };
       for (const record of info.registry.plugins) {
         const rank = originRank[record.origin] ?? Number.MAX_SAFE_INTEGER;
-        for (const channelId of Object.keys(record.channelConfigs ?? {})) {
+        for (const [channelId, channelConfig] of Object.entries(record.channelConfigs ?? {})) {
+          if (channelConfig.schema === undefined) {
+            continue;
+          }
           const current = ownerByChannelId.get(channelId);
           if (!current || rank <= current.originRank) {
             ownerByChannelId.set(channelId, {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1072,6 +1072,13 @@ function validateConfigObjectWithPluginsBase(
     return `${baseLocal}.${errorPath}`;
   };
 
+  const formatChannelConfigIssueMessage = (message: string, pluginId?: string): string => {
+    if (pluginId) {
+      return `invalid config for plugin ${pluginId}: ${message}`;
+    }
+    return formatRawChannelConfigIssueMessage(message);
+  };
+
   type RegistryInfo = {
     registry: PluginManifestRegistry;
     knownIds?: Set<string>;
@@ -1081,6 +1088,7 @@ function validateConfigObjectWithPluginsBase(
       string,
       {
         schema?: Record<string, unknown>;
+        pluginId?: string;
       }
     >;
   };
@@ -1211,6 +1219,7 @@ function validateConfigObjectWithPluginsBase(
     string,
     {
       schema?: Record<string, unknown>;
+      pluginId?: string;
     }
   > => {
     const info = ensureRegistry();
@@ -1220,10 +1229,32 @@ function validateConfigObjectWithPluginsBase(
           (entry) => [entry.channelId, { schema: entry.schema }] as const,
         ),
       );
+      const ownerByChannelId = new Map<
+        string,
+        { pluginId: string; origin: string; originRank: number }
+      >();
+      const originRank: Record<string, number> = { config: 0, workspace: 1, global: 2, bundled: 3 };
+      for (const record of info.registry.plugins) {
+        const rank = originRank[record.origin] ?? Number.MAX_SAFE_INTEGER;
+        for (const channelId of Object.keys(record.channelConfigs ?? {})) {
+          const current = ownerByChannelId.get(channelId);
+          if (!current || rank <= current.originRank) {
+            ownerByChannelId.set(channelId, {
+              pluginId: record.id,
+              origin: record.origin,
+              originRank: rank,
+            });
+          }
+        }
+      }
       for (const entry of collectChannelSchemaMetadata(info.registry)) {
         const current = info.channelSchemas.get(entry.id);
         if (entry.configSchema) {
-          info.channelSchemas.set(entry.id, { schema: entry.configSchema });
+          const owner = ownerByChannelId.get(entry.id);
+          info.channelSchemas.set(entry.id, {
+            schema: entry.configSchema,
+            pluginId: owner?.origin === "bundled" ? undefined : owner?.pluginId,
+          });
           continue;
         }
         if (!current) {
@@ -1531,12 +1562,12 @@ function validateConfigObjectWithPluginsBase(
         continue;
       }
 
-      const channelSchema = ensureChannelSchemas().get(trimmed)?.schema;
-      if (!channelSchema) {
+      const channelSchema = ensureChannelSchemas().get(trimmed);
+      if (!channelSchema?.schema) {
         continue;
       }
       const result = validateJsonSchemaValue({
-        schema: channelSchema,
+        schema: channelSchema.schema,
         cacheKey: `channel:${trimmed}`,
         value: config.channels[trimmed],
         applyDefaults: true, // Always apply defaults for AJV schema validation;
@@ -1548,7 +1579,7 @@ function validateConfigObjectWithPluginsBase(
             error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`;
           issues.push({
             path: pathResult,
-            message: formatRawChannelConfigIssueMessage(error.message),
+            message: formatChannelConfigIssueMessage(error.message, channelSchema.pluginId),
             allowedValues: error.allowedValues,
             allowedValuesHiddenCount: error.allowedValuesHiddenCount,
           });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
@@ -42,7 +43,7 @@ import { isRecord, resolveUserPath } from "../utils.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
-import { collectChannelSchemaMetadata } from "./channel-config-metadata.js";
+import { collectChannelSchemaMetadataWithOwnership } from "./channel-config-metadata.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
@@ -1073,8 +1074,9 @@ function validateConfigObjectWithPluginsBase(
   };
 
   const formatChannelConfigIssueMessage = (message: string, pluginId?: string): string => {
-    if (pluginId) {
-      return `invalid config for plugin ${pluginId}: ${message}`;
+    const safePluginId = pluginId ? sanitizeForLog(pluginId).trim() : "";
+    if (safePluginId) {
+      return `invalid config for plugin ${safePluginId}: ${message}`;
     }
     return formatRawChannelConfigIssueMessage(message);
   };
@@ -1229,34 +1231,12 @@ function validateConfigObjectWithPluginsBase(
           (entry) => [entry.channelId, { schema: entry.schema }] as const,
         ),
       );
-      const ownerByChannelId = new Map<
-        string,
-        { pluginId: string; origin: string; originRank: number }
-      >();
-      const originRank: Record<string, number> = { config: 0, workspace: 1, global: 2, bundled: 3 };
-      for (const record of info.registry.plugins) {
-        const rank = originRank[record.origin] ?? Number.MAX_SAFE_INTEGER;
-        for (const [channelId, channelConfig] of Object.entries(record.channelConfigs ?? {})) {
-          if (channelConfig.schema === undefined) {
-            continue;
-          }
-          const current = ownerByChannelId.get(channelId);
-          if (!current || rank <= current.originRank) {
-            ownerByChannelId.set(channelId, {
-              pluginId: record.id,
-              origin: record.origin,
-              originRank: rank,
-            });
-          }
-        }
-      }
-      for (const entry of collectChannelSchemaMetadata(info.registry)) {
+      for (const entry of collectChannelSchemaMetadataWithOwnership(info.registry)) {
         const current = info.channelSchemas.get(entry.id);
         if (entry.configSchema) {
-          const owner = ownerByChannelId.get(entry.id);
           info.channelSchemas.set(entry.id, {
             schema: entry.configSchema,
-            pluginId: owner?.origin === "bundled" ? undefined : owner?.pluginId,
+            pluginId: entry.schemaPluginOrigin === "bundled" ? undefined : entry.schemaPluginId,
           });
           continue;
         }


### PR DESCRIPTION
## Summary

- Clarify plugin-owned channel config validation errors by naming the plugin that owns the selected channel schema.
- Keep validation behavior unchanged: unsupported properties still fail, and bundled/raw channel diagnostics remain plugin-agnostic.
- Cover the metadata-only shadow case so diagnostics stay assigned to the plugin that actually supplied the schema.

## Linked context

Related to #77116. This is the narrower follow-up to #93141 based on maintainer guidance. It does not change Feishu bundle data and does not relax external `@larksuite/openclaw-lark` validation rules.

- Fix classification: root-cause diagnostic fix for plugin-owned channel schema validation.
- Maintainer-ready confidence: high; the changed path is covered by regression tests for both the direct external schema case and the closer metadata-only shadow case, plus a real CLI config-validation proof.
- Root cause: plugin-aware channel validation selected the external plugin-owned channel schema, but diagnostics did not retain the schema owner consistently with the channel schema metadata selection contract.
- Why this is root-cause fix: the fix derives diagnostic ownership only from channel config entries that actually provide a schema, so the error source follows the same plugin-owned schema selected for validation instead of a nearer metadata-only channel entry.
- Why it matters / User impact: unsupported-property config errors now point contributors and maintainers at the plugin that supplied the rejecting schema, reducing wrong-layer debugging when a channel has multiple metadata providers.
- Architecture / source-of-truth check: diagnostic ownership follows the selected `channelConfigs.<channel>.schema` provider and the registry origin precedence used for channel schema metadata; metadata-only channel entries without a schema cannot own schema validation failures.
- What did NOT change: validation semantics, Feishu bundle data, external plugin validation rules, Feishu runtime behavior, message delivery, and raw bundled channel diagnostics are unchanged; this PR only changes diagnostic attribution for plugin-owned channel validation errors.
- Patch quality notes: the diff is limited to the validation diagnostic owner mapping and targeted regression coverage; the patch quality risk is the public config/schema diagnostic surface, not runtime behavior, compatibility defaults, or delivery semantics.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: when an external plugin-owned channel schema rejects an unsupported channel property, the diagnostic now names the plugin that supplied the schema. A closer metadata-only channel entry no longer gets blamed for schema errors it did not define.
- Real environment tested: local OpenClaw checkout on Node.js 22.22.0 with pnpm 11.2.2, using a minimal local `openclaw-lark` plugin manifest loaded through `plugins.load.paths`.
- Exact steps or command run after this patch: `OPENCLAW_CONFIG_PATH=<redacted>/openclaw.json openclaw config validate --json`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ OPENCLAW_CONFIG_PATH=<redacted>/openclaw.json openclaw config validate --json
{
  "valid": false,
  "path": "<redacted>/openclaw.json",
  "issues": [
    {
      "path": "channels.feishu",
      "message": "invalid config for plugin openclaw-lark: must not have additional properties: \"unsupportedField\""
    }
  ]
}
Observed CLI exit code: 1
Expected plugin-owned additional-property diagnostic observed.
```

- Observed result after fix: the real OpenClaw CLI config-validation path rejects the unsupported `channels.feishu.unsupportedField` value and reports `invalid config for plugin openclaw-lark: must not have additional properties: "unsupportedField"`, including both the rejected field name and the actual schema owner.
- What was not tested: no live Feishu workspace or external `@larksuite/openclaw-lark` network integration was exercised; this PR only covers the local plugin-aware channel schema validation diagnostic path.
- Proof limitations or environment constraints: the runtime proof uses a minimal local `openclaw-lark` manifest to exercise the plugin-owned channel schema path deterministically without secrets or network calls.

## Tests and validation

- `OPENCLAW_CONFIG_PATH=<redacted>/openclaw.json openclaw config validate --json` -> intentionally exited `1` because the proof config includes `unsupportedField`; output shows `valid: false` and the expected plugin-owned diagnostic.
- `corepack pnpm@11.2.2 --dir . exec vitest run src/config/validation.channel-metadata.test.ts src/config/validation*.test.ts` -> `Exit code: 0`, `Test Files 1 passed (1)`, `Tests 12 passed (12)`.
- `corepack pnpm@11.2.2 --dir . run tsgo:core:test` -> `Exit code: 0`.
- `corepack pnpm@11.2.2 --dir . run lint:core` -> `Exit code: 0`.
- Local Codex diff review against `origin/main` reported no actionable correctness issues.
- Target test file: `src/config/validation.channel-metadata.test.ts`.
- Scenario locked in: external Feishu/Lark channel schema rejects `channels.feishu.unsupportedField` while a closer metadata-only `feishu` entry exists; the diagnostic remains assigned to `openclaw-lark`, the schema owner.
- Why this is the smallest reliable guardrail: the regression test covers the validator/source schema owner boundary directly, and the CLI proof covers the real config-validation path without requiring Feishu secrets or network message delivery.

## Risk checklist

- Risk labels considered: compatibility and message-delivery signals were checked because this touches config validation diagnostics on a public schema-facing path.
- Risk explanation: compatibility risk is limited to the diagnostic message prefix for plugin-owned channel schema failures; accepted configs still pass, rejected configs still fail, and the rejected property name remains visible. Message-delivery risk is not runtime-delivery risk here because the changed path runs during config validation diagnostics, not channel send/delivery execution.
- Why acceptable: the source-of-truth for the message prefix is the plugin-owned schema provider already selected by validation; the change does not alter schemas, defaults, config shape, Feishu bundle metadata, network calls, credentials, or delivery behavior.
- Related PR scan / maintenance context: #93141 was the broader bundled-metadata direction and was closed after maintainer guidance; this PR intentionally keeps the scope to diagnostic attribution on the plugin-owned validation path.

## Current review state

- RF-001: addressed by adding redacted terminal output from `openclaw config validate --json` that shows the plugin-owned additional-property diagnostic after this patch.
- RF-002: addressed by replacing mock-only proof in the PR body with copied output from the real OpenClaw CLI config-validation path.
- RF-003: addressed by the same real config-validation output against a plugin-owned Feishu/Lark schema path, while keeping the Vitest regression coverage as the code guardrail.
- RF-004: addressed as a proof-only blocker; no further code repair was needed because the remaining request was contributor-provided real behavior proof, now included above.
- Ready for maintainer review after local validation and local Codex diff review.
