### PR TITLE
fix(channels): use resolved accounts for status snapshots

### DIFF
--- a/src/channels/plugins/status.test.ts
+++ b/src/channels/plugins/status.test.ts
@@ -1,0 +1,78 @@
+// Verifies channel status snapshots use the account shape expected by plugin status hooks.
+import { describe, expect, it, vi } from "vitest";
+import { buildChannelAccountSnapshot } from "./status.js";
+import type { ChannelPlugin } from "./types.plugin.js";
+
+type TestAccount = {
+  accountId: string;
+  authToken: string;
+  fromNumber: string;
+};
+
+describe("buildChannelAccountSnapshot", () => {
+  it("passes resolved accounts to plugin-owned status snapshot builders", async () => {
+    const inspectAccount = vi.fn(() => ({
+      enabled: true,
+      configured: false,
+      tokenStatus: "missing",
+    }));
+    const resolveAccount = vi.fn(
+      (): TestAccount => ({
+        accountId: "default",
+        authToken: "resolved-token",
+        fromNumber: "+15557654321",
+      }),
+    );
+    const buildAccountSnapshot = vi.fn(({ account }: { account: TestAccount }) => ({
+      accountId: account.accountId,
+      name: account.fromNumber,
+      configured: Boolean(account.authToken && account.fromNumber),
+    }));
+    const plugin = {
+      id: "sms",
+      config: {
+        inspectAccount,
+        resolveAccount,
+      },
+      status: {
+        buildAccountSnapshot,
+      },
+    } as unknown as ChannelPlugin<TestAccount>;
+
+    const snapshot = await buildChannelAccountSnapshot({
+      plugin,
+      cfg: {},
+      accountId: "default",
+      runtime: {
+        accountId: "default",
+        running: true,
+        connected: true,
+      },
+    });
+
+    expect(inspectAccount).not.toHaveBeenCalled();
+    expect(resolveAccount).toHaveBeenCalledWith({}, "default");
+    expect(buildAccountSnapshot).toHaveBeenCalledWith({
+      account: {
+        accountId: "default",
+        authToken: "resolved-token",
+        fromNumber: "+15557654321",
+      },
+      audit: undefined,
+      cfg: {},
+      probe: undefined,
+      runtime: {
+        accountId: "default",
+        running: true,
+        connected: true,
+      },
+    });
+    expect(snapshot).toMatchObject({
+      accountId: "default",
+      name: "+15557654321",
+      configured: true,
+      running: true,
+      connected: true,
+    });
+  });
+});

--- a/src/channels/plugins/status.ts
+++ b/src/channels/plugins/status.ts
@@ -51,7 +51,9 @@ export async function buildChannelAccountSnapshotFromAccount<ResolvedAccount>(pa
     };
   }
 
