### PR TITLE
fix(control-ui): keep workboard card titles visible in overflowing columns (fixes #91717)

### DIFF
--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -377,6 +377,9 @@
   min-height: 0;
   padding: 10px;
   display: grid;
+  /* Pin implicit rows to content height so an overflowing column scrolls instead
+     of squeezing cards, which collapsed their line-clamped titles to 0px. */
+  grid-auto-rows: max-content;
   gap: 10px;
   align-content: start;
   overflow-y: auto;

--- a/ui/src/ui/e2e/workboard.e2e.test.ts
+++ b/ui/src/ui/e2e/workboard.e2e.test.ts
@@ -493,4 +493,58 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
       "utf-8",
     );
   });
+
+  it("keeps card titles visible when a column overflows its height", async () => {
+    const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
+    const crowdedColumnCardCount = 8;
+    const overflowTitle = (index: number) =>
+      `Overflowing backlog card ${index + 1} with a long title that wraps onto two lines`;
+    const crowdedCards = Array.from({ length: crowdedColumnCardCount }, (_, index) =>
+      card({
+        id: `overflow-card-${index + 1}`,
+        notes: "Acceptance: title stays visible while the column scrolls.",
+        position: 1000 + index,
+        status: "todo",
+        title: overflowTitle(index),
+        updatedAt: baseTime + index,
+      }),
+    );
+
+    const recorded = await newRecordedPage("workboard-overflow");
+    await installMockGateway(recorded.page, {
+      methodResponses: {
+        "config.get": workboardConfigSnapshot(),
+        "sessions.list": sessionsListResponse([sessionRow()]),
+        "tasks.list": { nextCursor: null, tasks: [] },
+        "workboard.cards.list": cardsListResponse(crowdedCards),
+      },
+    });
+
+    try {
+      // Constrain the height so the Todo column must overflow its visible area.
+      await recorded.page.setViewportSize({ height: 720, width: 1400 });
+      const response = await recorded.page.goto(`${server.baseUrl}workboard`);
+      expect(response?.status()).toBe(200);
+      const column = statusColumn(recorded.page, "Todo");
+      await column.waitFor({ state: "visible" });
+      await cardInColumn(recorded.page, "Todo", overflowTitle(0)).waitFor({ state: "visible" });
+      await captureScreenshot(recorded.page, artifacts, "09-overflow-column");
+
+      const titleHeights = await column
+        .locator(".workboard-card h3")
+        .evaluateAll((titles) => titles.map((title) => title.getBoundingClientRect().height));
+      expect(titleHeights).toHaveLength(crowdedColumnCardCount);
+      for (const height of titleHeights) {
+        // Squeezed implicit grid rows previously collapsed the line-clamped title to 0px.
+        expect(height).toBeGreaterThan(0);
+      }
+
+      const columnScrolls = await column
+        .locator(".workboard-column__cards")
+        .evaluate((cards) => cards.scrollHeight > cards.clientHeight + 1);
+      expect(columnScrolls).toBe(true);
+    } finally {
+      await closeRecordedPage(recorded, artifacts, "workboard-overflow");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #91717.
- In the Control UI Workboard, any column tall enough to overflow its visible
  height rendered its cards **without titles** (and notes/footer) — only the
  priority/agent chips and action buttons stayed visible. Sparse columns were
  fine. The card data was intact; this was purely a CSS layout bug.
- Root cause: `.workboard-column__cards` is `display: grid` with no
  `grid-auto-rows`, so when content exceeds the column height the implicit
  `auto` rows are compressed below their content size instead of letting the
  column scroll. Each squeezed `.workboard-card` (`overflow: hidden`) then
  clipped its own content, and the `<h3>` title (`-webkit-line-clamp` +
  `display: -webkit-box`) collapsed to `0px`.
- Fix: pin the implicit rows to content size with
  `grid-auto-rows: max-content;` so an overflowing column scrolls instead of
  squeezing cards. One CSS rule; runtime/markup unchanged.

Changed files:
- `ui/src/styles/workboard.css` — add `grid-auto-rows: max-content` to
  `.workboard-column__cards`.
- `ui/src/ui/e2e/workboard.e2e.test.ts` — add a focused regression test that
  loads a crowded column and asserts the card titles stay visible and the
  column scrolls.

## Real behavior proof

Behavior addressed: Workboard card titles disappearing in columns that overflow
their height (cards squeezed to ~86px, `<h3>` clamped to 0px).

Real environment tested: Control UI Workboard rendered in a real Chromium via
the existing Playwright + mocked-Gateway e2e harness (Vite dev server serving
`ui/` source). Host: Linux/WSL2, Node 22.22, Chromium for Testing 148.

Exact steps or command run after this patch:

```
# crowded Todo column (8 cards), constrained viewport height (720px)
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner ui/src/ui/e2e/workboard.e2e.test.ts \
  -t "keeps card titles visible"
```

Evidence after fix (same test, before vs after the one-line CSS change):

| state | crowded-column `<h3>` heights | column scrolls |
| --- | --- | --- |
| before fix (current `main`) | every title `0px` → test fails (`expected 0 to be greater than 0`) | n/a |
| after fix | all 8 titles `> 0px` → test passes | yes (`scrollHeight > clientHeight`) |

The e2e test also captures a full-page screenshot of the crowded board
(`.artifacts/control-ui-e2e/workboard/09-overflow-column.png`): before the fix
the Todo column shows 8 title-less cards; after the fix the titles, notes, and
footers render and the column scrolls.

Observed result after fix: all cards in the overflowing column show their titles
again; the column scrolls instead of squeezing cards. Sparse columns unchanged.

What was not tested: a live production Gateway/deployment (proof is the
mocked-Gateway e2e in real Chromium). Codex/Claude autoreview could not run in
this environment (no authenticated reviewer CLI locally); CI runs the standard
checks.

## Tests and validation

- `vitest.ui-e2e.config.ts` workboard e2e: 2 passed (existing flow + new
  regression test); the new test fails on current `main` and passes with the
  fix.
- `oxfmt --check` — clean on both files.
- `oxlint` (`scripts/run-oxlint.mjs`) — clean on the e2e test.
- `tsgo -p test/tsconfig/tsconfig.test.ui.json` — clean.

## Risk checklist

Did user-visible behavior change? Yes — overflowing Workboard columns now scroll
and keep card titles visible (bug fix only; no markup or data change).
Did config, environment, or migration behavior change? No.
Did security, auth, secrets, network, or tool execution behavior change? No.
Highest-risk area: CSS grid sizing of `.workboard-column__cards`.
Mitigation: minimal single-rule change matching the issue's diagnosis; covered
by a real-Chromium regression test; sparse columns verified unchanged.

## Current review state

Next action: maintainer review / CI.
Waiting on: CI on the pushed head.
Bot comments addressed: none yet (initial submission).
