### PR TITLE
fix(browser): notify agent when click triggers download

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -19,6 +19,7 @@ OpenClaw can run a **dedicated Chrome/Brave/Edge/Chromium profile** that the age
 - Deterministic tab control (list/open/focus/close).
 - Agent actions (click/type/drag/select), snapshots, screenshots, PDFs.
 - Playwright-backed profiles save direct attachment navigations under the managed downloads directory and return `{ url, suggestedFilename, path }` metadata after final-URL policy validation.
+- Playwright-backed agent actions return a `downloads` array with the same managed metadata when the action immediately starts one or more downloads.
 - A bundled `browser-automation` skill that teaches agents the snapshot,
   stable-tab, stale-ref, and manual-blocker recovery loop when the browser
   plugin is enabled.

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -32,6 +32,11 @@ type BrowserActResponse = {
   results?: Array<{ ok: boolean; error?: string }>;
   blockedByDialog?: boolean;
   browserState?: unknown;
+  /** Download info when a click/batch/evaluate action triggers a browser download. */
+  downloads?: {
+    count: number;
+    recent: Array<{ suggestedFilename: string; savedPath: string }>;
+  };
 };
 
 const BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS = 5_000;

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
   DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS,
 } from "./constants.js";
+import type { BrowserDownloadResult } from "./download-types.js";
 
 export type { BrowserFormField } from "./client-actions.types.js";
 
@@ -33,10 +34,7 @@ type BrowserActResponse = {
   blockedByDialog?: boolean;
   browserState?: unknown;
   /** Download info when a click/batch/evaluate action triggers a browser download. */
-  downloads?: {
-    count: number;
-    recent: Array<{ suggestedFilename: string; savedPath: string }>;
-  };
+  downloads?: BrowserDownloadResult[];
 };
 
 const BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS = 5_000;

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -210,6 +210,13 @@ describe("browser client", () => {
               url: "https://x",
               result: 1,
               results: [{ ok: true }],
+              downloads: [
+                {
+                  url: "https://x/report.pdf",
+                  suggestedFilename: "report.pdf",
+                  path: "/tmp/openclaw/downloads/report.pdf",
+                },
+              ],
             }),
           } as unknown as Response;
         }
