### PR TITLE
fix(compaction): skip replay-unsafe session sends

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2510,7 +2510,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "key",
+      apiKey: "dummy",
     });
 
     const compaction = expectCompactionResult(result);
@@ -2593,7 +2593,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "key",
+      apiKey: "dummy",
     });
 
     const compaction = expectCompactionResult(result);
@@ -2673,7 +2673,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "key",
+      apiKey: "dummy",
     });
 
     const compaction = expectCompactionResult(result);

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2719,6 +2719,12 @@ describe("compaction-safeguard double-compaction guard", () => {
                 name: "sessions_send",
                 arguments: { sessionKey: "agent:bee", message: "say bee" },
               },
+              {
+                type: "toolCall",
+                id: "call-2",
+                name: "message",
+                arguments: { action: "send", channel: "telegram", message: "status" },
+              },
             ],
             timestamp: now + 1,
           },
@@ -2734,6 +2740,19 @@ describe("compaction-safeguard double-compaction guard", () => {
             toolName: "sessions_send",
             content: [{ type: "text", text: "delivered" }],
             timestamp: now + 2,
+          },
+        },
+        {
+          type: "message",
+          id: "tool-2",
+          parentId: "tool-1",
+          timestamp: new Date(now + 3).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-2",
+            toolName: "message",
+            content: [{ type: "text", text: "sent" }],
+            timestamp: now + 3,
           },
         },
       ],
@@ -2765,11 +2784,22 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
     const messages = requireArray(summarizeCall.messages);
-    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
     const assistantMessage = requireRecord(messages[1]);
     expect(assistantMessage.content).toEqual([
       { type: "text", text: "I will ask the bee session and keep context." },
+      {
+        type: "toolCall",
+        id: "call-2",
+        name: "message",
+        arguments: { action: "send", channel: "telegram", message: "status" },
+      },
     ]);
+    expect(requireRecord(messages[2]).toolName).toBe("message");
     expect(JSON.stringify(messages)).not.toContain("sessions_send");
     expect(JSON.stringify(messages)).not.toContain("delivered");
   });

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2692,7 +2692,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(messages.map((message) => requireRecord(message).role)).toEqual(scenario.expectedRoles);
   });
 
-  it("keeps source-session sends as inert completed history", async () => {
+  it("keeps source-session sends as inert status history", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue("completed send summary");
 
@@ -2724,6 +2724,12 @@ describe("compaction-safeguard double-compaction guard", () => {
                 id: "call-1",
                 name: "functions.sessions_send",
                 arguments: { sessionKey: "agent:bee", message: "say bee" },
+              },
+              {
+                type: "toolCall",
+                id: "call-2",
+                name: "tools/sessions_send",
+                arguments: { sessionKey: "agent:wasp", message: "say wasp" },
               },
             ],
             timestamp: now + 1,
@@ -2773,8 +2779,10 @@ describe("compaction-safeguard double-compaction guard", () => {
     const messages = requireArray(summarizeCall.messages);
     expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
     expect(JSON.stringify(messages)).toContain("sessions_send completed");
+    expect(JSON.stringify(messages)).toContain("sessions_send delivery status unknown");
     expect(JSON.stringify(messages)).toContain("bee replied");
     expect(JSON.stringify(messages)).not.toContain("functions.sessions_send");
+    expect(JSON.stringify(messages)).not.toContain("tools/sessions_send");
   });
 
   it("preserves completed historical inter-session turns outside the active tail", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2510,7 +2510,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "test-key",
+      apiKey: "key",
     });
 
     const compaction = expectCompactionResult(result);
@@ -2593,7 +2593,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "test-key",
+      apiKey: "key",
     });
 
     const compaction = expectCompactionResult(result);
@@ -2673,7 +2673,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "test-key",
+      apiKey: "key",
     });
 
     const compaction = expectCompactionResult(result);

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2731,6 +2731,12 @@ describe("compaction-safeguard double-compaction guard", () => {
                 name: "tools/sessions_send",
                 arguments: { sessionKey: "agent:wasp", message: "say wasp" },
               },
+              {
+                type: "toolCall",
+                id: "call-3",
+                name: "sessions_send",
+                arguments: { sessionKey: "agent:ant", message: "say ant" },
+              },
             ],
             timestamp: now + 1,
           },
@@ -2744,8 +2750,21 @@ describe("compaction-safeguard double-compaction guard", () => {
             role: "toolResult",
             toolCallId: "call-1",
             toolName: "functions.sessions_send",
-            content: [{ type: "text", text: "bee replied" }],
+            content: [{ type: "text", text: '{"status":"ok","reply":"bee replied"}' }],
             timestamp: now + 2,
+          },
+        },
+        {
+          type: "message",
+          id: "tool-3",
+          parentId: "tool-1",
+          timestamp: new Date(now + 3).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-3",
+            toolName: "sessions_send",
+            content: [{ type: "text", text: '{"status":"error","error":"ant unavailable"}' }],
+            timestamp: now + 3,
           },
         },
       ],
