### PR TITLE
fix(cli): allow zero Discord timeout duration

### DIFF
--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -60,6 +60,8 @@ vi.mock("../../deps.js", () => ({
 
 const { createMessageCliHelpers } = await import("./helpers.js");
 
+const NON_NEGATIVE_INTEGER_FLAGS = new Set(["--delete-days", "--duration-min"]);
+
 const baseSendOptions = {
   channel: "discord",
   target: "123",
@@ -365,7 +367,7 @@ describe("runMessageAction", () => {
 
     await expect(runMessageAction(action, opts)).rejects.toThrow("exit");
 
-    const kind = flag === "--delete-days" ? "non-negative" : "positive";
+    const kind = NON_NEGATIVE_INTEGER_FLAGS.has(flag) ? "non-negative" : "positive";
     expect(errorMock).toHaveBeenCalledWith(`Error: ${flag} must be a ${kind} integer.`);
     expect(ensurePluginRegistryLoaded).not.toHaveBeenCalled();
     expect(messageCommandMock).not.toHaveBeenCalled();
@@ -390,7 +392,7 @@ describe("runMessageAction", () => {
       }),
     ).rejects.toThrow("exit");
 
-    const kind = flag === "--delete-days" ? "non-negative" : "positive";
+    const kind = NON_NEGATIVE_INTEGER_FLAGS.has(flag) ? "non-negative" : "positive";
     expect(errorMock).toHaveBeenCalledWith(`Error: ${flag} must be a ${kind} integer.`);
     expect(messageCommandMock).not.toHaveBeenCalled();
     expect(exitMock).toHaveBeenCalledWith(1);
@@ -413,6 +415,27 @@ describe("runMessageAction", () => {
       guildId: "g",
       userId: "u",
       deleteDays: "0",
+    });
+    expect(exitMock).toHaveBeenCalledWith(0);
+  });
+
+  it("allows zero duration-min for clearing Discord timeouts", async () => {
+    const runMessageAction = createRunMessageAction();
+
+    await expect(
+      runMessageAction("timeout", {
+        guildId: "g",
+        userId: "u",
+        durationMin: "0",
+      }),
+    ).rejects.toThrow("exit");
+
+    expect(errorMock).not.toHaveBeenCalled();
+    expectMessageCommandOptions({
+      action: "timeout",
+      guildId: "g",
+      userId: "u",
+      durationMin: "0",
     });
     expect(exitMock).toHaveBeenCalledWith(0);
   });

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -34,11 +34,13 @@ const CHANNEL_MESSAGE_ACTION_NAME_SET = new Set<string>(CHANNEL_MESSAGE_ACTION_N
 const STRICT_POSITIVE_INTEGER_OPTIONS = new Map([
   ["pollDurationHours", "--poll-duration-hours"],
   ["pollDurationSeconds", "--poll-duration-seconds"],
-  ["durationMin", "--duration-min"],
   ["limit", "--limit"],
   ["autoArchiveMin", "--auto-archive-min"],
 ]);
-const STRICT_NON_NEGATIVE_INTEGER_OPTIONS = new Map([["deleteDays", "--delete-days"]]);
+const STRICT_NON_NEGATIVE_INTEGER_OPTIONS = new Map([
+  ["durationMin", "--duration-min"],
+  ["deleteDays", "--delete-days"],
+]);
 
 type MessagePluginLoadOptions = { scope: PluginRegistryScope; onlyChannelIds?: string[] };
 type MessagePluginPreloadPlan =


### PR DESCRIPTION
## Summary

- Fixes a CLI/runtime mismatch for Discord timeout clearing.
- `openclaw message timeout --duration-min 0` should be accepted because the Discord runtime treats zero minutes as clearing the timeout.
- The shared CLI numeric validator now treats `durationMin` as non-negative, matching `deleteDays` and the Discord moderation path.
- Out of scope: changing Discord moderation auth, live Discord delivery behavior, or other numeric CLI flags.

## Linked context

Closes #93327

Related #92483, #92490

Was this requested by a maintainer or owner?

No. This is a focused bug fix from source-level behavior evidence.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the CLI rejected `--duration-min 0` before dispatch, even though Discord timeout clearing is represented downstream by `durationMinutes: 0` and `communication_disabled_until: null`.
- Real environment tested: macOS local checkout on current PR branch `fix/discord-timeout-zero`, rebuilt locally with `node scripts/build-all.mjs cliStartup` from PR SHA `e18ca11d`.
- Exact steps or command run after this patch:

```sh
node scripts/build-all.mjs cliStartup
tmp_home=$(mktemp -d)
HOME="$tmp_home" \
XDG_CONFIG_HOME="$tmp_home/.config" \
XDG_DATA_HOME="$tmp_home/.local/share" \
XDG_STATE_HOME="$tmp_home/.local/state" \
node openclaw.mjs message timeout \
  --channel discord \
  --guild-id 123456789012345678 \
  --user-id 234567890123456789 \
  --duration-min 0 \
  --dry-run \
  --json
rm -rf "$tmp_home"

pnpm vitest run src/cli/program/message/helpers.test.ts
pnpm vitest run extensions/discord/src/actions/runtime.test.ts
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/cli/program/message/helpers.test.ts extensions/discord/src/actions/runtime.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/send.creates-thread.test.ts
pnpm oxlint src/cli/program/message/helpers.ts src/cli/program/message/helpers.test.ts
pnpm oxfmt src/cli/program/message/helpers.ts src/cli/program/message/helpers.test.ts --check
git diff --check
pnpm tsgo:core
pnpm tsgo:core:test
```

- Evidence after fix:

```text
$ node scripts/build-all.mjs cliStartup
[build-all] phase timings: total 14.7s; slowest write-cli-startup-metadata 8.15s; tsdown 5.08s; runtime-postbuild 966ms; check-cli-bootstrap-imports 296ms; write-cli-compat 99ms; build-stamp 53ms; runtime-postbuild-stamp 50ms

$ HOME="$tmp_home" XDG_CONFIG_HOME="$tmp_home/.config" XDG_DATA_HOME="$tmp_home/.local/share" XDG_STATE_HOME="$tmp_home/.local/state" node openclaw.mjs message timeout --channel discord --guild-id 123456789012345678 --user-id 234567890123456789 --duration-min 0 --dry-run --json
{
  "action": "timeout",
  "channel": "discord",
  "dryRun": true,
  "handledBy": "dry-run",
  "payload": {
    "ok": true,
    "dryRun": true,
    "channel": "discord",
    "action": "timeout"
  }
}

src/cli/program/message/helpers.test.ts: 41 tests passed
extensions/discord/src/actions/runtime.test.ts: 94 tests passed
Combined CLI + Discord shard run: 4 files passed, 183 tests passed
Focused agent delivery-target test that timed out once in CI: passed locally
oxlint: passed
oxfmt --check: all matched files use the correct format
git diff --check: passed
tsgo:core: passed
tsgo:core:test: passed
```

- Observed result after fix: the real CLI accepts `--duration-min 0` and reaches the dry-run dispatch path instead of failing with `--duration-min must be a positive integer.` The helper regression test also proves `durationMin: "0"` reaches `messageCommand` for the timeout action without a CLI validation error, while malformed values still fail before plugin loading or dispatch.
- What was not tested: a live Discord guild/member timeout clear against the Discord API was not executed.
- Proof limitations or environment constraints: the changed behavior is at the local CLI validation boundary, so live guild mutation was intentionally avoided. The dry-run CLI proof exercises the public command path without sending a Discord moderation request.
- Before evidence: prior code placed `durationMin` in `STRICT_POSITIVE_INTEGER_OPTIONS`, causing `--duration-min 0` to fail with `--duration-min must be a positive integer.`

## Tests and validation

Commands run are listed above.

Regression coverage added:

- `src/cli/program/message/helpers.test.ts` now verifies `durationMin: "0"` is allowed through the CLI helper for the timeout action.
- Existing malformed numeric coverage was kept and now expects the correct non-negative validation wording for `--duration-min`.

What failed before this fix: `--duration-min 0` was rejected by the CLI validator before reaching the Discord timeout path.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The CLI now accepts an explicit zero-minute Discord timeout duration.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Discord moderation command validation.

How is that risk mitigated?

The change only widens `durationMin` from positive integer to non-negative integer, matching the Discord runtime validator and existing agent tool schema. Malformed and fractional values remain rejected before dispatch. The real CLI dry-run output proves `--duration-min 0` now passes the validation boundary without sending a live Discord moderation request.

## Current review state

What is the next action?

Ready for automated checks and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI and maintainer/automation review.

Which bot or reviewer comments were addressed?

ClawSweeper asked for real CLI behavior proof. The PR body now includes the exact after-fix dry-run command and output.
