### PR TITLE
Persist ClawHub skill install provenance

### DIFF
--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -3,7 +3,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 
 const fetchClawHubSkillDetailMock = vi.fn();
 const fetchClawHubSkillInstallResolutionMock = vi.fn();
@@ -21,6 +22,7 @@ const withExtractedArchiveRootMock = vi.fn();
 const installPackageDirMock = vi.fn();
 const evaluateSkillInstallPolicyMock = vi.fn();
 const pathExistsMock = vi.fn();
+const tempDirs = createTrackedTempDirs();
 
 vi.mock("../../infra/clawhub.js", () => ({
   fetchClawHubSkillDetail: fetchClawHubSkillDetailMock,
@@ -165,6 +167,10 @@ async function writeClawHubOriginFixture(params: {
 }
 
 describe("skills-clawhub", () => {
+  afterEach(async () => {
+    await tempDirs.cleanup();
+  });
+
   beforeEach(() => {
     fetchClawHubSkillDetailMock.mockReset();
     fetchClawHubSkillInstallResolutionMock.mockReset();
@@ -302,7 +308,7 @@ describe("skills-clawhub", () => {
   });
 
   it("persists install artifact and verification provenance in the ClawHub lockfile", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-lock-"));
+    const workspaceDir = await tempDirs.make("openclaw-skills-lock-");
     const skillContent = "---\nname: agentreceipt\ndescription: Receipt helper\n---\n";
     const skillSha256 = createHash("sha256").update(skillContent).digest("hex");
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
@@ -377,7 +383,7 @@ describe("skills-clawhub", () => {
   });
 
   it("keeps installing when the ClawHub verification snapshot is unavailable", async () => {
-    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-lock-"));
+    const workspaceDir = await tempDirs.make("openclaw-skills-lock-");
     fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
       await fs.mkdir(params.targetDir, { recursive: true });

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -1,4 +1,5 @@
 // ClawHub lifecycle tests cover registry metadata lookup and error handling.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchClawHubSkillDetailMock = vi.fn();
 const fetchClawHubSkillInstallResolutionMock = vi.fn();
+const fetchClawHubSkillVerificationMock = vi.fn();
 const downloadClawHubSkillArchiveMock = vi.fn();
 const downloadClawHubSkillArchiveUrlMock = vi.fn();
 const downloadClawHubGitHubSkillArchiveMock = vi.fn();
@@ -23,6 +25,7 @@ const pathExistsMock = vi.fn();
 vi.mock("../../infra/clawhub.js", () => ({
   fetchClawHubSkillDetail: fetchClawHubSkillDetailMock,
   fetchClawHubSkillInstallResolution: fetchClawHubSkillInstallResolutionMock,
+  fetchClawHubSkillVerification: fetchClawHubSkillVerificationMock,
   downloadClawHubSkillArchive: downloadClawHubSkillArchiveMock,
   downloadClawHubSkillArchiveUrl: downloadClawHubSkillArchiveUrlMock,
   downloadClawHubGitHubSkillArchive: downloadClawHubGitHubSkillArchiveMock,
@@ -165,6 +168,7 @@ describe("skills-clawhub", () => {
   beforeEach(() => {
     fetchClawHubSkillDetailMock.mockReset();
     fetchClawHubSkillInstallResolutionMock.mockReset();
+    fetchClawHubSkillVerificationMock.mockReset();
     downloadClawHubSkillArchiveMock.mockReset();
     downloadClawHubSkillArchiveUrlMock.mockReset();
     downloadClawHubGitHubSkillArchiveMock.mockReset();
@@ -205,19 +209,36 @@ describe("skills-clawhub", () => {
         downloadUrl: "https://clawhub.ai/api/v1/download?slug=agentreceipt&version=1.0.0",
       },
     });
+    fetchClawHubSkillVerificationMock.mockResolvedValue({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      card: { available: true, sha256: "card-sha" },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: { source: "unavailable" },
+      security: { status: "clean", signals: { staticScan: { engineVersion: "v2.4.24" } } },
+      signature: { status: "unsigned" },
+    });
     downloadClawHubSkillArchiveMock.mockResolvedValue({
       archivePath: "/tmp/agentreceipt.zip",
       integrity: "sha256-test",
+      sha256Hex: "a".repeat(64),
+      artifact: "archive",
       cleanup: archiveCleanupMock,
     });
     downloadClawHubSkillArchiveUrlMock.mockResolvedValue({
       archivePath: "/tmp/agentreceipt.zip",
       integrity: "sha256-test",
+      sha256Hex: "a".repeat(64),
+      artifact: "archive",
       cleanup: archiveCleanupMock,
     });
     downloadClawHubGitHubSkillArchiveMock.mockResolvedValue({
       archivePath: "/tmp/github-agentreceipt.zip",
       integrity: "sha256-github-test",
+      sha256Hex: "b".repeat(64),
+      artifact: "archive",
       cleanup: archiveCleanupMock,
     });
     reportClawHubSkillInstallTelemetryMock.mockResolvedValue(undefined);
@@ -263,13 +284,125 @@ describe("skills-clawhub", () => {
       baseUrl: undefined,
       root: "/tmp/workspace",
       skills: expect.objectContaining({
-        agentreceipt: {
+        agentreceipt: expect.objectContaining({
           version: "1.0.0",
           installedAt: expect.any(Number),
           registry: "https://clawhub.ai",
-        },
+        }),
       }),
     });
+    const telemetrySkills = reportClawHubSkillInstallTelemetryMock.mock.calls[0]?.[0]?.skills as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    expect(Object.keys(telemetrySkills?.agentreceipt ?? {}).toSorted()).toEqual([
+      "installedAt",
+      "registry",
+      "version",
+    ]);
+  });
+
+  it("persists install artifact and verification provenance in the ClawHub lockfile", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-lock-"));
+    const skillContent = "---\nname: agentreceipt\ndescription: Receipt helper\n---\n";
+    const skillSha256 = createHash("sha256").update(skillContent).digest("hex");
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), skillContent, "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+        slug: "agentreceipt",
+        version: "1.0.0",
+        baseUrl: undefined,
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt).toMatchObject({
+        version: "1.0.0",
+        registry: "https://clawhub.ai",
+        artifact: {
+          kind: "archive",
+          sha256: "a".repeat(64),
+          integrity: "sha256-test",
+        },
+        skillFile: {
+          path: "SKILL.md",
+          sha256: skillSha256,
+        },
+        verification: {
+          schema: "clawhub.skill.verify.v1",
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          provenance: { source: "unavailable" },
+          security: { status: "clean", signals: { staticScan: { engineVersion: "v2.4.24" } } },
+        },
+      });
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin).toMatchObject({
+        version: 1,
+        slug: "agentreceipt",
+        installedVersion: "1.0.0",
+        artifact: {
+          kind: "archive",
+          sha256: "a".repeat(64),
+          integrity: "sha256-test",
+        },
+        skillFile: {
+          path: "SKILL.md",
+          sha256: skillSha256,
+        },
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps installing when the ClawHub verification snapshot is unavailable", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-lock-"));
+    fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expectInstalledSkill(result, { slug: "agentreceipt", version: "1.0.0" });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt?.verification).toBeUndefined();
+      expect(lock.skills.agentreceipt?.artifact).toMatchObject({
+        sha256: "a".repeat(64),
+        integrity: "sha256-test",
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   it("installs GitHub-backed ClawHub skills from the pinned resolver source path", async () => {

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -1,5 +1,7 @@
 // ClawHub lifecycle helpers fetch skill registry metadata and package details.
+import { createHash } from "node:crypto";
 import fsSync from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -8,13 +10,16 @@ import {
   downloadClawHubSkillArchiveUrl,
   fetchClawHubSkillDetail,
   fetchClawHubSkillInstallResolution,
+  fetchClawHubSkillVerification,
   isDefaultClawHubBaseUrl,
   reportClawHubSkillInstallTelemetry,
   resolveClawHubBaseUrl,
   searchClawHubSkills,
+  type ClawHubDownloadResult,
   type ClawHubSkillDetail,
   type ClawHubSkillInstallResolutionResponse,
   type ClawHubSkillSearchResult,
+  type ClawHubSkillVerificationResponse,
 } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { pathExists } from "../../infra/fs-safe.js";
@@ -34,24 +39,53 @@ const SKILL_ORIGIN_RELATIVE_PATH = path.join(DOT_DIR, "origin.json");
 const LOCAL_SKILL_CARD_FILENAME = "skill-card.md";
 const LOCAL_SKILL_CARD_MAX_BYTES = 256 * 1024;
 
+type ClawHubSkillDownloadedArtifactLock = {
+  kind: ClawHubDownloadResult["artifact"];
+  sha256: string;
+  integrity: string;
+};
+
+type ClawHubSkillFileLock = {
+  path: string;
+  sha256: string;
+};
+
+type ClawHubSkillVerificationLock = {
+  schema: ClawHubSkillVerificationResponse["schema"];
+  ok: boolean;
+  decision: ClawHubSkillVerificationResponse["decision"];
+  reasons: string[];
+  card?: unknown;
+  artifact?: unknown;
+  provenance?: unknown;
+  security?: unknown;
+  signature?: unknown;
+};
+
+type ClawHubSkillLockEntry = {
+  version: string;
+  installedAt: number;
+  registry?: string;
+  sourceUrl?: string;
+  artifact?: ClawHubSkillDownloadedArtifactLock;
+  skillFile?: ClawHubSkillFileLock;
+  verification?: ClawHubSkillVerificationLock;
+};
+
 export type ClawHubSkillOrigin = {
   version: 1;
   registry: string;
   slug: string;
   installedVersion: string;
   installedAt: number;
+  sourceUrl?: string;
+  artifact?: ClawHubSkillDownloadedArtifactLock;
+  skillFile?: ClawHubSkillFileLock;
 };
 
 export type ClawHubSkillsLockfile = {
   version: 1;
-  skills: Record<
-    string,
-    {
-      version: string;
-      installedAt: number;
-      registry?: string;
-    }
-  >;
+  skills: Record<string, ClawHubSkillLockEntry>;
 };
 
 export type ClawHubSkillsLockfileStatusRead =
@@ -233,6 +267,94 @@ function readRealPathSync(candidate: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function normalizeOptionalStringValue(raw: unknown): string | undefined {
+  return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+}
+
+function readSkillDetailSourceUrl(detail: ClawHubSkillDetail | undefined): string | undefined {
+  const skill = detail?.skill;
+  if (!skill || typeof skill !== "object") {
+    return undefined;
+  }
+  return normalizeOptionalStringValue((skill as { sourceUrl?: unknown }).sourceUrl);
+}
+
+function buildDownloadedArtifactLock(
+  archive: ClawHubDownloadResult,
+): ClawHubSkillDownloadedArtifactLock {
+  return {
+    kind: archive.artifact,
+    sha256: archive.sha256Hex,
+    integrity: archive.integrity,
+  };
+}
+
+function buildInstallTelemetrySkills(
+  skills: ClawHubSkillsLockfile["skills"],
+): Record<string, { version: string; installedAt: number; registry?: string }> {
+  return Object.fromEntries(
+    Object.entries(skills).map(([slug, entry]) => [
+      slug,
+      {
+        version: entry.version,
+        installedAt: entry.installedAt,
+        ...(entry.registry ? { registry: entry.registry } : {}),
+      },
+    ]),
+  );
+}
+
+function snapshotClawHubSkillVerification(
+  verification: ClawHubSkillVerificationResponse,
+): ClawHubSkillVerificationLock {
+  return {
+    schema: verification.schema,
+    ok: verification.ok,
+    decision: verification.decision,
+    reasons: [...verification.reasons],
+    ...(verification.card !== undefined ? { card: verification.card } : {}),
+    ...(verification.artifact !== undefined ? { artifact: verification.artifact } : {}),
+    ...(verification.provenance !== undefined ? { provenance: verification.provenance } : {}),
+    ...(verification.security !== undefined ? { security: verification.security } : {}),
+    ...(verification.signature !== undefined ? { signature: verification.signature } : {}),
+  };
+}
+
+async function fetchInstallVerificationLock(params: {
+  slug: string;
+  version?: string;
+  baseUrl?: string;
+}): Promise<ClawHubSkillVerificationLock | undefined> {
+  try {
+    const verification = await fetchClawHubSkillVerification({
+      slug: params.slug,
+      version: params.version,
+      baseUrl: params.baseUrl,
+    });
+    return snapshotClawHubSkillVerification(verification);
+  } catch {
+    return undefined;
+  }
+}
+
+async function readInstalledSkillFileLock(
+  skillDir: string,
+): Promise<ClawHubSkillFileLock | undefined> {
+  for (const marker of CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS) {
+    const candidate = path.join(skillDir, marker);
+    try {
+      const content = await fs.readFile(candidate);
+      return {
+        path: marker,
+        sha256: createHash("sha256").update(content).digest("hex"),
+      };
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
 }
 
 export function readClawHubSkillsLockfileStatusSync(
@@ -983,24 +1105,46 @@ async function performClawHubSkillInstall(
       }
 
       const installedAt = Date.now();
+      const artifact = buildDownloadedArtifactLock(archive);
+      const sourceUrl =
+        latestResolution?.installKind === "github"
+          ? normalizeOptionalStringValue(latestResolution.github.sourceUrl)
+          : readSkillDetailSourceUrl(detail);
+      const verificationVersion =
+        latestResolution?.installKind === "github" && !params.version ? undefined : version;
+      const [skillFile, verification] = await Promise.all([
+        readInstalledSkillFileLock(install.targetDir),
+        fetchInstallVerificationLock({
+          slug: params.slug,
+          version: verificationVersion,
+          baseUrl: params.baseUrl,
+        }),
+      ]);
       await writeClawHubSkillOrigin(install.targetDir, {
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),
         slug: params.slug,
         installedVersion: version,
         installedAt,
+        ...(sourceUrl ? { sourceUrl } : {}),
+        artifact,
+        ...(skillFile ? { skillFile } : {}),
       });
       const lock = await readClawHubSkillsLockfile(params.workspaceDir);
       lock.skills[params.slug] = {
         version,
         installedAt,
         registry: resolveClawHubBaseUrl(params.baseUrl),
+        ...(sourceUrl ? { sourceUrl } : {}),
+        artifact,
+        ...(skillFile ? { skillFile } : {}),
+        ...(verification ? { verification } : {}),
       };
       await writeClawHubSkillsLockfile(params.workspaceDir, lock);
       await reportClawHubSkillInstallTelemetry({
         baseUrl: params.baseUrl,
         root: params.workspaceDir,
-        skills: lock.skills,
+        skills: buildInstallTelemetrySkills(lock.skills),
       }).catch(() => undefined);
 
       return {


### PR DESCRIPTION
## Summary

Refs #92077.

This PR implements a narrow, local lockfile slice of the ClawHub skill provenance work:

- persists the downloaded ClawHub artifact SHA256/integrity in `.clawhub/lock.json`
- records the installed `SKILL.md` filename and SHA256 after extraction
- snapshots the ClawHub skill verification envelope fields that are useful for audit (`decision`, `reasons`, `card`, `artifact`, `provenance`, `security`, `signature`)
- keeps install telemetry backwards-shaped so the richer local lock data is not sent back to ClawHub telemetry

This intentionally does not close #92077. Source URL requirements, publish-time source validation, pinned install syntax, richer audit commands, and sandbox-by-default remain larger follow-up decisions.

## Verification

- `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts`
- `node scripts/run-vitest.mjs src/cli/skills-cli.verify.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:test:src`
- `pnpm exec oxfmt --check --threads=1 src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts`
- `node scripts/run-oxlint.mjs src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: ClawHub skill installs now leave local audit data that ties the install to the downloaded artifact, installed `SKILL.md`, and ClawHub verification response.

Real environment tested: local macOS checkout, Node v22.18.0, pnpm v11.2.2, live `https://clawhub.ai`.

Exact command run after this patch:

```bash
node --import tsx -e 'const fs = await import("node:fs/promises"); const os = await import("node:os"); const path = await import("node:path"); const { installSkillFromClawHub } = await import("./src/skills/lifecycle/clawhub.ts"); const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-lock-proof-")); try { const result = await installSkillFromClawHub({ workspaceDir: root, slug: "openclaw-find-skills", logger: { info: (message) => console.log(`info:${message}`) } }); console.log(`result:${JSON.stringify(result)}`); if (!result.ok) process.exit(1); const lock = JSON.parse(await fs.readFile(path.join(root, ".clawhub", "lock.json"), "utf8")); const entry = lock.skills["openclaw-find-skills"]; console.log(`lock:${JSON.stringify({ version: entry.version, artifact: entry.artifact, skillFile: entry.skillFile, verification: entry.verification && { ok: entry.verification.ok, decision: entry.verification.decision, reasons: entry.verification.reasons, provenance: entry.verification.provenance, securityStatus: entry.verification.security?.status } }, null, 2)}`); } finally { await fs.rm(root, { recursive: true, force: true }); }'
```

Observed result after fix:

```json
{
  "version": "1.0.0",
  "artifact": {
    "kind": "archive",
    "sha256": "9fb2b8e43f8301560f50a4484742c51e2d02be1f6a437f4d51e345f970addaca",
    "integrity": "sha256-n7K45D+DAVYPUKRIR0LFHi0Cvh9qQ39NUeNF+XCt2so="
  },
  "skillFile": {
    "path": "SKILL.md",
    "sha256": "6895c10c93ec17ca64b2b06ff15cbfa4278e7a011cb9464d9fc4b90a029af71b"
  },
  "verification": {
    "ok": false,
    "decision": "fail",
    "reasons": ["security.status_not_clean"],
    "provenance": {
      "source": "unavailable",
      "reason": "No server-resolved GitHub import provenance is stored for this version."
    },
    "securityStatus": "suspicious"
  }
}
```

What was not tested: full `openclaw skills audit` / frozen install behavior, because this PR only persists the lock data needed for those later features.