@@ -2778,9 +2797,13 @@ describe("compaction-safeguard double-compaction guard", () => {
     const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
     const messages = requireArray(summarizeCall.messages);
     expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
-    expect(JSON.stringify(messages)).toContain("sessions_send completed");
-    expect(JSON.stringify(messages)).toContain("sessions_send delivery status unknown");
+    expect(JSON.stringify(messages)).toContain("sessions_send result received");
+    expect(JSON.stringify(messages)).toContain("sessions_send result missing");
     expect(JSON.stringify(messages)).toContain("bee replied");
+    expect(JSON.stringify(messages)).toContain("ant unavailable");
+    expect(JSON.stringify(messages)).toContain("agent:wasp");
+    expect(JSON.stringify(messages)).toContain("say wasp");
+    expect(JSON.stringify(messages)).not.toContain("sessions_send completed");
     expect(JSON.stringify(messages)).not.toContain("functions.sessions_send");
     expect(JSON.stringify(messages)).not.toContain("tools/sessions_send");
   });

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2602,6 +2602,90 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 
+  it("preserves unfinished inter-session work after a tool result", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("unfinished branch summary");
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: {
+            role: "user",
+            content: "continue the delegated task",
+            provenance: {
+              kind: "inter_session",
+              sourceSessionKey: "agent:pm",
+              sourceTool: "sessions_send",
+            },
+            timestamp: now,
+          },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: new Date(now + 1).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+            timestamp: now + 1,
+          },
+        },
+        {
+          type: "message",
+          id: "tool-1",
+          parentId: "assistant-1",
+          timestamp: new Date(now + 2).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-read",
+            toolName: "read",
+            content: [{ type: "text", text: "partial evidence" }],
+            timestamp: now + 2,
+          },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-8",
+        tokensBefore: 38085,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "dummy",
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("unfinished branch summary");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const messages = requireArray(summarizeCall.messages);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+  });
+
   it("keeps source-session sends as inert completed history", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue("completed send summary");

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2602,9 +2602,9 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("does not replay source-session sessions_send tool calls as fallback history", async () => {
+  it("keeps source-session sends as inert completed history", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("user request summary");
+    mockSummarizeInStages.mockResolvedValue("completed send summary");
 
     const now = Date.now();
     const sessionManager = {
@@ -2632,7 +2632,7 @@ describe("compaction-safeguard double-compaction guard", () => {
               {
                 type: "toolCall",
                 id: "call-1",
-                name: "sessions_send",
+                name: "functions.sessions_send",
                 arguments: { sessionKey: "agent:bee", message: "say bee" },
               },
             ],
@@ -2647,8 +2647,8 @@ describe("compaction-safeguard double-compaction guard", () => {
           message: {
             role: "toolResult",
             toolCallId: "call-1",
-            toolName: "sessions_send",
-            content: [{ type: "text", text: "delivered" }],
+            toolName: "functions.sessions_send",
+            content: [{ type: "text", text: "bee replied" }],
             timestamp: now + 2,
           },
         },
@@ -2677,17 +2677,19 @@ describe("compaction-safeguard double-compaction guard", () => {
     });
 
     const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("user request summary");
+    expect(compaction.summary).toContain("completed send summary");
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
     const messages = requireArray(summarizeCall.messages);
-    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user"]);
-    expect(JSON.stringify(messages)).not.toContain("sessions_send");
+    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
+    expect(JSON.stringify(messages)).toContain("sessions_send completed");
+    expect(JSON.stringify(messages)).toContain("bee replied");
+    expect(JSON.stringify(messages)).not.toContain("functions.sessions_send");
   });
 
-  it("preserves assistant text while filtering sessions_send tool calls as fallback history", async () => {
+  it("preserves completed historical inter-session turns outside the active tail", async () => {
     mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue("mixed branch summary");
+    mockSummarizeInStages.mockResolvedValue("historical branch summary");
 
     const now = Date.now();
     const sessionManager = {
@@ -2700,7 +2702,12 @@ describe("compaction-safeguard double-compaction guard", () => {
           timestamp: new Date(now).toISOString(),
           message: {
             role: "user",
-            content: "ask the bee session to respond",
+            content: "historical inter-session request",
+            provenance: {
+              kind: "inter_session",
+              sourceSessionKey: "agent:pm",
+              sourceTool: "sessions_send",
+            },
             timestamp: now,
           },
         },
@@ -2711,47 +2718,25 @@ describe("compaction-safeguard double-compaction guard", () => {
           timestamp: new Date(now + 1).toISOString(),
           message: {
             role: "assistant",
-            content: [
-              { type: "text", text: "I will ask the bee session and keep context." },
-              {
-                type: "toolCall",
-                id: "call-1",
-                name: "sessions_send",
-                arguments: { sessionKey: "agent:bee", message: "say bee" },
-              },
-              {
-                type: "toolCall",
-                id: "call-2",
-                name: "message",
-                arguments: { action: "send", channel: "telegram", message: "status" },
-              },
-            ],
+            content: [{ type: "text", text: "historical reply" }],
             timestamp: now + 1,
           },
         },
         {
           type: "message",
-          id: "tool-1",
+          id: "user-2",
           parentId: "assistant-1",
           timestamp: new Date(now + 2).toISOString(),
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "sessions_send",
-            content: [{ type: "text", text: "delivered" }],
-            timestamp: now + 2,
-          },
+          message: { role: "user", content: "later user request", timestamp: now + 2 },
         },
         {
           type: "message",
-          id: "tool-2",
-          parentId: "tool-1",
+          id: "assistant-2",
+          parentId: "user-2",
           timestamp: new Date(now + 3).toISOString(),
           message: {
-            role: "toolResult",
-            toolCallId: "call-2",
-            toolName: "message",
-            content: [{ type: "text", text: "sent" }],
+            role: "assistant",
+            content: [{ type: "text", text: "later reply" }],
             timestamp: now + 3,
           },
         },
@@ -2764,7 +2749,7 @@ describe("compaction-safeguard double-compaction guard", () => {
       preparation: {
         messagesToSummarize: [] as AgentMessage[],
         turnPrefixMessages: [] as AgentMessage[],
-        firstKeptEntryId: "entry-9",
+        firstKeptEntryId: "entry-8",
         tokensBefore: 38085,
         fileOps: { read: [], edited: [], written: [] },
         settings: { reserveTokens: 4000 },
@@ -2780,28 +2765,18 @@ describe("compaction-safeguard double-compaction guard", () => {
     });
 
     const compaction = expectCompactionResult(result);
-    expect(compaction.summary).toContain("mixed branch summary");
+    expect(compaction.summary).toContain("historical branch summary");
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
     const messages = requireArray(summarizeCall.messages);
     expect(messages.map((message) => requireRecord(message).role)).toEqual([
       "user",
       "assistant",
-      "toolResult",
+      "user",
+      "assistant",
     ]);
-    const assistantMessage = requireRecord(messages[1]);
-    expect(assistantMessage.content).toEqual([
-      { type: "text", text: "I will ask the bee session and keep context." },
-      {
-        type: "toolCall",
-        id: "call-2",
-        name: "message",
-        arguments: { action: "send", channel: "telegram", message: "status" },
-      },
-    ]);
-    expect(requireRecord(messages[2]).toolName).toBe("message");
-    expect(JSON.stringify(messages)).not.toContain("sessions_send");
-    expect(JSON.stringify(messages)).not.toContain("delivered");
+    expect(JSON.stringify(messages)).toContain("historical inter-session request");
+    expect(JSON.stringify(messages)).toContain("historical reply");
   });
 
   it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2537,6 +2537,154 @@ describe("compaction-safeguard double-compaction guard", () => {
     ).toBe(true);
   });
 
+  it("does not replay inter-session sessions_send branch turns as fallback history", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("branch summary");
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: {
+            role: "user",
+            content: "say bee",
+            provenance: {
+              kind: "inter_session",
+              sourceSessionKey: "agent:pm",
+              sourceTool: "sessions_send",
+            },
+            timestamp: now,
+          },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: new Date(now + 1).toISOString(),
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "bee reply" }],
+            timestamp: now + 1,
+          },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 38085,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "test-key",
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("No prior history.");
+    expect(mockSummarizeInStages).not.toHaveBeenCalled();
+    expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
+  });
+
+  it("does not replay source-session sessions_send tool calls as fallback history", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("user request summary");
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: {
+            role: "user",
+            content: "ask the bee session to respond",
+            timestamp: now,
+          },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: new Date(now + 1).toISOString(),
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-1",
+                name: "sessions_send",
+                arguments: { sessionKey: "agent:bee", message: "say bee" },
+              },
+            ],
+            timestamp: now + 1,
+          },
+        },
+        {
+          type: "message",
+          id: "tool-1",
+          parentId: "assistant-1",
+          timestamp: new Date(now + 2).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "sessions_send",
+            content: [{ type: "text", text: "delivered" }],
+            timestamp: now + 2,
+          },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-8",
+        tokensBefore: 38085,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "test-key",
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("user request summary");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const messages = requireArray(summarizeCall.messages);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user"]);
+    expect(JSON.stringify(messages)).not.toContain("sessions_send");
+  });
+
   it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue("branch summary with visible turns");

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2510,7 +2510,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "dummy",
+      apiKey: "test-key",
     });
 
     const compaction = expectCompactionResult(result);
