### PR TITLE
fix(whatsapp): recover quoted reply context when WhatsApp strips the payload

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -5,6 +5,7 @@ import { formatLocationText, type NormalizedLocation } from "openclaw/plugin-sdk
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveComparableIdentity, type WhatsAppReplyContext } from "../identity.js";
+import { lookupInboundMessageMetaForTarget } from "../quoted-message.js";
 import { jidToE164 } from "../text-runtime.js";
 import { parseVcard } from "../vcard.js";
 import type { WhatsAppStructuredContactContext } from "./types.js";
@@ -403,22 +404,34 @@ export function extractLocationData(
 
 export function describeReplyContext(
   rawMessage: proto.IMessage | undefined,
+  ctx?: { accountId?: string; remoteJid?: string },
 ): WhatsAppReplyContext | null {
   const message = unwrapMessage(rawMessage);
   if (!message) {
     return null;
   }
   const contextInfo = extractContextInfo(message);
+  const id = contextInfo?.stanzaId || undefined;
   const quoted = normalizeMessage(contextInfo?.quotedMessage as proto.IMessage | undefined);
-  if (!quoted) {
+  if (!contextInfo || (!quoted && !id)) {
     return null;
   }
-  const location = extractLocationData(quoted);
+  // When WA strips the quoted payload (old/cross-device/forwarded messages),
+  // fall back to the inbound message cache so reply context is never silently lost.
+  const cached =
+    id && ctx?.accountId && ctx.remoteJid
+      ? lookupInboundMessageMetaForTarget(ctx.accountId, ctx.remoteJid, id)
+      : undefined;
+  const location = quoted ? extractLocationData(quoted) : undefined;
   const locationText = location ? formatLocationText(location) : undefined;
-  const text = extractText(quoted);
-  let body: string | undefined = [text, locationText].filter(Boolean).join("\n").trim();
+  const text = quoted ? extractText(quoted) : undefined;
+  let body: string | undefined =
+    [text, locationText].filter(Boolean).join("\n").trim() || cached?.body;
   if (!body) {
-    body = extractMediaPlaceholder(quoted);
+    body = quoted ? extractMediaPlaceholder(quoted) : undefined;
+  }
+  if (!body && id) {
+    body = "[Quoted message unavailable]";
   }
   if (!body) {
     const quotedType = quoted ? getMessageContentType(quoted) : undefined;
@@ -427,13 +440,14 @@ export function describeReplyContext(
     );
     return null;
   }
-  const senderJid = contextInfo?.participant ?? undefined;
+  const senderJid = contextInfo?.participant ?? cached?.participant ?? undefined;
   const sender = resolveComparableIdentity({
     jid: senderJid,
+    e164: cached?.participantE164,
     label: senderJid ? (jidToE164(senderJid) ?? senderJid) : "unknown sender",
   });
   return {
-    id: contextInfo?.stanzaId || undefined,
+    id,
     body,
     sender,
   };

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1013,7 +1013,10 @@ export async function attachWebInboxToSocket(
         return null;
       }
     }
-    const replyContext = describeReplyContext(msg.message as proto.IMessage | undefined);
+    const replyContext = describeReplyContext(msg.message as proto.IMessage | undefined, {
+      accountId: options.accountId,
+      remoteJid: msg.key.remoteJid ?? undefined,
+    });
 
     let mediaPath: string | undefined;
     let mediaType: string | undefined;

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -25,6 +25,7 @@ import {
   waitForMessageCalls,
 } from "./monitor-inbox.test-harness.js";
 import type { InboxOnMessage } from "./monitor-inbox.test-harness.js";
+import { cacheInboundMessageMeta } from "./quoted-message.js";
 import { DEFAULT_WHATSAPP_SOCKET_TIMING } from "./socket-timing.js";
 
 const { imageOps, sleepWithAbortMock } = vi.hoisted(() => ({
@@ -1394,5 +1395,59 @@ describe("web monitor inbox", () => {
         message: { conversation: "original" },
       },
     });
+  });
+
+  it("recovers reply context from inbound cache when quotedMessage payload is stripped", async () => {
+    // WhatsApp sometimes omits the quotedMessage payload for old/cross-device/forwarded
+    // messages while still sending contextInfo.stanzaId. Pre-populate the cache so
+    // describeReplyContext can recover the body and sender from it.
+    const remoteJid = "999@s.whatsapp.net";
+    const cachedMsgId = nextMessageId("cached-original");
+    cacheInboundMessageMeta(DEFAULT_ACCOUNT_ID, remoteJid, cachedMsgId, {
+      body: "cached original text",
+      participant: "111@s.whatsapp.net",
+      participantE164: "+111",
+      fromMe: false,
+    });
+
+    const onMessage = vi.fn(async (msg) => {
+      await msg.platform.reply("pong");
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: nextMessageId("stripped-reply"),
+            fromMe: false,
+            remoteJid,
+          },
+          message: {
+            extendedTextMessage: {
+              text: "reply to something old",
+              contextInfo: {
+                stanzaId: cachedMsgId,
+                participant: "111@s.whatsapp.net",
+                // quotedMessage intentionally absent — simulates WA stripping the payload
+              },
+            },
+          },
+          messageTimestamp: 1_700_000_000,
+          pushName: "Tester",
+        },
+      ],
+    };
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = inboundMessage(onMessage);
+    expect(inbound.quote?.id).toBe(cachedMsgId);
+    expect(inbound.quote?.body).toBe("cached original text");
+    expect(inbound.quote?.sender?.e164).toBe("+111");
+
+    await listener.close();
   });
 });


