### PR TITLE
[codex] Preserve Discord self-reply context

### DIFF
--- a/extensions/discord/src/durable-delivery.test.ts
+++ b/extensions/discord/src/durable-delivery.test.ts
@@ -12,6 +12,10 @@ import {
   installDiscordOutboundModuleSpies,
   resetDiscordOutboundMocks,
 } from "./outbound-adapter.test-harness.js";
+import {
+  resetDiscordSelfReplyContextPolicyForTest,
+  shouldPreserveDiscordSelfReplyBody,
+} from "./self-reply-context.js";
 
 const hoisted = createDiscordOutboundHoisted();
 await installDiscordOutboundModuleSpies(hoisted);
@@ -25,6 +29,7 @@ beforeAll(async () => {
 describe("durable Discord delivery", () => {
   beforeEach(() => {
     resetDiscordOutboundMocks(hoisted);
+    resetDiscordSelfReplyContextPolicyForTest();
     setActivePluginRegistry(
       createTestRegistry([
         {
@@ -37,11 +42,12 @@ describe("durable Discord delivery", () => {
   });
 
   afterEach(() => {
+    resetDiscordSelfReplyContextPolicyForTest();
     resetPluginRuntimeStateForTest();
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
-  it("fans out planned text chunks and retries a transient failure on a later chunk", async () => {
+  it("fans out marked notification text chunks and records each chunk for self-reply context", async () => {
     hoisted.sendMessageDiscordMock
       .mockResolvedValueOnce({
         messageId: "msg-chunk-1",
@@ -64,7 +70,18 @@ describe("durable Discord delivery", () => {
       },
       channel: "discord",
       to: "channel:123456",
-      payloads: [{ text: "first chunk\nsecond chunk" }],
+      payloads: [
+        {
+          text: "first chunk\nsecond chunk",
+          channelData: {
+            openclaw: {
+              replyContext: {
+                preserveSelfQuoteBody: true,
+              },
+            },
+          },
+        },
+      ],
       formatting: {
         chunkMode: "newline",
         maxLinesPerMessage: 1,
@@ -100,5 +117,7 @@ describe("durable Discord delivery", () => {
       "second chunk",
       "second chunk",
     ]);
+    expect(shouldPreserveDiscordSelfReplyBody("msg-chunk-1")).toBe(true);
+    expect(shouldPreserveDiscordSelfReplyBody("msg-chunk-2")).toBe(true);
   });
 });

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -17,6 +17,7 @@ import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/sess
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDiscordConversationIdentity } from "../conversation-identity.js";
 import { ChannelType } from "../internal/discord.js";
+import { shouldPreserveDiscordSelfReplyBody } from "../self-reply-context.js";
 import { normalizeDiscordAllowList, normalizeDiscordSlug } from "./allow-list.js";
 import { resolveTimestampMs } from "./format.js";
 import {
@@ -44,21 +45,6 @@ function normalizeDiscordDmOwnerEntry(entry: string): string | undefined {
 
 function isContextAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
-}
-
-function shouldPreserveDiscordSelfReplyBody(body: string | undefined): boolean {
-  const normalized = body?.replace(/\r\n?/g, "\n").trim();
-  if (!normalized) {
-    return false;
-  }
-  return (
-    /^Cron job "[^"\n]+" (?:failed|skipped) \d+ times\n(?:Last error|Skip reason): [\s\S]+$/.test(
-      normalized,
-    ) ||
-    /^[^\n]*Cron job "[^"\n]+" has been auto-disabled after \d+ consecutive schedule errors\. Last error: [\s\S]+$/.test(
-      normalized,
-    )
-  );
 }
 
 export async function buildDiscordMessageProcessContext(params: {
@@ -333,7 +319,9 @@ export async function buildDiscordMessageProcessContext(params: {
           storePath,
           sessionKey: effectiveSessionKey,
         });
-  const preserveSelfReplyBody = shouldPreserveDiscordSelfReplyBody(replyContext?.body);
+  const preserveSelfReplyBody =
+    Boolean(botUserId && replyContext?.senderId === botUserId) &&
+    shouldPreserveDiscordSelfReplyBody(replyContext?.id);
 
   const ctxPayload = await buildChannelInboundEventContext({
     channel: "discord",

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -322,6 +322,7 @@ export async function buildDiscordMessageProcessContext(params: {
   const ctxPayload = await buildChannelInboundEventContext({
     channel: "discord",
     resolveSupplementalMedia: true,
+    suppressSelfQuoteBody: false,
     contextVisibility: contextVisibilityMode,
     accountId: route.accountId,
     messageId: canonicalMessageId ?? message.id,

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -46,6 +46,21 @@ function isContextAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
 }
 
+function shouldPreserveDiscordSelfReplyBody(body: string | undefined): boolean {
+  const normalized = body?.replace(/\r\n?/g, "\n").trim();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    /^Cron job "[^"\n]+" (?:failed|skipped) \d+ times\n(?:Last error|Skip reason): [\s\S]+$/.test(
+      normalized,
+    ) ||
+    /^[^\n]*Cron job "[^"\n]+" has been auto-disabled after \d+ consecutive schedule errors\. Last error: [\s\S]+$/.test(
+      normalized,
+    )
+  );
+}
+
 export async function buildDiscordMessageProcessContext(params: {
   ctx: DiscordMessagePreflightContext;
   text: string;
@@ -318,11 +333,12 @@ export async function buildDiscordMessageProcessContext(params: {
           storePath,
           sessionKey: effectiveSessionKey,
         });
+  const preserveSelfReplyBody = shouldPreserveDiscordSelfReplyBody(replyContext?.body);
 
   const ctxPayload = await buildChannelInboundEventContext({
     channel: "discord",
     resolveSupplementalMedia: true,
-    suppressSelfQuoteBody: false,
+    suppressSelfQuoteBody: !preserveSelfReplyBody,
     contextVisibility: contextVisibilityMode,
     accountId: route.accountId,
     messageId: canonicalMessageId ?? message.id,

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1434,7 +1434,7 @@ describe("processDiscordMessage session routing", () => {
     const alertBody = "System notification: build failed\nReview the deployment dashboard.";
     recordDiscordSelfReplyContextPolicy({
       payload: createSelfQuotePreservablePayload(alertBody),
-      results: [{ channel: "discord", messageId: "m-alert" }],
+      results: [{ messageId: "m-alert" }],
     });
     const ctx = await createBaseContext({
       botUserId: "bot-1",

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1350,7 +1350,7 @@ describe("processDiscordMessage session routing", () => {
     expect(dispatchCtx.MediaPaths).toBeUndefined();
   });
 
-  it("injects the bot's previous message body when users reply to it", async () => {
+  it("does not inject the bot's previous message body when users reply to it", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("self-reply media should not be fetched");
     });
@@ -1404,7 +1404,69 @@ describe("processDiscordMessage session routing", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(dispatchCtx.ReplyToId).toBe("m-bot-previous");
     expect(dispatchCtx.ReplyToSender).toBe("Spartacus");
-    expect(dispatchCtx.ReplyToBody).toBe("The same stale bot response keeps looping.");
+    expect(dispatchCtx.ReplyToBody).toBeUndefined();
+    expect(dispatchCtx.MediaPath).toBeUndefined();
+    expect(dispatchCtx.MediaPaths).toBeUndefined();
+  });
+
+  it("injects bot-authored cron failure alert body when users reply to it", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("self-reply media should not be fetched");
+    });
+    const alertBody =
+      'Cron job "WhatsApp Incremental Archive" failed 1 times\n' +
+      "Last error: check git status (agent) failed";
+    const ctx = await createBaseContext({
+      botUserId: "bot-1",
+      cfg: {
+        channels: { discord: { contextVisibility: "all" } },
+        messages: { ackReaction: "👀" },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+      discordRestFetch: fetchImpl,
+      message: {
+        id: "m-alert-reply",
+        channelId: "c1",
+        content: "<@bot> please investigate this",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+        messageReference: {
+          type: 0,
+          message_id: "m-cron-alert",
+          channel_id: "c1",
+        },
+        referencedMessage: {
+          id: "m-cron-alert",
+          channelId: "c1",
+          content: alertBody,
+          timestamp: new Date().toISOString(),
+          attachments: [
+            {
+              id: "att-cron-alert",
+              url: "https://cdn.discordapp.com/attachments/alert.png",
+              content_type: "image/png",
+              filename: "alert.png",
+            },
+          ],
+          author: {
+            id: "bot-1",
+            username: "SnabbelClaw",
+            discriminator: "0",
+            globalName: "SnabbelClaw",
+          },
+        },
+      },
+      baseText: "<@bot> please investigate this",
+      messageText: "<@bot> please investigate this",
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const dispatchCtx = requireRecord(getLastDispatchCtx(), "dispatch context");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(dispatchCtx.ReplyToId).toBe("m-cron-alert");
+    expect(dispatchCtx.ReplyToSender).toBe("SnabbelClaw");
+    expect(dispatchCtx.ReplyToBody).toBe(alertBody);
     expect(dispatchCtx.MediaPath).toBeUndefined();
     expect(dispatchCtx.MediaPaths).toBeUndefined();
   });

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -9,6 +9,10 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import * as runtimeEnvModule from "openclaw/plugin-sdk/runtime-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  recordDiscordSelfReplyContextPolicy,
+  resetDiscordSelfReplyContextPolicyForTest,
+} from "../self-reply-context.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
 
 const sendMocks = vi.hoisted(() => ({
@@ -64,6 +68,19 @@ function createNonTerminalToolWarningPayload(): ReplyPayload {
     },
     { nonTerminalToolErrorWarning: true },
   );
+}
+
+function createSelfQuotePreservablePayload(text: string): ReplyPayload {
+  return {
+    text,
+    channelData: {
+      openclaw: {
+        replyContext: {
+          preserveSelfQuoteBody: true,
+        },
+      },
+    },
+  };
 }
 
 vi.mock("../send.js", () => ({
@@ -524,6 +541,7 @@ beforeEach(() => {
   }));
   resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
   threadBindingTesting.resetThreadBindingsForTests();
+  resetDiscordSelfReplyContextPolicyForTest();
 });
 
 function getLastRouteUpdate():
@@ -1409,13 +1427,15 @@ describe("processDiscordMessage session routing", () => {
     expect(dispatchCtx.MediaPaths).toBeUndefined();
   });
 
-  it("injects bot-authored cron failure alert body when users reply to it", async () => {
+  it("injects marked bot-authored notification body when users reply to it", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("self-reply media should not be fetched");
     });
-    const alertBody =
-      'Cron job "WhatsApp Incremental Archive" failed 1 times\n' +
-      "Last error: check git status (agent) failed";
+    const alertBody = "System notification: build failed\nReview the deployment dashboard.";
+    recordDiscordSelfReplyContextPolicy({
+      payload: createSelfQuotePreservablePayload(alertBody),
+      results: [{ channel: "discord", messageId: "m-alert" }],
+    });
     const ctx = await createBaseContext({
       botUserId: "bot-1",
       cfg: {
@@ -1432,17 +1452,17 @@ describe("processDiscordMessage session routing", () => {
         attachments: [],
         messageReference: {
           type: 0,
-          message_id: "m-cron-alert",
+          message_id: "m-alert",
           channel_id: "c1",
         },
         referencedMessage: {
-          id: "m-cron-alert",
+          id: "m-alert",
           channelId: "c1",
           content: alertBody,
           timestamp: new Date().toISOString(),
           attachments: [
             {
-              id: "att-cron-alert",
+              id: "att-alert",
               url: "https://cdn.discordapp.com/attachments/alert.png",
               content_type: "image/png",
               filename: "alert.png",
@@ -1464,7 +1484,7 @@ describe("processDiscordMessage session routing", () => {
 
     const dispatchCtx = requireRecord(getLastDispatchCtx(), "dispatch context");
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(dispatchCtx.ReplyToId).toBe("m-cron-alert");
+    expect(dispatchCtx.ReplyToId).toBe("m-alert");
     expect(dispatchCtx.ReplyToSender).toBe("SnabbelClaw");
     expect(dispatchCtx.ReplyToBody).toBe(alertBody);
     expect(dispatchCtx.MediaPath).toBeUndefined();

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1350,7 +1350,7 @@ describe("processDiscordMessage session routing", () => {
     expect(dispatchCtx.MediaPaths).toBeUndefined();
   });
 
-  it("does not inject the bot's previous message body when users reply to it", async () => {
+  it("injects the bot's previous message body when users reply to it", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("self-reply media should not be fetched");
     });
@@ -1404,8 +1404,9 @@ describe("processDiscordMessage session routing", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(dispatchCtx.ReplyToId).toBe("m-bot-previous");
     expect(dispatchCtx.ReplyToSender).toBe("Spartacus");
-    expect(dispatchCtx.ReplyToBody).toBeUndefined();
-    expect(JSON.stringify(dispatchCtx)).not.toContain("The same stale bot response keeps looping.");
+    expect(dispatchCtx.ReplyToBody).toBe("The same stale bot response keeps looping.");
+    expect(dispatchCtx.MediaPath).toBeUndefined();
+    expect(dispatchCtx.MediaPaths).toBeUndefined();
   });
 
   it("stores DM lastRoute with user target for direct-session continuity", async () => {

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -8,6 +8,10 @@ import {
   mockDiscordBoundThreadManager,
   resetDiscordOutboundMocks,
 } from "./outbound-adapter.test-harness.js";
+import {
+  resetDiscordSelfReplyContextPolicyForTest,
+  shouldPreserveDiscordSelfReplyBody,
+} from "./self-reply-context.js";
 
 const hoisted = createDiscordOutboundHoisted();
 await installDiscordOutboundModuleSpies(hoisted);
@@ -37,6 +41,19 @@ function mockObjectArg(
     throw new Error(`expected ${label} call ${callIndex} argument ${argIndex} to be an object`);
   }
   return value as Record<string, unknown>;
+}
+
+function createSelfQuotePreservablePayload(text: string) {
+  return {
+    text,
+    channelData: {
+      openclaw: {
+        replyContext: {
+          preserveSelfQuoteBody: true,
+        },
+      },
+    },
+  };
 }
 
 beforeAll(async () => {
@@ -88,6 +105,7 @@ describe("normalizeDiscordOutboundTarget", () => {
 describe("discordOutbound", () => {
   beforeEach(() => {
     resetDiscordOutboundMocks(hoisted);
+    resetDiscordSelfReplyContextPolicyForTest();
   });
 
   it("routes text sends to thread target when threadId is provided", async () => {
@@ -502,6 +520,46 @@ describe("discordOutbound", () => {
     }
 
     expect(markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("records self-reply body context only for marked outbound payloads", async () => {
+    await discordOutbound.afterDeliverPayload?.({
+      cfg: {},
+      target: {
+        channel: "discord",
+        to: "channel:parent-1",
+        accountId: "default",
+      },
+      payload: { text: "ordinary assistant reply" },
+      results: [{ channel: "discord", messageId: "msg-ordinary" }],
+    });
+
+    expect(shouldPreserveDiscordSelfReplyBody("msg-ordinary")).toBe(false);
+
+    await discordOutbound.afterDeliverPayload?.({
+      cfg: {},
+      target: {
+        channel: "discord",
+        to: "channel:parent-1",
+        accountId: "default",
+      },
+      payload: createSelfQuotePreservablePayload("System notification: deployment failed"),
+      results: [
+        {
+          channel: "discord",
+          messageId: "msg-marked",
+          receipt: {
+            primaryPlatformMessageId: "msg-marked",
+            platformMessageIds: ["msg-marked", "msg-marked-followup"],
+            parts: [],
+            sentAt: 123,
+          },
+        },
+      ],
+    });
+
+    expect(shouldPreserveDiscordSelfReplyBody("msg-marked")).toBe(true);
+    expect(shouldPreserveDiscordSelfReplyBody("msg-marked-followup")).toBe(true);
   });
 
   it("sends component payload media sequences with the component message first", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -26,6 +26,7 @@ import {
   type DiscordSendFn,
   type DiscordVoiceSendFn,
 } from "./outbound-send-context.js";
+import { recordDiscordSelfReplyContextPolicy } from "./self-reply-context.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE =
@@ -309,12 +310,13 @@ export const discordOutbound: ChannelOutboundAdapter = {
           }),
       }),
   }),
-  afterDeliverPayload: async ({ target, payload }) => {
+  afterDeliverPayload: async ({ target, payload, results }) => {
     notifyDiscordInboundEventOutboundPayloadSuccess({
       payload,
       to: resolveDiscordOutboundTarget({ to: target.to, threadId: target.threadId }),
       accountId: target.accountId,
     });
+    recordDiscordSelfReplyContextPolicy({ payload, results });
     const threadId = normalizeOptionalStringifiedId(target.threadId);
     if (!threadId) {
       return;

--- a/extensions/discord/src/self-reply-context.ts
+++ b/extensions/discord/src/self-reply-context.ts
@@ -1,0 +1,67 @@
+// Discord plugin module implements self-reply context policy for sent bot messages.
+import { listMessageReceiptPlatformIds } from "openclaw/plugin-sdk/channel-outbound";
+import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
+
+type DiscordSelfReplyContextDeliveryResult = {
+  messageId?: string;
+  receipt?: MessageReceipt;
+};
+
+const OPENCLAW_CHANNEL_DATA_KEY = "openclaw";
+const REPLY_CONTEXT_POLICY_KEY = "replyContext";
+const MAX_RECORDED_REPLY_CONTEXT_MESSAGES = 1000;
+const preservedSelfQuoteBodyMessageIds = new Set<string>();
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function shouldPreservePayloadSelfQuoteBody(payload: Pick<ReplyPayload, "channelData">): boolean {
+  const channelData = readRecord(payload.channelData);
+  const openclawData = readRecord(channelData?.[OPENCLAW_CHANNEL_DATA_KEY]);
+  const replyContext = readRecord(openclawData?.[REPLY_CONTEXT_POLICY_KEY]);
+  return replyContext?.preserveSelfQuoteBody === true;
+}
+
+function rememberMessageId(messageId: string | undefined): void {
+  const normalized = messageId?.trim();
+  if (!normalized || normalized === "unknown") {
+    return;
+  }
+  if (preservedSelfQuoteBodyMessageIds.size >= MAX_RECORDED_REPLY_CONTEXT_MESSAGES) {
+    const oldest = preservedSelfQuoteBodyMessageIds.values().next().value;
+    if (oldest) {
+      preservedSelfQuoteBodyMessageIds.delete(oldest);
+    }
+  }
+  preservedSelfQuoteBodyMessageIds.add(normalized);
+}
+
+export function recordDiscordSelfReplyContextPolicy(params: {
+  payload: Pick<ReplyPayload, "channelData">;
+  results: readonly DiscordSelfReplyContextDeliveryResult[];
+}): void {
+  if (!shouldPreservePayloadSelfQuoteBody(params.payload)) {
+    return;
+  }
+  for (const result of params.results) {
+    rememberMessageId(result.messageId);
+    if (result.receipt) {
+      for (const messageId of listMessageReceiptPlatformIds(result.receipt)) {
+        rememberMessageId(messageId);
+      }
+    }
+  }
+}
+
+export function shouldPreserveDiscordSelfReplyBody(messageId: string | undefined): boolean {
+  const normalized = messageId?.trim();
+  return Boolean(normalized && preservedSelfQuoteBodyMessageIds.has(normalized));
+}
+
+export function resetDiscordSelfReplyContextPolicyForTest(): void {
+  preservedSelfQuoteBodyMessageIds.clear();
+}

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -618,6 +618,41 @@ describe("finalizeChannelInboundContext supplemental media resolution", () => {
     expect(result.supplemental?.quote).toEqual({ id: "reply-1", sender: "Bot" });
   });
 
+  it("preserves self-authored quote body when media remains suppressed", async () => {
+    const media = vi.fn(async () => [{ path: "/tmp/self.png", contentType: "image/png" }]);
+    const result = await finalizeChannelInboundContext({
+      context: {
+        Body: "hello",
+        RawBody: "hello",
+        From: "test:u1",
+        To: "test:room",
+        SessionKey: "session",
+        ChatType: "group",
+      },
+      resolveSupplementalMedia: true,
+      contextVisibility: "all",
+      suppressSelfQuoteBody: false,
+      supplemental: {
+        quote: {
+          id: "reply-1",
+          body: "previous bot reply",
+          sender: "Bot",
+          isSelf: true,
+          media,
+        },
+      },
+    });
+
+    expect(media).not.toHaveBeenCalled();
+    expect(result.context.MediaPath).toBeUndefined();
+    expect(result.context.ReplyToBody).toBe("previous bot reply");
+    expect(result.supplemental?.quote).toEqual({
+      id: "reply-1",
+      body: "previous bot reply",
+      sender: "Bot",
+    });
+  });
+
   it("does not resolve media for hidden quotes", async () => {
     const media = vi.fn(async () => [{ path: "/tmp/hidden.png", contentType: "image/png" }]);
     const result = await finalizeChannelInboundContext({

--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -120,6 +120,38 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(deliveryRequest.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
+  it("marks Discord failure alert payloads as self-quote preservable", async () => {
+    mocks.resolveDeliveryTarget.mockResolvedValue({
+      ok: true,
+      channel: "discord",
+      to: "channel:123",
+      accountId: "bot-a",
+      mode: "explicit",
+    });
+
+    await sendFailureNotificationAnnounce(
+      {} as never,
+      {} as never,
+      "main",
+      "job-1",
+      { channel: "discord", to: "channel:123", accountId: "bot-a" },
+      "Cron failed",
+    );
+
+    expect(firstDeliveryRequest().payloads).toEqual([
+      {
+        text: "Cron failed",
+        channelData: {
+          openclaw: {
+            replyContext: {
+              preserveSelfQuoteBody: true,
+            },
+          },
+        },
+      },
+    ]);
+  });
+
   it("uses sessionKey for delivery-target resolution and outbound context", async () => {
     await sendFailureNotificationAnnounce(
       {} as never,

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -1,4 +1,5 @@
 /** Sends cron announce payloads and best-effort failure notifications. */
+import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { sendDurableMessageBatch } from "../channels/message/runtime.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
@@ -31,6 +32,23 @@ export {
 
 const FAILURE_NOTIFICATION_TIMEOUT_MS = 30_000;
 const cronDeliveryLogger = getChildLogger({ subsystem: "cron-delivery" });
+
+function createCronNotificationPayload(params: { text: string; channel: string }): ReplyPayload {
+  const payload: ReplyPayload = { text: params.text };
+  if (params.channel !== "discord") {
+    return payload;
+  }
+  return {
+    ...payload,
+    channelData: {
+      openclaw: {
+        replyContext: {
+          preserveSelfQuoteBody: true,
+        },
+      },
+    },
+  };
+}
 
 /** Channel target metadata used for cron announcements and failure notifications. */
 export type CronAnnounceTarget = {
@@ -106,7 +124,12 @@ async function deliverCronAnnouncePayload(params: {
     to: params.delivery.resolvedTarget.to,
     accountId: params.delivery.resolvedTarget.accountId,
     threadId: params.delivery.resolvedTarget.threadId,
-    payloads: [{ text: params.message }],
+    payloads: [
+      createCronNotificationPayload({
+        text: params.message,
+        channel: params.delivery.resolvedTarget.channel,
+      }),
+    ],
     session: params.delivery.session,
     identity: params.delivery.identity,
     bestEffort: false,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -81,6 +81,7 @@ import {
 import type { DeliveryMirror } from "./mirror.js";
 import {
   createOutboundPayloadPlan,
+  hasOutboundTransportChannelData,
   summarizeOutboundPayloadForTransport,
   type NormalizedOutboundPayload,
   type OutboundPayloadPlan,
@@ -711,7 +712,12 @@ function deliveryKindForPayload(
   if (payloadSummary.mediaUrls.length > 0 || payload.mediaUrl || payload.mediaUrls?.length) {
     return "media";
   }
-  if (payload.presentation || payload.interactive || payload.channelData || payload.audioAsVoice) {
+  if (
+    payload.presentation ||
+    payload.interactive ||
+    hasOutboundTransportChannelData(payload.channelData) ||
+    payload.audioAsVoice
+  ) {
     return "other";
   }
   return "text";
@@ -767,7 +773,15 @@ function emitMessageDeliveryError(params: {
 function normalizeEmptyPayloadForDelivery(payload: ReplyPayload): ReplyPayload | null {
   const text = typeof payload.text === "string" ? payload.text : "";
   if (!text.trim()) {
-    if (!hasReplyPayloadContent({ ...payload, text })) {
+    if (
+      !hasReplyPayloadContent({
+        ...payload,
+        text,
+        channelData: hasOutboundTransportChannelData(payload.channelData)
+          ? payload.channelData
+          : undefined,
+      })
+    ) {
       return null;
     }
     if (text) {
@@ -1719,7 +1733,9 @@ async function deliverOutboundPayloadsCore(
           hasReplyPayloadContent({
             presentation: effectivePayload.presentation,
             interactive: effectivePayload.interactive,
-            channelData: effectivePayload.channelData,
+            channelData: hasOutboundTransportChannelData(effectivePayload.channelData)
+              ? effectivePayload.channelData
+              : undefined,
           }) ||
           effectivePayload.audioAsVoice === true)
       ) {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -200,6 +200,35 @@ type IndexedPreparedOutboundPayloadPlanEntry = PreparedOutboundPayloadPlanEntry 
   sourceIndex: number;
 };
 
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function hasOnlyOpenClawReplyContextMetadata(channelData: Record<string, unknown>): boolean {
+  const channelDataKeys = Object.keys(channelData);
+  if (channelDataKeys.length !== 1) {
+    return false;
+  }
+  const openclawData = readRecord(channelData.openclaw);
+  if (!openclawData || Object.keys(openclawData).length !== 1) {
+    return false;
+  }
+  const replyContext = readRecord(openclawData.replyContext);
+  if (!replyContext) {
+    return false;
+  }
+  return Object.keys(replyContext).length === 1 && replyContext.preserveSelfQuoteBody === true;
+}
+
+export function hasOutboundTransportChannelData(value: unknown): value is Record<string, unknown> {
+  if (!hasReplyChannelData(value)) {
+    return false;
+  }
+  return !hasOnlyOpenClawReplyContextMetadata(value);
+}
+
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
   context: Pick<OutboundPayloadPlanContext, "extractMarkdownImages"> = {},
@@ -243,7 +272,7 @@ function createOutboundPayloadPlanEntry(
   if (!isRenderablePayload(normalizedPayload) && !isSilent) {
     return null;
   }
-  const hasChannelData = hasReplyChannelData(normalizedPayload.channelData);
+  const hasChannelData = hasOutboundTransportChannelData(normalizedPayload.channelData);
   return {
     payload: normalizedPayload,
     hasPresentation: hasMessagePresentationBlocks(normalizedPayload.presentation),
@@ -376,7 +405,9 @@ export function summarizeOutboundPayloadForTransport(
     presentation: payload.presentation,
     delivery: payload.delivery,
     interactive: payload.interactive,
-    channelData: payload.channelData,
+    channelData: hasOutboundTransportChannelData(payload.channelData)
+      ? payload.channelData
+      : undefined,
     ...(text || !spokenText ? {} : { hookContent: spokenText }),
   };
 }


### PR DESCRIPTION
## Summary

- replace Discord self-reply preservation heuristics with an explicit OpenClaw reply-context marker on outbound cron notifications
- record delivered Discord message IDs for marked payloads, then preserve only those bot-authored quote bodies when users reply
- keep ordinary bot self-reply bodies/media suppressed, and treat OpenClaw-only marker metadata as non-transport data so normal Discord text chunking still applies

## Root cause

Discord reply context included the referenced bot message, but the shared inbound-context finalizer suppresses self-authored quote bodies by default. That default is correct for ordinary bot replies because it prevents self-echo loops, but it also removed the useful body from user replies to OpenClaw-generated notifications.

The first attempted fix recognized specific cron alert text. This update makes the behavior generic: cron delivery marks notification payloads with `channelData.openclaw.replyContext.preserveSelfQuoteBody`, Discord outbound delivery records the actual platform message IDs returned by the send, and inbound context preserves a self-authored quote body only when the user replied to one of those recorded IDs.

## Real behavior proof

- **Behavior addressed**: A Discord user can reply to an OpenClaw/SnabbelClaw notification and the agent receives the notification body as reply context, while ordinary bot-authored reply bodies remain suppressed.
- **Real environment tested**: Local OpenClaw source checkout on macOS with dependencies installed by `pnpm install --frozen-lockfile`, running the patched Discord inbound context builder and outbound marker policy through `node --import tsx`.
- **Exact steps or command run after this patch**: Ran a local OpenClaw source command that records a marked Discord outbound notification ID, builds Discord inbound reply context for a user reply to that marked bot message, and compares it with a reply to an unmarked bot message:

```bash
node --import tsx --eval 'import { createBaseDiscordMessageContext } from "./extensions/discord/src/monitor/message-handler.test-harness.ts"; import { buildDiscordMessageProcessContext } from "./extensions/discord/src/monitor/message-handler.context.ts"; import { recordDiscordSelfReplyContextPolicy, resetDiscordSelfReplyContextPolicyForTest } from "./extensions/discord/src/self-reply-context.ts"; /* record a marked outbound notification id, build marked and unmarked Discord reply contexts, print ReplyTo fields */'
```

- **Evidence after fix**: Terminal output from that patched source command:

```json
{
  "markedNotificationReply": {
    "ReplyToId": "m-marked-notification",
    "ReplyToSender": "SnabbelClaw",
    "ReplyToBody": "System notification: build failed\nReview the deployment dashboard.",
    "MediaPath": null,
    "MediaPaths": null
  },
  "ordinaryBotReply": {
    "ReplyToId": "m-ordinary-bot-reply",
    "ReplyToSender": "SnabbelClaw",
    "ReplyToBody": null,
    "MediaPath": null,
    "MediaPaths": null
  }
}
```

- **Observed result after fix**: The marked bot-authored notification text is present in `ReplyToBody` for the user reply, while the unmarked ordinary bot-authored message still has `ReplyToBody: null` and self-quote attachments remain absent.
- **What was not tested**: A live Discord gateway session against the public Discord API was not run.

## Verification

- `node scripts/run-vitest.mjs extensions/discord/src/durable-delivery.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/monitor/message-handler.process.test.ts src/cron/delivery.failure-notify.test.ts src/channels/inbound-event/context.test.ts`
- `pnpm format:check extensions/discord/src/self-reply-context.ts extensions/discord/src/monitor/message-handler.context.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/discord/src/outbound-adapter.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/durable-delivery.test.ts src/cron/delivery.ts src/cron/delivery.failure-notify.test.ts src/infra/outbound/payloads.ts src/infra/outbound/deliver.ts`
- `git diff --check`
- independent Codex subagent review after the generic rewrite: no blocking findings; specifically checked genericity and marker-only transport behavior
