### PR TITLE
fix(auto-reply): redact secrets in /debug show and /debug set output

### DIFF
--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -248,7 +248,9 @@ export const handleDebugCommand: CommandHandler = async (params, allowTextComman
         reply: { text: "⚙️ Debug overrides: (none)" },
       };
     }
-    const json = JSON.stringify(overrides, null, 2);
+    const schema = loadGatewayRuntimeConfigSchema();
+    const redactedOverrides = redactConfigObject(overrides, schema.uiHints);
+    const json = JSON.stringify(redactedOverrides, null, 2);
     return {
       shouldContinue: false,
       reply: {
@@ -292,8 +294,14 @@ export const handleDebugCommand: CommandHandler = async (params, allowTextComman
         reply: { text: `⚠️ ${result.error ?? "Invalid override."}` },
       };
     }
-    const valueLabel =
-      typeof debugCommand.value === "string"
+    const parsedOverridePath = parseConfigPath(debugCommand.path);
+    const valueLabel = parsedOverridePath.path
+      ? formatConfigSetValueLabel({
+          path: parsedOverridePath.path,
+          value: debugCommand.value,
+          uiHints: loadGatewayRuntimeConfigSchema().uiHints,
+        })
+      : typeof debugCommand.value === "string"
         ? `"${debugCommand.value}"`
         : JSON.stringify(debugCommand.value);
     return {

--- a/src/auto-reply/reply/commands-gating.test.ts
+++ b/src/auto-reply/reply/commands-gating.test.ts
@@ -182,6 +182,20 @@ vi.mock("./debug-commands.js", () => ({
     if (!raw.startsWith("/debug")) {
       return null;
     }
+    const parts = raw.trim().split(/\s+/);
+    const action = parts[1];
+    if (action === "set") {
+      const assignment = raw.slice(raw.indexOf(" set ") + 5).trim();
+      const equalsIndex = assignment.indexOf("=");
+      return {
+        action: "set",
+        path: assignment.slice(0, equalsIndex),
+        value: JSON.parse(assignment.slice(equalsIndex + 1)),
+      };
+    }
+    if (action === "unset") {
+      return { action: "unset", path: parts.slice(2).join(" ") };
+    }
     return { action: "show" };
   }),
 }));