### PR DESCRIPTION
## What

When WhatsApp delivers a reply where the `quotedMessage` payload is stripped (old messages, cross-device replies, forwarded content), `describeReplyContext` returned `null` and all reply context was silently lost — even though `contextInfo.stanzaId` and `contextInfo.participant` were still present.

## Root Cause

`describeReplyContext` had a hard `if (!quoted) return null` with no fallback. The `lookupInboundMessageMetaForTarget` helper in `quoted-message.ts` already exists and can recover the body and sender from the inbound message cache — it was just never wired into this path.

## Fix

- Added optional `ctx?: { accountId?: string; remoteJid?: string }` param to `describeReplyContext` (backwards compatible — all callers without context still work)
- When `quotedMessage` is absent but `stanzaId` exists, fall back to `lookupInboundMessageMetaForTarget(ctx.accountId, ctx.remoteJid, stanzaId)`
- Recover `body`, `participant`, and `participantE164` from the cache entry
- Added `[Quoted message unavailable]` fallback when id is present but neither the payload nor the cache has the body, so reply context is preserved at the structural level
- Wired `accountId` and `remoteJid` from `monitor.ts` into the call site

## Testing

- 75 WhatsApp extension tests passing (all pre-existing tests pass)
- New regression test: `recovers reply context from inbound cache when quotedMessage payload is stripped` — pre-seeds the cache with a known message, sends a reply with `stanzaId` but no `quotedMessage`, verifies `inbound.quote.body` and `inbound.quote.sender.e164` are recovered correctly

## Context

Confirmed against 6 months of production use running OpenClaw as a personal AI assistant on WhatsApp. Stripped payload replies are frequent in practice — old messages, cross-device conversations, and forwarded content all trigger this. The cache infrastructure (`cacheInboundMessageMeta` / `lookupInboundMessageMetaForTarget`) was already built; this PR wires it into the one place that was missing it.

## AI-Assisted PR Checklist

- [x] Marked as AI-assisted
- [x] Testing level: fully tested (75 WA extension suite tests + new regression test that fails without the change and passes with it)
- [x] Code reviewed and understood — root cause confirmed, fix is minimal (3 files, +80/-8)
- [x] Backwards compatible — `ctx` param is optional, no existing callers break

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real behavior proof

- **Behavior or issue addressed:** When WhatsApp delivers a reply whose `quotedMessage` payload is stripped (old / cross-device / forwarded messages) but `contextInfo.stanzaId` survives, `describeReplyContext` returned `null` and all reply context was silently lost.
- **Real environment tested:** OpenClaw checkout on macOS (Darwin arm64, Node v22), running the actual patched `describeReplyContext` and `cacheInboundMessageMeta` modules from this branch via `node --import tsx` — not a mocked harness, the real module graph.
- **Exact steps or command run after this patch:** Seeded the inbound message cache with a known original message, then constructed the exact failure payload — an `extendedTextMessage` reply carrying `contextInfo.stanzaId` + `participant` but with `quotedMessage` absent — and invoked the patched function:
  `node --import tsx proof-replyctx.mts`
- **Evidence after fix:** live stdout from the patched module:

```console
$ node --import tsx proof-replyctx.mts
describeReplyContext result on stripped-payload reply:
{
  "id": "ORIG-MSG-ABC123",
  "body": "the original message text that WA later stripped",
  "sender": {
    "jid": "919892065882@s.whatsapp.net",
    "e164": "+919892065882",
    "label": "+919892065882",
    "lid": null
  }
}
RESULT: reply context RECOVERED from cache (pre-fix this returned null)
```

- **Observed result after fix:** the patched `describeReplyContext` recovered `id`, `body`, and `sender` (jid + e164) from the inbound cache for a reply with no `quotedMessage` payload. Against the pre-fix code path (`if (!quoted) return null`) this same input yields `null` — i.e. the reply context that was previously dropped is now preserved.
- **What was not tested:** full end-to-end delivery through a live gateway socket to a real device was not exercised here; the inbound-message extraction path that consumes this function was verified directly.
