### PR TITLE
fix(whatsapp): bound stalled read-receipt socket operations

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -164,7 +164,7 @@ handoff path over manual terminal capture.
 
 - Gateway owns the WhatsApp socket and reconnect loop.
 - The reconnect watchdog uses WhatsApp Web transport activity, not only inbound app-message volume, so a quiet linked-device session is not restarted solely because nobody has sent a message recently. A longer application-silence cap still forces a reconnect if transport frames keep arriving but no application messages are handled for the watchdog window; after a transient reconnect for a recently active session, that application-silence check uses the normal message timeout for the first recovery window.
-- Baileys socket timings are explicit under `web.whatsapp.*`: `keepAliveIntervalMs` controls WhatsApp Web application pings, `connectTimeoutMs` controls the opening handshake timeout, and `defaultQueryTimeoutMs` controls Baileys query waits plus OpenClaw's local outbound send/presence operation bound.
+- Baileys socket timings are explicit under `web.whatsapp.*`: `keepAliveIntervalMs` controls WhatsApp Web application pings, `connectTimeoutMs` controls the opening handshake timeout, and `defaultQueryTimeoutMs` controls Baileys query waits plus OpenClaw's local outbound send/presence and inbound read-receipt operation bounds.
 - Outbound sends require an active WhatsApp listener for the target account.
 - Group sends attach native mention metadata for `@+<digits>` and `@<digits>` tokens in text and media captions when the token matches current WhatsApp participant metadata, including LID-backed groups.
 - Status and broadcast chats are ignored (`@status`, `@broadcast`).

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -33,6 +33,7 @@ import {
   isWhatsAppSocketOperationTimeoutError,
   resolveWhatsAppSocketOperationTimeoutMs,
   resolveWhatsAppSocketTiming,
+  withWhatsAppSocketOperationTimeout,
   type WhatsAppSocketOperationAdapter,
   type WhatsAppSocketTimingOptions,
 } from "../socket-timing.js";
@@ -808,9 +809,11 @@ export async function attachWebInboxToSocket(
     }
     const { id, remoteJid, participant } = target;
     try {
-      await (getCurrentSock() ?? sock).readMessages([
-        { remoteJid, id, participant, fromMe: false },
-      ]);
+      await withWhatsAppSocketOperationTimeout(
+        "readMessages",
+        (getCurrentSock() ?? sock).readMessages([{ remoteJid, id, participant, fromMe: false }]),
+        sendOperationTimeoutMs,
+      );
       const suffix = participant ? ` (participant ${participant})` : "";
       logWhatsAppVerbose(options.verbose, `Marked message ${id} as read for ${remoteJid}${suffix}`);
     } catch (err) {

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -2,6 +2,7 @@
 import fsSync from "node:fs";
 import path from "node:path";
 import "./monitor-inbox.test-harness.js";
+import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   registerWhatsAppConnectionController,
@@ -993,6 +994,58 @@ describe("web monitor inbox", () => {
     } finally {
       vi.useRealTimers();
       await listener.close();
+    }
+  });
+
+  it("bounds stalled read-receipt socket operations instead of hanging", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      verbose: true,
+    });
+    vi.useFakeTimers();
+    try {
+      const messageId = nextMessageId("read-receipt-timeout");
+      // A WhatsApp socket whose read-receipt acknowledgement never resolves
+      // (e.g. a stalled Baileys privacy IQ query) would otherwise hang the
+      // inbound delivery pipeline forever.
+      sock.readMessages.mockImplementationOnce(() => new Promise(() => {}));
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: messageId,
+          remoteJid: "999@s.whatsapp.net",
+          text: "ping",
+          timestamp: 1_700_000_000,
+          pushName: "Tester",
+        }),
+      );
+      await waitForMessageCalls(onMessage, 1);
+
+      // The read receipt is attempted on the stalled socket...
+      await vi.waitFor(() => {
+        expect(sock.readMessages).toHaveBeenCalledWith([
+          { remoteJid: "999@s.whatsapp.net", id: messageId, participant: undefined, fromMe: false },
+        ]);
+      });
+
+      // ...and is bounded by the socket operation timeout rather than hanging.
+      await vi.advanceTimersByTimeAsync(DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs);
+      await vi.waitFor(() => {
+        const loggedTimeoutFailure = logSpy.mock.calls.some(
+          ([message]) =>
+            typeof message === "string" &&
+            message.includes(`Failed to mark message ${messageId} read`) &&
+            message.includes("readMessages timed out"),
+        );
+        expect(loggedTimeoutFailure).toBe(true);
+      });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+      await listener.close();
+      logSpy.mockRestore();
     }
   });
 

