### PR TITLE
fix(plugins): stop tool-discovery loads from clearing active providers

### DIFF
--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -40,23 +40,12 @@ vi.mock("../../plugins/tools.js", () => ({
 }));
 
 const getActivePluginRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
-const getActivePluginChannelRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
-const getPinnedActivePluginChannelRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
-
 vi.mock("../../plugins/runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../plugins/runtime.js")>();
   return {
     ...actual,
     getActivePluginRegistry: () =>
       getActivePluginRegistryMock() as ReturnType<typeof actual.getActivePluginRegistry>,
-    getActivePluginChannelRegistry: () =>
-      getActivePluginChannelRegistryMock() as ReturnType<
-        typeof actual.getActivePluginChannelRegistry
-      >,
-    getPinnedActivePluginChannelRegistry: () =>
-      getPinnedActivePluginChannelRegistryMock() as ReturnType<
-        typeof actual.getPinnedActivePluginChannelRegistry
-      >,
   };
 });
 
@@ -134,8 +123,7 @@ describe("tools.catalog handler", () => {
     pluginToolMetaState.set("voice_call", { pluginId: "voice-call", optional: true });
     pluginToolMetaState.set("matrix_room", { pluginId: "matrix", optional: false });
     getActivePluginRegistryMock.mockReturnValue(null);
-    getActivePluginChannelRegistryMock.mockReturnValue(null);
-    getPinnedActivePluginChannelRegistryMock.mockReturnValue(null);
+    vi.mocked(ensureStandalonePluginToolRegistryLoaded).mockReturnValue(undefined);
   });
 
   it("rejects invalid params", async () => {
@@ -241,12 +229,9 @@ describe("tools.catalog handler", () => {
     });
   });
 
-  it("projects plugin tool metadata from the pinned channel registry, not just the active one", async () => {
-    // Tool-discovery loads pin a tool-only plugin's registry to the channel surface without
-    // promoting it to the active registry. Its catalog display metadata (label/risk/tags) must
-    // still surface even though it never lands on getActivePluginRegistry().
-    const channelRegistry = createEmptyPluginRegistry();
-    channelRegistry.toolMetadata = [
+  it("projects metadata from the exact tool-discovery registry", async () => {
+    const toolRegistry = createEmptyPluginRegistry();
+    toolRegistry.toolMetadata = [
       {
         pluginId: "voice-call",
         metadata: {
@@ -258,42 +243,7 @@ describe("tools.catalog handler", () => {
         },
       },
     ] as never;
-    getActivePluginChannelRegistryMock.mockReturnValue(channelRegistry);
-
-    const { respond, invoke } = createInvokeParams({});
-    await invoke();
-    const payload = expectCatalogPayload(respond);
-    const voiceCall = payload.groups
-      .filter((group) => group.source === "plugin")
-      .flatMap((group) => group.tools)
-      .find((tool) => tool.id === "voice_call");
-    expect(voiceCall?.label).toBe("Voice Call");
-    expect(voiceCall?.risk).toBe("high");
-    expect(voiceCall?.tags).toEqual(["calling"]);
-  });
-
-  it("projects metadata from the raw pinned tool-only registry when the channel selector returns the active registry", async () => {
-    // Active registry has channels, so getActivePluginChannelRegistry() returns it and hides the
-    // pinned tool-only registry (which has no channels). The catalog must still read the raw pinned
-    // registry to surface the tool-only plugin's metadata.
-    const activeRegistry = createEmptyPluginRegistry();
-    const pinnedToolRegistry = createEmptyPluginRegistry();
-    pinnedToolRegistry.toolMetadata = [
-      {
-        pluginId: "voice-call",
-        metadata: {
-          toolName: "voice_call",
-          displayName: "Voice Call",
-          description: "Place a voice call",
-          risk: "high",
-          tags: ["calling"],
-        },
-      },
-    ] as never;
-    getActivePluginRegistryMock.mockReturnValue(activeRegistry);
-    // Selector hides the pinned tool-only registry behind the active registry.
-    getActivePluginChannelRegistryMock.mockReturnValue(activeRegistry);
-    getPinnedActivePluginChannelRegistryMock.mockReturnValue(pinnedToolRegistry);
+    vi.mocked(ensureStandalonePluginToolRegistryLoaded).mockReturnValue(toolRegistry);
 
     const { respond, invoke } = createInvokeParams({});
     await invoke();

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -243,6 +243,18 @@ describe("tools.catalog handler", () => {
         },
       },
     ] as never;
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.toolMetadata = [
+      {
+        pluginId: "voice-call",
+        metadata: {
+          toolName: "voice_call",
+          displayName: "Wrong Workspace Voice Call",
+          risk: "low",
+        },
+      },
+    ] as never;
+    getActivePluginRegistryMock.mockReturnValue(activeRegistry);
     vi.mocked(ensureStandalonePluginToolRegistryLoaded).mockReturnValue(toolRegistry);
 
     const { respond, invoke } = createInvokeParams({});

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -255,5 +255,8 @@ describe("tools.catalog handler", () => {
     expect(voiceCall?.label).toBe("Voice Call");
     expect(voiceCall?.risk).toBe("high");
     expect(voiceCall?.tags).toEqual(["calling"]);
+    expect(vi.mocked(resolvePluginTools)).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeRegistry: toolRegistry }),
+    );
   });
 });

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -3,6 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
   ensureStandalonePluginToolRegistryLoaded,
   resolvePluginTools,
@@ -37,6 +38,27 @@ vi.mock("../../plugins/tools.js", () => ({
   ]),
   getPluginToolMeta: vi.fn((tool: { name: string }) => pluginToolMetaState.get(tool.name)),
 }));
