### PR TITLE
fix(whatsapp): notify user when trailing media send fails instead of silent drop

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -673,6 +673,47 @@ describe("deliverWebReply", () => {
     expect(replyText(msg)).not.toContain("boom");
   });
 
+  it("notifies user when a non-first media send fails instead of dropping silently", async () => {
+    vi.clearAllMocks();
+    const msg = makeMsg();
+    // Two media items: first load succeeds and sends, second load succeeds but send fails.
+    (loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }).mockResolvedValueOnce({
+      buffer: Buffer.from("img1"),
+      contentType: "image/jpeg",
+      kind: "image",
+    });
+    (loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }).mockResolvedValueOnce({
+      buffer: Buffer.from("img2"),
+      contentType: "image/jpeg",
+      kind: "image",
+    });
+    // First sendMedia resolves; second sendMedia rejects.
+    (msg.platform.sendMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }).mockResolvedValueOnce(
+      createAcceptedWhatsAppSendResult("media", "media-first-ok"),
+    );
+    (msg.platform.sendMedia as unknown as { mockRejectedValueOnce: (v: unknown) => void }).mockRejectedValueOnce(
+      new Error("upload failed"),
+    );
+
+    await deliverWebReply({
+      replyResult: {
+        text: "caption",
+        mediaUrls: ["http://example.com/img1.jpg", "http://example.com/img2.jpg"],
+      },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 200,
+      replyLogger,
+      skipLog: true,
+    });
+
+    // First media succeeded — no text reply for it.
+    // Second media failed — user must be notified, not silently dropped.
+    expect(msg.platform.reply).toHaveBeenCalledTimes(1);
+    expect(replyText(msg)).toContain("⚠️ Media unavailable");
+    expect(replyText(msg)).not.toContain("upload failed");
+  });
+
   it("sanitizes XML tool-call blocks for outbound sendPayload delivery", async () => {
     const sendWhatsApp = vi.fn(async (_to: string, _text: string) => ({
       messageId: "wa-1",

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -322,6 +322,15 @@ export async function deliverWebReply(params: {
       whatsappOutboundLog.error(`Failed sending web media to ${msg.from}: ${formatError(error)}`);
       replyLogger.warn({ err: error, mediaUrl }, "failed to send web media reply");
       if (!isFirst) {
+        // Non-first media failures were silently dropped before. Notify the user
+        // so they know a trailing attachment did not arrive.
+        whatsappOutboundLog.warn(`Trailing media failed; sent warning to ${msg.from}`);
+        rememberSendResult(
+          await sendWithRetry(
+            () => msg.platform.reply("⚠️ Media unavailable.", getQuote()),
+            "media:fallback-unavailable",
+          ),
+        );
         return;
       }
       const warning = "⚠️ Media failed.";


### PR DESCRIPTION
## Problem

When a reply contains multiple media attachments and a **non-first** send fails, the `onError` callback in `deliver-reply.ts` returns early without any user notification:

```typescript
onError: async ({ error, mediaUrl, caption, isFirst }) => {
  whatsappOutboundLog.error(...);
  replyLogger.warn(...);
  if (!isFirst) {
    return;  // ← silent drop: user never knows the attachment failed
  }
  // first-item fallback logic...
```

The error is logged server-side only. The recipient sees the first media attachment (or its text fallback) but the second, third, etc. simply never arrive with no indication of failure.

## Fix

Replace the silent `return` with a brief text reply so the user knows the attachment was unavailable:

```typescript
if (!isFirst) {
  whatsappOutboundLog.warn(`Trailing media failed; sent warning to ${msg.from}`);
  rememberSendResult(
    await sendWithRetry(
      () => msg.platform.reply("⚠️ Media unavailable.", getQuote()),
      "media:fallback-unavailable",
    ),
  );
  return;
}
```

## Test

Added `deliver-reply.test.ts`: *"notifies user when a non-first media send fails instead of dropping silently"*

Sets up two-media reply where first send succeeds and second fails (non-retryable error). Asserts `reply` is called exactly once with `"⚠️ Media unavailable"`.

All 29 `deliver-reply` tests pass.

Observed on a production deployment where multi-attachment replies occasionally lost trailing attachments without any visible error to the recipient.

## Real behavior proof

- **Behavior or issue addressed:** In `deliverWebReply`, when a reply has multiple media attachments and a **non-first** send fails, the `onError` callback returned early with no user notification — the recipient silently never received the trailing attachment(s).
- **Real environment tested:** OpenClaw checkout on macOS (Darwin arm64, Node v22). Ran the actual patched `deliverWebReply` from this branch via `node --import tsx`, loading two real local image files through the real `loadWebMedia` path (files placed under the allowed local root `/tmp/openclaw`).
- **Exact steps or command run after this patch:** built a reply with two media URLs, wired a transport whose `sendMedia` accepts the first send and rejects the second (trailing) send with an upload error, then invoked delivery:
  `node --import tsx proof-media.mts`
- **Evidence after fix:** live stdout from the patched delivery path:

```console
$ node --import tsx proof-media.mts
platform.sendMedia() call #1 -> OK
[whatsapp] Sent media reply to +10000000000 (0.00MB)
platform.sendMedia() call #2 -> FAILS (simulated upload error)
[whatsapp] Failed sending web media to +10000000000: upload failed
[whatsapp] Trailing media failed; sent warning to +10000000000
platform.reply() called -> "⚠️ Media unavailable."

replies sent to user: ["⚠️ Media unavailable."]
RESULT: trailing media failure now NOTIFIES the user (pre-fix this was silently dropped)
```

- **Observed result after fix:** when the trailing media send failed, the patched code sent the user a `⚠️ Media unavailable.` reply instead of returning silently. The raw error string (`upload failed`) was kept server-side only and not leaked to the user.
- **What was not tested:** delivery against a live WhatsApp socket to a real device was not exercised; the failure was injected at the transport boundary (`platform.sendMedia`) so the real `deliverWebReply` error-handling branch executed end to end.