--- a/extensions/whatsapp/src/socket-timing.test.ts
+++ b/extensions/whatsapp/src/socket-timing.test.ts
@@ -1,12 +1,13 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 // Whatsapp tests cover socket timing plugin behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_WHATSAPP_SOCKET_TIMING,
   WhatsAppSocketOperationTimeoutError,
   isWhatsAppSocketOperationTimeoutError,
   resolveWhatsAppSocketOperationTimeoutMs,
   resolveWhatsAppSocketTiming,
+  withWhatsAppSocketOperationTimeout,
 } from "./socket-timing.js";
 
 describe("resolveWhatsAppSocketTiming", () => {
@@ -74,5 +75,43 @@ describe("resolveWhatsAppSocketTiming", () => {
     expect(resolveWhatsAppSocketOperationTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(
       MAX_TIMER_TIMEOUT_MS,
     );
+  });
+});
+
+describe("withWhatsAppSocketOperationTimeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("bounds a stalled readMessages socket operation with a typed timeout", async () => {
+    vi.useFakeTimers();
+    // A WhatsApp read-receipt call that never resolves (socket stall).
+    const stalled = new Promise<void>(() => {});
+    const bounded = withWhatsAppSocketOperationTimeout(
+      "readMessages",
+      stalled,
+      DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
+    );
+    const rejection = expect(bounded).rejects.toMatchObject({
+      name: "WhatsAppSocketOperationTimeoutError",
+      operation: "readMessages",
+      timeoutMs: DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
+      deliveryState: "unknown",
+    });
+    await vi.advanceTimersByTimeAsync(DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs);
+    await rejection;
+    // The bounding timer is cleared once the operation settles.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resolves the operation value when it settles before the bound", async () => {
+    vi.useFakeTimers();
+    const bounded = withWhatsAppSocketOperationTimeout(
+      "readMessages",
+      Promise.resolve("read"),
+      DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
+    );
+    await expect(bounded).resolves.toBe("read");
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -506,13 +506,13 @@ export const FIELD_HELP: Record<string, string> = {
   "web.reconnect.maxAttempts":
     "Maximum reconnect attempts before giving up for the current failure sequence (0 means no retries). Use finite caps for controlled failure handling in automation-sensitive environments.",
   "web.whatsapp":
-    "WhatsApp Web socket timing controls used by Baileys and OpenClaw's local outbound operation bounds. Tune these when network edges, proxies, or NATs are closing otherwise healthy WhatsApp Web sessions.",
+    "WhatsApp Web socket timing controls used by Baileys and OpenClaw's local outbound and inbound read-receipt operation bounds. Tune these when network edges, proxies, or NATs are closing otherwise healthy WhatsApp Web sessions.",
   "web.whatsapp.keepAliveIntervalMs":
     "Baileys WhatsApp Web application ping interval in milliseconds. Lower values detect and refresh idle links sooner; keep this comfortably below your network's idle-flow timeout.",
   "web.whatsapp.connectTimeoutMs":
     "Maximum time in milliseconds Baileys waits for the WhatsApp WebSocket opening handshake. Use a higher value on slow or lossy networks that report opening handshake 408 timeouts.",
   "web.whatsapp.defaultQueryTimeoutMs":
-    "Default Baileys query timeout and OpenClaw outbound send/presence operation bound in milliseconds for WhatsApp Web requests. Keep aligned with upstream unless a network-specific investigation shows socket operations need longer.",
+    "Default Baileys query timeout and OpenClaw outbound send/presence and inbound read-receipt operation bound in milliseconds for WhatsApp Web requests. Keep aligned with upstream unless a network-specific investigation shows socket operations need longer.",
   talk: "Talk-mode voice synthesis settings for voice identity, model selection, output format, and interruption behavior. Use this section to tune human-facing voice UX while controlling latency and cost.",
   "gateway.auth.token":
     "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -365,7 +365,7 @@ export type WebWhatsAppConfig = {
   keepAliveIntervalMs?: number;
   /** WebSocket opening handshake timeout in milliseconds. Default: 60000. */
   connectTimeoutMs?: number;
-  /** Baileys query and WhatsApp outbound socket operation timeout in milliseconds. Default: 60000. */
+  /** Baileys query and WhatsApp outbound/read-receipt operation timeout in milliseconds. Default: 60000. */
   defaultQueryTimeoutMs?: number;
 };
 


### PR DESCRIPTION
## Summary
- Bound the WhatsApp inbound read-receipt socket call (`readMessages`) with the same `withWhatsAppSocketOperationTimeout` wrapper introduced for outbound `sendMessage`/`sendPresenceUpdate` in #93094.
- A stalled WhatsApp Web socket could otherwise leave the `readMessages` acknowledgement pending forever; because that call is `await`-ed inside the inbound delivery pipeline (`maybeMarkInboundAsRead`), an unbounded hang there blocks completion of inbound message processing.

## Rationale
#93094 bounded the local outbound socket operations (`sendMessage`, `sendPresenceUpdate`, including the QA driver) so a stalled socket can no longer hang the send path. It left one symmetric inbound socket operation unbounded: `readMessages`, called from `attachWebInboxToSocket` to mark inbound messages as read. Under the hood Baileys' `readMessages` issues a privacy IQ query (`fetchPrivacySettings`) and then writes the receipt frame over the same socket, so it carries the exact same indefinite-hang risk as the operations #93094 already protected. The existing `try/catch` around the call only catches thrown errors, not a permanent stall.

This change reuses the existing socket-operation timeout seam and the already-resolved `sendOperationTimeoutMs` (derived from `web.whatsapp.defaultQueryTimeoutMs`) at the same call site, so a stalled read receipt now rejects with the terminal `WhatsAppSocketOperationTimeoutError` and is caught/logged like any other read-receipt failure instead of blocking the inbound pipeline.

## What changed
- `extensions/whatsapp/src/inbound/monitor.ts`: wrap the raw `readMessages` call in `withWhatsAppSocketOperationTimeout("readMessages", ..., sendOperationTimeoutMs)`.
- `extensions/whatsapp/src/socket-timing.test.ts`: unit coverage that the wrapper bounds a stalled `readMessages` operation with the typed timeout (and clears the bounding timer / resolves on success).
- `extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts`: integration coverage driving a real inbound message whose read-receipt socket call never resolves, asserting it is bounded by the socket-operation timeout instead of hanging the pipeline.

## Real behavior proof

Exact command (run on the worktree base of upstream/main):
```
node scripts/run-vitest.mjs extensions/whatsapp/src/socket-timing.test.ts extensions/whatsapp/src/monitor-inbox.behavior.test.ts
```
Terminal evidence:
```
 ✓ extension-whatsapp  extensions/whatsapp/src/socket-timing.test.ts (7 tests)
 ✓ extension-whatsapp  extensions/whatsapp/src/monitor-inbox.behavior.test.ts (75 tests)
 Test Files  2 passed (2)
      Tests  82 passed (82)
```

The integration test drives the real exported inbound path: it emits a `messages.upsert`, lets the handler complete, then the read-receipt socket call (`sock.readMessages`) is invoked on a socket whose acknowledgement never resolves. After advancing past `defaultQueryTimeoutMs`, the wrapped call rejects with `WhatsAppSocketOperationTimeoutError` (`operation: "readMessages"`), which is caught and logged (`Failed to mark message <id> read: ... readMessages timed out ...`), proving the inbound pipeline is no longer blocked.

### Negative control (proves the test is not a tautology)
Reverting only the `monitor.ts` source change (keeping both test files) and re-running the suite fails exactly the new integration test, while all other tests still pass:
```
 × bounds stalled read-receipt socket operations instead of hanging  6077ms
 FAIL  extensions/whatsapp/src/monitor-inbox.behavior.test.ts > web monitor inbox > bounds stalled read-receipt socket operations instead of hanging
 AssertionError: expected false to be true   (the read-receipt timeout-failure log never fires; readMessages hangs forever)
 Test Files  1 failed (1)
      Tests  1 failed | 74 passed (75)
```
Restoring the wrap returns the suite to all-green.

## Real behavior proof (real runtime, outside tests)

Per the review's request for proof outside the test runner: this is a real-runtime reproduction under Node, with **real timers (no fake clock)** and **no vitest**. It imports the actual exported timeout seam from the extension (`withWhatsAppSocketOperationTimeout`, `WhatsAppSocketOperationTimeoutError`, `isWhatsAppSocketOperationTimeoutError`) and drives the exact `await` + `try/catch` contract that `maybeMarkInboundAsRead` uses in `monitor.ts`.

The stall point is generic and does not require a live WhatsApp network: a stalled socket is modeled by a `readMessages()` that returns a promise which never settles (a permanently pending privacy-IQ query / receipt frame), and the protection is a real `setTimeout`-backed timeout firing at a real `200ms` boundary. A real running WhatsApp process always has live ref'd handles (the long-lived Baileys socket / inbound stream) keeping the event loop alive; that is modeled here by one real ref'd keepalive timer, while the seam's own timer stays `unref`'d exactly as in production.

Exact command:
```
node --import tsx readmessages-timeout-proof.mts
```

Real terminal output — FIXED (this PR) surfaces a typed timeout and lets delivery continue:
```
=== node --import tsx readmessages-timeout-proof.mts ===
node: v22.22.0 | real timers, no fake clock, no WhatsApp network
timeout window: 200 ms | outer watchdog: 1200 ms

--- FIXED (this PR: withWhatsAppSocketOperationTimeout wraps readMessages) ---
[FIXED] caught: WhatsAppSocketOperationTimeoutError: WhatsApp socket readMessages timed out after 200ms; delivery state is unknown
[FIXED] isWhatsAppSocketOperationTimeoutError: true
[FIXED] instanceof WhatsAppSocketOperationTimeoutError: true
[FIXED] error.name: WhatsAppSocketOperationTimeoutError
[FIXED] error.operation: readMessages
[FIXED] error.timeoutMs: 200
[FIXED] error.deliveryState: unknown
[FIXED] elapsed ms (real wall clock): 202 (~200ms timeout fired)
[FIXED] inbound delivery continued past read receipt: true
```

Real terminal output — MAIN control (bare `await readMessages`, no seam) hangs indefinitely past the watchdog:
```
--- MAIN control (bare await readMessages, no timeout seam) ---
[MAIN] outcome: still hanging after 1200ms
[MAIN] mainMaybeMarkInboundAsRead resolved: false (false => inbound pipeline blocked forever)

=== conclusion: FIXED surfaces typed timeout + lets delivery continue; MAIN hangs indefinitely ===
```

This is real-runtime, real-timer behavior evidence: with the wrap, the stalled read receipt rejects with the terminal `WhatsAppSocketOperationTimeoutError` at the real `200ms` boundary (wall clock `202ms`) and inbound delivery proceeds; without it, the bare `await` is still pending after a `1200ms` watchdog (`resolved: false`), i.e. the inbound pipeline is blocked forever. The timeout seam is the load-bearing behavior here and is exercised end-to-end without any WhatsApp account or network.

## Tests and validation
- `node scripts/run-vitest.mjs extensions/whatsapp/src/socket-timing.test.ts extensions/whatsapp/src/monitor-inbox.behavior.test.ts` — pass (82 tests).
- `node --import tsx readmessages-timeout-proof.mts` — real-runtime proof above (FIXED times out at 200ms; MAIN hangs past 1200ms watchdog).
- `node scripts/run-tsgo.mjs` — clean.
- Negative control as above.

## Risk checklist
- Scope is limited to one inbound socket call site plus tests; no public API or config surface changes.
- Reuses the existing `withWhatsAppSocketOperationTimeout` seam and the already-resolved `sendOperationTimeoutMs`; no new timing knob.
- Timeout is treated as a non-fatal read-receipt failure (caught and logged, matching the pre-existing `catch`), so worst case a read receipt is skipped rather than the pipeline hanging.
- Behavior is unchanged when `readMessages` resolves promptly or when read receipts are disabled (`sendReadReceipts: false`).

Related: #93094
