### PR TITLE
fix(auth-profiles): import legacy auth-profiles.json into SQLite store on load

### DIFF
--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -12,6 +12,7 @@ import { loadJsonFile } from "../../infra/json-file.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { asBoolean } from "../../utils/boolean.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
+import { evaluateStoredCredentialEligibility } from "./credential-state.js";
 import { isLegacyOAuthRef } from "./legacy-oauth-ref.js";
 import {
   hasOAuthIdentity,
@@ -20,7 +21,7 @@ import {
   normalizeAuthEmailToken,
   normalizeAuthIdentityToken,
 } from "./oauth-shared.js";
-import { resolveLegacyAuthStorePath } from "./paths.js";
+import { resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
 import { readPersistedAuthProfileStoreRaw } from "./sqlite.js";
 import {
   coerceAuthProfileState,
@@ -801,6 +802,46 @@ export function mergeOAuthFileIntoStore(store: AuthProfileStore): boolean {
       provider,
       ...creds,
     };
+    mutated = true;
+  }
+  return mutated;
+}
+
+/**
+ * Imports a legacy per-agent auth-profiles.json store into missing profiles.
+ *
+ * The runtime store moved to SQLite, but installs upgraded from versions that
+ * persisted credentials in auth-profiles.json only run the JSON->SQLite import
+ * via `openclaw doctor --fix`. Without this lazy merge the upgraded SQLite store
+ * starts empty, so every provider that references an auth profile fails with
+ * "401 invalid api key" until the operator re-runs doctor. Mirrors
+ * `mergeOAuthFileIntoStore`, which already back-fills the legacy oauth.json.
+ *
+ * Only profiles whose credential resolves to usable material are imported. An
+ * OAuth profile that carries just an `oauthRef` sidecar reference (no inline
+ * access/refresh token) classifies as `unresolved_ref`; doctor deliberately
+ * leaves those in JSON until the sidecar token material exists, so the lazy
+ * import skips them rather than persisting an unusable profile into SQLite.
+ */
+export function mergeLegacyJsonProfilesIntoStore(
+  store: AuthProfileStore,
+  agentDir?: string,
+): boolean {
+  const legacyStore = coercePersistedAuthProfileStore(loadJsonFile(resolveAuthStorePath(agentDir)));
+  if (!legacyStore) {
+    return false;
+  }
+  let mutated = false;
+  for (const [profileId, credential] of Object.entries(legacyStore.profiles)) {
+    if (store.profiles[profileId]) {
+      continue;
+    }
+    // Skip unresolved OAuth sidecar refs that doctor leaves in JSON until token
+    // material exists; importing them would persist an unusable profile.
+    if (evaluateStoredCredentialEligibility({ credential }).reasonCode === "unresolved_ref") {
+      continue;
+    }
+    store.profiles[profileId] = credential;
     mutated = true;
   }
   return mutated;

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -16,6 +16,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { withEnvAsync } from "../../test-utils/env.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { testing as externalAuthTesting } from "./external-auth.js";
+import { resolveAuthStorePath } from "./paths.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   clearLastGoodProfileWithLock,
@@ -118,6 +119,110 @@ function expectOAuthCredentialFields(
   }
   return credential;
 }
+
+describe("legacy auth-profiles.json lazy migration", () => {
+  it("loads and persists legacy JSON profiles when the SQLite store is empty", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-profile-legacy-json-",
+      async ({ agentDir }) => {
+        fs.mkdirSync(agentDir, { recursive: true });
+        // Simulate an install upgraded from a version that only persisted
+        // credentials in auth-profiles.json (SQLite store still empty).
+        fs.writeFileSync(
+          resolveAuthStorePath(agentDir),
+          JSON.stringify({
+            version: 1,
+            profiles: {
+              "litellm:manual": {
+                type: "api_key",
+                provider: "litellm",
+                key: "legacy-secret-key",
+              },
+            },
+          }),
+        );
+
+        // Empty SQLite store before load.
+        expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+
+        // Runtime load should surface the legacy profile...
+        const runtime = loadAuthProfileStoreForRuntime(agentDir);
+        expect(runtime.profiles["litellm:manual"]).toMatchObject({
+          type: "api_key",
+          provider: "litellm",
+          key: "legacy-secret-key",
+        });
+
+        // ...and persist it to SQLite so it survives without the JSON file.
+        const persisted = loadPersistedAuthProfileStore(agentDir);
+        expect(persisted?.profiles["litellm:manual"]).toMatchObject({
+          type: "api_key",
+          provider: "litellm",
+          key: "legacy-secret-key",
+        });
+      },
+      { clearOAuthDir: true },
+    );
+  });
+
+  it("imports resolvable credentials but skips oauthRef-only profiles", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-profile-legacy-json-oauthref-",
+      async ({ agentDir }) => {
+        fs.mkdirSync(agentDir, { recursive: true });
+        // Legacy JSON carrying a resolvable api_key profile alongside an
+        // unresolved OAuth sidecar ref (no inline access/refresh token), the
+        // shape doctor deliberately leaves in JSON until token material exists.
+        fs.writeFileSync(
+          resolveAuthStorePath(agentDir),
+          JSON.stringify({
+            version: 1,
+            profiles: {
+              "litellm:manual": {
+                type: "api_key",
+                provider: "litellm",
+                key: "legacy-secret-key",
+              },
+              "openai-codex:default": {
+                type: "oauth",
+                provider: "openai-codex",
+                oauthRef: {
+                  source: "openclaw-credentials",
+                  provider: "openai-codex",
+                  id: "0123456789abcdef0123456789abcdef",
+                },
+              },
+            },
+          }),
+        );
+
+        // Empty SQLite store before load.
+        expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+
+        // Runtime load surfaces only the resolvable api_key profile; the
+        // oauthRef-only entry is skipped.
+        const runtime = loadAuthProfileStoreForRuntime(agentDir);
+        expect(runtime.profiles["litellm:manual"]).toMatchObject({
+          type: "api_key",
+          provider: "litellm",
+          key: "legacy-secret-key",
+        });
+        expect(runtime.profiles["openai-codex:default"]).toBeUndefined();
+
+        // Only the api_key is persisted to SQLite; the oauthRef-only profile
+        // stays in JSON for doctor to repair once the sidecar token exists.
+        const persisted = loadPersistedAuthProfileStore(agentDir);
+        expect(persisted?.profiles["litellm:manual"]).toMatchObject({
+          type: "api_key",
+          provider: "litellm",
+          key: "legacy-secret-key",
+        });
+        expect(persisted?.profiles["openai-codex:default"]).toBeUndefined();
+      },
+      { clearOAuthDir: true },
+    );
+  });
+});
 
 describe("promoteAuthProfileInOrder", () => {
   it("refreshes inherited main selection state without advancing credential ownership", async () => {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -30,6 +30,7 @@ import {
   buildPersistedAuthProfileSecretsStore,
   loadPersistedAuthProfileStore,
   mergeAuthProfileStores,
+  mergeLegacyJsonProfilesIntoStore,
   mergeOAuthFileIntoStore,
 } from "./persisted.js";
 import {
@@ -927,8 +928,9 @@ function loadAuthProfileStoreForAgent(
   };
 
   const mergedOAuth = mergeOAuthFileIntoStore(store);
+  const mergedLegacyJson = mergeLegacyJsonProfilesIntoStore(store, agentDir);
   const forceReadOnly = process.env.OPENCLAW_AUTH_STORE_READONLY === "1";
-  const shouldWrite = !readOnly && !forceReadOnly && mergedOAuth;
+  const shouldWrite = !readOnly && !forceReadOnly && (mergedOAuth || mergedLegacyJson);
   if (shouldWrite) {
     saveAuthProfileStore(store, agentDir);
   }


### PR DESCRIPTION
## What Problem This Solves

After upgrading an install that stored credentials in per-agent `auth-profiles.json` to a 6.x build, **every agent fails with `401 invalid api key`** for any provider whose credentials resolve through an auth profile.

The runtime auth-profile store now loads exclusively from the per-agent SQLite store (`auth_profile_store` in `<agentDir>/openclaw-agent.sqlite`). The legacy `auth-profiles.json` → SQLite import only runs through `openclaw doctor --fix`, behind an interactive prompt. So after a normal upgrade the SQLite store is empty:

- `openclaw models auth list --agent <id>` → `Profiles: (none)`
- `resolveAuthProfileOrder` returns `[]` (empty `store.profiles` → empty `storeProfiles` → empty `baseOrder`)
- the provider can't resolve its referenced profile → `401 invalid api key` on every agent

The credentials in `auth-profiles.json` are still valid — they are just never read at boot.

## Root cause

`loadAuthProfileStoreForAgent` (`src/agents/auth-profiles/store.ts`) already back-fills the legacy `oauth.json` into an empty SQLite store via `mergeOAuthFileIntoStore`, but there is **no equivalent back-fill for `auth-profiles.json`** (the flat api_key/token profiles). They only get imported by the `doctor --fix` migration.

## Fix

Mirror the existing oauth back-fill: add `mergeLegacyJsonProfilesIntoStore(store, agentDir)` (`persisted.ts`) and call it alongside `mergeOAuthFileIntoStore` when the SQLite store is empty, persisting the result one-shot.

The comprehensive `doctor --fix` migration (backup + delete the JSON + AWS-SDK markers + OAuth sidecar handling) is unchanged; this only adds a lazy safety-net for the common api_key/token case and does **not** delete the JSON.

## Reproduction

Minimal (added as a test): an agent dir with an `auth-profiles.json` api_key profile + empty SQLite store → `loadAuthProfileStoreForRuntime(agentDir).profiles` is empty before the fix, and contains the profile (persisted to SQLite) after.

Real: upgraded a production install (9 agents) from `2026.5.28` to `2026.6.6`. Every agent returned `All models failed: ... 401 invalid api key`; `auth_profile_store` had 0 rows; `paste-api-key` / `doctor --fix` populated SQLite and restored auth (survives restart).

## Testing

- New test in `profiles.test.ts` (`legacy auth-profiles.json lazy migration`): passes with the fix, fails without it.
- `tsc` typecheck and `oxlint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Evidence

Run locally against this branch (post-push head), Node 24 / pnpm 11, vitest 4.1.7. The auth-profiles tests run under `test/vitest/vitest.agents-core.config.ts` (the unit config excludes `src/agents/**`).

### Validation (re-runnable)

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts \
  src/agents/auth-profiles/profiles.test.ts -t "legacy auth-profiles.json lazy migration"
#  Test Files 1 passed (1)   Tests 2 passed | 11 skipped (13)

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/auth-profiles/profiles.test.ts
#  Test Files 1 passed (1)   Tests 13 passed (13)

node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts "src/agents/auth-profiles/"
#  Test Files 20 passed (20)   Tests 241 passed (241)
```

### Before/after behavior (not source inspection)

A harness seeds a per-agent legacy `auth-profiles.json` (`{ "litellm:manual": { type:"api_key", provider:"litellm", key:"…" } }`) plus an **empty** SQLite store, then calls the real `loadAuthProfileStoreForRuntime(agentDir)` and `resolveAuthProfileOrder({ store, provider:"litellm" })` (no `cfg`, so any candidate comes purely from the store back-fill). Run unchanged against both commits:

**BEFORE** (parent commit, fix absent): `resolveAuthProfileOrder` returns no candidates → auth would 401; SQLite is never created.
```json
{ "resolveAuthProfileOrder_litellm": [], "sqlite_exists_after_load": false }
# AssertionError: expected [] to include 'litellm:manual'
```
**AFTER** (this branch): the legacy profile is imported on load, resolves, and is persisted (survives JSON deletion).
```json
{ "runtime_litellm_manual": { "type":"api_key", "provider":"litellm", "key":"legacy-secret-key" },
  "resolveAuthProfileOrder_litellm": ["litellm:manual"],
  "loadPersisted_post_load_keys": ["litellm:manual"], "sqlite_exists_after_load": true }
```
Only the commit differed; harness and seeded inputs were byte-identical.

### oauthRef-only profiles are skipped

`mergeLegacyJsonProfilesIntoStore` reuses the store's canonical `evaluateStoredCredentialEligibility` (the same gate `resolveAuthProfileOrder`/doctor use) and skips entries whose `reasonCode === "unresolved_ref"` — the OAuth sidecar shape doctor deliberately leaves in JSON until token material exists. New test: a legacy JSON with an `api_key` profile **and** an `oauthRef`-only `openai-codex:default` → after load, SQLite contains `litellm:manual` only; `openai-codex:default` stays in JSON (undefined in store). Negative control: temporarily disabling the skip makes that test fail (`expected { type:'oauth', … } to be undefined`), confirming the guard is genuinely exercised.

### Why steady-state loads stay safe

The import only fills profile ids **absent** from SQLite (`if (store.profiles[profileId]) continue;`), so it is **idempotent** — once a profile is back-filled and persisted, later loads short-circuit and never re-read or overwrite it. With the eligibility gate it now promotes only resolvable credentials, matching doctor's boundary. Net: upgraded installs recover working auth on the first load without a doctor round-trip, while the SQLite-only steady state is preserved as soon as the one-time back-fill completes.

Files: `src/agents/auth-profiles/persisted.ts` (`mergeLegacyJsonProfilesIntoStore`, skip via `credential-state.ts`), `store.ts` (`loadAuthProfileStoreForAgent`), `order.ts` (`resolveAuthProfileOrder`), test in `profiles.test.ts`.
