### PR TITLE
fix(feishu): enforce perm tool account gates

### DIFF
--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -2,13 +2,15 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
-import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+import { resolveAnyEnabledFeishuToolsConfig, resolveFeishuToolAccount } from "./tool-account.js";
 import {
   jsonToolResult,
   toolExecutionErrorResult,
   unknownToolActionResult,
 } from "./tool-result.js";
+import { resolveToolsConfig } from "./tools-config.js";
 
 type ListTokenType =
   | "doc"
@@ -130,6 +132,17 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
 
   type FeishuPermExecuteParams = FeishuPermParams & { accountId?: string };
 
+  const createPermClient = (
+    params: FeishuPermExecuteParams | undefined,
+    defaultAccountId?: string,
+  ) => {
+    const account = resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId });
+    if (!resolveToolsConfig(account.config.tools).perm) {
+      throw new Error(`Feishu Perm tools are disabled for account "${account.accountId}"`);
+    }
+    return createFeishuClient(account);
+  };
+
   api.registerTool(
     (ctx) => {
       const defaultAccountId = ctx.agentAccountId;
@@ -141,11 +154,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
         async execute(_toolCallId, params) {
           const p = params as FeishuPermExecuteParams;
           try {
-            const client = createFeishuToolClient({
-              api,
-              executeParams: p,
-              defaultAccountId,
-            });
+            const client = createPermClient(p, defaultAccountId);
             switch (p.action) {
               case "list":
                 return jsonToolResult(await listMembers(client, p.token, p.type));

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -205,6 +205,38 @@ describe("feishu tool account routing", () => {
     expect(lastClientAppId()).toBe("app-b");
   });
 
+  test("perm tool rejects a disabled contextual account when another account enables it", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { perm: false },
+        toolsB: { perm: true },
+      }),
+    );
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm", { agentAccountId: "a" });
+    const result = await tool.execute("call", { action: "unknown_action" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Perm tools are disabled for account "a"');
+  });
+
+  test("perm tool rejects an explicit disabled account override", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { perm: false },
+        toolsB: { perm: true },
+      }),
+    );
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm", { agentAccountId: "b" });
+    const result = await tool.execute("call", { action: "unknown_action", accountId: "a" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Perm tools are disabled for account "a"');
+  });
+
   test("bitable tool registers when only second account enables it and routes to agentAccountId", async () => {
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({


### PR DESCRIPTION
## Summary

Enforce the Feishu permission tool setting on the resolved account before running permission operations.

## Changes

- Resolve the selected Feishu account before constructing the permission client.
- Reject `feishu_perm` execution when that selected account has permission tooling disabled.
- Add contextual and explicit-account routing regression coverage.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/tool-account-routing.test.ts --reporter=verbose`
- `node scripts/run-oxlint.mjs extensions/feishu/src/perm.ts extensions/feishu/src/tool-account-routing.test.ts`
- `git diff --check -- extensions/feishu/src/perm.ts extensions/feishu/src/tool-account-routing.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

No changelog update; release notes are maintainer-owned.
