### PR TITLE
fix #93044: control-ui webchat double-renders agent replies when dmScope=main

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -274,6 +274,34 @@ describe("buildChatItems", () => {
     ]);
   });
 
+  it("keeps formatting-only assistant updates separate for the same source message", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          __openclaw: { id: "reply-formatted" },
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival first\n\nsecond" }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          __openclaw: { id: "reply-formatted" },
+          role: "assistant",
+          content: [{ type: "text", text: "first second" }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "Parzival first\n\nsecond" },
+    ]);
+    expect(messageRecord(groups[1]).content).toStrictEqual([
+      { type: "text", text: "first second" },
+    ]);
+  });
+
   it("keeps relay-labeled assistant updates separate when source message id repeats with new text", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -142,6 +142,109 @@ describe("buildChatItems", () => {
     expect(groups[0].messages[0].duplicateCount).toBe(3);
   });
 
+  it("deduplicates relay-labeled assistant copies by source message id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          id: "reply-1",
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival There it is." }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          id: "reply-1",
+          role: "assistant",
+          content: [{ type: "text", text: "There it is." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(groups[0].messages).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "There it is." },
+    ]);
+  });
+
+  it("deduplicates relay-labeled assistant copies by event messageId", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          messageId: "reply-2",
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival Found it." }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          messageId: "reply-2",
+          role: "assistant",
+          content: [{ type: "text", text: "Found it." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(groups[0].messages).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([{ type: "text", text: "Found it." }]);
+  });
+
+  it("deduplicates relay-labeled assistant copies by OpenClaw transcript metadata id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          __openclaw: { id: "reply-3" },
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival On it." }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          __openclaw: { id: "reply-3" },
+          role: "assistant",
+          content: [{ type: "text", text: "On it." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(groups[0].messages).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([{ type: "text", text: "On it." }]);
+  });
+
+  it("keeps identical assistant text separate when source message ids differ", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          id: "reply-4",
+          role: "assistant",
+          content: [{ type: "text", text: "Same update" }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          id: "reply-5",
+          role: "assistant",
+          content: [{ type: "text", text: "Same update" }],
+          senderLabel: "Parzival",
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].messages).toHaveLength(2);
+    expect(groups[0].messages[0].duplicateCount).toBeUndefined();
+    expect(groups[0].messages[1].duplicateCount).toBeUndefined();
+  });
+
   it("suppresses assistant HEARTBEAT_OK acknowledgements before rendering history", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -302,6 +302,32 @@ describe("buildChatItems", () => {
     ]);
   });
 
