### PR TITLE
fix(doctor): suppress false empty groupAllowFrom warning when all accounts have populated allowlists

### DIFF
--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -66,7 +66,20 @@ export function scanEmptyAllowlistPolicyWarnings(
           shouldSkipGroupWarning ?? params.shouldSkipDefaultEmptyGroupAllowlistWarning,
       }),
     );
-    if (params.extraWarningsForAccount) {
+    // Suppress plugin extra warnings for the top-level record when
+    // all enabled accounts have their own allowlists (issue #92684).
+    const skipExtras =
+      shouldSkipGroupWarning
+        ? shouldSkipGroupWarning({
+            account,
+            channelName,
+            dmPolicy,
+            effectiveAllowFrom,
+            parent,
+            prefix,
+          } as Parameters<NonNullable<typeof shouldSkipGroupWarning>>[0])
+        : false;
+    if (params.extraWarningsForAccount && !skipExtras) {
       warnings.push(
         ...params.extraWarningsForAccount({
           account,
@@ -90,17 +103,19 @@ export function scanEmptyAllowlistPolicyWarnings(
       continue;
     }
     const accounts = asObjectRecord(channelConfig.accounts);
-    // When the top-level groupAllowFrom is empty but every real account
+    // When the top-level groupAllowFrom is empty but every enabled account
     // has its own populated groupAllowFrom/allowFrom, the parent scope is
-    // never reached at runtime — suppress the false-positive warning
-    // (issue #92684).
-    const allAccountsHaveAllowlists =
-      accounts &&
-      Object.keys(accounts).length > 0 &&
-      Object.values(accounts).every((entry) => {
-        if (!entry || typeof entry !== "object" || isDisabledRecord(entry)) {
-          return true;
-        }
+    // never reached at runtime — suppress the false-positive warning and
+    // plugin extra warnings for the top-level record (issue #92684).
+    const enabledAccounts =
+      accounts
+        ? Object.values(accounts).filter(
+            (entry) => entry && typeof entry === "object" && !isDisabledRecord(entry),
+          )
+        : [];
+    const allEnabledAccountsHaveAllowlists =
+      enabledAccounts.length > 0 &&
+      enabledAccounts.every((entry) => {
         const rec = entry as DoctorAccountRecord;
         return (
           ((rec.groupAllowFrom as DoctorAllowFromList | undefined)?.length ?? 0) > 0 ||
@@ -108,7 +123,7 @@ export function scanEmptyAllowlistPolicyWarnings(
         );
       });
     const skipForTopLevel =
-      allAccountsHaveAllowlists ? () => true : undefined;
+      allEnabledAccountsHaveAllowlists ? () => true : undefined;
 
     checkAccount(
       channelConfig,

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -37,6 +37,7 @@ export function scanEmptyAllowlistPolicyWarnings(
     prefix: string,
     channelName: string,
     parent?: DoctorAccountRecord,
+    shouldSkipGroupWarning?: ScanEmptyAllowlistPolicyWarningsParams["shouldSkipDefaultEmptyGroupAllowlistWarning"],
   ) => {
     const accountDm = asObjectRecord(account.dm);
     const parentDm = asObjectRecord(parent?.dm);
@@ -62,7 +63,7 @@ export function scanEmptyAllowlistPolicyWarnings(
         parent,
         prefix,
         shouldSkipDefaultEmptyGroupAllowlistWarning:
-          params.shouldSkipDefaultEmptyGroupAllowlistWarning,
+          shouldSkipGroupWarning ?? params.shouldSkipDefaultEmptyGroupAllowlistWarning,
       }),
     );
     if (params.extraWarningsForAccount) {
@@ -88,9 +89,34 @@ export function scanEmptyAllowlistPolicyWarnings(
     if (isDisabledRecord(channelConfig)) {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, channelName);
-
     const accounts = asObjectRecord(channelConfig.accounts);
+    // When the top-level groupAllowFrom is empty but every real account
+    // has its own populated groupAllowFrom/allowFrom, the parent scope is
+    // never reached at runtime — suppress the false-positive warning
+    // (issue #92684).
+    const allAccountsHaveAllowlists =
+      accounts &&
+      Object.keys(accounts).length > 0 &&
+      Object.values(accounts).every((entry) => {
+        if (!entry || typeof entry !== "object" || isDisabledRecord(entry)) {
+          return true;
+        }
+        const rec = entry as DoctorAccountRecord;
+        return (
+          ((rec.groupAllowFrom as DoctorAllowFromList | undefined)?.length ?? 0) > 0 ||
+          ((rec.allowFrom as DoctorAllowFromList | undefined)?.length ?? 0) > 0
+        );
+      });
+    const skipForTopLevel =
+      allAccountsHaveAllowlists ? () => true : undefined;
+
+    checkAccount(
+      channelConfig,
+      `channels.${channelName}`,
+      channelName,
+      undefined,
+      skipForTopLevel,
+    );
     if (!accounts) {
       continue;
     }


### PR DESCRIPTION
## Summary

Fixes #92684: `openclaw doctor` falsely warns "all group messages will be silently dropped" when a channel has `groupPolicy: "allowlist"` with an empty top-level `groupAllowFrom`, but every real account under it carries its own populated `groupAllowFrom`/`allowFrom`.

**Fix**: In `scanEmptyAllowlistPolicyWarnings`, detect when all non-disabled accounts have populated allowlists and pass a `shouldSkipGroupWarning` function to suppress the false positive for the top-level scope.

## Real behavior proof

- **Behavior or issue addressed:** doctor false-positively warns about empty top-level groupAllowFrom despite per-account allowlists
- **Real environment tested:** macOS, Node v22.22.3, latest upstream/main (301213a05)
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run src/commands/doctor/repair-sequencing.test.ts --reporter=verbose`
- **Evidence after fix:** 12/12 passed — includes "applies ordered repairs and sanitizes empty-allowlist warnings"
- **Observed result after fix:** Top-level empty groupAllowFrom no longer triggers warning when every account supplies its own list
- **What was not tested:** End-to-end `openclaw doctor` with live multi-account channel config (requires gateway)

Closes #92684.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Code <noreply@anthropic.com>