### PR TITLE
fix(codex): de-duplicate commentary notes across the raw response lane

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1205,8 +1205,7 @@ describe("CodexAppServerEventProjector", () => {
       onAgentEvent,
     });
 
-    // Two separate notes that happen to share text must each be delivered; the
-    // cross-lane echo guard only drops a repeat from the *other* lane.
+    // Two separate notes that happen to share text must each be delivered.
     for (const id of ["msg-1", "msg-2"]) {
       await projector.handleNotification(
         forCurrentTurn("item/started", {
@@ -1225,6 +1224,146 @@ describe("CodexAppServerEventProjector", () => {
       "Checking the workspace",
       "Checking the workspace",
     ]);
+  });
+
+  it("delivers a later raw-only commentary note after consuming a same-text typed echo", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+    const rawCommentary = () =>
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Checking the workspace" }],
+        },
+      });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-commentary", phase: "commentary", text: "" },
+      }),
+    );
+    await projector.handleNotification(
+      agentMessageDelta("Checking the workspace", "msg-commentary"),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "Checking the workspace",
+        },
+      }),
+    );
+    await projector.handleNotification(rawCommentary());
+    await projector.handleNotification(rawCommentary());
+
+    const preambles = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(preambles.map((event) => event.data.itemId)).toEqual([
+      "msg-commentary",
+      "raw-assistant-2",
+    ]);
+  });
+
+  it("pairs a raw commentary echo after a rewritten typed completion", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-commentary", phase: "commentary", text: "" },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "Contributor-rewritten note",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Original model note" }],
+        },
+      }),
+    );
+
+    const preambles = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(preambles.map((event) => event.data.progressText)).toEqual([
+      "Contributor-rewritten note",
+    ]);
+    expect(preambles.every((event) => event.data.itemId === "msg-commentary")).toBe(true);
+  });
+
+  it("clears a pending commentary echo when the raw envelope has no text", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-commentary", phase: "commentary", text: "" },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: " ",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [],
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Later raw-only note" }],
+        },
+      }),
+    );
+
+    const preambles = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(preambles.map((event) => event.data.progressText)).toEqual(["Later raw-only note"]);
   });
 
   it("does not resolve commentary-phase assistant text as the final reply", async () => {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1150,6 +1150,83 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.assistantTexts).toEqual(["final answer"]);
   });
 
