### PR TITLE
fix(control-ui): restore provider quota pill in chat composer controls

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -16,6 +16,7 @@ import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
   renderChatSessionSelect as renderChatSessionSelectBase,
   renderChatModelSelect,
+  renderChatQuotaPill,
   resetChatSessionPickerState,
   resolveSessionOptionGroups,
 } from "./chat/session-controls.ts";
@@ -390,7 +391,7 @@ export function renderChatControls(state: AppViewState) {
         }
       }}
     >
-      ${renderChatModelSelect(state)}
+      ${renderChatModelSelect(state)} ${renderChatQuotaPill(state)}
     </div>
     <div class="chat-settings-popover-wrapper">
       <button

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -739,7 +739,7 @@ function renderChatSessionPickerPopover(
   `;
 }
 
-function renderChatQuotaPill(state: AppViewState) {
+export function renderChatQuotaPill(state: AppViewState) {
   const windows = collectQuotaWindowsFromAuthStatus(
     state.modelAuthStatusResult,
     isMonitoredAuthProvider,


### PR DESCRIPTION
## Summary

- Restore the provider quota pill (usage/limit UI) that was accidentally removed from the Chat composer controls in v2026.6.1
- PR #88772 refactored the Chat header and moved session selection to the sidebar with `sessionSwitcherOnly=true`, which suppressed both the model select and the quota pill
- The model select was correctly re-added to the composer controls, but the quota pill was missed
- The quota data path and pill rendering implementation remained intact — only the call site was missing

Fixes #93041

## Linked context

- Introduced by PR #88772 (`feat: calm composer controls`, merged May 31 as `2b30951b8090`)
- Maintainer analysis: https://github.com/openclaw/openclaw/issues/93041#issuecomment-4702737312

## Real behavior proof (required for external PRs)

**Behavior addressed**: The provider quota pill (showing usage % for Codex/OpenAI rate limits) is now rendered in the chat composer controls, restoring the behavior present before v2026.6.1.

**Real setup tested**: Frontend-only change — verified through build and test suite.

**Exact steps or command run after fix**:

```bash
pnpm build
pnpm test -- --run ui/src/ui/views/chat.test.ts
```

**After-fix evidence**:

```
$ pnpm build
✓ built in 2.97s
[build-all] ui:build done in 5.15s

$ pnpm test -- --run ui/src/ui/views/chat.test.ts
 RUN  v4.1.7
 Test Files  1 passed (1)
      Tests  104 passed (104)
```

**Observed result after the fix**: Build succeeds, all 104 tests pass including the existing test that asserts `data-chat-provider-usage="true"` element is rendered with correct text content ("Usage 28%"), href ("/usage"), and title.

**What was not tested**: Live browser screenshot against a running Gateway with real OpenAI/Codex OAuth credentials.

## Tests and validation

- `ui/src/ui/views/chat.test.ts` — 104 tests pass, including the existing `"shows provider quota in the chat header when usage data is loaded"` test
- No existing tests needed modification

## Risk checklist

Did user-visible behavior change? (`Yes`)
- The quota pill reappears in the composer controls area for users with monitored auth providers (Codex/OpenAI OAuth)

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- The quota pill adding extra horizontal space in the composer controls on narrow viewports

How is that risk mitigated?
- The pill reuses existing CSS classes and layout — it was previously rendered in the same row via `renderChatSessionSelect` (old header path), so all layout handling is already battle-tested

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- Live browser screenshot with real OpenAI OAuth credentials (cannot produce in current environment)

Which bot or reviewer comments were addressed?
- N/A — no clawsweeper comments on this issue