+  it("keeps differently cased sender text separate for the same source message", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          __openclaw: { id: "reply-case-change" },
+          role: "assistant",
+          content: [{ type: "text", text: "PARZIVAL answer" }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          __openclaw: { id: "reply-case-change" },
+          role: "assistant",
+          content: [{ type: "text", text: "answer" }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "PARZIVAL answer" },
+    ]);
+    expect(messageRecord(groups[1]).content).toStrictEqual([{ type: "text", text: "answer" }]);
+  });
+
   it("keeps relay-labeled assistant updates separate when source message id repeats with new text", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -331,6 +331,31 @@ describe("buildChatItems", () => {
     expect(groups[0].messages[1].duplicateCount).toBeUndefined();
   });
 
+  it("keeps same-id user relay copies separate so sender identity is preserved", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          __openclaw: { id: "user-1" },
+          role: "user",
+          content: [{ type: "text", text: "Alice hello" }],
+          senderLabel: "Alice",
+          timestamp: 1,
+        },
+        {
+          __openclaw: { id: "user-1" },
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.senderLabel)).toEqual(["Alice", null]);
+    expect(groups[0].messages).toHaveLength(1);
+    expect(groups[1].messages).toHaveLength(1);
+  });
+
   it("suppresses assistant HEARTBEAT_OK acknowledgements before rendering history", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -219,18 +219,104 @@ describe("buildChatItems", () => {
     expect(messageRecord(groups[0]).content).toStrictEqual([{ type: "text", text: "On it." }]);
   });
 
+  it("deduplicates relay-labeled assistant copies by OpenClaw metadata before surface ids", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          id: "relay-surface-copy",
+          __openclaw: { id: "reply-4" },
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival Ship it." }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          id: "native-surface-copy",
+          __openclaw: { id: "reply-4" },
+          role: "assistant",
+          content: [{ type: "text", text: "Ship it." }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBeNull();
+    expect(groups[0].messages).toHaveLength(1);
+    expect(messageRecord(groups[0]).content).toStrictEqual([{ type: "text", text: "Ship it." }]);
+  });
+
+  it("keeps native assistant updates separate when source message id repeats with new text", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          __openclaw: { id: "reply-5" },
+          role: "assistant",
+          content: [{ type: "text", text: "Draft one" }],
+          timestamp: 1,
+        },
+        {
+          __openclaw: { id: "reply-5" },
+          role: "assistant",
+          content: [{ type: "text", text: "Draft two" }],
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].messages).toHaveLength(2);
+    expect(messageRecord(groups[0], 0).content).toStrictEqual([
+      { type: "text", text: "Draft one" },
+    ]);
+    expect(messageRecord(groups[0], 1).content).toStrictEqual([
+      { type: "text", text: "Draft two" },
+    ]);
+  });
+
+  it("keeps relay-labeled assistant updates separate when source message id repeats with new text", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          __openclaw: { id: "reply-6" },
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival Draft one" }],
+          senderLabel: "Parzival",
+          timestamp: 1,
+        },
+        {
+          __openclaw: { id: "reply-6" },
+          role: "assistant",
+          content: [{ type: "text", text: "Parzival Draft two" }],
+          senderLabel: "Parzival",
+          timestamp: 2,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].senderLabel).toBe("Parzival");
+    expect(groups[0].messages).toHaveLength(2);
+    expect(messageRecord(groups[0], 0).content).toStrictEqual([
+      { type: "text", text: "Parzival Draft one" },
+    ]);
+    expect(messageRecord(groups[0], 1).content).toStrictEqual([
+      { type: "text", text: "Parzival Draft two" },
+    ]);
+  });
+
   it("keeps identical assistant text separate when source message ids differ", () => {
     const groups = messageGroups({
       messages: [
         {
-          id: "reply-4",
+          id: "reply-7",
           role: "assistant",
           content: [{ type: "text", text: "Same update" }],
           senderLabel: "Parzival",
           timestamp: 1,
         },
         {
-          id: "reply-5",
+          id: "reply-8",
           role: "assistant",
           content: [{ type: "text", text: "Same update" }],
           senderLabel: "Parzival",

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -241,16 +241,16 @@ function sourceMessageId(message: unknown): string | null {
   if (!record) {
     return null;
   }
-  const id = typeof record.id === "string" ? record.id.trim() : "";
-  if (id) {
-    return id;
+  const openclawId = asRecord(record["__openclaw"])?.id;
+  if (typeof openclawId === "string" && openclawId.trim()) {
+    return openclawId.trim();
   }
   const messageId = typeof record.messageId === "string" ? record.messageId.trim() : "";
   if (messageId) {
     return messageId;
   }
-  const openclawId = asRecord(record["__openclaw"])?.id;
-  return typeof openclawId === "string" && openclawId.trim() ? openclawId.trim() : null;
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  return id || null;
 }
 
 function collapseDuplicateSourceKey(message: unknown): string | null {
@@ -276,6 +276,73 @@ function prefersNativeChatSurface(message: unknown): boolean {
   }
   const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
   return (role === "user" || role === "assistant") && !(normalized.senderLabel ?? "").trim();
+}
+
+function normalizeDuplicateText(text: string): string {
+  return text.trim().replace(/\s+/g, " ");
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripSenderLabelPrefix(text: string, senderLabel: string): string {
+  const normalizedText = normalizeDuplicateText(text);
+  const label = normalizeDuplicateText(senderLabel);
+  if (!label) {
+    return normalizedText;
+  }
+  return normalizedText
+    .replace(new RegExp(`^${escapeRegExp(label)}(?::|：|-|—)?\\s+`, "i"), "")
+    .trim();
+}
+
+function sourceDuplicateDisplayParts(message: unknown): {
+  role: string;
+  senderLabel: string;
+  text: string;
+} | null {
+  const normalized = safeNormalizeMessage(message);
+  if (!normalized) {
+    return null;
+  }
+  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+  if (role !== "user" && role !== "assistant") {
+    return null;
+  }
+  const textParts: string[] = [];
+  for (const block of normalized.content) {
+    if (block.type !== "text" || typeof block.text !== "string") {
+      return null;
+    }
+    textParts.push(block.text);
+  }
+  const text = normalizeDuplicateText(textParts.join("\n"));
+  if (!text) {
+    return null;
+  }
+  return {
+    role,
+    senderLabel: (normalized.senderLabel ?? "").trim(),
+    text,
+  };
+}
+
+function isSameSourceRelayNativeDuplicate(previousMessage: unknown, nextMessage: unknown): boolean {
+  const previous = sourceDuplicateDisplayParts(previousMessage);
+  const next = sourceDuplicateDisplayParts(nextMessage);
+  if (!previous || !next || previous.role !== next.role) {
+    return false;
+  }
+  if (Boolean(previous.senderLabel) === Boolean(next.senderLabel)) {
+    return false;
+  }
+  const labeled = previous.senderLabel ? previous : next;
+  const native = previous.senderLabel ? next : previous;
+  return (
+    labeled.text === native.text ||
+    stripSenderLabelPrefix(labeled.text, labeled.senderLabel) === native.text
+  );
 }
 
 function collapseDuplicateDisplaySignature(message: unknown): string | null {
@@ -324,7 +391,12 @@ function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem[] {
     const signature = collapseDuplicateDisplaySignature(item.message);
     const sourceKey = collapseDuplicateSourceKey(item.message);
     const previous = collapsed[collapsed.length - 1];
-    if (sourceKey && previousSourceKey === sourceKey && previous?.kind === "message") {
+    if (
+      sourceKey &&
+      previousSourceKey === sourceKey &&
+      previous?.kind === "message" &&
+      isSameSourceRelayNativeDuplicate(previous.message, item.message)
+    ) {
       if (!prefersNativeChatSurface(previous.message) && prefersNativeChatSurface(item.message)) {
         collapsed[collapsed.length - 1] = item;
         previousSignature = signature;

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -278,23 +278,16 @@ function prefersNativeChatSurface(message: unknown): boolean {
   return (role === "user" || role === "assistant") && !(normalized.senderLabel ?? "").trim();
 }
 
-function normalizeDuplicateText(text: string): string {
-  return text.trim().replace(/\s+/g, " ");
-}
-
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function stripSenderLabelPrefix(text: string, senderLabel: string): string {
-  const normalizedText = normalizeDuplicateText(text);
-  const label = normalizeDuplicateText(senderLabel);
+  const label = senderLabel.trim();
   if (!label) {
-    return normalizedText;
+    return text;
   }
-  return normalizedText
-    .replace(new RegExp(`^${escapeRegExp(label)}(?::|：|-|—)?\\s+`, "i"), "")
-    .trim();
+  return text.replace(new RegExp(`^${escapeRegExp(label)}(?::|：|-|—)?[ \\t]+`, "i"), "");
 }
 
 function sourceDuplicateDisplayParts(message: unknown): {
@@ -317,8 +310,8 @@ function sourceDuplicateDisplayParts(message: unknown): {
     }
     textParts.push(block.text);
   }
-  const text = normalizeDuplicateText(textParts.join("\n"));
-  if (!text) {
+  const text = textParts.join("\n");
+  if (!text.trim()) {
     return null;
   }
   return {

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -262,7 +262,7 @@ function collapseDuplicateSourceKey(message: unknown): string | null {
     return null;
   }
   const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
-  if (role !== "user" && role !== "assistant") {
+  if (role !== "assistant") {
     return null;
   }
   const id = sourceMessageId(message);
@@ -307,7 +307,7 @@ function sourceDuplicateDisplayParts(message: unknown): {
     return null;
   }
   const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
-  if (role !== "user" && role !== "assistant") {
+  if (role !== "assistant") {
     return null;
   }
   const textParts: string[] = [];

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -287,7 +287,7 @@ function stripSenderLabelPrefix(text: string, senderLabel: string): string {
   if (!label) {
     return text;
   }
-  return text.replace(new RegExp(`^${escapeRegExp(label)}(?::|：|-|—)?[ \\t]+`, "i"), "");
+  return text.replace(new RegExp(`^${escapeRegExp(label)}(?::|：|-|—)?[ \\t]+`), "");
 }
 
 function sourceDuplicateDisplayParts(message: unknown): {

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -232,9 +232,54 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   return result;
 }
 
+function isPendingSendMessage(message: unknown): boolean {
+  return asRecord(asRecord(message)?.["__openclaw"])?.kind === "pending-send";
+}
+
+function sourceMessageId(message: unknown): string | null {
+  const record = asRecord(message);
+  if (!record) {
+    return null;
+  }
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  if (id) {
+    return id;
+  }
+  const messageId = typeof record.messageId === "string" ? record.messageId.trim() : "";
+  if (messageId) {
+    return messageId;
+  }
+  const openclawId = asRecord(record["__openclaw"])?.id;
+  return typeof openclawId === "string" && openclawId.trim() ? openclawId.trim() : null;
+}
+
+function collapseDuplicateSourceKey(message: unknown): string | null {
+  if (isPendingSendMessage(message)) {
+    return null;
+  }
+  const normalized = safeNormalizeMessage(message);
+  if (!normalized) {
+    return null;
+  }
+  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+  if (role !== "user" && role !== "assistant") {
+    return null;
+  }
+  const id = sourceMessageId(message);
+  return id ? `${role}:${id}` : null;
+}
+
+function prefersNativeChatSurface(message: unknown): boolean {
+  const normalized = safeNormalizeMessage(message);
+  if (!normalized) {
+    return false;
+  }
+  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+  return (role === "user" || role === "assistant") && !(normalized.senderLabel ?? "").trim();
+}
+
 function collapseDuplicateDisplaySignature(message: unknown): string | null {
-  const marker = asRecord(message)?.["__openclaw"];
-  if (asRecord(marker)?.kind === "pending-send") {
+  if (isPendingSendMessage(message)) {
     return null;
   }
   const normalized = safeNormalizeMessage(message);
@@ -267,21 +312,37 @@ function collapseDuplicateDisplaySignature(message: unknown): string | null {
 function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem[] {
   const collapsed: ChatItem[] = [];
   let previousSignature: string | null = null;
+  let previousSourceKey: string | null = null;
 
   for (const item of items) {
     if (item.kind !== "message") {
       collapsed.push(item);
       previousSignature = null;
+      previousSourceKey = null;
       continue;
     }
     const signature = collapseDuplicateDisplaySignature(item.message);
+    const sourceKey = collapseDuplicateSourceKey(item.message);
     const previous = collapsed[collapsed.length - 1];
-    if (signature && previousSignature === signature && previous?.kind === "message") {
+    if (sourceKey && previousSourceKey === sourceKey && previous?.kind === "message") {
+      if (!prefersNativeChatSurface(previous.message) && prefersNativeChatSurface(item.message)) {
+        collapsed[collapsed.length - 1] = item;
+        previousSignature = signature;
+      }
+      continue;
+    }
+    if (
+      signature &&
+      previousSignature === signature &&
+      previous?.kind === "message" &&
+      !(sourceKey && previousSourceKey && sourceKey !== previousSourceKey)
+    ) {
       previous.duplicateCount = (previous.duplicateCount ?? 1) + 1;
       continue;
     }
     collapsed.push(item);
     previousSignature = signature;
+    previousSourceKey = sourceKey;
   }
 
   return collapsed;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Root cause: Control UI's previous duplicate collapse compared display-derived fields (`role`, `senderLabel`, and rendered text). With `dmScope=main`, the same underlying assistant transcript message can arrive through two render surfaces: the native webchat copy and the main-session relay copy. Those two projections can have different sender labels or prefixed text, so display-signature collapse treated one source message as two visible assistant replies.

Why does this matter now?

The duplicate reply makes normal agent conversations look like the agent answered twice, and the relay-envelope copy is noisier than the native chat surface.

What is the intended outcome?

Root-cause fix: the renderer now collapses only adjacent assistant relay/native copies that share the same source-of-truth message identity, while keeping the native unlabelled copy for display.

What is intentionally out of scope?

This does not change gateway delivery, transcript persistence, relay fanout behavior, API shape, schema, config, protocol, compatibility, default behavior, or migration behavior; it only changes Control UI render-time collapse behavior.

What does success look like?

A duplicated assistant reply with the same source id renders once, but distinct assistant updates, different source ids, pending sends, and user sender identities remain preserved.

What should reviewers focus on?

Please focus on the `buildChatItems` duplicate-collapse logic and the regression tests around source id precedence, content preservation, and user sender identity.

- Fix classification: Root-cause fix at the Control UI renderer boundary.
- Root cause: Control UI used transformed display fields as the duplicate identity source, so the native webchat copy and the relay-labeled copy of one assistant transcript message did not share a display signature and rendered as two assistant replies.
- Why this is root-cause fix: The patch moves duplicate identity for this path to the source message boundary before display labels are applied, then verifies the raw vs transformed text relationship before collapsing. It fixes the renderer invariant that one assistant source message should not paint twice, instead of hiding arbitrary repeated text.
- Architecture / source-of-truth check: `__openclaw.id` is the canonical source-of-truth identity for the underlying transcript message because gateway transcript metadata is attached before Control UI rendering; `messageId` and `id` are only fallback identity carriers when that metadata is absent.
- What did NOT change: No public contract surface changed: API, schema, config, protocol, compatibility, default behavior, migration behavior, gateway delivery, transcript persistence, and relay fanout remain unchanged.
- Patch quality notes: The default return guards are boundary checks for non-renderable, pending-send, non-assistant, or non-text shapes in the renderer; they prevent over-collapsing and do not mask the reported duplicate-render cause.

## Linked context

Which issue does this close?

Closes #93044

Which issues, PRs, or discussions are related?

Related #93044. Competition scan found external PR #93065 for the same issue; daily-fix classified it as weak / needs-proof and allowed a new issue-flow PR rather than using `init-pr` on someone else's PR. Related open PR scan for public-contract overlap found no same-contract open PRs.

Was this requested by a maintainer or owner?

Opened from the public issue report.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Control UI webchat no longer double-renders a single assistant reply when the same source message arrives as both a relay-labeled copy and a native copy under `dmScope=main`.
- Real environment tested: OpenClaw Control UI browser runtime in Chromium, serving the real Control UI `/chat?session=main` page from the Vite e2e server. The Gateway protocol history payload used the `dmScope=main` source-id shape from the issue: adjacent relay/native assistant copies sharing the same `__openclaw.id`.
- Exact steps or command run after this patch: Started the Control UI e2e server, opened `/chat?session=main` in Playwright Chromium, injected a `chat.startup` history payload with one user message plus adjacent relay/native assistant copies that share `__openclaw.id`, then counted the rendered chat groups and bubbles in the browser DOM.
- Evidence after fix: Copied live browser-run output from the Control UI proof:

```text
Control UI dmScope=main proof passed
scenario=Control UI /chat?session=main with dmScope=main-shaped transcript history containing adjacent relay/native assistant copies sharing __openclaw.id.
chat.startup requests=1
assistant groups=1
assistant bubbles=1
native assistant bubble count=1
relay-labeled duplicate bubble count=0
```

Copied browser DOM observation from the same run:

```json
{
  "title": "OpenClaw Control",
  "groupCount": 2,
  "assistantGroupCount": 1,
  "assistantBubbleCount": 1,
  "exactNativeBubbleCount": 1,
  "relayLabeledBubbleCount": 0,
  "assistantReplyOccurrences": 1,
  "gatewayRequests": {
    "chatStartupRequestCount": 1,
    "lastChatStartupParams": {
      "sessionKey": "main",
      "limit": 100
    }
  }
}
```

- Observed result after fix: The Control UI page rendered the Telegram-style user prompt once and the assistant reply once as the native assistant bubble. The relay-labeled duplicate copy with the same `__openclaw.id` did not render as a second assistant bubble.
- What was not tested: No unrelated surfaces were exercised; this proof targets the Control UI chat render path changed by this PR, while gateway delivery, transcript persistence, and relay fanout remain unchanged by the patch.
- Proof limitations or environment constraints: The browser proof uses the existing Control UI e2e Gateway shim to provide the dmScope=main-shaped `chat.startup` history payload, so it proves the user-visible Control UI rendering behavior without changing or relying on external Telegram credentials.
- Before evidence (optional but encouraged): The new regression tests first failed on the previous implementation: the relay/native assistant copy produced two groups when `__openclaw.id` was shared but surface ids differed, and same-source different-content messages were incorrectly collapsed.

## Tests and validation

Which commands did you run?

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts`
- `npx oxfmt --check ui/src/ui/chat/build-chat-items.ts ui/src/ui/chat/build-chat-items.test.ts`
- `git diff --check`

What regression coverage was added or updated?

Added regression coverage for relay/native assistant dedupe by `id`, `messageId`, and `__openclaw.id`; `__openclaw.id` priority over surface ids; same-source different assistant text staying separate; different-source identical assistant text staying separate; and same-source user relay/native entries preserving sender identity.

What failed before this fix, if known?

Before the fix, the representative relay/native assistant copies rendered as two messages when their visible text differed by relay sender prefix or when their surface ids differed despite the same `__openclaw.id`. A later review case also showed same-source user entries could be collapsed and lose `senderLabel` before the assistant-only guard was added.

If no test was added, why not?

Tests were added for the issue behavior and the review-discovered edge cases.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Duplicate assistant relay/native copies now render once in Control UI chat history.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Risk explanation: the merge risk is message-delivery presentation, specifically over-collapsing chat history items that are not true duplicate assistant relay/native copies. The public contract risk is low because the patch stays inside Control UI renderer internals and does not alter API, schema, config, protocol, compatibility, default behavior, migration behavior, gateway delivery, transcript storage, or relay fanout.

How is that risk mitigated?

Why acceptable: the source-id collapse is restricted to assistant messages, skips pending sends, requires adjacent messages to share a source id, requires one labeled and one native surface, and only collapses when the text is equal after removing the sender-label prefix. Regression tests cover same-id changed content, different source ids, and user sender identity preservation.

## Current review state

What is the next action?

Ready for maintainer review after CI runs.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author locally; CI and maintainer review are the next external steps.

Which bot or reviewer comments were addressed?

Pre-submit independent review feedback was addressed by adding guards and tests for source id precedence, same-source content changes, relay-labeled updates, and user sender identity preservation.
