### PR TITLE
fix(imessage): honor configured send transport for attachment sends

### DIFF
--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -331,6 +331,132 @@ describe("sendMessageIMessage receipts", () => {
     ]);
   });
 
+  it("honors applescript transport for plain image attachments", async () => {
+    const client = createClient({ message_id: 12345 });
+    const runCliJson = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "p:0/media-guid", transferGuid: "transfer-1" });
+
+    await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: {
+        channels: {
+          imessage: {
+            sendTransport: "auto",
+            accounts: { work: { sendTransport: "applescript" } },
+          },
+        },
+      },
+      accountId: "work",
+      client,
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    // A plain image attachment is fully supported by AppleScript automation, so
+    // the configured transport is honored as-is.
+    expect(client["request"]).not.toHaveBeenCalled();
+    expect(runCliJson.mock.calls).toEqual([
+      [
+        [
+          "send-attachment",
+          "--chat",
+          "chat-1",
+          "--file",
+          "/tmp/image.png",
+          "--transport",
+          "applescript",
+        ],
+      ],
+    ]);
+  });
+
+  it("falls back to auto transport for applescript voice/audio attachments", async () => {
+    const client = createClient({ message_id: 12345 });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });
+
+    await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: {
+        channels: {
+          imessage: {
+            sendTransport: "auto",
+            accounts: { work: { sendTransport: "applescript" } },
+          },
+        },
+      },
+      accountId: "work",
+      client,
+      mediaUrl: "/tmp/voice.caf",
+      audioAsVoice: true,
+      resolveAttachmentImpl: async () => ({ path: "/tmp/voice.caf", contentType: "audio/x-caf" }),
+      runCliJson,
+    });
+
+    // The send-attachment CLI rejects `--transport applescript` together with
+    // `--audio`. This send was hardcoded to `auto` before sendTransport was
+    // honored on the media path, so it narrowly falls back to `auto` to avoid
+    // regressing existing AppleScript-configured users.
+    expect(client["request"]).not.toHaveBeenCalled();
+    expect(runCliJson.mock.calls).toEqual([
+      [
+        [
+          "send-attachment",
+          "--chat",
+          "chat-1",
+          "--file",
+          "/tmp/voice.caf",
+          "--audio",
+          "--transport",
+          "auto",
+        ],
+      ],
+    ]);
+  });
+
+  it("falls back to auto transport for applescript threaded voice reply attachments", async () => {
+    const client = createClient({ message_id: 12345 });
+    const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });
+
+    await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: {
+        channels: {
+          imessage: {
+            sendTransport: "auto",
+            actions: { reply: true },
+            accounts: { work: { sendTransport: "applescript" } },
+          },
+        },
+      },
+      accountId: "work",
+      client,
+      mediaUrl: "/tmp/voice.caf",
+      audioAsVoice: true,
+      replyToId: "p:0/reply-guid",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/voice.caf", contentType: "audio/x-caf" }),
+      runCliJson,
+    });
+
+    // Both --audio and --reply-to are unsupported under applescript, so the
+    // transport narrowly falls back to `auto` while still carrying the flags.
+    expect(client["request"]).not.toHaveBeenCalled();
+    expect(runCliJson.mock.calls).toEqual([
+      [
+        [
+          "send-attachment",
+          "--chat",
+          "chat-1",
+          "--file",
+          "/tmp/voice.caf",
+          "--audio",
+          "--reply-to",
+          "p:0/reply-guid",
+          "--transport",
+          "auto",
+        ],
+      ],
+    ]);
+  });
+
   it("sends audioAsVoice media through send-attachment audio transport", async () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -255,6 +255,48 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.sentAt).toBeGreaterThan(0);
   });
 
+  it("honors the configured send transport for send-attachment media", async () => {
+    const client = createClient({ message_id: 12345 });
+    const runCliJson = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "p:0/media-guid", transferGuid: "transfer-1" });
+
+    await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: {
+        channels: {
+          imessage: {
+            sendTransport: "auto",
+            accounts: {
+              work: {
+                sendTransport: "applescript",
+              },
+            },
+          },
+        },
+      },
+      accountId: "work",
+      client,
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    expect(client["request"]).not.toHaveBeenCalled();
+    expect(runCliJson.mock.calls).toEqual([
+      [
+        [
+          "send-attachment",
+          "--chat",
+          "chat-1",
+          "--file",
+          "/tmp/image.png",
+          "--transport",
+          "applescript",
+        ],
+      ],
+    ]);
+  });
+
   it("sends audioAsVoice media through send-attachment audio transport", async () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -297,6 +297,40 @@ describe("sendMessageIMessage receipts", () => {
     ]);
   });
 
