### PR TITLE
#92776: fix(agents): prevent indefinite session model pinning from polluted fallback origin

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -663,7 +663,12 @@ describe("resolveAgentConfig", () => {
         primaryModel: "gpt-5.4",
         probeState: new Map(),
       }),
-    ).toBeUndefined();
+    ).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+      fallbackProvider: "google",
+      fallbackModel: "gemini-3-pro",
+    });
     expect(
       resolveAutoFallbackPrimaryProbe({
         entry: {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -151,24 +151,28 @@ export function resolveAutoFallbackPrimaryProbe(params: {
     return undefined;
   }
 
-  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
-  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
   const overrideProvider = normalizeOptionalString(entry.providerOverride);
   const overrideModel = normalizeOptionalString(entry.modelOverride);
   const primaryProvider = normalizeOptionalString(params.primaryProvider);
   const primaryModel = normalizeOptionalString(params.primaryModel);
-  if (!originProvider || !originModel || !overrideProvider || !overrideModel) {
+  if (!overrideProvider || !overrideModel) {
     return undefined;
   }
   if (!primaryProvider || !primaryModel) {
     return undefined;
   }
-  if (originProvider !== primaryProvider || originModel !== primaryModel) {
+  if (overrideProvider === primaryProvider && overrideModel === primaryModel) {
     return undefined;
   }
-  if (overrideProvider === originProvider && overrideModel === originModel) {
-    return undefined;
-  }
+
+  // Use the current configured primary as the probe origin rather than
+  // requiring a persisted origin that matches.  The persisted origin
+  // can be missing (first fallback), polluted with the failing model
+  // instead of the primary (#92776), or stale (primary changed).
+  // Using the current primary ensures the snap-back probe fires and
+  // clears the auto-fallback override once the primary is available.
+  const probeOriginProvider = primaryProvider;
+  const probeOriginModel = primaryModel;
 
   const now = params.now ?? Date.now();
   const minIntervalMs = params.minIntervalMs ?? AUTO_FALLBACK_PRIMARY_PROBE_INTERVAL_MS;
@@ -181,8 +185,8 @@ export function resolveAutoFallbackPrimaryProbe(params: {
   });
   const key = autoFallbackPrimaryProbeStateKey({
     sessionKey: params.sessionKey,
-    primaryProvider: originProvider,
-    primaryModel: originModel,
+    primaryProvider: probeOriginProvider,
+    primaryModel: probeOriginModel,
   });
   const lastProbeAt = state.get(key);
   if (
@@ -197,8 +201,8 @@ export function resolveAutoFallbackPrimaryProbe(params: {
     entry.authProfileOverrideSource ??
     (entry.authProfileOverrideCompactionCount !== undefined ? "auto" : undefined);
   return {
-    provider: originProvider,
-    model: originModel,
+    provider: probeOriginProvider,
+    model: probeOriginModel,
     fallbackProvider: overrideProvider,
     fallbackModel: overrideModel,
     ...(fallbackAuthProfileId
@@ -263,11 +267,14 @@ export function entryMatchesAutoFallbackPrimaryProbe(
   if (entry.modelOverrideSource !== "auto" && !recoveredAutoFallbackOverride) {
     return false;
   }
+  // Match on the fallback override (the model the session was stuck on).
+  // We intentionally do NOT require the persisted origin to match the
+  // probe origin — the origin can be polluted (#92776) and the probe
+  // now always uses the current configured primary.  Matching only on
+  // the override ensures polluted session entries can still be updated.
   return (
     normalizeOptionalString(entry.providerOverride) === probe.fallbackProvider &&
-    normalizeOptionalString(entry.modelOverride) === probe.fallbackModel &&
-    normalizeOptionalString(entry.modelOverrideFallbackOriginProvider) === probe.provider &&
-    normalizeOptionalString(entry.modelOverrideFallbackOriginModel) === probe.model
+    normalizeOptionalString(entry.modelOverride) === probe.fallbackModel
   );
 }
 


### PR DESCRIPTION
## Summary

- Fix indefinite session model pinning caused by polluted
  `modelOverrideFallbackOrigin` fields. When the origin recorded the
  failing model instead of the configured primary, the snap-back probe
  (`resolveAutoFallbackPrimaryProbe`) returned undefined on every turn,
  leaving the session permanently stuck on a degraded fallback model.
- Fix: use the current configured primary as the probe origin instead of
  requiring a matching persisted origin. Also relax
  `entryMatchesAutoFallbackPrimaryProbe` to match on the fallback
  override alone, so polluted session entries can be updated.

Fixes #92776

## Linked context

- PR #82676 shipped the snap-back-probe fix but the guard in
  `resolveAutoFallbackPrimaryProbe` starved it of valid input when
  origin fields were polluted.
- ClawSweeper review on #82544 correctly identified: "current main and
  the latest release still preserve auto-created fallback model pins
  across later turns." This PR fixes the upstream mechanism.

## Real behavior proof

**Behavior addressed**: Session model pinning no longer persists
indefinitely when `modelOverrideFallbackOrigin` is polluted. The
snap-back probe now uses the configured primary as origin, ensuring it
fires on every turn until the primary becomes available.

**Real setup tested**: Linux 4.19.112, Node.js v22.21.1, OpenClaw main,
vitest.

**Exact steps or command run after fix**:

```bash
node scripts/run-vitest.mjs src/agents/agent-scope.test.ts
node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
```

**After-fix evidence**:

```
✓ src/agents/agent-scope.test.ts (44 tests | 44 passed)
  - resolves a viable auto-fallback primary probe with all metadata
  - skips primary probes for strict or stale fallback selections
    (updated: origin-mismatch now returns valid probe instead of undefined)
  - identifies legacy auto fallback overrides without origin metadata

✓ src/agents/agent-command.live-model-switch.test.ts (64 tests | 64 passed)
✓ src/auto-reply/reply/agent-runner-execution.test.ts (201 tests | 201 passed)
```

All 309 tests pass.

**Observed result after the fix**: When origin doesn't match the current
primary (polluted or stale), the probe returns a valid probe targeting
the current primary instead of undefined. The probe fires, the primary
is tried, and if available, the override is cleared (snap-back).

**What was not tested**: End-to-end session with polluted origin on a
live OpenClaw instance with real provider chain.

**Proof limitations or environment constraints**: Unit test environment.
The behavioral change is verified through existing and updated test
coverage for `resolveAutoFallbackPrimaryProbe`.

## Tests and validation

```bash
node scripts/run-vitest.mjs src/agents/agent-scope.test.ts
node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
```

Updated test: "skips primary probes for strict or stale fallback
selections" — when origin differs from primary, the probe now returns
a valid probe (`{provider: primary, model: primary, fallbackProvider:
override, fallbackModel: override}`) instead of undefined.

## Risk checklist

Did user-visible behavior change? (`Yes`)
- Sessions stuck on degraded fallback models due to polluted origin
  will snap back to the configured primary when it becomes available.

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- Changing the probe guard logic could cause the primary model to be
  probed more aggressively. The existing minIntervalMs throttle (default
  5 min) prevents excessive probing.

How is that risk mitigated?
- Probe interval throttle unchanged.
- If the primary is available, the override is cleared (desired behavior).
- If the primary is still unavailable, fallback chain runs as before.
- Existing test coverage validates both paths.

## Current review state

What is the next action?
- ClawSweeper review.

What is still waiting on author, maintainer, CI, or external proof?
- E2E proof with live polluted session (requires real provider chain
  and multi-turn scenario). Unit tests cover the behavioral change.

Which bot or reviewer comments were addressed?
- ✅ Fix matches the reporter's sketch: use configured primary as origin
  rather than requiring persisted origin to match exactly.
- ✅ One-shot migration is unnecessary — the relaxed guard means existing
  polluted sessions will snap back on their next turn without migration.
