### PR TITLE
fix(skill-workshop): add Global/Selected-agent scope toggle to Control UI

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -5531,15 +5531,19 @@ public struct SkillsDetailResult: Codable, Sendable {
 
 public struct SkillsProposalsListParams: Codable, Sendable {
     public let agentid: String?
+    public let scope: AnyCodable?
 
     public init(
-        agentid: String? = nil)
+        agentid: String? = nil,
+        scope: AnyCodable?)
     {
         self.agentid = agentid
+        self.scope = scope
     }
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
+        case scope
     }
 }
 
@@ -5567,18 +5571,22 @@ public struct SkillsProposalsListResult: Codable, Sendable {
 
 public struct SkillsProposalInspectParams: Codable, Sendable {
     public let agentid: String?
+    public let scope: AnyCodable?
     public let proposalid: String
 
     public init(
         agentid: String? = nil,
+        scope: AnyCodable?,
         proposalid: String)
     {
         self.agentid = agentid
+        self.scope = scope
         self.proposalid = proposalid
     }
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
+        case scope
         case proposalid = "proposalId"
     }
 }
@@ -5721,6 +5729,7 @@ public struct SkillsProposalReviseParams: Codable, Sendable {
 
 public struct SkillsProposalRequestRevisionParams: Codable, Sendable {
     public let agentid: String?
+    public let scope: AnyCodable?
     public let targetagentid: String?
     public let proposalid: String
     public let instructions: String
@@ -5730,6 +5739,7 @@ public struct SkillsProposalRequestRevisionParams: Codable, Sendable {
 
     public init(
         agentid: String? = nil,
+        scope: AnyCodable?,
         targetagentid: String?,
         proposalid: String,
         instructions: String,
@@ -5738,6 +5748,7 @@ public struct SkillsProposalRequestRevisionParams: Codable, Sendable {
         idempotencykey: String)
     {
         self.agentid = agentid
+        self.scope = scope
         self.targetagentid = targetagentid
         self.proposalid = proposalid
         self.instructions = instructions
@@ -5748,6 +5759,7 @@ public struct SkillsProposalRequestRevisionParams: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
+        case scope
         case targetagentid = "targetAgentId"
         case proposalid = "proposalId"
         case instructions
@@ -5777,21 +5789,25 @@ public struct SkillsProposalRequestRevisionResult: Codable, Sendable {
 
 public struct SkillsProposalActionParams: Codable, Sendable {
     public let agentid: String?
+    public let scope: AnyCodable?
     public let proposalid: String
     public let reason: String?
 
     public init(
         agentid: String? = nil,
+        scope: AnyCodable?,
         proposalid: String,
         reason: String?)
     {
         self.agentid = agentid
+        self.scope = scope
         self.proposalid = proposalid
         self.reason = reason
     }
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
+        case scope
         case proposalid = "proposalId"
         case reason
     }

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -690,10 +690,18 @@ const SkillProposalManifestEntrySchema = Type.Object(
   { additionalProperties: false },
 );
 
+/**
+ * Visibility scope for skill-workshop proposal reads and actions.
+ * "agent" keeps the legacy per-workspace filter; "global" spans every
+ * agent workspace so the Control UI can show all proposals at once.
+ */
+export const SkillProposalScopeSchema = Type.Union([Type.Literal("agent"), Type.Literal("global")]);
+
 /** Lists skill-workshop proposals for the selected agent scope. */
 export const SkillsProposalsListParamsSchema = Type.Object(
   {
     agentId: Type.Optional(NonEmptyString),
+    scope: Type.Optional(SkillProposalScopeSchema),
   },
   { additionalProperties: false },
 );
@@ -712,6 +720,7 @@ export const SkillsProposalsListResultSchema = Type.Object(
 export const SkillsProposalInspectParamsSchema = Type.Object(
   {
     agentId: Type.Optional(NonEmptyString),
+    scope: Type.Optional(SkillProposalScopeSchema),
     proposalId: NonEmptyString,
   },
   { additionalProperties: false },
@@ -773,6 +782,7 @@ export const SkillsProposalReviseParamsSchema = Type.Object(
 export const SkillsProposalRequestRevisionParamsSchema = Type.Object(
   {
     agentId: Type.Optional(NonEmptyString),
+    scope: Type.Optional(SkillProposalScopeSchema),
     targetAgentId: Type.Optional(NonEmptyString),
     proposalId: NonEmptyString,
     instructions: Type.String({ minLength: 1, maxLength: 32_768 }),
@@ -796,6 +806,7 @@ export const SkillsProposalRequestRevisionResultSchema = Type.Object(
 export const SkillsProposalActionParamsSchema = Type.Object(
   {
     agentId: Type.Optional(NonEmptyString),
+    scope: Type.Optional(SkillProposalScopeSchema),
     proposalId: NonEmptyString,
     reason: Type.Optional(Type.String()),
   },

--- a/src/gateway/server-methods/skills.proposals.test.ts
+++ b/src/gateway/server-methods/skills.proposals.test.ts
@@ -18,6 +18,8 @@ let stateDir = "";
 const mocks = vi.hoisted(() => ({
   chatSend: vi.fn(),
   workspaceDir: "",
+  workspaceDirs: [] as string[],
+  workspaceAgentIds: {} as Record<string, string>,
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -30,6 +32,12 @@ vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: () => ["main"],
   resolveDefaultAgentId: () => "main",
   resolveAgentWorkspaceDir: () => mocks.workspaceDir,
+  resolveAgentIdByWorkspacePath: (_cfg: unknown, workspacePath: string) =>
+    mocks.workspaceAgentIds[workspacePath],
+}));
+
+vi.mock("../../agents/workspace-dirs.js", () => ({
+  listAgentWorkspaceDirs: () => mocks.workspaceDirs,
 }));
 
 vi.mock("../../skills/lifecycle/clawhub.js", () => ({
@@ -79,6 +87,7 @@ describe("skills proposal gateway handlers", () => {
       respond(true, { runId: "run-skill-workshop-revision", status: "started" }, undefined);
     });
     mocks.workspaceDir = await tempDirs.make("openclaw-skills-proposals-gateway-");
+    mocks.workspaceAgentIds = {};
     stateDir = testState.stateDir;
   });
 
@@ -200,6 +209,79 @@ describe("skills proposal gateway handlers", () => {
     ]);
   });
 
+  it("lists, inspects, and applies across workspaces in global scope", async () => {
+    const firstWorkspaceDir = mocks.workspaceDir;
+    const first = await callHandler("skills.proposals.create", {
+      name: "Global First Skill",
+      description: "First global proposal",
+      content: "# Global First\n",
+    });
+    expect(first.ok).toBe(true);
+    const firstCreated = first.response as { record: { id: string } };
+
+    const secondWorkspaceDir = await tempDirs.make("openclaw-skills-proposals-gateway-global-");
+    mocks.workspaceDir = secondWorkspaceDir;
+    const second = await callHandler("skills.proposals.create", {
+      name: "Global Second Skill",
+      description: "Second global proposal",
+      content: "# Global Second\n",
+    });
+    expect(second.ok).toBe(true);
+    const secondCreated = second.response as { record: { id: string } };
+
+    // Both agent workspaces participate in global resolution.
+    mocks.workspaceDirs = [firstWorkspaceDir, secondWorkspaceDir];
+
+    // Agent scope only sees the currently resolved workspace...
+    const agentScoped = await callHandler("skills.proposals.list", {});
+    expect((agentScoped.response as { proposals: Array<{ id: string }> }).proposals).toEqual([
+      expect.objectContaining({ id: secondCreated.record.id }),
+    ]);
+
+    // ...global scope spans every workspace.
+    const globalList = await callHandler("skills.proposals.list", { scope: "global" });
+    expect(globalList.ok).toBe(true);
+    const globalIds = (globalList.response as { proposals: Array<{ id: string }> }).proposals
+      .map((proposal) => proposal.id)
+      .toSorted();
+    expect(globalIds).toEqual([firstCreated.record.id, secondCreated.record.id].toSorted());
+
+    // A proposal hidden from the resolved agent workspace is still inspectable in global scope.
+    const globalInspect = await callHandler("skills.proposals.inspect", {
+      scope: "global",
+      proposalId: firstCreated.record.id,
+    });
+    expect(globalInspect.ok).toBe(true);
+    expect((globalInspect.response as { record: { id: string } }).record.id).toBe(
+      firstCreated.record.id,
+    );
+
+    // Applying in global scope writes into the proposal's own workspace, not the resolved one.
+    const globalApply = await callHandler("skills.proposals.apply", {
+      scope: "global",
+      proposalId: firstCreated.record.id,
+    });
+    expect(globalApply.ok).toBe(true);
+    await expect(
+      fs.readFile(path.join(firstWorkspaceDir, "skills", "global-first-skill", "SKILL.md"), "utf8"),
+    ).resolves.toContain("Global First");
+
+    mocks.workspaceDir = firstWorkspaceDir;
+  });
+
+  it("fails fast when a global-scope action cannot resolve an owning workspace", async () => {
+    // Only the resolved agent workspace participates; an unknown proposal id
+    // maps to no owning workspace, so a global-scope action must error rather
+    // than silently target the resolved (default) workspace.
+    mocks.workspaceDirs = [mocks.workspaceDir];
+    const apply = await callHandler("skills.proposals.apply", {
+      scope: "global",
+      proposalId: "missing-proposal-id",
+    });
+    expect(apply.ok).toBe(false);
+    expect((apply.error as { code?: string }).code).toBe("INVALID_REQUEST");
+  });
+
   it("rejects invalid params before touching workshop state", async () => {
     const result = await callHandler("skills.proposals.create", {
       name: "Missing Content",
@@ -254,6 +336,60 @@ describe("skills proposal gateway handlers", () => {
     expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(
       "Make the support files 5",
     );
+  });
+
+  it("routes global-scope revisions to the proposal's owning workspace and agent", async () => {
+    // A proposal created in a second agent workspace is invisible from the
+    // default ("main") workspace. A global-scope revision must resolve the
+    // owning workspace/agent from the proposal id and hand off to that agent,
+    // instead of failing against (or routing to) the default workspace.
+    const defaultWorkspaceDir = mocks.workspaceDir;
+    const ownerWorkspaceDir = await tempDirs.make("openclaw-skills-proposals-gateway-owner-");
+    mocks.workspaceDir = ownerWorkspaceDir;
+    const create = await callHandler("skills.proposals.create", {
+      name: "Owner Workspace Skill",
+      description: "Lives in a non-default workspace",
+      content: "# Owner Workspace Skill\n",
+    });
+    expect(create.ok).toBe(true);
+    const created = create.response as { record: { id: string } };
+
+    // Resolve back to the default workspace; only global scope can reach the
+    // owner workspace, which maps to the "owner" agent.
+    mocks.workspaceDir = defaultWorkspaceDir;
+    mocks.workspaceDirs = [defaultWorkspaceDir, ownerWorkspaceDir];
+    mocks.workspaceAgentIds = { [ownerWorkspaceDir]: "owner" };
+    mocks.chatSend.mockClear();
+
+    const result = await callHandler("skills.proposals.requestRevision", {
+      scope: "global",
+      proposalId: created.record.id,
+      instructions: "Tighten the owner workspace skill",
+      sessionKey: "agent:owner:session:skill-workshop",
+      targetAgentId: "selected-chat-agent",
+      idempotencyKey: "revision-run-global",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      response: { runId: "run-skill-workshop-revision", status: "started" },
+    });
+    expect(mocks.chatSend).toHaveBeenCalledTimes(1);
+    const forwarded = mocks.chatSend.mock.calls[0]?.[0] as {
+      params?: Record<string, unknown>;
+    };
+    // Global scope must ignore a selected-chat targetAgentId and target the
+    // resolved owning agent ("owner"), not the default ("main") or selected chat agent.
+    expect(forwarded.params).toMatchObject({
+      agentId: "owner",
+      sessionKey: "agent:owner:session:skill-workshop",
+      idempotencyKey: "revision-run-global",
+    });
+    expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
+      `Revise Skill Workshop proposal \`${created.record.id}\``,
+    );
+
+    mocks.workspaceDir = defaultWorkspaceDir;
   });
 
   it("does not start revision chat turns for non-pending proposals", async () => {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import {
   listAgentIds,
+  resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
@@ -52,6 +53,7 @@ import {
   inspectSkillProposal,
   listSkillProposals,
   proposeCreateSkill,
+  resolveSkillProposalWorkspaceDir,
   proposeUpdateSkill,
   quarantineSkillProposal,
   rejectSkillProposal,
@@ -72,6 +74,13 @@ function resolveSkillsAgentWorkspace(params: unknown, context: GatewayRequestCon
     params && typeof params === "object" && "agentId" in params
       ? normalizeOptionalString((params as { agentId?: unknown }).agentId)
       : undefined;
+  const scopeRaw =
+    params && typeof params === "object" && "scope" in params
+      ? normalizeOptionalString((params as { scope?: unknown }).scope)
+      : undefined;
+  // Global scope spans every agent workspace. An explicit agentId always wins
+  // so callers can still pin a single workspace even when scope is supplied.
+  const global = scopeRaw === "global" && !agentIdRaw;
   const agentId = agentIdRaw ? normalizeAgentId(agentIdRaw) : resolveDefaultAgentId(cfg);
   if (agentIdRaw) {
     // Explicit agent routing must name a configured agent; otherwise a typo
@@ -88,8 +97,49 @@ function resolveSkillsAgentWorkspace(params: unknown, context: GatewayRequestCon
     ok: true as const,
     cfg,
     agentId,
+    global,
     workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
   };
+}
+
+/**
+ * Resolves the workspace directory and owning agent a proposal action should
+ * target. In global scope both are derived from the proposal itself so the
+ * write (and any revision hand-off) lands on the workspace where the skill
+ * actually lives; otherwise the resolved agent-scoped values are used unchanged.
+ */
+async function resolveProposalActionTarget(
+  resolved: ResolvedSkillsWorkspace,
+  proposalId: string,
+): Promise<{ workspaceDir: string; agentId: string }> {
+  if (!resolved.global) {
+    return { workspaceDir: resolved.workspaceDir, agentId: resolved.agentId };
+  }
+  const owning = await resolveSkillProposalWorkspaceDir(
+    proposalId,
+    listAgentWorkspaceDirs(resolved.cfg),
+  );
+  if (!owning) {
+    // Fail fast rather than silently falling back to the resolved (default)
+    // agent workspace: a global-scope action that cannot find the proposal's
+    // owning workspace must not write into an unintended one.
+    throw new Error(
+      `Unable to resolve an owning agent workspace for proposal ${proposalId} in global scope`,
+    );
+  }
+  // Map the owning workspace back to its agent so revision hand-offs reach the
+  // proposal's real owner instead of the default workspace's agent.
+  return {
+    workspaceDir: owning,
+    agentId: resolveAgentIdByWorkspacePath(resolved.cfg, owning) ?? resolved.agentId,
+  };
+}
+
+async function resolveProposalActionWorkspaceDir(
+  resolved: ResolvedSkillsWorkspace,
+  proposalId: string,
+): Promise<string> {
+  return (await resolveProposalActionTarget(resolved, proposalId)).workspaceDir;
 }
 
 type ResolvedSkillsWorkspace = Extract<
@@ -333,7 +383,8 @@ export const skillsHandlers: GatewayRequestHandlers = {
       respond,
       context,
       validate: validateSkillsProposalsListParams,
-      run: (_parsedParams, resolved) => listSkillProposals({ workspaceDir: resolved.workspaceDir }),
+      run: (_parsedParams, resolved) =>
+        listSkillProposals(resolved.global ? {} : { workspaceDir: resolved.workspaceDir }),
     });
   },
   "skills.proposals.inspect": async ({ params, respond, context }) => {
@@ -344,9 +395,10 @@ export const skillsHandlers: GatewayRequestHandlers = {
       context,
       validate: validateSkillsProposalInspectParams,
       run: async (parsedParams, resolved) => {
-        const proposal = await inspectSkillProposal(parsedParams.proposalId, {
-          workspaceDir: resolved.workspaceDir,
-        });
+        const proposal = await inspectSkillProposal(
+          parsedParams.proposalId,
+          resolved.global ? {} : { workspaceDir: resolved.workspaceDir },
+        );
         if (!proposal) {
           respond(
             false,
@@ -434,8 +486,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
       context,
       validate: validateSkillsProposalRequestRevisionParams,
       run: async (parsedParams, resolved) => {
+        const target = await resolveProposalActionTarget(resolved, parsedParams.proposalId);
         const proposal = await inspectSkillProposal(parsedParams.proposalId, {
-          workspaceDir: resolved.workspaceDir,
+          workspaceDir: target.workspaceDir,
         });
         if (!proposal) {
           respond(
@@ -460,15 +513,16 @@ export const skillsHandlers: GatewayRequestHandlers = {
           return SKILL_PROPOSAL_RESPONSE_HANDLED;
         }
         await forwardSkillWorkshopRevisionToChatSend(opts, {
-          agentId: resolved.agentId,
+          agentId: target.agentId,
           idempotencyKey: parsedParams.idempotencyKey,
           instructions: parsedParams.instructions,
           proposal,
           sessionId: parsedParams.sessionId,
           sessionKey: parsedParams.sessionKey,
-          targetAgentId: parsedParams.targetAgentId
-            ? normalizeAgentId(parsedParams.targetAgentId)
-            : undefined,
+          targetAgentId:
+            parsedParams.scope !== "global" && parsedParams.targetAgentId
+              ? normalizeAgentId(parsedParams.targetAgentId)
+              : undefined,
         });
         return SKILL_PROPOSAL_RESPONSE_HANDLED;
       },
@@ -481,9 +535,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
       respond,
       context,
       validate: validateSkillsProposalActionParams,
-      run: (parsedParams, resolved) =>
+      run: async (parsedParams, resolved) =>
         applySkillProposal({
-          workspaceDir: resolved.workspaceDir,
+          workspaceDir: await resolveProposalActionWorkspaceDir(resolved, parsedParams.proposalId),
           config: resolved.cfg,
           proposalId: parsedParams.proposalId,
           reason: parsedParams.reason,
@@ -497,9 +551,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
       respond,
       context,
       validate: validateSkillsProposalActionParams,
-      run: (parsedParams, resolved) =>
+      run: async (parsedParams, resolved) =>
         rejectSkillProposal({
-          workspaceDir: resolved.workspaceDir,
+          workspaceDir: await resolveProposalActionWorkspaceDir(resolved, parsedParams.proposalId),
           proposalId: parsedParams.proposalId,
           reason: parsedParams.reason,
         }),
@@ -512,9 +566,9 @@ export const skillsHandlers: GatewayRequestHandlers = {
       respond,
       context,
       validate: validateSkillsProposalActionParams,
-      run: (parsedParams, resolved) =>
+      run: async (parsedParams, resolved) =>
         quarantineSkillProposal({
-          workspaceDir: resolved.workspaceDir,
+          workspaceDir: await resolveProposalActionWorkspaceDir(resolved, parsedParams.proposalId),
           proposalId: parsedParams.proposalId,
           reason: parsedParams.reason,
         }),

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -95,6 +95,28 @@ export async function listSkillProposals(
   return { ...manifest, proposals };
 }
 
+/**
+ * Resolves the agent workspace that owns a proposal by matching its target
+ * paths against candidate workspace directories. Used by global-scope reads
+ * and actions so writes still land in the proposal's own agent workspace
+ * rather than a UI-selected default.
+ */
+export async function resolveSkillProposalWorkspaceDir(
+  proposalId: string,
+  candidateWorkspaceDirs: readonly string[],
+): Promise<string | undefined> {
+  const read = await readSkillProposal(proposalId);
+  if (!read) {
+    return undefined;
+  }
+  for (const workspaceDir of candidateWorkspaceDirs) {
+    if (isProposalInWorkspace(read.record, workspaceDir)) {
+      return workspaceDir;
+    }
+  }
+  return undefined;
+}
+
 export async function readSkillProposalDraftFile(filePath: string): Promise<string> {
   const read = await readLocalFileSafely({
     filePath,

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:15:44.091Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.867Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:13:08.679Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.211Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:14:26.064Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.342Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:18:51.284Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:39.053Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:14:40.929Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.724Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:16:59.385Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.394Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:15:54.483Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.995Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:14:21.384Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.471Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:14:37.035Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.597Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:18:26.232Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.909Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:17:24.230Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.523Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:13:27.465Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:37.081Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:17:40.292Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.652Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:15:58.014Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.125Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:16:03.485Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.266Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:17:27.586Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:38.787Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:13:09.666Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:36.667Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-06-16T14:13:18.605Z",
+  "fallbackKeys": [
+    "skillWorkshop.header.scopeAgent",
+    "skillWorkshop.header.scopeAgentTooltip",
+    "skillWorkshop.header.scopeAria",
+    "skillWorkshop.header.scopeGlobal",
+    "skillWorkshop.header.scopeGlobalTooltip"
+  ],
+  "generatedAt": "2026-06-16T17:24:36.953Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "bfdd6339c3aba583ed162882d2b8b63ad910e66c5a66737c1b5dcfce89190597",
-  "totalKeys": 1378,
+  "sourceHash": "0d3231bb31f3b858ba8df81872e9a74ba7d040e68c1fff7a65e1756aac3fea22",
+  "totalKeys": 1383,
   "translatedKeys": 1378,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -455,6 +455,11 @@ export const ar: TranslationMap = {
       useCurrentChatAria: "استخدام المحادثة الحالية لطلبات المراجعة",
       useCurrentChatTooltip:
         "إرسال طلبات المراجعة إلى جلسة المحادثة الحالية بدلاً من جلسة workshop الخاصة بالمقترح.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -460,6 +460,11 @@ export const de: TranslationMap = {
       useCurrentChatAria: "Aktuellen Chat für Überarbeitungsanfragen verwenden",
       useCurrentChatTooltip:
         "Überarbeitungsanfragen an die aktuelle Chat-Sitzung statt an die Workshop-Sitzung des Vorschlags senden.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -454,6 +454,11 @@ export const en: TranslationMap = {
       useCurrentChatAria: "Use current chat for revision requests",
       useCurrentChatTooltip:
         "Send revision requests to the current chat session instead of the proposal's workshop session.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -457,6 +457,11 @@ export const es: TranslationMap = {
       useCurrentChatAria: "Usar el chat actual para las solicitudes de revisión",
       useCurrentChatTooltip:
         "Enviar las solicitudes de revisión a la sesión de chat actual en lugar de la sesión de workshop de la propuesta.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -457,6 +457,11 @@ export const fa: TranslationMap = {
       useCurrentChatAria: "استفاده از گفتگوی فعلی برای درخواست‌های بازبینی",
       useCurrentChatTooltip:
         "درخواست‌های بازبینی را به جای جلسه کارگاهی پیشنهاد، به جلسه گفتگوی فعلی ارسال کنید.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -459,6 +459,11 @@ export const fr: TranslationMap = {
       useCurrentChatAria: "Utiliser la discussion actuelle pour les demandes de révision",
       useCurrentChatTooltip:
         "Envoyer les demandes de révision à la session de discussion actuelle plutôt qu'à la session d'atelier de la proposition.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -456,6 +456,11 @@ export const id: TranslationMap = {
       useCurrentChatAria: "Gunakan obrolan saat ini untuk permintaan revisi",
       useCurrentChatTooltip:
         "Kirim permintaan revisi ke sesi obrolan saat ini alih-alih sesi workshop proposal.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -458,6 +458,11 @@ export const it: TranslationMap = {
       useCurrentChatAria: "Usa la chat corrente per le richieste di revisione",
       useCurrentChatTooltip:
         "Invia le richieste di revisione alla sessione di chat corrente invece che alla sessione di workshop della proposta.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -459,6 +459,11 @@ export const ja_JP: TranslationMap = {
       useCurrentChatAria: "修正リクエストに現在のチャットを使用",
       useCurrentChatTooltip:
         "修正リクエストを提案のワークショップセッションではなく現在のチャットセッションに送信します。",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -454,6 +454,11 @@ export const ko: TranslationMap = {
       useCurrentChat: "현재 채팅 사용",
       useCurrentChatAria: "수정 요청에 현재 채팅 사용",
       useCurrentChatTooltip: "수정 요청을 제안의 워크숍 세션 대신 현재 채팅 세션으로 보냅니다.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -458,6 +458,11 @@ export const nl: TranslationMap = {
       useCurrentChatAria: "Huidige chat gebruiken voor revisieverzoeken",
       useCurrentChatTooltip:
         "Stuur revisieverzoeken naar de huidige chatsessie in plaats van de workshopsessie van het voorstel.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -457,6 +457,11 @@ export const pl: TranslationMap = {
       useCurrentChatAria: "Użyj bieżącego czatu do próśb o poprawki",
       useCurrentChatTooltip:
         "Wysyłaj prośby o poprawki do bieżącej sesji czatu zamiast do sesji warsztatu propozycji.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -456,6 +456,11 @@ export const pt_BR: TranslationMap = {
       useCurrentChatAria: "Usar conversa atual para solicitações de revisão",
       useCurrentChatTooltip:
         "Enviar solicitações de revisão para a sessão de conversa atual em vez da sessão de workshop da proposta.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -453,6 +453,11 @@ export const th: TranslationMap = {
       useCurrentChat: "ใช้แชทปัจจุบัน",
       useCurrentChatAria: "ใช้แชทปัจจุบันสำหรับคำขอแก้ไข",
       useCurrentChatTooltip: "ส่งคำขอแก้ไขไปยังเซสชันแชทปัจจุบันแทนเซสชัน workshop ของข้อเสนอ",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -459,6 +459,11 @@ export const tr: TranslationMap = {
       useCurrentChatAria: "Revizyon istekleri için mevcut sohbeti kullan",
       useCurrentChatTooltip:
         "Revizyon isteklerini önerinin çalışma alanı oturumu yerine mevcut sohbet oturumuna gönder.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -458,6 +458,11 @@ export const uk: TranslationMap = {
       useCurrentChatAria: "Використовувати поточний чат для запитів на перегляд",
       useCurrentChatTooltip:
         "Надсилати запити на перегляд до поточної сесії чату замість сесії воркшопу пропозиції.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -457,6 +457,11 @@ export const vi: TranslationMap = {
       useCurrentChatAria: "Dùng cuộc trò chuyện hiện tại cho yêu cầu chỉnh sửa",
       useCurrentChatTooltip:
         "Gửi yêu cầu chỉnh sửa đến phiên trò chuyện hiện tại thay vì phiên workshop của đề xuất.",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -452,6 +452,11 @@ export const zh_CN: TranslationMap = {
       useCurrentChat: "使用当前聊天",
       useCurrentChatAria: "将当前聊天用于修订请求",
       useCurrentChatTooltip: "将修订请求发送到当前聊天会话，而不是提案的工作坊会话。",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -452,6 +452,11 @@ export const zh_TW: TranslationMap = {
       useCurrentChat: "使用目前的對話",
       useCurrentChatAria: "使用目前的對話進行修訂請求",
       useCurrentChatTooltip: "將修訂請求傳送至目前的對話工作階段，而非提案的工作坊工作階段。",
+      scopeAria: "Proposal visibility scope",
+      scopeGlobal: "Global",
+      scopeGlobalTooltip: "Show proposals from every agent workspace.",
+      scopeAgent: "Selected agent",
+      scopeAgentTooltip: "Show only proposals for the selected agent.",
     },
   },
   activity: {

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -938,6 +938,48 @@
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
+.sw-scope-switch {
+  display: inline-flex;
+  align-items: center;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+}
+
+.sw-scope-switch__opt {
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  border: none;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+  white-space: nowrap;
+}
+
+.sw-scope-switch__opt:hover {
+  color: var(--text);
+}
+
+.sw-scope-switch__opt.is-active {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elevated));
+}
+
+.sw-scope-switch__opt:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
 .sw-mode-switch {
   position: relative;
   display: inline-grid;

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -2435,6 +2435,55 @@ describe("handleSendChat", () => {
     expect(userMessage.content).toEqual([{ type: "text", text: "Make the support files 5" }]);
   });
 
+  it("omits selected chat target routing for global Skill Workshop revision drafts", async () => {
+    const sent = createDeferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "skills.proposals.requestRevision") {
+        return sent.promise;
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      sessionKey: "global",
+    });
+    (host as ChatHost & { assistantAgentId?: string }).assistantAgentId = "selected-chat-agent";
+    (host as ChatHost & { currentSessionId?: string }).currentSessionId = "session-selected";
+
+    const send = handleSendChat(host, "Revise with owner routing", {
+      restoreDraft: true,
+      skillWorkshopRevision: {
+        proposalId: "originless-global-proposal-20260616-abc123",
+        scope: "global",
+      },
+    });
+    await Promise.resolve();
+
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
+      "skills.proposals.requestRevision",
+      "global revision request payload",
+    );
+    expect(payload).toMatchObject({
+      proposalId: "originless-global-proposal-20260616-abc123",
+      scope: "global",
+      instructions: "Revise with owner routing",
+      sessionKey: "global",
+      sessionId: "session-selected",
+    });
+    expect(payload).not.toHaveProperty("targetAgentId");
+    expect(payload).not.toHaveProperty("agentId");
+
+    sent.resolve({ runId: host.chatQueue[0]?.sendRunId, status: "started" });
+    await send;
+
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "Revise with owner routing" }],
+    });
+  });
+
   it("treats slash-like Skill Workshop revision drafts as revision instructions", async () => {
     const sent = createDeferred<unknown>();
     const request = vi.fn((method: string) => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1051,13 +1051,22 @@ async function sendQueuedChatMessage(
   }
 
   try {
+    const skillWorkshopRevisionTargetAgentId =
+      prepared.skillWorkshopRevision && prepared.skillWorkshopRevision.scope !== "global"
+        ? prepared.agentId
+        : undefined;
     const ack = prepared.skillWorkshopRevision
       ? await requestSkillWorkshopRevisionChatSend(host as unknown as ChatState, {
           proposalId: prepared.skillWorkshopRevision.proposalId,
           ...(prepared.skillWorkshopRevision.agentId
             ? { agentId: prepared.skillWorkshopRevision.agentId }
             : {}),
-          ...(prepared.agentId ? { targetAgentId: prepared.agentId } : {}),
+          ...(prepared.skillWorkshopRevision.scope
+            ? { scope: prepared.skillWorkshopRevision.scope }
+            : {}),
+          ...(skillWorkshopRevisionTargetAgentId
+            ? { targetAgentId: skillWorkshopRevisionTargetAgentId }
+            : {}),
           instructions: message,
           runId,
           sessionKey,
@@ -1256,6 +1265,7 @@ function chatSubmitKey(
     message.trim(),
     skillWorkshopRevision?.proposalId ?? "",
     skillWorkshopRevision?.agentId ?? "",
+    skillWorkshopRevision?.scope ?? "",
     attachments.map(attachmentSubmitSignature),
   ]);
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -133,6 +133,7 @@ import {
 } from "./controllers/sessions.ts";
 import {
   countSkillWorkshopProposals,
+  loadSkillWorkshopProposals,
   requestSkillWorkshopRevision,
   runSkillWorkshopLifecycleAction,
   selectSkillWorkshopProposal,
@@ -233,6 +234,39 @@ function runUiTask<Args extends unknown[]>(
 const SKILL_WORKSHOP_MODE_KEY = "openclaw:control-ui:skill-workshop-mode:v1";
 const SKILL_WORKSHOP_CURRENT_CHAT_REVISIONS_KEY =
   "openclaw:control-ui:skill-workshop-current-chat-revisions:v1";
+const SKILL_WORKSHOP_SCOPE_KEY = "openclaw:control-ui:skill-workshop-scope:v1";
+
+export function loadSkillWorkshopScope(): "global" | "agent" {
+  try {
+    const raw = getSafeLocalStorage()?.getItem(SKILL_WORKSHOP_SCOPE_KEY);
+    return raw === "agent" ? "agent" : "global";
+  } catch {
+    return "global";
+  }
+}
+
+/**
+ * Keeps the workshop's agent-scope target in sync with the nav selection so an
+ * "Agent" scope query and the highlighted agent always agree.
+ */
+export function syncSkillWorkshopScopeAgentId(state: AppViewState): void {
+  state.skillWorkshopScopeAgentId = resolveSidebarSelectedAgentId(state);
+}
+
+function setSkillWorkshopScope(state: AppViewState, scope: "global" | "agent"): void {
+  if (state.skillWorkshopScope === scope) {
+    return;
+  }
+  state.skillWorkshopScope = scope;
+  syncSkillWorkshopScopeAgentId(state);
+  try {
+    getSafeLocalStorage()?.setItem(SKILL_WORKSHOP_SCOPE_KEY, scope);
+  } catch {
+    // Scope persistence is a convenience; the in-memory switch still works.
+  }
+  state.skillWorkshopLoaded = false;
+  void loadSkillWorkshopProposals(state, { force: true });
+}
 
 export function loadSkillWorkshopMode(): "board" | "today" {
   try {
@@ -274,8 +308,38 @@ function setSkillWorkshopMode(state: AppViewState, mode: "board" | "today"): voi
 
 function renderSkillWorkshopHeaderControls(state: AppViewState) {
   const useCurrentChatLabel = t("skillWorkshop.header.useCurrentChat");
+  // The agent-scope target is synced from a lifecycle hook (see app.ts
+  // `updated`), not here, so this render stays free of state mutation.
+  const scope = state.skillWorkshopScope;
   return html`
     <div class="sw-header-controls">
+      <div
+        class="sw-scope-switch"
+        role="radiogroup"
+        aria-label=${t("skillWorkshop.header.scopeAria")}
+        data-scope=${scope}
+      >
+        <button
+          type="button"
+          class="sw-scope-switch__opt ${scope === "global" ? "is-active" : ""}"
+          role="radio"
+          aria-checked=${scope === "global" ? "true" : "false"}
+          title=${t("skillWorkshop.header.scopeGlobalTooltip")}
+          @click=${() => setSkillWorkshopScope(state, "global")}
+        >
+          ${t("skillWorkshop.header.scopeGlobal")}
+        </button>
+        <button
+          type="button"
+          class="sw-scope-switch__opt ${scope === "agent" ? "is-active" : ""}"
+          role="radio"
+          aria-checked=${scope === "agent" ? "true" : "false"}
+          title=${t("skillWorkshop.header.scopeAgentTooltip")}
+          @click=${() => setSkillWorkshopScope(state, "agent")}
+        >
+          ${t("skillWorkshop.header.scopeAgent")}
+        </button>
+      </div>
       <label
         class="sw-revision-session-toggle"
         title=${t("skillWorkshop.header.useCurrentChatTooltip")}
@@ -429,12 +493,16 @@ async function sendSkillWorkshopRevisionRequest(
     await switchChatSessionAndWait(state, sessionKey);
   }
   const proposalAgentId = proposal.origin?.agentId?.trim();
+  // When the proposal's owning agent is known, pin it directly. Otherwise fall
+  // back to global scope so the gateway resolves the owning workspace from the
+  // proposal id itself, rather than silently defaulting a cross-workspace
+  // (e.g. gateway-created, origin-less) proposal to the selected/default agent.
+  const revision = proposalAgentId
+    ? { proposalId: proposal.key, agentId: proposalAgentId }
+    : { proposalId: proposal.key, scope: "global" as const };
   await state.handleSendChat(instructions, {
     restoreDraft: true,
-    skillWorkshopRevision: {
-      proposalId: proposal.key,
-      ...(proposalAgentId ? { agentId: proposalAgentId } : {}),
-    },
+    skillWorkshopRevision: revision,
   });
 }
 

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -474,6 +474,9 @@ export async function refreshActiveTab(host: SettingsHost, opts?: { chatStartup?
         await loadSkills(app);
         break;
       case "skillWorkshop":
+        // Keep agent-scope queries aligned with the visible nav selection so an
+        // "Agent" scope refresh targets the same agent the user is viewing.
+        app.skillWorkshopScopeAgentId = resolveDreamingAgentIdForSession(host);
         await loadSkillWorkshopProposals(app, { force: true });
         break;
       case "agents":

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -45,8 +45,10 @@ import { initNativeBridge } from "./app-native-bridge.ts";
 import { createChatSession as createChatSessionInternal } from "./app-render.helpers.ts";
 import {
   loadSkillWorkshopMode,
+  loadSkillWorkshopScope,
   loadSkillWorkshopUseCurrentChatForRevisions,
   renderApp,
+  syncSkillWorkshopScopeAgentId,
 } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
@@ -653,6 +655,8 @@ export class OpenClawApp extends LitElement {
   @state() skillWorkshopQueueWidth = 360;
   @state() skillWorkshopMode: SkillWorkshopState["skillWorkshopMode"] = loadSkillWorkshopMode();
   @state() skillWorkshopUseCurrentChatForRevisions = loadSkillWorkshopUseCurrentChatForRevisions();
+  @state() skillWorkshopScope: SkillWorkshopState["skillWorkshopScope"] = loadSkillWorkshopScope();
+  @state() skillWorkshopScopeAgentId: string | null = null;
 
   @state() healthLoading = false;
   @state() healthResult: HealthSummary | null = null;
@@ -852,6 +856,14 @@ export class OpenClawApp extends LitElement {
 
   protected override updated(changed: Map<PropertyKey, unknown>) {
     handleUpdated(this as unknown as Parameters<typeof handleUpdated>[0], changed);
+    // Keep the Skill Workshop agent-scope target aligned with the visible nav
+    // selection from a lifecycle hook rather than during render, so an "Agent"
+    // scope query and the highlighted agent agree without mutating state mid-render.
+    if (this.tab === "skillWorkshop" && (changed.has("tab") || changed.has("sessionKey"))) {
+      syncSkillWorkshopScopeAgentId(
+        this as unknown as Parameters<typeof syncSkillWorkshopScopeAgentId>[0],
+      );
+    }
     // Some render callbacks assign tab directly while preparing nested panel state.
     if (changed.has("tab") && this.tab !== "chat" && this.chatMobileControlsOpen) {
       this.setChatMobileControlsOpen(false);

--- a/ui/src/ui/chat/composer-persistence.ts
+++ b/ui/src/ui/chat/composer-persistence.ts
@@ -180,9 +180,11 @@ function normalizeSkillWorkshopRevision(
     return undefined;
   }
   const agentId = normalizeOptionalString(entry.agentId);
+  const scope = entry.scope === "global" ? "global" : undefined;
   return {
     proposalId,
     ...(agentId ? { agentId: normalizeAgentId(agentId) } : {}),
+    ...(scope ? { scope } : {}),
   };
 }
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1906,6 +1906,35 @@ describe("sendChatMessage", () => {
     });
   });
 
+  it("does not override global Skill Workshop revision owner routing with the selected chat agent", async () => {
+    const request = vi.fn().mockResolvedValue({ runId: "run-revision", status: "started" });
+    const state = createState({
+      sessionKey: "global",
+      currentSessionId: "session-visible",
+      assistantAgentId: "selected-chat-agent",
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await requestSkillWorkshopRevisionChatSend(state, {
+      proposalId: "originless-global-proposal-20260616-abc123",
+      scope: "global",
+      targetAgentId: "selected-chat-agent",
+      instructions: "Revise with owner routing",
+      runId: "run-revision",
+    });
+
+    expect(result).toEqual({ runId: "run-revision", status: "started" });
+    expect(request).toHaveBeenCalledWith("skills.proposals.requestRevision", {
+      scope: "global",
+      proposalId: "originless-global-proposal-20260616-abc123",
+      instructions: "Revise with owner routing",
+      sessionKey: "global",
+      sessionId: "session-visible",
+      idempotencyKey: "run-revision",
+    });
+  });
+
   it("adopts the run id and terminal status from the chat.send ack", async () => {
     const request = vi.fn().mockResolvedValue({ runId: "gateway-complete-run", status: "ok" });
     const state = createState({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -985,16 +985,20 @@ export async function requestSkillWorkshopRevisionChatSend(
     runId: string;
     sessionKey?: string;
     agentId?: string;
+    scope?: "global";
     targetAgentId?: string;
   },
 ): Promise<ChatSendAck> {
   const routing = resolveChatSendRouting(state, {
     sessionKey: params.sessionKey,
-    agentId: params.targetAgentId,
+    agentId: params.scope === "global" ? undefined : params.targetAgentId,
   });
   const payload = await state.client!.request("skills.proposals.requestRevision", {
     ...(params.agentId ? { agentId: normalizeAgentId(params.agentId) } : {}),
-    ...(routing.selectedAgentId ? { targetAgentId: routing.selectedAgentId } : {}),
+    ...(params.scope ? { scope: params.scope } : {}),
+    ...(params.scope !== "global" && routing.selectedAgentId
+      ? { targetAgentId: routing.selectedAgentId }
+      : {}),
     proposalId: params.proposalId,
     instructions: params.instructions,
     sessionKey: routing.sessionKey,

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -5,10 +5,32 @@ import type {
   SkillWorkshopActionNotice,
   SkillWorkshopMode,
   SkillWorkshopProposal,
+  SkillWorkshopScope,
   SkillWorkshopStatusFilter,
 } from "../views/skill-workshop.ts";
 
 const SKILL_WORKSHOP_NOTICE_MS = 2800;
+
+/**
+ * Builds the agent-scoping params for proposal RPCs from the active scope
+ * toggle. Global scope asks the gateway to span every agent workspace; agent
+ * scope pins the nav-selected agent so the list matches the visible selection.
+ *
+ * Agent scope requires a concrete agent id. If the nav selection has not
+ * resolved one yet (e.g. first paint with a persisted "agent" scope), fall back
+ * to global scope rather than sending empty params, which the gateway would
+ * otherwise silently default-route to a single (default) agent workspace and
+ * show the wrong slice.
+ */
+function skillWorkshopScopeParams(
+  state: SkillWorkshopState,
+): { scope: "global" } | { agentId: string } {
+  if (state.skillWorkshopScope === "global") {
+    return { scope: "global" };
+  }
+  const agentId = state.skillWorkshopScopeAgentId?.trim();
+  return agentId ? { agentId } : { scope: "global" };
+}
 
 type SkillProposalStatus = "pending" | "applied" | "rejected" | "quarantined" | "stale";
 type SkillProposalKind = "create" | "update";
@@ -94,6 +116,8 @@ export type SkillWorkshopState = {
   skillWorkshopQueueWidth: number;
   skillWorkshopMode: SkillWorkshopMode;
   skillWorkshopUseCurrentChatForRevisions: boolean;
+  skillWorkshopScope: SkillWorkshopScope;
+  skillWorkshopScopeAgentId: string | null;
 };
 
 function getErrorMessage(err: unknown): string {
@@ -297,7 +321,10 @@ export async function loadSkillWorkshopProposals(
   state.skillWorkshopLoading = true;
   state.skillWorkshopError = null;
   try {
-    const result = await state.client.request<SkillProposalManifest>("skills.proposals.list", {});
+    const result = await state.client.request<SkillProposalManifest>(
+      "skills.proposals.list",
+      skillWorkshopScopeParams(state),
+    );
     const previousByKey = new Map(
       state.skillWorkshopProposals.map((proposal) => [proposal.key, proposal]),
     );
@@ -338,6 +365,7 @@ export async function loadSkillWorkshopProposalDetail(
       "skills.proposals.inspect",
       {
         proposalId,
+        ...skillWorkshopScopeParams(state),
       },
     );
     mergeProposal(state, proposalFromInspect(result, existing));
@@ -375,7 +403,7 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopError = null;
   try {
     const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
-    await state.client.request(method, { proposalId });
+    await state.client.request(method, { proposalId, ...skillWorkshopScopeParams(state) });
     await refreshAfterMutation(state, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
     showActionNotice(state, updated ?? previous, action === "apply" ? "Applied" : "Rejected");

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -11,6 +11,7 @@ export type ChatAttachment = {
 export type ChatQueueSkillWorkshopRevision = {
   proposalId: string;
   agentId?: string;
+  scope?: "global";
 };
 
 export type ChatQueueItem = {

--- a/ui/src/ui/views/skill-workshop.ts
+++ b/ui/src/ui/views/skill-workshop.ts
@@ -42,6 +42,8 @@ export type SkillWorkshopProposal = {
 export type SkillWorkshopStatusFilter = "all" | SkillWorkshopProposalStatus;
 export type SkillWorkshopAction = "apply" | "revise" | "reject";
 export type SkillWorkshopMode = "board" | "today";
+/** Proposal visibility scope: every agent workspace vs. the selected agent. */
+export type SkillWorkshopScope = "global" | "agent";
 
 export type SkillWorkshopActionBusy = {
   key: string;


### PR DESCRIPTION
## Summary

On a multi-agent install the **Skill Workshop** panel in the Control UI renders an empty
"No proposals yet" state for every agent, even when proposals exist on disk. This adds a
**Global / Selected-agent** scope toggle (and the server `scope` param behind it) so the
workshop can span every agent workspace in one call, while still letting you pin a single
agent. Default is **Global**.

## The bug

`skills.proposals.list` is invoked from the UI with empty params `{}`. The server backfills
the **default agent** and filters proposals to that one workspace. On a multi-agent install
the default agent typically owns ~0 proposals, so the panel is blank for every agent. The
empty-state subtitle tracks the selected agent, but the list call never re-scopes, so it
never populates. A single-agent install never hits this (the default agent *is* the only
agent, so its workspace holds everything).

Ground truth on the test install: the store holds **22 proposals** (14 applied / 7 pending /
1 stale); `{ agentId: "anvil" }` → 11, `chisel` → 5, `forge` → 3, `pylon` → 3, but `{}` (what
the UI sends) → **0**.

## The fix

**Server** (`skills.proposals` methods + service + schema)
- New `scope` param. `scope: "global"` (no explicit `agentId`) passes `{}` to the store so
  `list` / `inspect` span every agent workspace instead of one.
- `resolveSkillProposalWorkspaceDir()` derives the owning workspace from a proposal's own
  target paths, so global-scope `apply` / `reject` / `quarantine` still write into the
  proposal's real home workspace. An explicit `agentId` always overrides `scope`. Global-scope
  mutations now **fail fast** with `INVALID_REQUEST` when the owning workspace can't be
  resolved, rather than silently routing the write to the default workspace.

**Revision routing** (`skills.proposals.requestRevision` + UI)
- `requestRevision` now resolves the proposal's owning workspace **and agent** and hands the
  revision turn to that owner, instead of the resolved default agent. A globally-listed
  proposal created in another workspace (or one without an `origin.agentId`) previously fell
  back to the default workspace and failed handoff. Adds `scope` to the `requestRevision`
  schema and regenerates the Swift binding so all four proposal RPCs share one scope contract.
- The UI revision request pins the proposal's owning agent when known, else sends
  `scope: "global"` so the gateway resolves the owner — closing the origin-less gap.

**UI** (`app-render`, controller, view, settings, app state, css, i18n)
- A **Global / Selected agent** control in the workshop header (`role="radiogroup"`),
  persisted to localStorage, default **global**. Selected-agent stays synced to the nav
  selection. Agent scope falls back to global until an agent id resolves, so first paint can't
  briefly default-route to a single workspace.
  The nav-selection sync runs from a lifecycle hook (`app updated`), not during render, so the
  render path no longer mutates state.

## Before / After (same gateway version, `v2026.6.8-beta.1`)

Stock vs patched on the **same** build and the **same** on-disk data — one commit of difference.

**Before** — six live states, all empty while 22 proposals sit on disk:

![before](https://raw.githubusercontent.com/ragesaq/openclaw/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope/skill-workshop-before-3toggles.gif)

**After** — six live states, all populated:

![after](https://raw.githubusercontent.com/ragesaq/openclaw/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope/skill-workshop-after-3scopes.gif)

| Scope | View | Result |
|---|---|---|
| Global | Board · All | **22** — every agent, one view |
| Global | Board · Applied | **14** in use |
| Global | Today | **7** waiting |
| Selected: Anvil | Board · All | **11** |
| Selected: Chisel | Board · All | **5** |
| Selected: Forge | Board · All | **3** |

Global 22 = Anvil 11 + Chisel 5 + Forge 3 + Pylon 3, so per-agent scoping returns the real
subset (not "always show everything"). Contact sheets:
[before](https://raw.githubusercontent.com/ragesaq/openclaw/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope/before_sheet.png) ·
[after](https://raw.githubusercontent.com/ragesaq/openclaw/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope/after_sheet.png).
Full methodology + frames:
[`.proof/skill-workshop-scope/`](https://github.com/ragesaq/openclaw/tree/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope).

## Real behavior proof

- **Behavior or issue addressed:** The Skill Workshop panel showed "No proposals yet" for
  every agent on a multi-agent install while 22 proposals existed on disk, because the UI's
  empty-params `list` call resolved to the (empty) default-agent workspace. After the fix the
  default **Global** scope spans every agent workspace and the panel populates.
- **Real environment tested:** A real OpenClaw gateway built from this exact fix commit
  (version badge `v2026.6.8-beta.1`), run as an isolated instance from a throwaway state dir
  whose agent workspaces point at the real `workspace-council/<agent>` paths, against a
  physical copy of the real on-disk proposal store (22 proposals). No production files touched;
  the prod gateway was left untouched.
- **Exact steps or command run after this patch:** Built the fix into a `dist/control-ui`
  bundle, launched the patched gateway, opened the Control UI Skill Workshop panel, and drove
  the real UI controls through six live states — Global (Board · All, Board · Applied, Today)
  and Selected-agent (Anvil, Chisel, Forge). Each state was DOM-confirmed (tab counts +
  selected agent) before capture.
- **Evidence after fix:** Animated capture from the running patched UI (stock-vs-patched on the
  same build and same on-disk data):

  ![after](https://raw.githubusercontent.com/ragesaq/openclaw/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope/skill-workshop-after-3scopes.gif)

  Per-state contact sheet:
  [after_sheet.png](https://raw.githubusercontent.com/ragesaq/openclaw/proof/skill-workshop-scope-evidence/.proof/skill-workshop-scope/after_sheet.png).
- **Observed result after fix:** Global · All renders **22**, Global · Applied **14**, Today
  **7**; Selected-agent renders Anvil **11**, Chisel **5**, Forge **3**. Global 22 equals the
  sum of the per-agent subsets (11 + 5 + 3 + Pylon 3), confirming the scope switch returns the
  real per-workspace data rather than always showing everything. The pre-fix capture shows all
  six states empty on the same data.
- **What was not tested:** The native macOS Swift app was not built or launched; only the
  generated `GatewayModels.swift` protocol binding was regenerated and compiled-checked via the
  protocol drift gate. Non-Latin locale glyph rendering was not visually inspected (the new
  i18n keys ship as English fallback, matching the established pattern for net-new keys).

## Validation

- `node scripts/run-vitest.mjs run src/gateway/server-methods/skills.proposals.test.ts`
  → **16 passed** (2 projects × 8), exit 0, on this branch. Covers global list/inspect/apply
  across workspaces, the explicit-`agentId` override, the fail-fast when a global-scope
  mutation can't resolve an owning workspace, and a global-scope **revision** routing to the
  proposal's owning workspace and agent — now including a defensive case proving a
  client-supplied `targetAgentId` cannot override global owner resolution.
- `node scripts/run-vitest.mjs run ui/src/ui/app-chat.test.ts ui/src/ui/controllers/chat.test.ts`
  → **213 passed**, exit 0 — the scope-threaded revision payload and chat send path, plus two
  new cases proving a global revision draft omits the selected-chat `targetAgentId` at both the
  draft (`app-chat`) and request-builder (`controllers/chat`) layers.
- `pnpm protocol:gen` + `pnpm protocol:gen:swift` → generated `GatewayModels.swift` bindings
  regenerated for the new `scope` param; the `git diff --exit-code` drift gate is clean.
- `pnpm ui:build` produces a `dist/control-ui` bundle carrying the scope switch.
- i18n: `en.ts` is the source change; foreign bundles + `.i18n/*.meta.json` regenerated through
  the canonical sync (English fallback for the 5 net-new keys); offline drift `check` reports
  all 18 locales clean.
- Branch rebased clean onto current `main` (1 commit, no conflicts).

## Owner-routing guard (closes the P1 routing finding)

Origin-less global revisions can no longer be hijacked by the selected/default chat agent.
The guard is applied defense-in-depth at three layers:

- **UI draft** (`ui/src/ui/app-chat.ts`): a `scope: "global"` revision draft omits `targetAgentId`.
- **Request builder** (`ui/src/ui/controllers/chat.ts`): global revisions suppress selected-agent
  routing before the payload is built.
- **Gateway** (`src/gateway/server-methods/skills.ts`): the handler ignores any client-supplied
  `targetAgentId` when `scope === "global"`, so proposal-owner resolution always wins — even
  against a malformed non-Control-UI client.

## Remaining risk

`scope: "global"` deliberately spans every agent workspace. This surface is the local,
single-operator Control UI, and per-agent scoping (`agentId`) is unchanged and always
overrides `scope`, so there is no new cross-tenant exposure beyond what the operator's own
UI already reaches. No dependency on another PR.
