### PR TITLE
fix(status): ignore stale context after model switch

### DIFF
--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,8 +1,21 @@
 // Status message tests cover status message formatting and persistence.
 import { afterEach, describe, expect, it } from "vitest";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { formatFastModeLabel } from "./status-labels.js";
 import { buildStatusMessage } from "./status-message.js";
+
+function statusTestModel(id: string, name: string, contextWindow: number): ModelDefinitionConfig {
+  return {
+    id,
+    name,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens: 8_192,
+  };
+}
 
 afterEach(() => {
   cliBackendsTesting.resetDepsForTest();
@@ -25,9 +38,10 @@ describe("buildStatusMessage context window", () => {
         models: {
           providers: {
             "ollama-cloud": {
+              baseUrl: "https://ollama.com",
               models: [
-                { id: "deepseek-v4-pro", contextWindow: 1_000_000 },
-                { id: "glm-5.1", contextWindow: 200_000 },
+                statusTestModel("deepseek-v4-pro", "DeepSeek V4 Pro", 1_000_000),
+                statusTestModel("glm-5.1", "GLM 5.1", 200_000),
               ],
             },
           },
@@ -94,7 +108,8 @@ describe("buildStatusMessage context window", () => {
         models: {
           providers: {
             anthropic: {
-              models: [{ id: "claude-haiku-4-5", contextWindow: 200_000 }],
+              baseUrl: "https://api.anthropic.com",
+              models: [statusTestModel("claude-haiku-4-5", "Claude Haiku 4.5", 200_000)],
             },
           },
         },

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,6 +1,12 @@
 // Status message tests cover status message formatting and persistence.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.js";
 import { formatFastModeLabel } from "./status-labels.js";
+import { buildStatusMessage } from "./status-message.js";
+
+afterEach(() => {
+  cliBackendsTesting.resetDepsForTest();
+});
 
 describe("formatFastModeLabel", () => {
   it("shows fast mode when enabled", () => {
@@ -9,5 +15,112 @@ describe("formatFastModeLabel", () => {
 
   it("shows fast mode when disabled", () => {
     expect(formatFastModeLabel(false)).toBe("Fast: off");
+  });
+});
+
+describe("buildStatusMessage context window", () => {
+  it("ignores stale runtime context after a manual session model switch", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "ollama-cloud": {
+              models: [
+                { id: "deepseek-v4-pro", contextWindow: 1_000_000 },
+                { id: "glm-5.1", contextWindow: 200_000 },
+              ],
+            },
+          },
+        },
+      },
+      agent: {
+        model: "ollama-cloud/deepseek-v4-pro",
+        contextTokens: 1_000_000,
+      },
+      configuredDefaultModelLabel: "ollama-cloud/deepseek-v4-pro",
+      explicitConfiguredContextTokens: 1_000_000,
+      runtimeContextTokens: 1_000_000,
+      sessionEntry: {
+        sessionId: "manual-switch-stale-runtime",
+        updatedAt: 0,
+        providerOverride: "ollama-cloud",
+        modelOverride: "glm-5.1",
+        modelOverrideSource: "user",
+        modelProvider: "ollama-cloud",
+        model: "deepseek-v4-pro",
+        totalTokens: 128_393,
+        totalTokensFresh: true,
+      },
+      sessionKey: "agent:main:telegram:direct:584667058",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("Session selected: ollama-cloud/glm-5.1");
+    expect(text).toContain("Context: 128k/200k");
+    expect(text).not.toContain("Context: 128k/1.0m");
+  });
+
+  it("keeps trusted runtime context for config-backed runtime aliases", () => {
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: ({ backend }) =>
+        backend === "claude-cli"
+          ? {
+              pluginId: "anthropic",
+              backend: {
+                id: "claude-cli",
+                modelProvider: "anthropic",
+                config: { command: "claude" },
+                bundleMcp: false,
+              },
+            }
+          : undefined,
+      resolvePluginSetupRegistry: () => {
+        throw new Error("setup registry should not load for a targeted runtime alias");
+      },
+      resolveRuntimeCliBackends: () => [],
+    });
+
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": { command: "claude" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: {
+              models: [{ id: "claude-haiku-4-5", contextWindow: 200_000 }],
+            },
+          },
+        },
+      },
+      agent: {
+        model: "anthropic/claude-haiku-4-5",
+        contextTokens: 200_000,
+      },
+      runtimeContextTokens: 1_000_000,
+      sessionEntry: {
+        sessionId: "runtime-alias-context",
+        updatedAt: 0,
+        modelProvider: "claude-cli",
+        model: "claude-haiku-4-5",
+        totalTokens: 36_000,
+        totalTokensFresh: true,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "oauth",
+      activeModelAuth: "oauth",
+    });
+
+    expect(text).toContain("Model: anthropic/claude-haiku-4-5");
+    expect(text).toContain("Context: 36k/1.0m");
+    expect(text).not.toContain("Context: 36k/200k");
   });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -785,21 +785,24 @@ export function buildStatusMessage(args: StatusArgs): string {
         ? (cappedAgentContextTokens ?? activeContextTokens)
         : cappedAgentContextTokens))
     : undefined;
+  const runtimeSnapshotHasFallbackProvenance =
+    initialFallbackState.active ||
+    hasSessionAutoModelFallbackProvenance(entry) ||
+    areRuntimeModelRefsEquivalent(activeModelLabel, modelRefs.selected.label || "unknown", {
+      config: args.config,
+    });
   // When a fallback model is active, the selected-model context limit that
   // callers keep on the agent config is often stale. Prefer an explicit runtime
-  // snapshot when available. Separately, callers can pass an explicit configured
-  // cap that should still apply on fallback paths, but it cannot exceed the
-  // active runtime window when that window is known. Persisted runtime snapshots
-  // still take precedence over configured caps so historical fallback sessions
-  // keep their last known live limit even if the active model later becomes
-  // unresolvable.
+  // snapshot only when it belongs to a real fallback/equivalent runtime. A
+  // transcript-derived previous model is stale after a manual switch and must
+  // not pin the newly selected model to the old context window. Separately,
+  // callers can pass an explicit configured cap that should still apply on
+  // fallback paths, but it cannot exceed the active runtime window when that
+  // window is known. Persisted runtime snapshots still take precedence over
+  // configured caps so historical fallback sessions keep their last known live
+  // limit even if the active model later becomes unresolvable.
   const contextTokens = runtimeDiffersFromSelected
-    ? (explicitRuntimeContextTokens ??
-      (() => {
-        const runtimeSnapshotHasFallbackProvenance =
-          initialFallbackState.active ||
-          hasSessionAutoModelFallbackProvenance(entry) ||
-          areRuntimeModelRefsEquivalent(activeModelLabel, modelRefs.selected.label || "unknown");
+    ? (() => {
         if (!runtimeSnapshotHasFallbackProvenance) {
           if (typeof selectedContextTokens === "number") {
             if (explicitConfiguredContextTokens !== undefined) {
@@ -817,6 +820,9 @@ export function buildStatusMessage(args: StatusArgs): string {
             return agentContextTokens;
           }
           return DEFAULT_CONTEXT_TOKENS;
+        }
+        if (explicitRuntimeContextTokens !== undefined) {
+          return explicitRuntimeContextTokens;
         }
         if (cappedPersistedContextTokens !== undefined) {
           const trustedPersistedContextTokens = cappedPersistedContextTokens;
@@ -849,7 +855,7 @@ export function buildStatusMessage(args: StatusArgs): string {
           return activeContextTokens;
         }
         return DEFAULT_CONTEXT_TOKENS;
-      })())
+      })()
     : (resolveContextTokensForModel({
         cfg: contextConfig,
         ...(contextLookupProvider ? { provider: contextLookupProvider } : {}),


### PR DESCRIPTION
## Purpose

Manual session model switches should make `/status` report the context window for the newly selected model. The current status formatter can still trust a transcript/runtime snapshot from the previous model, so a session pinned to `ollama-cloud/glm-5.1` can continue to display the old `ollama-cloud/deepseek-v4-pro` `1.0m` context window.

## Summary

- Keep `/status` context-window display aligned with the session-selected model after manual model switches.
- Trust explicit runtime context tokens only when the runtime snapshot has fallback or equivalent-runtime provenance.
- Add regression coverage for both the stale-runtime case and config-backed runtime aliases that should still keep their runtime window.

## Root Cause

`src/status/status-message.ts` treated `runtimeContextTokens` as authoritative whenever the runtime model differed from the selected model. That is correct for real fallback or equivalent runtime alias paths, but wrong after a manual session model switch because the runtime snapshot can describe the previous transcript model.

## Real Behavior Proof

Behavior addressed: `/status` now uses the session-selected model's configured context window after a manual model switch instead of pinning the display to stale runtime context tokens from the previous model.

Real environment tested: Crabbox Docker provider, lease `cbx_9a713b50341d`, clean synced PR branch checkout in `node:22-bookworm`.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider docker --docker-image node:22-bookworm --idle-timeout 90m --ttl 240m --timing-json --shell -- "corepack enable && corepack pnpm install --frozen-lockfile && node scripts/run-vitest.mjs src/status/status-message.test.ts"`

Evidence after fix: `src/status/status-message.test.ts` builds the stale manual-switch status input where the selected model is `ollama-cloud/glm-5.1`, the previous runtime snapshot is `ollama-cloud/deepseek-v4-pro`, and the stale runtime context is `1_000_000`.

Observed result after fix: Crabbox passed `src/status/status-message.test.ts` with 1 test file and 4 tests. The regression test asserts `Session selected: ollama-cloud/glm-5.1`, `Context: 128k/200k`, and not `Context: 128k/1.0m`.

What was not tested: No live Telegram/openclaw2 package upgrade was rerun from this PR branch; the focused proof covers the status-message decision path that formats the incorrect context window.

## Verification

- `pnpm check:test-types`
- `node scripts/run-vitest.mjs src/status/status-message.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`
- Crabbox Docker proof: provider `docker`, lease `cbx_9a713b50341d`, exit 0.

