### PR TITLE
fix(telegram): recover pid-reused ingress claims

### DIFF
--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -258,7 +258,7 @@ describe("Telegram ingress spool", () => {
     });
   });
 
-  it("does not treat stale claims with reused pids as live-owned", () => {
+  it("does not treat claims with the current process pid as other live process claims", () => {
     const now = Date.now();
     expect(
       isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess({
@@ -270,7 +270,7 @@ describe("Telegram ingress spool", () => {
         claim: {
           processId: "other-process",
           processPid: process.pid,
-          claimedAt: now - TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS - 1,
+          claimedAt: now,
         },
       }),
     ).toBe(false);

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -212,6 +212,7 @@ export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
   return Boolean(
     claim.claim &&
     claim.claim.processId !== TELEGRAM_SPOOLED_UPDATE_PROCESS_ID &&
+    claim.claim.processPid !== process.pid &&
     isFreshClaimOwner(claim.claim) &&
     processExists(claim.claim.processPid),
   );


### PR DESCRIPTION
Summary
- Treat same-PID Telegram ingress claims as not owned by another live process.
- Tighten the regression test to cover Docker PID reuse with a fresh claim from a previous process UUID.

Proof
- New regression fails before the predicate fix: `expected true to be false` in `telegram-ingress-spool.test.ts`.
- After fix: `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-spool.test.ts` passes, 8 tests.
- Live HamVerBot repro: stale claimed Telegram row recovered after this predicate change; fresh `@HamVerBot` messages reached Claude and delivered via `sendRichMessage`.
