### PR TITLE
fix(thinking): clamp below-range requests down to the cheapest level,…

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -648,6 +648,20 @@ describe("listThinkingLevels", () => {
       }),
     ).toBe("high");
   });
+
+  it("clamps a below-range request down to the cheapest level on a no-off profile", () => {
+    providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
+      levels: [{ id: "low" }, { id: "medium" }, { id: "high" }],
+    });
+
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "demo-noff",
+        model: "demo-model",
+        level: "off",
+      }),
+    ).toBe("low");
+  });
 });
 
 describe("listThinkingLevelLabels", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -350,7 +350,7 @@ function resolveSupportedThinkingLevelFromProfile(
   const ranked = profile.levels.toSorted((a, b) => b.rank - a.rank);
   return (
     ranked.find((entry) => entry.id !== "off" && entry.rank <= requestedRank)?.id ??
-    ranked.find((entry) => entry.id !== "off")?.id ??
+    ranked.findLast((entry) => entry.id !== "off")?.id ??
     "off"
   );
 }


### PR DESCRIPTION
**TL;DR** For session sitting at thinking `off` no-off ("reasoning only") models get silently bumped to the **most expensive** reasoning level — and the wrong value is persisted into the session.

## Summary

**What's wrong?** `resolveSupportedThinkingLevelFromProfile` (`src/auto-reply/thinking.ts`) clamps a requested thinking level to the closest supported one. It sorts the supported levels **descending** by rank, then:

```ts
const ranked = profile.levels.toSorted((a, b) => b.rank - a.rank); // descending
return (
  ranked.find((entry) => entry.id !== "off" && entry.rank <= requestedRank)?.id ??
  ranked.find((entry) => entry.id !== "off")?.id ??   // ← bug: first of a descending list = most expensive
  "off"
);
```

The second fallback only fires when **every** supported level exceeds the request — exactly the case of a stored `off` on a profile that has no `off` level. `ranked.find(non-off)` returns the *first* entry of a descending list, i.e. the **highest** level. So `off` → `high` (max spend) instead of `off` → `low`.

**Who hits it?** `src/auto-reply/reply/directive-handling.persist.ts`: when a session's current thinking level is not supported by a newly-selected model, it calls `resolveSupportedThinkingLevel(...)` and **writes the result back** to the session (`sessionEntry.thinkingLevel = remappedThinkingLevel`). So a user who keeps thinking off and switches their session onto a no-off model is silently remapped to maximum reasoning, persisted, on every later turn — never having asked for it.

**The fix.** One word: `ranked.find` → `ranked.findLast` on the second fallback. On a descending list, `findLast(non-off)` is the **lowest** non-off level. A below-range request now clamps **down** to the cheapest reasoning level, never up. Mid-range requests are unaffected (they resolve via the first `.find` branch). Regression test included.

```diff
-    ranked.find((entry) => entry.id !== "off")?.id ??
+    ranked.findLast((entry) => entry.id !== "off")?.id ??
```

## Real behavior proof

Behavior or issue addressed: a session at thinking `off` switched onto a model whose profile has no `off` level was remapped (and persisted) to the most expensive reasoning level instead of the cheapest.
Real environment tested: OpenClaw checkout of this branch on Linux/Node 24 (Oracle Linux `aarch64`); the change is pure core clamp logic, exercised by a deterministic unit test that mocks a no-off provider profile (the exact shape `directive-handling.persist.ts` feeds in).
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts` (green); to prove the regression, swap in `main`'s pre-fix file and run the new case — `git checkout origin/main -- src/auto-reply/thinking.ts && node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts -t "clamps a below-range request down"` (red), then `git checkout HEAD -- src/auto-reply/thinking.ts` to restore.
Evidence after fix: screenshot of the gree→red run below. With the old `ranked.find` the new test fails `AssertionError: expected 'high' to be 'low'`; with `ranked.findLast` the full suite is green (54 passed). The mocked profile is `[low, medium, high]` (no off) and the request is `off`,  "reasoning-only" models.
Observed result after fix: `resolveSupportedThinkingLevel({ provider, model, level: "off" })` against a no-off profile returns `low` (cheapest), where on `main` it returned `high` (most expensive). Mid-range clamps (`adaptive`→`medium`, `xhigh`→`high`) are unchanged.
What was not tested: a live end-to-end model switch needs a bundled no-off model in the catalog — fireworks/gpt-oss-120b

```
$ node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts
[test] starting test/vitest/vitest.auto-reply.config.ts

 RUN  v4.1.7 /tmp/oc-clamp

 ✓  auto-reply  src/auto-reply/thinking.test.ts (54 tests) 98ms

 Test Files  1 passed (1)
      Tests  54 passed (54)
   Start at  15:12:38
   Duration  795ms (transform 218ms, setup 218ms, import 305ms, tests 98ms, environment 0ms)

[test] passed 1 Vitest shard in 8.66s
$ sed -i 's/ranked\.findLast(/ranked.find(/' src/auto-reply/thinking.ts
$ node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts | grep -A100 "Failed Tests"
[test] starting test/vitest/vitest.auto-reply.config.ts

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL   auto-reply  src/auto-reply/thinking.test.ts > listThinkingLevels > clamps a below-range request down to the cheapest level on a no-off profile
AssertionError: expected 'high' to be 'low' // Object.is equality

Expected: "low"
Received: "high"

 ❯ src/auto-reply/thinking.test.ts:664:7
    662|         level: "off",
    663|       }),
    664|     ).toBe("low");
       |       ^
    665|   });
    666| });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

[test] failed 1 Vitest shard in 8.74s
```

<img width="1213" height="678" alt="image" src="https://github.com/user-attachments/assets/6d414de6-784a-4b4a-a27a-33ebaa5d0ea2" />


## Tests and validation

- `src/auto-reply/thinking.test.ts`: **54 passed**, incl. the new `clamps a below-range request down to the cheapest level on a no-off profile` case — proven **red on `main`** (`expected 'high' to be 'low'`) and green with the fix.
- `tsgo` core + core-test lanes: clean. oxfmt: clean.
- No existing test pinned the old escalate-up behavior, so nothing was rewritten to accommodate the change.

## Risk checklist

- Strictly cost-reducing: the only behavior change is that a below-range request resolves to the cheapest supported level instead of the most expensive. It cannot raise spend or block a model.
- Single fallback branch touched; the first `.find` (closest level at or below the request) and the final `"off"` default are unchanged. Off-only, binary, and full profiles are unaffected (they either contain the requested level or have a level at/below it).
- No config, schema, persistence, or protocol surface changes. Plugin-agnostic core fix; benefits every provider with a no-off profile, not just Fireworks.
- Net **+21/−1** across 2 files (1 prod line + a regression test).

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?
Maintainer: review/land + ordering vs the sibling PR.
CI: standard checks. No external proof outstanding.

Which bot or reviewer comments were addressed? None posted yet.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>