@@ -2776,7 +2776,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     const { result } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
-      apiKey: "test-key",
+      apiKey: "dummy",
     });
 
     const compaction = expectCompactionResult(result);

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2602,7 +2602,10 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 
-  it("preserves unfinished inter-session work after a tool result", async () => {
+  it.each([
+    { toolName: "read", expectedRoles: ["user", "assistant", "toolResult"] },
+    { toolName: "functions.sessions_send", expectedRoles: ["user", "assistant"] },
+  ])("preserves unfinished inter-session work after a $toolName result", async (scenario) => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue("unfinished branch summary");
 
@@ -2633,7 +2636,14 @@ describe("compaction-safeguard double-compaction guard", () => {
           timestamp: new Date(now + 1).toISOString(),
           message: {
             role: "assistant",
-            content: [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+            content: [
+              {
+                type: "toolCall",
+                id: "call-tool",
+                name: scenario.toolName,
+                arguments: {},
+              },
+            ],
             timestamp: now + 1,
           },
         },
@@ -2644,8 +2654,8 @@ describe("compaction-safeguard double-compaction guard", () => {
           timestamp: new Date(now + 2).toISOString(),
           message: {
             role: "toolResult",
-            toolCallId: "call-read",
-            toolName: "read",
+            toolCallId: "call-tool",
+            toolName: scenario.toolName,
             content: [{ type: "text", text: "partial evidence" }],
             timestamp: now + 2,
           },
@@ -2679,11 +2689,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
     const messages = requireArray(summarizeCall.messages);
-    expect(messages.map((message) => requireRecord(message).role)).toEqual([
-      "user",
-      "assistant",
-      "toolResult",
-    ]);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual(scenario.expectedRoles);
   });
 
   it("keeps source-session sends as inert completed history", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2685,6 +2685,95 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(JSON.stringify(messages)).not.toContain("sessions_send");
   });
 
+  it("preserves assistant text while filtering sessions_send tool calls as fallback history", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("mixed branch summary");
+
+    const now = Date.now();
+    const sessionManager = {
+      ...stubSessionManager(),
+      getBranch: () => [
+        {
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: new Date(now).toISOString(),
+          message: {
+            role: "user",
+            content: "ask the bee session to respond",
+            timestamp: now,
+          },
+        },
+        {
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: new Date(now + 1).toISOString(),
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I will ask the bee session and keep context." },
+              {
+                type: "toolCall",
+                id: "call-1",
+                name: "sessions_send",
+                arguments: { sessionKey: "agent:bee", message: "say bee" },
+              },
+            ],
+            timestamp: now + 1,
+          },
+        },
+        {
+          type: "message",
+          id: "tool-1",
+          parentId: "assistant-1",
+          timestamp: new Date(now + 2).toISOString(),
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "sessions_send",
+            content: [{ type: "text", text: "delivered" }],
+            timestamp: now + 2,
+          },
+        },
+      ],
+    } as ExtensionContext["sessionManager"];
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-9",
+        tokensBefore: 38085,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "test-key",
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("mixed branch summary");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const summarizeCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const messages = requireArray(summarizeCall.messages);
+    expect(messages.map((message) => requireRecord(message).role)).toEqual(["user", "assistant"]);
+    const assistantMessage = requireRecord(messages[1]);
+    expect(assistantMessage.content).toEqual([
+      { type: "text", text: "I will ask the bee session and keep context." },
+    ]);
+    expect(JSON.stringify(messages)).not.toContain("sessions_send");
+    expect(JSON.stringify(messages)).not.toContain("delivered");
+  });
+
   it("recovers user and assistant branch turns when compaction preparation has only tool output", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue("branch summary with visible turns");

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -12,6 +12,7 @@ import {
   getCompactionProvider,
   type CompactionProvider,
 } from "../../plugins/compaction-provider.js";
+import { normalizeInputProvenance } from "../../sessions/input-provenance.js";
 import { normalizeAcceptedSessionSpawnResult } from "../accepted-session-spawn.js";
 import {
   buildHistoryPrunePlanWithWorker,
@@ -33,6 +34,7 @@ import {
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "../copilot-dynamic-headers.js";
+import { isMessagingToolSendAction } from "../embedded-agent-messaging.js";
 import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import type { AgentMessage } from "../runtime/index.js";
@@ -74,6 +76,7 @@ const DEFAULT_QUALITY_GUARD_MAX_RETRIES = 1;
 const MAX_RECENT_TURNS_PRESERVE = 12;
 const MAX_QUALITY_GUARD_MAX_RETRIES = 3;
 const MAX_RECENT_TURN_TEXT_CHARS = 600;
+const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
 const PREVIOUS_SUMMARY_REDISTILL_PREFIX =
   "Previous compaction summary to re-distill with the current conversation. " +
   "Prune stale, duplicate, or superseded details instead of preserving it verbatim.";
@@ -176,6 +179,110 @@ function collectSessionBranchMessages(sessionManager: unknown): AgentMessage[] {
         : undefined,
     )
     .filter((message): message is AgentMessage => Boolean(message));
+}
+
+function isReplayUnsafeInterSessionInput(message: AgentMessage): boolean {
+  if ((message as { role?: unknown }).role !== "user") {
+    return false;
+  }
+  const provenance = normalizeInputProvenance((message as { provenance?: unknown }).provenance);
+  return provenance?.kind === "inter_session" && provenance.sourceTool === "sessions_send";
+}
+
+function recordOrEmpty(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+type ReplayUnsafeToolCalls = {
+  found: boolean;
+  ids: Set<string>;
+};
+
+function collectReplayUnsafeMessagingToolCalls(message: AgentMessage): ReplayUnsafeToolCalls {
+  const content = (message as { content?: unknown }).content;
+  const ids = new Set<string>();
+  let found = false;
+  if (!Array.isArray(content)) {
+    return { found, ids };
+  }
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as {
+      type?: unknown;
+      id?: unknown;
+      name?: unknown;
+      arguments?: unknown;
+      input?: unknown;
+    };
+    if (typeof record.type !== "string" || !TOOL_CALL_BLOCK_TYPES.has(record.type)) {
+      continue;
+    }
+    if (typeof record.name !== "string" || !record.name.trim()) {
+      continue;
+    }
+    const args = recordOrEmpty(record.arguments ?? record.input);
+    if (!isMessagingToolSendAction(record.name, args)) {
+      continue;
+    }
+    found = true;
+    if (typeof record.id === "string" && record.id.trim()) {
+      ids.add(record.id.trim());
+    }
+  }
+  return { found, ids };
+}
+
+function isReplayUnsafeMessagingToolResult(
+  message: AgentMessage,
+  replayUnsafeToolCallIds: Set<string>,
+): boolean {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return false;
+  }
+  const toolResultId = extractToolResultId(
+    message as Extract<AgentMessage, { role: "toolResult" }>,
+  );
+  if (toolResultId && replayUnsafeToolCallIds.has(toolResultId)) {
+    return true;
+  }
+  return (message as { toolName?: unknown }).toolName === "sessions_send";
+}
+
+function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): AgentMessage[] {
+  const filtered: AgentMessage[] = [];
+  const replayUnsafeToolCallIds = new Set<string>();
+  let skippingInterSessionReply = false;
+  for (const message of messages) {
+    if (isReplayUnsafeInterSessionInput(message)) {
+      skippingInterSessionReply = true;
+      continue;
+    }
+    const role = (message as { role?: unknown }).role;
+    if (skippingInterSessionReply) {
+      if (role === "assistant" || role === "toolResult") {
+        continue;
+      }
+      skippingInterSessionReply = false;
+    }
+    if (role === "assistant") {
+      const replayUnsafeToolCalls = collectReplayUnsafeMessagingToolCalls(message);
+      if (replayUnsafeToolCalls.found) {
+        for (const id of replayUnsafeToolCalls.ids) {
+          replayUnsafeToolCallIds.add(id);
+        }
+        continue;
+      }
+    }
+    if (isReplayUnsafeMessagingToolResult(message, replayUnsafeToolCallIds)) {
+      continue;
+    }
+    filtered.push(message);
+  }
+  return filtered;
 }
 
 function containsRealConversation(messages: AgentMessage[]): boolean {
@@ -899,8 +1006,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     let hasRealSummarizable = containsRealConversation(baseMessagesToSummarize);
     let hasRealTurnPrefix = containsRealConversation(baseTurnPrefixMessages);
     if (!hasRealSummarizable && !hasRealTurnPrefix) {
-      const branchMessages = stripRuntimeContextCustomMessages(
-        collectSessionBranchMessages(ctx.sessionManager),
+      const branchMessages = filterReplayUnsafeSessionBranchMessages(
+        stripRuntimeContextCustomMessages(collectSessionBranchMessages(ctx.sessionManager)),
       );
       if (containsRealConversation(branchMessages)) {
         log.info(

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -312,6 +312,7 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
         const type = (block as { type?: unknown }).type;
         return typeof type === "string" && TOOL_CALL_BLOCK_TYPES.has(type);
       }));
+  const activeInput = sanitizedMessages[turnStart - 1];
 
   // A completed sessions_send target run is already delivered to its caller.
   // Require terminal text so compaction after tool output can still recover unfinished work.
@@ -319,7 +320,8 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
     endsWithTerminalAssistantText &&
     turnStart < sanitizedMessages.length &&
     turnStart > 0 &&
-    isReplayUnsafeInterSessionInput(sanitizedMessages[turnStart - 1])
+    activeInput !== undefined &&
+    isReplayUnsafeInterSessionInput(activeInput)
   ) {
     return sanitizedMessages.slice(0, turnStart - 1);
   }

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -301,7 +301,8 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
 
   const tailMessage = messages.at(-1);
   const endsWithTerminalAssistantText =
-    tailMessage?.role === "assistant" &&
+    tailMessage !== undefined &&
+    tailMessage.role === "assistant" &&
     Boolean(extractMessageText(tailMessage).trim()) &&
     (!Array.isArray(tailMessage.content) ||
       !tailMessage.content.some((block) => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -195,21 +195,18 @@ function recordOrEmpty(value: unknown): Record<string, unknown> {
     : {};
 }
 
-type ReplayUnsafeToolCalls = {
-  found: boolean;
-  ids: Set<string>;
-};
-
-function collectReplayUnsafeMessagingToolCalls(message: AgentMessage): ReplayUnsafeToolCalls {
+function filterReplayUnsafeMessagingToolCalls(
+  message: AgentMessage,
+  replayUnsafeToolCallIds: Set<string>,
+): AgentMessage | undefined {
   const content = (message as { content?: unknown }).content;
-  const ids = new Set<string>();
-  let found = false;
   if (!Array.isArray(content)) {
-    return { found, ids };
+    return message;
   }
-  for (const block of content) {
+  let removed = false;
+  const filteredContent = content.filter((block) => {
     if (!block || typeof block !== "object") {
-      continue;
+      return true;
     }
     const record = block as {
       type?: unknown;
@@ -219,21 +216,27 @@ function collectReplayUnsafeMessagingToolCalls(message: AgentMessage): ReplayUns
       input?: unknown;
     };
     if (typeof record.type !== "string" || !TOOL_CALL_BLOCK_TYPES.has(record.type)) {
-      continue;
+      return true;
     }
     if (typeof record.name !== "string" || !record.name.trim()) {
-      continue;
+      return true;
     }
     const args = recordOrEmpty(record.arguments ?? record.input);
     if (!isMessagingToolSendAction(record.name, args)) {
-      continue;
+      return true;
     }
-    found = true;
+    removed = true;
     if (typeof record.id === "string" && record.id.trim()) {
-      ids.add(record.id.trim());
+      replayUnsafeToolCallIds.add(record.id.trim());
     }
+    return false;
+  });
+  if (!removed) {
+    return message;
   }
-  return { found, ids };
+  return filteredContent.length > 0
+    ? ({ ...message, content: filteredContent } as AgentMessage)
+    : undefined;
 }
 
 function isReplayUnsafeMessagingToolResult(
@@ -269,13 +272,15 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
       skippingInterSessionReply = false;
     }
     if (role === "assistant") {
-      const replayUnsafeToolCalls = collectReplayUnsafeMessagingToolCalls(message);
-      if (replayUnsafeToolCalls.found) {
-        for (const id of replayUnsafeToolCalls.ids) {
-          replayUnsafeToolCallIds.add(id);
-        }
+      const filteredMessage = filterReplayUnsafeMessagingToolCalls(
+        message,
+        replayUnsafeToolCallIds,
+      );
+      if (!filteredMessage) {
         continue;
       }
+      filtered.push(filteredMessage);
+      continue;
     }
     if (isReplayUnsafeMessagingToolResult(message, replayUnsafeToolCallIds)) {
       continue;

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -34,7 +34,6 @@ import {
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "../copilot-dynamic-headers.js";
-import { isMessagingToolSendAction } from "../embedded-agent-messaging.js";
 import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import type { AgentMessage } from "../runtime/index.js";
@@ -189,13 +188,7 @@ function isReplayUnsafeInterSessionInput(message: AgentMessage): boolean {
   return provenance?.kind === "inter_session" && provenance.sourceTool === "sessions_send";
 }
 
-function recordOrEmpty(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
-function filterReplayUnsafeMessagingToolCalls(
+function filterReplayUnsafeSessionsSendCalls(
   message: AgentMessage,
   replayUnsafeToolCallIds: Set<string>,
 ): AgentMessage | undefined {
@@ -212,17 +205,11 @@ function filterReplayUnsafeMessagingToolCalls(
       type?: unknown;
       id?: unknown;
       name?: unknown;
-      arguments?: unknown;
-      input?: unknown;
     };
     if (typeof record.type !== "string" || !TOOL_CALL_BLOCK_TYPES.has(record.type)) {
       return true;
     }
-    if (typeof record.name !== "string" || !record.name.trim()) {
-      return true;
-    }
-    const args = recordOrEmpty(record.arguments ?? record.input);
-    if (!isMessagingToolSendAction(record.name, args)) {
+    if (record.name !== "sessions_send") {
       return true;
     }
     removed = true;
@@ -239,7 +226,7 @@ function filterReplayUnsafeMessagingToolCalls(
     : undefined;
 }
 
-function isReplayUnsafeMessagingToolResult(
+function isReplayUnsafeSessionsSendResult(
   message: AgentMessage,
   replayUnsafeToolCallIds: Set<string>,
 ): boolean {
@@ -272,17 +259,16 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
       skippingInterSessionReply = false;
     }
     if (role === "assistant") {
-      const filteredMessage = filterReplayUnsafeMessagingToolCalls(
-        message,
-        replayUnsafeToolCallIds,
-      );
+      // Only sessions_send is already delivered out-of-band. Other messaging calls
+      // remain ordinary transcript history and must survive fallback compaction.
+      const filteredMessage = filterReplayUnsafeSessionsSendCalls(message, replayUnsafeToolCallIds);
       if (!filteredMessage) {
         continue;
       }
       filtered.push(filteredMessage);
       continue;
     }
-    if (isReplayUnsafeMessagingToolResult(message, replayUnsafeToolCallIds)) {
+    if (isReplayUnsafeSessionsSendResult(message, replayUnsafeToolCallIds)) {
       continue;
     }
     filtered.push(message);

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -287,7 +287,7 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
     turnStart -= 1;
   }
 
-  const tailMessage = sanitizedMessages.at(-1);
+  const tailMessage = messages.at(-1);
   const endsWithTerminalAssistantText =
     tailMessage?.role === "assistant" &&
     Boolean(extractMessageText(tailMessage).trim()) &&

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -202,6 +202,7 @@ function isSessionsSendToolName(value: unknown): boolean {
 
 function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
   const sendCallIds = new Set<string>();
+  const resolvedCallIds = new Set<string>();
   const resultTextByCallId = new Map<string, string>();
 
   for (const message of messages) {
@@ -233,6 +234,7 @@ function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
     if (!callId || !sendCallIds.has(callId)) {
       continue;
     }
+    resolvedCallIds.add(callId);
     const resultText = extractMessageText(message) || formatNonTextPlaceholder(message.content);
     if (resultText) {
       resultTextByCallId.set(callId, resultText);
@@ -257,11 +259,15 @@ function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
         replaced = true;
         const callId = typeof record.id === "string" ? record.id.trim() : "";
         const resultText = callId ? resultTextByCallId.get(callId) : undefined;
+        const resolved = Boolean(callId && resolvedCallIds.has(callId));
         return {
           type: "text",
-          text: resultText
-            ? `sessions_send completed; delivery call omitted from replay.\nResult: ${resultText}`
-            : "sessions_send completed; delivery call omitted from replay.",
+          text:
+            resolved && resultText
+              ? `sessions_send completed; delivery call omitted from replay.\nResult: ${resultText}`
+              : resolved
+                ? "sessions_send completed; delivery call omitted from replay."
+                : "sessions_send delivery status unknown; delivery call omitted from replay.",
         };
       });
       return replaced ? [{ ...message, content } as AgentMessage] : [message];

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -287,9 +287,23 @@ function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): Agen
     turnStart -= 1;
   }
 
+  const tailMessage = sanitizedMessages.at(-1);
+  const endsWithTerminalAssistantText =
+    tailMessage?.role === "assistant" &&
+    Boolean(extractMessageText(tailMessage).trim()) &&
+    (!Array.isArray(tailMessage.content) ||
+      !tailMessage.content.some((block) => {
+        if (!block || typeof block !== "object") {
+          return false;
+        }
+        const type = (block as { type?: unknown }).type;
+        return typeof type === "string" && TOOL_CALL_BLOCK_TYPES.has(type);
+      }));
+
   // A completed sessions_send target run is already delivered to its caller.
-  // Drop only that active tail; historical inter-session decisions remain summary input.
+  // Require terminal text so compaction after tool output can still recover unfinished work.
   if (
+    endsWithTerminalAssistantText &&
     turnStart < sanitizedMessages.length &&
     turnStart > 0 &&
     isReplayUnsafeInterSessionInput(sanitizedMessages[turnStart - 1])

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -188,92 +188,115 @@ function isReplayUnsafeInterSessionInput(message: AgentMessage): boolean {
   return provenance?.kind === "inter_session" && provenance.sourceTool === "sessions_send";
 }
 
-function filterReplayUnsafeSessionsSendCalls(
-  message: AgentMessage,
-  replayUnsafeToolCallIds: Set<string>,
-): AgentMessage | undefined {
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return message;
-  }
-  let removed = false;
-  const filteredContent = content.filter((block) => {
-    if (!block || typeof block !== "object") {
-      return true;
-    }
-    const record = block as {
-      type?: unknown;
-      id?: unknown;
-      name?: unknown;
-    };
-    if (typeof record.type !== "string" || !TOOL_CALL_BLOCK_TYPES.has(record.type)) {
-      return true;
-    }
-    if (record.name !== "sessions_send") {
-      return true;
-    }
-    removed = true;
-    if (typeof record.id === "string" && record.id.trim()) {
-      replayUnsafeToolCallIds.add(record.id.trim());
-    }
+function isSessionsSendToolName(value: unknown): boolean {
+  if (typeof value !== "string") {
     return false;
-  });
-  if (!removed) {
-    return message;
   }
-  return filteredContent.length > 0
-    ? ({ ...message, content: filteredContent } as AgentMessage)
-    : undefined;
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/^(?:functions?|tools?)[./_-]/, "") === "sessions_send"
+  );
 }
 
-function isReplayUnsafeSessionsSendResult(
-  message: AgentMessage,
-  replayUnsafeToolCallIds: Set<string>,
-): boolean {
-  if ((message as { role?: unknown }).role !== "toolResult") {
-    return false;
+function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
+  const sendCallIds = new Set<string>();
+  const resultTextByCallId = new Map<string, string>();
+
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content) {
+      if (!block || typeof block !== "object") {
+        continue;
+      }
+      const record = block as { type?: unknown; id?: unknown; name?: unknown };
+      if (
+        typeof record.type === "string" &&
+        TOOL_CALL_BLOCK_TYPES.has(record.type) &&
+        isSessionsSendToolName(record.name) &&
+        typeof record.id === "string" &&
+        record.id.trim()
+      ) {
+        sendCallIds.add(record.id.trim());
+      }
+    }
   }
-  const toolResultId = extractToolResultId(
-    message as Extract<AgentMessage, { role: "toolResult" }>,
-  );
-  if (toolResultId && replayUnsafeToolCallIds.has(toolResultId)) {
-    return true;
+
+  for (const message of messages) {
+    if (message.role !== "toolResult") {
+      continue;
+    }
+    const callId = extractToolResultId(message);
+    if (!callId || !sendCallIds.has(callId)) {
+      continue;
+    }
+    const resultText = extractMessageText(message) || formatNonTextPlaceholder(message.content);
+    if (resultText) {
+      resultTextByCallId.set(callId, resultText);
+    }
   }
-  return (message as { toolName?: unknown }).toolName === "sessions_send";
+
+  return messages.flatMap((message) => {
+    if (message.role === "assistant" && Array.isArray(message.content)) {
+      let replaced = false;
+      const content = message.content.map((block) => {
+        if (!block || typeof block !== "object") {
+          return block;
+        }
+        const record = block as { type?: unknown; id?: unknown; name?: unknown };
+        if (
+          typeof record.type !== "string" ||
+          !TOOL_CALL_BLOCK_TYPES.has(record.type) ||
+          !isSessionsSendToolName(record.name)
+        ) {
+          return block;
+        }
+        replaced = true;
+        const callId = typeof record.id === "string" ? record.id.trim() : "";
+        const resultText = callId ? resultTextByCallId.get(callId) : undefined;
+        return {
+          type: "text",
+          text: resultText
+            ? `sessions_send completed; delivery call omitted from replay.\nResult: ${resultText}`
+            : "sessions_send completed; delivery call omitted from replay.",
+        };
+      });
+      return replaced ? [{ ...message, content } as AgentMessage] : [message];
+    }
+    if (message.role === "toolResult") {
+      const callId = extractToolResultId(message);
+      if ((callId && sendCallIds.has(callId)) || isSessionsSendToolName(message.toolName)) {
+        return [];
+      }
+    }
+    return [message];
+  });
 }
 
 function filterReplayUnsafeSessionBranchMessages(messages: AgentMessage[]): AgentMessage[] {
-  const filtered: AgentMessage[] = [];
-  const replayUnsafeToolCallIds = new Set<string>();
-  let skippingInterSessionReply = false;
-  for (const message of messages) {
-    if (isReplayUnsafeInterSessionInput(message)) {
-      skippingInterSessionReply = true;
-      continue;
+  const sanitizedMessages = sanitizeSourceSessionSends(messages);
+  let turnStart = sanitizedMessages.length;
+  while (turnStart > 0) {
+    const role = (sanitizedMessages[turnStart - 1] as { role?: unknown }).role;
+    if (role !== "assistant" && role !== "toolResult") {
+      break;
     }
-    const role = (message as { role?: unknown }).role;
-    if (skippingInterSessionReply) {
-      if (role === "assistant" || role === "toolResult") {
-        continue;
-      }
-      skippingInterSessionReply = false;
-    }
-    if (role === "assistant") {
-      // Only sessions_send is already delivered out-of-band. Other messaging calls
-      // remain ordinary transcript history and must survive fallback compaction.
-      const filteredMessage = filterReplayUnsafeSessionsSendCalls(message, replayUnsafeToolCallIds);
-      if (!filteredMessage) {
-        continue;
-      }
-      filtered.push(filteredMessage);
-      continue;
-    }
-    if (isReplayUnsafeSessionsSendResult(message, replayUnsafeToolCallIds)) {
-      continue;
-    }
-    filtered.push(message);
+    turnStart -= 1;
   }
-  return filtered;
+
+  // A completed sessions_send target run is already delivered to its caller.
+  // Drop only that active tail; historical inter-session decisions remain summary input.
+  if (
+    turnStart < sanitizedMessages.length &&
+    turnStart > 0 &&
+    isReplayUnsafeInterSessionInput(sanitizedMessages[turnStart - 1])
+  ) {
+    return sanitizedMessages.slice(0, turnStart - 1);
+  }
+  return sanitizedMessages;
 }
 
 function containsRealConversation(messages: AgentMessage[]): boolean {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -248,7 +248,12 @@ function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
         if (!block || typeof block !== "object") {
           return block;
         }
-        const record = block as { type?: unknown; id?: unknown; name?: unknown };
+        const record = block as {
+          type?: unknown;
+          id?: unknown;
+          name?: unknown;
+          arguments?: unknown;
+        };
         if (
           typeof record.type !== "string" ||
           !TOOL_CALL_BLOCK_TYPES.has(record.type) ||
@@ -260,14 +265,15 @@ function sanitizeSourceSessionSends(messages: AgentMessage[]): AgentMessage[] {
         const callId = typeof record.id === "string" ? record.id.trim() : "";
         const resultText = callId ? resultTextByCallId.get(callId) : undefined;
         const resolved = Boolean(callId && resolvedCallIds.has(callId));
+        const requestText = JSON.stringify({ callId: callId || undefined, args: record.arguments });
         return {
           type: "text",
           text:
             resolved && resultText
-              ? `sessions_send completed; delivery call omitted from replay.\nResult: ${resultText}`
+              ? `sessions_send result received; delivery call omitted from replay.\nRequest: ${requestText}\nResult: ${resultText}`
               : resolved
-                ? "sessions_send completed; delivery call omitted from replay."
-                : "sessions_send delivery status unknown; delivery call omitted from replay.",
+                ? `sessions_send result received; delivery call omitted from replay.\nRequest: ${requestText}\nResult: [empty]`
+                : `sessions_send result missing; delivery call omitted from replay.\nRequest: ${requestText}`,
         };
       });
       return replaced ? [{ ...message, content } as AgentMessage] : [message];


### PR DESCRIPTION
Fixes #84139.

## Summary

- Filters only the completed active target-side `sessions_send` tail from compaction branch fallback. Historical turns and unfinished turns ending in tool calls/results remain recoverable.
- Converts source-side `sessions_send` calls into inert summary text, preserving call IDs, arguments, returned results, failures, empty results, and missing-result state without leaving executable tool-call blocks to replay.
- Recognizes provider-prefixed tool names and keeps ordinary compaction fallback unchanged.

## Root cause

When normal compaction preparation contained no real conversation, the safeguard reused the session branch verbatim. That could replay an already-delivered target-side inter-session turn or an already-executed source-side `sessions_send` call. The previous candidate filter was too broad: it also removed historical and unfinished work.

The repaired patch stays at the compaction fallback owner boundary. It drops a target-side turn only when the original branch ends in terminal assistant text. Source-side send calls/results become inert evidence instead of executable tool history.

## Compatibility and scope

- No public API, config, schema, protocol, persistence, provider-routing, or delivery-execution changes.
- No normal compaction behavior change when branch fallback is not needed.
- Root `CHANGELOG.md` remains release-owned; this PR body carries release-note context.

## Merge risk

- `merge-risk: session-state`: over-filtering could lose recovery context.
- `merge-risk: message-delivery`: under-filtering could replay a side effect.

The focused tests cover completed target turns, historical target turns, ordinary and nested unfinished tool work, resolved/failed/missing source-side sends, namespaced tool names, and normal fallback preservation.

## Proof

Rebased current head: `e9dafd53382c7abc45d285dddf98d882abf85f33`

Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/29480862149

```text
oxfmt --check (2 changed files): passed
plugin-sdk boundary DTS and targeted oxlint: passed
src/agents/agent-hooks/compaction-safeguard.test.ts: 111 passed
git diff --check: passed
fresh aggregate autoreview: no accepted/actionable findings
```

Behavior verification remains source-level and focused rather than a live timing capture across two running agents. The linked intermittent path is therefore partially, not fully, reproduced end to end.

## Contributor credit

Original fix and regression direction by @mushuiyu886. Maintainer repair commits retain `Co-authored-by: 杨浩宇0668001029 <yang.haoyu@xydigit.com>`.
