### PR TITLE
fix(cli): accept --no-color after subcommands

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -16,6 +16,7 @@ import {
   isRootVersionInvocation,
   normalizeGeneratedHelpCommandArgv,
   normalizeRootHelpTargetArgv,
+  normalizeRootNoColorArgv,
   shouldMigrateState,
   shouldMigrateStateFromPath,
 } from "./argv.js";
@@ -169,6 +170,61 @@ describe("argv helpers", () => {
     },
   ])("normalizes root help targets: $name", ({ argv, expected }) => {
     expect(normalizeRootHelpTargetArgv(argv)).toEqual(expected);
+  });
+
+  it.each([
+    {
+      name: "subcommand trailing no-color",
+      argv: ["node", "openclaw", "doctor", "--no-color", "--post-upgrade", "--json"],
+      expected: ["node", "openclaw", "--no-color", "doctor", "--post-upgrade", "--json"],
+    },
+    {
+      name: "keeps existing root options first",
+      argv: ["node", "openclaw", "--profile", "work", "doctor", "--no-color", "--lint", "--json"],
+      expected: [
+        "node",
+        "openclaw",
+        "--profile",
+        "work",
+        "--no-color",
+        "doctor",
+        "--lint",
+        "--json",
+      ],
+    },
+    {
+      name: "keeps no-color after possible command option value",
+      argv: ["node", "openclaw", "doctor", "--lint", "--json", "--no-color"],
+      expected: ["node", "openclaw", "doctor", "--lint", "--json", "--no-color"],
+    },
+    {
+      name: "flag terminator leaves no-color positional",
+      argv: ["node", "openclaw", "doctor", "--", "--no-color"],
+      expected: ["node", "openclaw", "doctor", "--", "--no-color"],
+    },
+    {
+      name: "command option value remains literal",
+      argv: ["node", "openclaw", "agent", "--message", "--no-color"],
+      expected: ["node", "openclaw", "agent", "--message", "--no-color"],
+    },
+    {
+      name: "assigned command option value does not block no-color",
+      argv: ["node", "openclaw", "agent", "--message=hello", "--no-color"],
+      expected: ["node", "openclaw", "--no-color", "agent", "--message=hello"],
+    },
+  ])("normalizes root --no-color before command parsing: $name", ({ argv, expected }) => {
+    expect(normalizeRootNoColorArgv(argv)).toEqual(expected);
+  });
+
+  it("allows final command metadata to lift no-color after boolean command flags", () => {
+    const argv = ["node", "openclaw", "doctor", "--lint", "--json", "--no-color"];
+
+    expect(
+      normalizeRootNoColorArgv(argv, {
+        shouldPreserveNoColor: ({ remainingArgs, noColorIndex }) =>
+          remainingArgs[noColorIndex - 1] === "--message",
+      }),
+    ).toEqual(["node", "openclaw", "--no-color", "doctor", "--lint", "--json"]);
   });
 
   it.each([

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -253,6 +253,76 @@ export function normalizeRootHelpTargetArgv(argv: string[]): string[] {
   return [argv[0], argv[1], ...rootOptions, ...targetPath, "--help"];
 }
 
+export type NormalizeRootNoColorArgvOptions = {
+  shouldPreserveNoColor?: (params: {
+    remainingArgs: readonly string[];
+    noColorIndex: number;
+  }) => boolean;
+};
+
+function isPossibleCommandOptionValue(
+  remainingArgs: readonly string[],
+  noColorIndex: number,
+): boolean {
+  const previous = remainingArgs[noColorIndex - 1];
+  if (!previous?.startsWith("-") || previous === FLAG_TERMINATOR) {
+    return false;
+  }
+  return !previous.includes("=");
+}
+
+export function normalizeRootNoColorArgv(
+  argv: string[],
+  options: NormalizeRootNoColorArgvOptions = {},
+): string[] {
+  const prefix = argv.slice(0, 2);
+  const args = argv.slice(2);
+  let rootPrefixEnd = 0;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    const consumed = consumeRootOptionToken(args, index);
+    if (consumed <= 0) {
+      break;
+    }
+    rootPrefixEnd = index + consumed;
+    index += consumed - 1;
+  }
+
+  const rootPrefix = args.slice(0, rootPrefixEnd);
+  const remainingArgs = args.slice(rootPrefixEnd);
+  const movedNoColorArgs: string[] = [];
+  const nextArgs: string[] = [];
+  for (let index = 0; index < remainingArgs.length; index += 1) {
+    const arg = remainingArgs[index];
+    if (arg === FLAG_TERMINATOR) {
+      nextArgs.push(...remainingArgs.slice(index));
+      break;
+    }
+    if (arg === "--no-color") {
+      // Commander can treat dash-prefixed tokens as command option values.
+      // Early callers stay conservative; final Commander parse can pass metadata.
+      const shouldPreserve =
+        options.shouldPreserveNoColor?.({ remainingArgs, noColorIndex: index }) ??
+        isPossibleCommandOptionValue(remainingArgs, index);
+      if (shouldPreserve) {
+        nextArgs.push(arg);
+        continue;
+      }
+      movedNoColorArgs.push(arg);
+      continue;
+    }
+    nextArgs.push(arg);
+  }
+
+  if (movedNoColorArgs.length === 0) {
+    return argv;
+  }
+  return [...prefix, ...rootPrefix, ...movedNoColorArgs, ...nextArgs];
+}
+
 export function getFlagValue(argv: string[], name: string): string | null | undefined {
   const args = argv.slice(2);
   for (let i = 0; i < args.length; i += 1) {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { Command as CommanderCommand, Option as CommanderOption } from "commander";
 import { resolveStateDir } from "../config/paths.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
+import { FLAG_TERMINATOR, isValueToken } from "../infra/cli-root-options.js";
 import { isTruthyEnvValue, normalizeEnv } from "../infra/env.js";
 import { isMainModule } from "../infra/is-main.js";
 import type { ProxyHandle } from "../infra/net/proxy/proxy-lifecycle.js";
@@ -13,7 +15,11 @@ import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import type { PluginManifestCommandAliasRegistry } from "../plugins/manifest-command-aliases.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { normalizeGeneratedHelpCommandArgv, normalizeRootHelpTargetArgv } from "./argv.js";
+import {
+  normalizeGeneratedHelpCommandArgv,
+  normalizeRootHelpTargetArgv,
+  normalizeRootNoColorArgv,
+} from "./argv.js";
 import {
   isReservedNonPluginCommandRoot,
   shouldRegisterPrimaryCommandOnly,
@@ -315,6 +321,69 @@ function isCommanderParseExit(error: unknown): error is { exitCode: number } {
   );
 }
 
+function findCommandOption(command: CommanderCommand, token: string): CommanderOption | undefined {
+  const equalsIndex = token.indexOf("=");
+  const flag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+  return command.options.find((option) => option.long === flag || option.short === flag);
+}
+
+function findSubcommand(command: CommanderCommand, name: string): CommanderCommand | undefined {
+  return command.commands.find(
+    (subcommand) => subcommand.name() === name || subcommand.aliases().includes(name),
+  );
+}
+
+function shouldOptionConsumeFollowingToken(
+  option: CommanderOption | undefined,
+  token: string,
+  next: string | undefined,
+): boolean {
+  if (!option || token.includes("=")) {
+    return false;
+  }
+  if (option.required) {
+    return true;
+  }
+  return option.optional && isValueToken(next);
+}
+
+function isNoColorConsumedAsCommandOptionValue(
+  program: CommanderCommand,
+  remainingArgs: readonly string[],
+  noColorIndex: number,
+): boolean {
+  let command = program;
+  let pendingValue = false;
+  for (let index = 0; index < noColorIndex; index += 1) {
+    const arg = remainingArgs[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      return false;
+    }
+    if (pendingValue) {
+      pendingValue = false;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      const option = findCommandOption(command, arg);
+      if (!option && index === noColorIndex - 1 && !arg.includes("=")) {
+        // Unknown option surfaces may allow arbitrary flags; keep the value-safe behavior there.
+        return true;
+      }
+      pendingValue = shouldOptionConsumeFollowingToken(option, arg, remainingArgs[index + 1]);
+      continue;
+    }
+    command = findSubcommand(command, arg) ?? command;
+  }
+  return pendingValue;
+}
+
+function normalizeRootNoColorArgvForProgram(argv: string[], program: CommanderCommand): string[] {
+  return normalizeRootNoColorArgv(argv, {
+    shouldPreserveNoColor: ({ remainingArgs, noColorIndex }) =>
+      isNoColorConsumedAsCommandOptionValue(program, remainingArgs, noColorIndex),
+  });
+}
+
 async function ensureCliEnvProxyDispatcher(): Promise<void> {
   try {
     const { hasEnvHttpProxyAgentConfigured } = await import("../infra/net/proxy-env.js");
@@ -499,7 +568,7 @@ export async function runCli(argv: string[] = process.argv) {
     }
     return;
   }
-  const normalizedArgv = normalizeRootHelpTargetArgv(parsedProfile.argv);
+  const normalizedArgv = normalizeRootHelpTargetArgv(normalizeRootNoColorArgv(parsedProfile.argv));
   const normalizedInvocation = resolveCliArgvInvocation(normalizedArgv);
   const isHelpOrVersionInvocation = normalizedInvocation.hasHelpOrVersion;
   startupTrace.mark("argv");
@@ -753,7 +822,7 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
 
-    const parseArgv = normalizeGeneratedHelpCommandArgv(rewriteUpdateFlagArgv(normalizedArgv));
+    let parseArgv = normalizeGeneratedHelpCommandArgv(rewriteUpdateFlagArgv(normalizedArgv));
     const suppressStartupProgress = hasJsonOutputFlag(parseArgv);
     const { createCliProgress } = await loadProgressModule();
     const startupProgress = createCliProgress({
@@ -895,6 +964,7 @@ export async function runCli(argv: string[] = process.argv) {
         }
       }
 
+      parseArgv = normalizeRootNoColorArgvForProgram(parseArgv, program);
       stopStartupProgress();
 
       try {


### PR DESCRIPTION
## Summary

- Root `--no-color` is accepted before a subcommand, but non-help subcommands can reject it when callers append it after the subcommand, for example `openclaw doctor --no-color ...` or `openclaw doctor --lint --json --no-color`.
- This matters for automation/proof runners that append global output flags after the command they are invoking.
- This PR normalizes unambiguous trailing `--no-color` tokens back into the root option prefix before Commander parses the final command.
- Out of scope: changing doctor behavior, changing color rendering, or broadly reordering every root option after subcommands.
- Success looks like real subcommands accepting trailing `--no-color` while `--no-color` still remains a literal value when a required command option would consume it.
- Reviewer focus: argv normalization around `--`, required option values such as `--message --no-color`, and the final Commander-metadata pass that handles boolean command flags without a hard-coded allowlist.

## Linked context

No separate issue. This is a small source-proven CLI parser bug found while running Windows upgrade proof commands.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: root `--no-color` after a subcommand could be parsed as an unknown command option instead of the root option on non-help command paths.
- Real environment tested: Windows source checkout on branch `fix/cli-no-color-subcommands`, commit `361f9c0a57`, Node `v22.22.0`, isolated OpenClaw state under `.artifacts/no-color-proof`, source rebuilt through `scripts/run-node.mjs`, then verified through built `dist/entry.js`.
- Exact steps or command run after this patch:

```powershell
node dist/entry.js doctor --lint --json --no-color --severity-min error
```

- Evidence after fix:

```json
{"ok":true,"checksRun":22,"checksSkipped":0,"findings":[]}
```

- Observed result after fix: the command accepts `--no-color` after `doctor` boolean flags and reaches doctor lint JSON output; Commander no longer rejects it as an unknown command option.
- What was not tested: full CLI suite, packaged npm install, every subcommand/plugin command combination.
- Proof limitations or environment constraints: source checkout proof only, not a packaged release artifact. The source runner rebuild output was omitted from the evidence block; the copied output above is from a clean `dist/entry.js` run after rebuild.
- Before evidence (optional but encouraged): on installed `OpenClaw 2026.6.8-beta.1`, `openclaw doctor --no-color --lint --json --severity-min error` exited before doctor ran with `OpenClaw does not recognize option "--no-color". Try: openclaw doctor error --help`.

## Tests and validation

Commands run:

```powershell
node scripts/run-vitest.mjs src/cli/argv.test.ts
node scripts/run-oxlint.mjs src\cli\argv.ts src\cli\run-main.ts src\cli\argv.test.ts
node_modules\.bin\oxfmt.cmd --check --threads=1 src\cli\argv.ts src\cli\run-main.ts src\cli\argv.test.ts
git diff --check
node scripts/run-node.mjs doctor --lint --json --no-color --severity-min error
node dist/entry.js doctor --lint --json --no-color --severity-min error
node dist/entry.js setup --wizard --no-color --help
python -X utf8 .agents\skills\autoreview\scripts\autoreview --mode local
```

Results:

```text
argv focused Vitest: 117 passed
oxlint: passed
oxfmt --check: passed
git diff --check: passed
doctor real CLI proof: {"ok":true,"checksRun":22,"checksSkipped":0,"findings":[]}
setup --wizard --no-color --help: rendered setup help without unknown-option failure
autoreview: clean, no accepted/actionable findings
```

Regression coverage added:

- Moves `--no-color` from an unambiguous subcommand position to the root option prefix.
- Preserves existing root option prefixes such as `--profile work`.
- Leaves `--no-color` after `--` positional.
- Preserves literal required-option values such as `agent --message --no-color`.
- Lets final Commander command metadata lift `--no-color` after boolean command flags without a hand-maintained boolean allowlist.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The CLI now accepts root `--no-color` after subcommands in unambiguous positions.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Accidentally treating a user-provided literal `--no-color` as the root flag when a command option expects it as a value.

How is that risk mitigated?

The early normalization remains conservative, the final parse uses Commander option metadata, and tests cover required-option values plus the `--` terminator.

## Current review state

What is the next action?

Wait for CI, ClawSweeper, and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and ClawSweeper are pending after PR creation.

Which bot or reviewer comments were addressed?

Local autoreview findings were addressed before opening: preserving `--no-color` as a required option value, and avoiding a hard-coded boolean allowlist by using final Commander command metadata.
