### PR TITLE
fix(memory): swap rollback-journal sidecar during atomic reindex

### DIFF
--- a/extensions/memory-core/src/memory/manager-atomic-reindex.ts
+++ b/extensions/memory-core/src/memory/manager-atomic-reindex.ts
@@ -26,6 +26,13 @@ const defaultFileOps: MemoryIndexFileOps = {
 };
 
 const transientFileErrorCodes = new Set(["EBUSY", "EPERM", "EACCES"]);
+// SQLite keeps WAL/SHM sidecars under journal_mode=WAL, but NFS-backed stores
+// fall back to journal_mode=DELETE and leave a rollback-journal (-journal)
+// sidecar instead. Index file operations must cover all three so a swap never
+// strands a stale -journal next to the freshly published database, which would
+// trigger an erroneous rollback the next time SQLite opens the index.
+const memoryIndexFileSuffixes = ["", "-wal", "-shm", "-journal"] as const;
+const memoryIndexSidecarSuffixes = ["-wal", "-shm", "-journal"] as const;
 const defaultMaxRenameAttempts = 6;
 const defaultRenameRetryDelayMs = 25;
 const defaultMaxRemoveAttempts = 10;
@@ -76,8 +83,7 @@ export async function moveMemoryIndexFiles(
   options: MemoryIndexFileOptions = {},
 ): Promise<void> {
   const resolvedOptions = resolveMemoryIndexFileOptions(options);
-  const suffixes = ["", "-wal", "-shm"];
-  for (const suffix of suffixes) {
+  for (const suffix of memoryIndexFileSuffixes) {
     const source = `${sourceBase}${suffix}`;
     const target = `${targetBase}${suffix}`;
     await renameWithRetry(source, target, resolvedOptions, suffix !== "");
@@ -107,8 +113,7 @@ export async function removeMemoryIndexFiles(
   options: MemoryIndexFileOptions = {},
 ): Promise<void> {
   const resolvedOptions = resolveMemoryIndexFileOptions(options);
-  const suffixes = ["", "-wal", "-shm"];
-  for (const suffix of suffixes) {
+  for (const suffix of memoryIndexFileSuffixes) {
     await rmWithRetry(`${basePath}${suffix}`, resolvedOptions);
   }
 }
@@ -117,8 +122,9 @@ async function removeMemoryIndexSidecars(
   basePath: string,
   options: ResolvedMemoryIndexFileOptions,
 ): Promise<void> {
-  await rmWithRetry(`${basePath}-wal`, options);
-  await rmWithRetry(`${basePath}-shm`, options);
+  for (const suffix of memoryIndexSidecarSuffixes) {
+    await rmWithRetry(`${basePath}${suffix}`, options);
+  }
 }
 
 async function moveMemoryIndexSidecars(
@@ -126,8 +132,7 @@ async function moveMemoryIndexSidecars(
   targetBase: string,
   options: ResolvedMemoryIndexFileOptions,
 ): Promise<void> {
-  const suffixes = ["-wal", "-shm"];
-  for (const suffix of suffixes) {
+  for (const suffix of memoryIndexSidecarSuffixes) {
     await renameWithRetry(`${sourceBase}${suffix}`, `${targetBase}${suffix}`, options, true);
   }
 }

--- a/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.atomic-reindex.test.ts
@@ -99,7 +99,8 @@ describe("memory manager atomic reindex", () => {
       renameRetryDelayMs: 10,
     });
 
-    expect(rename).toHaveBeenCalledTimes(4);
+    // main (1 retry) + -wal + -shm + -journal.
+    expect(rename).toHaveBeenCalledTimes(5);
     expect(wait).toHaveBeenCalledTimes(1);
     expect(wait).toHaveBeenCalledWith(10);
   });
@@ -128,7 +129,8 @@ describe("memory manager atomic reindex", () => {
       .fn()
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(Object.assign(new Error("missing wal"), { code: "ENOENT" }))
-      .mockRejectedValueOnce(Object.assign(new Error("missing shm"), { code: "ENOENT" }));
+      .mockRejectedValueOnce(Object.assign(new Error("missing shm"), { code: "ENOENT" }))
+      .mockRejectedValueOnce(Object.assign(new Error("missing journal"), { code: "ENOENT" }));
     const wait = vi.fn().mockResolvedValue(undefined);
 
     await moveMemoryIndexFiles("index.sqlite.tmp", "index.sqlite", {
@@ -137,7 +139,8 @@ describe("memory manager atomic reindex", () => {
       renameRetryDelayMs: 10,
     });
 
-    expect(rename).toHaveBeenCalledTimes(3);
+    // main + the three optional sidecars (-wal, -shm, -journal), none retried.
+    expect(rename).toHaveBeenCalledTimes(4);
     expect(wait).not.toHaveBeenCalled();
   });
 
@@ -202,6 +205,7 @@ describe("memory manager atomic reindex", () => {
         "index.sqlite.tmp",
         "index.sqlite.tmp-wal",
         "index.sqlite.tmp-shm",
+        "index.sqlite.tmp-journal",
       ]);
       expect(wait).toHaveBeenCalledTimes(1);
       expect(wait).toHaveBeenCalledWith(10);
@@ -273,6 +277,7 @@ describe("memory manager atomic reindex", () => {
       "rm:index.sqlite.tmp:closed",
       "rm:index.sqlite.tmp-wal:closed",
       "rm:index.sqlite.tmp-shm:closed",
+      "rm:index.sqlite.tmp-journal:closed",
     ]);
   });
 
@@ -313,8 +318,10 @@ describe("memory manager atomic reindex", () => {
     writeChunkMarker(tempIndexPath, "after");
     await fs.writeFile(`${indexPath}-wal`, "stale wal");
     await fs.writeFile(`${indexPath}-shm`, "stale shm");
+    await fs.writeFile(`${indexPath}-journal`, "stale journal");
     await fs.writeFile(`${tempIndexPath}-wal`, "closed temp wal");
     await fs.writeFile(`${tempIndexPath}-shm`, "closed temp shm");
+    await fs.writeFile(`${tempIndexPath}-journal`, "closed temp journal");
 
     const events: string[] = [];
     const realRename = fs.rename;
@@ -340,21 +347,90 @@ describe("memory manager atomic reindex", () => {
     });
 
     expect(readChunkMarker(indexPath)).toBe("after");
-    expect(rename).toHaveBeenCalledTimes(3);
+    expect(rename).toHaveBeenCalledTimes(4);
     expect(events).toEqual([
       "rename:index.sqlite-wal->index.sqlite.backup-<uuid>-wal",
       "rename:index.sqlite-shm->index.sqlite.backup-<uuid>-shm",
+      "rename:index.sqlite-journal->index.sqlite.backup-<uuid>-journal",
       "rename:index.sqlite.tmp->index.sqlite",
       "rm:index.sqlite.backup-<uuid>:after",
       "rm:index.sqlite.backup-<uuid>-wal:after",
       "rm:index.sqlite.backup-<uuid>-shm:after",
+      "rm:index.sqlite.backup-<uuid>-journal:after",
       "rm:index.sqlite.tmp-wal:after",
       "rm:index.sqlite.tmp-shm:after",
+      "rm:index.sqlite.tmp-journal:after",
     ]);
     await expectPathMissing(`${indexPath}-wal`);
     await expectPathMissing(`${indexPath}-shm`);
+    await expectPathMissing(`${indexPath}-journal`);
     await expectPathMissing(`${tempIndexPath}-wal`);
     await expectPathMissing(`${tempIndexPath}-shm`);
+    await expectPathMissing(`${tempIndexPath}-journal`);
+  });
+
+  it("does not strand a stale rollback-journal next to the published index", async () => {
+    // journal_mode=DELETE stores (e.g. NFS-backed) leave a -journal sidecar
+    // instead of -wal/-shm. A swap that ignores it would publish the new main
+    // file beside a stale rollback journal, so the next open would roll the
+    // fresh index back to a torn state. The journal must be cleared on publish.
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+    await fs.writeFile(`${indexPath}-journal`, "stale rollback journal");
+
+    await runMemoryAtomicReindex({
+      targetPath: indexPath,
+      tempPath: tempIndexPath,
+      build: async () => undefined,
+    });
+
+    // Real disk readback across the swap boundary.
+    expect(readChunkMarker(indexPath)).toBe("after");
+    await expectPathMissing(`${indexPath}-journal`);
+  });
+
+  it("removes the temp rollback-journal sidecar when a reindex build fails", async () => {
+    // A crashed/failed reindex on a DELETE-mode store can leave a temp
+    // -journal sidecar. Cleanup must remove it alongside the temp main file so
+    // the startup orphan sweep is never required to reclaim it.
+    writeChunkMarker(indexPath, "before");
+    writeChunkMarker(tempIndexPath, "after");
+    await fs.writeFile(`${tempIndexPath}-journal`, "temp rollback journal");
+
+    await expect(
+      runMemoryAtomicReindex({
+        targetPath: indexPath,
+        tempPath: tempIndexPath,
+        build: async () => {
+          throw new Error("embedding failure");
+        },
+      }),
+    ).rejects.toThrow("embedding failure");
+
+    // The prior index survives and the temp triplet (incl. -journal) is gone.
+    expect(readChunkMarker(indexPath)).toBe("before");
+    await expectPathMissing(tempIndexPath);
+    await expectPathMissing(`${tempIndexPath}-journal`);
+  });
+
+  it("moves the rollback-journal sidecar with the main index across the real filesystem", async () => {
+    // moveMemoryIndexFiles is the Windows backup-protocol restore primitive.
+    // It must carry the -journal sidecar so a DELETE-mode index is recovered
+    // intact when a publish is rolled back.
+    const sourceBase = `${indexPath}.tmp`;
+    writeChunkMarker(sourceBase, "recovered");
+    await fs.writeFile(`${sourceBase}-journal`, "recovered journal");
+
+    await moveMemoryIndexFiles(sourceBase, indexPath);
+
+    // Real disk readback at the destination. Inspect the relocated journal
+    // before opening the DB, since opening index.sqlite would treat a sibling
+    // -journal as a hot journal and consume it.
+    await expect(fs.readFile(`${indexPath}-journal`, "utf8")).resolves.toBe("recovered journal");
+    await expectPathMissing(sourceBase);
+    await expectPathMissing(`${sourceBase}-journal`);
+    await fs.rm(`${indexPath}-journal`, { force: true });
+    expect(readChunkMarker(indexPath)).toBe("recovered");
   });
 
   it("reports publish before post-swap cleanup failures", async () => {


### PR DESCRIPTION
## Summary

The memory-core atomic reindex file operations hardcoded the WAL sidecar pair (`-wal`/`-shm`) when moving, removing, and backing up index files. NFS-backed memory stores run SQLite under `journal_mode=DELETE`, which produces a rollback-journal (`-journal`) sidecar instead of `-wal`/`-shm`.

As a result, an index swap left the previous target's **stale `-journal`** next to the freshly published database. The next time SQLite opens that index it treats the leftover journal as a *hot journal* and rolls the brand-new index back to a torn state — silent index corruption. The same omission also leaked the temp `-journal` on a failed reindex and dropped it during the Windows backup-rollback path.

This is the reindex-swap counterpart to the startup orphan cleanup landed in #93182, which already taught the startup sweep about the `-journal` suffix on `DELETE`-mode stores. That fix only covered `manager-db.ts` startup cleanup; the actual swap/move/remove pipeline in `manager-atomic-reindex.ts` still only handled `-wal`/`-shm`.

## What changed

`extensions/memory-core/src/memory/manager-atomic-reindex.ts`:

- Introduced shared suffix constants `memoryIndexFileSuffixes = ["", "-wal", "-shm", "-journal"]` and `memoryIndexSidecarSuffixes = ["-wal", "-shm", "-journal"]`.
- Routed all four hardcoded suffix sites through them: `moveMemoryIndexFiles`, `removeMemoryIndexFiles`, `removeMemoryIndexSidecars`, and the swap backup mover `moveMemoryIndexSidecars`.

The set now lives in one place so it cannot drift apart between move/remove/backup paths again.

## Real behavior proof

**Reproduction of the bug on the current `main` source** (no fix applied), driving the real exported `runMemoryAtomicReindex` against real on-disk SQLite databases:

```
BEFORE: [ 'index.sqlite', 'index.sqlite-journal', 'index.sqlite.tmp' ]
AFTER (upstream, no fix): [ 'index.sqlite', 'index.sqlite-journal' ]
journal still present? true
```

The stale `index.sqlite-journal` survives the swap next to the newly published `index.sqlite` — exactly the hot-journal hazard described above.

**Negative control** — reverting only the source change while keeping the new tests makes the suite fail (proving the tests exercise the fixed behavior, not a tautology):

```
 ❯ manager.atomic-reindex.test.ts (21 tests | 9 failed)
   × retries transient rename failures during index swaps
   × does not retry missing optional sqlite sidecar files
   × closes temp resources before removing temp files after build failure
   × backs up stale target sidecars before replacing the main index
   × removes the temp rollback-journal sidecar when a reindex build fails
   × moves the rollback-journal sidecar with the main index across the real filesystem
   ...
 Tests  9 failed | 12 passed (21)
```

**With the fix applied** the full suite passes:

```
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Tests and validation

`extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`:

- Added `does not strand a stale rollback-journal next to the published index` — seeds a real `-journal` on the target, runs `runMemoryAtomicReindex`, and reads back from disk that the journal is gone and the published DB carries the new content.
- Added `removes the temp rollback-journal sidecar when a reindex build fails` — a failed build must clean the temp triplet including `-journal`; verified by disk readback.
- Added `moves the rollback-journal sidecar with the main index across the real filesystem` — drives `moveMemoryIndexFiles` (the Windows backup-protocol restore primitive) over the real filesystem and reads back the relocated `-journal`.
- Updated the existing sidecar count/event assertions to reflect the now-complete three-sidecar sweep.

**Command:** `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.atomic-reindex.test.ts`

The new tests drive the real exported functions and read back across the real filesystem / real SQLite boundary.

## Risk checklist

- **Scope**: two files (source + its test), one extension (`memory-core`).
- **Behavior**: WAL-mode stores are unaffected — the extra `-journal` rename/remove is optional and no-ops with `ENOENT` (already the existing handling for missing `-wal`/`-shm`).
- **No API/signature changes**; pure suffix-set widening behind existing helpers.
- **Type check**: `manager-atomic-reindex.ts` and its test introduce no new tsgo errors (verified against the `upstream/main` baseline for the same `extensions/memory-core` project).

## Real behavior proof

Behavior addressed: A hot SQLite rollback journal left beside a newly published memory index silently rolls the fresh database back to old contents on the next open.

Real environment tested: macOS arm64 on APFS, Blacksmith Testbox Linux x64, and Blacksmith Testbox Linux arm64, using real on-disk SQLite databases and child-process hard kills.

Exact steps or command run after this patch: `node qa/scenarios/sqlite-atomic-reindex-journal-repro.mjs`; `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.atomic-reindex.test.ts extensions/memory-core/src/memory/manager-db-probe.test.ts`

Evidence after fix: Copied terminal output from `node qa/scenarios/sqlite-atomic-reindex-journal-repro.mjs` on macOS arm64, Linux x64, and Linux arm64 showed `journalAfter: false`, `integrity_check: ok`, and reopened rows with the `new-` prefix. Focused Linux x64 and Linux arm64 runs each passed 34 tests across 2 files.

Observed result after fix: Atomic reindex publishes the new database without leaving a target `-journal`, so SQLite does not roll the fresh index back to stale contents.

What was not tested: Native Windows Testbox was blocked by provider capacity after more than eight minutes queued with no run URL or IP. A real NFS or SMB mount was not available; DELETE-mode rollback-journal behavior itself was exercised directly.