### PR TITLE
fix(codex): dedupe raw commentary progress

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1150,6 +1150,63 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.assistantTexts).toEqual(["final answer"]);
   });
 
+  it("dedupes typed and raw commentary progress for the same assistant note", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "",
+        },
+      }),
+    );
+    await projector.handleNotification(agentMessageDelta("Checking", "msg-commentary"));
+    await projector.handleNotification(
+      agentMessageDelta(" the app-server stream", "msg-commentary"),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "Checking the app-server stream",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          type: "message",
+          id: "raw-commentary",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Checking the app-server stream" }],
+        },
+      }),
+    );
+
+    const progressEvents = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(progressEvents.map((event) => event.data.itemId)).toEqual([
+      "msg-commentary",
+      "msg-commentary",
+    ]);
+    expect(progressEvents.map((event) => event.data.progressText)).toEqual([
+      "Checking",
+      "Checking the app-server stream",
+    ]);
+  });
+
   it("does not resolve commentary-phase assistant text as the final reply", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -149,6 +149,8 @@ export class CodexAppServerEventProjector {
   private readonly assistantItemOrder: string[] = [];
   private readonly assistantPhaseByItem = new Map<string, string>();
   private readonly lastCommentaryProgressTextByItem = new Map<string, string>();
+  private readonly commentaryProgressItemIdByText = new Map<string, string>();
+  private readonly rawAssistantItemIds = new Set<string>();
   private readonly reasoningTextByGroup = new Map<string, ReasoningTextGroup>();
   private readonly reasoningItemOrder = new Map<string, number>();
   private readonly planTextByItem = new Map<string, string>();
@@ -923,6 +925,7 @@ export class CodexAppServerEventProjector {
     if (phase) {
       this.assistantPhaseByItem.set(itemId, phase);
     }
+    this.rawAssistantItemIds.add(itemId);
     this.rememberAssistantItem(itemId);
     this.assistantTextByItem.set(itemId, text);
     if (phase === "commentary") {
@@ -1065,7 +1068,16 @@ export class CodexAppServerEventProjector {
     ) {
       return;
     }
+    const existingItemId = this.commentaryProgressItemIdByText.get(progressText);
+    if (
+      existingItemId &&
+      existingItemId !== params.itemId &&
+      (this.rawAssistantItemIds.has(existingItemId) || this.rawAssistantItemIds.has(params.itemId))
+    ) {
+      return;
+    }
     this.lastCommentaryProgressTextByItem.set(params.itemId, progressText);
+    this.commentaryProgressItemIdByText.set(progressText, params.itemId);
     this.emitAgentEvent({
       stream: "item",
       data: {


### PR DESCRIPTION
## Summary

Fixes #93296.

- dedupes Codex app-server commentary progress when the same assistant note arrives through both the typed `agentMessage` lane and the raw `rawResponseItem/completed` lane
- keeps normal same-item commentary progress snapshots intact
- adds a regression that reproduces typed + raw commentary for the same note and asserts the raw duplicate is not emitted as another preamble

## Duplicate checks

Before coding, checked open and closed PRs/issues by issue number, behavior, file, and event names:

- `93296`, `gpt-5.4-mini`, `duplicate commentary notes`, `verbose mode duplicate`
- `event-projector rawResponseItem commentary duplicate`
- `extensions/codex/src/app-server/event-projector.ts commentary`
- `rawResponseItem/completed`, `emitCommentaryProgress`, `noteCommentaryProgress`

I found adjacent/history PRs for commentary delivery and progress lanes, but no open PR that owns the typed/raw duplicate path for #93296.

## Surface map

- Typed lane: `item/agentMessage/delta` and `item/completed` still emit keyed commentary snapshots for the typed item id.
- Raw lane: `rawResponseItem/completed` now records raw assistant item ids before emitting commentary.
- Dedupe boundary: `emitCommentaryProgress` suppresses a progress event only when the same normalized text was already emitted under a different item id and one side is a raw assistant item. This avoids broad Discord/channel-specific behavior and avoids suppressing distinct typed commentary items.
- Downstream delivery: unchanged; `noteCommentaryProgress` can continue flushing by item id because the duplicate raw preamble is removed before dispatch.
- Config/security/upgrade behavior: unchanged; this only changes in-memory event projection for Codex app-server progress events.

## Tests

- `pnpm test -- extensions/codex/src/app-server/event-projector.test.ts`

Result: 1 file passed, 91 tests passed.
