### PR TITLE
fix(status): use selected model for usage

### DIFF
--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1192,6 +1192,81 @@ describe("buildStatusReply subagent summary", () => {
     expect(providerUsageCall[0]?.providers).toEqual(["deepseek"]);
   });
 
+  it("uses session-selected usage when a stale runtime snapshot differs", async () => {
+    registerStatusCodexHarness();
+    const usageResetBase = Math.floor(Date.now() / 1000);
+    providerUsageMock.loadProviderUsageSummary.mockImplementation(async (params) => ({
+      updatedAt: Date.now(),
+      providers: params.providers?.includes("deepseek")
+        ? [
+            {
+              provider: "deepseek",
+              displayName: "DeepSeek",
+              windows: [],
+              summary: "Balance ¥22.75",
+            },
+          ]
+        : [
+            {
+              provider: "openai",
+              displayName: "OpenAI",
+              windows: [
+                {
+                  label: "5h",
+                  usedPercent: 9,
+                  resetAt: (usageResetBase + 60 * 60) * 1000,
+                },
+              ],
+            },
+          ],
+    }));
+
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-selected-openai-stale-deepseek",
+        updatedAt: 0,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+        modelOverrideSource: "user",
+        modelProvider: "deepseek",
+        model: "deepseek-v4-flash",
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      provider: "openai",
+      model: "gpt-5.5",
+      contextTokens: 1_000_000,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "oauth",
+      activeModelAuthOverride: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: openai/gpt-5.5");
+    expect(normalized).toContain("Usage: 5h 91% left");
+    expect(normalized).not.toContain("Balance ¥22.75");
+    const providerUsageCalls = providerUsageMock.loadProviderUsageSummary.mock.calls.map(
+      ([params]) => params?.providers,
+    );
+    expect(providerUsageCalls).toContainEqual(["openai"]);
+    expect(providerUsageCalls).not.toContainEqual(["deepseek"]);
+  });
+
   it("uses Codex OAuth auth labels for explicit OpenAI OpenClaw auth order", async () => {
     await withTempHome(
       async (dir) => {

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -373,11 +373,22 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     // labels differ; prefer the active auth label so status matches execution.
     selectedModelAuth = activeModelAuth;
   }
-  const usageAuthLabel = modelRefs.activeDiffers ? activeModelAuth : selectedModelAuth;
+  const hasSessionModelOverride = Boolean(
+    sessionEntry?.providerOverride?.trim() || sessionEntry?.modelOverride?.trim(),
+  );
+  const useSelectedModelUsage =
+    hasSessionModelOverride &&
+    (sessionEntry?.modelOverrideSource === "user" ||
+      (sessionEntry?.modelOverrideSource !== "auto" &&
+        !hasSessionAutoModelFallbackProvenance(sessionEntry)));
+  const usageStatusProvider = useSelectedModelUsage ? selectedStatusProvider : activeStatusProvider;
+  const usageProvider = useSelectedModelUsage ? provider : activeProvider;
+  const usageAuthLabel =
+    modelRefs.activeDiffers && !useSelectedModelUsage ? activeModelAuth : selectedModelAuth;
   const selectedUsageCredentialType = resolveUsageCredentialType(usageAuthLabel);
   const useCodexSyntheticUsage =
     shouldUseCodexSyntheticUsage({
-      provider: activeStatusProvider,
+      provider: usageStatusProvider,
       effectiveHarness,
     }) &&
     (selectedUsageCredentialType === "oauth" || selectedUsageCredentialType === "token");
@@ -390,8 +401,8 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     : undefined;
   const usageCredentialType = useCodexSyntheticUsage ? "token" : selectedUsageCredentialType;
   const currentUsageProvider =
-    resolveUsageProviderId(activeStatusProvider, { credentialType: usageCredentialType }) ??
-    resolveUsageProviderId(activeProvider, { credentialType: usageCredentialType });
+    resolveUsageProviderId(usageStatusProvider, { credentialType: usageCredentialType }) ??
+    resolveUsageProviderId(usageProvider, { credentialType: usageCredentialType });
   let usageLine: string | null = null;
   if (
     currentUsageProvider &&


### PR DESCRIPTION
## Summary

- Make `/status` usage probes follow a user-selected session model instead of a stale active runtime snapshot.
- Keep active-runtime usage behavior for auto fallback/runtime-alias cases.
- Add regression coverage for an OpenAI session override with stale DeepSeek runtime state.

Fixes #93322.

## Root Cause

`buildStatusText` chose the usage provider from the active runtime provider whenever the active runtime model differed from the selected model. After `/model`, the stored runtime snapshot can still describe the previous/default model until a later turn refreshes it, so `/status` could show the selected OpenAI model while querying and displaying DeepSeek usage.

## Real behavior proof

- Behavior or issue addressed: After a user selects `openai/gpt-5.5`, status usage must use the selected OpenAI profile even when the persisted active runtime snapshot still says `deepseek/deepseek-v4-flash`.
- Real environment tested: Local OpenClaw source checkout on macOS, branch `codex/fix-status-selected-usage-93322`, commit `9229111`, with isolated `OPENCLAW_STATE_DIR` and a local provider usage responder returning an OpenAI WHAM payload. No secrets or live account data were used.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with a focused runtime probe that imports `src/status/status-text.ts`, persists a token auth profile in the isolated state dir, renders `/status`, and renders the same `buildStatusText` path that `session_status` calls from `src/agents/tools/session-status-tool.ts:883`.
- Evidence after fix: Terminal transcript:
```text
$ node --import tsx --input-type=module < status-selected-usage-probe.mts
/status selected line: 📌 Session selected: openai/gpt-5.5 · 🔑 token (openai-proof)
/status usage line: 📊 Usage: 5h 91% left ⏱59m · Week 61% left ⏱2d 23h
/status stale DeepSeek balance present: no
session_status shared renderer selected line: 📌 Session selected: openai/gpt-5.5 · 🔑 token (openai-proof)
session_status shared renderer usage line: 📊 Usage: 5h 91% left ⏱59m · Week 61% left ⏱2d 23h
session_status shared renderer stale DeepSeek balance present: no
usage endpoint calls: 2
selected model visible on both surfaces: yes
OpenAI usage visible on both surfaces: yes
stale DeepSeek balance absent on both surfaces: yes
```
- Observed result after fix: Both status surfaces rendered `openai/gpt-5.5` and `Usage: 5h 91% left`; neither output rendered the stale DeepSeek `Balance ¥22.75`, and the provider usage endpoint was called twice for the selected usage path.
- What was not tested: Live Telegram Desktop capture and real provider billing endpoints were outside this draft proof; the changed behavior is the shared status usage-provider selection path.

## Verification

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts -- --reporter=verbose`
- `pnpm format:check -- src/status/status-text.ts src/auto-reply/reply/commands-status.test.ts`
- `git diff --check -- src/status/status-text.ts src/auto-reply/reply/commands-status.test.ts`
- Attempted `.agents/skills/autoreview/scripts/autoreview --mode local`; blocked before review by local Codex CLI config error: `unknown variant default, expected fast or flex in service_tier`.
