### PR TITLE
fix(agents): repair retained compaction tool-use pairs

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1350,6 +1350,62 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(droppedCall?.customInstructions).toContain("Keep security caveats.");
   });
 
+  it("uses repaired no-drop prune output for summarization", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("mock summary");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+    });
+
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "assistant" as const,
+            content: [{ type: "toolCall", id: "call-timeout", name: "read", arguments: {} }],
+            timestamp: 1,
+          },
+          { role: "user" as const, content: "continue after timeout", timestamp: 2 },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 300_000,
+        fileOps: {
+          read: [],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4000 },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event,
+      apiKey: "test-key",
+    });
+
+    expectCompactionResult(result);
+    const summaryCall = requireRecord(mockCallArg(mockSummarizeInStages));
+    const summaryMessages = requireArray(summaryCall.messages);
+    expect(summaryMessages.map((message) => (message as { role?: unknown }).role)).toEqual([
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+    expect(summaryMessages[1]).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-timeout",
+      isError: true,
+    });
+  });
+
   it("caps summarization reserve tokens to the model output limit", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue("mock summary");

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1087,6 +1087,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         const { newContentTokens, maxHistoryTokens, pruned } = prunePlan;
 
         if (newContentTokens > maxHistoryTokens && pruned) {
+          messagesToSummarize = pruned.messages;
+
           if (pruned.droppedChunks > 0) {
             const newContentRatio = (newContentTokens / contextWindowTokens) * 100;
             log.warn(
@@ -1095,7 +1097,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               )}% of context; dropped ${pruned.droppedChunks} older chunk(s) ` +
                 `(${pruned.droppedMessages} messages) to fit history budget.`,
             );
-            messagesToSummarize = pruned.messages;
 
             // Summarize dropped messages so context isn't lost
             if (pruned.droppedMessagesList.length > 0) {

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -359,7 +359,10 @@ export function pruneHistoryForContextShare(params: {
   const defaultShare = isHandoff ? 0.2 : 0.5; // Stricter budget for handoff snapshots
   const maxHistoryShare = params.maxHistoryShare ?? defaultShare;
   const budgetTokens = Math.max(1, Math.floor(params.maxContextTokens * maxHistoryShare));
-  let keptMessages = params.messages;
+  // Validate the retained history before any budget-driven chunk drop. Some
+  // timeout paths leave an assistant tool_use in history without its matching
+  // result even when the history already fits the target budget.
+  let keptMessages = repairToolUseResultPairing(params.messages).messages;
   const allDroppedMessages: AgentMessage[] = [];
   let droppedChunks = 0;
   let droppedMessages = 0;

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -297,6 +297,29 @@ describe("pruneHistoryForContextShare", () => {
     expect(pruned.messages.length).toBe(1);
   });
 
+  it("repairs retained tool_use turns even when no chunks are pruned", () => {
+    const messages: AgentMessage[] = [
+      makeAssistantToolCall(1, "call_timeout", "needs result"),
+      makeMessage(2, 100),
+    ];
+
+    const pruned = pruneHistoryForContextShare({
+      messages,
+      maxContextTokens: 100_000,
+      maxHistoryShare: 0.5,
+      parts: 2,
+    });
+
+    expect(pruned.droppedChunks).toBe(0);
+    expect(pruned.messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "user"]);
+    const repairedResult = pruned.messages[1];
+    expect(repairedResult).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call_timeout",
+      isError: true,
+    });
+  });
+
   it("removes orphaned tool_result messages when tool_use is dropped", () => {
     // Pruning the assistant tool_use must also drop its result; orphaned
     // toolResult messages are not meaningful model context.


### PR DESCRIPTION
Fixes #93321

## Summary

- Repairs compaction history pruning before any budget-driven chunk drop so retained history cannot keep an assistant tool call without a matching tool result.
- Adopts the repaired prune output in the production `compaction-safeguard` caller even when `droppedChunks === 0`, which was the missing caller boundary from the first review.
- Reuses the existing `repairToolUseResultPairing()` transcript repair contract instead of adding provider-specific compaction logic.
- Adds both helper-level and caller-level regressions for the no-prune dangling tool-use path.
- Out of scope: changing provider adapters, replay policy, or compaction summary prompt behavior.

## Linked context

Closes #93321

Related: strict provider validation rejects compacted transcripts with `tool_use ids were found without tool_result blocks` when an assistant tool call survives without a result.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: The production compaction-safeguard path must not pass a retained assistant tool call without a matching tool result into summarization/replay. Before this fix, a no-drop prune plan could leave the caller using the original retained `assistant,user` transcript even though the planner had repaired it.
- Real environment tested: Local OpenClaw checkout on macOS at `/Users/apple/code/workspaces/openclaw/openclaw`, branch `wolf/compaction-drop-orphan-tool-use`, head `c7952f7ad494e734cfe09630e55bb992f548c08c`. The runtime probe invokes the registered `session_before_compact` handler from `src/agents/agent-hooks/compaction-safeguard.ts` directly with a redacted timeout-shaped retained transcript. It is not only a mocked Vitest assertion; it exercises the actual local compaction-safeguard extension handler boundary that prepares retained history before provider replay.
- Exact steps or command run after this patch:

~~~console
$ node --import tsx --input-type=module <<'RUNTIME_PROBE'
# registers compactionSafeguardExtension, sets runtime model config, sends a redacted retained transcript:
# input messages: assistant(toolCall call-timeout), user("continue after timeout")
# captures the messages delivered to the real handler's summarization boundary
RUNTIME_PROBE

$ node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts -t "uses repaired no-drop prune output for summarization"
$ node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts
$ node scripts/run-vitest.mjs src/agents/compaction.test.ts -t "repairs retained tool_use turns even when no chunks are pruned"
$ node scripts/run-vitest.mjs src/agents/compaction.test.ts src/agents/session-transcript-repair.test.ts
$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --base origin/main
$ git diff --check
$ node scripts/check-no-conflict-markers.mjs
$ node_modules/.bin/oxfmt --check --threads=1 src/agents/compaction-planning.ts src/agents/compaction.test.ts src/agents/agent-hooks/compaction-safeguard.ts src/agents/agent-hooks/compaction-safeguard.test.ts
$ gitleaks protect --staged --redact
~~~

- Evidence after fix:

~~~console
probe.branch wolf/compaction-drop-orphan-tool-use
probe.input.roles assistant,user
probe.output.cancelled no
probe.output.summary redacted summary from local runtime probe
probe.summarizer.roles assistant,toolResult,user
probe.toolResult.id call-timeout
probe.toolResult.isError true
probe.containsDanglingToolUse no

$ node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts -t "uses repaired no-drop prune output for summarization"
Test Files  2 passed (2)
Tests  2 passed | 190 skipped (192)

$ node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts
Test Files  1 passed (1)
Tests  96 passed (96)

$ node scripts/run-vitest.mjs src/agents/compaction.test.ts -t "repairs retained tool_use turns even when no chunks are pruned"
Test Files  2 passed (2)
Tests  2 passed | 34 skipped (36)

$ node scripts/run-vitest.mjs src/agents/compaction.test.ts src/agents/session-transcript-repair.test.ts
Test Files  1 passed (1)
Tests  48 passed (48)
Test Files  1 passed (1)
Tests  18 passed (18)

$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs --base origin/main
[check:changed] lanes=core, coreTests
[check:changed] src/agents/agent-hooks/compaction-safeguard.test.ts: core test
[check:changed] src/agents/agent-hooks/compaction-safeguard.ts: core production
[check:changed] src/agents/compaction-planning.ts: core production
[check:changed] src/agents/compaction.test.ts: core test
...
Database-first legacy-store guard passed.
...
Import cycle check: 0 runtime value cycle(s).
~~~

`git diff --check`, conflict-marker check, targeted `oxfmt --check`, and staged `gitleaks protect --staged --redact` also exited 0.

- Observed result after fix: The retained transcript begins as `assistant,user`; before summarization, the compaction-safeguard handler supplies `assistant,toolResult,user`, with a synthetic error `toolResult` for `call-timeout`. The runtime probe reports `probe.containsDanglingToolUse no`, `probe.output.cancelled no`, and the handler does not cancel compaction.
- What was not tested: No live external Anthropic/Bedrock API request was made. The proof intentionally redacts API material and captures the local OpenClaw compaction boundary before provider replay, which is the boundary that creates or prevents the invalid retained transcript shape.
- Proof limitations or environment constraints: This proof uses the actual local compaction-safeguard extension handler with redacted runtime inputs and mocked auth/model output so no external provider key or user data is required. Provider adapter behavior, replay policy, and summary prompt content are out of scope for this fix.
- Before evidence: The new caller-level regression failed before the caller fix with:

~~~console
AssertionError: expected [ 'assistant', 'user' ] to deeply equal [ 'assistant', 'toolResult', 'user' ]
~~~

The helper-level regression also failed on current `main` before the first patch with the same retained transcript shape mismatch.

## Tests and validation

- Added helper-level regression coverage in `src/agents/compaction.test.ts` for retained dangling tool-use repair when no chunks are pruned.
- Added caller-level regression coverage in `src/agents/agent-hooks/compaction-safeguard.test.ts` proving the production compaction-safeguard handler adopts repaired no-drop prune output before summarization.
- Passed focused caller regression test: `2` tests across the two selected Vitest shards.
- Passed full compaction-safeguard suite: `96` tests.
- Passed focused compaction and transcript repair tests: `18` + `48` tests.
- Passed `check-changed --base origin/main` for core/coreTests changed lanes.
- Passed formatting, whitespace/conflict-marker, and staged secret checks.
- GitHub Actions checks are currently green on head `c7952f7ad494e734cfe09630e55bb992f548c08c`, including Real behavior proof, OpenGrep, CodeQL/security lanes, check-lint, prod/test types, and affected node shards.

## Duplicate audit

Immediately before pushing the follow-up, I reran five live open-PR searches. Each query only returned this PR, `#93332`, and no separate open PR coverage:

- `Fixes #93321`: only `#93332`
- `#93321`: only `#93332`
- `orphaned tool_use compaction`: only `#93332`
- `tool_result blocks compaction`: only `#93332`
- `compaction tool_use`: only `#93332`

## Risk checklist

Did user-visible behavior change? `Yes` - compaction now repairs retained dangling tool calls instead of preserving an invalid strict-provider transcript.

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? Transcript repair can add a synthetic error tool result to retained compaction history.

How is that risk mitigated? The PR reuses the existing `repairToolUseResultPairing()` behavior already used by replay/session repair paths, adopts the repaired output at the production caller boundary, and covers both helper-level and caller-level no-drop behavior.

## Current review state

ClawSweeper's previous durable review requested redacted real OpenClaw session or compaction proof. The PR body now leads with the local runtime compaction-safeguard handler proof showing the repaired `assistant,toolResult,user` retained transcript shape on head `c7952f7ad494e734cfe09630e55bb992f548c08c`.

The last re-review request timed out while waiting for exact-review Codex capacity, so this update consolidates the proof section and requests a fresh review.
