### PR TITLE
fix(plugins): enforce install policy in wrappers

### DIFF
--- a/src/auto-reply/reply/commands-plugins.install.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempHome } from "../../config/home-env.test-harness.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { expectObjectFields, mockFirstObjectArg } from "../../test-utils/mock-call-assertions.js";
 import { createCommandWorkspaceHarness } from "./commands-filesystem.test-support.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
@@ -64,6 +65,7 @@ function buildPluginsParams(
   commandBodyNormalized: string,
   workspaceDir: string,
   options: {
+    cfg?: OpenClawConfig;
     gatewayClientScopes?: string[];
     omitGatewayClientScopes?: boolean;
     senderIsOwner?: boolean;
@@ -72,6 +74,7 @@ function buildPluginsParams(
   const params = buildPluginsCommandParams({
     commandBodyNormalized,
     workspaceDir,
+    ...(options.cfg ? { cfg: options.cfg } : {}),
     gatewayClientScopes: options.gatewayClientScopes ?? [
       "operator.admin",
       "operator.write",
@@ -111,6 +114,72 @@ describe("handleCommands /plugins install", () => {
     installPluginFromGitSpecMock.mockReset();
     persistPluginInstallMock.mockReset();
     await workspaceHarness.cleanupWorkspaces();
+  });
+
+  it("passes the active config to npm install policy preflight", async () => {
+    const policyConfig: OpenClawConfig = {
+      commands: {
+        text: true,
+        plugins: true,
+      },
+      plugins: {
+        enabled: true,
+      },
+      security: {
+        installPolicy: {
+          enabled: true,
+          exec: {
+            source: "exec",
+            command: process.execPath,
+            args: ["-e", "process.exit(1)"],
+            allowInsecurePath: true,
+          },
+        },
+      },
+    };
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "policy-plugin",
+      targetDir: "/tmp/policy-plugin",
+      version: "1.0.0",
+      extensions: ["index.js"],
+      npmResolution: {
+        name: "@acme/policy-plugin",
+        version: "1.0.0",
+        resolvedSpec: "@acme/policy-plugin@1.0.0",
+      },
+    });
+    persistPluginInstallMock.mockResolvedValue({});
+
+    await withTempHome("openclaw-command-plugins-home-", async (home) => {
+      await fs.writeFile(
+        path.join(home, ".openclaw", "openclaw.json"),
+        `${JSON.stringify(policyConfig, null, 2)}\n`,
+      );
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      const params = buildPluginsParams(
+        "/plugins install @acme/policy-plugin@1.0.0",
+        workspaceDir,
+        { cfg: policyConfig },
+      );
+
+      const result = await handlePluginsCommand(params, true);
+
+      if (result === null) {
+        throw new Error("expected plugin install result");
+      }
+      expect(result.reply?.text).toContain('Installed plugin "policy-plugin"');
+      expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
+        spec: "@acme/policy-plugin@1.0.0",
+        config: policyConfig,
+      });
+      expectPersistedInstall("policy-plugin", {
+        source: "npm",
+        spec: "@acme/policy-plugin@1.0.0",
+        installPath: "/tmp/policy-plugin",
+        version: "1.0.0",
+      });
+    });
   });
 
   it("installs a plugin from a local path", async () => {

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -215,6 +215,7 @@ function findTrustedCatalogPackageInstall(packageName: string):
 
 async function installPluginFromPluginsCommand(params: {
   raw: string;
+  config: OpenClawConfig;
   snapshot: ConfigSnapshotForInstallPersist;
 }): Promise<{ ok: true; pluginId: string } | { ok: false; error: string }> {
   const fileSpec = resolveFileNpmSpecToLocalPath(params.raw);
@@ -227,6 +228,7 @@ async function installPluginFromPluginsCommand(params: {
   if (fs.existsSync(resolved)) {
     const result = await installPluginFromPath({
       path: resolved,
+      config: params.config,
       logger: createPluginInstallLogger(),
     });
     if (!result.ok) {
@@ -258,6 +260,7 @@ async function installPluginFromPluginsCommand(params: {
   if (gitSpec) {
     const result = await installPluginFromGitSpec({
       spec: params.raw,
+      config: params.config,
       logger: createPluginInstallLogger(),
     });
     if (!result.ok) {
@@ -284,6 +287,7 @@ async function installPluginFromPluginsCommand(params: {
   if (clawhubSpec) {
     const result = await installPluginFromClawHub({
       spec: params.raw,
+      config: params.config,
       logger: createPluginInstallLogger(),
     });
     if (!result.ok) {
@@ -314,6 +318,7 @@ async function installPluginFromPluginsCommand(params: {
   });
   const result = await installPluginFromNpmSpec({
     spec: params.raw,
+    config: params.config,
     ...(officialNpmTrust
       ? {
           expectedPluginId: officialNpmTrust.pluginId,
@@ -469,6 +474,7 @@ export const handlePluginsCommand: CommandHandler = async (params, allowTextComm
     }
     const installed = await installPluginFromPluginsCommand({
       raw: pluginsCommand.spec,
+      config: loadedConfig.snapshot.config,
       snapshot: loadedConfig.snapshot,
     });
     if (!installed.ok) {

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -131,11 +131,13 @@ function readFirstMockCall(mock: unknown, label: string): unknown[] {
 
 type NpmPackInstallCall = {
   archivePath?: string;
+  config?: OpenClawConfig;
   expectedPluginId?: string;
   trustedSourceLinkedOfficialInstall?: boolean;
 };
 
 type NpmSpecInstallCall = {
+  config?: OpenClawConfig;
   expectedIntegrity?: string;
   expectedPluginId?: string;
   mode?: string;
@@ -145,6 +147,7 @@ type NpmSpecInstallCall = {
 };
 
 type ClawHubInstallCall = {
+  config?: OpenClawConfig;
   expectedPluginId?: string;
   mode?: string;
   spec?: string;
@@ -313,6 +316,19 @@ describe("ensureOnboardingPluginInstalled", () => {
 
   it("uses a guarded npm-pack install override for the matching plugin id", async () => {
     const archivePath = path.resolve("tmp/demo-plugin.tgz");
+    const cfg: OpenClawConfig = {
+      security: {
+        installPolicy: {
+          enabled: true,
+          exec: {
+            source: "exec",
+            command: process.execPath,
+            args: ["-e", "process.exit(1)"],
+            allowInsecurePath: true,
+          },
+        },
+      },
+    };
     process.env.OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES = "1";
     process.env.OPENCLAW_PLUGIN_INSTALL_OVERRIDES = JSON.stringify({
       "other-plugin": "npm:@demo/other@1.0.0",
@@ -337,7 +353,7 @@ describe("ensureOnboardingPluginInstalled", () => {
 
     const select = vi.fn(async () => "npm");
     const result = await ensureOnboardingPluginInstalled({
-      cfg: {},
+      cfg,
       entry: {
         pluginId: "demo-plugin",
         label: "Demo Plugin",
@@ -361,6 +377,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       "installPluginFromNpmPackArchive",
     ) as [NpmPackInstallCall];
     expect(packCall.archivePath).toBe(archivePath);
+    expect(packCall.config).toBe(cfg);
     expect(packCall.expectedPluginId).toBe("demo-plugin");
     expect(packCall).not.toHaveProperty("trustedSourceLinkedOfficialInstall");
     const [, recordUpdate] = readFirstMockCall(recordPluginInstall, "recordPluginInstall") as [
@@ -428,6 +445,19 @@ describe("ensureOnboardingPluginInstalled", () => {
   });
 
   it("installs and records ClawHub provider plugins with source facts", async () => {
+    const cfg: OpenClawConfig = {
+      security: {
+        installPolicy: {
+          enabled: true,
+          exec: {
+            source: "exec",
+            command: process.execPath,
+            args: ["-e", "process.exit(1)"],
+            allowInsecurePath: true,
+          },
+        },
+      },
+    };
     installPluginFromClawHub.mockImplementation(async (params) => {
       params.logger?.info?.("Downloading demo-plugin from ClawHub…");
       return {
@@ -457,7 +487,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     const update = vi.fn();
 
     const result = await ensureOnboardingPluginInstalled({
-      cfg: {},
+      cfg,
       entry: {
         pluginId: "demo-plugin",
         label: "Demo Provider",
@@ -479,6 +509,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       "installPluginFromClawHub",
     ) as [ClawHubInstallCall];
     expect(clawHubCall.spec).toBe("clawhub:demo-plugin@2026.5.2");
+    expect(clawHubCall.config).toBe(cfg);
     expect(clawHubCall.expectedPluginId).toBe("demo-plugin");
     expect(clawHubCall.mode).toBe("install");
     expect(clawHubCall.timeoutMs).toBe(300_000);
@@ -507,6 +538,19 @@ describe("ensureOnboardingPluginInstalled", () => {
   });
 
   it("passes npm specs and optional expected integrity to npm installs with progress", async () => {
+    const cfg: OpenClawConfig = {
+      security: {
+        installPolicy: {
+          enabled: true,
+          exec: {
+            source: "exec",
+            command: process.execPath,
+            args: ["-e", "process.exit(1)"],
+            allowInsecurePath: true,
+          },
+        },
+      },
+    };
     const npmResolution = {
       name: "@wecom/wecom-openclaw-plugin",
       version: "1.2.3",
@@ -538,7 +582,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     const update = vi.fn();
 
     const result = await ensureOnboardingPluginInstalled({
-      cfg: {},
+      cfg,
       entry: {
         pluginId: "demo-plugin",
         label: "WeCom",
@@ -559,6 +603,7 @@ describe("ensureOnboardingPluginInstalled", () => {
       NpmSpecInstallCall,
     ];
     expect(npmCall.spec).toBe("@wecom/wecom-openclaw-plugin@1.2.3");
+    expect(npmCall.config).toBe(cfg);
     expect(npmCall.mode).toBe("update");
     expect(npmCall.expectedPluginId).toBe("demo-plugin");
     expect(npmCall.expectedIntegrity).toBe("sha512-wecom");

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -660,6 +660,7 @@ function logInstallWarningWithSpacing(runtime: RuntimeEnv, message: string): voi
 }
 
 async function installPluginFromNpmSpecWithProgress(params: {
+  cfg: OpenClawConfig;
   entry: OnboardingPluginInstallEntry;
   npmSpec: string;
   prompter: WizardPrompter;
@@ -689,6 +690,7 @@ async function installPluginFromNpmSpecWithProgress(params: {
       installPluginFromNpmSpec({
         spec: params.npmSpec,
         mode: "update",
+        config: params.cfg,
         timeoutMs: ONBOARDING_PLUGIN_INSTALL_TIMEOUT_MS,
         expectedPluginId: params.entry.pluginId,
         expectedIntegrity: params.entry.install.expectedIntegrity,
@@ -735,6 +737,7 @@ async function installPluginFromNpmSpecWithProgress(params: {
 }
 
 async function installPluginFromNpmPackArchiveWithProgress(params: {
+  cfg: OpenClawConfig;
   entry: OnboardingPluginInstallEntry;
   archivePath: string;
   prompter: WizardPrompter;
@@ -763,6 +766,7 @@ async function installPluginFromNpmPackArchiveWithProgress(params: {
       installPluginFromNpmPackArchive({
         archivePath: params.archivePath,
         timeoutMs: ONBOARDING_PLUGIN_INSTALL_TIMEOUT_MS,
+        config: params.cfg,
         expectedPluginId: params.entry.pluginId,
         expectedIntegrity: params.entry.install.expectedIntegrity,
         extensionsDir: resolveDefaultPluginExtensionsDir(),
@@ -810,6 +814,7 @@ async function installPluginFromOverride(params: {
   const installOutcome =
     params.override.kind === "npm"
       ? await installPluginFromNpmSpecWithProgress({
+          cfg: params.cfg,
           entry,
           npmSpec: params.override.spec,
           prompter,
@@ -817,6 +822,7 @@ async function installPluginFromOverride(params: {
           trustedSourceLinkedOfficialInstall: false,
         })
       : await installPluginFromNpmPackArchiveWithProgress({
+          cfg: params.cfg,
           entry,
           archivePath: params.override.archivePath,
           prompter,
@@ -918,6 +924,7 @@ async function installPluginFromOverride(params: {
 }
 
 async function installPluginFromClawHubSpecWithProgress(params: {
+  cfg: OpenClawConfig;
   entry: OnboardingPluginInstallEntry;
   clawhubSpec: string;
   prompter: WizardPrompter;
@@ -947,6 +954,7 @@ async function installPluginFromClawHubSpecWithProgress(params: {
       installPluginFromClawHub({
         spec: params.clawhubSpec,
         timeoutMs: ONBOARDING_PLUGIN_INSTALL_TIMEOUT_MS,
+        config: params.cfg,
         extensionsDir: resolveDefaultPluginExtensionsDir(),
         expectedPluginId: params.entry.pluginId,
         mode: "install",
@@ -1116,6 +1124,7 @@ export async function ensureOnboardingPluginInstalled(params: {
   let shouldTryNpm = choice === "npm";
   if (choice === "clawhub" && clawhubInstallSpec) {
     const installOutcome = await installPluginFromClawHubSpecWithProgress({
+      cfg: next,
       entry,
       clawhubSpec: clawhubInstallSpec,
       prompter,
@@ -1229,6 +1238,7 @@ export async function ensureOnboardingPluginInstalled(params: {
   }
 
   const installOutcome = await installPluginFromNpmSpecWithProgress({
+    cfg: next,
     entry,
     npmSpec: npmInstallSpec,
     prompter,


### PR DESCRIPTION
## Summary

Ensure plugin install wrapper flows pass the active OpenClaw config into the existing installer policy checks before install side effects.

## Changes

- Thread active config through `/plugins install` path, git, ClawHub, and npm install calls.
- Thread setup/onboarding config through npm, npm-pack, and ClawHub plugin install helpers.
- Add focused regressions proving install wrappers forward `security.installPolicy` config to installer preflight paths.

## Validation

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-plugins.install.test.ts src/commands/onboarding-plugin-install.test.ts --reporter=dot`
  - `src/commands/onboarding-plugin-install.test.ts`: 27 passed
  - `src/auto-reply/reply/commands-plugins.install.test.ts`: 10 passed
  - `[test] passed 2 Vitest shards in 6.92s`
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
  - `autoreview clean: no accepted/actionable findings reported`
- Rebased on `upstream/main` at `9dbe25e0f6`; current PR head tested at `dc8d8ef1f6`.

Real behavior proof:

```text
$ node --import tsx /tmp/openclaw-pr93357-proof-REDACTED/proof.ts
Install policy target=plugin:policy-proof-plugin request=plugin-dir/install origin=plugin-package pathKind=directory source=local-path/user: blocked by install policy: wrapper policy proof block
Installing to /tmp/openclaw-pr93357-wrapper-proof-REDACTED/state/extensions/policy-proof-plugin...
[plugins] policy-proof-plugin missing register/activate export
Installed plugin: policy-proof-plugin
Restart the gateway to load plugins.
PR 93357 /plugins install wrapper proof
blocked.reply=⚠️ blocked by install policy: wrapper policy proof block
blocked.installedDirExists=false
allowed.reply=🔌 Installed plugin "policy-proof-plugin". Gateway restart will load the new plugin source.
allowed.installedDirExists=true
fixture=/tmp/openclaw-pr93357-wrapper-proof-REDACTED
```

Behavior addressed: `/plugins install` wrapper calls now use the loaded `security.installPolicy` config when invoking installer preflight checks.
Real environment tested: local source checkout, isolated temporary `HOME`, `OPENCLAW_HOME`, `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_STATE_DIR`; no network or secrets.
Exact steps or command run after this patch: the proof script imported `handlePluginsCommand`, installed a local native plugin fixture through `/plugins install`, and switched the policy exec response between `block` and `allow`.
Evidence after fix: the blocked wrapper install returned `blocked by install policy: wrapper policy proof block` and `blocked.installedDirExists=false`; the allowed wrapper install returned the installed-plugin reply and `allowed.installedDirExists=true`.
Observed result after fix: policy blocks happen before managed install directory creation, and the same wrapper install succeeds when the policy returns allow.
What was not tested: real npm, npm-pack, Git, or ClawHub network installs; those paths are covered by focused config-forwarding unit tests in this PR.

## Notes

- No `CHANGELOG.md` update.
- AI-assisted with Codex.