@@ -346,6 +353,13 @@ describe("browser client", () => {
     expect(act.ok).toBe(true);
     expect(act.targetId).toBe("t1");
     expect(act.results).toEqual([{ ok: true }]);
+    expect(act.downloads).toEqual([
+      {
+        url: "https://x/report.pdf",
+        suggestedFilename: "report.pdf",
+        path: "/tmp/openclaw/downloads/report.pdf",
+      },
+    ]);
 
     const fileChooser = await browserArmFileChooser("http://127.0.0.1:18791", {
       paths: ["/tmp/a.txt"],

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -417,23 +417,21 @@ describe("pw-session action download capture", () => {
 
     capture.dispose();
 
-    // After dispose, a new download is fired. The page's download handler
-    // looks at state.actionDownloadCaptures.at(-1), but our capture was
-    // removed from the list. The download should fall through to
-    // managedSave.catch(() => {}) without being captured.
-    const saveAs2 = vi.fn(async () => {});
+    // After dispose: the capture is removed from actionDownloadCaptures.
+    // A new download fires — it won't be added to this capture's
+    // promises (the handler can't find the capture in the list).
+    // Re-draining returns the pre-dispose results (promises array
+    // is not cleared by dispose — this is benign, callers should
+    // drain before disposing).
     handlers.get("download")?.[0]?.({
       suggestedFilename: () => "post.txt",
-      saveAs: saveAs2,
+      saveAs: vi.fn(async () => {}),
     });
 
-    // The disposed capture won't see new downloads from the page handler.
-    // But it may still return its previously captured results on re-drain
-    // since capture.promises is not cleared by dispose.
-    await capture.drain();
-    // The key assertion: the post-dispose download's saveAs was never called
-    // because it wasn't captured (fell through to managedSave.catch).
-    expect(saveAs2).not.toHaveBeenCalled();
+    const afterDrain = await capture.drain();
+    // Still returns pre-dispose download; new download not captured
+    expect(afterDrain?.count).toBe(1);
+    expect(afterDrain?.recent[0]?.suggestedFilename).toBe("pre.txt");
   });
 
   it("double dispose is safe", () => {

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -359,3 +359,165 @@ describe("pw-session ensurePageState", () => {
     expect(state2.requests).toStrictEqual([]);
   });
 });
+
+describe("pw-session action download capture", () => {
+  it("captures multiple concurrent downloads within one action", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
+
+    const saveAsA = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "download-a", "utf8");
+    });
+    const saveAsB = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "download-b", "utf8");
+    });
+    const saveAsC = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "download-c", "utf8");
+    });
+
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "a.txt",
+      saveAs: saveAsA,
+    });
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "b.txt",
+      saveAs: saveAsB,
+    });
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "c.txt",
+      saveAs: saveAsC,
+    });
+
+    const result = await capture.drain();
+    capture.dispose();
+
+    expect(result?.count).toBe(3);
+    expect(result?.recent.map((d) => d.suggestedFilename)).toEqual(["a.txt", "b.txt", "c.txt"]);
+    for (const d of result?.recent ?? []) {
+      expect(path.dirname(d.savedPath)).toBe(DEFAULT_DOWNLOAD_DIR);
+    }
+  });
+
+  it("dispose prevents new downloads from being captured after disposal", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
+
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "pre-dispose", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "pre.txt",
+      saveAs,
+    });
+
+    const result = await capture.drain();
+    expect(result?.count).toBe(1);
+
+    capture.dispose();
+
+    // After dispose, a new download is fired. The page's download handler
+    // looks at state.actionDownloadCaptures.at(-1), but our capture was
+    // removed from the list. The download should fall through to
+    // managedSave.catch(() => {}) without being captured.
+    const saveAs2 = vi.fn(async () => {});
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "post.txt",
+      saveAs: saveAs2,
+    });
+
+    // The disposed capture won't see new downloads from the page handler.
+    // But it may still return its previously captured results on re-drain
+    // since capture.promises is not cleared by dispose.
+    const afterDispose = await capture.drain();
+    // The key assertion: the post-dispose download's saveAs was never called
+    // because it wasn't captured (fell through to managedSave.catch).
+    expect(saveAs2).not.toHaveBeenCalled();
+  });
+
+  it("double dispose is safe", () => {
+    const { page } = fakePage();
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
+
+    capture.dispose();
+    expect(() => capture.dispose()).not.toThrow();
+  });
+
+  it("broadcasts downloads to all active captures to prevent misattribution", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+
+    const capture1 = beginActionDownloadCaptureOnPage(page);
+    const capture2 = beginActionDownloadCaptureOnPage(page);
+
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "shared", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "shared.txt",
+      saveAs,
+    });
+
+    // Both captures receive the download, preventing misattribution
+    const result1 = await capture1.drain();
+    const result2 = await capture2.drain();
+
+    expect(result1?.count).toBe(1);
+    expect(result1?.recent[0]?.suggestedFilename).toBe("shared.txt");
+    expect(result2?.count).toBe(1);
+    expect(result2?.recent[0]?.suggestedFilename).toBe("shared.txt");
+    expect(result1?.recent[0]?.savedPath).toBe(result2?.recent[0]?.savedPath);
+
+    capture1.dispose();
+    capture2.dispose();
+  });
+
+  it("non-overlapping sequential captures see their own downloads", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+
+    const capture1 = beginActionDownloadCaptureOnPage(page);
+    const saveAs1 = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "first", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "first.txt",
+      saveAs: saveAs1,
+    });
+    const result1 = await capture1.drain();
+    capture1.dispose();
+
+    expect(result1?.count).toBe(1);
+    expect(result1?.recent[0]?.suggestedFilename).toBe("first.txt");
+
+    // Second capture starts after first is disposed
+    const capture2 = beginActionDownloadCaptureOnPage(page);
+    const saveAs2 = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "second", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "second.txt",
+      saveAs: saveAs2,
+    });
+    const result2 = await capture2.drain();
+    capture2.dispose();
+
+    expect(result2?.count).toBe(1);
+    expect(result2?.recent[0]?.suggestedFilename).toBe("second.txt");
+    expect(saveAs1).toHaveBeenCalledTimes(1);
+    expect(saveAs2).toHaveBeenCalledTimes(1);
+  });
+
+  it("graceMs=0 returns immediately when no download has arrived", async () => {
+    const { page } = fakePage();
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
+
+    const result = await capture.drain({ graceMs: 0 });
+    capture.dispose();
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -430,7 +430,7 @@ describe("pw-session action download capture", () => {
     // The disposed capture won't see new downloads from the page handler.
     // But it may still return its previously captured results on re-drain
     // since capture.promises is not cleared by dispose.
-    const afterDispose = await capture.drain();
+    await capture.drain();
     // The key assertion: the post-dispose download's saveAs was never called
     // because it wasn't captured (fell through to managedSave.catch).
     expect(saveAs2).not.toHaveBeenCalled();

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -4,9 +4,11 @@ import path from "node:path";
 import type { Page } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
+import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
   beginActionDownloadCaptureOnPage,
   ensurePageState,
+  isDownloadStartingNavigationError,
   refLocator,
   rememberRoleRefsForTarget,
   restoreRoleRefsForTarget,
@@ -14,6 +16,7 @@ import {
 import { BROWSER_REF_MARKER_ATTRIBUTE } from "./pw-session.page-cdp.js";
 
 type MutableDownload = {
+  url?: () => string;
   suggestedFilename: () => string;
   saveAs: ReturnType<typeof vi.fn>;
   path?: () => Promise<string>;
@@ -40,6 +43,14 @@ function fakePage(): {
     handlers.set(event, list);
     return undefined as unknown;
   });
+  const off = vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+    const list = handlers.get(event) ?? [];
+    handlers.set(
+      event,
+      list.filter((handler) => handler !== cb),
+    );
+    return undefined as unknown;
+  });
   const getByRole = vi.fn(() => ({ nth: vi.fn(() => ({ ok: true })) }));
   const frameLocator = vi.fn(() => ({
     getByRole: vi.fn(() => ({ nth: vi.fn(() => ({ ok: true })) })),
@@ -49,6 +60,7 @@ function fakePage(): {
 
   const page = {
     on,
+    off,
     getByRole,
     frameLocator,
     locator,
@@ -240,79 +252,263 @@ describe("pw-session ensurePageState", () => {
     expect(download.saveAs).not.toHaveBeenCalled();
   });
 
-  it("captures only downloads owned by an active action", async () => {
+  it("reports all downloads owned by the active action with managed metadata", async () => {
     const { page, handlers } = fakePage();
     ensurePageState(page);
     const capture = beginActionDownloadCaptureOnPage(page);
-    const saveAs = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "action-download", "utf8");
+    const firstSave = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "first-action-download", "utf8");
     });
-    const download: MutableDownload = {
-      suggestedFilename: () => "clicked.txt",
-      saveAs,
-    };
+    const secondSave = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "second-action-download", "utf8");
+    });
 
-    handlers.get("download")?.[0]?.(download);
+    for (const download of [
+      {
+        url: () => "https://example.com/first.txt",
+        suggestedFilename: () => "first.txt",
+        saveAs: firstSave,
+      },
+      {
+        url: () => "https://example.com/second.txt",
+        suggestedFilename: () => "second.txt",
+        saveAs: secondSave,
+      },
+    ]) {
+      handlers.get("download")?.[0]?.(download);
+    }
+
     const result = await capture.drain();
     capture.dispose();
 
-    expect(result).toEqual({
-      count: 1,
-      recent: [
-        {
-          suggestedFilename: "clicked.txt",
-          savedPath: expect.stringMatching(/clicked\.txt$/),
-        },
-      ],
-    });
-    const savedPath = result?.recent[0]?.savedPath ?? "";
-    expect(path.dirname(savedPath)).toBe(DEFAULT_DOWNLOAD_DIR);
-    await expect(fs.readFile(savedPath, "utf8")).resolves.toBe("action-download");
+    expect(result).toEqual([
+      {
+        url: "https://example.com/first.txt",
+        suggestedFilename: "first.txt",
+        path: expect.stringMatching(/-first\.txt$/),
+      },
+      {
+        url: "https://example.com/second.txt",
+        suggestedFilename: "second.txt",
+        path: expect.stringMatching(/-second\.txt$/),
+      },
+    ]);
+    await expect(fs.readFile(result?.[0]?.path ?? "", "utf8")).resolves.toBe(
+      "first-action-download",
+    );
+    await expect(fs.readFile(result?.[1]?.path ?? "", "utf8")).resolves.toBe(
+      "second-action-download",
+    );
   });
 
-  it("waits briefly for action downloads that arrive after the action returns", async () => {
+  it("waits only the requested first-event grace for a just-late action download", async () => {
     const { page, handlers } = fakePage();
     ensurePageState(page);
     const capture = beginActionDownloadCaptureOnPage(page);
     const saveAs = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "late-download", "utf8");
+      await fs.writeFile(outPath, "late-action-download", "utf8");
     });
-    const drain = capture.drain({ graceMs: 1000 });
+    const drain = capture.drain({ graceMs: 1_000 });
 
-    setTimeout(() => {
+    setImmediate(() => {
       handlers.get("download")?.[0]?.({
+        url: () => "https://example.com/late.txt",
         suggestedFilename: () => "late.txt",
         saveAs,
       });
-    }, 0);
+    });
 
-    const result = await drain;
+    await expect(drain).resolves.toEqual([
+      expect.objectContaining({ suggestedFilename: "late.txt" }),
+    ]);
     capture.dispose();
-
-    expect(result?.count).toBe(1);
-    expect(result?.recent[0]?.suggestedFilename).toBe("late.txt");
-    await expect(fs.readFile(result?.recent[0]?.savedPath ?? "", "utf8")).resolves.toBe(
-      "late-download",
-    );
   });
 
-  it("does not let action captures steal explicit waiter downloads", async () => {
+  it("keeps started saves with their owner and assigns future downloads to the latest action", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const first = beginActionDownloadCaptureOnPage(page);
+    const firstSaveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "first-action-download", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      url: () => "https://example.com/first.txt",
+      suggestedFilename: () => "first.txt",
+      saveAs: firstSaveAs,
+    });
+
+    const latest = beginActionDownloadCaptureOnPage(page);
+    first.dispose();
+    const latestSaveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "latest-action-download", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      url: () => "https://example.com/latest.txt",
+      suggestedFilename: () => "latest.txt",
+      saveAs: latestSaveAs,
+    });
+
+    await expect(first.drain()).resolves.toEqual([
+      expect.objectContaining({ suggestedFilename: "first.txt" }),
+    ]);
+    await expect(latest.drain()).resolves.toEqual([
+      expect.objectContaining({ suggestedFilename: "latest.txt" }),
+    ]);
+    latest.dispose();
+    expect(firstSaveAs).toHaveBeenCalledOnce();
+    expect(latestSaveAs).toHaveBeenCalledOnce();
+  });
+
+  it("leaves action capture empty while an explicit download owner is armed", async () => {
     const { page, handlers } = fakePage();
     const state = ensurePageState(page);
     state.downloadWaiterDepth = 1;
     const capture = beginActionDownloadCaptureOnPage(page);
     const download = {
-      suggestedFilename: () => "report.pdf",
+      suggestedFilename: () => "explicit.txt",
       saveAs: vi.fn(async () => {}),
     };
 
     handlers.get("download")?.[0]?.(download);
-    const result = await capture.drain();
-    capture.dispose();
 
-    expect(result).toBeUndefined();
+    await expect(capture.drain()).resolves.toBeUndefined();
+    capture.dispose();
     expect(download).not.toHaveProperty("path");
     expect(download.saveAs).not.toHaveBeenCalled();
+  });
+
+  it("validates action-owned download URLs before saving bytes", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const blocked = new Error("blocked action download");
+    const beforeSave = vi.fn(async () => {
+      throw blocked;
+    });
+    const capture = beginActionDownloadCaptureOnPage(page, { beforeSave });
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "blocked-action-download", "utf8");
+    });
+
+    handlers.get("download")?.[0]?.({
+      url: () => "http://127.0.0.1/private.txt",
+      suggestedFilename: () => "private.txt",
+      saveAs,
+    });
+
+    await expect(capture.drain()).rejects.toBe(blocked);
+    capture.dispose();
+    expect(beforeSave).toHaveBeenCalledWith({
+      url: "http://127.0.0.1/private.txt",
+      suggestedFilename: "private.txt",
+    });
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it("surfaces action-owned download save failures without an unhandled rejection", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
+    const error = new Error("action download save failed");
+
+    handlers.get("download")?.[0]?.({
+      suggestedFilename: () => "failed.txt",
+      saveAs: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    await expect(capture.drain()).rejects.toBe(error);
+    capture.dispose();
+  });
+
+  it("captures navigation downloads under managed paths", async () => {
+    const { page, handlers } = fakePage();
+    const state = ensurePageState(page);
+    const capture = createDownloadCaptureForPage(page, state, 1_000);
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "attachment", "utf8");
+    });
+    const download = {
+      url: () => "https://example.com/export.csv",
+      suggestedFilename: () => "export.csv",
+      saveAs,
+    };
+
+    for (const handler of handlers.get("download") ?? []) {
+      handler(download);
+    }
+
+    const result = await capture.promise;
+    expect(result.url).toBe("https://example.com/export.csv");
+    expect(result.suggestedFilename).toBe("export.csv");
+    expect(path.dirname(result.path)).toBe(DEFAULT_DOWNLOAD_DIR);
+    expect(path.basename(result.path)).toMatch(/-export\.csv$/);
+    expect(firstSavePath(saveAs)).not.toBe(result.path);
+    await expect(fs.readFile(result.path, "utf8")).resolves.toBe("attachment");
+  });
+
+  it("validates captured navigation downloads before saving managed bytes", async () => {
+    const { page, handlers } = fakePage();
+    const state = ensurePageState(page);
+    const blocked = new Error("blocked download");
+    const beforeSave = vi.fn(async () => {
+      throw blocked;
+    });
+    const capture = createDownloadCaptureForPage(page, state, 1_000, { beforeSave });
+    const saveAs = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "blocked", "utf8");
+    });
+    const download = {
+      url: () => "http://127.0.0.1:18080/export.csv",
+      suggestedFilename: () => "export.csv",
+      saveAs,
+    };
+
+    for (const handler of handlers.get("download") ?? []) {
+      handler(download);
+    }
+
+    await expect(capture.promise).rejects.toBe(blocked);
+    expect(beforeSave).toHaveBeenCalledWith({
+      url: "http://127.0.0.1:18080/export.csv",
+      suggestedFilename: "export.csv",
+    });
+    expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it("lets explicit download owners arm while passive capture yields", () => {
+    const { page } = fakePage();
+    const state = ensurePageState(page);
+    state.downloadWaiterDepth = 1;
+
+    const passive = createDownloadCaptureForPage(page, state, 1_000);
+    const explicit = createDownloadCaptureForPage(page, state, 1_000, { mode: "explicit" });
+
+    expect(passive.armed).toBe(false);
+    expect(explicit.armed).toBe(true);
+    expect(state.downloadWaiterDepth).toBe(2);
+    explicit.cancel();
+    expect(state.downloadWaiterDepth).toBe(1);
+  });
+
+  it("recognizes Playwright download-starting navigation aborts", () => {
+    expect(isDownloadStartingNavigationError(new Error("page.goto: Download is starting"))).toBe(
+      true,
+    );
+    expect(isDownloadStartingNavigationError(new Error("page.goto: net::ERR_ABORTED"))).toBe(false);
+    expect(
+      isDownloadStartingNavigationError(
+        new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/download"),
+        "http://127.0.0.1:3333/download",
+      ),
+    ).toBe(true);
+    expect(
+      isDownloadStartingNavigationError(
+        new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/other"),
+        "http://127.0.0.1:3333/download",
+      ),
+    ).toBe(false);
+    expect(isDownloadStartingNavigationError(new Error("Navigation failed"))).toBe(false);
   });
 
   it("tracks page errors and network requests (best-effort)", () => {
@@ -357,165 +553,5 @@ describe("pw-session ensurePageState", () => {
     expect(state2.console).toStrictEqual([]);
     expect(state2.errors).toStrictEqual([]);
     expect(state2.requests).toStrictEqual([]);
-  });
-});
-
-describe("pw-session action download capture", () => {
-  it("captures multiple concurrent downloads within one action", async () => {
-    const { page, handlers } = fakePage();
-    ensurePageState(page);
-    const capture = beginActionDownloadCaptureOnPage(page);
-
-    const saveAsA = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "download-a", "utf8");
-    });
-    const saveAsB = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "download-b", "utf8");
-    });
-    const saveAsC = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "download-c", "utf8");
-    });
-
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "a.txt",
-      saveAs: saveAsA,
-    });
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "b.txt",
-      saveAs: saveAsB,
-    });
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "c.txt",
-      saveAs: saveAsC,
-    });
-
-    const result = await capture.drain();
-    capture.dispose();
-
-    expect(result?.count).toBe(3);
-    expect(result?.recent.map((d) => d.suggestedFilename)).toEqual(["a.txt", "b.txt", "c.txt"]);
-    for (const d of result?.recent ?? []) {
-      expect(path.dirname(d.savedPath)).toBe(DEFAULT_DOWNLOAD_DIR);
-    }
-  });
-
-  it("dispose prevents new downloads from being captured after disposal", async () => {
-    const { page, handlers } = fakePage();
-    ensurePageState(page);
-    const capture = beginActionDownloadCaptureOnPage(page);
-
-    const saveAs = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "pre-dispose", "utf8");
-    });
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "pre.txt",
-      saveAs,
-    });
-
-    const result = await capture.drain();
-    expect(result?.count).toBe(1);
-
-    capture.dispose();
-
-    // After dispose: the capture is removed from actionDownloadCaptures.
-    // A new download fires — it won't be added to this capture's
-    // promises (the handler can't find the capture in the list).
-    // Re-draining returns the pre-dispose results (promises array
-    // is not cleared by dispose — this is benign, callers should
-    // drain before disposing).
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "post.txt",
-      saveAs: vi.fn(async () => {}),
-    });
-
-    const afterDrain = await capture.drain();
-    // Still returns pre-dispose download; new download not captured
-    expect(afterDrain?.count).toBe(1);
-    expect(afterDrain?.recent[0]?.suggestedFilename).toBe("pre.txt");
-  });
-
-  it("double dispose is safe", () => {
-    const { page } = fakePage();
-    ensurePageState(page);
-    const capture = beginActionDownloadCaptureOnPage(page);
-
-    capture.dispose();
-    expect(() => capture.dispose()).not.toThrow();
-  });
-
-  it("broadcasts downloads to all active captures to prevent misattribution", async () => {
-    const { page, handlers } = fakePage();
-    ensurePageState(page);
-
-    const capture1 = beginActionDownloadCaptureOnPage(page);
-    const capture2 = beginActionDownloadCaptureOnPage(page);
-
-    const saveAs = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "shared", "utf8");
-    });
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "shared.txt",
-      saveAs,
-    });
-
-    // Both captures receive the download, preventing misattribution
-    const result1 = await capture1.drain();
-    const result2 = await capture2.drain();
-
-    expect(result1?.count).toBe(1);
-    expect(result1?.recent[0]?.suggestedFilename).toBe("shared.txt");
-    expect(result2?.count).toBe(1);
-    expect(result2?.recent[0]?.suggestedFilename).toBe("shared.txt");
-    expect(result1?.recent[0]?.savedPath).toBe(result2?.recent[0]?.savedPath);
-
-    capture1.dispose();
-    capture2.dispose();
-  });
-
-  it("non-overlapping sequential captures see their own downloads", async () => {
-    const { page, handlers } = fakePage();
-    ensurePageState(page);
-
-    const capture1 = beginActionDownloadCaptureOnPage(page);
-    const saveAs1 = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "first", "utf8");
-    });
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "first.txt",
-      saveAs: saveAs1,
-    });
-    const result1 = await capture1.drain();
-    capture1.dispose();
-
-    expect(result1?.count).toBe(1);
-    expect(result1?.recent[0]?.suggestedFilename).toBe("first.txt");
-
-    // Second capture starts after first is disposed
-    const capture2 = beginActionDownloadCaptureOnPage(page);
-    const saveAs2 = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "second", "utf8");
-    });
-    handlers.get("download")?.[0]?.({
-      suggestedFilename: () => "second.txt",
-      saveAs: saveAs2,
-    });
-    const result2 = await capture2.drain();
-    capture2.dispose();
-
-    expect(result2?.count).toBe(1);
-    expect(result2?.recent[0]?.suggestedFilename).toBe("second.txt");
-    expect(saveAs1).toHaveBeenCalledTimes(1);
-    expect(saveAs2).toHaveBeenCalledTimes(1);
-  });
-
-  it("graceMs=0 returns immediately when no download has arrived", async () => {
-    const { page } = fakePage();
-    ensurePageState(page);
-    const capture = beginActionDownloadCaptureOnPage(page);
-
-    const result = await capture.drain({ graceMs: 0 });
-    capture.dispose();
-
-    expect(result).toBeUndefined();
   });
 });

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -308,7 +308,7 @@ describe("pw-session ensurePageState", () => {
     const saveAs = vi.fn(async (outPath: string) => {
       await fs.writeFile(outPath, "late-action-download", "utf8");
     });
-    const drain = capture.drain({ graceMs: 1_000 });
+    const drain = capture.drain({ firstEventGraceMs: 1_000 });
 
     setImmediate(() => {
       handlers.get("download")?.[0]?.({
@@ -321,6 +321,75 @@ describe("pw-session ensurePageState", () => {
     await expect(drain).resolves.toEqual([
       expect.objectContaining({ suggestedFilename: "late.txt" }),
     ]);
+    capture.dispose();
+  });
+
+  it("keeps a quiet window open for sibling downloads after the first event", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
+    const save = (contents: string) =>
+      vi.fn(async (outPath: string) => {
+        await fs.writeFile(outPath, contents, "utf8");
+      });
+
+    handlers.get("download")?.[0]?.({
+      url: () => "https://example.com/first.txt",
+      suggestedFilename: () => "first.txt",
+      saveAs: save("first"),
+    });
+    setImmediate(() => {
+      handlers.get("download")?.[0]?.({
+        url: () => "https://example.com/second.txt",
+        suggestedFilename: () => "second.txt",
+        saveAs: save("second"),
+      });
+    });
+
+    await expect(capture.drain({ quietMs: 1_000 })).resolves.toEqual([
+      expect.objectContaining({ suggestedFilename: "first.txt" }),
+      expect.objectContaining({ suggestedFilename: "second.txt" }),
+    ]);
+    capture.dispose();
+  });
+
+  it("detaches ownership before waiting for slow file saves", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    let releaseFirstSave: (() => void) | undefined;
+    const firstSaveGate = new Promise<void>((resolve) => {
+      releaseFirstSave = resolve;
+    });
+    const beforeSave = vi.fn(async () => {});
+    const capture = beginActionDownloadCaptureOnPage(page, { beforeSave });
+    const firstSave = vi.fn(async (outPath: string) => {
+      await firstSaveGate;
+      await fs.writeFile(outPath, "first", "utf8");
+    });
+    handlers.get("download")?.[0]?.({
+      url: () => "https://example.com/first.txt",
+      suggestedFilename: () => "first.txt",
+      saveAs: firstSave,
+    });
+
+    const drain = capture.drain();
+    const lateSave = vi.fn(async (outPath: string) => {
+      await fs.writeFile(outPath, "late", "utf8");
+    });
+    const lateDownload: MutableDownload = {
+      url: () => "https://example.com/late.txt",
+      suggestedFilename: () => "late.txt",
+      saveAs: lateSave,
+    };
+    handlers.get("download")?.[0]?.(lateDownload);
+    releaseFirstSave?.();
+
+    await expect(drain).resolves.toEqual([
+      expect.objectContaining({ suggestedFilename: "first.txt" }),
+    ]);
+    await expect(lateDownload.path?.()).resolves.toMatch(/-late\.txt$/);
+    expect(beforeSave).toHaveBeenCalledOnce();
+    expect(lateSave).toHaveBeenCalledOnce();
     capture.dispose();
   });
 
@@ -402,6 +471,74 @@ describe("pw-session ensurePageState", () => {
       suggestedFilename: "private.txt",
     });
     expect(saveAs).not.toHaveBeenCalled();
+  });
+
+  it("drains late siblings before surfacing the first download policy failure", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const blocked = new Error("blocked action download");
+    const beforeSave = vi.fn(async () => {
+      throw blocked;
+    });
+    const capture = beginActionDownloadCaptureOnPage(page, { beforeSave });
+    const firstSave = vi.fn(async () => {});
+    const secondSave = vi.fn(async () => {});
+
+    handlers.get("download")?.[0]?.({
+      url: () => "http://127.0.0.1/first.txt",
+      suggestedFilename: () => "first.txt",
+      saveAs: firstSave,
+    });
+    setImmediate(() => {
+      handlers.get("download")?.[0]?.({
+        url: () => "http://127.0.0.1/second.txt",
+        suggestedFilename: () => "second.txt",
+        saveAs: secondSave,
+      });
+    });
+
+    await expect(capture.drain({ quietMs: 1_000 })).rejects.toBe(blocked);
+    capture.dispose();
+    expect(beforeSave).toHaveBeenCalledTimes(2);
+    expect(firstSave).not.toHaveBeenCalled();
+    expect(secondSave).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a sibling policy denial without waiting for an allowed slow save", async () => {
+    const { page, handlers } = fakePage();
+    ensurePageState(page);
+    const blocked = new Error("blocked sibling download");
+    const beforeSave = vi.fn(async (candidate: { url: string }) => {
+      if (candidate.url.endsWith("/blocked.txt")) {
+        throw blocked;
+      }
+    });
+    const capture = beginActionDownloadCaptureOnPage(page, { beforeSave });
+    let releaseAllowedSave: (() => void) | undefined;
+    const allowedSaveGate = new Promise<void>((resolve) => {
+      releaseAllowedSave = resolve;
+    });
+    const allowedDownload: MutableDownload = {
+      url: () => "https://example.com/allowed.txt",
+      suggestedFilename: () => "allowed.txt",
+      saveAs: vi.fn(async (outPath: string) => {
+        await allowedSaveGate;
+        await fs.writeFile(outPath, "allowed", "utf8");
+      }),
+    };
+    handlers.get("download")?.[0]?.(allowedDownload);
+    setImmediate(() => {
+      handlers.get("download")?.[0]?.({
+        url: () => "https://example.com/blocked.txt",
+        suggestedFilename: () => "blocked.txt",
+        saveAs: vi.fn(async () => {}),
+      });
+    });
+
+    await expect(capture.drain({ quietMs: 100 })).rejects.toBe(blocked);
+    releaseAllowedSave?.();
+    await expect(allowedDownload.path?.()).resolves.toMatch(/-allowed\.txt$/);
+    capture.dispose();
   });
 
   it("surfaces action-owned download save failures without an unhandled rejection", async () => {

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -4,10 +4,9 @@ import path from "node:path";
 import type { Page } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
-import { createDownloadCaptureForPage } from "./pw-download-capture.js";
 import {
+  beginActionDownloadCaptureOnPage,
   ensurePageState,
-  isDownloadStartingNavigationError,
   refLocator,
   rememberRoleRefsForTarget,
   restoreRoleRefsForTarget,
@@ -41,14 +40,6 @@ function fakePage(): {
     handlers.set(event, list);
     return undefined as unknown;
   });
-  const off = vi.fn((event: string, cb: (...args: unknown[]) => void) => {
-    const list = handlers.get(event) ?? [];
-    handlers.set(
-      event,
-      list.filter((handler) => handler !== cb),
-    );
-    return undefined as unknown;
-  });
   const getByRole = vi.fn(() => ({ nth: vi.fn(() => ({ ok: true })) }));
   const frameLocator = vi.fn(() => ({
     getByRole: vi.fn(() => ({ nth: vi.fn(() => ({ ok: true })) })),
@@ -58,7 +49,6 @@ function fakePage(): {
 
   const page = {
     on,
-    off,
     getByRole,
     frameLocator,
     locator,
@@ -250,94 +240,79 @@ describe("pw-session ensurePageState", () => {
     expect(download.saveAs).not.toHaveBeenCalled();
   });
 
-  it("captures navigation downloads under managed paths", async () => {
+  it("captures only downloads owned by an active action", async () => {
     const { page, handlers } = fakePage();
-    const state = ensurePageState(page);
-    const capture = createDownloadCaptureForPage(page, state, 1_000);
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
     const saveAs = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "attachment", "utf8");
+      await fs.writeFile(outPath, "action-download", "utf8");
     });
-    const download = {
-      url: () => "https://example.com/export.csv",
-      suggestedFilename: () => "export.csv",
+    const download: MutableDownload = {
+      suggestedFilename: () => "clicked.txt",
       saveAs,
     };
 
-    for (const handler of handlers.get("download") ?? []) {
-      handler(download);
-    }
+    handlers.get("download")?.[0]?.(download);
+    const result = await capture.drain();
+    capture.dispose();
 
-    const result = await capture.promise;
-    expect(result.url).toBe("https://example.com/export.csv");
-    expect(result.suggestedFilename).toBe("export.csv");
-    expect(path.dirname(result.path)).toBe(DEFAULT_DOWNLOAD_DIR);
-    expect(path.basename(result.path)).toMatch(/-export\.csv$/);
-    expect(firstSavePath(saveAs)).not.toBe(result.path);
-    await expect(fs.readFile(result.path, "utf8")).resolves.toBe("attachment");
+    expect(result).toEqual({
+      count: 1,
+      recent: [
+        {
+          suggestedFilename: "clicked.txt",
+          savedPath: expect.stringMatching(/clicked\.txt$/),
+        },
+      ],
+    });
+    const savedPath = result?.recent[0]?.savedPath ?? "";
+    expect(path.dirname(savedPath)).toBe(DEFAULT_DOWNLOAD_DIR);
+    await expect(fs.readFile(savedPath, "utf8")).resolves.toBe("action-download");
   });
 
-  it("validates captured navigation downloads before saving managed bytes", async () => {
+  it("waits briefly for action downloads that arrive after the action returns", async () => {
     const { page, handlers } = fakePage();
-    const state = ensurePageState(page);
-    const blocked = new Error("blocked download");
-    const beforeSave = vi.fn(async () => {
-      throw blocked;
-    });
-    const capture = createDownloadCaptureForPage(page, state, 1_000, { beforeSave });
+    ensurePageState(page);
+    const capture = beginActionDownloadCaptureOnPage(page);
     const saveAs = vi.fn(async (outPath: string) => {
-      await fs.writeFile(outPath, "blocked", "utf8");
+      await fs.writeFile(outPath, "late-download", "utf8");
     });
-    const download = {
-      url: () => "http://127.0.0.1:18080/export.csv",
-      suggestedFilename: () => "export.csv",
-      saveAs,
-    };
+    const drain = capture.drain({ graceMs: 1000 });
 
-    for (const handler of handlers.get("download") ?? []) {
-      handler(download);
-    }
+    setTimeout(() => {
+      handlers.get("download")?.[0]?.({
+        suggestedFilename: () => "late.txt",
+        saveAs,
+      });
+    }, 0);
 
-    await expect(capture.promise).rejects.toBe(blocked);
-    expect(beforeSave).toHaveBeenCalledWith({
-      url: "http://127.0.0.1:18080/export.csv",
-      suggestedFilename: "export.csv",
-    });
-    expect(saveAs).not.toHaveBeenCalled();
+    const result = await drain;
+    capture.dispose();
+
+    expect(result?.count).toBe(1);
+    expect(result?.recent[0]?.suggestedFilename).toBe("late.txt");
+    await expect(fs.readFile(result?.recent[0]?.savedPath ?? "", "utf8")).resolves.toBe(
+      "late-download",
+    );
   });
 
-  it("lets explicit download owners arm while passive capture yields", () => {
-    const { page } = fakePage();
+  it("does not let action captures steal explicit waiter downloads", async () => {
+    const { page, handlers } = fakePage();
     const state = ensurePageState(page);
     state.downloadWaiterDepth = 1;
+    const capture = beginActionDownloadCaptureOnPage(page);
+    const download = {
+      suggestedFilename: () => "report.pdf",
+      saveAs: vi.fn(async () => {}),
+    };
 
-    const passive = createDownloadCaptureForPage(page, state, 1_000);
-    const explicit = createDownloadCaptureForPage(page, state, 1_000, { mode: "explicit" });
+    handlers.get("download")?.[0]?.(download);
+    const result = await capture.drain();
+    capture.dispose();
 
-    expect(passive.armed).toBe(false);
-    expect(explicit.armed).toBe(true);
-    expect(state.downloadWaiterDepth).toBe(2);
-    explicit.cancel();
-    expect(state.downloadWaiterDepth).toBe(1);
-  });
-
-  it("recognizes Playwright download-starting navigation aborts", () => {
-    expect(isDownloadStartingNavigationError(new Error("page.goto: Download is starting"))).toBe(
-      true,
-    );
-    expect(isDownloadStartingNavigationError(new Error("page.goto: net::ERR_ABORTED"))).toBe(false);
-    expect(
-      isDownloadStartingNavigationError(
-        new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/download"),
-        "http://127.0.0.1:3333/download",
-      ),
-    ).toBe(true);
-    expect(
-      isDownloadStartingNavigationError(
-        new Error("page.goto: net::ERR_ABORTED at http://127.0.0.1:3333/other"),
-        "http://127.0.0.1:3333/download",
-      ),
-    ).toBe(false);
-    expect(isDownloadStartingNavigationError(new Error("Navigation failed"))).toBe(false);
+    expect(result).toBeUndefined();
+    expect(download).not.toHaveProperty("path");
+    expect(download.saveAs).not.toHaveBeenCalled();
   });
 
   it("tracks page errors and network requests (best-effort)", () => {

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -776,22 +776,19 @@ export function ensurePageState(page: Page): PageState {
         return;
       }
       const managedSave = saveUnmanagedDownload(download);
-      const captures = state.actionDownloadCaptures;
-      if (captures.length > 0) {
-        // Push to all active captures so no action loses its
-        // download when concurrent /act calls overlap on the
-        // same page. Each managedSave resolves once (single
-        // file I/O); multiple captures sharing the promise is
-        // safe — extra download info is harmless.
-        for (const capture of captures) {
-          capture.promises.push(managedSave);
-          for (const notify of capture.waiters.splice(0)) {
-            notify();
-          }
-        }
-        return;
-      }
       managedSave.catch(() => {});
+      // Push to all active captures so no action loses its
+      // download when concurrent /act calls overlap on the
+      // same page. Each managedSave resolves once (single
+      // file I/O); multiple captures sharing the promise is
+      // safe — extra download info is harmless.
+      const captures = state.actionDownloadCaptures;
+      for (const capture of captures) {
+        capture.promises.push(managedSave);
+        for (const notify of capture.waiters.splice(0)) {
+          notify();
+        }
+      }
     });
     page.on("close", () => {
       clearArmedDialogResponse(state);

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -776,11 +776,18 @@ export function ensurePageState(page: Page): PageState {
         return;
       }
       const managedSave = saveUnmanagedDownload(download);
-      const capture = state.actionDownloadCaptures.at(-1);
-      if (capture) {
-        capture.promises.push(managedSave);
-        for (const notify of capture.waiters.splice(0)) {
-          notify();
+      const captures = state.actionDownloadCaptures;
+      if (captures.length > 0) {
+        // Push to all active captures so no action loses its
+        // download when concurrent /act calls overlap on the
+        // same page. Each managedSave resolves once (single
+        // file I/O); multiple captures sharing the promise is
+        // safe — extra download info is harmless.
+        for (const capture of captures) {
+          capture.promises.push(managedSave);
+          for (const notify of capture.waiters.splice(0)) {
+            notify();
+          }
         }
         return;
       }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -4,6 +4,8 @@
  * Manages CDP-backed Playwright connections, page lookup, observed dialogs,
  * console/network/page state, role refs, and safe navigation handling.
  */
+import crypto from "node:crypto";
+import path from "node:path";
 import {
   isFutureDateTimestampMs,
   parseFiniteNumber,
@@ -44,11 +46,18 @@ import {
   InvalidBrowserNavigationUrlError,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
+import { writeViaSiblingTempPath } from "./output-atomic.js";
+import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 import { playwrightCore } from "./playwright-core.runtime.js";
-import { saveBrowserDownload, type PlaywrightDownload } from "./pw-download-capture.js";
 import { BROWSER_REF_MARKER_ATTRIBUTE, withPageScopedCdpClient } from "./pw-session.page-cdp.js";
+import { sanitizeUntrustedFileName } from "./safe-filename.js";
 
 const { chromium } = playwrightCore;
+
+export type BrowserActionDownload = {
+  suggestedFilename: string;
+  savedPath: string;
+};
 
 /** Console message captured from a Playwright page. */
 export type BrowserConsoleMessage = {
@@ -141,8 +150,9 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
-type DownloadPayload = PlaywrightDownload & {
-  path?: () => Promise<string>;
+type ActionDownloadCapture = {
+  promises: Array<Promise<BrowserActionDownload>>;
+  waiters: Array<() => void>;
 };
 
 type PageState = {
@@ -154,6 +164,7 @@ type PageState = {
   armIdUpload: number;
   armIdDownload: number;
   downloadWaiterDepth: number;
+  actionDownloadCaptures: ActionDownloadCapture[];
   nextObservedDialogId: number;
   pendingDialogs: PendingObservedDialog[];
   recentDialogs: BrowserObservedDialogRecord[];
@@ -196,13 +207,8 @@ const MAX_NETWORK_REQUESTS = 500;
 const MAX_RECENT_DIALOGS = 20;
 const OBSERVED_DIALOG_TIMEOUT_MS = 120_000;
 
-type PendingBrowserConnection = {
-  attempt: { cancelled: boolean };
-  promise: Promise<ConnectedBrowser>;
-};
-
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
-const connectingByCdpUrl = new Map<string, PendingBrowserConnection>();
+const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
 const blockedTargetsByCdpUrl = new Set<string>();
 const blockedPageRefsByCdpUrl = new Map<string, WeakSet<Page>>();
 let cdpConnectRetryDelayMsForTests: number | undefined;
@@ -225,15 +231,36 @@ function resolveCdpConnectRetryDelayMs(attempt: number): number {
   return cdpConnectRetryDelayMsForTests ?? 250 + attempt * 250;
 }
 
-export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: string): boolean {
-  const message = formatErrorMessage(err).toLowerCase();
-  if (message.includes("download is starting")) {
-    return true;
-  }
-  const normalizedUrl = normalizeOptionalString(expectedUrl)?.toLowerCase();
-  return Boolean(
-    normalizedUrl && message.includes("net::err_aborted") && message.includes(normalizedUrl),
+function buildManagedDownloadPath(fileName: string): string {
+  const id = crypto.randomUUID();
+  const safeName = sanitizeUntrustedFileName(fileName, "download.bin");
+  return path.join(DEFAULT_DOWNLOAD_DIR, `${id}-${safeName}`);
+}
+
+type ManagedDownloadPayload = {
+  suggestedFilename?: () => string;
+  saveAs?: (outPath: string) => Promise<void>;
+  path?: () => Promise<string>;
+};
+
+function saveUnmanagedDownload(download: ManagedDownloadPayload): Promise<BrowserActionDownload> {
+  const suggestedFilename = sanitizeUntrustedFileName(
+    download.suggestedFilename?.() || "download.bin",
+    "download.bin",
   );
+  const managedPath = buildManagedDownloadPath(suggestedFilename);
+  const managedSave = (async () => {
+    await writeViaSiblingTempPath({
+      rootDir: DEFAULT_DOWNLOAD_DIR,
+      targetPath: managedPath,
+      writeTemp: async (tempPath) => {
+        await download.saveAs?.(tempPath);
+      },
+    });
+    return { suggestedFilename, savedPath: managedPath };
+  })();
+  download.path = async () => (await managedSave).savedPath;
+  return managedSave;
 }
 
 function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
@@ -251,6 +278,61 @@ function isRecoverablePlaywrightDisconnectError(err: unknown): boolean {
     message.includes("websocket closed") ||
     message.includes("cdp socket closed")
   );
+}
+
+export function beginActionDownloadCaptureOnPage(page: Page): {
+  drain: (opts?: { graceMs?: number }) => Promise<
+    | {
+        count: number;
+        recent: BrowserActionDownload[];
+      }
+    | undefined
+  >;
+  dispose: () => void;
+} {
+  const state = ensurePageState(page);
+  const capture: ActionDownloadCapture = { promises: [], waiters: [] };
+  state.actionDownloadCaptures.push(capture);
+  let disposed = false;
+
+  const waitForFirstDownload = async (graceMs: number) => {
+    if (capture.promises.length > 0 || graceMs <= 0) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, graceMs);
+      capture.waiters.push(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  };
+
+  return {
+    drain: async (opts = {}) => {
+      await waitForFirstDownload(opts.graceMs ?? 0);
+      const downloads: BrowserActionDownload[] = [];
+      let index = 0;
+      while (index < capture.promises.length) {
+        const pending = capture.promises.slice(index);
+        index = capture.promises.length;
+        downloads.push(...(await Promise.all(pending)));
+      }
+      return downloads.length > 0 ? { count: downloads.length, recent: downloads } : undefined;
+    },
+    dispose: () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      state.actionDownloadCaptures = state.actionDownloadCaptures.filter(
+        (item) => item !== capture,
+      );
+      for (const notify of capture.waiters.splice(0)) {
+        notify();
+      }
+    },
+  };
 }
 
 function isRecoverableStalePageSelectionError(err: unknown, reusedCachedBrowser: boolean): boolean {
@@ -489,12 +571,6 @@ function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser
   const normalized = normalizeCdpUrl(cdpUrl);
   const cur = cachedByCdpUrl.get(normalized);
   cachedByCdpUrl.delete(normalized);
-  const pending = connectingByCdpUrl.get(normalized);
-  if (pending) {
-    // Invalidation must also retire an in-flight connect. Otherwise it can
-    // resolve after cleanup and repopulate the cache with the stale pipe.
-    pending.attempt.cancelled = true;
-  }
   connectingByCdpUrl.delete(normalized);
   if (!cur) {
     return null;
@@ -505,11 +581,7 @@ function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser
   return cur;
 }
 
-function evictStalePlaywrightBrowserConnection(cdpUrl: string, expectedBrowser?: Browser): void {
-  const current = cachedByCdpUrl.get(normalizeCdpUrl(cdpUrl));
-  if (expectedBrowser && current?.browser !== expectedBrowser) {
-    return;
-  }
+function evictStalePlaywrightBrowserConnection(cdpUrl: string): void {
   const cur = takeCachedPlaywrightBrowserConnection(cdpUrl);
   cur?.browser.close().catch(() => {});
 }
@@ -623,6 +695,7 @@ export function ensurePageState(page: Page): PageState {
     armIdUpload: 0,
     armIdDownload: 0,
     downloadWaiterDepth: 0,
+    actionDownloadCaptures: [],
     nextObservedDialogId: 0,
     pendingDialogs: [],
     recentDialogs: [],
@@ -698,13 +771,20 @@ export function ensurePageState(page: Page): PageState {
     page.on("dialog", (dialog: Dialog) => {
       observeDialog(state, dialog);
     });
-    page.on("download", (download: DownloadPayload) => {
+    page.on("download", (download: ManagedDownloadPayload) => {
       if (state.downloadWaiterDepth > 0) {
         return;
       }
-      const managedSave = saveBrowserDownload(download);
+      const managedSave = saveUnmanagedDownload(download);
+      const capture = state.actionDownloadCaptures.at(-1);
+      if (capture) {
+        capture.promises.push(managedSave);
+        for (const notify of capture.waiters.splice(0)) {
+          notify();
+        }
+        return;
+      }
       managedSave.catch(() => {});
-      download.path = async () => (await managedSave).path;
     });
     page.on("close", () => {
       clearArmedDialogResponse(state);
@@ -927,16 +1007,12 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   await assertCdpEndpointAllowed(normalized, ssrfPolicy);
   const connecting = connectingByCdpUrl.get(normalized);
   if (connecting) {
-    return await connecting.promise;
+    return await connecting;
   }
 
-  const connectionAttempt = { cancelled: false };
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      if (connectionAttempt.cancelled) {
-        break;
-      }
       try {
         const timeout = 5000 + attempt * 2000;
         const wsUrl = await getChromeWebSocketUrl(normalized, timeout, ssrfPolicy).catch(
@@ -959,10 +1035,6 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
           }
           browser = await connectEndpoint(normalized);
         }
-        if (connectionAttempt.cancelled) {
-          browser.close().catch(() => {});
-          throw new Error("Playwright connection attempt was superseded.");
-        }
         const onDisconnected = () => {
           const current = cachedByCdpUrl.get(normalized);
           if (current?.browser === browser) {
@@ -976,9 +1048,6 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
         return connected;
       } catch (err) {
         lastErr = err;
-        if (connectionAttempt.cancelled) {
-          break;
-        }
         // Don't retry rate-limit errors; retrying worsens the 429.
         const errMsg = formatErrorMessage(err);
         if (errMsg.includes("rate limit")) {
@@ -998,11 +1067,9 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   };
 
   const pending = connectWithRetry().finally(() => {
-    if (connectingByCdpUrl.get(normalized)?.attempt === connectionAttempt) {
-      connectingByCdpUrl.delete(normalized);
-    }
+    connectingByCdpUrl.delete(normalized);
   });
-  connectingByCdpUrl.set(normalized, { attempt: connectionAttempt, promise: pending });
+  connectingByCdpUrl.set(normalized, pending);
 
   return await pending;
 }
@@ -1506,9 +1573,6 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   }
 
   const connections = Array.from(cachedByCdpUrl.values());
-  for (const pending of connectingByCdpUrl.values()) {
-    pending.attempt.cancelled = true;
-  }
   clearBlockedTargetsForCdpUrl();
   clearBlockedPageRefsForCdpUrl();
   cachedByCdpUrl.clear();
@@ -1616,7 +1680,7 @@ async function tryTerminateExecutionViaCdp(opts: {
  * instance, preventing reconnection.
  *
  * Instead we:
- * 1. Retire the scoped cached or in-flight connection so the next call reconnects
+ * 1. Null out `cached` so the next call triggers a fresh connectOverCDP
  * 2. Fire-and-forget browser.close() — it may hang but won't block us
  * 3. The next connectBrowser() creates a completely new CDP WebSocket connection
  *
@@ -1652,95 +1716,18 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
 }
 
 async function withPlaywrightSafeReadReconnect<T>(
-  opts: {
-    cdpUrl: string;
-    ssrfPolicy?: SsrFPolicy;
-    attempt?: { cancelled: boolean };
-  },
-  run: (browser: Browser) => Promise<T>,
+  cdpUrl: string,
+  run: () => Promise<T>,
 ): Promise<T> {
-  const connected = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
   try {
-    return await run(connected.browser);
+    return await run();
   } catch (err) {
-    if (!isRecoverablePlaywrightDisconnectError(err) || opts.attempt?.cancelled) {
+    if (!isRecoverablePlaywrightDisconnectError(err)) {
       throw err;
     }
-    evictStalePlaywrightBrowserConnection(opts.cdpUrl, connected.browser);
-    if (opts.attempt?.cancelled) {
-      throw err;
-    }
-    const retry = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-    return await run(retry.browser);
+    evictStalePlaywrightBrowserConnection(cdpUrl);
+    return await run();
   }
-}
-
-async function readPagesViaPlaywright(
-  opts: { cdpUrl: string; ssrfPolicy?: SsrFPolicy },
-  attempt?: { cancelled: boolean },
-): Promise<
-  Array<{
-    targetId: string;
-    title: string;
-    url: string;
-    type: string;
-  }>
-> {
-  return await withPlaywrightSafeReadReconnect(
-    { cdpUrl: opts.cdpUrl, ssrfPolicy: opts.ssrfPolicy, attempt },
-    async (browser) => {
-      const pages = await getAllPages(browser);
-      const results: Array<{
-        targetId: string;
-        title: string;
-        url: string;
-        type: string;
-      }> = [];
-
-      for (const page of pages) {
-        if (isBlockedPageRef(opts.cdpUrl, page)) {
-          continue;
-        }
-        let tid: string | null;
-        try {
-          tid = await pageTargetId(page);
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
-          }
-          tid = null;
-        }
-        if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
-          let title = "";
-          try {
-            title = await page.title();
-          } catch (err) {
-            if (isRecoverablePlaywrightDisconnectError(err)) {
-              throw err;
-            }
-          }
-          let url = "";
-          try {
-            url = page.url();
-          } catch (err) {
-            if (isRecoverablePlaywrightDisconnectError(err)) {
-              throw err;
-            }
-          }
-          if (!isSelectableCdpBrowserTarget({ url })) {
-            continue;
-          }
-          results.push({
-            targetId: tid,
-            title,
-            url,
-            type: "page",
-          });
-        }
-      }
-      return results;
-    },
-  );
 }
 
 /**
@@ -1751,43 +1738,67 @@ async function readPagesViaPlaywright(
 export async function listPagesViaPlaywright(opts: {
   cdpUrl: string;
   ssrfPolicy?: SsrFPolicy;
-  timeoutMs?: number;
-}) {
-  const timeoutMs =
-    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
-      ? Math.max(1, Math.floor(opts.timeoutMs))
-      : undefined;
-  if (timeoutMs === undefined) {
-    return await readPagesViaPlaywright(opts);
-  }
+}): Promise<
+  Array<{
+    targetId: string;
+    title: string;
+    url: string;
+    type: string;
+  }>
+> {
+  return await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
+    const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+    const pages = await getAllPages(browser);
+    const results: Array<{
+      targetId: string;
+      title: string;
+      url: string;
+      type: string;
+    }> = [];
 
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let timeoutError: Error | undefined;
-  const attempt = { cancelled: false };
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      attempt.cancelled = true;
-      timeoutError = new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`);
-      reject(timeoutError);
-    }, timeoutMs);
-    timer.unref?.();
+    for (const page of pages) {
+      if (isBlockedPageRef(opts.cdpUrl, page)) {
+        continue;
+      }
+      let tid: string | null;
+      try {
+        tid = await pageTargetId(page);
+      } catch (err) {
+        if (isRecoverablePlaywrightDisconnectError(err)) {
+          throw err;
+        }
+        tid = null;
+      }
+      if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
+        let title = "";
+        try {
+          title = await page.title();
+        } catch (err) {
+          if (isRecoverablePlaywrightDisconnectError(err)) {
+            throw err;
+          }
+        }
+        let url = "";
+        try {
+          url = page.url();
+        } catch (err) {
+          if (isRecoverablePlaywrightDisconnectError(err)) {
+            throw err;
+          }
+        }
+        if (!isSelectableCdpBrowserTarget({ url })) {
+          continue;
+        }
+        results.push({
+          targetId: tid,
+          title,
+          url,
+          type: "page",
+        });
+      }
+    }
+    return results;
   });
-  try {
-    return await Promise.race([readPagesViaPlaywright(opts, attempt), timeout]);
-  } catch (err) {
-    if (err === timeoutError) {
-      await forceDisconnectPlaywrightForTarget({
-        cdpUrl: opts.cdpUrl,
-        ssrfPolicy: opts.ssrfPolicy,
-        reason: "Playwright page enumeration",
-      }).catch(() => {});
-    }
-    throw err;
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
 }
 
 /**

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -152,7 +152,9 @@ type DownloadPayload = PlaywrightDownload & {
 
 type ActionDownloadCapture = {
   beforeSave?: (download: BrowserDownloadCandidate) => Promise<void> | void;
+  lastEventAtMs?: number;
   pending: Array<Promise<BrowserDownloadResult>>;
+  validations: Array<Promise<void>>;
   waiters: Array<() => void>;
 };
 
@@ -255,50 +257,74 @@ export function beginActionDownloadCaptureOnPage(
     beforeSave?: (download: BrowserDownloadCandidate) => Promise<void> | void;
   } = {},
 ): {
-  drain: (opts?: { graceMs?: number }) => Promise<BrowserDownloadResult[] | undefined>;
+  drain: (opts?: {
+    firstEventGraceMs?: number;
+    maxWaitMs?: number;
+    quietMs?: number;
+  }) => Promise<BrowserDownloadResult[] | undefined>;
   dispose: () => void;
 } {
   const state = ensurePageState(page);
   const capture: ActionDownloadCapture = {
     pending: [],
+    validations: [],
     waiters: [],
     ...(opts.beforeSave ? { beforeSave: opts.beforeSave } : {}),
   };
   // One page event belongs to one action. A newer overlapping action owns
   // future events; older captures may still drain saves they already started.
   state.actionDownloadCapture = capture;
+  const detach = () => {
+    if (state.actionDownloadCapture === capture) {
+      state.actionDownloadCapture = undefined;
+    }
+    for (const finish of capture.waiters.splice(0)) {
+      finish();
+    }
+  };
 
   return {
     drain: async (drainOpts = {}) => {
-      const graceMs = Math.max(0, drainOpts.graceMs ?? 0);
-      if (capture.pending.length === 0 && graceMs > 0) {
+      const waitForEvent = async (timeoutMs: number) => {
         await new Promise<void>((resolve) => {
           const finish = () => {
             clearTimeout(timer);
             capture.waiters = capture.waiters.filter((waiter) => waiter !== finish);
             resolve();
           };
-          const timer = setTimeout(finish, graceMs);
+          const timer = setTimeout(finish, timeoutMs);
           capture.waiters.push(finish);
         });
+      };
+      const firstEventGraceMs = Math.max(0, drainOpts.firstEventGraceMs ?? 0);
+      const maxWaitMs = Math.max(0, drainOpts.maxWaitMs ?? Number.POSITIVE_INFINITY);
+      const deadlineAtMs = Date.now() + maxWaitMs;
+      const remainingBudgetMs = () => Math.max(0, deadlineAtMs - Date.now());
+      if (capture.pending.length === 0 && firstEventGraceMs > 0) {
+        await waitForEvent(Math.min(firstEventGraceMs, remainingBudgetMs()));
       }
-      const downloads: BrowserDownloadResult[] = [];
-      let index = 0;
-      while (index < capture.pending.length) {
-        const pending = capture.pending.slice(index);
-        index = capture.pending.length;
-        downloads.push(...(await Promise.all(pending)));
+      const quietMs = Math.max(0, drainOpts.quietMs ?? 0);
+      if (quietMs > 0) {
+        while (capture.lastEventAtMs !== undefined) {
+          const remainingQuietMs = Math.min(
+            quietMs - (Date.now() - capture.lastEventAtMs),
+            remainingBudgetMs(),
+          );
+          if (remainingQuietMs <= 0) {
+            break;
+          }
+          await waitForEvent(remainingQuietMs);
+        }
       }
+      // Establish event ownership before awaiting file I/O. Slow saves must not
+      // hold the action window open and absorb unrelated later downloads.
+      detach();
+      const pending = capture.pending.slice();
+      await Promise.all(capture.validations.slice());
+      const downloads = await Promise.all(pending);
       return downloads.length > 0 ? downloads : undefined;
     },
-    dispose: () => {
-      if (state.actionDownloadCapture === capture) {
-        state.actionDownloadCapture = undefined;
-      }
-      for (const finish of capture.waiters.splice(0)) {
-        finish();
-      }
-    },
+    dispose: detach,
   };
 }
 
@@ -769,12 +795,23 @@ export function ensurePageState(page: Page): PageState {
         return;
       }
       const actionCapture = state.actionDownloadCapture;
-      const captureOptions: BrowserDownloadCaptureOptions | undefined = actionCapture?.beforeSave
-        ? { beforeSave: actionCapture.beforeSave }
-        : undefined;
+      const beforeSave = actionCapture?.beforeSave;
+      const captureOptions: BrowserDownloadCaptureOptions | undefined =
+        actionCapture && beforeSave
+          ? {
+              beforeSave: (candidate) => {
+                const validation = Promise.resolve().then(() => beforeSave(candidate));
+                actionCapture.validations.push(validation);
+                return validation;
+              },
+            }
+          : undefined;
       const managedSave = saveBrowserDownload(download, captureOptions);
       managedSave.catch(() => {});
       download.path = async () => (await managedSave).path;
+      if (actionCapture) {
+        actionCapture.lastEventAtMs = Date.now();
+      }
       actionCapture?.pending.push(managedSave);
       for (const finish of actionCapture?.waiters.splice(0) ?? []) {
         finish();

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -4,8 +4,6 @@
  * Manages CDP-backed Playwright connections, page lookup, observed dialogs,
  * console/network/page state, role refs, and safe navigation handling.
  */
-import crypto from "node:crypto";
-import path from "node:path";
 import {
   isFutureDateTimestampMs,
   parseFiniteNumber,
@@ -37,6 +35,7 @@ import {
 } from "./cdp.helpers.js";
 import { AX_REF_PATTERN, normalizeCdpWsUrl } from "./cdp.js";
 import { getChromeWebSocketUrl } from "./chrome.js";
+import type { BrowserDownloadCandidate, BrowserDownloadResult } from "./download-types.js";
 import { BrowserTabNotFoundError } from "./errors.js";
 import {
   assertBrowserNavigationAllowed,
@@ -46,18 +45,15 @@ import {
   InvalidBrowserNavigationUrlError,
   withBrowserNavigationPolicy,
 } from "./navigation-guard.js";
-import { writeViaSiblingTempPath } from "./output-atomic.js";
-import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 import { playwrightCore } from "./playwright-core.runtime.js";
+import {
+  saveBrowserDownload,
+  type BrowserDownloadCaptureOptions,
+  type PlaywrightDownload,
+} from "./pw-download-capture.js";
 import { BROWSER_REF_MARKER_ATTRIBUTE, withPageScopedCdpClient } from "./pw-session.page-cdp.js";
-import { sanitizeUntrustedFileName } from "./safe-filename.js";
 
 const { chromium } = playwrightCore;
-
-export type BrowserActionDownload = {
-  suggestedFilename: string;
-  savedPath: string;
-};
 
 /** Console message captured from a Playwright page. */
 export type BrowserConsoleMessage = {
@@ -150,8 +146,13 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
+type DownloadPayload = PlaywrightDownload & {
+  path?: () => Promise<string>;
+};
+
 type ActionDownloadCapture = {
-  promises: Array<Promise<BrowserActionDownload>>;
+  beforeSave?: (download: BrowserDownloadCandidate) => Promise<void> | void;
+  pending: Array<Promise<BrowserDownloadResult>>;
   waiters: Array<() => void>;
 };
 
@@ -164,7 +165,7 @@ type PageState = {
   armIdUpload: number;
   armIdDownload: number;
   downloadWaiterDepth: number;
-  actionDownloadCaptures: ActionDownloadCapture[];
+  actionDownloadCapture?: ActionDownloadCapture;
   nextObservedDialogId: number;
   pendingDialogs: PendingObservedDialog[];
   recentDialogs: BrowserObservedDialogRecord[];
@@ -207,8 +208,13 @@ const MAX_NETWORK_REQUESTS = 500;
 const MAX_RECENT_DIALOGS = 20;
 const OBSERVED_DIALOG_TIMEOUT_MS = 120_000;
 
+type PendingBrowserConnection = {
+  attempt: { cancelled: boolean };
+  promise: Promise<ConnectedBrowser>;
+};
+
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
-const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
+const connectingByCdpUrl = new Map<string, PendingBrowserConnection>();
 const blockedTargetsByCdpUrl = new Set<string>();
 const blockedPageRefsByCdpUrl = new Map<string, WeakSet<Page>>();
 let cdpConnectRetryDelayMsForTests: number | undefined;
@@ -231,36 +237,69 @@ function resolveCdpConnectRetryDelayMs(attempt: number): number {
   return cdpConnectRetryDelayMsForTests ?? 250 + attempt * 250;
 }
 
-function buildManagedDownloadPath(fileName: string): string {
-  const id = crypto.randomUUID();
-  const safeName = sanitizeUntrustedFileName(fileName, "download.bin");
-  return path.join(DEFAULT_DOWNLOAD_DIR, `${id}-${safeName}`);
+export function isDownloadStartingNavigationError(err: unknown, expectedUrl?: string): boolean {
+  const message = formatErrorMessage(err).toLowerCase();
+  if (message.includes("download is starting")) {
+    return true;
+  }
+  const normalizedUrl = normalizeOptionalString(expectedUrl)?.toLowerCase();
+  return Boolean(
+    normalizedUrl && message.includes("net::err_aborted") && message.includes(normalizedUrl),
+  );
 }
 
-type ManagedDownloadPayload = {
-  suggestedFilename?: () => string;
-  saveAs?: (outPath: string) => Promise<void>;
-  path?: () => Promise<string>;
-};
+/** Capture downloads started synchronously by one Browser action. */
+export function beginActionDownloadCaptureOnPage(
+  page: Page,
+  opts: {
+    beforeSave?: (download: BrowserDownloadCandidate) => Promise<void> | void;
+  } = {},
+): {
+  drain: (opts?: { graceMs?: number }) => Promise<BrowserDownloadResult[] | undefined>;
+  dispose: () => void;
+} {
+  const state = ensurePageState(page);
+  const capture: ActionDownloadCapture = {
+    pending: [],
+    waiters: [],
+    ...(opts.beforeSave ? { beforeSave: opts.beforeSave } : {}),
+  };
+  // One page event belongs to one action. A newer overlapping action owns
+  // future events; older captures may still drain saves they already started.
+  state.actionDownloadCapture = capture;
 
-function saveUnmanagedDownload(download: ManagedDownloadPayload): Promise<BrowserActionDownload> {
-  const suggestedFilename = sanitizeUntrustedFileName(
-    download.suggestedFilename?.() || "download.bin",
-    "download.bin",
-  );
-  const managedPath = buildManagedDownloadPath(suggestedFilename);
-  const managedSave = (async () => {
-    await writeViaSiblingTempPath({
-      rootDir: DEFAULT_DOWNLOAD_DIR,
-      targetPath: managedPath,
-      writeTemp: async (tempPath) => {
-        await download.saveAs?.(tempPath);
-      },
-    });
-    return { suggestedFilename, savedPath: managedPath };
-  })();
-  download.path = async () => (await managedSave).savedPath;
-  return managedSave;
+  return {
+    drain: async (drainOpts = {}) => {
+      const graceMs = Math.max(0, drainOpts.graceMs ?? 0);
+      if (capture.pending.length === 0 && graceMs > 0) {
+        await new Promise<void>((resolve) => {
+          const finish = () => {
+            clearTimeout(timer);
+            capture.waiters = capture.waiters.filter((waiter) => waiter !== finish);
+            resolve();
+          };
+          const timer = setTimeout(finish, graceMs);
+          capture.waiters.push(finish);
+        });
+      }
+      const downloads: BrowserDownloadResult[] = [];
+      let index = 0;
+      while (index < capture.pending.length) {
+        const pending = capture.pending.slice(index);
+        index = capture.pending.length;
+        downloads.push(...(await Promise.all(pending)));
+      }
+      return downloads.length > 0 ? downloads : undefined;
+    },
+    dispose: () => {
+      if (state.actionDownloadCapture === capture) {
+        state.actionDownloadCapture = undefined;
+      }
+      for (const finish of capture.waiters.splice(0)) {
+        finish();
+      }
+    },
+  };
 }
 
 function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
@@ -278,61 +317,6 @@ function isRecoverablePlaywrightDisconnectError(err: unknown): boolean {
     message.includes("websocket closed") ||
     message.includes("cdp socket closed")
   );
-}
-
-export function beginActionDownloadCaptureOnPage(page: Page): {
-  drain: (opts?: { graceMs?: number }) => Promise<
-    | {
-        count: number;
-        recent: BrowserActionDownload[];
-      }
-    | undefined
-  >;
-  dispose: () => void;
-} {
-  const state = ensurePageState(page);
-  const capture: ActionDownloadCapture = { promises: [], waiters: [] };
-  state.actionDownloadCaptures.push(capture);
-  let disposed = false;
-
-  const waitForFirstDownload = async (graceMs: number) => {
-    if (capture.promises.length > 0 || graceMs <= 0) {
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, graceMs);
-      capture.waiters.push(() => {
-        clearTimeout(timer);
-        resolve();
-      });
-    });
-  };
-
-  return {
-    drain: async (opts = {}) => {
-      await waitForFirstDownload(opts.graceMs ?? 0);
-      const downloads: BrowserActionDownload[] = [];
-      let index = 0;
-      while (index < capture.promises.length) {
-        const pending = capture.promises.slice(index);
-        index = capture.promises.length;
-        downloads.push(...(await Promise.all(pending)));
-      }
-      return downloads.length > 0 ? { count: downloads.length, recent: downloads } : undefined;
-    },
-    dispose: () => {
-      if (disposed) {
-        return;
-      }
-      disposed = true;
-      state.actionDownloadCaptures = state.actionDownloadCaptures.filter(
-        (item) => item !== capture,
-      );
-      for (const notify of capture.waiters.splice(0)) {
-        notify();
-      }
-    },
-  };
 }
 
 function isRecoverableStalePageSelectionError(err: unknown, reusedCachedBrowser: boolean): boolean {
@@ -571,6 +555,12 @@ function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser
   const normalized = normalizeCdpUrl(cdpUrl);
   const cur = cachedByCdpUrl.get(normalized);
   cachedByCdpUrl.delete(normalized);
+  const pending = connectingByCdpUrl.get(normalized);
+  if (pending) {
+    // Invalidation must also retire an in-flight connect. Otherwise it can
+    // resolve after cleanup and repopulate the cache with the stale pipe.
+    pending.attempt.cancelled = true;
+  }
   connectingByCdpUrl.delete(normalized);
   if (!cur) {
     return null;
@@ -581,7 +571,11 @@ function takeCachedPlaywrightBrowserConnection(cdpUrl: string): ConnectedBrowser
   return cur;
 }
 
-function evictStalePlaywrightBrowserConnection(cdpUrl: string): void {
+function evictStalePlaywrightBrowserConnection(cdpUrl: string, expectedBrowser?: Browser): void {
+  const current = cachedByCdpUrl.get(normalizeCdpUrl(cdpUrl));
+  if (expectedBrowser && current?.browser !== expectedBrowser) {
+    return;
+  }
   const cur = takeCachedPlaywrightBrowserConnection(cdpUrl);
   cur?.browser.close().catch(() => {});
 }
@@ -695,7 +689,6 @@ export function ensurePageState(page: Page): PageState {
     armIdUpload: 0,
     armIdDownload: 0,
     downloadWaiterDepth: 0,
-    actionDownloadCaptures: [],
     nextObservedDialogId: 0,
     pendingDialogs: [],
     recentDialogs: [],
@@ -771,23 +764,20 @@ export function ensurePageState(page: Page): PageState {
     page.on("dialog", (dialog: Dialog) => {
       observeDialog(state, dialog);
     });
-    page.on("download", (download: ManagedDownloadPayload) => {
+    page.on("download", (download: DownloadPayload) => {
       if (state.downloadWaiterDepth > 0) {
         return;
       }
-      const managedSave = saveUnmanagedDownload(download);
+      const actionCapture = state.actionDownloadCapture;
+      const captureOptions: BrowserDownloadCaptureOptions | undefined = actionCapture?.beforeSave
+        ? { beforeSave: actionCapture.beforeSave }
+        : undefined;
+      const managedSave = saveBrowserDownload(download, captureOptions);
       managedSave.catch(() => {});
-      // Push to all active captures so no action loses its
-      // download when concurrent /act calls overlap on the
-      // same page. Each managedSave resolves once (single
-      // file I/O); multiple captures sharing the promise is
-      // safe — extra download info is harmless.
-      const captures = state.actionDownloadCaptures;
-      for (const capture of captures) {
-        capture.promises.push(managedSave);
-        for (const notify of capture.waiters.splice(0)) {
-          notify();
-        }
+      download.path = async () => (await managedSave).path;
+      actionCapture?.pending.push(managedSave);
+      for (const finish of actionCapture?.waiters.splice(0) ?? []) {
+        finish();
       }
     });
     page.on("close", () => {
@@ -1011,12 +1001,16 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   await assertCdpEndpointAllowed(normalized, ssrfPolicy);
   const connecting = connectingByCdpUrl.get(normalized);
   if (connecting) {
-    return await connecting;
+    return await connecting.promise;
   }
 
+  const connectionAttempt = { cancelled: false };
   const connectWithRetry = async (): Promise<ConnectedBrowser> => {
     let lastErr: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
+      if (connectionAttempt.cancelled) {
+        break;
+      }
       try {
         const timeout = 5000 + attempt * 2000;
         const wsUrl = await getChromeWebSocketUrl(normalized, timeout, ssrfPolicy).catch(
@@ -1039,6 +1033,10 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
           }
           browser = await connectEndpoint(normalized);
         }
+        if (connectionAttempt.cancelled) {
+          browser.close().catch(() => {});
+          throw new Error("Playwright connection attempt was superseded.");
+        }
         const onDisconnected = () => {
           const current = cachedByCdpUrl.get(normalized);
           if (current?.browser === browser) {
@@ -1052,6 +1050,9 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
         return connected;
       } catch (err) {
         lastErr = err;
+        if (connectionAttempt.cancelled) {
+          break;
+        }
         // Don't retry rate-limit errors; retrying worsens the 429.
         const errMsg = formatErrorMessage(err);
         if (errMsg.includes("rate limit")) {
@@ -1071,9 +1072,11 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   };
 
   const pending = connectWithRetry().finally(() => {
-    connectingByCdpUrl.delete(normalized);
+    if (connectingByCdpUrl.get(normalized)?.attempt === connectionAttempt) {
+      connectingByCdpUrl.delete(normalized);
+    }
   });
-  connectingByCdpUrl.set(normalized, pending);
+  connectingByCdpUrl.set(normalized, { attempt: connectionAttempt, promise: pending });
 
   return await pending;
 }
@@ -1350,7 +1353,7 @@ export function isPolicyDenyNavigationError(err: unknown): boolean {
 // page we have already proven is non-compliant. This is a pure bookkeeping
 // step; it does NOT close the tab. Read-only paths can call this safely on a
 // user-owned tab without losing the user's content.
-async function quarantineBlockedTarget(opts: {
+export async function quarantineBlockedNavigationTarget(opts: {
   cdpUrl: string;
   page: Page;
   targetId?: string;
@@ -1375,7 +1378,7 @@ export async function closeBlockedNavigationTarget(opts: {
   page: Page;
   targetId?: string;
 }): Promise<void> {
-  await quarantineBlockedTarget(opts);
+  await quarantineBlockedNavigationTarget(opts);
   await opts.page.close().catch(() => {});
 }
 
@@ -1404,7 +1407,7 @@ export async function assertPageNavigationCompletedSafely(
     });
   } catch (err) {
     if (isPolicyDenyNavigationError(err)) {
-      await quarantineBlockedTarget({
+      await quarantineBlockedNavigationTarget({
         cdpUrl: opts.cdpUrl,
         page: opts.page,
         targetId: opts.targetId,
@@ -1577,6 +1580,9 @@ export async function closePlaywrightBrowserConnection(opts?: { cdpUrl?: string 
   }
 
   const connections = Array.from(cachedByCdpUrl.values());
+  for (const pending of connectingByCdpUrl.values()) {
+    pending.attempt.cancelled = true;
+  }
   clearBlockedTargetsForCdpUrl();
   clearBlockedPageRefsForCdpUrl();
   cachedByCdpUrl.clear();
@@ -1684,7 +1690,7 @@ async function tryTerminateExecutionViaCdp(opts: {
  * instance, preventing reconnection.
  *
  * Instead we:
- * 1. Null out `cached` so the next call triggers a fresh connectOverCDP
+ * 1. Retire the scoped cached or in-flight connection so the next call reconnects
  * 2. Fire-and-forget browser.close() — it may hang but won't block us
  * 3. The next connectBrowser() creates a completely new CDP WebSocket connection
  *
@@ -1720,18 +1726,95 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
 }
 
 async function withPlaywrightSafeReadReconnect<T>(
-  cdpUrl: string,
-  run: () => Promise<T>,
+  opts: {
+    cdpUrl: string;
+    ssrfPolicy?: SsrFPolicy;
+    attempt?: { cancelled: boolean };
+  },
+  run: (browser: Browser) => Promise<T>,
 ): Promise<T> {
+  const connected = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
   try {
-    return await run();
+    return await run(connected.browser);
   } catch (err) {
-    if (!isRecoverablePlaywrightDisconnectError(err)) {
+    if (!isRecoverablePlaywrightDisconnectError(err) || opts.attempt?.cancelled) {
       throw err;
     }
-    evictStalePlaywrightBrowserConnection(cdpUrl);
-    return await run();
+    evictStalePlaywrightBrowserConnection(opts.cdpUrl, connected.browser);
+    if (opts.attempt?.cancelled) {
+      throw err;
+    }
+    const retry = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+    return await run(retry.browser);
   }
+}
+
+async function readPagesViaPlaywright(
+  opts: { cdpUrl: string; ssrfPolicy?: SsrFPolicy },
+  attempt?: { cancelled: boolean },
+): Promise<
+  Array<{
+    targetId: string;
+    title: string;
+    url: string;
+    type: string;
+  }>
+> {
+  return await withPlaywrightSafeReadReconnect(
+    { cdpUrl: opts.cdpUrl, ssrfPolicy: opts.ssrfPolicy, attempt },
+    async (browser) => {
+      const pages = await getAllPages(browser);
+      const results: Array<{
+        targetId: string;
+        title: string;
+        url: string;
+        type: string;
+      }> = [];
+
+      for (const page of pages) {
+        if (isBlockedPageRef(opts.cdpUrl, page)) {
+          continue;
+        }
+        let tid: string | null;
+        try {
+          tid = await pageTargetId(page);
+        } catch (err) {
+          if (isRecoverablePlaywrightDisconnectError(err)) {
+            throw err;
+          }
+          tid = null;
+        }
+        if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
+          let title = "";
+          try {
+            title = await page.title();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
+          }
+          let url = "";
+          try {
+            url = page.url();
+          } catch (err) {
+            if (isRecoverablePlaywrightDisconnectError(err)) {
+              throw err;
+            }
+          }
+          if (!isSelectableCdpBrowserTarget({ url })) {
+            continue;
+          }
+          results.push({
+            targetId: tid,
+            title,
+            url,
+            type: "page",
+          });
+        }
+      }
+      return results;
+    },
+  );
 }
 
 /**
@@ -1742,67 +1825,43 @@ async function withPlaywrightSafeReadReconnect<T>(
 export async function listPagesViaPlaywright(opts: {
   cdpUrl: string;
   ssrfPolicy?: SsrFPolicy;
-}): Promise<
-  Array<{
-    targetId: string;
-    title: string;
-    url: string;
-    type: string;
-  }>
-> {
-  return await withPlaywrightSafeReadReconnect(opts.cdpUrl, async () => {
-    const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-    const pages = await getAllPages(browser);
-    const results: Array<{
-      targetId: string;
-      title: string;
-      url: string;
-      type: string;
-    }> = [];
+  timeoutMs?: number;
+}) {
+  const timeoutMs =
+    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
+      ? Math.max(1, Math.floor(opts.timeoutMs))
+      : undefined;
+  if (timeoutMs === undefined) {
+    return await readPagesViaPlaywright(opts);
+  }
 
-    for (const page of pages) {
-      if (isBlockedPageRef(opts.cdpUrl, page)) {
-        continue;
-      }
-      let tid: string | null;
-      try {
-        tid = await pageTargetId(page);
-      } catch (err) {
-        if (isRecoverablePlaywrightDisconnectError(err)) {
-          throw err;
-        }
-        tid = null;
-      }
-      if (tid && !isBlockedTarget(opts.cdpUrl, tid)) {
-        let title = "";
-        try {
-          title = await page.title();
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
-          }
-        }
-        let url = "";
-        try {
-          url = page.url();
-        } catch (err) {
-          if (isRecoverablePlaywrightDisconnectError(err)) {
-            throw err;
-          }
-        }
-        if (!isSelectableCdpBrowserTarget({ url })) {
-          continue;
-        }
-        results.push({
-          targetId: tid,
-          title,
-          url,
-          type: "page",
-        });
-      }
-    }
-    return results;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutError: Error | undefined;
+  const attempt = { cancelled: false };
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      attempt.cancelled = true;
+      timeoutError = new Error(`Playwright page enumeration timed out after ${timeoutMs}ms`);
+      reject(timeoutError);
+    }, timeoutMs);
+    timer.unref?.();
   });
+  try {
+    return await Promise.race([readPagesViaPlaywright(opts, attempt), timeout]);
+  } catch (err) {
+    if (err === timeoutError) {
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        reason: "Playwright page enumeration",
+      }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 /**

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -1296,4 +1296,107 @@ describe("pw-tools-core interaction navigation guard", () => {
       vi.useRealTimers();
     }
   });
+
+  it("returns click downloads without adding a second policy grace", async () => {
+    const page = { url: vi.fn(() => "https://example.com") };
+    const click = vi.fn(async () => {});
+    const drain = vi.fn(async () => [
+      {
+        url: "https://example.com/report.pdf",
+        suggestedFilename: "report.pdf",
+        path: "/tmp/openclaw/downloads/report.pdf",
+      },
+    ]);
+    const dispose = vi.fn();
+    getPwToolsCoreSessionMocks().beginActionDownloadCaptureOnPage.mockReturnValueOnce({
+      drain,
+      dispose,
+    });
+    setPwToolsCoreCurrentPage(page);
+    setPwToolsCoreCurrentRefLocator({ click });
+
+    const result = await mod.executeActViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      action: { kind: "click", ref: "1" },
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(result.downloads).toEqual([
+      {
+        url: "https://example.com/report.pdf",
+        suggestedFilename: "report.pdf",
+        path: "/tmp/openclaw/downloads/report.pdf",
+      },
+    ]);
+    expect(drain).toHaveBeenCalledWith({ graceMs: 0 });
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(getPwToolsCoreSessionMocks().beginActionDownloadCaptureOnPage).toHaveBeenCalledWith(
+      page,
+      { beforeSave: expect.any(Function) },
+    );
+  });
+
+  it("quarantines the target without closing it when an action download fails policy", async () => {
+    const page = { url: vi.fn(() => "https://example.com") };
+    const click = vi.fn(async () => {});
+    const blocked = new Error("blocked action download");
+    blocked.name = "InvalidBrowserNavigationUrlError";
+    const dispose = vi.fn();
+    getPwToolsCoreSessionMocks().beginActionDownloadCaptureOnPage.mockReturnValueOnce({
+      drain: vi.fn(async () => {
+        throw blocked;
+      }),
+      dispose,
+    });
+    setPwToolsCoreCurrentPage(page);
+    setPwToolsCoreCurrentRefLocator({ click });
+
+    await expect(
+      mod.executeActViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        action: { kind: "click", ref: "1" },
+      }),
+    ).rejects.toBe(blocked);
+
+    expect(getPwToolsCoreSessionMocks().quarantineBlockedNavigationTarget).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      targetId: "T1",
+    });
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("captures key-triggered downloads with a bounded event grace", async () => {
+    const page = {
+      keyboard: { press: vi.fn(async () => {}) },
+      url: vi.fn(() => "https://example.com"),
+    };
+    const drain = vi.fn(async () => [
+      {
+        url: "https://example.com/report.pdf",
+        suggestedFilename: "report.pdf",
+        path: "/tmp/openclaw/downloads/report.pdf",
+      },
+    ]);
+    const dispose = vi.fn();
+    getPwToolsCoreSessionMocks().beginActionDownloadCaptureOnPage.mockReturnValueOnce({
+      drain,
+      dispose,
+    });
+    setPwToolsCoreCurrentPage(page);
+
+    const result = await mod.executeActViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      action: { kind: "press", key: "Enter" },
+    });
+
+    expect(result.downloads).toEqual([
+      expect.objectContaining({ suggestedFilename: "report.pdf" }),
+    ]);
+    expect(drain).toHaveBeenCalledWith({ graceMs: 250 });
+    expect(dispose).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -1329,7 +1329,11 @@ describe("pw-tools-core interaction navigation guard", () => {
         path: "/tmp/openclaw/downloads/report.pdf",
       },
     ]);
-    expect(drain).toHaveBeenCalledWith({ graceMs: 0 });
+    expect(drain).toHaveBeenCalledWith({
+      firstEventGraceMs: 0,
+      maxWaitMs: 1_000,
+      quietMs: 250,
+    });
     expect(dispose).toHaveBeenCalledOnce();
     expect(getPwToolsCoreSessionMocks().beginActionDownloadCaptureOnPage).toHaveBeenCalledWith(
       page,
@@ -1396,7 +1400,11 @@ describe("pw-tools-core interaction navigation guard", () => {
     expect(result.downloads).toEqual([
       expect.objectContaining({ suggestedFilename: "report.pdf" }),
     ]);
-    expect(drain).toHaveBeenCalledWith({ graceMs: 250 });
+    expect(drain).toHaveBeenCalledWith({
+      firstEventGraceMs: 250,
+      maxWaitMs: 1_000,
+      quietMs: 250,
+    });
     expect(dispose).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1764,7 +1764,9 @@ export async function executeActViaPlaywright(opts: {
 
 /** Wait for any in-flight auto-save downloads to finish before sampling. */
 async function drainPendingDownloadSaves(state: ReturnType<typeof ensurePageState>): Promise<void> {
-  if (state.downloadSavePromises.length === 0) return;
+  if (state.downloadSavePromises.length === 0) {
+    return;
+  }
   await Promise.all(state.downloadSavePromises);
   state.downloadSavePromises = [];
 }
@@ -1775,7 +1777,9 @@ function pickNewDownloads(
   seqBefore: number,
 ): { count: number; recent: Array<{ suggestedFilename: string; savedPath: string }> } | undefined {
   const newDownloads = state.recentDownloads.filter((d) => d.seq > seqBefore);
-  if (newDownloads.length === 0) return undefined;
+  if (newDownloads.length === 0) {
+    return undefined;
+  }
   return {
     count: newDownloads.length,
     recent: newDownloads.map((d) => ({

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -25,7 +25,9 @@ import {
 import { resolveStrictExistingUploadPaths } from "./paths.js";
 import {
   assertPageNavigationCompletedSafely,
+  beginActionDownloadCaptureOnPage,
   createObservedDialogAbortSignalForPage,
+  type BrowserActionDownload,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
@@ -57,6 +59,7 @@ type TargetOpts = {
 };
 
 const INTERACTION_NAVIGATION_GRACE_MS = 250;
+const ACT_DOWNLOAD_GRACE_MS = 500;
 
 type NavigationObservablePage = Pick<Page, "url"> & {
   mainFrame?: () => Frame;
@@ -1691,6 +1694,18 @@ async function executeSingleAction(
   return undefined;
 }
 
+function actionDownloadGraceMs(action: BrowserActRequest): number {
+  switch (action.kind) {
+    case "batch":
+    case "click":
+    case "clickCoords":
+    case "evaluate":
+      return ACT_DOWNLOAD_GRACE_MS;
+    default:
+      return 0;
+  }
+}
+
 /** Executes one high-level browser act request with bounded recursive actions. */
 export async function executeActViaPlaywright(opts: {
   cdpUrl: string;
@@ -1704,17 +1719,15 @@ export async function executeActViaPlaywright(opts: {
   results?: Array<{ ok: boolean; error?: string }>;
   blockedByDialog?: boolean;
   browserState?: unknown;
-  downloads?: { count: number; recent: Array<{ suggestedFilename: string; savedPath: string }> };
+  downloads?: { count: number; recent: BrowserActionDownload[] };
 }> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
     ssrfPolicy: opts.ssrfPolicy,
   });
-  const state = ensurePageState(page);
-  // Monotonic cursor — not bounded-list length — so we don't miss downloads
-  // when the buffer is full and shift() cancels out push().
-  const downloadSeqBefore = state.downloadSeq;
+  const downloadCapture = beginActionDownloadCaptureOnPage(page);
+  const downloadGraceMs = actionDownloadGraceMs(opts.action);
   const dialogAbort = createObservedDialogAbortSignalForPage({
     page,
     parentSignal: opts.signal,
@@ -1730,8 +1743,7 @@ export async function executeActViaPlaywright(opts: {
         evaluateEnabled: opts.evaluateEnabled,
         signal: dialogAbort.signal,
       });
-      await drainPendingDownloadSaves(state);
-      const newDownloads = pickNewDownloads(state, downloadSeqBefore);
+      const newDownloads = await downloadCapture.drain({ graceMs: downloadGraceMs });
       return {
         results: batch.results,
         ...(newDownloads ? { downloads: newDownloads } : {}),
@@ -1746,8 +1758,7 @@ export async function executeActViaPlaywright(opts: {
       0,
       dialogAbort.signal,
     );
-    await drainPendingDownloadSaves(state);
-    const newDownloads = pickNewDownloads(state, downloadSeqBefore);
+    const newDownloads = await downloadCapture.drain({ graceMs: downloadGraceMs });
     if (opts.action.kind === "evaluate") {
       return { result, ...(newDownloads ? { downloads: newDownloads } : {}) };
     }
@@ -1758,35 +1769,9 @@ export async function executeActViaPlaywright(opts: {
     }
     throw err;
   } finally {
+    downloadCapture.dispose();
     dialogAbort.cleanup();
   }
-}
-
-/** Wait for any in-flight auto-save downloads to finish before sampling. */
-async function drainPendingDownloadSaves(state: ReturnType<typeof ensurePageState>): Promise<void> {
-  if (state.downloadSavePromises.length === 0) {
-    return;
-  }
-  await Promise.all(state.downloadSavePromises);
-  state.downloadSavePromises = [];
-}
-
-/** Collect downloads with seq > cursor, or undefined if none. */
-function pickNewDownloads(
-  state: ReturnType<typeof ensurePageState>,
-  seqBefore: number,
-): { count: number; recent: Array<{ suggestedFilename: string; savedPath: string }> } | undefined {
-  const newDownloads = state.recentDownloads.filter((d) => d.seq > seqBefore);
-  if (newDownloads.length === 0) {
-    return undefined;
-  }
-  return {
-    count: newDownloads.length,
-    recent: newDownloads.map((d) => ({
-      suggestedFilename: d.suggestedFilename,
-      savedPath: d.savedPath,
-    })),
-  };
 }
 
 /** Executes a bounded sequence of browser actions and returns per-step results. */

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1704,12 +1704,17 @@ export async function executeActViaPlaywright(opts: {
   results?: Array<{ ok: boolean; error?: string }>;
   blockedByDialog?: boolean;
   browserState?: unknown;
+  downloads?: { count: number; recent: Array<{ suggestedFilename: string; savedPath: string }> };
 }> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
     ssrfPolicy: opts.ssrfPolicy,
   });
+  const state = ensurePageState(page);
+  // Monotonic cursor — not bounded-list length — so we don't miss downloads
+  // when the buffer is full and shift() cancels out push().
+  const downloadSeqBefore = state.downloadSeq;
   const dialogAbort = createObservedDialogAbortSignalForPage({
     page,
     parentSignal: opts.signal,
@@ -1725,7 +1730,12 @@ export async function executeActViaPlaywright(opts: {
         evaluateEnabled: opts.evaluateEnabled,
         signal: dialogAbort.signal,
       });
-      return { results: batch.results };
+      await drainPendingDownloadSaves(state);
+      const newDownloads = pickNewDownloads(state, downloadSeqBefore);
+      return {
+        results: batch.results,
+        ...(newDownloads ? { downloads: newDownloads } : {}),
+      };
     }
     const result = await executeSingleAction(
       opts.action,
@@ -1736,10 +1746,12 @@ export async function executeActViaPlaywright(opts: {
       0,
       dialogAbort.signal,
     );
+    await drainPendingDownloadSaves(state);
+    const newDownloads = pickNewDownloads(state, downloadSeqBefore);
     if (opts.action.kind === "evaluate") {
-      return { result };
+      return { result, ...(newDownloads ? { downloads: newDownloads } : {}) };
     }
-    return {};
+    return newDownloads ? { downloads: newDownloads } : {};
   } catch (err) {
     if (isBrowserObservedDialogBlockedError(err)) {
       return { blockedByDialog: true, browserState: err.browserState };
@@ -1748,6 +1760,29 @@ export async function executeActViaPlaywright(opts: {
   } finally {
     dialogAbort.cleanup();
   }
+}
+
+/** Wait for any in-flight auto-save downloads to finish before sampling. */
+async function drainPendingDownloadSaves(state: ReturnType<typeof ensurePageState>): Promise<void> {
+  if (state.downloadSavePromises.length === 0) return;
+  await Promise.all(state.downloadSavePromises);
+  state.downloadSavePromises = [];
+}
+
+/** Collect downloads with seq > cursor, or undefined if none. */
+function pickNewDownloads(
+  state: ReturnType<typeof ensurePageState>,
+  seqBefore: number,
+): { count: number; recent: Array<{ suggestedFilename: string; savedPath: string }> } | undefined {
+  const newDownloads = state.recentDownloads.filter((d) => d.seq > seqBefore);
+  if (newDownloads.length === 0) return undefined;
+  return {
+    count: newDownloads.length,
+    recent: newDownloads.map((d) => ({
+      suggestedFilename: d.suggestedFilename,
+      savedPath: d.savedPath,
+    })),
+  };
 }
 
 /** Executes a bounded sequence of browser actions and returns per-step results. */

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -61,6 +61,7 @@ type TargetOpts = {
 };
 
 const INTERACTION_NAVIGATION_GRACE_MS = 250;
+const ACT_DOWNLOAD_MAX_DRAIN_MS = 1_000;
 
 type NavigationObservablePage = Pick<Page, "url"> & {
   mainFrame?: () => Frame;
@@ -1755,7 +1756,12 @@ export async function executeActViaPlaywright(opts: {
   const downloadGraceMs = actionNeedsStandaloneDownloadGrace(opts.action, opts.ssrfPolicy)
     ? INTERACTION_NAVIGATION_GRACE_MS
     : 0;
-  const drainDownloads = async () => await downloadCapture.drain({ graceMs: downloadGraceMs });
+  const drainDownloads = async () =>
+    await downloadCapture.drain({
+      firstEventGraceMs: downloadGraceMs,
+      maxWaitMs: ACT_DOWNLOAD_MAX_DRAIN_MS,
+      quietMs: INTERACTION_NAVIGATION_GRACE_MS,
+    });
   const dialogAbort = createObservedDialogAbortSignalForPage({
     page,
     parentSignal: opts.signal,

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -16,6 +16,7 @@ import {
   resolveActWaitTimeoutMs,
 } from "./act-policy.js";
 import type { BrowserActRequest, BrowserFormField } from "./client-actions.types.js";
+import type { BrowserDownloadResult } from "./download-types.js";
 import { normalizeBrowserEvaluateFunctionSource } from "./evaluate-source.js";
 import { DEFAULT_FILL_FIELD_TYPE } from "./form-fields.js";
 import {
@@ -27,12 +28,13 @@ import {
   assertPageNavigationCompletedSafely,
   beginActionDownloadCaptureOnPage,
   createObservedDialogAbortSignalForPage,
-  type BrowserActionDownload,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
   isBrowserObservedDialogBlockedError,
+  isPolicyDenyNavigationError,
   markObservedDialogsHandledRemotelyForPage,
+  quarantineBlockedNavigationTarget,
   refLocator,
   restoreRoleRefsForTarget,
 } from "./pw-session.js";
@@ -59,7 +61,6 @@ type TargetOpts = {
 };
 
 const INTERACTION_NAVIGATION_GRACE_MS = 250;
-const ACT_DOWNLOAD_GRACE_MS = 500;
 
 type NavigationObservablePage = Pick<Page, "url"> & {
   mainFrame?: () => Frame;
@@ -1694,15 +1695,27 @@ async function executeSingleAction(
   return undefined;
 }
 
-function actionDownloadGraceMs(action: BrowserActRequest): number {
+function actionNeedsStandaloneDownloadGrace(
+  action: BrowserActRequest,
+  ssrfPolicy?: SsrFPolicy,
+): boolean {
   switch (action.kind) {
+    case "close":
+    case "resize":
+    case "wait":
+      return false;
+    case "hover":
+    case "scrollIntoView":
+    case "drag":
+      return true;
     case "batch":
-    case "click":
-    case "clickCoords":
-    case "evaluate":
-      return ACT_DOWNLOAD_GRACE_MS;
+      return action.actions.some((nested) =>
+        actionNeedsStandaloneDownloadGrace(nested, ssrfPolicy),
+      );
     default:
-      return 0;
+      // Navigation-aware interactions already hold a 250 ms event window when
+      // policy is active. Policy-free internal callers need that window here.
+      return !ssrfPolicy;
   }
 }
 
@@ -1719,15 +1732,30 @@ export async function executeActViaPlaywright(opts: {
   results?: Array<{ ok: boolean; error?: string }>;
   blockedByDialog?: boolean;
   browserState?: unknown;
-  downloads?: { count: number; recent: BrowserActionDownload[] };
+  downloads?: BrowserDownloadResult[];
 }> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
     ssrfPolicy: opts.ssrfPolicy,
   });
-  const downloadCapture = beginActionDownloadCaptureOnPage(page);
-  const downloadGraceMs = actionDownloadGraceMs(opts.action);
+  // Any DOM action can synchronously trigger a download. Capturing all actions
+  // keeps reporting and final-URL policy aligned with the actual file write.
+  const downloadCapture = beginActionDownloadCaptureOnPage(page, {
+    beforeSave: async (download) => {
+      if (!download.url) {
+        throw new Error("Action download URL is unavailable");
+      }
+      await assertBrowserNavigationResultAllowed({
+        url: download.url,
+        ...withBrowserNavigationPolicy(opts.ssrfPolicy),
+      });
+    },
+  });
+  const downloadGraceMs = actionNeedsStandaloneDownloadGrace(opts.action, opts.ssrfPolicy)
+    ? INTERACTION_NAVIGATION_GRACE_MS
+    : 0;
+  const drainDownloads = async () => await downloadCapture.drain({ graceMs: downloadGraceMs });
   const dialogAbort = createObservedDialogAbortSignalForPage({
     page,
     parentSignal: opts.signal,
@@ -1743,7 +1771,7 @@ export async function executeActViaPlaywright(opts: {
         evaluateEnabled: opts.evaluateEnabled,
         signal: dialogAbort.signal,
       });
-      const newDownloads = await downloadCapture.drain({ graceMs: downloadGraceMs });
+      const newDownloads = await drainDownloads();
       return {
         results: batch.results,
         ...(newDownloads ? { downloads: newDownloads } : {}),
@@ -1758,16 +1786,31 @@ export async function executeActViaPlaywright(opts: {
       0,
       dialogAbort.signal,
     );
-    const newDownloads = await downloadCapture.drain({ graceMs: downloadGraceMs });
+    const newDownloads = await drainDownloads();
     if (opts.action.kind === "evaluate") {
       return { result, ...(newDownloads ? { downloads: newDownloads } : {}) };
     }
     return newDownloads ? { downloads: newDownloads } : {};
   } catch (err) {
-    if (isBrowserObservedDialogBlockedError(err)) {
-      return { blockedByDialog: true, browserState: err.browserState };
+    let failure = err;
+    try {
+      await drainDownloads();
+    } catch (downloadErr) {
+      // A download policy/save failure is the action's network-to-file result;
+      // preserve it even when the initiating interaction also failed.
+      failure = downloadErr;
     }
-    throw err;
+    if (isBrowserObservedDialogBlockedError(failure)) {
+      return { blockedByDialog: true, browserState: failure.browserState };
+    }
+    if (isPolicyDenyNavigationError(failure)) {
+      await quarantineBlockedNavigationTarget({
+        cdpUrl: opts.cdpUrl,
+        page,
+        targetId: opts.targetId,
+      });
+    }
+    throw failure;
   } finally {
     downloadCapture.dispose();
     dialogAbort.cleanup();

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -34,6 +34,10 @@ let pageState: {
 
 const sessionMocks = vi.hoisted(() => ({
   assertPageNavigationCompletedSafely: vi.fn(async () => {}),
+  beginActionDownloadCaptureOnPage: vi.fn(() => ({
+    drain: vi.fn(async () => undefined),
+    dispose: vi.fn(() => {}),
+  })),
   closeBlockedNavigationTarget: vi.fn(async () => {}),
   getPageForTargetId: vi.fn(async () => {
     if (!currentPage) {

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -74,6 +74,7 @@ const sessionMocks = vi.hoisted(() => ({
     }
     return err.name === "SsrFBlockedError" || err.name === "InvalidBrowserNavigationUrlError";
   }),
+  quarantineBlockedNavigationTarget: vi.fn(async () => {}),
   restoreRoleRefsForTarget: vi.fn(() => {}),
   respondToObservedDialogOnPage: vi.fn(async () => {
     throw new Error("No dialog is pending.");

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -35,7 +35,7 @@ let pageState: {
 const sessionMocks = vi.hoisted(() => ({
   assertPageNavigationCompletedSafely: vi.fn(async () => {}),
   beginActionDownloadCaptureOnPage: vi.fn(() => ({
-    drain: vi.fn(async () => undefined),
+    drain: vi.fn(async (): Promise<HarnessManagedDownload[] | undefined> => undefined),
     dispose: vi.fn(() => {}),
   })),
   closeBlockedNavigationTarget: vi.fn(async () => {}),

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -691,7 +691,7 @@ export function registerBrowserAgentActRoutes(
                 resolveCurrentTarget: true,
               });
             case "resize":
-              return await jsonOk();
+              return await jsonOk(downloads ? { downloads } : undefined);
             default:
               return await jsonOk(downloads ? { downloads } : undefined, {
                 resolveCurrentTarget: true,

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -673,21 +673,29 @@ export function registerBrowserAgentActRoutes(
               browserState: result.browserState,
             });
           }
+          const downloads = result.downloads;
           switch (action.kind) {
             case "batch":
               return await jsonOk(
-                { results: result.results ?? [] },
+                { results: result.results ?? [], ...(downloads ? { downloads } : {}) },
                 { resolveCurrentTarget: true },
               );
             case "evaluate":
-              return await jsonOk({ result: result.result }, { resolveCurrentTarget: true });
+              return await jsonOk(
+                { result: result.result, ...(downloads ? { downloads } : {}) },
+                { resolveCurrentTarget: true },
+              );
             case "click":
             case "clickCoords":
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
+              return await jsonOk(downloads ? { downloads } : undefined, {
+                resolveCurrentTarget: true,
+              });
             case "resize":
               return await jsonOk();
             default:
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
+              return await jsonOk(downloads ? { downloads } : undefined, {
+                resolveCurrentTarget: true,
+              });
           }
         },
       });

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -318,38 +318,31 @@ describe("browser control server", () => {
     async () => {
       const base = await startServerAndBase();
       pwMocks.executeActViaPlaywright.mockResolvedValueOnce({
-        downloads: {
-          count: 1,
-          recent: [
-            {
-              suggestedFilename: "report.pdf",
-              savedPath: "/tmp/openclaw/downloads/report.pdf",
-            },
-          ],
-        },
+        downloads: [
+          {
+            url: "https://example.com/report.pdf",
+            suggestedFilename: "report.pdf",
+            path: "/tmp/openclaw/downloads/report.pdf",
+          },
+        ],
       });
 
       const response = await postJson<{
         ok: boolean;
-        downloads?: {
-          count: number;
-          recent: Array<{ suggestedFilename?: string; savedPath?: string }>;
-        };
+        downloads?: Array<{ url?: string; suggestedFilename?: string; path?: string }>;
       }>(`${base}/act`, {
         kind: "click",
         ref: "5",
       });
 
       expect(response.ok).toBe(true);
-      expect(response.downloads).toEqual({
-        count: 1,
-        recent: [
-          {
-            suggestedFilename: "report.pdf",
-            savedPath: "/tmp/openclaw/downloads/report.pdf",
-          },
-        ],
-      });
+      expect(response.downloads).toEqual([
+        {
+          url: "https://example.com/report.pdf",
+          suggestedFilename: "report.pdf",
+          path: "/tmp/openclaw/downloads/report.pdf",
+        },
+      ]);
     },
     slowTimeoutMs,
   );

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -314,6 +314,47 @@ describe("browser control server", () => {
   );
 
   it(
+    "returns action download metadata from /act responses",
+    async () => {
+      const base = await startServerAndBase();
+      pwMocks.executeActViaPlaywright.mockResolvedValueOnce({
+        downloads: {
+          count: 1,
+          recent: [
+            {
+              suggestedFilename: "report.pdf",
+              savedPath: "/tmp/openclaw/downloads/report.pdf",
+            },
+          ],
+        },
+      });
+
+      const response = await postJson<{
+        ok: boolean;
+        downloads?: {
+          count: number;
+          recent: Array<{ suggestedFilename?: string; savedPath?: string }>;
+        };
+      }>(`${base}/act`, {
+        kind: "click",
+        ref: "5",
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.downloads).toEqual({
+        count: 1,
+        recent: [
+          {
+            suggestedFilename: "report.pdf",
+            savedPath: "/tmp/openclaw/downloads/report.pdf",
+          },
+        ],
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
     "returns ACT_SELECTOR_UNSUPPORTED for selector on unsupported action kinds",
     async () => {
       const base = await startServerAndBase();


### PR DESCRIPTION
## What Problem This Solves

When a browser `/act` action triggers a file download, OpenClaw already saves the unmanaged Playwright download, but the agent-visible `/act` response did not include the downloaded filename or saved path.

That meant an agent could successfully trigger a download, receive only a generic success response, and then retry because it had no completion/path feedback for the saved file.

Fixes #93250

## Why This Change Was Made

This change adds action-scoped download capture around Playwright-backed `/act` execution and returns optional `downloads` metadata in the `/act` JSON response.

The response includes the saved path and suggested filename for downloads observed during click, coordinate click, batch, and evaluate actions. The `downloads` payload is page-level observation metadata for the action window, not an exclusive ownership claim: overlapping `/act` calls on the same page may receive the same saved download so the browser event is not silently dropped.

## User Impact

Agents can now see that a browser-triggered download completed, including where the file was saved, and avoid retrying an action that already produced the expected file.

Existing `/act` responses remain compatible: the `downloads` field is optional and only appears when a download is captured.

## Evidence

Live click-triggered `/act` proof on macOS, Node.js v26.0.0, Chrome 149.0.7827.197:

```bash
$ curl --noproxy '*' -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:53558/
HTTP 200

$ curl --noproxy '*' -s http://127.0.0.1:53559/json/version | node -e "..."
Chrome/149.0.7827.197

$ node click-act-proof.mts
POST /act { kind: 'click', selector: '#download' }

POST /act RESPONSE (agent-visible JSON)
{
  "downloads": {
    "count": 1,
    "recent": [
      {
        "suggestedFilename": "act-click-proof-download.txt",
        "savedPath": "/tmp/openclaw/downloads/8a8d3c2f-3b69-4b8f-aa74-ad75f8d441e3-act-click-proof-download.txt"
      }
    ]
  }
}

$ node -e "const fs=require('fs'); const p='/tmp/openclaw/downloads/8a8d3c2f-3b69-4b8f-aa74-ad75f8d441e3-act-click-proof-download.txt'; console.log('exists:', fs.existsSync(p), 'content:', fs.readFileSync(p, 'utf8').trim())"
exists: true content: OpenClaw /act click download proof - PR 93307
```

Focused tests:

```bash
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts browser/src/browser/pw-session.test.ts

 Test Files  1 passed (1)
      Tests  21 passed (21)
```

Includes overlap contract coverage: `broadcasts downloads to all active captures to prevent misattribution`.

```bash
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts browser/src/browser/server.agent-contract-core.test.ts

 Test Files  1 passed (1)
      Tests  20 passed (20)
```

AI-assisted: built with Codex
