### PR TITLE
fix(plugins): require owner for plugin writes

### DIFF
--- a/src/auto-reply/reply/commands-plugins.install.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install.test.ts
@@ -60,12 +60,31 @@ vi.mock("../../cli/plugins-install-persist.js", async (importOriginal) => ({
 
 const workspaceHarness = createCommandWorkspaceHarness("openclaw-command-plugins-install-");
 
-function buildPluginsParams(commandBodyNormalized: string, workspaceDir: string) {
-  return buildPluginsCommandParams({
+function buildPluginsParams(
+  commandBodyNormalized: string,
+  workspaceDir: string,
+  options: {
+    gatewayClientScopes?: string[];
+    omitGatewayClientScopes?: boolean;
+    senderIsOwner?: boolean;
+  } = {},
+) {
+  const params = buildPluginsCommandParams({
     commandBodyNormalized,
     workspaceDir,
-    gatewayClientScopes: ["operator.admin", "operator.write", "operator.pairing"],
+    gatewayClientScopes: options.gatewayClientScopes ?? [
+      "operator.admin",
+      "operator.write",
+      "operator.pairing",
+    ],
   });
+  if (options.senderIsOwner !== undefined) {
+    params.command.senderIsOwner = options.senderIsOwner;
+  }
+  if (options.omitGatewayClientScopes) {
+    delete params.ctx.GatewayClientScopes;
+  }
+  return params;
 }
 
 function expectPersistedInstall(pluginId: string, expectedInstall: Record<string, unknown>): void {
@@ -120,6 +139,66 @@ describe("handleCommands /plugins install", () => {
         source: "path",
         sourcePath: pluginDir,
         installPath: "/tmp/path-install-plugin",
+        version: "0.0.1",
+      });
+    });
+  });
+
+  it("blocks channel-authorized non-owner plugin installs before installer side effects", async () => {
+    await withTempHome("openclaw-command-plugins-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      const pluginDir = path.join(workspaceDir, "fixtures", "channel-installed-plugin");
+      await fs.mkdir(pluginDir, { recursive: true });
+
+      const params = buildPluginsParams(`/plugins install ${pluginDir}`, workspaceDir, {
+        omitGatewayClientScopes: true,
+        senderIsOwner: false,
+      });
+      params.command.channel = "telegram";
+      params.command.channelId = "telegram";
+      params.command.surface = "telegram";
+      params.command.senderId = "telegram-user-3";
+      params.command.isAuthorizedSender = true;
+      params.ctx.Provider = "telegram";
+      params.ctx.Surface = "telegram";
+
+      const result = await handlePluginsCommand(params, true);
+
+      expect(result?.shouldContinue).toBe(false);
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
+      expect(persistPluginInstallMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows gateway clients with operator.admin to install plugins", async () => {
+    installPluginFromPathMock.mockResolvedValue({
+      ok: true,
+      pluginId: "gateway-admin-plugin",
+      targetDir: "/tmp/gateway-admin-plugin",
+      version: "0.0.1",
+      extensions: ["index.js"],
+    });
+    persistPluginInstallMock.mockResolvedValue({});
+
+    await withTempHome("openclaw-command-plugins-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      const pluginDir = path.join(workspaceDir, "fixtures", "gateway-admin-plugin");
+      await fs.mkdir(pluginDir, { recursive: true });
+
+      const params = buildPluginsParams(`/plugins install ${pluginDir}`, workspaceDir, {
+        gatewayClientScopes: ["operator.admin", "operator.write"],
+        senderIsOwner: false,
+      });
+
+      const result = await handlePluginsCommand(params, true);
+
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain('Installed plugin "gateway-admin-plugin"');
+      expect(mockFirstObjectArg(installPluginFromPathMock).path).toBe(pluginDir);
+      expectPersistedInstall("gateway-admin-plugin", {
+        source: "path",
+        sourcePath: pluginDir,
+        installPath: "/tmp/gateway-admin-plugin",
         version: "0.0.1",
       });
     });

--- a/src/auto-reply/reply/commands-plugins.test.ts
+++ b/src/auto-reply/reply/commands-plugins.test.ts
@@ -134,13 +134,17 @@ const WRITE_GATEWAY_SCOPES = ["operator.admin", "operator.write", "operator.pair
 function buildPluginsParams(
   commandBodyNormalized: string,
   cfg: OpenClawConfig,
-  options?: { gatewayClientScopes?: string[] },
+  options?: { gatewayClientScopes?: string[]; omitGatewayClientScopes?: boolean },
 ) {
-  return buildPluginsCommandParams({
+  const params = buildPluginsCommandParams({
     commandBodyNormalized,
     cfg,
     gatewayClientScopes: options?.gatewayClientScopes,
   });
+  if (options?.omitGatewayClientScopes) {
+    delete params.ctx.GatewayClientScopes;
+  }
+  return params;
 }
 
 type MockCalls = {
@@ -280,6 +284,41 @@ describe("handlePluginsCommand", () => {
 
     const result = await handlePluginsCommand(params, true);
     expect(result?.reply?.text).toContain("requires operator.admin");
+  });
+
+  it("blocks channel-authorized non-owner plugin toggles before config mutation", async () => {
+    const params = buildPluginsParams("/plugins enable superpowers", buildCfg(), {
+      omitGatewayClientScopes: true,
+    });
+    params.command.channel = "telegram";
+    params.command.channelId = "telegram";
+    params.command.surface = "telegram";
+    params.command.senderId = "telegram-user-3";
+    params.command.senderIsOwner = false;
+    params.command.isAuthorizedSender = true;
+    params.ctx.Provider = "telegram";
+    params.ctx.Surface = "telegram";
+
+    const result = await handlePluginsCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
+    expect(refreshPluginRegistryAfterConfigMutationMock).not.toHaveBeenCalled();
+  });
+
+  it("allows gateway clients with operator.admin to toggle plugins", async () => {
+    validateConfigObjectWithPluginsMock.mockImplementation((next) => ({ ok: true, config: next }));
+    const params = buildPluginsParams("/plugins disable superpowers", buildCfg(), {
+      gatewayClientScopes: ["operator.admin", "operator.write"],
+    });
+    params.command.senderIsOwner = false;
+
+    const result = await handlePluginsCommand(params, true);
+
+    expect(result?.reply?.text).toContain('Plugin "superpowers" disabled');
+    expectLastReplaceConfig(false);
+    expectLastRegistryRefresh(false);
   });
 
   it("enables and disables a discovered plugin", async () => {

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -41,6 +41,7 @@ import {
 } from "../../plugins/status.js";
 import { resolveUserPath } from "../../utils.js";
 import {
+  rejectNonOwnerCommand,
   rejectUnauthorizedCommand,
   requireCommandFlagEnabled,
   requireGatewayClientScope,
@@ -140,6 +141,10 @@ function formatPluginsList(report: PluginStatusReport): string {
 
 function isPluginsWriteAction(action: string): boolean {
   return action === "install" || action === "enable" || action === "disable";
+}
+
+function hasGatewayAdminScope(params: Parameters<CommandHandler>[0]): boolean {
+  return params.ctx.GatewayClientScopes?.includes("operator.admin") === true;
 }
 
 function rejectNixModePluginWrite(): {
@@ -441,6 +446,12 @@ export const handlePluginsCommand: CommandHandler = async (params, allowTextComm
     });
     if (missingAdminScope) {
       return missingAdminScope;
+    }
+    if (!params.command.senderIsOwner && !hasGatewayAdminScope(params)) {
+      const nonOwner = rejectNonOwnerCommand(params, "/plugins write");
+      if (nonOwner) {
+        return nonOwner;
+      }
     }
     const nixModeWrite = rejectNixModePluginWrite();
     if (nixModeWrite) {


### PR DESCRIPTION
## Summary

Require owner identity or Gateway `operator.admin` before `/plugins install`, `/plugins enable`, or `/plugins disable` can mutate trusted plugin state.

## Changes

- Add an owner/admin guard to plugin write commands after the existing Gateway scope check.
- Preserve read-only `/plugins list` and `/plugins inspect` behavior for authorized senders.
- Preserve Gateway clients with `operator.admin` for plugin install and toggle commands.
- Add regression coverage for channel-originated non-owner plugin install/toggle attempts stopping before installer, persistence, or config mutation side effects.

## Validation

- `corepack pnpm exec oxfmt --write src/auto-reply/reply/commands-plugins.ts src/auto-reply/reply/commands-plugins.install.test.ts src/auto-reply/reply/commands-plugins.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/commands-plugins.install.test.ts src/auto-reply/reply/commands-plugins.test.ts --reporter=dot` passed: 2 files, 17 tests.
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` returned clean: no accepted/actionable findings.

## Notes

- Compatibility impact: authorized channel users who are not owners can no longer install, enable, or disable plugins; owner identity or Gateway `operator.admin` is required for plugin writes.
- `CHANGELOG.md` was not updated.
- Shipped-state check: npm `openclaw` latest is `2026.6.6`, and local `v2026.6.6` still has the prior write-command gate.