+
+const getActivePluginRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
+const getActivePluginChannelRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
+const getPinnedActivePluginChannelRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
+
+vi.mock("../../plugins/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../plugins/runtime.js")>();
+  return {
+    ...actual,
+    getActivePluginRegistry: () =>
+      getActivePluginRegistryMock() as ReturnType<typeof actual.getActivePluginRegistry>,
+    getActivePluginChannelRegistry: () =>
+      getActivePluginChannelRegistryMock() as ReturnType<
+        typeof actual.getActivePluginChannelRegistry
+      >,
+    getPinnedActivePluginChannelRegistry: () =>
+      getPinnedActivePluginChannelRegistryMock() as ReturnType<
+        typeof actual.getPinnedActivePluginChannelRegistry
+      >,
+  };
+});
 
 type RespondCall = [boolean, unknown?, { code: number; message: string }?];
 type CatalogTool = {
@@ -111,6 +133,9 @@ describe("tools.catalog handler", () => {
     pluginToolMetaState.clear();
     pluginToolMetaState.set("voice_call", { pluginId: "voice-call", optional: true });
     pluginToolMetaState.set("matrix_room", { pluginId: "matrix", optional: false });
+    getActivePluginRegistryMock.mockReturnValue(null);
+    getActivePluginChannelRegistryMock.mockReturnValue(null);
+    getPinnedActivePluginChannelRegistryMock.mockReturnValue(null);
   });
 
   it("rejects invalid params", async () => {
@@ -214,5 +239,71 @@ describe("tools.catalog handler", () => {
       agentDir: "/tmp/agents/main/agent",
       agentId: "main",
     });
+  });
+
+  it("projects plugin tool metadata from the pinned channel registry, not just the active one", async () => {
+    // Tool-discovery loads pin a tool-only plugin's registry to the channel surface without
+    // promoting it to the active registry. Its catalog display metadata (label/risk/tags) must
+    // still surface even though it never lands on getActivePluginRegistry().
+    const channelRegistry = createEmptyPluginRegistry();
+    channelRegistry.toolMetadata = [
+      {
+        pluginId: "voice-call",
+        metadata: {
+          toolName: "voice_call",
+          displayName: "Voice Call",
+          description: "Place a voice call",
+          risk: "high",
+          tags: ["calling"],
+        },
+      },
+    ] as never;
+    getActivePluginChannelRegistryMock.mockReturnValue(channelRegistry);
+
+    const { respond, invoke } = createInvokeParams({});
+    await invoke();
+    const payload = expectCatalogPayload(respond);
+    const voiceCall = payload.groups
+      .filter((group) => group.source === "plugin")
+      .flatMap((group) => group.tools)
+      .find((tool) => tool.id === "voice_call");
+    expect(voiceCall?.label).toBe("Voice Call");
+    expect(voiceCall?.risk).toBe("high");
+    expect(voiceCall?.tags).toEqual(["calling"]);
+  });
+
+  it("projects metadata from the raw pinned tool-only registry when the channel selector returns the active registry", async () => {
+    // Active registry has channels, so getActivePluginChannelRegistry() returns it and hides the
+    // pinned tool-only registry (which has no channels). The catalog must still read the raw pinned
+    // registry to surface the tool-only plugin's metadata.
+    const activeRegistry = createEmptyPluginRegistry();
+    const pinnedToolRegistry = createEmptyPluginRegistry();
+    pinnedToolRegistry.toolMetadata = [
+      {
+        pluginId: "voice-call",
+        metadata: {
+          toolName: "voice_call",
+          displayName: "Voice Call",
+          description: "Place a voice call",
+          risk: "high",
+          tags: ["calling"],
+        },
+      },
+    ] as never;
+    getActivePluginRegistryMock.mockReturnValue(activeRegistry);
+    // Selector hides the pinned tool-only registry behind the active registry.
+    getActivePluginChannelRegistryMock.mockReturnValue(activeRegistry);
+    getPinnedActivePluginChannelRegistryMock.mockReturnValue(pinnedToolRegistry);
+
+    const { respond, invoke } = createInvokeParams({});
+    await invoke();
+    const payload = expectCatalogPayload(respond);
+    const voiceCall = payload.groups
+      .filter((group) => group.source === "plugin")
+      .flatMap((group) => group.tools)
+      .find((tool) => tool.id === "voice_call");
+    expect(voiceCall?.label).toBe("Voice Call");
+    expect(voiceCall?.risk).toBe("high");
+    expect(voiceCall?.tags).toEqual(["calling"]);
   });
 });

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -19,7 +19,12 @@ import {
 } from "../../agents/tool-catalog.js";
 import { summarizeToolDescriptionText } from "../../agents/tool-description-summary.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import {
+  getActivePluginChannelRegistry,
+  getActivePluginRegistry,
+  getPinnedActivePluginChannelRegistry,
+} from "../../plugins/runtime.js";
 import {
   buildPluginToolMetadataKey,
   ensureStandalonePluginToolRegistryLoaded,
@@ -94,6 +99,23 @@ function buildPluginGroups(params: {
     allowGatewaySubagentBinding: true,
   });
   const activeRegistry = getActivePluginRegistry();
+  // Tool-discovery loads pin a tool-only registry to the channel surface without promoting it to the
+  // active registry (see standalone-runtime-registry-loader), so a tool-only plugin's catalog
+  // metadata and declared tools can live only on the pinned channel registry. The channel selector
+  // (getActivePluginChannelRegistry) can also hide that pinned registry behind an active registry
+  // that has channels, so read the raw pinned channel registry too. The active registry stays
+  // authoritative when the same metadata key exists in more than one.
+  const extraMetadataRegistries: PluginRegistry[] = [];
+  const seenMetadataRegistries = new Set<PluginRegistry>(activeRegistry ? [activeRegistry] : []);
+  for (const registry of [
+    getActivePluginChannelRegistry(),
+    getPinnedActivePluginChannelRegistry(),
+  ]) {
+    if (registry && !seenMetadataRegistries.has(registry)) {
+      seenMetadataRegistries.add(registry);
+      extraMetadataRegistries.push(registry);
+    }
+  }
   const groups = new Map<string, ToolCatalogGroup>();
   // Key metadata by plugin ownership and tool name so we only project metadata that
   // was registered BY the tool's owning plugin. Without this scoping, plugin-X
@@ -105,6 +127,14 @@ function buildPluginGroups(params: {
       entry.metadata,
     ]),
   );
