### PR TITLE
fix(codex): preserve terminal outcome ordering

### DIFF
--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -436,6 +436,31 @@ export function readCodexNotificationItem(
     : undefined;
 }
 
+/** Reads the stable call id from a model-emitted raw tool item. */
+export function readRawResponseToolCallId(
+  notification: CodexServerNotification,
+): string | undefined {
+  if (notification.method !== "rawResponseItem/completed" || !isJsonObject(notification.params)) {
+    return undefined;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  if (!item) {
+    return undefined;
+  }
+  switch (readString(item, "type")) {
+    case "custom_tool_call":
+    case "function_call":
+    case "local_shell_call":
+    case "tool_search_call":
+      return readString(item, "call_id");
+    case "image_generation_call":
+    case "web_search_call":
+      return readString(item, "id");
+    default:
+      return undefined;
+  }
+}
+
 /** Maps Codex item types to the tool name shown in execution progress. */
 export function codexExecutionToolName(item: CodexThreadItem): string | undefined {
   if (item.type === "dynamicToolCall" && typeof item.tool === "string") {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -583,13 +583,15 @@ describe("Codex app-server dynamic tool build", () => {
     });
   });
 
-  it("forwards the tool outcome observer into Codex dynamic tools", async () => {
+  it("forwards tool outcome ordering into Codex dynamic tools", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     const onToolOutcome = vi.fn();
+    const allocateToolOutcomeOrdinal = vi.fn(() => 0);
     params.disableTools = false;
     params.onToolOutcome = onToolOutcome;
+    params.allocateToolOutcomeOrdinal = allocateToolOutcomeOrdinal;
     params.runtimePlan = createCodexRuntimePlanFixture();
     const factoryOptions: unknown[] = [];
     setOpenClawCodingToolsFactoryForTests((options) => {
@@ -599,7 +601,10 @@ describe("Codex app-server dynamic tool build", () => {
 
     await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
 
-    expect(factoryOptions[0]).toMatchObject({ onToolOutcome });
+    expect(factoryOptions[0]).toMatchObject({
+      onToolOutcome,
+      allocateToolOutcomeOrdinal,
+    });
   });
 
   it("preserves before-tool wrapping through Codex runtime normalization", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -291,6 +291,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
       toolBuildStages.mark(name);
     },
     onToolOutcome: params.onToolOutcome,
+    allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
   });
   toolBuildStages.mark("create-openclaw-coding-tools");
   const preNormalizationDiagnostics: RuntimeToolSchemaDiagnostic[] = [];

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -183,6 +183,7 @@ describe("dynamic tool execution helpers", () => {
     vi.useFakeTimers();
     let capturedSignal: AbortSignal | undefined;
     const onTimeout = vi.fn();
+    const onFallbackSelected = vi.fn();
     const onAgentToolResult = vi.fn();
     const response = handleDynamicToolCallWithTimeout({
       call: {
@@ -202,6 +203,7 @@ describe("dynamic tool execution helpers", () => {
       signal: new AbortController().signal,
       timeoutMs: 1,
       onAgentToolResult,
+      onFallbackSelected,
       onTimeout,
     });
 
@@ -217,6 +219,7 @@ describe("dynamic tool execution helpers", () => {
       ],
     });
     expect(capturedSignal?.aborted).toBe(true);
+    expect(onFallbackSelected).toHaveBeenCalledOnce();
     expect(onTimeout).toHaveBeenCalledTimes(1);
     expect(onAgentToolResult).toHaveBeenCalledWith({
       toolName: "message",

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -126,7 +126,9 @@ export async function handleDynamicToolCallWithTimeout(params: {
   toolBridge: Pick<CodexDynamicToolBridge, "handleToolCall">;
   signal: AbortSignal;
   timeoutMs: number;
+  toolCallOrdinal?: number;
   onAgentToolResult?: EmbeddedRunAttemptParams["onAgentToolResult"];
+  onFallbackSelected?: () => void;
   onTimeout?: () => void;
 }): Promise<CodexDynamicToolCallResponse> {
   // Timeout or run abort can win while a tool ignores cancellation. Keep the
@@ -159,6 +161,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
   };
   if (params.signal.aborted) {
     const message = "OpenClaw dynamic tool call aborted before execution.";
+    params.onFallbackSelected?.();
     notifyFailedToolResult(message);
     return failedDynamicToolResponse(message);
   }
@@ -169,6 +172,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
   let resolveAbort: ((response: CodexDynamicToolCallResponse) => void) | undefined;
   const abortFromRun = () => {
     const message = "OpenClaw dynamic tool call aborted.";
+    params.onFallbackSelected?.();
     controller.abort(params.signal.reason ?? new Error(message));
     notifyFailedToolResult(message);
     resolveAbort?.(failedDynamicToolResponse(message, { sideEffectEvidence: true }));
@@ -181,6 +185,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
     timeout = setTimeout(() => {
       timedOut = true;
       const timeoutDetails = formatDynamicToolTimeoutDetails({ call: params.call, timeoutMs });
+      params.onFallbackSelected?.();
       controller.abort(new Error(timeoutDetails.responseMessage));
       params.onTimeout?.();
       embeddedAgentLog.warn("codex dynamic tool call timed out", {
@@ -204,6 +209,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
       params.toolBridge.handleToolCall(params.call, {
         signal: controller.signal,
         onAgentToolResult: notifyAgentToolResult,
+        toolCallOrdinal: params.toolCallOrdinal,
       }),
       abortPromise,
       timeoutPromise,

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -66,6 +66,7 @@ type CodexDynamicToolHookContext = {
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
   onToolOutcome?: EmbeddedRunAttemptParams["onToolOutcome"];
+  allocateToolOutcomeOrdinal?: EmbeddedRunAttemptParams["allocateToolOutcomeOrdinal"];
 };
 
 type CodexToolResultHookContext = Omit<CodexDynamicToolHookContext, "config">;
@@ -107,6 +108,7 @@ export type CodexDynamicToolBridge = {
     options?: {
       signal?: AbortSignal;
       onAgentToolResult?: EmbeddedRunAttemptParams["onAgentToolResult"];
+      toolCallOrdinal?: number;
     },
   ) => Promise<CodexDynamicToolCallResponse>;
   telemetry: {
@@ -227,6 +229,7 @@ export function createCodexDynamicToolBridge(params: {
           isError: true,
           observer: params.hookContext?.onToolOutcome,
           toolName: call.tool,
+          toolCallOrdinal: options?.toolCallOrdinal,
         });
         notifyAgentToolResult(
           options?.onAgentToolResult,
@@ -326,6 +329,7 @@ export function createCodexDynamicToolBridge(params: {
           isError: resultIsError,
           observer: params.hookContext?.onToolOutcome,
           toolName,
+          toolCallOrdinal: options?.toolCallOrdinal,
         });
         const messagingTelemetryArgs = applyCurrentMessageProvider(
           toolName,
@@ -393,6 +397,7 @@ export function createCodexDynamicToolBridge(params: {
           isError: true,
           observer: params.hookContext?.onToolOutcome,
           toolName,
+          toolCallOrdinal: options?.toolCallOrdinal,
         });
         notifyAgentToolResult(options?.onAgentToolResult, toolName, failedResult, true);
         collectToolTelemetry({

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2788,22 +2788,24 @@ describe("CodexAppServerEventProjector", () => {
         terminalPresentation = observation.terminalPresentation;
       },
     });
+    const item = {
+      type: "commandExecution",
+      id: "command-clear-presentation",
+      command: "git status --short",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status: "completed",
+      commandActions: [{ type: "unknown", command: "git status --short" }],
+      aggregatedOutput: "",
+      exitCode: 0,
+      durationMs: 1,
+    };
 
+    await projector.handleNotification(forCurrentTurn("item/started", { item }));
     await projector.handleNotification(
       forCurrentTurn("item/completed", {
-        item: {
-          type: "commandExecution",
-          id: "command-clear-presentation",
-          command: "git status --short",
-          cwd: "/workspace",
-          processId: null,
-          source: "agent",
-          status: "completed",
-          commandActions: [{ type: "unknown", command: "git status --short" }],
-          aggregatedOutput: "",
-          exitCode: 0,
-          durationMs: 1,
-        },
+        item,
       }),
     );
 
@@ -2826,8 +2828,89 @@ describe("CodexAppServerEventProjector", () => {
           id: "image-view-clear-presentation",
           path: "/workspace/reference.png",
         },
+        {
+          type: "dynamicToolCall",
+          id: "stale-dynamic-tool",
+          turnId: "turn-old",
+          tool: "web_fetch",
+          status: "completed",
+        },
       ]),
     );
+
+    expect(terminalPresentation).toBeUndefined();
+  });
+
+  it("keeps a later dynamic presentation over an earlier snapshot-only native tool", async () => {
+    let terminalPresentation: string | undefined = "later dynamic result";
+    let latestOrdinal = 1;
+    let nextOrdinal = 0;
+    const projector = await createProjector({
+      ...(await createParams()),
+      allocateToolOutcomeOrdinal: () => nextOrdinal++,
+      onToolOutcome: (observation) => {
+        const ordinal = observation.toolCallOrdinal ?? latestOrdinal + 1;
+        if (ordinal >= latestOrdinal) {
+          latestOrdinal = ordinal;
+          terminalPresentation = observation.terminalPresentation;
+        }
+      },
+    });
+    const nativeItem = {
+      type: "imageView",
+      id: "image-view-before-dynamic",
+      path: "/workspace/reference.png",
+    };
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: nativeItem,
+      }),
+    );
+
+    await projector.handleNotification(
+      turnCompleted([
+        nativeItem,
+        {
+          type: "dynamicToolCall",
+          id: "dynamic-after-image-view",
+          turnId: TURN_ID,
+          tool: "web_fetch",
+          status: "completed",
+        },
+        {
+          type: "imageView",
+          id: "stale-image-view",
+          turnId: "turn-old",
+          path: "/workspace/stale.png",
+        },
+      ]),
+    );
+
+    expect(terminalPresentation).toBe("later dynamic result");
+  });
+
+  it("clears a prior presentation for a completion-only native item without a turn snapshot", async () => {
+    let terminalPresentation: string | undefined = "stale dynamic result";
+    let nextOrdinal = 1;
+    const projector = await createProjector({
+      ...(await createParams()),
+      allocateToolOutcomeOrdinal: () => nextOrdinal++,
+      onToolOutcome: (observation) => {
+        terminalPresentation = observation.terminalPresentation;
+      },
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "imageView",
+          id: "completion-only-image-view",
+          path: "/workspace/reference.png",
+        },
+      }),
+    );
+    await projector.handleNotification(turnCompleted([]));
 
     expect(terminalPresentation).toBeUndefined();
   });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -171,6 +171,7 @@ export class CodexAppServerEventProjector {
     { toolName: string; meta?: string; asyncStarted?: boolean }
   >();
   private readonly terminalPresentationClearedItemIds = new Set<string>();
+  private readonly nativeToolOutcomeOrdinals = new Map<string, number>();
   private readonly sideEffectingToolItemIds = new Set<string>();
   private readonly sideEffectingDynamicToolCallIds = new Set<string>();
   private readonly toolTranscriptMessages: AgentMessage[] = [];
@@ -215,6 +216,21 @@ export class CodexAppServerEventProjector {
   hasCompletedTerminalAssistantText(): boolean {
     const finalItem = this.resolveFinalAssistantTextItem();
     return finalItem !== undefined && this.completedItemIds.has(finalItem.itemId);
+  }
+
+  /** Resolves the shared model-order position for a native tool item. */
+  recordNativeToolOutcome(item: CodexThreadItem | undefined): void {
+    if (
+      !item ||
+      this.nativeToolOutcomeOrdinals.has(item.id) ||
+      !shouldClearTerminalPresentationForNativeItem(item)
+    ) {
+      return;
+    }
+    const ordinal = this.params.allocateToolOutcomeOrdinal?.(item.id);
+    if (ordinal !== undefined) {
+      this.nativeToolOutcomeOrdinals.set(item.id, ordinal);
+    }
   }
 
   async handleNotification(notification: CodexServerNotification): Promise<void> {
@@ -583,6 +599,7 @@ export class CodexAppServerEventProjector {
     if (itemId) {
       this.activeItemIds.add(itemId);
     }
+    this.recordNativeToolOutcome(item);
     if (item?.type === "contextCompaction" && itemId) {
       this.activeCompactionItemIds.add(itemId);
       await runAgentHarnessBeforeCompactionHook({
@@ -623,6 +640,7 @@ export class CodexAppServerEventProjector {
 
   private async handleItemCompleted(params: JsonObject): Promise<void> {
     const item = readItem(params.item);
+    this.recordNativeToolOutcome(item);
     this.clearTerminalPresentationForNativeItem(item);
     const itemId = item?.id ?? readString(params, "itemId") ?? readString(params, "id");
     if (itemId) {
@@ -766,8 +784,23 @@ export class CodexAppServerEventProjector {
         "codex app-server turn failed";
       this.promptErrorSource = "prompt";
     }
-    for (const item of turn.items ?? []) {
-      this.clearTerminalPresentationForNativeItem(item);
+    const turnItems = turn.items ?? [];
+    // The final snapshot is authoritative when item notifications were omitted.
+    // Only its last relevant tool may change the terminal presentation.
+    for (let index = turnItems.length - 1; index >= 0; index -= 1) {
+      const item = turnItems[index];
+      if (!item || !this.isCurrentTurnSnapshotItem(item)) {
+        continue;
+      }
+      if (item?.type === "dynamicToolCall") {
+        break;
+      }
+      if (shouldClearTerminalPresentationForNativeItem(item)) {
+        this.clearTerminalPresentationForNativeItem(item);
+        break;
+      }
+    }
+    for (const item of turnItems) {
       this.rememberAssistantPhase(item);
       if (item.type === "agentMessage" && typeof item.text === "string") {
         this.rememberAssistantItem(item.id);
@@ -1132,11 +1165,13 @@ export class CodexAppServerEventProjector {
     ) {
       return;
     }
+    const toolCallOrdinal = this.nativeToolOutcomeOrdinals.get(item.id);
     this.terminalPresentationClearedItemIds.add(item.id);
     this.params.onToolOutcome?.({
       toolName: itemName(item) ?? item.type,
       argsHash: "",
       resultHash: "",
+      ...(toolCallOrdinal !== undefined ? { toolCallOrdinal } : {}),
       terminalPresentation: undefined,
       presentationOnly: true,
     });

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -1,6 +1,14 @@
 // Codex tests cover run attemptynamic tools plugin behavior.
 import path from "node:path";
-import { onAgentEvent, type AgentEventPayload } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  onAgentEvent,
+  wrapToolWithBeforeToolCallHook,
+  type AgentEventPayload,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  createTerminalPresentationContractTool,
+  textToolResult,
+} from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import {
   emitTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
@@ -18,6 +26,7 @@ import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import type { CodexDynamicToolCallParams } from "./protocol.js";
 import {
   createParams,
+  createCodexRuntimePlanFixture,
   createRuntimeDynamicTool,
   createStartedThreadHarness,
   runCodexAppServerAttempt,
@@ -53,6 +62,246 @@ function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string>
 setupRunAttemptTestHooks();
 
 describe("runCodexAppServerAttempt dynamic tools", () => {
+  it("preserves model order across queued native and dynamic tools", async () => {
+    let rejectSlowTool!: (error: Error) => void;
+    const slowToolResult = new Promise<never>((_resolve, reject) => {
+      rejectSlowTool = reject;
+    });
+    const slowTool = createRuntimeDynamicTool("slow_failure");
+    slowTool.execute = vi.fn(() => slowToolResult);
+    const laterTool = createTerminalPresentationContractTool({
+      name: "fast_summary",
+      result: textToolResult("fast result"),
+      format: () => "later dynamic summary",
+    });
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    let terminalPresentation: string | undefined;
+    let latestOrdinal = -1;
+    let nextOrdinal = 0;
+    const onExecutionPhase = vi.fn();
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.allocateToolOutcomeOrdinal = () => nextOrdinal++;
+    params.onExecutionPhase = onExecutionPhase;
+    params.onToolOutcome = (observation) => {
+      const ordinal = observation.toolCallOrdinal ?? latestOrdinal + 1;
+      if (ordinal >= latestOrdinal) {
+        latestOrdinal = ordinal;
+        terminalPresentation = observation.terminalPresentation;
+      }
+    };
+    testing.setOpenClawCodingToolsFactoryForTests((options) =>
+      [slowTool, laterTool].map((tool) =>
+        wrapToolWithBeforeToolCallHook(tool, {
+          runId: options?.runId,
+          sessionId: options?.sessionId,
+          sessionKey: options?.sessionKey,
+          onToolOutcome: options?.onToolOutcome,
+          allocateToolOutcomeOrdinal: options?.allocateToolOutcomeOrdinal,
+        }),
+      ),
+    );
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("thread/start");
+    await vi.waitFor(() =>
+      expect(onExecutionPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: "turn_accepted" }),
+      ),
+    );
+    for (const item of [
+      {
+        type: "function_call",
+        name: "slow_failure",
+        arguments: "{}",
+        call_id: "call-slow",
+      },
+      {
+        type: "function_call",
+        name: "shell_command",
+        arguments: '{"command":"git status --short"}',
+        call_id: "command-before-dynamic",
+      },
+    ]) {
+      await harness.notify({
+        method: "rawResponseItem/completed",
+        params: { threadId: "thread-1", turnId: "turn-1", item },
+      });
+    }
+    const webSearchItem = {
+      type: "webSearch",
+      id: "web-search-before-dynamic",
+      query: "OpenClaw",
+      status: "completed",
+      durationMs: 1,
+    };
+    const webSearchStarted = harness.notify({
+      method: "item/started",
+      params: { threadId: "thread-1", turnId: "turn-1", item: webSearchItem },
+    });
+    const rawWebSearch = harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "web_search_call",
+          status: "completed",
+          action: { type: "search", query: "OpenClaw" },
+        },
+      },
+    });
+    await harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "function_call",
+          name: "fast_summary",
+          arguments: "{}",
+          call_id: "call-later",
+        },
+      },
+    });
+    await rawWebSearch;
+    const slowCall = harness.handleServerRequest({
+      id: "request-slow",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-slow",
+        namespace: null,
+        tool: "slow_failure",
+        arguments: {},
+      },
+    });
+    const nativeItem = {
+      type: "commandExecution",
+      id: "command-before-dynamic",
+      command: "git status --short",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status: "completed",
+      commandActions: [{ type: "unknown", command: "git status --short" }],
+      aggregatedOutput: "",
+      exitCode: 0,
+      durationMs: 1,
+    };
+    const nativeStarted = harness.notify({
+      method: "item/started",
+      params: { threadId: "thread-1", turnId: "turn-1", item: nativeItem },
+    });
+    await harness.handleServerRequest({
+      id: "request-later",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-later",
+        namespace: null,
+        tool: "fast_summary",
+        arguments: {},
+      },
+    });
+    await nativeStarted;
+    await webSearchStarted;
+    await harness.notify({
+      method: "item/completed",
+      params: { threadId: "thread-1", turnId: "turn-1", item: nativeItem },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: { threadId: "thread-1", turnId: "turn-1", item: webSearchItem },
+    });
+    rejectSlowTool(new Error("slow failure"));
+    await slowCall;
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(terminalPresentation).toBe("later dynamic summary");
+  });
+
+  it("suppresses a late dynamic tool presentation after its timeout response", async () => {
+    let resolveSlowTool!: (result: ReturnType<typeof textToolResult>) => void;
+    const slowToolResult = new Promise<ReturnType<typeof textToolResult>>((resolve) => {
+      resolveSlowTool = resolve;
+    });
+    const formatTerminalPresentation = vi.fn(() => "late success summary");
+    const slowTool = createTerminalPresentationContractTool({
+      name: "slow_summary",
+      result: textToolResult("unused"),
+      format: formatTerminalPresentation,
+    });
+    slowTool.execute = vi.fn(() => slowToolResult);
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    let terminalPresentation: string | undefined = "previous summary";
+    let latestOrdinal = -1;
+    let nextOrdinal = 0;
+    const onExecutionPhase = vi.fn();
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.allocateToolOutcomeOrdinal = () => nextOrdinal++;
+    params.onExecutionPhase = onExecutionPhase;
+    params.onToolOutcome = (observation) => {
+      const ordinal = observation.toolCallOrdinal ?? latestOrdinal + 1;
+      if (ordinal >= latestOrdinal) {
+        latestOrdinal = ordinal;
+        terminalPresentation = observation.terminalPresentation;
+      }
+    };
+    testing.setOpenClawCodingToolsFactoryForTests((options) => [
+      wrapToolWithBeforeToolCallHook(slowTool, {
+        runId: options?.runId,
+        sessionId: options?.sessionId,
+        sessionKey: options?.sessionKey,
+        onToolOutcome: options?.onToolOutcome,
+        allocateToolOutcomeOrdinal: options?.allocateToolOutcomeOrdinal,
+      }),
+    ]);
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("thread/start");
+    await vi.waitFor(() =>
+      expect(onExecutionPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: "turn_accepted" }),
+      ),
+    );
+    const response = await harness.handleServerRequest({
+      id: "request-timeout",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-timeout",
+        namespace: null,
+        tool: "slow_summary",
+        arguments: { timeoutMs: 1 },
+      },
+    });
+    expect(response).toMatchObject({ success: false });
+    expect(terminalPresentation).toBeUndefined();
+
+    resolveSlowTool(textToolResult("late result"));
+    await vi.waitFor(() => {
+      expect(formatTerminalPresentation).toHaveBeenCalled();
+    });
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(terminalPresentation).toBeUndefined();
+  });
+
   it("passes the live run session key to Codex dynamic tools when sandbox policy uses another key", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
@@ -93,6 +342,11 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
 
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("thread/start");
+    await vi.waitFor(() =>
+      expect(onExecutionPhase).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: "turn_accepted" }),
+      ),
+    );
 
     const toolResult = (await harness.handleServerRequest({
       id: "request-tool-1",

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -85,6 +85,8 @@ import {
   isCurrentThreadTurnRequestParams,
   isNativeResponseStreamDeltaNotification,
   isTerminalTurnStatus,
+  readCodexNotificationItem,
+  readRawResponseToolCallId,
 } from "./attempt-notifications.js";
 import {
   buildCodexAppServerPromptTimeoutOutcome,
@@ -677,8 +679,45 @@ export async function runCodexAppServerAttempt(
     );
   }
   let yieldDetected = false;
+  const toolOutcomeOrdinals = new Map<string, number>();
+  const suppressedDynamicToolOutcomeOrdinals = new Set<number>();
+  const onCodexToolOutcome = params.onToolOutcome
+    ? (observation: Parameters<NonNullable<typeof params.onToolOutcome>>[0]) => {
+        if (
+          observation.toolCallOrdinal !== undefined &&
+          suppressedDynamicToolOutcomeOrdinals.has(observation.toolCallOrdinal)
+        ) {
+          return;
+        }
+        params.onToolOutcome?.(observation);
+      }
+    : undefined;
+  const baseAllocateToolOutcomeOrdinal = params.allocateToolOutcomeOrdinal;
+  const allocateCodexToolOutcomeOrdinal = baseAllocateToolOutcomeOrdinal
+    ? (toolCallId?: string): number => {
+        const reservedOrdinal = toolCallId ? toolOutcomeOrdinals.get(toolCallId) : undefined;
+        if (reservedOrdinal !== undefined) {
+          return reservedOrdinal;
+        }
+        const ordinal = baseAllocateToolOutcomeOrdinal(toolCallId);
+        if (toolCallId) {
+          toolOutcomeOrdinals.set(toolCallId, ordinal);
+        }
+        return ordinal;
+      }
+    : undefined;
+  const dynamicToolParams =
+    allocateCodexToolOutcomeOrdinal || onCodexToolOutcome
+      ? {
+          ...params,
+          ...(allocateCodexToolOutcomeOrdinal
+            ? { allocateToolOutcomeOrdinal: allocateCodexToolOutcomeOrdinal }
+            : {}),
+          ...(onCodexToolOutcome ? { onToolOutcome: onCodexToolOutcome } : {}),
+        }
+      : params;
   const tools = await buildDynamicTools({
-    params,
+    params: dynamicToolParams,
     resolvedWorkspace,
     effectiveWorkspace,
     effectiveCwd,
@@ -695,7 +734,7 @@ export async function runCodexAppServerAttempt(
     onCodexAppServerEvent: (event) => emitCodexAppServerEvent(params, event),
   });
   const registeredTools = await buildDynamicTools({
-    params,
+    params: dynamicToolParams,
     resolvedWorkspace,
     effectiveWorkspace,
     effectiveCwd,
@@ -732,7 +771,8 @@ export async function runCodexAppServerAttempt(
       currentThreadId: params.currentThreadTs,
       replyToMode: params.replyToMode,
       hasRepliedRef: params.hasRepliedRef,
-      onToolOutcome: params.onToolOutcome,
+      onToolOutcome: onCodexToolOutcome,
+      allocateToolOutcomeOrdinal: allocateCodexToolOutcomeOrdinal,
     },
   });
   const hadSessionFile = await pathExists(activeSessionFile);
@@ -1703,6 +1743,20 @@ export async function runCodexAppServerAttempt(
       correlation.matchesActiveTurn === true ||
       (!isNativeResponseStreamDelta && correlation.matchesActiveTurn !== false) ||
       nativeResponseStreamDeltaMatchesActiveTurn;
+    if (correlation.matchesActiveTurn === true) {
+      const modelToolCallId = readRawResponseToolCallId(notification);
+      if (modelToolCallId) {
+        // Raw response items arrive in model order before Codex schedules tool
+        // futures, so later lifecycle races reuse this authoritative position.
+        allocateCodexToolOutcomeOrdinal?.(modelToolCallId);
+      }
+      const nativeItem = readCodexNotificationItem(notification.params);
+      if (nativeItem?.type === "webSearch") {
+        // Upstream omits the raw web-search id. Its lifecycle still follows the
+        // model stream, so reserve synchronously before queued projection.
+        projector.recordNativeToolOutcome(nativeItem);
+      }
+    }
     if (notificationMatchesActiveTurn) {
       // If Codex app-server exposes raw response deltas, treat them as activity
       // only when scoped to this turn or attributable to a single lease.
@@ -1818,6 +1872,7 @@ export async function runCodexAppServerAttempt(
       if (!call || call.threadId !== thread.threadId || call.turnId !== turnId) {
         return undefined;
       }
+      const toolCallOrdinal = allocateCodexToolOutcomeOrdinal?.(call.callId);
       armCompletionWatchOnResponse = true;
       markCurrentTurnRequestProgress();
       turnCrossedToolHandoff = true;
@@ -1888,7 +1943,13 @@ export async function runCodexAppServerAttempt(
           toolBridge,
           signal: runAbortController.signal,
           timeoutMs: dynamicToolTimeoutMs,
+          toolCallOrdinal,
           onAgentToolResult: params.onAgentToolResult,
+          onFallbackSelected: () => {
+            if (toolCallOrdinal !== undefined) {
+              suppressedDynamicToolOutcomeOrdinals.add(toolCallOrdinal);
+            }
+          },
           onTimeout: () => {
             trajectoryRecorder?.recordEvent("tool.timeout", {
               threadId: call.threadId,
@@ -1900,6 +1961,19 @@ export async function runCodexAppServerAttempt(
           },
         });
         const protocolResponse = toCodexDynamicToolProtocolResponse(response);
+        if (!protocolResponse.success && toolCallOrdinal !== undefined) {
+          // The underlying tool may ignore cancellation and finish after the
+          // timeout response. Its late presentation must not replace this failure.
+          suppressedDynamicToolOutcomeOrdinals.add(toolCallOrdinal);
+          params.onToolOutcome?.({
+            toolName: call.tool,
+            argsHash: "",
+            resultHash: "",
+            toolCallOrdinal,
+            terminalPresentation: undefined,
+            presentationOnly: true,
+          });
+        }
         const toolDurationMs = Math.max(0, Date.now() - toolStartedAt);
         trajectoryRecorder?.recordEvent("tool.result", {
           threadId: call.threadId,
@@ -1986,6 +2060,7 @@ export async function runCodexAppServerAttempt(
         }
         throw error;
       } finally {
+        toolOutcomeOrdinals.delete(call.callId);
         unsubscribeToolDiagnosticObserver();
       }
     } finally {
@@ -2371,12 +2446,17 @@ export async function runCodexAppServerAttempt(
     prompt: codexTurnPromptText,
     imagesCount: params.images?.length ?? 0,
   });
-  projectorRef.current = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId, {
-    nativePostToolUseRelayEnabled:
-      nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&
-      nativeHookRelay.shouldRelayEvent("post_tool_use"),
-    trajectoryRecorder,
-  });
+  projectorRef.current = new CodexAppServerEventProjector(
+    dynamicToolParams,
+    thread.threadId,
+    activeTurnId,
+    {
+      nativePostToolUseRelayEnabled:
+        nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&
+        nativeHookRelay.shouldRelayEvent("post_tool_use"),
+      trajectoryRecorder,
+    },
+  );
   if (
     isTerminalTurnStatus(turn.turn.status) ||
     pendingNotifications.some((notification) =>

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -126,7 +126,7 @@ export type HookContext = {
   channelId?: string;
   loopDetection?: ToolLoopDetectionConfig;
   onToolOutcome?: ToolOutcomeObserver;
-  allocateToolOutcomeOrdinal?: () => number;
+  allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
   skillsSnapshot?: SkillSnapshot;
   skillCommand?: {
     commandName: string;
@@ -302,6 +302,7 @@ export function finalizeToolTerminalPresentation(params: {
   isError: boolean;
   observer?: ToolOutcomeObserver;
   toolName?: string;
+  toolCallOrdinal?: number;
 }): void {
   const key = buildAdjustedParamsKey({
     runId: params.runId,
@@ -313,11 +314,12 @@ export function finalizeToolTerminalPresentation(params: {
   if (!observer) {
     return;
   }
+  const toolCallOrdinal = pending?.toolCallOrdinal ?? params.toolCallOrdinal;
   observer({
     toolName: pending?.tool.name || params.toolName || "tool",
     argsHash: "",
     resultHash: "",
-    ...(pending?.toolCallOrdinal !== undefined ? { toolCallOrdinal: pending.toolCallOrdinal } : {}),
+    ...(toolCallOrdinal !== undefined ? { toolCallOrdinal } : {}),
     terminalPresentation: params.isError
       ? undefined
       : pending
@@ -1292,7 +1294,7 @@ export function wrapToolWithBeforeToolCallHook(
     execute: async (toolCallId, params, signal, onUpdate) => {
       // Allocate before any async preparation so parallel completions retain
       // the assistant message's tool-call order.
-      const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.();
+      const toolCallOrdinal = ctx?.allocateToolOutcomeOrdinal?.(toolCallId);
       const prepare = (tool as BeforeToolCallPreparingTool).prepareBeforeToolCallParams;
       const preparedParams = prepare
         ? await prepare(params, {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -554,7 +554,7 @@ export function createOpenClawCodingTools(options?: {
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
   /** Supplies run-global model-call ordering for parallel tool outcomes. */
-  allocateToolOutcomeOrdinal?: () => number;
+  allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
   /** Runtime-only resolved skill paths that the read tool may load under workspaceOnly. */
   skillsSnapshot?: SkillSnapshot;
 }): AnyAgentTool[] {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -66,7 +66,7 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   /** Live observer called after wrapped tool outcomes are recorded. */
   onToolOutcome?: ToolOutcomeObserver;
   /** Supplies run-global model-call ordering for parallel tool outcomes. */
-  allocateToolOutcomeOrdinal?: () => number;
+  allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
   model: Model;
   authStorage: AuthStorage;
   /** Auth profile store already resolved during startup for this attempt. */


### PR DESCRIPTION
## Summary

- derive Codex tool outcome order from raw model call order, then reuse it across native and dynamic lifecycle events
- prevent delayed native completions, earlier dynamic failures, and cancellation-ignoring timed-out tools from replacing the actual last tool presentation
- ignore stale prior-turn snapshot items and cover the ID-less native web-search path

Follow-up to #93228 and its ordering review findings:
- https://github.com/openclaw/openclaw/pull/93228#discussion_r3412175624
- https://github.com/openclaw/openclaw/pull/93228#discussion_r3412543044

## Verification

- `pnpm test extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/dynamic-tool-execution.test.ts src/agents/agent-tools.before-tool-call.integration.e2e.test.ts`
- Crabbox Azure Linux run `run_ec1338fa8af3`: `pnpm check:changed`, `pnpm build`, and the same focused 168-test set
- fresh autoreview: no actionable findings

## Real behavior proof

Behavior addressed: Codex incomplete-turn fallback now selects the last model-ordered tool outcome instead of notification or completion order.
Real environment tested: Azure Linux `Standard_D32ads_v6` through Crabbox.
Exact steps or command run after this patch: changed checks, full production build, then focused core/Codex E2E tests.
Evidence after fix: Crabbox run `run_ec1338fa8af3` exited 0; 22 core E2E and 146 Codex extension tests passed.
Observed result after fix: delayed native command/web-search completions and earlier dynamic failures no longer clear a later dynamic summary; late success after timeout is suppressed.
What was not tested: live provider traffic against a production Codex account.
