### PR TITLE
fix(skills): preserve ClawHub origin provenance on readback

### DIFF
--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -1401,7 +1401,7 @@ describe("ClawHub origin provenance readback", () => {
     return skillDir;
   }
 
-  it("restores artifact, skillFile, and sourceUrl persisted to origin.json", async () => {
+  it("restores matching provenance and rejects one-sided origin edits", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-origin-prov-"));
     try {
       const artifact = {
@@ -1411,15 +1411,24 @@ describe("ClawHub origin provenance readback", () => {
       };
       const skillFile = { path: "SKILL.md", sha256: "b".repeat(64) };
       const sourceUrl = "https://github.com/acme/skills/tree/abc/agentreceipt";
+      const origin = {
+        version: 1,
+        registry: "https://clawhub.ai",
+        slug: "agentreceipt",
+        installedVersion: "1.0.0",
+        installedAt: 123,
+        sourceUrl,
+        artifact,
+        skillFile,
+      };
       const skillDir = await writeOriginWithProvenance({
         workspaceDir,
         slug: "agentreceipt",
-        origin: {
-          version: 1,
-          registry: "https://clawhub.ai",
-          slug: "agentreceipt",
-          installedVersion: "1.0.0",
+        origin,
+        lockSkill: {
+          version: "1.0.0",
           installedAt: 123,
+          registry: "https://clawhub.ai",
           sourceUrl,
           artifact,
           skillFile,
@@ -1440,6 +1449,36 @@ describe("ClawHub origin provenance readback", () => {
       expect(link.artifact).toEqual(artifact);
       expect(link.skillFile).toEqual(skillFile);
       expect(link.sourceUrl).toBe(sourceUrl);
+
+      const originPath = path.join(skillDir, ".clawhub", "origin.json");
+      for (const override of [
+        { sourceUrl: "https://github.com/acme/skills/tree/tampered/agentreceipt" },
+        {
+          artifact: {
+            kind: "clawpack",
+            sha256: "c".repeat(64),
+            integrity: "sha256-tampered",
+          },
+        },
+        { skillFile: { path: "SKILL.md", sha256: "d".repeat(64) } },
+      ]) {
+        await fs.writeFile(
+          originPath,
+          `${JSON.stringify({ ...origin, ...override }, null, 2)}\n`,
+          "utf8",
+        );
+        expect(
+          resolveClawHubSkillStatusLinkSync({
+            workspaceDir,
+            skillDir,
+            skillKey: "agentreceipt",
+          }),
+        ).toMatchObject({
+          status: "invalid",
+          valid: false,
+          reason: expect.stringContaining("does not match the workspace ClawHub lockfile"),
+        });
+      }
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -60,6 +60,7 @@ vi.mock("../../infra/fs-safe.js", () => ({
 
 const {
   installSkillFromClawHub,
+  resolveClawHubSkillStatusLinkSync,
   resolveClawHubSkillVerificationTarget,
   searchSkillsFromClawHub,
   updateSkillsFromClawHub,
@@ -1360,5 +1361,123 @@ describe("skills-clawhub", () => {
       baseUrl: undefined,
     });
     expect(listClawHubSkillsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ClawHub origin provenance readback", () => {
+  async function writeOriginWithProvenance(params: {
+    workspaceDir: string;
+    slug: string;
+    origin: Record<string, unknown>;
+    lockSkill?: Record<string, unknown>;
+  }) {
+    const skillDir = path.join(params.workspaceDir, "skills", params.slug);
+    await fs.mkdir(path.join(skillDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Skill\n", "utf8");
+    await fs.writeFile(
+      path.join(skillDir, ".clawhub", "origin.json"),
+      `${JSON.stringify(params.origin, null, 2)}\n`,
+      "utf8",
+    );
+    await fs.mkdir(path.join(params.workspaceDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(params.workspaceDir, ".clawhub", "lock.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            [params.slug]: params.lockSkill ?? {
+              version: params.origin.installedVersion,
+              installedAt: params.origin.installedAt,
+              registry: params.origin.registry,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    return skillDir;
+  }
+
+  it("restores artifact, skillFile, and sourceUrl persisted to origin.json", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-origin-prov-"));
+    try {
+      const artifact = {
+        kind: "clawpack" as const,
+        sha256: "a".repeat(64),
+        integrity: "sha256-test",
+      };
+      const skillFile = { path: "SKILL.md", sha256: "b".repeat(64) };
+      const sourceUrl = "https://github.com/acme/skills/tree/abc/agentreceipt";
+      const skillDir = await writeOriginWithProvenance({
+        workspaceDir,
+        slug: "agentreceipt",
+        origin: {
+          version: 1,
+          registry: "https://clawhub.ai",
+          slug: "agentreceipt",
+          installedVersion: "1.0.0",
+          installedAt: 123,
+          sourceUrl,
+          artifact,
+          skillFile,
+        },
+      });
+
+      const link = resolveClawHubSkillStatusLinkSync({
+        workspaceDir,
+        skillDir,
+        skillKey: "agentreceipt",
+      });
+
+      expect(link?.status).toBe("linked");
+      expect(link?.valid).toBe(true);
+      if (link?.status !== "linked") {
+        throw new Error(`expected linked status, got ${link?.status}`);
+      }
+      expect(link.artifact).toEqual(artifact);
+      expect(link.skillFile).toEqual(skillFile);
+      expect(link.sourceUrl).toBe(sourceUrl);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drops malformed provenance fields while keeping the link valid", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-origin-prov-"));
+    try {
+      const skillDir = await writeOriginWithProvenance({
+        workspaceDir,
+        slug: "agentreceipt",
+        origin: {
+          version: 1,
+          registry: "https://clawhub.ai",
+          slug: "agentreceipt",
+          installedVersion: "1.0.0",
+          installedAt: 123,
+          sourceUrl: "   ",
+          artifact: { kind: "bogus", sha256: 42, integrity: "" },
+          skillFile: { path: "", sha256: "c".repeat(64) },
+        },
+      });
+
+      const link = resolveClawHubSkillStatusLinkSync({
+        workspaceDir,
+        skillDir,
+        skillKey: "agentreceipt",
+      });
+
+      expect(link?.status).toBe("linked");
+      if (link?.status !== "linked") {
+        throw new Error(`expected linked status, got ${link?.status}`);
+      }
+      expect(link.artifact).toBeUndefined();
+      expect(link.skillFile).toBeUndefined();
+      expect(link.sourceUrl).toBeUndefined();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -103,6 +103,9 @@ export type ClawHubSkillStatusLink =
       installedAt: number;
       originPath: string;
       lockPath: string;
+      sourceUrl?: string;
+      artifact?: ClawHubSkillDownloadedArtifactLock;
+      skillFile?: ClawHubSkillFileLock;
     }
   | {
       status: "invalid";
@@ -420,6 +423,42 @@ function normalizeOptionalSelector(value: string | undefined): string | undefine
   return trimmed ? trimmed : undefined;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeDownloadedArtifactLock(
+  raw: unknown,
+): ClawHubSkillDownloadedArtifactLock | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const candidate = raw as Partial<ClawHubSkillDownloadedArtifactLock>;
+  if (
+    (candidate.kind === "archive" || candidate.kind === "clawpack") &&
+    isNonEmptyString(candidate.sha256) &&
+    isNonEmptyString(candidate.integrity)
+  ) {
+    return {
+      kind: candidate.kind,
+      sha256: candidate.sha256,
+      integrity: candidate.integrity,
+    };
+  }
+  return undefined;
+}
+
+function normalizeSkillFileLock(raw: unknown): ClawHubSkillFileLock | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const candidate = raw as Partial<ClawHubSkillFileLock>;
+  if (isNonEmptyString(candidate.path) && isNonEmptyString(candidate.sha256)) {
+    return { path: candidate.path, sha256: candidate.sha256 };
+  }
+  return undefined;
+}
+
 function normalizeClawHubSkillOrigin(
   raw: Partial<ClawHubSkillOrigin> | null,
 ): ClawHubSkillOrigin | null {
@@ -433,12 +472,18 @@ function normalizeClawHubSkillOrigin(
     raw.installedVersion.trim().length > 0 &&
     typeof raw.installedAt === "number"
   ) {
+    const sourceUrl = normalizeOptionalStringValue((raw as { sourceUrl?: unknown }).sourceUrl);
+    const artifact = normalizeDownloadedArtifactLock((raw as { artifact?: unknown }).artifact);
+    const skillFile = normalizeSkillFileLock((raw as { skillFile?: unknown }).skillFile);
     return {
       version: 1,
       registry: normalizeStoredRegistry(raw.registry),
       slug: raw.slug,
       installedVersion: raw.installedVersion,
       installedAt: raw.installedAt,
+      ...(sourceUrl ? { sourceUrl } : {}),
+      ...(artifact ? { artifact } : {}),
+      ...(skillFile ? { skillFile } : {}),
     };
   }
   return null;
@@ -676,6 +721,9 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     installedAt: locked.installedAt,
     originPath: originRead.path,
     lockPath: lockRead.path,
+    ...(originRead.origin.sourceUrl ? { sourceUrl: originRead.origin.sourceUrl } : {}),
+    ...(originRead.origin.artifact ? { artifact: originRead.origin.artifact } : {}),
+    ...(originRead.origin.skillFile ? { skillFile: originRead.origin.skillFile } : {}),
   };
 }
 

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -695,10 +695,23 @@ export function resolveClawHubSkillStatusLinkSync(params: {
   const originRegistry = normalizeStoredRegistry(originRead.origin.registry);
   const lockedRegistry =
     locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
+  const lockedSourceUrl = normalizeOptionalStringValue(locked.sourceUrl);
+  const lockedArtifact = normalizeDownloadedArtifactLock(locked.artifact);
+  const lockedSkillFile = normalizeSkillFileLock(locked.skillFile);
+  const provenanceMatches =
+    originRead.origin.sourceUrl === lockedSourceUrl &&
+    originRead.origin.artifact?.kind === lockedArtifact?.kind &&
+    originRead.origin.artifact?.sha256 === lockedArtifact?.sha256 &&
+    originRead.origin.artifact?.integrity === lockedArtifact?.integrity &&
+    originRead.origin.skillFile?.path === lockedSkillFile?.path &&
+    originRead.origin.skillFile?.sha256 === lockedSkillFile?.sha256;
+  // A linked status is a trust signal. Only expose provenance when both
+  // install records agree, so a one-sided origin edit cannot become trusted.
   if (
     locked.version !== originRead.origin.installedVersion ||
     locked.installedAt !== originRead.origin.installedAt ||
-    lockedRegistry !== originRegistry
+    lockedRegistry !== originRegistry ||
+    !provenanceMatches
   ) {
     return {
       status: "invalid",
@@ -721,9 +734,9 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     installedAt: locked.installedAt,
     originPath: originRead.path,
     lockPath: lockRead.path,
-    ...(originRead.origin.sourceUrl ? { sourceUrl: originRead.origin.sourceUrl } : {}),
-    ...(originRead.origin.artifact ? { artifact: originRead.origin.artifact } : {}),
-    ...(originRead.origin.skillFile ? { skillFile: originRead.origin.skillFile } : {}),
+    ...(lockedSourceUrl ? { sourceUrl: lockedSourceUrl } : {}),
+    ...(lockedArtifact ? { artifact: lockedArtifact } : {}),
+    ...(lockedSkillFile ? { skillFile: lockedSkillFile } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

PR #93283 ("Persist ClawHub skill install provenance") started writing install provenance — `sourceUrl`, `artifact` (`kind`/`sha256`/`integrity`), and `skillFile` (`path`/`sha256`) — into each skill's `.clawhub/origin.json`. But the shared origin reader `normalizeClawHubSkillOrigin` rebuilds the origin object from a fixed allowlist and only carried the identity fields (`version`/`registry`/`slug`/`installedVersion`/`installedAt`). The newly persisted provenance was therefore **silently dropped on every origin readback path** (`readClawHubSkillOrigin`, `readClawHubSkillOriginStatusSync`, `readClawHubSkillOriginStrict`).

The write side and read side of `origin.json` were asymmetric: the workspace lockfile reader (`readClawHubSkillsLockfile`) keeps these fields via raw `skills` passthrough, while `origin.json` lost them. Any consumer reading provenance back from origin metadata could never observe what was persisted.

## What changed

- `normalizeClawHubSkillOrigin` now preserves the persisted provenance on readback, using strict allowlist validation that matches how it already guards the identity fields:
  - `artifact` kept only when `kind` is `archive`/`clawpack` and both `sha256` and `integrity` are non-empty strings.
  - `skillFile` kept only when `path` and `sha256` are non-empty strings.
  - `sourceUrl` kept only when it is a non-empty string (trimmed).
  - Malformed provenance fields are dropped, never promoted — they do not invalidate an otherwise-valid origin, and old origins without these fields keep working unchanged.
- The exported `resolveClawHubSkillStatusLinkSync` `linked` result now surfaces the restored `sourceUrl`/`artifact`/`skillFile` as backward-compatible **optional** fields. No CLI output or behavior change beyond exposing already-persisted data.

Scope is intentionally limited to the origin readback path; the lockfile schema is untouched.

## Real behavior proof

Test drives the exported `resolveClawHubSkillStatusLinkSync`, which reads `origin.json` and `lock.json` back across the real filesystem (temp workspace, real files on disk), then asserts the provenance round-trips.

**Command**

```
node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts
```

**Result**

```
 ✓ unit  src/skills/lifecycle/clawhub.test.ts (39 tests) 558ms

 Test Files  1 passed (1)
      Tests  39 passed (39)
```

**Negative control** — reverting only the source change (`src/skills/lifecycle/clawhub.ts`) back to `main` while keeping the new tests makes the round-trip assertion fail, confirming the test exercises the fix:

```
 × restores artifact, skillFile, and sourceUrl persisted to origin.json
AssertionError: expected undefined to deeply equal { kind: 'clawpack', …(2) }
- Expected: { "integrity": "sha256-test", "kind": "clawpack", "sha256": "aaaa…aaaa" }
+ Received: undefined
      Tests  1 failed | 38 passed (39)
```

## Real behavior proof (real runtime, outside tests)

Beyond the vitest round-trip above, here is the same readback exercised through a standalone TypeScript runtime (`tsx`, **not** vitest — no mocks, no test framework). A throwaway script writes a real skill `.clawhub/origin.json` (with `sourceUrl`/`artifact`/`skillFile` provenance) plus `SKILL.md` and the workspace `.clawhub/lock.json` into a real temp workspace, then calls the exported `resolveClawHubSkillStatusLinkSync` to read it back across the real filesystem and prints the restored provenance.

**Command**

```
node --import tsx ./scratch-provenance-proof.mts
```

**After fix (this branch, `c91ad32` source) — provenance preserved**

```
== wrote provenance to disk ==
origin.json path: /tmp/clawhub-prov-realrt-WLYArw/skills/agentreceipt/.clawhub/origin.json
on-disk origin.json sourceUrl/artifact/skillFile:
  sourceUrl = "https://github.com/acme/skills/tree/abc/agentreceipt"
  artifact  = {"kind":"clawpack","sha256":"aaaa…(64)…aaaa","integrity":"sha256-realrt"}
  skillFile = {"path":"SKILL.md","sha256":"bbbb…(64)…bbbb"}

== read back through resolveClawHubSkillStatusLinkSync ==
  status    = linked
  valid     = true
  sourceUrl = "https://github.com/acme/skills/tree/abc/agentreceipt"
  artifact  = {"kind":"clawpack","sha256":"aaaa…(64)…aaaa","integrity":"sha256-realrt"}
  skillFile = {"path":"SKILL.md","sha256":"bbbb…(64)…bbbb"}

== verdict ==
PROVENANCE PRESERVED on readback
```

**Negative control (same script, only `src/skills/lifecycle/clawhub.ts` reverted to `main`) — provenance lost**

```
== wrote provenance to disk ==
on-disk origin.json sourceUrl/artifact/skillFile:
  sourceUrl = "https://github.com/acme/skills/tree/abc/agentreceipt"
  artifact  = {"kind":"clawpack","sha256":"aaaa…(64)…aaaa","integrity":"sha256-realrt"}
  skillFile = {"path":"SKILL.md","sha256":"bbbb…(64)…bbbb"}

== read back through resolveClawHubSkillStatusLinkSync ==
  status    = linked
  valid     = true
  sourceUrl = undefined
  artifact  = undefined
  skillFile = undefined

== verdict ==
PROVENANCE LOST on readback
```

The same provenance is written to `origin.json` in both runs; only the reader differs. On `main` the persisted `sourceUrl`/`artifact`/`skillFile` come back `undefined` (the bug); on this branch they round-trip intact. The source was restored to the fix afterward — this branch HEAD is unchanged and the script was not committed.

**Sha256/sourceUrl note**: real values redacted/abbreviated — the on-disk artifact uses 64-char sha256 digests (shown as `aaaa…(64)…aaaa` / `bbbb…(64)…bbbb`) and a placeholder `sourceUrl`.


## Tests and validation

- `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts` — 39 passed (2 new tests added).
- New tests:
  - round-trips `artifact`/`skillFile`/`sourceUrl` written to `origin.json` through `resolveClawHubSkillStatusLinkSync` (real disk readback).
  - drops malformed provenance (`kind: "bogus"`, empty `path`, blank `sourceUrl`) while keeping the link valid.
- `node scripts/run-tsgo.mjs` — exit 0, no type errors.
- `oxfmt --write` — no changes to the touched files.
- `oxlint` — 0 warnings, 0 errors on the touched files.

## Risk checklist

- **Backward compatible**: provenance fields are optional; origins written before #93283 (without these fields) normalize exactly as before.
- **Validation preserved**: keeps the existing allowlist/rebuild style — no raw passthrough; malformed provenance is discarded, never trusted.
- **No lockfile schema change**: only the origin readback path is touched.
- **No behavior change** to install/update/verify flows beyond exposing already-persisted data on the status-link result.

