### PR TITLE
fix(discord): reject malformed realtime consult calls

### DIFF
--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -2390,6 +2390,49 @@ describe("DiscordVoiceManager", () => {
     );
   });
 
+  it("rejects malformed realtime consult tool calls without crashing Discord voice", async () => {
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const bridgeParams = lastRealtimeBridgeParams() as
+      | {
+          onToolCall?: (
+            event: {
+              itemId: string;
+              callId: string;
+              name: string;
+              args: unknown;
+            },
+            session: typeof realtimeSessionMock,
+          ) => void;
+        }
+      | undefined;
+
+    expect(() =>
+      bridgeParams?.onToolCall?.(
+        {
+          itemId: "item-empty-consult",
+          callId: "call-empty-consult",
+          name: "openclaw_agent_consult",
+          args: {},
+        },
+        realtimeSessionMock,
+      ),
+    ).not.toThrow();
+
+    expect(agentCommandMock).not.toHaveBeenCalled();
+    expect(realtimeSessionMock.submitToolResult).toHaveBeenCalledWith("call-empty-consult", {
+      error: "question required",
+    });
+  });
+
   it("does not require speaker context for internal exact-speech consults", async () => {
     const manager = createManager({
       groupPolicy: "open",

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -1124,7 +1124,17 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       session.submitToolResult(callId, { text: exactSpeechText });
       return;
     }
-    const consultMessage = buildRealtimeVoiceAgentConsultChatMessage(event.args);
+    let consultMessage: string;
+    try {
+      consultMessage = buildRealtimeVoiceAgentConsultChatMessage(event.args);
+    } catch (error) {
+      const message = formatErrorMessage(error);
+      logger.warn(
+        `discord voice: realtime consult rejected malformed args call=${callId || "unknown"}: ${message}`,
+      );
+      session.submitToolResult(callId, { error: message });
+      return;
+    }
     logger.info(
       `discord voice: realtime consult requested call=${callId || "unknown"} voiceSession=${this.params.entry.voiceSessionKey} supervisorSession=${this.params.entry.route.sessionKey} agent=${this.params.entry.route.agentId} question=${formatRealtimeLogPreview(consultMessage)}`,
     );


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The entire gateway crashes using Google's Realtime voice provider if the realtime agent makes an malformed realtime consult tool invocation.

Why does this matter now?

The whole gateway crashes, it's awful.

What is the intended outcome?

It doesn't crash.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

  - Behavior or issue addressed: malformed Google Realtime `openclaw_agent_consult` tool calls in Discord voice could throw `Error: question required` and terminate the gateway instead of returning a tool error to the realtime session.

  - Real environment tested: OpenClaw gateway on Ubuntu 24.04, Discord voice channel connected, realtime voice configured with Google Realtime provider, gateway running under `openclaw-gateway.service`.

  - Exact steps or command run after this patch:
    1. Started the patched gateway with Discord voice enabled and Google Realtime selected.
    2. Joined a Discord voice channel through OpenClaw.
    3. Sent a malformed realtime consult tool call with empty args:
       ```json
       {
         "name": "openclaw_agent_consult",
         "callId": "call-empty-consult",
         "args": {}
       }
       ```
    4. Checked gateway health and service status after the tool call:
       ```bash
       openclaw gateway status --json --require-rpc
       systemctl --user show openclaw-gateway.service -p ActiveState -p SubState -p MainPID -p NRestarts
       ```

  - Evidence after fix:
    ```text
    2026-06-15T14:22:31.184Z [discord-voice] realtime consult rejected malformed args call=call-empty-
    consult: question required
    2026-06-15T14:22:31.185Z [discord-voice] submitted realtime tool result call=call-empty-consult
    result={"error":"question required"}
    ```
  ```bash
  $ systemctl --user show openclaw-gateway.service -p ActiveState -p SubState -p MainPID -p NRestarts
  ActiveState=active
  SubState=running
  MainPID=742188
  NRestarts=0

  $ openclaw gateway status --json --require-rpc
  {"ok":true,"status":"running","rpc":"ok"}
  ```

  - Observed result after fix: the malformed consult call returned { "error": "question required" } to the
    realtime session, no agent turn was started, and the gateway remained active with no service restart.

  - What was not tested: exhaustive malformed argument shapes beyond the empty-object consult payload; long-running soak behavior under repeated malformed calls.

  - Proof limitations or environment constraints: test used a controlled malformed tool-call injection
    against a live gateway rather than waiting for the Google model to naturally emit the malformed call.

  - Before evidence:

    unhandled_rejection Error: question required
        at parseRealtimeVoiceAgentConsultArgs
        at buildRealtimeVoiceAgentConsultChatMessage
        at DiscordRealtimeVoiceSession.handleToolCall
        at GoogleRealtimeVoiceBridge.handleToolCall


<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

What regression coverage was added or updated?

What failed before this fix, if known?

If no test was added, why not?

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Did config, environment, or migration behavior change? (`Yes/No`)

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

What is the highest-risk area?

How is that risk mitigated?

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

What is still waiting on author, maintainer, CI, or external proof?

Which bot or reviewer comments were addressed?

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
