### PR TITLE
feat(msteams): per-call topLevel override on send action for proactive new channel threads

### DIFF
--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -418,12 +418,18 @@ function describeMSTeamsMessageTool({
     capabilities: enabled ? ["presentation"] : [],
     schema: enabled
       ? {
-          actions: ["unpin"],
+          actions: ["unpin", "send"],
           properties: {
             pinnedMessageId: Type.Optional(
               Type.String({
                 description:
                   "Pinned message resource ID for unpin (from pin or list-pins, not the chat message ID).",
+              }),
+            ),
+            topLevel: Type.Optional(
+              Type.Boolean({
+                description:
+                  "Force a new root post / new thread in a channel (skips the in-thread reply chain). Ignored for DMs and group chats. Use for proactive warnings, broadcasts, cross-team announcements.",
               }),
             ),
           },
@@ -722,6 +728,43 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
             ctx.action === "send"
               ? normalizeMessagePresentation(ctx.params.presentation)
               : undefined;
+          // Per-call `topLevel: true` opens a new root post / thread in a channel,
+          // bypassing the static channel `replyStyle` config. Only meaningful for
+          // plain-text sends — DMs/group-chats already default to top-level.
+          // Card sends with `presentation` keep their existing path; if topLevel
+          // is desired there too, extend `sendAdaptiveCardMSTeams` to accept
+          // replyStyleOverride in a follow-up.
+          if (
+            ctx.action === "send" &&
+            !presentation &&
+            (ctx.params.topLevel === true || ctx.params.topLevel === "true")
+          ) {
+            return await runWithRequiredActionTarget({
+              actionLabel: "Send (top-level / new thread)",
+              toolParams: ctx.params,
+              run: async (to) => {
+                const { sendMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await sendMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  text: resolveActionContent(ctx.params),
+                  mediaLocalRoots: ctx.mediaLocalRoots,
+                  mediaReadFile: ctx.mediaReadFile,
+                  replyStyleOverride: "top-level",
+                });
+                return jsonActionResultWithDetails(
+                  {
+                    ok: true,
+                    channel: "msteams",
+                    topLevel: true,
+                    messageId: result.messageId,
+                    conversationId: result.conversationId,
+                  },
+                  { ok: true, channel: "msteams", messageId: result.messageId },
+                );
+              },
+            });
+          }
           if (ctx.action === "send" && presentation) {
             const card = buildMSTeamsPresentationCard({
               presentation,

--- a/extensions/msteams/src/send-context.test.ts
+++ b/extensions/msteams/src/send-context.test.ts
@@ -93,6 +93,73 @@ describe("resolveMSTeamsSendContext", () => {
     });
   });
 
+  it("honors replyStyleOverride before the config-derived replyStyle for channels", async () => {
+    sendContextMockState.store.get.mockResolvedValue(
+      channelRef({
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
+        threadId: "thread-root-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      }),
+    );
+
+    const cfg = {
+      channels: {
+        msteams: {
+          enabled: true,
+          appId: "app-id",
+          appPassword: "app-password",
+          tenantId: "tenant-id",
+          // The channel has the default "thread" reply style — without the
+          // override below, the resolved context would carry replyStyle:"thread".
+          replyStyle: "thread" as const,
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      resolveMSTeamsSendContext({
+        cfg,
+        to: "conversation:19:channel@thread.tacv2",
+        replyStyleOverride: "top-level",
+      }),
+    ).resolves.toMatchObject({
+      conversationId: "19:channel@thread.tacv2",
+      replyStyle: "top-level",
+    });
+  });
+
+  it("falls back to the config-derived replyStyle when no override is passed", async () => {
+    sendContextMockState.store.get.mockResolvedValue(
+      channelRef({
+        serviceUrl: "https://smba.trafficmanager.net/amer/",
+        threadId: "thread-root-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      }),
+    );
+
+    const cfg = {
+      channels: {
+        msteams: {
+          enabled: true,
+          appId: "app-id",
+          appPassword: "app-password",
+          tenantId: "tenant-id",
+          replyStyle: "thread" as const,
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      resolveMSTeamsSendContext({
+        cfg,
+        to: "conversation:19:channel@thread.tacv2",
+      }),
+    ).resolves.toMatchObject({
+      conversationId: "19:channel@thread.tacv2",
+      replyStyle: "thread",
+    });
+  });
+
   it("removes stored conversation references with blocked serviceUrl hosts", async () => {
     sendContextMockState.store.get.mockResolvedValue(
       channelRef({

--- a/extensions/msteams/src/send-context.ts
+++ b/extensions/msteams/src/send-context.ts
@@ -148,6 +148,15 @@ async function findConversationReference(recipient: {
 export async function resolveMSTeamsSendContext(params: {
   cfg: OpenClawConfig;
   to: string;
+  /**
+   * Optional per-call override for the resolved reply style. When set, takes
+   * precedence over the config-derived `resolveMSTeamsProactiveReplyStyle`
+   * lookup. Used by callers that want to force a fresh root post / new thread
+   * (`"top-level"`) in a channel without changing the static channel config.
+   * Ignored for DM and group-chat conversation types — those already default
+   * to `"top-level"` regardless.
+   */
+  replyStyleOverride?: MSTeamsReplyStyle;
 }): Promise<MSTeamsProactiveContext> {
   const msteamsCfg = params.cfg.channels?.msteams;
 
@@ -236,12 +245,14 @@ export async function resolveMSTeamsSendContext(params: {
     // groupChat, or unknown defaults to groupChat behavior
     conversationType = "groupChat";
   }
-  const replyStyle = resolveMSTeamsProactiveReplyStyle({
-    cfg: msteamsCfg,
-    conversationId,
-    ref: safeRef,
-    conversationType,
-  });
+  const replyStyle =
+    params.replyStyleOverride ??
+    resolveMSTeamsProactiveReplyStyle({
+      cfg: msteamsCfg,
+      conversationId,
+      ref: safeRef,
+      conversationType,
+    });
 
   // Get SharePoint site ID from config (required for file uploads in group chats/channels)
   const sharePointSiteId = msteamsCfg.sharePointSiteId;

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -6,7 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
-import { loadOutboundMediaFromUrl, type OpenClawConfig } from "../runtime-api.js";
+import { loadOutboundMediaFromUrl, type MSTeamsReplyStyle, type OpenClawConfig } from "../runtime-api.js";
 import {
   classifyMSTeamsSendError,
   formatMSTeamsSendErrorHint,
@@ -44,6 +44,13 @@ type SendMSTeamsMessageParams = {
   filename?: string;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  /**
+   * Optional per-call override for the resolved reply style. When `"top-level"`
+   * is passed, the send opens a new root post / new thread in a channel
+   * regardless of the static channel `replyStyle` config. Ignored for DM and
+   * group-chat conversations. See `resolveMSTeamsSendContext`.
+   */
+  replyStyleOverride?: MSTeamsReplyStyle;
 };
 
 type SendMSTeamsMessageResult = {
@@ -149,13 +156,14 @@ type SendMSTeamsCardResult = {
 export async function sendMessageMSTeams(
   params: SendMSTeamsMessageParams,
 ): Promise<SendMSTeamsMessageResult> {
-  const { cfg, to, text, mediaUrl, filename, mediaLocalRoots, mediaReadFile } = params;
+  const { cfg, to, text, mediaUrl, filename, mediaLocalRoots, mediaReadFile, replyStyleOverride } =
+    params;
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "msteams",
   });
   const messageText = convertMarkdownTables(text ?? "", tableMode);
-  const ctx = await resolveMSTeamsSendContext({ cfg, to });
+  const ctx = await resolveMSTeamsSendContext({ cfg, to, replyStyleOverride });
   const {
     app,
     conversationId,


### PR DESCRIPTION
Closes the gap surfaced in #93288.

## Summary
Adds a `topLevel: true` option to the msteams `message`/`send` action so the bot can post a fresh root post / new thread in a channel without flipping the static `channels.msteams.replyStyle` config (which is correctly set to `"thread"` for the @mention reply path).

## Motivation
Two distinct behaviors are needed in the same channel:
1. **Reply path** (existing, works via static `replyStyle: "thread"`): bot is @mentioned inside a thread → reply lands in the same thread.
2. **Proactive new-thread path** (missing today): bot is asked, via DM/cron/skill, to post a warehouse warning, broadcast, or cross-team announcement → must surface as a fresh root post, not as a reply under whichever thread happened to last seed the conversation reference.

Globally setting `replyStyle: "top-level"` is not acceptable because it breaks (1). There is currently no per-call override.

## Changes
- `send-context.ts`: `resolveMSTeamsSendContext` accepts an optional `replyStyleOverride: MSTeamsReplyStyle` and honors it before the config-derived `resolveMSTeamsProactiveReplyStyle()` lookup.
- `send.ts`: `SendMSTeamsMessageParams` accepts `replyStyleOverride` and forwards it.
- `channel.ts`: `describeMSTeamsMessageTool` exposes a `topLevel` boolean on the `send` action schema. `handleAction` has a new branch for `send` + `!presentation` + `topLevel: true` that routes through `sendMessageMSTeams` with `replyStyleOverride: "top-level"`.
- `send-context.test.ts`: two new tests — override honored, fallback to config when omitted.

## Backwards compatibility
Omitting `topLevel` leaves all existing behavior untouched. `topLevel: true` is silently ignored for DM/group-chat conversation types (they already default to `top-level` regardless). Card sends (with `presentation`) keep their existing path; extending `sendAdaptiveCardMSTeams` is left as a follow-up.

## Test plan
- [x] Unit: `extensions/msteams/src/send-context.test.ts` — override honored vs. config fallback.
- [x] Live: patched plugin running against production tenant; agent invokes the tool with `topLevel: true`, send goes out without the `;messageid=` suffix on the conversation reference, surfaces as a fresh root post in a Posts-style channel; `topLevel` omitted leaves the in-thread reply behavior untouched.

## Sample usage
```jsonc
{
  "channel": "msteams",
  "action": "send",
  "target": "conversation:19:abc...@thread.tacv2",
  "topLevel": true,
  "message": "Warehouse alert: incoming delivery delayed."
}
```