+  const runtimeFields = projectSafeChannelAccountSnapshotFields(params.runtime);
   return {
+    ...runtimeFields,
     ...snapshot,
     accountId: normalizeOptionalString(snapshot.accountId) ? snapshot.accountId : params.accountId,
     enabled: snapshot.enabled ?? params.enabledFallback,
@@ -86,9 +88,12 @@ export async function buildChannelAccountSnapshot<ResolvedAccount>(params: {
   probe?: unknown;
   audit?: unknown;
 }): Promise<ChannelAccountSnapshot> {
-  const inspectedAccount = await inspectChannelAccount(params);
-  const account = (inspectedAccount ??
-    params.plugin.config.resolveAccount(params.cfg, params.accountId)) as ResolvedAccount;
+  const account = (
+    params.plugin.status?.buildAccountSnapshot
+      ? params.plugin.config.resolveAccount(params.cfg, params.accountId)
+      : ((await inspectChannelAccount(params)) ??
+        params.plugin.config.resolveAccount(params.cfg, params.accountId))
+  ) as ResolvedAccount;
   return await buildChannelAccountSnapshotFromAccount({
     ...params,
     account,


### PR DESCRIPTION
## Summary

- Fixes channel status snapshots for plugins, like SMS, whose safe `inspectAccount()` output is not the same shape as their resolved runtime account.
- This matters now because a real Twilio SMS account was configured and the gateway registered its webhook, but `openclaw channels status --channel sms --json` incorrectly reported `configured: false`.
- Intended outcome: plugin-owned status builders receive the resolved account shape they are designed for, while safe runtime fields like `running`/`connected` are still preserved in status output.
- Out of scope: Twilio API probing, SMS config migration, plugin install cleanup, Discord voice fixes, and version/build marker changes.
- Success looks like SMS status reporting `configured: true` for a configured account, with regression coverage for plugins that expose both `inspectAccount()` and `status.buildAccountSnapshot()`.
- Reviewers should focus on the account-source choice in `buildChannelAccountSnapshot`, the safe runtime-field merge order, and whether the test captures the intended contract.

## Linked context

Which issue does this close?

Closes N/A

Which issues, PRs, or discussions are related?

Related N/A

Was this requested by a maintainer or owner?

Requested during owner/operator investigation of a live OpenClaw git checkout where SMS was configured but status reported it as unconfigured.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw channels status --channel sms --json` reported SMS as unconfigured even though `channels.sms` had Twilio credentials and the gateway registered the SMS webhook route.
- Real environment tested: Local OpenClaw gateway running from a git checkout on `main`, with Twilio SMS configured inline in `~/.openclaw/openclaw.json`.
- Exact steps or command run after this patch:
  `openclaw channels status --channel sms --json`
- Evidence after fix:
  ```json
  {
    "channels": {
      "sms": {
        "configured": true
      }
    },
    "channelAccounts": {
      "sms": [
        {
          "accountId": "default",
          "name": "+REDACTED",
          "enabled": true,
          "configured": true,
          "statusState": "configured"
        }
      ]
    }
  }
  ```
- Observed result after fix: SMS status now reports the configured account as configured instead of falling back to the safe inspection summary.
- What was not tested: Live Twilio webhook delivery and Twilio API probe behavior.
- Proof limitations or environment constraints: Output was redacted to avoid exposing the configured phone number and endpoint details.
- Before evidence:
  ```json
  {
    "channels": {
      "sms": {
        "configured": false
      }
    },
    "channelAccounts": {
      "sms": [
        {
          "accountId": "default",
          "name": "SMS",
          "enabled": true,
          "configured": false,
          "statusState": "unconfigured"
        }
      ]
    }
  }
  ```

## Tests and validation

Which commands did you run?

```bash
PATH=/home/openclaw/.openclaw/tools/node-v22.22.0/bin:$PATH \
  /home/openclaw/.openclaw/tools/node-v22.22.0/bin/node \
  scripts/run-vitest.mjs run \
  --config test/vitest/vitest.channels.config.ts \
  src/channels/plugins/status.test.ts
```

What regression coverage was added or updated?

Added `src/channels/plugins/status.test.ts`, covering a plugin that has both a safe `inspectAccount()` summary and a plugin-owned `status.buildAccountSnapshot()` that needs the resolved account.

What failed before this fix, if known?

SMS status could report `configured: false` because the status builder received the safe inspection summary instead of the resolved account containing Twilio account fields.

If no test was added, why not?

A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No external behavior change. The fix passes the resolved account to the plugin-owned status builder inside the existing status path; it does not add new network calls or expose raw secrets.

What is the highest-risk area?

Accidentally exposing sensitive account fields in status output.

How is that risk mitigated?

The status output still comes from the plugin-owned snapshot builder plus safe projected runtime fields. Runtime field merging uses `projectSafeChannelAccountSnapshotFields`, and the regression test verifies status output behavior without exposing credential fields.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on maintainer review and CI.

Which bot or reviewer comments were addressed?

N/A.