### PR TITLE
fix(outbound): guard cross-context message mutations

### DIFF
--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -361,6 +361,55 @@ describe("runMessageAction context isolation", () => {
       message: /Cross-context messaging denied/,
     },
     {
+      name: "blocks cross-provider message mutations by default",
+      action: "edit" as const,
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "forum",
+        target: "@opsbot",
+        messageId: "forum-message-1",
+        message: "updated",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+      message: /Cross-context messaging denied/,
+    },
+    {
+      name: "blocks cross-provider delete mutations by default",
+      action: "delete" as const,
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "forum",
+        target: "@opsbot",
+        messageId: "forum-message-1",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+      message: /Cross-context messaging denied/,
+    },
+    {
+      name: "blocks cross-provider pin mutations by default",
+      action: "pin" as const,
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "forum",
+        target: "@opsbot",
+        messageId: "forum-message-1",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+      message: /Cross-context messaging denied/,
+    },
+    {
+      name: "blocks cross-provider unpin mutations by default",
+      action: "unpin" as const,
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "forum",
+        target: "@opsbot",
+        messageId: "forum-message-1",
+      },
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "workspace" },
+      message: /Cross-context messaging denied/,
+    },
+    {
       name: "blocks same-provider cross-context when disabled",
       action: "send" as const,
       cfg: {

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -107,7 +107,7 @@ const richChatConfig = {
 function expectCrossContextPolicyResult(params: {
   cfg: OpenClawConfig;
   channel: string;
-  action: "send" | "upload-file";
+  action: ChannelMessageActionName;
   to: string;
   currentChannelId: string;
   currentChannelProvider: string;
@@ -228,6 +228,56 @@ describe("outbound policy helpers", () => {
   ])("enforces cross-context policy for %j", (params) => {
     expectCrossContextPolicyResult(params);
   });
+
+  it.each(["edit", "delete", "pin", "unpin"] satisfies ChannelMessageActionName[])(
+    "blocks cross-provider %s actions by default",
+    (action) => {
+      expectCrossContextPolicyResult({
+        cfg: workspaceConfig,
+        channel: "forum",
+        action,
+        to: "forum:@ops",
+        currentChannelId: "C12345678",
+        currentChannelProvider: "workspace",
+        expected: /target provider "forum" while bound to "workspace"/,
+      });
+    },
+  );
+
+  it.each(["edit", "delete", "pin", "unpin"] satisfies ChannelMessageActionName[])(
+    "allows cross-provider %s actions when explicitly enabled",
+    (action) => {
+      expectCrossContextPolicyResult({
+        cfg: {
+          ...workspaceConfig,
+          tools: {
+            message: { crossContext: { allowAcrossProviders: true } },
+          },
+        } as OpenClawConfig,
+        channel: "forum",
+        action,
+        to: "forum:@ops",
+        currentChannelId: "C12345678",
+        currentChannelProvider: "workspace",
+        expected: "allow",
+      });
+    },
+  );
+
+  it.each(["edit", "delete", "pin", "unpin"] satisfies ChannelMessageActionName[])(
+    "allows current-context %s actions without cross-provider opt-in",
+    (action) => {
+      expectCrossContextPolicyResult({
+        cfg: workspaceConfig,
+        channel: "workspace",
+        action,
+        to: "C12345678",
+        currentChannelId: "C12345678",
+        currentChannelProvider: "workspace",
+        expected: "allow",
+      });
+    },
+  );
 
   it("allows a routable alias of the native current channel", () => {
     expect(() =>

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -34,11 +34,18 @@ const CONTEXT_GUARDED_ACTIONS = new Set<ChannelMessageActionName>([
   "sendWithEffect",
   "sendAttachment",
   "upload-file",
+  "edit",
+  "delete",
+  "pin",
+  "unpin",
   "thread-create",
   "thread-reply",
   "sticker",
 ]);
 
+// Mutations are guarded above, but markers only apply to outbound payloads that
+// create new visible content. Existing-message edits/pins/deletes should not
+// grow cross-context forwarding text.
 const CONTEXT_MARKER_ACTIONS = new Set<ChannelMessageActionName>([
   "send",
   "poll",


### PR DESCRIPTION
## Summary

Applies the existing cross-context message policy to message mutation actions so cross-provider `edit`, `delete`, `pin`, and `unpin` calls are denied by default unless cross-provider messaging is explicitly enabled.

Refs NVIDIA-dev/openclaw-tracking#750.

## Changes

- Added `edit`, `delete`, `pin`, and `unpin` to the shared outbound `CONTEXT_GUARDED_ACTIONS` set.
- Added pure policy regression coverage for default cross-provider denial and explicit `allowAcrossProviders` allowance across all four mutation actions.
- Added runner-level dry-run coverage proving a cross-provider mutation reaches the shared policy gate before dispatch.

## Validation

- `node scripts/run-vitest.mjs src/infra/outbound/outbound-policy.test.ts src/infra/outbound/message-action-runner.context.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`

## Notes

No `CHANGELOG.md` update. `USER.md` is intentionally not included in this PR.
