### PR TITLE
fix(signal): require approval id header for reactions

### DIFF
--- a/extensions/signal/src/approval-handler.runtime.test.ts
+++ b/extensions/signal/src/approval-handler.runtime.test.ts
@@ -13,6 +13,103 @@ vi.mock("./send.js", () => ({
 
 const { signalApprovalNativeRuntime } = await import("./approval-handler.runtime.js");
 
+function buildExecRequest() {
+  return {
+    id: "exec-1",
+    request: {
+      command: "echo hi",
+      agentId: "main",
+      turnSourceChannel: "signal",
+      turnSourceTo: "+15551230000",
+      turnSourceAccountId: "default",
+      sessionKey: "agent:main:signal:+15551230000",
+    },
+    createdAtMs: 0,
+    expiresAtMs: 60_000,
+  };
+}
+
+function buildPluginRequest() {
+  return {
+    id: "plugin:approval-1",
+    request: {
+      title: "Plugin approval",
+      description: "Allow plugin action",
+      agentId: "main",
+      turnSourceChannel: "signal",
+      turnSourceTo: "+15551230000",
+      turnSourceAccountId: "default",
+      sessionKey: "agent:main:signal:+15551230000",
+    },
+    createdAtMs: 0,
+    expiresAtMs: 60_000,
+  };
+}
+
+function buildExecView() {
+  return {
+    approvalId: "exec-1",
+    approvalKind: "exec",
+    phase: "pending",
+    title: "Exec Approval Required",
+    description: "A command needs your approval.",
+    metadata: [],
+    ask: "always",
+    agentId: "main",
+    commandText: "echo hi",
+    cwd: "/tmp/work",
+    host: "gateway",
+    sessionKey: "agent:main:signal:+15551230000",
+    actions: [
+      {
+        kind: "decision",
+        decision: "allow-once",
+        label: "Allow Once",
+        style: "primary",
+        command: "/approve exec-1 allow-once",
+      },
+      {
+        kind: "decision",
+        decision: "deny",
+        label: "Deny",
+        style: "danger",
+        command: "/approve exec-1 deny",
+      },
+    ],
+    expiresAtMs: 60_000,
+  };
+}
+
+function buildPluginView() {
+  return {
+    approvalId: "plugin:approval-1",
+    approvalKind: "plugin",
+    phase: "pending",
+    title: "Plugin approval",
+    description: "Allow plugin action",
+    metadata: [],
+    agentId: "main",
+    severity: "warning",
+    actions: [
+      {
+        kind: "decision",
+        decision: "allow-once",
+        label: "Allow Once",
+        style: "primary",
+        command: "/approve plugin:approval-1 allow-once",
+      },
+      {
+        kind: "decision",
+        decision: "deny",
+        label: "Deny",
+        style: "danger",
+        command: "/approve plugin:approval-1 deny",
+      },
+    ],
+    expiresAtMs: 60_000,
+  };
+}
+
 function buildPendingContent(params: {
   manualText: string;
   reactionText?: string;
@@ -123,5 +220,65 @@ describe("Signal approval native runtime", () => {
       expect.stringContaining("React with:\n\n👍 Allow Once\n👎 Deny"),
       expect.any(Object),
     );
+  });
+
+  it("delivers runtime-built exec approval prompts with canonical reaction bindings", async () => {
+    const prepared = await signalApprovalNativeRuntime.transport.prepareTarget({
+      plannedTarget: { target: { to: "+15551230000" } },
+      accountId: "default",
+      context: {
+        baseUrl: "http://127.0.0.1:18080",
+        account: "+15550001111",
+        accountUuid: "abcdef12-3456-7890-abcd-ef1234567890",
+      },
+    } as never);
+    const request = buildExecRequest();
+    const pendingPayload = await signalApprovalNativeRuntime.presentation.buildPendingPayload({
+      request,
+      nowMs: 0,
+      view: buildExecView(),
+    } as never);
+
+    await signalApprovalNativeRuntime.transport.deliverPending({
+      cfg: { channels: { signal: { allowFrom: ["+15551230000"] } } },
+      preparedTarget: prepared!.target,
+      pendingPayload,
+    } as never);
+
+    const deliveredText = sendMocks.sendMessageSignal.mock.calls.at(-1)?.[1] as string;
+    expect(deliveredText).toContain("ID: exec-1");
+    expect(deliveredText).toContain("/approve exec-1 allow-once");
+    expect(deliveredText).toContain("React with:\n\n👍 Allow Once");
+    expect(deliveredText).not.toContain("<id>");
+  });
+
+  it("delivers runtime-built plugin approval prompts with canonical reaction bindings", async () => {
+    const prepared = await signalApprovalNativeRuntime.transport.prepareTarget({
+      plannedTarget: { target: { to: "+15551230000" } },
+      accountId: "default",
+      context: {
+        baseUrl: "http://127.0.0.1:18080",
+        account: "+15550001111",
+        accountUuid: "abcdef12-3456-7890-abcd-ef1234567890",
+      },
+    } as never);
+    const request = buildPluginRequest();
+    const pendingPayload = await signalApprovalNativeRuntime.presentation.buildPendingPayload({
+      request,
+      nowMs: 0,
+      view: buildPluginView(),
+    } as never);
+
+    await signalApprovalNativeRuntime.transport.deliverPending({
+      cfg: { channels: { signal: { allowFrom: ["+15551230000"] } } },
+      preparedTarget: prepared!.target,
+      pendingPayload,
+    } as never);
+
+    const deliveredText = sendMocks.sendMessageSignal.mock.calls.at(-1)?.[1] as string;
+    expect(deliveredText).toContain("ID: plugin:approval-1");
+    expect(deliveredText).toContain("/approve plugin:approval-1 allow-once");
+    expect(deliveredText).toContain("React with:\n\n👍 Allow Once");
+    expect(deliveredText).not.toContain("<id>");
   });
 });

--- a/extensions/signal/src/approval-native.test.ts
+++ b/extensions/signal/src/approval-native.test.ts
@@ -260,7 +260,7 @@ describe("signal approval capability", () => {
     ).toBe(false);
   });
 
-  it("renders target-mode exec prompts without unbound reaction choices", () => {
+  it("renders target-mode exec prompts with canonical ids for send-time reactions", () => {
     const cfg = buildConfig({
       signal: { allowFrom: ["+15551230000"] },
       approvals: {
@@ -285,6 +285,7 @@ describe("signal approval capability", () => {
     });
     const text = payload?.text ?? "";
 
+    expect(text).toContain("Approval required.\nID: exec-1");
     expect(text).toContain("/approve exec-1 allow-once");
     expect(text).not.toContain("React with:");
     expect(text).not.toContain("👍 Allow Once");
@@ -293,6 +294,36 @@ describe("signal approval capability", () => {
     expect(text).not.toContain("1️⃣ Allow Once");
     expect(text).not.toContain("2️⃣ Allow Always");
     expect(text).not.toContain("3️⃣ Deny");
+  });
+
+  it("renders target-mode plugin prompts with canonical ids for send-time reactions", () => {
+    const cfg = buildConfig({
+      signal: { allowFrom: ["+15551230000"] },
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "signal", to: "+15551230000" }],
+        },
+      },
+    });
+    const request = buildPluginRequest("+15551230000");
+
+    const payload = signalApprovalCapability.render?.plugin?.buildPendingPayload?.({
+      cfg,
+      request,
+      target: { channel: "signal", to: "+15551230000", source: "target" },
+      nowMs: 0,
+    });
+    const text = payload?.text ?? "";
+
+    expect(text).toContain("Plugin approval required");
+    expect(text).toContain("ID: plugin:approval-1");
+    expect(text).toContain("/approve plugin:approval-1 allow-once");
+    expect(text).not.toContain("React with:");
+    expect(text).not.toContain("👍 Allow Once");
+    expect(text).not.toContain("👎 Deny");
+    expect(text).not.toContain("<id>");
   });
 
   it("does not show reaction choices when Signal has no explicit approvers", () => {
@@ -315,6 +346,7 @@ describe("signal approval capability", () => {
     });
     const text = payload?.text ?? "";
 
+    expect(text).toContain("Approval required.\nID: exec-1");
     expect(text).toContain("/approve exec-1 allow-once");
     expect(text).not.toContain("React with:");
     expect(text).not.toContain("👍 Allow Once");

--- a/extensions/signal/src/approval-native.ts
+++ b/extensions/signal/src/approval-native.ts
@@ -220,14 +220,37 @@ const shouldSuppressSignalForwardingFallback =
   });
 
 function buildSignalExecPendingPayload(params: { request: ExecApprovalRequest; nowMs: number }) {
-  return buildApprovalReactionPendingContentForRequest(params).manualFallbackPayload;
+  return withCanonicalApprovalIdHeader(
+    buildApprovalReactionPendingContentForRequest(params).manualFallbackPayload,
+    params.request.id,
+  );
 }
 
 function buildSignalPluginPendingPayload(params: {
   request: PluginApprovalRequest;
   nowMs: number;
 }) {
-  return buildApprovalReactionPendingContentForRequest(params).manualFallbackPayload;
+  return withCanonicalApprovalIdHeader(
+    buildApprovalReactionPendingContentForRequest(params).manualFallbackPayload,
+    params.request.id,
+  );
+}
+
+function withCanonicalApprovalIdHeader(payload: ReplyPayload, approvalId: string): ReplyPayload {
+  const text = payload.text ?? "";
+  if (!text.trim() || new RegExp(`^\\s*ID:\\s*${escapeRegExp(approvalId)}\\s*$`, "im").test(text)) {
+    return payload;
+  }
+  const lines = text.split(/\r?\n/);
+  const [firstLine, ...rest] = lines;
+  return {
+    ...payload,
+    text: [firstLine, `ID: ${approvalId}`, ...rest].join("\n"),
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export const signalApprovalCapability: ChannelApprovalCapability = createChannelApprovalCapability({

--- a/extensions/signal/src/approval-reactions.test.ts
+++ b/extensions/signal/src/approval-reactions.test.ts
@@ -135,6 +135,83 @@ describe("Signal approval reactions", () => {
     });
   });
 
+  it("does not register target-mode outbound approval snippets without canonical id headers", () => {
+    const cfg = {
+      channels: {
+        signal: {
+          allowFrom: ["+15551230000"],
+        },
+      },
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "targets" as const,
+          targets: [{ channel: "signal", to: "+15551230000" }],
+        },
+      },
+    };
+    const text = "Use this command later:\nReply with: /approve plugin:abc allow-once|deny";
+
+    expect(
+      appendSignalApprovalReactionHintForOutboundMessage({
+        cfg,
+        accountId: "default",
+        to: "+15551230000",
+        text,
+        targetAuthor: "+15550009999",
+      }),
+    ).toBe(text);
+    expect(
+      registerSignalApprovalReactionTargetForOutboundMessage({
+        cfg,
+        accountId: "default",
+        to: "+15551230000",
+        messageId: "1700000000010",
+        text,
+        targetAuthor: "+15550009999",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not register target-mode outbound approval prompts with mismatched ids", () => {
+    const cfg = {
+      channels: {
+        signal: {
+          allowFrom: ["+15551230000"],
+        },
+      },
+      approvals: {
+        plugin: {
+          enabled: true,
+          mode: "targets" as const,
+          targets: [{ channel: "signal", to: "+15551230000" }],
+        },
+      },
+    };
+    const text =
+      "Plugin approval required\nID: plugin:abc\n\nReply with: /approve plugin:def allow-once|deny";
+
+    expect(
+      appendSignalApprovalReactionHintForOutboundMessage({
+        cfg,
+        accountId: "default",
+        to: "+15551230000",
+        text,
+        targetAuthor: "+15550009999",
+      }),
+    ).toBe(text);
+    expect(
+      registerSignalApprovalReactionTargetForOutboundMessage({
+        cfg,
+        accountId: "default",
+        to: "+15551230000",
+        messageId: "1700000000011",
+        text,
+        targetAuthor: "+15550009999",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps target-mode outbound prompts manual when the target route is disabled", () => {
     const text =
       "Plugin approval required\nID: plugin:abc\n\nReply with: /approve plugin:abc allow-once|deny";

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -340,21 +340,30 @@ function normalizeApprovalDecision(value: string): ExecApprovalReplyDecision | n
   return null;
 }
 
+const APPROVAL_ID_LINE_RE = /^\s*ID:\s*([A-Za-z0-9][A-Za-z0-9._:-]*)\s*$/i;
+const APPROVE_COMMAND_LINE_RE = /\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i;
+
 export function extractSignalApprovalPromptBinding(text: string): {
   approvalId: string;
   allowedDecisions: ExecApprovalReplyDecision[];
 } | null {
+  const lines = text.split(/\r?\n/);
+  // Only canonical approval prompts carry the SDK-emitted "ID: <approvalId>"
+  // header. Bare `/approve` snippets in ordinary model output must not become
+  // native reaction targets for a pending approval.
+  const idHeaderMatch = lines
+    .map((line) => line.match(APPROVAL_ID_LINE_RE))
+    .find((match): match is RegExpMatchArray => Boolean(match));
+  if (!idHeaderMatch) {
+    return null;
+  }
+  const approvalId = idHeaderMatch[1];
   const allowedDecisions: ExecApprovalReplyDecision[] = [];
-  let approvalId = "";
-  for (const line of text.split(/\r?\n/)) {
-    const match = line.match(/\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i);
-    if (!match) {
+  for (const line of lines) {
+    const match = line.match(APPROVE_COMMAND_LINE_RE);
+    if (!match || match[1] !== approvalId) {
       continue;
     }
-    if (approvalId && match[1] !== approvalId) {
-      continue;
-    }
-    approvalId ||= match[1];
     for (const decisionText of match[2].split(/[\s|,]+/)) {
       const decision = normalizeApprovalDecision(decisionText);
       if (decision && !allowedDecisions.includes(decision)) {
@@ -362,7 +371,7 @@ export function extractSignalApprovalPromptBinding(text: string): {
       }
     }
   }
-  return approvalId && allowedDecisions.length > 0 ? { approvalId, allowedDecisions } : null;
+  return allowedDecisions.length > 0 ? { approvalId, allowedDecisions } : null;
 }
 
 function buildTargetRoute(params: {

--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -1,6 +1,7 @@
 // Signal plugin module implements channel behavior.
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { buildDmGroupAccountAllowlistAdapter } from "openclaw/plugin-sdk/allowlist-config-edit";
+import type { ChannelOutboundPayloadHint } from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/channel-outbound";
@@ -190,6 +191,7 @@ async function sendFormattedSignalText(ctx: {
   cfg: Parameters<typeof resolveSignalAccount>[0]["cfg"];
   to: string;
   text: string;
+  hint?: ChannelOutboundPayloadHint;
   accountId?: string | null;
   deps?: { [channelId: string]: unknown };
   abortSignal?: AbortSignal;
@@ -223,6 +225,7 @@ async function sendFormattedSignalText(ctx: {
       accountId: ctx.accountId ?? undefined,
       textMode: "plain",
       textStyles: chunk.styles,
+      approvalReactionBinding: ctx.hint?.kind === "approval-pending",
     });
     results.push(result);
   }
@@ -233,6 +236,7 @@ async function sendFormattedSignalMedia(ctx: {
   cfg: Parameters<typeof resolveSignalAccount>[0]["cfg"];
   to: string;
   text: string;
+  hint?: ChannelOutboundPayloadHint;
   mediaUrl: string;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
@@ -266,6 +270,7 @@ async function sendFormattedSignalMedia(ctx: {
     accountId: ctx.accountId ?? undefined,
     textMode: "plain",
     textStyles: formatted.styles,
+    approvalReactionBinding: ctx.hint?.kind === "approval-pending",
   });
   return attachChannelToResult("signal", result);
 }
@@ -404,11 +409,12 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
             payload,
             hint,
           }),
-        sendFormattedText: async ({ cfg, to, text, accountId, deps, abortSignal }) =>
+        sendFormattedText: async ({ cfg, to, text, hint, accountId, deps, abortSignal }) =>
           await sendFormattedSignalText({
             cfg,
             to,
             text,
+            hint,
             accountId,
             deps,
             abortSignal,
@@ -420,6 +426,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
           mediaUrl,
           mediaLocalRoots,
           mediaReadFile,
+          hint,
           accountId,
           deps,
           abortSignal,
@@ -428,6 +435,7 @@ export const signalPlugin: ChannelPlugin<ResolvedSignalAccount, SignalProbe> =
             cfg,
             to,
             text,
+            hint,
             mediaUrl,
             mediaLocalRoots,
             mediaReadFile,

--- a/extensions/signal/src/send.approval-reactions.behavior.test.ts
+++ b/extensions/signal/src/send.approval-reactions.behavior.test.ts
@@ -124,7 +124,8 @@ describe("sendMessageSignal approval reaction behavior", () => {
     });
     closeServer = server.close;
     const cfg = buildCfg(server.baseUrl);
-    const text = "Use this command later:\nReply with: /approve plugin:abc allow-once|deny";
+    const text =
+      "Use this command later:\nID: plugin:abc\n\nReply with: /approve plugin:abc allow-once|deny";
 
     await sendMessageSignal("+15551230000", text, { cfg });
 
@@ -147,7 +148,7 @@ describe("sendMessageSignal approval reaction behavior", () => {
     expect(resolverMocks.resolveSignalApproval).not.toHaveBeenCalled();
   });
 
-  it("sends canonical approval prompts with reaction hints and resolves authorized reactions", async () => {
+  it("sends approval-owned prompts with reaction hints and resolves authorized reactions", async () => {
     const calls: RpcCall[] = [];
     const server = await withSignalRpcServer(async (req, res) => {
       expect(req.method).toBe("POST");
@@ -164,7 +165,10 @@ describe("sendMessageSignal approval reaction behavior", () => {
     const text =
       "Plugin approval required\nID: plugin:abc\n\nReply with: /approve plugin:abc allow-once|deny";
 
-    await sendMessageSignal("+15551230000", text, { cfg });
+    await sendMessageSignal("+15551230000", text, {
+      cfg,
+      approvalReactionBinding: true,
+    });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.method).toBe("send");
@@ -229,7 +233,10 @@ describe("sendMessageSignal approval reaction behavior", () => {
     expect(text).toContain("/approve exec-1 allow-once");
     expect(text).not.toContain("React with:");
 
-    await sendMessageSignal("+15551230000", text, { cfg });
+    await sendMessageSignal("+15551230000", text, {
+      cfg,
+      approvalReactionBinding: true,
+    });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]?.method).toBe("send");

--- a/extensions/signal/src/send.approval-reactions.behavior.test.ts
+++ b/extensions/signal/src/send.approval-reactions.behavior.test.ts
@@ -1,6 +1,7 @@
 // Signal tests cover real send-path approval reaction behavior.
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { signalApprovalCapability } from "./approval-native.js";
 import {
   clearSignalApprovalReactionTargetsForTest,
   maybeResolveSignalApprovalReaction,
@@ -81,6 +82,11 @@ function buildCfg(baseUrl: string) {
       },
     },
     approvals: {
+      exec: {
+        enabled: true,
+        mode: "targets" as const,
+        targets: [{ channel: "signal", to: "+15551230000" }],
+      },
       plugin: {
         enabled: true,
         mode: "targets" as const,
@@ -179,6 +185,71 @@ describe("sendMessageSignal approval reaction behavior", () => {
     expect(resolverMocks.resolveSignalApproval).toHaveBeenCalledWith({
       cfg,
       approvalId: "plugin:abc",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
+
+  it("preserves rendered target-mode exec approval reactions through send and reaction resolution", async () => {
+    const calls: RpcCall[] = [];
+    const server = await withSignalRpcServer(async (req, res) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/api/v1/rpc");
+      const body = JSON.parse(await readRequestBody(req)) as RpcCall & { id?: unknown };
+      calls.push(body);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({ jsonrpc: "2.0", result: { timestamp: 1700000001012 }, id: body.id }),
+      );
+    });
+    closeServer = server.close;
+    const cfg = buildCfg(server.baseUrl);
+    const payload = signalApprovalCapability.render?.exec?.buildPendingPayload?.({
+      cfg,
+      request: {
+        id: "exec-1",
+        request: {
+          command: "echo hi",
+          agentId: "main",
+          turnSourceChannel: "slack",
+          turnSourceTo: "C123",
+          turnSourceAccountId: "default",
+          sessionKey: "agent:main:slack:C123",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      target: { channel: "signal", to: "+15551230000", source: "target" },
+      nowMs: 0,
+    });
+    const text = payload?.text ?? "";
+
+    expect(text).toContain("Approval required.\nID: exec-1");
+    expect(text).toContain("/approve exec-1 allow-once");
+    expect(text).not.toContain("React with:");
+
+    await sendMessageSignal("+15551230000", text, { cfg });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("send");
+    expect(calls[0]?.params?.message).toContain("Approval required.\nID: exec-1");
+    expect(calls[0]?.params?.message).toContain("React with:");
+
+    await expect(
+      maybeResolveSignalApprovalReaction({
+        cfg,
+        accountId: "default",
+        conversationKey: "+15551230000",
+        messageId: "1700000001012",
+        reactionKey: "\u{1F44D}",
+        actorId: "+15551230000",
+        targetAuthor: "+15550001111",
+      }),
+    ).resolves.toBe(true);
+    expect(resolverMocks.resolveSignalApproval).toHaveBeenCalledWith({
+      cfg,
+      approvalId: "exec-1",
       decision: "allow-once",
       senderId: "+15551230000",
       gatewayUrl: undefined,

--- a/extensions/signal/src/send.approval-reactions.behavior.test.ts
+++ b/extensions/signal/src/send.approval-reactions.behavior.test.ts
@@ -1,0 +1,187 @@
+// Signal tests cover real send-path approval reaction behavior.
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSignalApprovalReactionTargetsForTest,
+  maybeResolveSignalApprovalReaction,
+} from "./approval-reactions.js";
+import { sendMessageSignal } from "./send.js";
+
+const resolverMocks = vi.hoisted(() => ({
+  resolveSignalApproval: vi.fn(),
+  isApprovalNotFoundError: vi.fn(() => false),
+}));
+
+vi.mock("./approval-resolver.js", () => ({
+  resolveSignalApproval: resolverMocks.resolveSignalApproval,
+  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+}));
+
+type RpcCall = {
+  method?: string;
+  params?: Record<string, unknown>;
+};
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk: string) => {
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+async function withSignalRpcServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    void Promise.resolve(handler(req, res)).catch((error: unknown) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end(String(error));
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected local Signal RPC server to bind a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}
+
+function buildCfg(baseUrl: string) {
+  return {
+    channels: {
+      signal: {
+        apiMode: "native" as const,
+        accounts: {
+          default: {
+            httpUrl: baseUrl,
+            account: "+15550001111",
+            allowFrom: ["+15551230000"],
+          },
+        },
+      },
+    },
+    approvals: {
+      plugin: {
+        enabled: true,
+        mode: "targets" as const,
+        targets: [{ channel: "signal", to: "+15551230000" }],
+      },
+    },
+  };
+}
+
+describe("sendMessageSignal approval reaction behavior", () => {
+  let closeServer: (() => Promise<void>) | undefined;
+
+  beforeEach(() => {
+    clearSignalApprovalReactionTargetsForTest();
+    resolverMocks.resolveSignalApproval.mockReset().mockResolvedValue(undefined);
+    resolverMocks.isApprovalNotFoundError.mockReset().mockReturnValue(false);
+  });
+
+  afterEach(async () => {
+    await closeServer?.();
+    closeServer = undefined;
+  });
+
+  it("sends ordinary approval-command snippets without reaction hints or registered targets", async () => {
+    const calls: RpcCall[] = [];
+    const server = await withSignalRpcServer(async (req, res) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/api/v1/rpc");
+      const body = JSON.parse(await readRequestBody(req)) as RpcCall & { id?: unknown };
+      calls.push(body);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({ jsonrpc: "2.0", result: { timestamp: 1700000001010 }, id: body.id }),
+      );
+    });
+    closeServer = server.close;
+    const cfg = buildCfg(server.baseUrl);
+    const text = "Use this command later:\nReply with: /approve plugin:abc allow-once|deny";
+
+    await sendMessageSignal("+15551230000", text, { cfg });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("send");
+    expect(calls[0]?.params?.message).toBe(text);
+    expect(String(calls[0]?.params?.message)).not.toContain("React with:");
+
+    await expect(
+      maybeResolveSignalApprovalReaction({
+        cfg,
+        accountId: "default",
+        conversationKey: "+15551230000",
+        messageId: "1700000001010",
+        reactionKey: "\u{1F44D}",
+        actorId: "+15551230000",
+        targetAuthor: "+15550001111",
+      }),
+    ).resolves.toBe(false);
+    expect(resolverMocks.resolveSignalApproval).not.toHaveBeenCalled();
+  });
+
+  it("sends canonical approval prompts with reaction hints and resolves authorized reactions", async () => {
+    const calls: RpcCall[] = [];
+    const server = await withSignalRpcServer(async (req, res) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/api/v1/rpc");
+      const body = JSON.parse(await readRequestBody(req)) as RpcCall & { id?: unknown };
+      calls.push(body);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({ jsonrpc: "2.0", result: { timestamp: 1700000001011 }, id: body.id }),
+      );
+    });
+    closeServer = server.close;
+    const cfg = buildCfg(server.baseUrl);
+    const text =
+      "Plugin approval required\nID: plugin:abc\n\nReply with: /approve plugin:abc allow-once|deny";
+
+    await sendMessageSignal("+15551230000", text, { cfg });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("send");
+    expect(calls[0]?.params?.message).toContain("ID: plugin:abc");
+    expect(calls[0]?.params?.message).toContain("React with:");
+
+    await expect(
+      maybeResolveSignalApprovalReaction({
+        cfg,
+        accountId: "default",
+        conversationKey: "+15551230000",
+        messageId: "1700000001011",
+        reactionKey: "\u{1F44D}",
+        actorId: "+15551230000",
+        targetAuthor: "+15550001111",
+      }),
+    ).resolves.toBe(true);
+    expect(resolverMocks.resolveSignalApproval).toHaveBeenCalledWith({
+      cfg,
+      approvalId: "plugin:abc",
+      decision: "allow-once",
+      senderId: "+15551230000",
+      gatewayUrl: undefined,
+    });
+  });
+});

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -36,6 +36,7 @@ export type SignalSendOpts = {
   timeoutMs?: number;
   textMode?: "markdown" | "plain";
   textStyles?: SignalTextStyleRange[];
+  approvalReactionBinding?: boolean;
 };
 
 export type SignalSendResult = {
@@ -184,13 +185,16 @@ export async function sendMessageSignal(
   });
   const { baseUrl, account } = resolveSignalRpcContext(opts, accountInfo);
   const target = parseTarget(to);
-  const outboundText = appendSignalApprovalReactionHintForOutboundMessage({
-    cfg,
-    accountId: accountInfo.accountId,
-    to,
-    text: text ?? "",
-    targetAuthor: account,
-  });
+  const rawText = text ?? "";
+  const outboundText = opts.approvalReactionBinding
+    ? appendSignalApprovalReactionHintForOutboundMessage({
+        cfg,
+        accountId: accountInfo.accountId,
+        to,
+        text: rawText,
+        targetAuthor: account,
+      })
+    : rawText;
   let message = outboundText;
   let messageFromPlaceholder = false;
   let textStyles: SignalTextStyleRange[] = [];
@@ -273,14 +277,16 @@ export async function sendMessageSignal(
   });
   const timestamp = result?.timestamp;
   const messageId = timestamp ? String(timestamp) : "unknown";
-  registerSignalApprovalReactionTargetForOutboundMessage({
-    cfg,
-    accountId: accountInfo.accountId,
-    to,
-    messageId,
-    text: outboundText,
-    targetAuthor: account,
-  });
+  if (opts.approvalReactionBinding) {
+    registerSignalApprovalReactionTargetForOutboundMessage({
+      cfg,
+      accountId: accountInfo.accountId,
+      to,
+      messageId,
+      text: outboundText,
+      targetAuthor: account,
+    });
+  }
   return {
     messageId,
     timestamp,

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -22,6 +22,7 @@ export type ChannelOutboundContext = {
   cfg: OpenClawConfig;
   to: string;
   text: string;
+  hint?: ChannelOutboundPayloadHint;
   mediaUrl?: string;
   audioAsVoice?: boolean;
   mediaAccess?: OutboundMediaAccess;

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -6,6 +6,7 @@ import {
   getLoadedChannelPlugin,
   resolveChannelApprovalAdapter,
 } from "../channels/plugins/index.js";
+import type { ChannelOutboundPayloadHint } from "../channels/plugins/types.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type {
   ExecApprovalForwardingConfig,
@@ -367,6 +368,7 @@ async function deliverToTargets(params: {
   targets: ForwardTarget[];
   buildPayload: (target: ForwardTarget) => ReplyPayload;
   deliver: DeliverApprovalPayloads;
+  hint?: ChannelOutboundPayloadHint;
   beforeDeliver?: (target: ForwardTarget, payload: ReplyPayload) => Promise<void> | void;
   shouldSend?: () => boolean;
 }) {
@@ -387,6 +389,7 @@ async function deliverToTargets(params: {
         to: target.to,
         accountId: target.accountId,
         threadId: target.threadId,
+        hint: params.hint,
         payloads: [payload],
       });
       if (send.status === "failed" || send.status === "partial_failed") {
@@ -604,6 +607,11 @@ function createApprovalHandlers<
       return false;
     }
 
+    const pendingHint = {
+      kind: "approval-pending",
+      approvalKind: params.strategy.kind,
+    } satisfies ChannelOutboundPayloadHint;
+
     void deliverToTargets({
       cfg,
       targets: filteredTargets,
@@ -624,13 +632,11 @@ function createApprovalHandlers<
           cfg,
           target,
           payload,
-          hint: {
-            kind: "approval-pending",
-            approvalKind: params.strategy.kind,
-          },
+          hint: pendingHint,
         });
       },
       deliver: params.deliver,
+      hint: pendingHint,
       shouldSend: () => pending.get(requestId) === pendingEntry,
     }).catch((err: unknown) => {
       log.error(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -17,6 +17,7 @@ import type {
   ChannelDeliveryCapabilities,
   ChannelOutboundAdapter,
   ChannelOutboundContext,
+  ChannelOutboundPayloadHint,
   ChannelOutboundPayloadContext,
   ChannelOutboundTargetRef,
 } from "../../channels/plugins/types.adapters.js";
@@ -574,6 +575,7 @@ function createChannelOutboundContextBase(
   return {
     cfg: params.cfg,
     to: params.to,
+    hint: params.hint,
     accountId: params.accountId,
     replyToId: params.replyToId,
     replyToMode: params.replyToMode,
@@ -637,6 +639,7 @@ type DeliverOutboundPayloadsCoreParams = {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  hint?: ChannelOutboundPayloadHint;
   payloads: ReplyPayload[];
   replyToId?: string | null;
   replyToMode?: ReplyToMode;


### PR DESCRIPTION
## Summary

Signal approval reactions now bind only from OpenClaw-owned approval delivery paths, not from ordinary outbound Signal text that happens to contain copied approval commands.

## Changes

- Require Signal approval reaction extraction to see a canonical matching `ID: <approvalId>` header.
- Add the canonical ID header to Signal exec/plugin approval prompt renderers.
- Thread an `approval-pending` outbound hint through approval forwarding and channel delivery so only trusted approval payloads ask Signal send to append reaction controls and register reaction targets.
- Keep ordinary/model-generated Signal sends plain, even if they contain `ID:` plus `/approve` snippets.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-signal.config.ts extensions/signal/src/approval-handler.runtime.test.ts extensions/signal/src/approval-native.test.ts extensions/signal/src/approval-reactions.test.ts extensions/signal/src/send.approval-reactions.behavior.test.ts --reporter=dot`
  - 4 files passed, 40 tests passed.
- `node scripts/run-vitest.mjs src/infra/exec-approval-forwarder.test.ts src/infra/outbound/deliver.test.ts -- --reporter=dot`
  - 2 files passed, 118 tests passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/signal/src/approval-native.ts extensions/signal/src/approval-native.test.ts extensions/signal/src/approval-reactions.ts extensions/signal/src/approval-reactions.test.ts extensions/signal/src/approval-handler.runtime.test.ts extensions/signal/src/channel.ts extensions/signal/src/send.ts extensions/signal/src/send.approval-reactions.behavior.test.ts src/infra/exec-approval-forwarder.ts src/infra/outbound/deliver.ts src/channels/plugins/outbound.types.ts`
  - clean.
- `git diff --check`
  - clean.

## Notes

Compatibility decision: native Signal reaction controls intentionally require OpenClaw-owned approval delivery plus the canonical matching ID header. Custom or copied approval-looking text sent through ordinary Signal paths intentionally stays plain.

External Signal service/device proof is not available from this runner: the local config has no Signal channel, no Signal state was present under the local OpenClaw state directory, and `signal-cli` is not installed on `PATH`. I accept the local-endpoint proof gap for this PR because the proof exercises the production OpenClaw Signal renderer, outbound send, target registration, and reaction resolution code, with only the external Signal network/device replaced by the local JSON-RPC endpoint.