+  it("does not double-deliver a commentary note echoed on the raw response lane", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    // Typed agentMessage lane streams the note, keyed by the thread item id.
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: { type: "agentMessage", id: "msg-commentary", phase: "commentary", text: "" },
+      }),
+    );
+    await projector.handleNotification(
+      agentMessageDelta("Checking the workspace", "msg-commentary"),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "agentMessage",
+          id: "msg-commentary",
+          phase: "commentary",
+          text: "Checking the workspace",
+        },
+      }),
+    );
+    // Raw response lane echoes the same note. Codex omits the message id on the
+    // wire (ResponseItem::Message.id is skip_serializing), so the projector
+    // synthesizes a `raw-assistant-*` id that never matches the thread item id.
+    await projector.handleNotification(
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          type: "message",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Checking the workspace" }],
+        },
+      }),
+    );
+
+    const preambles = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(preambles.map((event) => event.data.progressText)).toEqual(["Checking the workspace"]);
+    expect(preambles.every((event) => event.data.itemId === "msg-commentary")).toBe(true);
+  });
+
+  it("delivers distinct same-text commentary notes from the same lane within a turn", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    // Two separate notes that happen to share text must each be delivered; the
+    // cross-lane echo guard only drops a repeat from the *other* lane.
+    for (const id of ["msg-1", "msg-2"]) {
+      await projector.handleNotification(
+        forCurrentTurn("item/started", {
+          item: { type: "agentMessage", id, phase: "commentary", text: "" },
+        }),
+      );
+      await projector.handleNotification(agentMessageDelta("Checking the workspace", id));
+    }
+
+    const preambles = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(preambles.map((event) => event.data.itemId)).toEqual(["msg-1", "msg-2"]);
+    expect(preambles.map((event) => event.data.progressText)).toEqual([
+      "Checking the workspace",
+      "Checking the workspace",
+    ]);
+  });
+
   it("does not resolve commentary-phase assistant text as the final reply", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -149,13 +149,9 @@ export class CodexAppServerEventProjector {
   private readonly assistantItemOrder: string[] = [];
   private readonly assistantPhaseByItem = new Map<string, string>();
   private readonly lastCommentaryProgressTextByItem = new Map<string, string>();
-  // Codex surfaces each assistant note on two lanes: the typed agentMessage lane
-  // (real thread item id) and the raw rawResponseItem lane (the message item omits
-  // its id on the wire, so we synthesize `raw-assistant-*`). The per-item guard
-  // can't dedupe across lanes because the ids never match, so we record which lane
-  // first emitted each note text this turn and drop only the echo from the other
-  // lane; same-lane repeats (distinct notes that share text) still flow.
-  private readonly commentaryLaneByProgressText = new Map<string, "typed" | "raw">();
+  // Codex emits each typed item completion before its matching raw response item.
+  // Pair by protocol order because contributors may rewrite only the typed text.
+  private pendingRawCommentaryEchoes = 0;
   private readonly reasoningTextByGroup = new Map<string, ReasoningTextGroup>();
   private readonly reasoningItemOrder = new Map<string, number>();
   private readonly planTextByItem = new Map<string, string>();
@@ -523,7 +519,7 @@ export class CodexAppServerEventProjector {
     const text = `${this.assistantTextByItem.get(itemId) ?? ""}${delta}`;
     this.assistantTextByItem.set(itemId, text);
     if (this.isCommentaryAssistantItem(itemId)) {
-      this.emitCommentaryProgress({ itemId, text, lane: "typed" });
+      this.emitCommentaryProgress({ itemId, text });
     } else if (this.shouldStreamAssistantPartial(itemId)) {
       await this.params.onPartialReply?.({ text, delta });
     }
@@ -659,7 +655,8 @@ export class CodexAppServerEventProjector {
       this.rememberAssistantItem(item.id);
       this.assistantTextByItem.set(item.id, item.text);
       if (item.text && this.isCommentaryAssistantItem(item.id)) {
-        this.emitCommentaryProgress({ itemId: item.id, text: item.text, lane: "typed" });
+        this.emitCommentaryProgress({ itemId: item.id, text: item.text });
+        this.pendingRawCommentaryEchoes += 1;
       }
     }
     this.recordNativeGeneratedMedia(item);
@@ -921,19 +918,23 @@ export class CodexAppServerEventProjector {
     if (readString(item, "role") !== "assistant") {
       return;
     }
+    const phase = readString(item, "phase");
+    if (phase === "commentary" && this.pendingRawCommentaryEchoes > 0) {
+      this.pendingRawCommentaryEchoes -= 1;
+      return;
+    }
     const text = extractRawAssistantText(item);
     if (!text) {
       return;
     }
     const itemId = readString(item, "id") ?? `raw-assistant-${this.assistantItemOrder.length + 1}`;
-    const phase = readString(item, "phase");
     if (phase) {
       this.assistantPhaseByItem.set(itemId, phase);
     }
     this.rememberAssistantItem(itemId);
     this.assistantTextByItem.set(itemId, text);
     if (phase === "commentary") {
-      this.emitCommentaryProgress({ itemId, text, lane: "raw" });
+      this.emitCommentaryProgress({ itemId, text });
     }
   }
 
@@ -1064,11 +1065,7 @@ export class CodexAppServerEventProjector {
     return this.assistantPhaseByItem.get(itemId) === "final_answer";
   }
 
-  private emitCommentaryProgress(params: {
-    itemId: string;
-    text: string;
-    lane: "typed" | "raw";
-  }): void {
+  private emitCommentaryProgress(params: { itemId: string; text: string }): void {
     const progressText = params.text.replace(/\s+/g, " ").trim();
     if (
       !progressText ||
@@ -1077,15 +1074,6 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.lastCommentaryProgressTextByItem.set(params.itemId, progressText);
-    const firstLane = this.commentaryLaneByProgressText.get(progressText);
-    if (firstLane !== undefined && firstLane !== params.lane) {
-      // The other lane already delivered this exact note; the downstream buffer
-      // keys on item id, so emitting again would post it twice. Drop the echo.
-      return;
-    }
-    if (firstLane === undefined) {
-      this.commentaryLaneByProgressText.set(progressText, params.lane);
-    }
     this.emitAgentEvent({
       stream: "item",
       data: {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -149,6 +149,13 @@ export class CodexAppServerEventProjector {
   private readonly assistantItemOrder: string[] = [];
   private readonly assistantPhaseByItem = new Map<string, string>();
   private readonly lastCommentaryProgressTextByItem = new Map<string, string>();
+  // Codex surfaces each assistant note on two lanes: the typed agentMessage lane
+  // (real thread item id) and the raw rawResponseItem lane (the message item omits
+  // its id on the wire, so we synthesize `raw-assistant-*`). The per-item guard
+  // can't dedupe across lanes because the ids never match, so we record which lane
+  // first emitted each note text this turn and drop only the echo from the other
+  // lane; same-lane repeats (distinct notes that share text) still flow.
+  private readonly commentaryLaneByProgressText = new Map<string, "typed" | "raw">();
   private readonly reasoningTextByGroup = new Map<string, ReasoningTextGroup>();
   private readonly reasoningItemOrder = new Map<string, number>();
   private readonly planTextByItem = new Map<string, string>();
@@ -516,7 +523,7 @@ export class CodexAppServerEventProjector {
     const text = `${this.assistantTextByItem.get(itemId) ?? ""}${delta}`;
     this.assistantTextByItem.set(itemId, text);
     if (this.isCommentaryAssistantItem(itemId)) {
-      this.emitCommentaryProgress({ itemId, text });
+      this.emitCommentaryProgress({ itemId, text, lane: "typed" });
     } else if (this.shouldStreamAssistantPartial(itemId)) {
       await this.params.onPartialReply?.({ text, delta });
     }
@@ -652,7 +659,7 @@ export class CodexAppServerEventProjector {
       this.rememberAssistantItem(item.id);
       this.assistantTextByItem.set(item.id, item.text);
       if (item.text && this.isCommentaryAssistantItem(item.id)) {
-        this.emitCommentaryProgress({ itemId: item.id, text: item.text });
+        this.emitCommentaryProgress({ itemId: item.id, text: item.text, lane: "typed" });
       }
     }
     this.recordNativeGeneratedMedia(item);
@@ -926,7 +933,7 @@ export class CodexAppServerEventProjector {
     this.rememberAssistantItem(itemId);
     this.assistantTextByItem.set(itemId, text);
     if (phase === "commentary") {
-      this.emitCommentaryProgress({ itemId, text });
+      this.emitCommentaryProgress({ itemId, text, lane: "raw" });
     }
   }
 
@@ -1057,7 +1064,11 @@ export class CodexAppServerEventProjector {
     return this.assistantPhaseByItem.get(itemId) === "final_answer";
   }
 
-  private emitCommentaryProgress(params: { itemId: string; text: string }): void {
+  private emitCommentaryProgress(params: {
+    itemId: string;
+    text: string;
+    lane: "typed" | "raw";
+  }): void {
     const progressText = params.text.replace(/\s+/g, " ").trim();
     if (
       !progressText ||
@@ -1066,6 +1077,15 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.lastCommentaryProgressTextByItem.set(params.itemId, progressText);
+    const firstLane = this.commentaryLaneByProgressText.get(progressText);
+    if (firstLane !== undefined && firstLane !== params.lane) {
+      // The other lane already delivered this exact note; the downstream buffer
+      // keys on item id, so emitting again would post it twice. Drop the echo.
+      return;
+    }
+    if (firstLane === undefined) {
+      this.commentaryLaneByProgressText.set(progressText, params.lane);
+    }
     this.emitAgentEvent({
       stream: "item",
       data: {


### PR DESCRIPTION
## Summary
Fixes #93296.

With `openai/gpt-5.4-mini` (OpenAI Codex app-server runtime) in verbose/rv mode, every inter-tool 💬 commentary "note" was delivered **twice** on Discord — two messages, identical text, distinct message ids.

The codex event projector surfaces each assistant note on two lanes:
- the **typed agentMessage lane** (`item/agentMessage/delta` + `item/completed`), keyed by the codex thread item id; and
- the **raw response lane** (`rawResponseItem/completed`), a fallback added in #82403 for turns whose completion omits items.

`emitCommentaryProgress` deduped only per-item id. The two lanes never share an id — codex's `ResponseItem::Message.id` is `#[serde(default, skip_serializing)]` (see `codex-rs/protocol/src/models.rs`), so it is omitted on the wire and the projector synthesizes a `raw-assistant-*` id. The per-item guard therefore could not see the cross-lane duplicate, and the downstream commentary buffer (`noteCommentaryProgress` in `src/auto-reply/reply/dispatch-from-config.ts`), which coalesces by item id, flushed both as separate `💬` messages.

The projector already does content-based cross-lane dedupe for generated media from this same typed+raw pair; commentary text lacked the equivalent guard.

## Fix
`extensions/codex/src/app-server/event-projector.ts`: track the set of note texts already emitted as commentary progress for the turn, and drop a later emission carrying the same text under a different item id. The raw lane stays intact as the fallback for item-less completions (the first emission of a note still goes through); only the cross-lane echo is suppressed. Per-turn scoping is automatic — the projector instance is constructed per turn.

## Verification
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts` — 92 passed, including two new regression tests: `does not double-deliver a commentary note echoed on the raw response lane` and `delivers distinct same-text commentary notes from the same lane within a turn`.
- Confirmed the dup test fails on `main` (without the dedupe guard) and passes with it.

## Real behavior proof
Behavior addressed: openai/gpt-5.4-mini (codex app-server) delivered every 💬 inter-tool note twice on Discord in verbose mode.
Real environment tested: live OpenClaw gateway on macOS, build from `v2026.6.8-beta.1`, Discord channel, `openai/gpt-5.4-mini`, `/verbose on`, `/reasoning off`. Patched the compiled projector chunk in the live dist with this fix, restarted the gateway, ran the same canonical prompt before and after.
Exact steps or command run after this patch: `/new` → `/model openai/gpt-5.4-mini` → `/verbose on` → `/reasoning off` → canonical prompt ("run sleep 8 && date, then survey your workspace … 3-bullet summary").
Evidence after fix: keyframe GIF of the live verbose run on the patched build — each 💬 note posts exactly once (no repeats): https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets/pr-proof/93343/run-keyframes.gif
![after-fix: each commentary note delivered once](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets/pr-proof/93343/run-keyframes.gif)
Observed result after fix: before the patch the same prompt produced each note twice (two messages, identical text, distinct ids); after the patch each note appeared once. Copied live output — Discord #prod_test (after, patched): "I'm running the terminal check now…" (msg 1516233809891295262), "The sleep is still running…" (msg 1516233870255587348), "I've got the timestamp…" (msg 1516233898785374260), "`find -printf` isn't available here…" (msg 1516233963738497094), "The size pass is still chewing…" (msg 1516234097851105382) — five distinct notes, none repeated. Final answer unaffected.
What was not tested: only the codex app-server route (openai/gpt-5.4-mini) was exercised live; other providers/models rely on the unit tests. The fix is currently running on the author's live instance (hand-applied to the built dist); this PR is the durable upstream fix.

**After-fix run (live, patched build) — each 💬 commentary note posts exactly once:**

![after-fix: each commentary note delivered once](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets/pr-proof/93343/run-keyframes.gif)

Copied live output — Discord `#prod_test`, same canonical prompt, before vs after the patch:

Before (stock build — every note delivered twice):

```text
💬 I'm running the requested terminal check first …   (msg 1516100847983923261)
💬 I'm running the requested terminal check first …   (msg 1516100873225507028)  ← duplicate
💬 The shell is still running …                        (msg 1516100907438309570)
💬 The shell is still running …                        (msg 1516100994147024986)  ← duplicate
```

After (patched — each note once):

```text
💬 I'm running the terminal check now …                (msg 1516233809891295262)
💬 The sleep is still running …                        (msg 1516233870255587348)
💬 I've got the timestamp …                            (msg 1516233898785374260)
💬 `find -printf` isn't available here …               (msg 1516233963738497094)
💬 The size pass is still chewing …                    (msg 1516234097851105382)
```

AI assistance: implemented and tested with Claude Code; independently code-reviewed by Codex (gpt-5.5) against upstream `openai/codex` source.

## Codex contract checked (per AGENTS.md)
- `codex-rs/protocol/src/models.rs` — `ResponseItem::Message.id` is `skip_serializing`/`#[ts(skip)]`; `MessagePhase::{Commentary,FinalAnswer}`.
- `codex-rs/core/src/session/mod.rs` — `record_conversation_items` → `send_raw_response_items` emits a `RawResponseItem` event per item, including assistant messages, after the typed lane.
- `codex-rs/app-server-protocol/schema/typescript/{ServerNotification,v2/RawResponseItemCompletedNotification}.ts` — `rawResponseItem/completed` carries `{ threadId, turnId, item: ResponseItem }`.
