### PR TITLE
fix(control-ui): respect agents.defaults.timeFormat for timestamps

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -20,4 +20,6 @@ export type ControlUiBootstrapConfig = {
   embedSandbox?: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   chatMessageMaxWidth?: string;
+  /** Resolved `agents.defaults.timeFormat`; "auto" keeps the browser locale default. */
+  timeFormat?: "auto" | "12" | "24";
 };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -47,6 +47,7 @@ describe("handleControlUiHttpRequest", () => {
       assistantAgentId: string;
       localMediaPreviewRoots?: string[];
       chatMessageMaxWidth?: string;
+      timeFormat?: "auto" | "12" | "24";
     };
   }
 
@@ -796,7 +797,7 @@ describe("handleControlUiHttpRequest", () => {
           {
             root: { kind: "resolved", path: tmp },
             config: {
-              agents: { defaults: { workspace: tmp } },
+              agents: { defaults: { workspace: tmp, timeFormat: "24" } },
               gateway: { controlUi: { chatMessageMaxWidth: "min(1280px, 82%)" } },
               ui: { assistant: { name: "</script><script>alert(1)//", avatar: "</script>.png" } },
             },
@@ -809,6 +810,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantAvatar).toBe("/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
         expect(parsed.chatMessageMaxWidth).toBe("min(1280px, 82%)");
+        expect(parsed.timeFormat).toBe("24");
         expect(Array.isArray(parsed.localMediaPreviewRoots)).toBe(true);
       },
     });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -979,6 +979,7 @@ export async function handleControlUiHttpRequest(
             : "scripts",
       allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
       chatMessageMaxWidth: config?.gateway?.controlUi?.chatMessageMaxWidth,
+      timeFormat: config?.agents?.defaults?.timeFormat,
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -2,6 +2,7 @@
 
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setUiTimeFormatPreference } from "../format.ts";
 import type { MessageGroup } from "../types/chat-types.ts";
 import {
   formatChatTimestampForDisplay,
@@ -2526,5 +2527,25 @@ describe("grouped chat rendering", () => {
     const sidebar = requireFirstMockArg(onOpenSidebar, "sidebar open");
     expect(sidebar.kind).toBe("markdown");
     expect(sidebar.fullMessageRequest).toBeUndefined();
+  });
+});
+
+describe("formatChatTimestampForDisplay time format", () => {
+  const timestamp = Date.UTC(2026, 0, 15, 19, 30);
+
+  afterEach(() => {
+    setUiTimeFormatPreference("auto");
+  });
+
+  it("renders an AM/PM clock when preference is 12", () => {
+    setUiTimeFormatPreference("12");
+    const display = formatChatTimestampForDisplay(timestamp);
+    expect(display.label).toMatch(/AM|PM/i);
+  });
+
+  it("renders a 24-hour clock with no AM/PM when preference is 24", () => {
+    setUiTimeFormatPreference("24");
+    const display = formatChatTimestampForDisplay(timestamp);
+    expect(display.label).not.toMatch(/AM|PM/i);
   });
 });

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -5,6 +5,7 @@ import { until } from "lit/directives/until.js";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { AssistantIdentity } from "../assistant-identity.ts";
 import type { EmbedSandboxMode } from "../embed-sandbox.ts";
+import { resolveUiHourCycleOptions } from "../format.ts";
 import { icons } from "../icons.ts";
 import { toSanitizedMarkdownHtml, toStreamingMarkdownHtml } from "../markdown.ts";
 import { openExternalUrlSafe } from "../open-external-url.ts";
@@ -63,8 +64,10 @@ export function formatChatTimestampForDisplay(timestamp: number): ChatTimestampD
     };
   }
 
