### PR TITLE
feat(gateway): restrict session tools by connecting client id

### DIFF
--- a/src/config/config.gateway-tools-by-client-id.test.ts
+++ b/src/config/config.gateway-tools-by-client-id.test.ts
@@ -1,0 +1,35 @@
+// Verifies gateway.tools.byClientId round-trips through the real config schema
+// (regression guard: the strict gateway.tools object must accept the key, or a
+// config that sets it is rejected at load/save/doctor time).
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectRaw } from "./validation.js";
+
+describe("config gateway.tools.byClientId schema", () => {
+  it("accepts a byClientId allow/deny restriction map", () => {
+    const result = validateConfigObjectRaw({
+      gateway: {
+        tools: {
+          allow: ["browser"],
+          byClientId: {
+            "example-restricted-ui": { allow: ["browser", "memory_search"] },
+            "another-client": { deny: ["nodes"] },
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects unknown keys inside a byClientId entry (strict inner object)", () => {
+    const result = validateConfigObjectRaw({
+      gateway: {
+        tools: {
+          byClientId: {
+            x: { allow: ["browser"], bogus: true },
+          },
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -459,6 +459,17 @@ export type GatewayToolsConfig = {
   deny?: string[];
   /** Tools to explicitly allow (removes from default deny list). */
   allow?: string[];
+  /**
+   * Per-client-id tool restrictions, keyed by the connecting gateway client's
+   * `client.id`. When an operator/webchat agent turn runs for a session whose
+   * operator connected with a matching `client.id`, the entry's `allow`/`deny`
+   * are applied as a RESTRICTION on top of the existing policy — they can only
+   * reduce the available tools, never escalate. This lets a deployment scope a
+   * specific connecting surface (identified by its `client.id`) to a reduced
+   * toolset even when it shares an operator path that would otherwise expose the
+   * full toolset.
+   */
+  byClientId?: Record<string, { allow?: string[]; deny?: string[] }>;
 };
 
 export type GatewayConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1069,6 +1069,17 @@ export const OpenClawSchema = z
           .object({
             deny: z.array(z.string()).optional(),
             allow: z.array(z.string()).optional(),
+            byClientId: z
+              .record(
+                z.string(),
+                z
+                  .object({
+                    allow: z.array(z.string()).optional(),
+                    deny: z.array(z.string()).optional(),
+                  })
+                  .strict(),
+              )
+              .optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/mcp-http.by-client-id.test.ts
+++ b/src/gateway/mcp-http.by-client-id.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Verify the registry-driven plumbing: McpLoopbackToolCache reads the operator
+// session's recorded client.id and forwards the matching
+// gateway.tools.byClientId allow/deny into resolveGatewayScopedTools.
+
+type MockTool = { name: string };
+
+const resolveGatewayScopedToolsMock = vi.hoisted(() =>
+  vi.fn<
+    (params: { allowToolNames?: Iterable<string>; excludeToolNames?: Iterable<string> }) => {
+      agentId: string;
+      tools: MockTool[];
+    }
+  >(() => ({ agentId: "main", tools: [{ name: "browser" }] })),
+);
+
+vi.mock("./tool-resolution.js", () => ({
+  resolveGatewayScopedTools: (...args: Parameters<typeof resolveGatewayScopedToolsMock>) =>
+    resolveGatewayScopedToolsMock(...args),
+}));
+
+vi.mock("../agents/tool-policy.js", () => ({
+  applyOwnerOnlyToolPolicy: (tools: MockTool[]) => tools,
+}));
+
+vi.mock("./mcp-http.schema.js", () => ({
+  buildMcpToolSchema: (tools: MockTool[]) => tools.map((t) => ({ name: t.name })),
+}));
+
+import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
+import {
+  resetSessionOperatorClientIdsForTest,
+  setSessionOperatorClientId,
+} from "./session-client-id-registry.js";
+
+const RESTRICTED_CLIENT = "example-restricted-ui";
+
+function makeCfg() {
+  return {
+    gateway: {
+      tools: {
+        byClientId: {
+          [RESTRICTED_CLIENT]: {
+            allow: ["browser", "memory_search", "memory_get"],
+          },
+        },
+      },
+    },
+  } as never;
+}
+
+function lastCall() {
+  const calls = resolveGatewayScopedToolsMock.mock.calls;
+  return calls[calls.length - 1]?.[0];
+}
+
+beforeEach(() => {
+  resolveGatewayScopedToolsMock.mockClear();
+  resetSessionOperatorClientIdsForTest();
+});
+
+afterEach(() => {
+  resetSessionOperatorClientIdsForTest();
+});
+
+describe("McpLoopbackToolCache gateway.tools.byClientId", () => {
+  it("applies the allow list for a session whose operator is a restricted client", () => {
+    const cache = new McpLoopbackToolCache();
+    setSessionOperatorClientId("agent:main:main", RESTRICTED_CLIENT);
+    cache.resolve({
+      cfg: makeCfg(),
+      sessionKey: "agent:main:main",
+      messageProvider: undefined,
+      accountId: undefined,
+      senderIsOwner: true,
+    });
+    const params = lastCall();
+    expect(Array.from(params?.allowToolNames ?? [])).toEqual([
+      "browser",
+      "memory_search",
+      "memory_get",
+    ]);
+  });
+
+  it("does not restrict a session whose operator has a different client.id", () => {
+    const cache = new McpLoopbackToolCache();
+    setSessionOperatorClientId("agent:main:main", "webchat-ui");
+    cache.resolve({
+      cfg: makeCfg(),
+      sessionKey: "agent:main:main",
+      messageProvider: undefined,
+      accountId: undefined,
+      senderIsOwner: true,
+    });
+    const params = lastCall();
+    expect(params?.allowToolNames).toBeUndefined();
+  });
+
+  it("does not restrict when no client.id is recorded for the session", () => {
+    const cache = new McpLoopbackToolCache();
+    cache.resolve({
+      cfg: makeCfg(),
+      sessionKey: "agent:main:main",
+      messageProvider: undefined,
+      accountId: undefined,
+      senderIsOwner: true,
+    });
+    const params = lastCall();
+    expect(params?.allowToolNames).toBeUndefined();
+  });
+
+  it("merges byClientId.deny into excludeToolNames (alongside native excludes)", () => {
+    const cache = new McpLoopbackToolCache();
+    setSessionOperatorClientId("agent:main:main", RESTRICTED_CLIENT);
+    const cfg = {
+      gateway: {
+        tools: {
+          byClientId: {
+            [RESTRICTED_CLIENT]: { deny: ["nodes"] },
+          },
+        },
+      },
+    } as never;
+    cache.resolve({
+      cfg,
+      sessionKey: "agent:main:main",
+      messageProvider: undefined,
+      accountId: undefined,
+      senderIsOwner: true,
+    });
+    const params = lastCall();
+    const excludes = Array.from(params?.excludeToolNames ?? []);
+    expect(excludes).toContain("nodes");
+    // native excludes are preserved
+    expect(excludes).toContain("exec");
+  });
+
+  it("keys the cache by client.id so the same session resolves differently per operator", () => {
+    const cache = new McpLoopbackToolCache();
+    const cfg = makeCfg();
+
+    setSessionOperatorClientId("agent:main:main", RESTRICTED_CLIENT);
+    cache.resolve({
+      cfg,
+      sessionKey: "agent:main:main",
+      messageProvider: undefined,
+      accountId: undefined,
+      senderIsOwner: true,
+    });
+    expect(Array.from(lastCall()?.allowToolNames ?? [])).toHaveLength(3);
+
+    setSessionOperatorClientId("agent:main:main", "webchat-ui");
+    cache.resolve({
+      cfg,
+      sessionKey: "agent:main:main",
+      messageProvider: undefined,
+      accountId: undefined,
+      senderIsOwner: true,
+    });
+    // A fresh resolve (not a cache hit) with no restriction.
+    expect(lastCall()?.allowToolNames).toBeUndefined();
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -8,6 +8,7 @@ import {
   type McpLoopbackTool,
   type McpToolSchemaEntry,
 } from "./mcp-http.schema.js";
+import { getSessionOperatorClientId } from "./session-client-id-registry.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 // MCP loopback runtime scopes gateway tools to the current session/channel
@@ -45,10 +46,27 @@ export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
   agentId: string | undefined;
   tools: McpLoopbackTool[];
 } {
+  // Per-client-id tool restriction (gateway.tools.byClientId). The operator turn
+  // records the connecting client's id against the session key; we read it back
+  // so a deployment can scope a specific connecting surface (identified by its
+  // client.id) to a reduced toolset. Restriction-only: allow intersects the final
+  // set and deny extends the exclude set, so it can never grant a tool the base
+  // policy already removed.
+  const clientId = getSessionOperatorClientId(params.sessionKey);
+  const byClientId = clientId ? params.cfg.gateway?.tools?.byClientId?.[clientId] : undefined;
+  // Pass the allow list through as-is: a present-but-empty allow is fail-closed
+  // (no tools); only an absent allow means "no restriction".
+  const clientAllow = byClientId?.allow;
+  const clientDeny = byClientId?.deny && byClientId.deny.length > 0 ? byClientId.deny : undefined;
+  const excludeToolNames = clientDeny
+    ? new Set<string>([...NATIVE_TOOL_EXCLUDE, ...clientDeny])
+    : NATIVE_TOOL_EXCLUDE;
   const scoped = resolveGatewayScopedTools({
     ...params,
     surface: "loopback",
-    excludeToolNames: NATIVE_TOOL_EXCLUDE,
+    excludeToolNames,
+    allowToolNames: clientAllow,
+    inheritedDenyToolNames: clientDeny,
   });
   return {
     agentId: scoped.agentId,
@@ -72,6 +90,7 @@ export class McpLoopbackToolCache {
       params.inboundEventKind ?? "",
       params.sourceReplyDeliveryMode ?? "",
       params.requireExplicitMessageTarget === true ? "explicit-message-target" : "",
+      getSessionOperatorClientId(params.sessionKey) ?? "",
       params.senderIsOwner === true
         ? "owner"
         : params.senderIsOwner === false

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -148,6 +148,7 @@ import {
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { getMaxChatHistoryMessagesBytes, MAX_PAYLOAD_BYTES } from "../server-constants.js";
+import { setSessionOperatorClientId } from "../session-client-id-registry.js";
 import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
 import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import {
@@ -3224,6 +3225,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
     const clientInfo = client?.connect?.client;
+    // Record the connecting client's id against this session so the loopback
+    // MCP tool resolver (which only sees the session key) can apply
+    // gateway.tools.byClientId restrictions for this turn. Restriction-only:
+    // a client can at most narrow its own toolset, so the value is untrusted.
+    setSessionOperatorClientId(sessionKey, clientInfo?.id);
     const chatSendTraceAttributes = {
       runId: clientRunId,
       sessionKey,

--- a/src/gateway/session-client-id-registry.ts
+++ b/src/gateway/session-client-id-registry.ts
@@ -1,0 +1,75 @@
+/**
+ * Maps an operator/webchat session key to the gateway `client.id` of the
+ * connection that most recently started an agent turn for that session.
+ *
+ * The loopback MCP tool resolver only receives a session key (via the
+ * `x-session-key` header the CLI runner forwards). To apply per-client-id tool
+ * restrictions (`gateway.tools.byClientId`), it needs to know which client
+ * drove the turn. The operator turn entry point (`chat.send`) knows the
+ * connecting client's id, so it records the association here just before
+ * dispatching the agent run, and the loopback resolver reads it back.
+ *
+ * This is a RESTRICTION-only signal: it can only narrow the tool set for a
+ * turn, never widen it. A client lying about its id can at most restrict
+ * itself, so no trust is placed in the value.
+ *
+ * Entries are bounded: each carries a timestamp, is honored only within a TTL
+ * that comfortably outlasts a turn, and the map is capped (oldest evicted). This
+ * keeps the map small on a long-lived gateway and bounds how long a stale id
+ * from a prior turn could be reused if an unrelated turn for the same session
+ * key later reaches the loopback resolver. (Binding the id to the run-context
+ * lifecycle would close that window entirely; left as a follow-up.)
+ */
+const ENTRY_TTL_MS = 15 * 60_000;
+const MAX_ENTRIES = 512;
+
+type Entry = { clientId: string; time: number };
+const sessionKeyToClientId = new Map<string, Entry>();
+
+/** Record (or clear) the client.id that owns the next agent turn for a session. */
+export function setSessionOperatorClientId(
+  sessionKey: string,
+  clientId: string | undefined | null,
+): void {
+  const key = sessionKey.trim();
+  if (!key) {
+    return;
+  }
+  const normalized = typeof clientId === "string" ? clientId.trim() : "";
+  if (!normalized) {
+    sessionKeyToClientId.delete(key);
+    return;
+  }
+  sessionKeyToClientId.set(key, { clientId: normalized, time: Date.now() });
+  if (sessionKeyToClientId.size > MAX_ENTRIES) {
+    // Map preserves insertion order; drop the oldest entries down to the cap.
+    for (const oldestKey of sessionKeyToClientId.keys()) {
+      sessionKeyToClientId.delete(oldestKey);
+      if (sessionKeyToClientId.size <= MAX_ENTRIES) {
+        break;
+      }
+    }
+  }
+}
+
+/** Look up the client.id last associated with a session, if any and still fresh. */
+export function getSessionOperatorClientId(sessionKey: string): string | undefined {
+  const key = sessionKey.trim();
+  if (!key) {
+    return undefined;
+  }
+  const entry = sessionKeyToClientId.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  if (Date.now() - entry.time >= ENTRY_TTL_MS) {
+    sessionKeyToClientId.delete(key);
+    return undefined;
+  }
+  return entry.clientId;
+}
+
+/** Test-only: reset the registry. */
+export function resetSessionOperatorClientIdsForTest(): void {
+  sessionKeyToClientId.clear();
+}

--- a/src/gateway/tool-resolution.by-client-id.test.ts
+++ b/src/gateway/tool-resolution.by-client-id.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The per-client-id restriction is a pure post-filter on top of the existing
+// policy pipeline. We mock the heavyweight collaborators so the test isolates
+// the new allow/deny intersection behaviour in resolveGatewayScopedTools and
+// the registry-driven plumbing in McpLoopbackToolCache.
+
+type MockTool = { name: string; ownerOnly?: boolean };
+
+const ALL_TOOLS: MockTool[] = [
+  { name: "browser" },
+  { name: "memory_search" },
+  { name: "memory_get" },
+  { name: "nodes", ownerOnly: true },
+  { name: "exec" },
+  { name: "message" },
+];
+
+vi.mock("../agents/openclaw-tools.js", () => ({
+  createOpenClawTools: () => ALL_TOOLS.map((tool) => ({ ...tool })),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/ws",
+  resolveDefaultAgentId: () => "main",
+}));
+
+vi.mock("../agents/agent-tools.policy.js", () => ({
+  resolveEffectiveToolPolicy: () => ({ agentId: "main" }),
+  resolveGroupToolPolicy: () => undefined,
+  resolveInheritedToolPolicyForSession: () => undefined,
+  resolveSubagentToolPolicyForSession: () => undefined,
+}));
+
+vi.mock("../agents/subagent-capabilities.js", () => ({
+  isSubagentEnvelopeSession: () => false,
+  resolveSubagentCapabilityStore: () => undefined,
+}));
+
+// The pipeline is identity for these tests: it returns the tools untouched so we
+// can assert purely on the gatewayDeny + allow/deny restriction layers.
+vi.mock("../agents/tool-policy-pipeline.js", () => ({
+  applyToolPolicyPipeline: ({ tools }: { tools: MockTool[] }) => tools,
+  buildDefaultToolPolicyPipelineSteps: () => [],
+}));
+
+vi.mock("../agents/tool-policy.js", () => ({
+  collectExplicitAllowlist: () => undefined,
+  collectExplicitDenylist: () => [],
+  hasRestrictiveAllowPolicy: () => false,
+  mergeAlsoAllowPolicy: () => undefined,
+  replaceWithEffectiveToolAllowlist: () => {},
+  resolveToolProfilePolicy: () => undefined,
+}));
+
+vi.mock("../plugins/tools.js", () => ({
+  getPluginToolMeta: () => undefined,
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: () => {},
+}));
+
+vi.mock("../security/dangerous-tools.js", () => ({
+  DEFAULT_GATEWAY_HTTP_TOOL_DENY: [],
+  GATEWAY_OWNER_ONLY_CORE_TOOLS: [],
+}));
+
+import { resolveGatewayScopedTools } from "./tool-resolution.js";
+
+const cfg = {} as never;
+
+function names(result: ReturnType<typeof resolveGatewayScopedTools>): string[] {
+  return result.tools.map((tool) => tool.name).toSorted();
+}
+
+describe("resolveGatewayScopedTools allowToolNames (restriction-only)", () => {
+  it("intersects the final tools to only the allow list", () => {
+    const result = resolveGatewayScopedTools({
+      cfg,
+      sessionKey: "agent:main:main",
+      allowToolNames: ["browser", "memory_search", "memory_get"],
+    });
+    expect(names(result)).toEqual(["browser", "memory_get", "memory_search"]);
+  });
+
+  it("cannot escalate: an allow naming an unavailable tool yields nothing extra", () => {
+    const result = resolveGatewayScopedTools({
+      cfg,
+      sessionKey: "agent:main:main",
+      // "not_a_tool" is not produced by the policy pipeline, so it can never appear.
+      allowToolNames: ["browser", "not_a_tool"],
+    });
+    expect(names(result)).toEqual(["browser"]);
+  });
+
+  it("treats an explicit empty allow list as no tools (fail-closed)", () => {
+    const result = resolveGatewayScopedTools({
+      cfg,
+      sessionKey: "agent:main:main",
+      allowToolNames: [],
+    });
+    // A present-but-empty allow means "allow nothing", not "allow everything".
+    expect(names(result)).toEqual([]);
+  });
+
+  it("is a no-op when allowToolNames is omitted (no restriction)", () => {
+    const omitted = resolveGatewayScopedTools({ cfg, sessionKey: "agent:main:main" });
+    expect(names(omitted)).toEqual(ALL_TOOLS.map((t) => t.name).toSorted());
+  });
+
+  it("still applies excludeToolNames alongside the allow intersection", () => {
+    const result = resolveGatewayScopedTools({
+      cfg,
+      sessionKey: "agent:main:main",
+      allowToolNames: ["browser", "exec"],
+      excludeToolNames: ["exec"],
+    });
+    expect(names(result)).toEqual(["browser"]);
+  });
+});

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -56,6 +56,20 @@ export function resolveGatewayScopedTools(params: {
   allowMediaInvokeCommands?: boolean;
   surface?: GatewayScopedToolSurface;
   excludeToolNames?: Iterable<string>;
+  /**
+   * When non-empty, restricts the FINAL returned tools to only these names
+   * (applied after the full policy pipeline + gatewayDenySet). This is a
+   * RESTRICTION-only intersection: it can never add a tool that the existing
+   * policy already removed, so it is safe even if the value originates from an
+   * untrusted client (e.g. a connecting client's self-reported client.id).
+   */
+  allowToolNames?: Iterable<string>;
+  /**
+   * Deny names (e.g. from a byClientId restriction) that must ALSO propagate to
+   * spawned subagents — added to the inherited denylist, not only the parent
+   * gatewayDenySet — so the restriction cannot be escaped via sessions_spawn.
+   */
+  inheritedDenyToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
 }) {
@@ -111,6 +125,10 @@ export function resolveGatewayScopedTools(params: {
     store: subagentStore,
   });
   const excludedToolNames = params.excludeToolNames ? Array.from(params.excludeToolNames) : [];
+  const byClientIdAllow = params.allowToolNames ? Array.from(params.allowToolNames) : undefined;
+  const inheritedDenyToolNames = params.inheritedDenyToolNames
+    ? Array.from(params.inheritedDenyToolNames)
+    : [];
   const surface = params.surface ?? "http";
   const gatewayToolsCfg = params.cfg.gateway?.tools;
   const defaultGatewayDeny =
@@ -140,22 +158,26 @@ export function resolveGatewayScopedTools(params: {
     ownerOnlyGatewayDeny.length > 0 ? { deny: ownerOnlyGatewayDeny } : undefined,
     Array.isArray(gatewayToolsCfg?.deny) ? { deny: gatewayToolsCfg.deny } : undefined,
   ]);
-  const inheritedToolDenylist = [...explicitDenylist];
+  const inheritedToolDenylist = [...explicitDenylist, ...inheritedDenyToolNames];
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
   const inheritedToolAllowlist: string[] = [];
-  const shouldInheritEffectiveToolAllowlist = [
-    profilePolicy,
-    providerProfilePolicy,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    groupPolicy,
-    subagentPolicy,
-    inheritedToolPolicy,
-    gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
-  ].some(hasRestrictiveAllowPolicy);
+  const shouldInheritEffectiveToolAllowlist =
+    [
+      profilePolicy,
+      providerProfilePolicy,
+      globalPolicy,
+      globalProviderPolicy,
+      agentPolicy,
+      agentProviderPolicy,
+      groupPolicy,
+      subagentPolicy,
+      inheritedToolPolicy,
+      gatewayRequestedTools.length > 0 ? { allow: gatewayRequestedTools } : undefined,
+    ].some(hasRestrictiveAllowPolicy) ||
+    // A byClientId allow list narrows the surface too, so spawned subagents must
+    // inherit the narrowed allowlist (not just the direct loopback turn).
+    (byClientIdAllow !== undefined && byClientIdAllow.length > 0);
 
   const allTools = createOpenClawTools({
     agentSessionKey: params.sessionKey,
@@ -224,7 +246,16 @@ export function resolveGatewayScopedTools(params: {
     ...(Array.isArray(gatewayToolsCfg?.deny) ? gatewayToolsCfg.deny : []),
     ...excludedToolNames,
   ]);
-  const tools = policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name));
+  const denyFiltered = policyFiltered.filter((tool) => !gatewayDenySet.has(tool.name));
+
+  // byClientId restriction applies after the full policy pipeline + gatewayDenySet.
+  // An explicitly-present allow list (even empty) is fail-CLOSED: empty => no tools.
+  // Only an ABSENT allow list means "no restriction".
+  const allowSet = byClientIdAllow ? new Set(byClientIdAllow) : undefined;
+  const tools = allowSet ? denyFiltered.filter((tool) => allowSet.has(tool.name)) : denyFiltered;
+
+  // Capture the inherited allowlist from the FINAL (byClientId-restricted) set so
+  // spawned subagents inherit the narrowed surface, not the unrestricted parent.
   if (shouldInheritEffectiveToolAllowlist) {
     replaceWithEffectiveToolAllowlist(inheritedToolAllowlist, tools);
   }


### PR DESCRIPTION
## What

Adds `gateway.tools.byClientId` — per-`client.id` `{ allow?, deny? }` tool restrictions for the loopback MCP tool surface.

## How

- The operator turn records the connecting client's `client.id` against the session key in a new in-process registry (`session-client-id-registry`, bounded by TTL + entry cap).
- The loopback MCP tool resolver reads it back and forwards the matching `allow`/`deny` into `resolveGatewayScopedTools` as a **restriction-only** filter: `allow` intersects the final tool set, `deny` extends the exclude set. It can only *narrow* a client's toolset, never escalate — a client lying about its id can at most restrict itself, so the value is untrusted.
- A present-but-empty `allow` is **fail-closed** (no tools), not a no-op.
- The restriction propagates to spawned subagents (it feeds the inherited allow/deny lists), so it cannot be escaped via `sessions_spawn`.

## Why

Lets a deployment scope a specific connecting surface (identified by its `client.id`) to a reduced toolset even when that surface shares the operator path that would otherwise expose the full toolset.

## Testing

- Builds clean (`build-all` / tsdown).
- Unit tests: allow-intersection, no-escalation, empty-allow fail-closed, deny-exclusion; the registry-driven plumbing in `McpLoopbackToolCache` (allow/deny forwarding, per-`client.id` cache keying, no-restriction paths); and a config round-trip asserting `gateway.tools.byClientId` is accepted by the real `OpenClawSchema`.
- No behavior change for sessions without a matching `byClientId` entry.

## Not tested / follow-ups

- No end-to-end `sessions_spawn` integration test; subagent inheritance is covered at the resolver level only.
- Binding the recorded `client.id` to the run-context lifecycle (vs the bounded process-global map) would fully close the stale-reuse window for non-`chat.send` turns on the same session key; left as a follow-up, with the bounded TTL + cap as the interim mitigation.

Opened as a draft for review.