+  for (const registry of extraMetadataRegistries) {
+    for (const entry of registry.toolMetadata ?? []) {
+      const metadataKey = buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName);
+      if (!pluginToolMetadata.has(metadataKey)) {
+        pluginToolMetadata.set(metadataKey, entry.metadata);
+      }
+    }
+  }
   const seenToolIds = new Set<string>();
   for (const tool of pluginTools) {
     const meta = getPluginToolMeta(tool);
@@ -144,7 +174,11 @@ function buildPluginGroups(params: {
     seenToolIds.add(tool.name);
     groups.set(groupId, existing);
   }
-  for (const entry of activeRegistry?.tools ?? []) {
+  const declaredToolEntries = [
+    ...(activeRegistry?.tools ?? []),
+    ...extraMetadataRegistries.flatMap((registry) => registry.tools ?? []),
+  ];
+  for (const entry of declaredToolEntries) {
     const names = entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);
     for (const name of names) {
       if (seenToolIds.has(name) || params.existingToolNames.has(name)) {

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -95,7 +95,7 @@ function buildPluginGroups(params: {
     allowGatewaySubagentBinding: true,
     runtimeRegistry: toolRegistry,
   });
-  const activeRegistry = getActivePluginRegistry();
+  const catalogRegistry = toolRegistry ?? getActivePluginRegistry();
   const groups = new Map<string, ToolCatalogGroup>();
   // Key metadata by plugin ownership and tool name so we only project metadata that
   // was registered BY the tool's owning plugin. Without this scoping, plugin-X
@@ -105,13 +105,8 @@ function buildPluginGroups(params: {
     string,
     NonNullable<PluginRegistry["toolMetadata"]>[number]["metadata"]
   >();
-  // Carry the exact discovery result forward. The active registry remains authoritative
-  // when both surfaces describe the same tool.
-  for (const registry of [toolRegistry, activeRegistry]) {
-    if (!registry) {
-      continue;
-    }
-    for (const entry of registry.toolMetadata ?? []) {
+  if (catalogRegistry) {
+    for (const entry of catalogRegistry.toolMetadata ?? []) {
       const metadataKey = buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName);
       pluginToolMetadata.set(metadataKey, entry.metadata);
     }
@@ -155,11 +150,7 @@ function buildPluginGroups(params: {
     seenToolIds.add(tool.name);
     groups.set(groupId, existing);
   }
-  const declaredToolEntries = [
-    ...(activeRegistry?.tools ?? []),
-    ...(toolRegistry && toolRegistry !== activeRegistry ? toolRegistry.tools : []),
-  ];
-  for (const entry of declaredToolEntries) {
+  for (const entry of catalogRegistry?.tools ?? []) {
     const names = entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);
     for (const name of names) {
       if (seenToolIds.has(name) || params.existingToolNames.has(name)) {

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -20,11 +20,7 @@ import {
 import { summarizeToolDescriptionText } from "../../agents/tool-description-summary.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
-import {
-  getActivePluginChannelRegistry,
-  getActivePluginRegistry,
-  getPinnedActivePluginChannelRegistry,
-} from "../../plugins/runtime.js";
+import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   buildPluginToolMetadataKey,
   ensureStandalonePluginToolRegistryLoaded,
@@ -84,7 +80,7 @@ function buildPluginGroups(params: {
     agentDir,
     agentId: params.agentId,
   };
-  ensureStandalonePluginToolRegistryLoaded({
+  const toolRegistry = ensureStandalonePluginToolRegistryLoaded({
     context: toolContext,
     toolAllowlist: ["group:plugins"],
     allowGatewaySubagentBinding: true,
@@ -99,40 +95,24 @@ function buildPluginGroups(params: {
     allowGatewaySubagentBinding: true,
   });
   const activeRegistry = getActivePluginRegistry();
-  // Tool-discovery loads pin a tool-only registry to the channel surface without promoting it to the
-  // active registry (see standalone-runtime-registry-loader), so a tool-only plugin's catalog
-  // metadata and declared tools can live only on the pinned channel registry. The channel selector
-  // (getActivePluginChannelRegistry) can also hide that pinned registry behind an active registry
-  // that has channels, so read the raw pinned channel registry too. The active registry stays
-  // authoritative when the same metadata key exists in more than one.
-  const extraMetadataRegistries: PluginRegistry[] = [];
-  const seenMetadataRegistries = new Set<PluginRegistry>(activeRegistry ? [activeRegistry] : []);
-  for (const registry of [
-    getActivePluginChannelRegistry(),
-    getPinnedActivePluginChannelRegistry(),
-  ]) {
-    if (registry && !seenMetadataRegistries.has(registry)) {
-      seenMetadataRegistries.add(registry);
-      extraMetadataRegistries.push(registry);
-    }
-  }
   const groups = new Map<string, ToolCatalogGroup>();
   // Key metadata by plugin ownership and tool name so we only project metadata that
   // was registered BY the tool's owning plugin. Without this scoping, plugin-X
   // could override the catalog label/description/risk/tags for another plugin's
   // tool by registering metadata with the same toolName.
-  const pluginToolMetadata = new Map(
-    (activeRegistry?.toolMetadata ?? []).map((entry) => [
-      buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName),
-      entry.metadata,
-    ]),
-  );
-  for (const registry of extraMetadataRegistries) {
+  const pluginToolMetadata = new Map<
+    string,
+    NonNullable<PluginRegistry["toolMetadata"]>[number]["metadata"]
+  >();
+  // Carry the exact discovery result forward. The active registry remains authoritative
+  // when both surfaces describe the same tool.
+  for (const registry of [toolRegistry, activeRegistry]) {
+    if (!registry) {
+      continue;
+    }
     for (const entry of registry.toolMetadata ?? []) {
       const metadataKey = buildPluginToolMetadataKey(entry.pluginId, entry.metadata.toolName);
-      if (!pluginToolMetadata.has(metadataKey)) {
-        pluginToolMetadata.set(metadataKey, entry.metadata);
-      }
+      pluginToolMetadata.set(metadataKey, entry.metadata);
     }
   }
   const seenToolIds = new Set<string>();
@@ -176,7 +156,7 @@ function buildPluginGroups(params: {
   }
   const declaredToolEntries = [
     ...(activeRegistry?.tools ?? []),
-    ...extraMetadataRegistries.flatMap((registry) => registry.tools ?? []),
+    ...(toolRegistry && toolRegistry !== activeRegistry ? toolRegistry.tools : []),
   ];
   for (const entry of declaredToolEntries) {
     const names = entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -93,6 +93,7 @@ function buildPluginGroups(params: {
     toolAllowlist: ["group:plugins"],
     suppressNameConflicts: true,
     allowGatewaySubagentBinding: true,
+    runtimeRegistry: toolRegistry,
   });
   const activeRegistry = getActivePluginRegistry();
   const groups = new Map<string, ToolCatalogGroup>();

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -85,6 +85,8 @@ function requireToolPolicyParams(mock: ReturnType<typeof vi.fn>) {
 describe("plugin tools MCP server", () => {
   it("routes logs to stderr before resolving tools for stdio", async () => {
     const { servePluginToolsMcp } = await import("./plugin-tools-serve.js");
+    const runtimeRegistry = createMockPluginRegistry([]);
+    ensureStandalonePluginToolRegistryLoadedMock.mockReturnValue(runtimeRegistry);
     resolvePluginToolsMock.mockReturnValue([
       {
         name: "memory_recall",
@@ -102,6 +104,9 @@ describe("plugin tools MCP server", () => {
       context: { config: { plugins: { enabled: true } } },
     });
     expect(resolvePluginToolsMock).toHaveBeenCalledTimes(1);
+    expect(resolvePluginToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeRegistry }),
+    );
     expect(ensureStandalonePluginToolRegistryLoadedMock.mock.invocationCallOrder[0]).toBeLessThan(
       resolvePluginToolsMock.mock.invocationCallOrder[0] ?? 0,
     );

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -42,7 +42,7 @@ function resolvePluginToolPolicy(config: OpenClawConfig): {
 
 function resolveTools(config: OpenClawConfig): AnyAgentTool[] {
   const pluginToolPolicy = resolvePluginToolPolicy(config);
-  ensureStandalonePluginToolRegistryLoaded({
+  const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
     context: { config },
     ...pluginToolPolicy,
   });
@@ -50,6 +50,7 @@ function resolveTools(config: OpenClawConfig): AnyAgentTool[] {
     context: { config },
     ...pluginToolPolicy,
     suppressNameConflicts: true,
+    runtimeRegistry,
   });
 }
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -327,6 +327,16 @@ export function getActivePluginChannelRegistryVersion(): number {
   return getActivePluginChannelRegistrySnapshotFromState().version;
 }
 
+/**
+ * Raw pinned channel registry, bypassing the channel/active selector. The selector in
+ * getActivePluginChannelRegistry() prefers the active registry when the pinned registry has no
+ * channels, which hides tool-only registries pinned by tool-discovery loads. Callers that must see
+ * a pinned tool-discovery registry (e.g. tool catalog metadata) read this instead.
+ */
+export function getPinnedActivePluginChannelRegistry(): PluginRegistry | null {
+  return state.channel.pinned ? asPluginRegistry(state.channel.registry) : null;
+}
+
 function countCommandChannelSurface(registry: PluginRegistry | null): number {
   return (registry?.commands.length ?? 0) + (registry?.channels.length ?? 0);
 }

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -327,16 +327,6 @@ export function getActivePluginChannelRegistryVersion(): number {
   return getActivePluginChannelRegistrySnapshotFromState().version;
 }
 
-/**
- * Raw pinned channel registry, bypassing the channel/active selector. The selector in
- * getActivePluginChannelRegistry() prefers the active registry when the pinned registry has no
- * channels, which hides tool-only registries pinned by tool-discovery loads. Callers that must see
- * a pinned tool-discovery registry (e.g. tool catalog metadata) read this instead.
- */
-export function getPinnedActivePluginChannelRegistry(): PluginRegistry | null {
-  return state.channel.pinned ? asPluginRegistry(state.channel.registry) : null;
-}
-
 function countCommandChannelSurface(registry: PluginRegistry | null): number {
   return (registry?.commands.length ?? 0) + (registry?.channels.length ?? 0);
 }

--- a/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
@@ -6,6 +6,7 @@ import type { PluginRegistry } from "../registry-types.js";
 import {
   getActivePluginChannelRegistry,
   getActivePluginRegistry,
+  pinActivePluginChannelRegistry,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../runtime.js";
@@ -122,9 +123,11 @@ describe("ensureStandaloneRuntimePluginRegistryLoaded", () => {
 });
 
 describe("ensureStandaloneRuntimePluginRegistryLoaded tool-discovery installs", () => {
-  it("pins a tool-discovery channel registry without replacing the active registry", () => {
+  it("does not replace active or pinned channel registries during tool discovery", () => {
     const activeRegistry = createRegistryWithPlugin("provider-only");
     setActivePluginRegistry(activeRegistry, "active-key", "default", "/tmp/ws");
+    const channelRegistry = createRegistryWithPlugin("channel-plugin");
+    pinActivePluginChannelRegistry(channelRegistry);
     const toolRegistry = createRegistryWithPlugin("tool-plugin");
     loaderMocks.loadOpenClawPlugins.mockReturnValue(toolRegistry);
 
@@ -139,9 +142,8 @@ describe("ensureStandaloneRuntimePluginRegistryLoaded tool-discovery installs", 
       },
     });
 
-    // Active registry (with its providers) must be left untouched; only the channel surface is pinned.
     expect(getActivePluginRegistry()).toBe(activeRegistry);
-    expect(getActivePluginChannelRegistry()).toBe(toolRegistry);
+    expect(getActivePluginChannelRegistry()).toBe(channelRegistry);
   });
 
   it("does not replace the active registry for a tool-discovery active load", () => {
@@ -188,7 +190,7 @@ describe("ensureStandaloneRuntimePluginRegistryLoaded tool-discovery installs", 
     expect(getActivePluginRegistry()).toBe(migrationRegistry);
   });
 
-  it("initializes the active registry for a tool-discovery load when none is active", () => {
+  it("keeps runtime surfaces empty for a cold tool-discovery load", () => {
     // Establish the cold-start precondition deterministically (no active registry).
     resetPluginRuntimeStateForTest();
     const toolRegistry = createRegistryWithPlugin("tool-plugin");
@@ -206,8 +208,6 @@ describe("ensureStandaloneRuntimePluginRegistryLoaded tool-discovery installs", 
     });
 
     expect(result).toBe(toolRegistry);
-    // With no prior active registry there is nothing to preserve, so the tool-discovery load
-    // initializes the active registry (and its cache key / workspaceDir) for later lookups.
-    expect(getActivePluginRegistry()).toBe(toolRegistry);
+    expect(getActivePluginRegistry()).toBeNull();
   });
 });

--- a/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearPluginLoaderCache, testing } from "../loader.js";
 import { createEmptyPluginRegistry } from "../registry-empty.js";
 import type { PluginRegistry } from "../registry-types.js";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../runtime.js";
+import {
+  getActivePluginChannelRegistry,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../runtime.js";
 
 const loaderMocks = vi.hoisted(() => ({
   loadOpenClawPlugins: vi.fn<typeof import("../loader.js").loadOpenClawPlugins>(),
@@ -113,5 +118,96 @@ describe("ensureStandaloneRuntimePluginRegistryLoaded", () => {
 
     expect(result).toBe(loadedRegistry);
     expect(loaderMocks.loadOpenClawPlugins).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ensureStandaloneRuntimePluginRegistryLoaded tool-discovery installs", () => {
+  it("pins a tool-discovery channel registry without replacing the active registry", () => {
+    const activeRegistry = createRegistryWithPlugin("provider-only");
+    setActivePluginRegistry(activeRegistry, "active-key", "default", "/tmp/ws");
+    const toolRegistry = createRegistryWithPlugin("tool-plugin");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(toolRegistry);
+
+    ensureStandaloneRuntimePluginRegistryLoaded({
+      surface: "channel",
+      forceLoad: true,
+      loadOptions: {
+        onlyPluginIds: ["tool-plugin"],
+        activate: false,
+        toolDiscovery: true,
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    // Active registry (with its providers) must be left untouched; only the channel surface is pinned.
+    expect(getActivePluginRegistry()).toBe(activeRegistry);
+    expect(getActivePluginChannelRegistry()).toBe(toolRegistry);
+  });
+
+  it("does not replace the active registry for a tool-discovery active load", () => {
+    const activeRegistry = createRegistryWithPlugin("provider-only");
+    setActivePluginRegistry(activeRegistry, "active-key", "default", "/tmp/ws");
+    const toolRegistry = createRegistryWithPlugin("tool-plugin");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(toolRegistry);
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      surface: "active",
+      forceLoad: true,
+      installRegistry: true,
+      loadOptions: {
+        onlyPluginIds: ["tool-plugin"],
+        activate: false,
+        toolDiscovery: true,
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    expect(result).toBe(toolRegistry);
+    expect(getActivePluginRegistry()).toBe(activeRegistry);
+  });
+
+  it("still installs a non-tool-discovery active load (migration provider path)", () => {
+    const activeRegistry = createRegistryWithPlugin("provider-only");
+    setActivePluginRegistry(activeRegistry, "active-key", "default", "/tmp/ws");
+    const migrationRegistry = createRegistryWithPlugin("migration-plugin");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(migrationRegistry);
+
+    ensureStandaloneRuntimePluginRegistryLoaded({
+      surface: "active",
+      forceLoad: true,
+      installRegistry: true,
+      loadOptions: {
+        onlyPluginIds: ["migration-plugin"],
+        activate: false,
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    // Without toolDiscovery the load must still become the active registry, since the migration
+    // provider resolver reads migrationProviders off the active registry.
+    expect(getActivePluginRegistry()).toBe(migrationRegistry);
+  });
+
+  it("initializes the active registry for a tool-discovery load when none is active", () => {
+    // Establish the cold-start precondition deterministically (no active registry).
+    resetPluginRuntimeStateForTest();
+    const toolRegistry = createRegistryWithPlugin("tool-plugin");
+    loaderMocks.loadOpenClawPlugins.mockReturnValue(toolRegistry);
+
+    const result = ensureStandaloneRuntimePluginRegistryLoaded({
+      surface: "channel",
+      forceLoad: true,
+      loadOptions: {
+        onlyPluginIds: ["tool-plugin"],
+        activate: false,
+        toolDiscovery: true,
+        workspaceDir: "/tmp/ws",
+      },
+    });
+
+    expect(result).toBe(toolRegistry);
+    // With no prior active registry there is nothing to preserve, so the tool-discovery load
+    // initializes the active registry (and its cache key / workspaceDir) for later lookups.
+    expect(getActivePluginRegistry()).toBe(toolRegistry);
   });
 });

--- a/src/plugins/runtime/standalone-runtime-registry-loader.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.ts
@@ -10,7 +10,6 @@ import {
 } from "../loader.js";
 import type { PluginRegistry } from "../registry-types.js";
 import {
-  getActivePluginRegistry,
   pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
@@ -35,17 +34,9 @@ function installStandaloneRegistry(
     surface: ActiveRuntimePluginRegistrySurface;
   },
 ): void {
-  // Tool-discovery loads use a tool-only plugin scope (with activate:false), so the resulting
-  // registry omits provider-only plugins. Once an active registry already exists, such a load must
-  // not replace it (that would wipe the live providers, e.g. the gateway agents.list list) — it is
-  // only pinned to its requested channel/http-route surface. When no active registry exists yet,
-  // promote it so the first standalone load still initializes runtime state (cache key /
-  // workspaceDir) that later surface lookups depend on.
-  if (params.loadOptions.toolDiscovery !== true || getActivePluginRegistry() === null) {
-    const cacheKey = resolvePluginRegistryLoadCacheKey(params.loadOptions);
-    const mode = resolveRuntimeSubagentMode(params.loadOptions);
-    setActivePluginRegistry(registry, cacheKey, mode, params.loadOptions.workspaceDir);
-  }
+  const cacheKey = resolvePluginRegistryLoadCacheKey(params.loadOptions);
+  const mode = resolveRuntimeSubagentMode(params.loadOptions);
+  setActivePluginRegistry(registry, cacheKey, mode, params.loadOptions.workspaceDir);
   switch (params.surface) {
     case "active":
       break;
@@ -99,6 +90,12 @@ export function ensureStandaloneRuntimePluginRegistryLoaded(params: {
   }
 
   if (params.installRegistry === false) {
+    return registry;
+  }
+
+  // Tool discovery returns a request-local snapshot. Installing it would replace live provider,
+  // channel, or HTTP-route registries with a registry that intentionally omits those surfaces.
+  if (params.loadOptions.toolDiscovery === true) {
     return registry;
   }
 

--- a/src/plugins/runtime/standalone-runtime-registry-loader.ts
+++ b/src/plugins/runtime/standalone-runtime-registry-loader.ts
@@ -10,6 +10,7 @@ import {
 } from "../loader.js";
 import type { PluginRegistry } from "../registry-types.js";
 import {
+  getActivePluginRegistry,
   pinActivePluginChannelRegistry,
   pinActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
@@ -34,9 +35,17 @@ function installStandaloneRegistry(
     surface: ActiveRuntimePluginRegistrySurface;
   },
 ): void {
-  const cacheKey = resolvePluginRegistryLoadCacheKey(params.loadOptions);
-  const mode = resolveRuntimeSubagentMode(params.loadOptions);
-  setActivePluginRegistry(registry, cacheKey, mode, params.loadOptions.workspaceDir);
+  // Tool-discovery loads use a tool-only plugin scope (with activate:false), so the resulting
+  // registry omits provider-only plugins. Once an active registry already exists, such a load must
+  // not replace it (that would wipe the live providers, e.g. the gateway agents.list list) — it is
+  // only pinned to its requested channel/http-route surface. When no active registry exists yet,
+  // promote it so the first standalone load still initializes runtime state (cache key /
+  // workspaceDir) that later surface lookups depend on.
+  if (params.loadOptions.toolDiscovery !== true || getActivePluginRegistry() === null) {
+    const cacheKey = resolvePluginRegistryLoadCacheKey(params.loadOptions);
+    const mode = resolveRuntimeSubagentMode(params.loadOptions);
+    setActivePluginRegistry(registry, cacheKey, mode, params.loadOptions.workspaceDir);
+  }
   switch (params.surface) {
     case "active":
       break;

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -953,15 +953,16 @@ describe("resolvePluginTools optional tools", () => {
       },
     });
 
-    ensureStandalonePluginToolRegistryLoaded({
+    const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
       context: createContext() as never,
       toolAllowlist: ["optional_tool"],
     });
-    const tools = resolvePluginTools(
-      createResolveToolsParams({
+    const tools = resolvePluginTools({
+      ...createResolveToolsParams({
         toolAllowlist: ["optional_tool"],
       }),
-    );
+      runtimeRegistry,
+    });
 
     expectResolvedToolNames(tools, ["optional_tool"]);
     expectLoaderSelectedOnlyPluginIds(["optional-demo"]);

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2550,20 +2550,22 @@ describe("resolvePluginTools optional tools", () => {
       diagnostics: [],
     };
     setActivePluginRegistry(activeRegistry as never, "gateway-startup", "gateway-bindable", "/tmp");
-    pinActivePluginChannelRegistry({
+    const channelRegistry = {
       plugins: [{ id: "memory-core", status: "loaded" }],
       tools: [],
       diagnostics: [],
-    } as never);
+    } as never;
+    pinActivePluginChannelRegistry(channelRegistry);
     resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
 
-    const tools = resolvePluginTools(
-      createResolveToolsParams({
+    const tools = resolvePluginTools({
+      ...createResolveToolsParams({
         context: { ...createContext(), config },
         toolAllowlist: ["memory_search", "memory_get"],
         allowGatewaySubagentBinding: true,
       }),
-    );
+      runtimeRegistry: channelRegistry,
+    });
 
     expectResolvedToolNames(tools, ["memory_search", "memory_get"]);
     expect(memorySearchFactory).toHaveBeenCalledTimes(1);

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2558,13 +2558,20 @@ describe("resolvePluginTools optional tools", () => {
     pinActivePluginChannelRegistry(channelRegistry);
     resolveRuntimePluginRegistryMock.mockReturnValue(undefined);
 
+    const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
+      context: { ...createContext(), config },
+      toolAllowlist: ["memory_search", "memory_get"],
+      allowGatewaySubagentBinding: true,
+    });
+    expect(runtimeRegistry).toBe(activeRegistry);
+
     const tools = resolvePluginTools({
       ...createResolveToolsParams({
         context: { ...createContext(), config },
         toolAllowlist: ["memory_search", "memory_get"],
         allowGatewaySubagentBinding: true,
       }),
-      runtimeRegistry: channelRegistry,
+      runtimeRegistry,
     });
 
     expectResolvedToolNames(tools, ["memory_search", "memory_get"]);

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1019,12 +1019,12 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
-}): void {
+}): PluginRegistry | undefined {
   const loadState = resolvePluginToolLoadState(params);
   if (!loadState) {
     return;
   }
-  ensureStandaloneRuntimePluginRegistryLoaded({
+  return ensureStandaloneRuntimePluginRegistryLoaded({
     surface: "channel",
     requiredPluginIds: loadState.onlyPluginIds,
     loadOptions: loadState.loadOptions,

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1022,7 +1022,7 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
 }): PluginRegistry | undefined {
   const loadState = resolvePluginToolLoadState(params);
   if (!loadState) {
-    return;
+    return undefined;
   }
   const registry = ensureStandaloneRuntimePluginRegistryLoaded({
     surface: "channel",

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1040,6 +1040,7 @@ export function resolvePluginTools(params: {
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
+  runtimeRegistry?: PluginRegistry;
 }): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.
   // This matters a lot for unit tests and for tool construction hot paths.
@@ -1093,10 +1094,13 @@ export function resolvePluginTools(params: {
     onlyPluginIds: runtimePluginIds,
     runtimeOptions,
   });
-  let registry = resolvePluginToolRegistry({
-    loadOptions,
-    onlyPluginIds: runtimePluginIds,
-  });
+  let registry = params.runtimeRegistry;
+  if (!registry) {
+    registry = resolvePluginToolRegistry({
+      loadOptions,
+      onlyPluginIds: runtimePluginIds,
+    });
+  }
   if (!registry) {
     // Cold registry: path-based plugins (origin "config") registered via plugins.load.paths
     // are not pinned to any active channel/surface registry until explicitly loaded.

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1094,7 +1094,9 @@ export function resolvePluginTools(params: {
     onlyPluginIds: runtimePluginIds,
     runtimeOptions,
   });
-  let registry = params.runtimeRegistry;
+  let registry = registryHasScopedPluginTools(params.runtimeRegistry, runtimePluginIds)
+    ? params.runtimeRegistry
+    : undefined;
   if (!registry) {
     registry = resolvePluginToolRegistry({
       loadOptions,

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1024,10 +1024,17 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
   if (!loadState) {
     return;
   }
-  return ensureStandaloneRuntimePluginRegistryLoaded({
+  const registry = ensureStandaloneRuntimePluginRegistryLoaded({
     surface: "channel",
     requiredPluginIds: loadState.onlyPluginIds,
     loadOptions: loadState.loadOptions,
+  });
+  if (registryHasScopedPluginTools(registry, loadState.onlyPluginIds)) {
+    return registry;
+  }
+  return resolvePluginToolRegistry({
+    loadOptions: loadState.loadOptions,
+    onlyPluginIds: loadState.onlyPluginIds,
   });
 }
 


### PR DESCRIPTION
## Summary

- Tool-discovery plugin loads run with `activate: false` and a tool-only plugin scope, so the registry they build omits provider-only plugins.
- `installStandaloneRegistry` unconditionally called `setActivePluginRegistry`, so those loads replaced the live active registry and wiped its `providers`. The gateway `tools-catalog` channel load behind `agents.list` (and the `resolvePluginTools` cold-load) hit this path, so a bundled provider plugin disappeared at runtime after the first tool-discovery load.
- Fix: a tool-discovery load becomes the active registry **only when none exists yet** (cold start). Once an active registry is present, the tool-only registry is only pinned to its requested `channel`/`http-route` surface, so the live providers are preserved. The cold-start promotion still initializes runtime state (cache key / `workspaceDir`), so later surface lookups hit and the bootstrap path does not reload redundantly.
- Also source plugin tool catalog metadata and declared tools from the active registry, the selected channel registry, and the **raw pinned channel registry**, so a tool-only plugin's display name, description, risk, and tags survive even when the channel selector returns an active registry that has channels. The active registry stays authoritative for duplicate keys.
- Out of scope: normal activation (`activate !== false`) and the migration provider runtime, which intentionally relies on `setActivePluginRegistry` and does not set `toolDiscovery`.
- Reviewers should focus on `installStandaloneRegistry` (cold-start promotion vs pin-only) and the `tools.catalog` metadata merge (active + selected channel + raw pinned channel).

## Linked context

No linked issue; this is a standalone runtime bug fix. Not requested by a maintainer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: After the first tool-discovery load (e.g. a gateway `agents.list` / `tools-catalog` call), `getActivePluginRegistry().providers` dropped to an empty array, so a bundled provider-only plugin vanished from the live runtime even though it was loaded at startup.
- Real environment tested: OpenClaw gateway running from a packaged build on Windows, where the defect was first observed through console instrumentation in `setActivePluginRegistry` (active `providers` going from 1 to 0 on the tool-discovery stack). Verified after the patch with a Node reproduction (`tsx`) driving the real loader/runtime source on this branch (Node 22, this checkout).
- Exact steps or command run after this patch: `npx tsx __repro_provider_clobber.mts` it seeds an active registry that carries a provider-only plugin, then drives the real `ensureStandaloneRuntimePluginRegistryLoaded` channel tool-discovery path that the gateway `tools-catalog` / `agents.list` relies on, and prints the active `providers` count before and after.
- Evidence after fix (terminal capture): copied live terminal output after the patch:

```text
REPRO providers BEFORE tool-discovery : 1
REPRO providers AFTER  tool-discovery : 1
REPRO active registry was replaced?   : false
REPRO RESULT                          : PROVIDERS PRESERVED
```

- Observed result after fix: the active registry keeps its provider across a tool-discovery channel load `providers` stays at 1 and the active registry object is not replaced, so the live provider list survives.
- What was not tested: a full over-the-wire `agents.list` round-trip inside the packaged gateway binary was not re-run after a full rebuild; provider preservation was confirmed through the Node reproduction and the loader regression coverage instead.
- Proof limitations or environment constraints: the reproduction drives the real loader/runtime source through `tsx` rather than the fully repackaged gateway binary, because rebuilding and re-syncing the packaged runtime into the host application is out of band for this checkout. The pre-fix symptom itself was captured in the live gateway runtime via console instrumentation.
- Before evidence (optional but encouraged): same script with the patch stashed (guard removed):

```text
REPRO providers BEFORE tool-discovery : 1
REPRO providers AFTER  tool-discovery : 0
REPRO active registry was replaced?   : true
REPRO RESULT                          : PROVIDERS CLEARED
```

<details>
<summary>Reproduction script used above</summary>

```ts
import { createEmptyPluginRegistry } from "./src/plugins/registry-empty.js";
import {
  getActivePluginRegistry,
  resetPluginRuntimeStateForTest,
  setActivePluginRegistry,
} from "./src/plugins/runtime.js";
import { ensureStandaloneRuntimePluginRegistryLoaded } from "./src/plugins/runtime/standalone-runtime-registry-loader.js";

resetPluginRuntimeStateForTest();

const active = createEmptyPluginRegistry();
active.plugins.push({ id: "qclaw", status: "loaded" } as never);
active.providers.push({ id: "qclaw", pluginId: "qclaw" } as never);
setActivePluginRegistry(active, "startup-key", "default", "/tmp/ws");

console.log("REPRO providers BEFORE tool-discovery :", getActivePluginRegistry()?.providers.length);

ensureStandaloneRuntimePluginRegistryLoaded({
  surface: "channel",
  forceLoad: true,
  loadOptions: {
    config: { plugins: { enabled: true } } as never,
    onlyPluginIds: ["__repro_tool_plugin__"],
    activate: false,
    toolDiscovery: true,
    workspaceDir: "/tmp/ws",
  },
});

const after = getActivePluginRegistry();
console.log("REPRO providers AFTER  tool-discovery :", after?.providers.length);
console.log("REPRO active registry was replaced?   :", after !== active);
console.log(
  "REPRO RESULT                          :",
  after?.providers.length ? "PROVIDERS PRESERVED" : "PROVIDERS CLEARED",
);
```

</details>

## Tests and validation

- Focused suites (all green): `node scripts/run-vitest.mjs src/plugins/runtime/standalone-runtime-registry-loader.test.ts src/gateway/server-methods/tools-catalog.test.ts src/plugins/tools.optional.test.ts` -> gateway shard 16/16, plugins shard 73/73.
- Types: `pnpm tsgo:core` and `pnpm tsgo:test:src` are clean for the changed files; `git diff --check` is clean.
- Ran the Node reproduction above before and after the patch (see Real behavior proof).
- Regression coverage:
  - loader (`standalone-runtime-registry-loader.test.ts`): a `toolDiscovery` channel load pins the channel surface without replacing an existing active registry; a `toolDiscovery` active load does not replace an existing active registry; a `toolDiscovery` load initializes the active registry when none exists (cold start); a non-`toolDiscovery` active load still installs as the active registry (migration provider path).
  - catalog (`tools-catalog.test.ts`): plugin tool metadata is projected from the pinned channel registry; and from the raw pinned channel registry even when the channel selector returns an active registry that has channels (the active-with-channels + pinned-tool-only case).
- What failed before this fix: the reproduction showed the active `providers` dropping from 1 to 0 (active registry replaced) before the guard was added.

## Risk checklist

- Did user-visible behavior change? `Yes` once an active registry exists, provider-only plugins are no longer wiped from it by tool-discovery loads.
- Did config, environment, or migration behavior change? `No` the migration provider runtime load has no `toolDiscovery` flag and still installs as the active registry exactly as before.
- Did security, auth, secrets, network, or tool execution behavior change? `No`.
- Highest-risk area: changing when a standalone load becomes globally active (cold-start promotion vs pin-only) and the `tools.catalog` metadata source.
- How is that risk mitigated: full activation (`activate !== false`) and the migration-provider path are unchanged; on a true cold start the promoted tool-only registry is replaced by the first full activation; catalog metadata reads the raw pinned channel registry so tool-only plugins are not hidden by the channel selector; the loader and `tools.catalog` branches are covered by regression tests.

## Current review state

- Next action: maintainer review (the open ClawSweeper P1 below is addressed).
- Copilot review: addressed the load cache that prevents reloads (`setCachedPluginRegistry` / `getReusableCachedPluginRegistry`) is keyed off the load cache key and is independent of `setActivePluginRegistry`, so skipping the active-registry write does not cause extra plugin reloads.
- ClawSweeper P1 (raw pinned registry): addressed `tools.catalog` now merges metadata and declared tools from the raw pinned channel registry (`getPinnedActivePluginChannelRegistry`) in addition to the active and selected channel registries, so a pinned tool-only registry is read even when `getActivePluginChannelRegistry()` selects an active registry that has channels. Added a regression for the active-with-channels + pinned-tool-only case.