+  const hourCycle = resolveUiHourCycleOptions();
   return {
     label: date.toLocaleString([], {
+      ...hourCycle,
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -72,6 +75,7 @@ export function formatChatTimestampForDisplay(timestamp: number): ChatTimestampD
       minute: "2-digit",
     }),
     title: date.toLocaleString([], {
+      ...hourCycle,
       weekday: "long",
       month: "long",
       day: "numeric",

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -1,7 +1,8 @@
 /* @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../../../../src/gateway/control-ui-contract.js";
+import { resolveUiHourCycleOptions, setUiTimeFormatPreference } from "../format.ts";
 import { loadControlUiBootstrapConfig } from "./control-ui-bootstrap.ts";
 
 function requireFetchCall(fetchMock: ReturnType<typeof vi.fn>, index = 0) {
@@ -13,6 +14,45 @@ function requireFetchCall(fetchMock: ReturnType<typeof vi.fn>, index = 0) {
 }
 
 describe("loadControlUiBootstrapConfig", () => {
+  afterEach(() => {
+    setUiTimeFormatPreference("auto");
+  });
+
+  it("threads agents.defaults.timeFormat into the UI hour-cycle preference", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        basePath: "",
+        assistantName: "Main",
+        assistantAvatar: "M",
+        assistantAgentId: "main",
+        timeFormat: "24",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAvatarSource: null,
+      assistantAvatarStatus: null,
+      assistantAvatarReason: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      chatMessageMaxWidth: null,
+      serverVersion: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    expect(resolveUiHourCycleOptions()).toEqual({ hour12: false });
+
+    vi.unstubAllGlobals();
+  });
+
   it("loads assistant identity from the bootstrap endpoint", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../src/gateway/control-ui-contract.js";
 import { normalizeAssistantIdentity } from "../assistant-identity.ts";
 import { resolveControlUiAuthCandidates } from "../control-ui-auth.ts";
+import { setUiTimeFormatPreference } from "../format.ts";
 import { normalizeBasePath } from "../navigation.ts";
 import { normalizeAgentId, parseAgentSessionKey } from "../session-key.ts";
 import { loadLocalAssistantIdentity } from "../storage.ts";
@@ -136,6 +137,7 @@ export async function loadControlUiBootstrapConfig(
       typeof parsed.chatMessageMaxWidth === "string" && parsed.chatMessageMaxWidth.trim()
         ? parsed.chatMessageMaxWidth
         : null;
+    setUiTimeFormatPreference(parsed.timeFormat);
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
   }

--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover format behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   formatDateTimeMs,
   formatDateMs,
@@ -8,6 +8,7 @@ import {
   formatTimeMs,
   formatUnknownText,
   parseSessionKeyParts,
+  setUiTimeFormatPreference,
   stripThinkingTags,
 } from "./format.ts";
 
@@ -58,6 +59,44 @@ describe("date/time millisecond formatters", () => {
     expect(formatDateMs(8_640_000_000_000_001, undefined, "")).toBe("");
     expect(formatDateTimeMs(Number.NEGATIVE_INFINITY, undefined, "")).toBe("");
     expect(formatTimeMs(Number.POSITIVE_INFINITY, undefined, "")).toBe("");
+  });
+});
+
+describe("agents.defaults.timeFormat preference", () => {
+  // 19:30 UTC: 24-hour renders "19:30", 12-hour renders "7:30 PM".
+  const ts = Date.UTC(2026, 0, 15, 19, 30);
+  const opts: Intl.DateTimeFormatOptions = {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+  };
+
+  afterEach(() => {
+    setUiTimeFormatPreference("auto");
+  });
+
+  it("forces a 24-hour clock when preference is 24", () => {
+    setUiTimeFormatPreference("24");
+    expect(formatTimeMs(ts, opts, "")).toBe("19:30");
+  });
+
+  it("forces a 12-hour clock when preference is 12", () => {
+    setUiTimeFormatPreference("12");
+    const formatted = formatTimeMs(ts, opts, "");
+    expect(formatted).toContain("7:30");
+    expect(formatted).toMatch(/PM/i);
+  });
+
+  it("lets the caller override the resolved hour cycle", () => {
+    setUiTimeFormatPreference("24");
+    expect(formatTimeMs(ts, { ...opts, hour12: true }, "")).toMatch(/PM/i);
+  });
+
+  it("leaves rendering to the browser locale default for auto", () => {
+    setUiTimeFormatPreference("auto");
+    const auto = formatDateTimeMs(ts, opts, "");
+    const native = new Date(ts).toLocaleString([], opts);
+    expect(auto).toBe(native);
   });
 });
 

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -38,12 +38,33 @@ export function formatUnknownText(
   return Object.prototype.toString.call(value);
 }
 
+export type UiTimeFormatPreference = "auto" | "12" | "24";
+
+// Resolved `agents.defaults.timeFormat`, threaded in once at bootstrap. "auto"
+// (or unset) keeps the browser locale default so existing deployments render
+// unchanged; only "12"/"24" force an hour cycle across Control UI timestamps.
+let uiTimeFormatPreference: UiTimeFormatPreference = "auto";
+
+export function setUiTimeFormatPreference(value: UiTimeFormatPreference | null | undefined): void {
+  uiTimeFormatPreference = value === "12" || value === "24" ? value : "auto";
+}
+
+export function resolveUiHourCycleOptions(): Intl.DateTimeFormatOptions {
+  if (uiTimeFormatPreference === "12") {
+    return { hour12: true };
+  }
+  if (uiTimeFormatPreference === "24") {
+    return { hour12: false };
+  }
+  return {};
+}
+
 export function formatMs(ms?: number | null): string {
   const timestampMs = asDateTimestampMs(ms);
   if (timestampMs === undefined) {
     return t("common.na");
   }
-  return new Date(timestampMs).toLocaleString();
+  return new Date(timestampMs).toLocaleString([], resolveUiHourCycleOptions());
 }
 
 export function formatDateMs(
@@ -65,7 +86,7 @@ export function formatTimeMs(
   const timestampMs = asDateTimestampMs(ms);
   return timestampMs === undefined
     ? fallback
-    : new Date(timestampMs).toLocaleTimeString([], options);
+    : new Date(timestampMs).toLocaleTimeString([], { ...resolveUiHourCycleOptions(), ...options });
 }
 
 export function formatDateTimeMs(
@@ -74,7 +95,9 @@ export function formatDateTimeMs(
   fallback = t("common.na"),
 ): string {
   const timestampMs = asDateTimestampMs(ms);
-  return timestampMs === undefined ? fallback : new Date(timestampMs).toLocaleString([], options);
+  return timestampMs === undefined
+    ? fallback
+    : new Date(timestampMs).toLocaleString([], { ...resolveUiHourCycleOptions(), ...options });
 }
 
 export function formatList(values?: Array<string | null | undefined>): string {


### PR DESCRIPTION
## Summary

- Fixes the Control UI / WebChat rendering timestamps with a hardcoded locale clock, ignoring the existing `agents.defaults.timeFormat` setting (showing `10:45 PM` when the operator configured 24-hour).
- Threads the resolved `agents.defaults.timeFormat` through the gateway bootstrap config into a small UI hour-cycle helper, so `formatMs` / `formatTimeMs` / `formatDateTimeMs` and the WebChat group timestamp all honor `12` / `24`.
- Leaves `auto` (and unset) as the browser locale default, so existing deployments render exactly as before — only an explicit `12`/`24` forces an hour cycle.

## Linked context

Closes #58147

The config key already exists (`src/config/types.agent-defaults.ts`, `agents.defaults.timeFormat: "auto" | "12" | "24"`) and is documented as controlling 12h/24h rendering; the Control UI was simply not wired to it. No new config surface is added — one optional bootstrap field.

## Real behavior proof (required for external PRs)

Behavior addressed: Control UI / WebChat timestamps respect `agents.defaults.timeFormat`.

Real environment tested: a real local OpenClaw gateway started with `pnpm dev gateway run` (gateway **v2026.6.2**, local mode, DeepSeek V4 Pro agent) serving the real built Control UI, opened in a real browser (en-US locale) against a real chat session.

Exact steps or command run after this patch:

```text
1. Set agents.defaults.timeFormat="24" in ~/.openclaw/openclaw.json
2. pnpm dev gateway run    # gateway v2026.6.2, http server listening on :18789
3. Open Control UI in browser, view a chat session, read the timestamp + screenshot
4. Change the setting to "12", restart the gateway, reload, view a chat session, screenshot
```

Evidence after fix:

```text
# The real gateway emits the field on its bootstrap endpoint:
$ curl -s -H "Authorization: Bearer <redacted>" http://127.0.0.1:18789/control-ui-config.json
  timeFormat="24"  ->  {"serverVersion":"2026.6.2","timeFormat":"24", ...}
  timeFormat="12"  ->  {"serverVersion":"2026.6.2","timeFormat":"12", ...}

# Control UI chat timestamp (.chat-group-timestamp), real browser, en-US locale:
  agents.defaults.timeFormat = "24"  ->  "Jun 15, 2026, 22:50"      (24-hour, no AM/PM)
  agents.defaults.timeFormat = "12"  ->  "Jun 15, 2026, 10:45 PM"   (12-hour, with PM)
```

Screenshots of the real Control UI (v2026.6.2), same browser and en-US locale, only `agents.defaults.timeFormat` changed between captures, attached to this PR: 24-hour shows `Jun 15, 2026, 22:50`; 12-hour shows `Jun 15, 2026, 10:45 PM`.

Observed result after fix: the rendered timestamp flips between 24-hour and 12-hour exactly as configured. With the setting absent (`auto`), rendering matches the prior browser-locale default (no hour-cycle override emitted), so existing deployments are unaffected.

What was not tested: per-agent `timeFormat` overrides are intentionally out of scope — this fix consumes the global `agents.defaults` value the issue names. The bootstrap field is optional, so old/missing payloads keep current behavior.

Proof limitations or environment constraints: ran on a local single-host gateway; no multi-host/remote-gateway deployment was exercised.

## Tests and validation

- `git diff --check`; `pnpm format:check` (changed files clean).
- Type lanes green: `tsgo:core`, `tsgo:test:ui`, `tsgo:test:src`.
- Focused tests: `node scripts/run-vitest.mjs ui/src/ui/format.test.ts ui/src/ui/chat/grouped-render.test.ts ui/src/ui/controllers/control-ui-bootstrap.test.ts` and `node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts`.
- Build: `pnpm ui:build` passes locally; CI `build-artifacts` and `check-prod-types` are green.

## Risk checklist

Did user-visible behavior change? `Yes` — Control UI timestamps now follow `agents.defaults.timeFormat`; `auto`/unset is unchanged from today.

Did config, environment, or migration behavior change? `No` — reuses the existing `agents.defaults.timeFormat` key; the bootstrap payload field is additive and optional, safe for old/missing payloads.

Did security, auth, secrets, network, or tool execution behavior change? `No`.

Highest-risk area: the centralized hour-cycle merge inside the shared `format.ts` helpers affects every Control UI timestamp surface (cron, usage, activity, chat).

How is that risk mitigated? `auto`/unset resolves to an empty options object, so behavior is byte-identical to current rendering unless an operator explicitly sets `12`/`24`; caller-supplied options still override the resolved cycle.

Current review state: real behavior proof added (real gateway + real Control UI screenshots); awaiting maintainer review and CI.

AI-assisted (Claude Code). Proof above was run manually against a real local gateway and browser.