@@ -525,6 +539,56 @@ describe("command gating", () => {
     expect(output).toContain("Config updated: gateway.auth.token=");
     expect(output).toContain(REDACTED_SENTINEL);
     expect(output).not.toContain("OPENCLAW_CONFIG_SET_CANARY_TOKEN_65623");
+  });
+
+  it("redacts secret-shaped fields from /debug show replies", async () => {
+    getConfigOverridesMock.mockReturnValueOnce({
+      gateway: {
+        auth: {
+          token: "OPENCLAW_DEBUG_SHOW_CANARY_TOKEN_65623",
+        },
+      },
+      channels: {
+        telegram: {
+          botToken: "OPENCLAW_DEBUG_SHOW_CANARY_BOT_TOKEN_65623",
+        },
+      },
+      messages: {
+        ackReaction: ":)",
+      },
+    });
+    const params = buildParams("/debug show", {
+      commands: { debug: true, text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const result = await handleDebugCommand(params, true);
+    const output = result?.reply?.text ?? "";
+
+    expect(output).toContain("Debug overrides (memory-only)");
+    expect(output).toContain(REDACTED_SENTINEL);
+    expect(output).toContain("ackReaction");
+    expect(output).not.toContain("OPENCLAW_DEBUG_SHOW_CANARY_TOKEN_65623");
+    expect(output).not.toContain("OPENCLAW_DEBUG_SHOW_CANARY_BOT_TOKEN_65623");
+  });
+
+  it("redacts secret-shaped values from /debug set acknowledgements", async () => {
+    const params = buildParams(
+      '/debug set gateway.auth.token="OPENCLAW_DEBUG_SET_CANARY_TOKEN_65623"',
+      {
+        commands: { debug: true, text: true },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+      } as OpenClawConfig,
+    );
+    params.command.senderIsOwner = true;
+
+    const result = await handleDebugCommand(params, true);
+    const output = result?.reply?.text ?? "";
+
+    expect(output).toContain("Debug override set: gateway.auth.token=");
+    expect(output).toContain(REDACTED_SENTINEL);
+    expect(output).not.toContain("OPENCLAW_DEBUG_SET_CANARY_TOKEN_65623");
   });
 
   it("returns explicit unauthorized replies for native privileged commands", async () => {


### PR DESCRIPTION
## Summary

PR #88496 routed `/config show` and `/config set` chat output through the shared schema-aware config redaction path, but the sibling `/debug` commands in the very same handler (`handleDebugCommand` in `src/auto-reply/reply/commands-config.ts`) were left untouched. This is the asymmetric remainder of that fix:

- `/debug show` JSON-stringifies the **entire runtime override tree verbatim**, so every secret previously stashed via `/debug set` is printed in plaintext to chat-visible output.
- `/debug set` echoes the **raw value** it just stored.

`/debug set` accepts any config path (`setConfigOverride` -> `parseConfigPath`), so a secret-shaped override such as `gateway.auth.token` or `channels.<id>.botToken` set as a runtime override is leaked back into the chat surface, exactly the class of leak #88496 closed for `/config`.

## What changed

- `/debug show`: redact the override tree with `redactConfigObject(overrides, loadGatewayRuntimeConfigSchema().uiHints)` before rendering, matching the `/config show` contract.
- `/debug set`: reuse the existing `formatConfigSetValueLabel` helper (the same one `/config set` uses) so the acknowledgement value is redacted.
- All imports were already present in the file (`redactConfigObject`, `loadGatewayRuntimeConfigSchema`, `getConfigOverrides`); non-secret fields and env-var placeholders are preserved.

Touches one source file plus its test (`commands-gating.test.ts`).

## Real behavior proof (real runtime, outside tests)

**Behavior addressed**: `/debug show` and `/debug set` must not render plaintext config secrets stored in the process-local runtime override tree to chat-visible output.

**Real environment tested**: A standalone `tsx` script run against this PR's source checkout. It drives the **real exported** `setConfigOverride` / `getConfigOverrides` (`src/config/runtime-overrides.ts`) and the **real exported** `handleDebugCommand` (`src/auto-reply/reply/commands-config.ts`). No vitest harness, no mocked redaction. The secret crosses a real boundary: it is persisted into the module-level process override tree by `setConfigOverride`, read back by `getConfigOverrides`, then rendered by the real handler.

**Exact steps or command run after this patch**:

```sh
node --import tsx ./debug-redact-proof.mts
```

The script: (1) calls the real `setConfigOverride("gateway.auth.token", <secret>)`, `setConfigOverride("channels.telegram.botToken", <secret>)`, and a non-secret `messages.ackReaction`; (2) reads the raw tree back via the real `getConfigOverrides()` to confirm plaintext is actually stored in memory; (3) drives the real `handleDebugCommand("/debug show")` and `handleDebugCommand("/debug set ...")`.

**Evidence after fix (terminal capture)**:

````text
[readback] Raw getConfigOverrides() (proves plaintext IS stored in memory):
{
  "gateway": { "auth": { "token": "SK_DEBUG_PROOF_LIVE_TOKEN_0000111122223333" } },
  "channels": { "telegram": { "botToken": "TG_DEBUG_PROOF_LIVE_BOTTOKEN_4444555566667777" } },
  "messages": { "ackReaction": ":)" }
}
[readback] raw tree contains plaintext secrets: true

[/debug show] Real handler chat-visible output:
⚙️ Debug overrides (memory-only):
```json
{
  "gateway": { "auth": { "token": "__OPENCLAW_REDACTED__" } },
  "channels": { "telegram": { "botToken": "__OPENCLAW_REDACTED__" } },
  "messages": { "ackReaction": ":)" }
}
```

[/debug set] Real handler chat-visible acknowledgement:
⚙️ Debug override set: gateway.auth.token="__OPENCLAW_REDACTED__"

========== RESULT (PATCHED) ==========
raw memory stored plaintext secrets   : true (expect true)
/debug show leaked any secret          : false (expect false)
/debug show redacted sentinel present  : true (expect true)
/debug show kept non-secret ackReaction: true (expect true)
/debug set leaked secret               : false (expect false)
/debug set redacted sentinel present   : true (expect true)

PROOF PASS
````

**Negative control (same script against pre-fix code, `git stash` of the source change)**:

````text
[/debug show] Real handler chat-visible output:
⚙️ Debug overrides (memory-only):
```json
{
  "gateway": { "auth": { "token": "SK_DEBUG_PROOF_LIVE_TOKEN_0000111122223333" } },
  ...
````

The secret token is rendered in plaintext to chat-visible output before the fix, confirming the leak the patch closes.

**Observed result after fix**: Secret-shaped override fields (`gateway.auth.token`, `channels.telegram.botToken`) render as `__OPENCLAW_REDACTED__` while the non-secret `messages.ackReaction` is preserved; `/debug set` acknowledgement is also redacted.

**What was not tested**: A live gateway restart with real channel credentials was not run; the leak path is entirely in the synchronous in-process command handler, so no network auth is needed to exercise it.

## Tests and validation

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-gating.test.ts` -> 21 passed (includes 2 new tests: `redacts secret-shaped fields from /debug show replies`, `redacts secret-shaped values from /debug set acknowledgements`).
- Negative control: with the source change stashed, the 2 new tests fail (19 passed), confirming they actually exercise the fix.
- `oxlint` on changed files: 0 warnings, 0 errors.
- `oxfmt --check` on changed files: correct format.
- `tsgo -p tsconfig.json --noEmit`: no type errors.
- `git diff --check`: clean.

## Risk checklist

- Scope: one source file (`commands-config.ts`) plus its test. No behavior change for non-secret fields or for the empty-overrides path.
- Reuses the existing, already-imported redaction helpers (`redactConfigObject`, `formatConfigSetValueLabel`); no new dependencies.
- Env-var placeholders are preserved by the existing redaction logic, so `${ENV}`-style references in overrides are not mangled.
- No competing open PR touches `commands-config.ts`, `runtime-overrides.ts`, or `redact-snapshot.ts` (scanned all open PRs).