+  it("maps the configured bridge transport to the send-attachment dylib token", async () => {
+    const client = createClient({ message_id: 12345 });
+    const runCliJson = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "p:0/media-guid", transferGuid: "transfer-1" });
+
+    await sendMessageIMessage("chat_guid:chat-1", "", {
+      config: {
+        channels: {
+          imessage: {
+            sendTransport: "auto",
+            accounts: {
+              work: {
+                sendTransport: "bridge",
+              },
+            },
+          },
+        },
+      },
+      accountId: "work",
+      client,
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      runCliJson,
+    });
+
+    expect(client["request"]).not.toHaveBeenCalled();
+    // OpenClaw config exposes `bridge`, but the send-attachment CLI only accepts
+    // `auto`/`dylib`/`applescript`, so the bridge must reach the argv as `dylib`.
+    expect(runCliJson.mock.calls).toEqual([
+      [["send-attachment", "--chat", "chat-1", "--file", "/tmp/image.png", "--transport", "dylib"]],
+    ]);
+  });
+
   it("sends audioAsVoice media through send-attachment audio transport", async () => {
     const client = createClient({ message_id: 12345 });
     const runCliJson = vi.fn().mockResolvedValueOnce({ messageId: "p:0/voice-guid" });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -46,6 +46,19 @@ const MIN_PENDING_PERSISTED_ECHO_TTL_MS = 60_000;
 const PENDING_PERSISTED_ECHO_GRACE_MS = 5_000;
 type IMessageSendTransport = "auto" | "bridge" | "applescript";
 
+// OpenClaw config exposes the transport as `auto`/`bridge`/`applescript`. The
+// JSON-RPC `send` path forwards that token verbatim because the imsg RPC server
+// maps `bridge` to its IMCore bridge internally. The `send-attachment` CLI is a
+// different boundary: it accepts `auto`/`dylib`/`applescript` and rejects
+// `bridge`. The bridge is implemented by the injected helper dylib, so `bridge`
+// maps to `dylib` at the attachment argv boundary; `auto` and `applescript`
+// pass through unchanged.
+type IMessageAttachmentTransport = "auto" | "dylib" | "applescript";
+
+function toAttachmentTransport(transport: IMessageSendTransport): IMessageAttachmentTransport {
+  return transport === "bridge" ? "dylib" : transport;
+}
+
 type IMessageSendOpts = {
   cliPath?: string;
   dbPath?: string;
@@ -804,7 +817,7 @@ async function trySendAttachmentForTarget(params: {
       ...(params.audioAsVoice ? ["--audio"] : []),
       ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
       "--transport",
-      params.transport ?? "auto",
+      toAttachmentTransport(params.transport ?? "auto"),
     ]);
   } catch (error) {
     forgetPersistedIMessageEchoKey(pendingEchoKey);

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -55,8 +55,32 @@ type IMessageSendTransport = "auto" | "bridge" | "applescript";
 // pass through unchanged.
 type IMessageAttachmentTransport = "auto" | "dylib" | "applescript";
 
+// Map an OpenClaw transport token to the one the `send-attachment` CLI accepts.
+// The OpenClaw `bridge` token is the IMCore bridge, which the CLI exposes as
+// `dylib` (the injected helper dylib); `auto` and `applescript` are accepted
+// verbatim.
 function toAttachmentTransport(transport: IMessageSendTransport): IMessageAttachmentTransport {
   return transport === "bridge" ? "dylib" : transport;
+}
+
+// Resolve the `--transport` value for a `send-attachment` invocation, honoring
+// the configured transport where the CLI supports it. The `applescript`
+// transport cannot carry `--audio` (voice notes) or `--reply-to` (threaded
+// replies) — the CLI rejects those combinations. Before this fix the attachment
+// path was hardcoded to `auto`, so those sends already went out via `auto`;
+// to avoid regressing existing AppleScript-configured users we narrowly fall
+// back to `auto` for exactly those incompatible modes. Plain AppleScript image
+// attachments still honor `applescript`, and `bridge` always maps to `dylib`.
+function resolveAttachmentTransport(params: {
+  transport?: IMessageSendTransport;
+  audioAsVoice?: boolean;
+  replyToId?: string;
+}): IMessageAttachmentTransport {
+  const transport = params.transport ?? "auto";
+  if (transport === "applescript" && (params.audioAsVoice || params.replyToId)) {
+    return "auto";
+  }
+  return toAttachmentTransport(transport);
 }
 
 type IMessageSendOpts = {
@@ -817,7 +841,11 @@ async function trySendAttachmentForTarget(params: {
       ...(params.audioAsVoice ? ["--audio"] : []),
       ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
       "--transport",
-      toAttachmentTransport(params.transport ?? "auto"),
+      resolveAttachmentTransport({
+        transport: params.transport,
+        audioAsVoice: params.audioAsVoice,
+        replyToId: params.replyToId,
+      }),
     ]);
   } catch (error) {
     forgetPersistedIMessageEchoKey(pendingEchoKey);

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -759,6 +759,7 @@ async function trySendAttachmentForTarget(params: {
   replyToId?: string;
   echoText?: string;
   pendingEchoTtlMs: number;
+  transport?: IMessageSendTransport;
   runCliJson: (args: readonly string[]) => Promise<Record<string, unknown>>;
   resolveMessageGuidImpl?: IMessageSendOpts["resolveMessageGuidImpl"];
 }): Promise<IMessageSendResult | null> {
@@ -803,7 +804,7 @@ async function trySendAttachmentForTarget(params: {
       ...(params.audioAsVoice ? ["--audio"] : []),
       ...(params.replyToId ? ["--reply-to", params.replyToId] : []),
       "--transport",
-      "auto",
+      params.transport ?? "auto",
     ]);
   } catch (error) {
     forgetPersistedIMessageEchoKey(pendingEchoKey);
@@ -969,6 +970,7 @@ export async function sendMessageIMessage(
       ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),
       echoText: attachmentEchoText,
       pendingEchoTtlMs,
+      transport: sendTransport,
       runCliJson,
       resolveMessageGuidImpl: opts.resolveMessageGuidImpl,
     });


### PR DESCRIPTION
## Summary

PR #91783 introduced `channels.imessage.sendTransport` (`auto` / `bridge` / `applescript`) and threaded it into the `imsg rpc send` text path. The symmetric `send-attachment` media path was missed: it still passed a hardcoded `--transport auto`. As a result, an account configured with `sendTransport: "bridge"` or `sendTransport: "applescript"` honored that preference for text sends but silently fell back to `auto` for every attachment/media send.

This is the same class of omission as #93137 (an imessage gate applied to text but not the symmetric path).

## What changed

`extensions/imessage/src/send.ts`

- Thread the already-resolved `sendTransport` (`account.config.sendTransport ?? "auto"`) from `sendMessageIMessage` into `trySendAttachmentForTarget`, matching the RPC text send path.
- **Map the transport token to the attachment CLI contract** (`toAttachmentTransport`). OpenClaw config exposes `auto`/`bridge`/`applescript`, but `imsg send-attachment` accepts only `auto`/`dylib`/`applescript`. The JSON-RPC `send` path forwards `bridge` verbatim because the imsg RPC server maps it to the IMCore bridge internally; the CLI is a different boundary that expects the `dylib` token (the bridge is the injected helper dylib). So `bridge → dylib`; `auto`/`applescript` pass through.
- **Narrowly fall back to `auto` for AppleScript-incompatible attachment modes** (`resolveAttachmentTransport`). The CLI rejects `--transport applescript` when combined with `--audio` (voice notes) or `--reply-to` (threaded replies). Because the attachment path was hardcoded to `auto` before this PR, those exact sends already went out via `auto`; falling back to `auto` for just those modes preserves existing AppleScript-configured behavior instead of regressing it into a hard CLI failure. Plain AppleScript image attachments still honor `applescript`, and `bridge` always maps to `dylib`.

`extensions/imessage/src/send.test.ts`

- `sendTransport: "bridge"` → media argv carries `--transport dylib`.
- `sendTransport: "applescript"` plain image → `--transport applescript` (honored).
- `sendTransport: "applescript"` voice attachment → `--transport auto` (fallback, keeps `--audio`).
- `sendTransport: "applescript"` voice reply attachment → `--transport auto` (fallback, keeps `--audio --reply-to`).

## Root cause and contract

In `sendMessageIMessage`, `sendTransport` is resolved once and threaded into the RPC text send. The media branch built the `send-attachment` argv with a literal `"--transport", "auto"`, so the resolved transport was never honored. A naive literal forward would break `bridge` users (the CLI rejects `bridge`) and would also turn previously-working AppleScript voice/reply sends into hard failures (the CLI rejects `applescript` + `--audio`/`--reply-to`). The fix threads the value, maps `bridge → dylib`, and narrowly falls back to `auto` only for the AppleScript modes the CLI cannot serve.

The upstream CLI contract is the `openclaw/imsg` `send-attachment` command: `--transport` accepts `{auto, dylib, applescript}`, and `applescript` is rejected with `--audio` or `--reply-to`. (Sources/imsg/Commands/BridgeAttachmentCommand.swift.)

## Real behavior proof (real runtime, outside tests)

A real Node runtime run (`node --import tsx`, **not** Vitest). A throwaway `.mts` script imports the **real exported** `sendMessageIMessage`, installs the real plugin-state runtime, and injects a real `runCliJson` stub that **captures the actual `send-attachment` subprocess argv** at the CLI boundary. It drives the media path across configured transports and attachment modes and prints the real `--transport` token emitted.

**Exact command**: `TSX_TSCONFIG_PATH=tsconfig.json node --import tsx extensions/imessage/src/_proof_send_transport.mts`

(`TSX_TSCONFIG_PATH` only points the loader at the repo's `tsconfig.json` so `openclaw/plugin-sdk/*` resolves to the same `src/*.ts` the test suite uses in a source checkout; it does not touch the send path. The proof script is not committed.)

**Real terminal output — after fix (HEAD `d15bf4a`)**:

```
OK   config bridge, image attachment
       argv = ["send-attachment","--chat","chat-1","--file","/tmp/image.png","--transport","dylib"]
       --transport = dylib  (expected dylib)
OK   config applescript, image attachment
       argv = ["send-attachment","--chat","chat-1","--file","/tmp/image.png","--transport","applescript"]
       --transport = applescript  (expected applescript)
OK   config auto, image attachment
       argv = ["send-attachment","--chat","chat-1","--file","/tmp/image.png","--transport","auto"]
       --transport = auto  (expected auto)
OK   config applescript, VOICE attachment (CLI rejects applescript+--audio -> fallback)
       argv = ["send-attachment","--chat","chat-1","--file","/tmp/voice.caf","--audio","--transport","auto"]
       --transport = auto  (expected auto)
OK   config applescript, VOICE REPLY attachment (CLI rejects applescript+--audio/--reply-to -> fallback)
       argv = ["send-attachment","--chat","chat-1","--file","/tmp/voice.caf","--audio","--reply-to","p:0/reply-guid","--transport","auto"]
       --transport = auto  (expected auto)

PASS: bridge->dylib; plain applescript honored; auto unchanged; applescript+audio/reply narrowly falls back to auto.
```

**Negative control — same script, source temporarily reverted** (then restored; HEAD unchanged):

- Reverting the `bridge → dylib` map makes the bridge case emit `--transport bridge` (the token the CLI rejects).
- Reverting the AppleScript fallback makes the voice / voice-reply cases emit `--transport applescript` (the combination the CLI rejects), i.e. the regression this fix prevents.

The captured real subprocess argv shows each branch is load-bearing.

> Note: this proof drives the real TypeScript send path and the real CLI-argv boundary, but it does not exercise a live macOS device (Messages.app / injected dylib), which is unavailable in this environment. It proves the transport-token contract end to end at the `send-attachment` argv boundary; it does not claim live on-device media delivery.

## Real behavior proof (Vitest)

The tests drive the real exported `sendMessageIMessage` and capture the exact `send-attachment` subprocess argv through the injected `runCliJson` boundary.

**Exact command**: `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts`

**Result (after fix)**: 48 passed, including the four transport cases above.

```
 Test Files  1 passed (1)
      Tests  48 passed (48)
```

**Negative control**: reverting the `bridge → dylib` map fails the bridge test; reverting the AppleScript fallback fails the two voice/reply tests; restoring returns the suite to 48 passed.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts` — 48 passed.
- Negative controls (revert each branch, keep tests) — only the corresponding tests fail; restore — 48 passed.
- `node scripts/run-tsgo.mjs` — clean (exit 0).
- `node scripts/run-oxlint.mjs extensions/imessage/src/send.ts extensions/imessage/src/send.test.ts` — 0 warnings, 0 errors.
- `oxfmt --check` — correctly formatted.

## Risk checklist

- **Default behavior**: unchanged. `auto` stays `auto`; existing attachment tests that assert `--transport auto` still pass.
- **Compatibility (addresses prior review)**: a `bridge` account now emits the CLI-supported `dylib` instead of the rejected `bridge`. AppleScript voice/reply attachments no longer hard-fail at the CLI — they keep going out via `auto`, exactly as they did before `sendTransport` reached the media path. Plain AppleScript image attachments honor the configured transport.
- **Scope**: 2 files. Behind two small pure helpers at the attachment boundary; no public API or config schema change (`sendTransport` already exists from #91783).
