### PR TITLE
fix(openshell): pin mirror remote mutations

### DIFF
--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -859,5 +859,8 @@ function normalizeRemotePath(remotePath: string): string {
 
 function isRemotePathInside(root: string, candidate: string): boolean {
   const relative = path.posix.relative(root, candidate);
-  return relative === "" || (!relative.startsWith("..") && !path.posix.isAbsolute(relative));
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith("../") && !path.posix.isAbsolute(relative))
+  );
 }

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -91,6 +91,12 @@ export const PINNED_REMOTE_PATH_MUTATION_SCRIPT = [
   '    target="$parent/$4"',
   '    if [ -d "$target" ] && [ ! -L "$target" ]; then rm -rf -- "$target"; elif [ -e "$target" ] || [ -L "$target" ]; then rm -f -- "$target"; fi',
   "    ;;",
+  "  removefile)",
+  '    parent="$(pin_dir "$2" "$3" 0)"',
+  '    validate_basename "$4"',
+  '    target="$parent/$4"',
+  '    if [ -d "$target" ] && [ ! -L "$target" ]; then rmdir -- "$target"; elif [ -e "$target" ] || [ -L "$target" ]; then rm -f -- "$target"; fi',
+  "    ;;",
   "  rename)",
   '    src_parent="$(pin_dir "$2" "$3" 0)"',
   '    validate_basename "$4"',
@@ -251,6 +257,8 @@ async function createOpenShellSandboxBackend(params: {
     remoteAgentWorkspaceDir: params.pluginConfig.remoteAgentWorkspaceDir,
     runRemoteShellScript: async (command) => await impl.runRemoteShellScript(command),
     mkdirpRemotePath: async (remotePath, signal) => await impl.mkdirpRemotePath(remotePath, signal),
+    removeRemotePath: async (remotePath, removeParams) =>
+      await impl.removeRemotePath(remotePath, removeParams),
     renameRemotePath: async (fromRemotePath, toRemotePath, signal) =>
       await impl.renameRemotePath(fromRemotePath, toRemotePath, signal),
     syncLocalPathToRemote: async (localPath, remotePath) =>
@@ -309,6 +317,8 @@ class OpenShellSandboxBackendImpl {
       runRemoteShellScript: async (command) => await this.runRemoteShellScript(command),
       mkdirpRemotePath: async (remotePath, signal) =>
         await this.mkdirpRemotePath(remotePath, signal),
+      removeRemotePath: async (remotePath, removeParams) =>
+        await this.removeRemotePath(remotePath, removeParams),
       renameRemotePath: async (fromRemotePath, toRemotePath, signal) =>
         await this.renameRemotePath(fromRemotePath, toRemotePath, signal),
       syncLocalPathToRemote: async (localPath, remotePath) =>
@@ -382,6 +392,29 @@ class OpenShellSandboxBackendImpl {
     await this.runPinnedRemotePathMutation({
       args: ["mkdirp", target.root, target.relativePath],
       signal,
+    });
+  }
+
+  async removeRemotePath(
+    remotePath: string,
+    params?: {
+      recursive?: boolean;
+      signal?: AbortSignal;
+      allowFailure?: boolean;
+    },
+  ): Promise<void> {
+    const target = this.resolveRemoteTarget(remotePath);
+    await this.runPinnedRemotePathMutation({
+      args: [
+        params?.recursive ? "remove" : "removefile",
+        target.root,
+        path.posix.dirname(target.relativePath) === "."
+          ? ""
+          : path.posix.dirname(target.relativePath),
+        path.posix.basename(target.relativePath),
+      ],
+      signal: params?.signal,
+      allowFailure: params?.allowFailure,
     });
   }
 

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -80,20 +80,55 @@ export const PINNED_REMOTE_PATH_MUTATION_SCRIPT = [
   "  done",
   '  printf "%s\\n" "$current"',
   "}",
+  "pin_dir_or_missing() {",
+  '  root="$1"',
+  '  relative="$2"',
+  '  missing_ok="$3"',
+  '  case "$root" in /*) ;; *) die "remote root must be absolute: $root" ;; esac',
+  '  root="${root%/}"',
+  '  [ -n "$root" ] || root="/"',
+  '  if [ -L "$root" ]; then die "unsafe remote root symlink: $root"; fi',
+  '  if [ ! -d "$root" ]; then',
+  '    if [ -e "$root" ]; then die "unsafe remote root component: $root"; fi',
+  '    if [ "$missing_ok" = "1" ]; then printf "\\n"; return 0; fi',
+  '    die "remote directory not found: $root"',
+  "  fi",
+  '  canonical_root="$(cd "$root" && pwd -P)"',
+  '  current="$canonical_root"',
+  '  relative="${relative#/}"',
+  '  while [ -n "$relative" ]; do',
+  '    part="${relative%%/*}"',
+  '    if [ "$part" = "$relative" ]; then relative=""; else relative="${relative#*/}"; fi',
+  '    [ -n "$part" ] || continue',
+  '    case "$part" in "."|"..") die "unsafe remote directory component: $part" ;; esac',
+  '    if [ "$current" = "/" ]; then next="/$part"; else next="$current/$part"; fi',
+  '    if [ -L "$next" ]; then die "unsafe remote directory symlink: $next"; fi',
+  '    if [ -e "$next" ]; then',
+  '      if [ ! -d "$next" ]; then die "unsafe remote directory component: $next"; fi',
+  "    else",
+  '      if [ "$missing_ok" = "1" ]; then printf "\\n"; return 0; fi',
+  '      die "remote directory not found: $next"',
+  "    fi",
+  '    current="$next"',
+  "  done",
+  '  printf "%s\\n" "$current"',
+  "}",
   'operation="$1"',
   'case "$operation" in',
   "  mkdirp)",
   '    pin_dir "$2" "$3" 1 >/dev/null',
   "    ;;",
   "  remove)",
-  '    parent="$(pin_dir "$2" "$3" 0)"',
   '    validate_basename "$4"',
+  '    parent="$(pin_dir_or_missing "$2" "$3" "${5:-0}")"',
+  '    [ -n "$parent" ] || exit 0',
   '    target="$parent/$4"',
   '    if [ -d "$target" ] && [ ! -L "$target" ]; then rm -rf -- "$target"; elif [ -e "$target" ] || [ -L "$target" ]; then rm -f -- "$target"; fi',
   "    ;;",
   "  removefile)",
-  '    parent="$(pin_dir "$2" "$3" 0)"',
   '    validate_basename "$4"',
+  '    parent="$(pin_dir_or_missing "$2" "$3" "${5:-0}")"',
+  '    [ -n "$parent" ] || exit 0',
   '    target="$parent/$4"',
   '    if [ -d "$target" ] && [ ! -L "$target" ]; then rmdir -- "$target"; elif [ -e "$target" ] || [ -L "$target" ]; then rm -f -- "$target"; fi',
   "    ;;",
@@ -400,7 +435,7 @@ class OpenShellSandboxBackendImpl {
     params?: {
       recursive?: boolean;
       signal?: AbortSignal;
-      allowFailure?: boolean;
+      ignoreMissing?: boolean;
     },
   ): Promise<void> {
     const target = this.resolveRemoteTarget(remotePath);
@@ -412,9 +447,9 @@ class OpenShellSandboxBackendImpl {
           ? ""
           : path.posix.dirname(target.relativePath),
         path.posix.basename(target.relativePath),
+        params?.ignoreMissing ? "1" : "0",
       ],
       signal: params?.signal,
-      allowFailure: params?.allowFailure,
     });
   }
 
@@ -478,8 +513,8 @@ class OpenShellSandboxBackendImpl {
             ? ""
             : path.posix.dirname(target.relativePath),
           path.posix.basename(target.relativePath),
+          "1",
         ],
-        allowFailure: true,
       });
       return;
     }
@@ -492,8 +527,8 @@ class OpenShellSandboxBackendImpl {
             ? ""
             : path.posix.dirname(target.relativePath),
           path.posix.basename(target.relativePath),
+          "1",
         ],
-        allowFailure: true,
       });
       return;
     }
@@ -530,13 +565,11 @@ class OpenShellSandboxBackendImpl {
   private async runPinnedRemotePathMutation(params: {
     args: string[];
     signal?: AbortSignal;
-    allowFailure?: boolean;
   }): Promise<SandboxBackendCommandResult> {
     return await this.runRemoteShellScript({
       script: PINNED_REMOTE_PATH_MUTATION_SCRIPT,
       args: params.args,
       signal: params.signal,
-      allowFailure: params.allowFailure,
     });
   }
 

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -45,6 +45,66 @@ type PendingExec = {
 };
 
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
+export const PINNED_REMOTE_PATH_MUTATION_SCRIPT = [
+  "set -eu",
+  'die() { echo "$1" >&2; exit 1; }',
+  "validate_basename() {",
+  '  case "$1" in ""|"."|".."|*/*) die "unsafe remote basename: $1" ;; esac',
+  "}",
+  "pin_dir() {",
+  '  root="$1"',
+  '  relative="$2"',
+  '  create="$3"',
+  '  case "$root" in /*) ;; *) die "remote root must be absolute: $root" ;; esac',
+  '  root="${root%/}"',
+  '  [ -n "$root" ] || root="/"',
+  '  if [ -L "$root" ]; then die "unsafe remote root symlink: $root"; fi',
+  '  mkdir -p -- "$root"',
+  '  canonical_root="$(cd "$root" && pwd -P)"',
+  '  current="$canonical_root"',
+  '  relative="${relative#/}"',
+  '  while [ -n "$relative" ]; do',
+  '    part="${relative%%/*}"',
+  '    if [ "$part" = "$relative" ]; then relative=""; else relative="${relative#*/}"; fi',
+  '    [ -n "$part" ] || continue',
+  '    case "$part" in "."|"..") die "unsafe remote directory component: $part" ;; esac',
+  '    if [ "$current" = "/" ]; then next="/$part"; else next="$current/$part"; fi',
+  '    if [ -L "$next" ]; then die "unsafe remote directory symlink: $next"; fi',
+  '    if [ -e "$next" ]; then',
+  '      if [ ! -d "$next" ]; then die "unsafe remote directory component: $next"; fi',
+  "    else",
+  '      if [ "$create" != "1" ]; then die "remote directory not found: $next"; fi',
+  '      mkdir -- "$next"',
+  "    fi",
+  '    current="$next"',
+  "  done",
+  '  printf "%s\\n" "$current"',
+  "}",
+  'operation="$1"',
+  'case "$operation" in',
+  "  mkdirp)",
+  '    pin_dir "$2" "$3" 1 >/dev/null',
+  "    ;;",
+  "  remove)",
+  '    parent="$(pin_dir "$2" "$3" 0)"',
+  '    validate_basename "$4"',
+  '    target="$parent/$4"',
+  '    if [ -d "$target" ] && [ ! -L "$target" ]; then rm -rf -- "$target"; elif [ -e "$target" ] || [ -L "$target" ]; then rm -f -- "$target"; fi',
+  "    ;;",
+  "  rename)",
+  '    src_parent="$(pin_dir "$2" "$3" 0)"',
+  '    validate_basename "$4"',
+  '    dst_parent="$(pin_dir "$5" "$6" 1)"',
+  '    validate_basename "$7"',
+  '    if [ -L "$dst_parent/$7" ]; then die "unsafe remote rename target symlink: $dst_parent/$7"; fi',
+  '    if [ -d "$dst_parent/$7" ]; then die "unsafe remote rename target directory: $dst_parent/$7"; fi',
+  '    mv -- "$src_parent/$4" "$dst_parent/$7"',
+  "    ;;",
+  "  *)",
+  '    die "unknown remote path mutation: $operation"',
+  "    ;;",
+  "esac",
+].join("\n");
 const ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT = [
   "set -e",
   'target="$1"',
@@ -190,6 +250,9 @@ async function createOpenShellSandboxBackend(params: {
     remoteWorkspaceDir: params.pluginConfig.remoteWorkspaceDir,
     remoteAgentWorkspaceDir: params.pluginConfig.remoteAgentWorkspaceDir,
     runRemoteShellScript: async (command) => await impl.runRemoteShellScript(command),
+    mkdirpRemotePath: async (remotePath, signal) => await impl.mkdirpRemotePath(remotePath, signal),
+    renameRemotePath: async (fromRemotePath, toRemotePath, signal) =>
+      await impl.renameRemotePath(fromRemotePath, toRemotePath, signal),
     syncLocalPathToRemote: async (localPath, remotePath) =>
       await impl.syncLocalPathToRemote(localPath, remotePath),
   };
@@ -244,6 +307,10 @@ class OpenShellSandboxBackendImpl {
               backend: this.asHandle(),
             }),
       runRemoteShellScript: async (command) => await this.runRemoteShellScript(command),
+      mkdirpRemotePath: async (remotePath, signal) =>
+        await this.mkdirpRemotePath(remotePath, signal),
+      renameRemotePath: async (fromRemotePath, toRemotePath, signal) =>
+        await this.renameRemotePath(fromRemotePath, toRemotePath, signal),
       syncLocalPathToRemote: async (localPath, remotePath) =>
         await this.syncLocalPathToRemote(localPath, remotePath),
     };
@@ -310,6 +377,35 @@ class OpenShellSandboxBackendImpl {
     return await this.runRemoteShellScriptInternal(params);
   }
 
+  async mkdirpRemotePath(remotePath: string, signal?: AbortSignal): Promise<void> {
+    const target = this.resolveRemoteTarget(remotePath);
+    await this.runPinnedRemotePathMutation({
+      args: ["mkdirp", target.root, target.relativePath],
+      signal,
+    });
+  }
+
+  async renameRemotePath(
+    fromRemotePath: string,
+    toRemotePath: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const from = this.resolveRemoteTarget(fromRemotePath);
+    const to = this.resolveRemoteTarget(toRemotePath);
+    await this.runPinnedRemotePathMutation({
+      args: [
+        "rename",
+        from.root,
+        path.posix.dirname(from.relativePath) === "." ? "" : path.posix.dirname(from.relativePath),
+        path.posix.basename(from.relativePath),
+        to.root,
+        path.posix.dirname(to.relativePath) === "." ? "" : path.posix.dirname(to.relativePath),
+        path.posix.basename(to.relativePath),
+      ],
+      signal,
+    });
+  }
+
   private async runRemoteShellScriptInternal(
     params: SandboxBackendCommandParams,
   ): Promise<SandboxBackendCommandResult> {
@@ -338,33 +434,48 @@ class OpenShellSandboxBackendImpl {
   async syncLocalPathToRemote(localPath: string, remotePath: string): Promise<void> {
     await this.ensureSandboxExists();
     await this.maybeSeedRemoteWorkspace();
+    const target = this.resolveRemoteTarget(remotePath);
     const stats = await fs.lstat(localPath).catch(() => null);
     if (!stats) {
-      await this.runRemoteShellScript({
-        script: 'rm -rf -- "$1"',
-        args: [remotePath],
+      await this.runPinnedRemotePathMutation({
+        args: [
+          "remove",
+          target.root,
+          path.posix.dirname(target.relativePath) === "."
+            ? ""
+            : path.posix.dirname(target.relativePath),
+          path.posix.basename(target.relativePath),
+        ],
         allowFailure: true,
       });
       return;
     }
     if (stats.isSymbolicLink()) {
-      await this.runRemoteShellScript({
-        script: 'rm -rf -- "$1"',
-        args: [remotePath],
+      await this.runPinnedRemotePathMutation({
+        args: [
+          "remove",
+          target.root,
+          path.posix.dirname(target.relativePath) === "."
+            ? ""
+            : path.posix.dirname(target.relativePath),
+          path.posix.basename(target.relativePath),
+        ],
         allowFailure: true,
       });
       return;
     }
     if (stats.isDirectory()) {
-      await this.runRemoteShellScript({
-        script: 'mkdir -p -- "$1"',
-        args: [remotePath],
-      });
+      await this.mkdirpRemotePath(remotePath);
       return;
     }
-    await this.runRemoteShellScript({
-      script: 'mkdir -p -- "$(dirname -- "$1")"',
-      args: [remotePath],
+    await this.runPinnedRemotePathMutation({
+      args: [
+        "mkdirp",
+        target.root,
+        path.posix.dirname(target.relativePath) === "."
+          ? ""
+          : path.posix.dirname(target.relativePath),
+      ],
     });
     const result = await runOpenShellCli({
       context: this.params.execContext,
@@ -381,6 +492,34 @@ class OpenShellSandboxBackendImpl {
     if (result.code !== 0) {
       throw new Error(result.stderr.trim() || "openshell sandbox upload failed");
     }
+  }
+
+  private async runPinnedRemotePathMutation(params: {
+    args: string[];
+    signal?: AbortSignal;
+    allowFailure?: boolean;
+  }): Promise<SandboxBackendCommandResult> {
+    return await this.runRemoteShellScript({
+      script: PINNED_REMOTE_PATH_MUTATION_SCRIPT,
+      args: params.args,
+      signal: params.signal,
+      allowFailure: params.allowFailure,
+    });
+  }
+
+  private resolveRemoteTarget(remotePath: string): { root: string; relativePath: string } {
+    const normalized = normalizeRemotePath(remotePath);
+    const roots = [
+      normalizeRemotePath(this.params.remoteWorkspaceDir),
+      normalizeRemotePath(this.params.remoteAgentWorkspaceDir),
+    ].toSorted((a, b) => b.length - a.length);
+    for (const root of roots) {
+      if (isRemotePathInside(root, normalized)) {
+        const relativePath = path.posix.relative(root, normalized);
+        return { root, relativePath: relativePath === "." ? "" : relativePath };
+      }
+    }
+    throw new Error(`Remote path escapes OpenShell managed roots: ${remotePath}`);
   }
 
   private async ensureSandboxExists(): Promise<void> {
@@ -675,4 +814,17 @@ async function restoreMaterializedSkillsShadow(params: {
 
 function resolveOpenShellTmpRoot(): string {
   return path.resolve(resolvePreferredOpenClawTmpDir());
+}
+
+function normalizeRemotePath(remotePath: string): string {
+  const normalized = path.posix.normalize(remotePath.replace(/\\/g, "/"));
+  if (!path.posix.isAbsolute(normalized)) {
+    throw new Error(`OpenShell remote path must be absolute: ${remotePath}`);
+  }
+  return normalized;
+}
+
+function isRemotePathInside(root: string, candidate: string): boolean {
+  const relative = path.posix.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.posix.isAbsolute(relative));
 }

--- a/extensions/openshell/src/backend.types.ts
+++ b/extensions/openshell/src/backend.types.ts
@@ -9,6 +9,14 @@ export type OpenShellSandboxBackend = SandboxBackendHandle &
   RemoteShellSandboxHandle & {
     mode: "mirror" | "remote";
     mkdirpRemotePath(remotePath: string, signal?: AbortSignal): Promise<void>;
+    removeRemotePath(
+      remotePath: string,
+      params?: {
+        recursive?: boolean;
+        signal?: AbortSignal;
+        allowFailure?: boolean;
+      },
+    ): Promise<void>;
     renameRemotePath(
       fromRemotePath: string,
       toRemotePath: string,

--- a/extensions/openshell/src/backend.types.ts
+++ b/extensions/openshell/src/backend.types.ts
@@ -14,7 +14,7 @@ export type OpenShellSandboxBackend = SandboxBackendHandle &
       params?: {
         recursive?: boolean;
         signal?: AbortSignal;
-        allowFailure?: boolean;
+        ignoreMissing?: boolean;
       },
     ): Promise<void>;
     renameRemotePath(

--- a/extensions/openshell/src/backend.types.ts
+++ b/extensions/openshell/src/backend.types.ts
@@ -8,5 +8,11 @@ export type OpenShellFsBridgeContext = Parameters<
 export type OpenShellSandboxBackend = SandboxBackendHandle &
   RemoteShellSandboxHandle & {
     mode: "mirror" | "remote";
+    mkdirpRemotePath(remotePath: string, signal?: AbortSignal): Promise<void>;
+    renameRemotePath(
+      fromRemotePath: string,
+      toRemotePath: string,
+      signal?: AbortSignal,
+    ): Promise<void>;
     syncLocalPathToRemote(localPath: string, remotePath: string): Promise<void>;
   };

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -139,7 +139,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     await this.backend.removeRemotePath(target.containerPath, {
       recursive: params.recursive ?? false,
       signal: params.signal,
-      allowFailure: params.force !== false,
+      ignoreMissing: params.force !== false,
     });
     await fsPromises.rm(hostPath, {
       recursive: params.recursive ?? false,

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -117,11 +117,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
       allowFinalSymlinkForUnlink: false,
     });
     await fsPromises.mkdir(hostPath, { recursive: true });
-    await this.backend.runRemoteShellScript({
-      script: 'mkdir -p -- "$1"',
-      args: [target.containerPath],
-      signal: params.signal,
-    });
+    await this.backend.mkdirpRemotePath(target.containerPath, params.signal);
   }
 
   async remove(params: {
@@ -177,11 +173,7 @@ class OpenShellFsBridge implements SandboxFsBridge {
     });
     await fsPromises.mkdir(path.dirname(toHostPath), { recursive: true });
     await movePathWithCopyFallback({ from: fromHostPath, to: toHostPath });
-    await this.backend.runRemoteShellScript({
-      script: 'mkdir -p -- "$(dirname -- "$2")" && mv -- "$1" "$2"',
-      args: [from.containerPath, to.containerPath],
-      signal: params.signal,
-    });
+    await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal);
   }
 
   async stat(params: {

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -116,8 +116,8 @@ class OpenShellFsBridge implements SandboxFsBridge {
       allowMissingLeaf: true,
       allowFinalSymlinkForUnlink: false,
     });
-    await fsPromises.mkdir(hostPath, { recursive: true });
     await this.backend.mkdirpRemotePath(target.containerPath, params.signal);
+    await fsPromises.mkdir(hostPath, { recursive: true });
   }
 
   async remove(params: {
@@ -136,14 +136,14 @@ class OpenShellFsBridge implements SandboxFsBridge {
       allowMissingLeaf: params.force !== false,
       allowFinalSymlinkForUnlink: true,
     });
-    await fsPromises.rm(hostPath, {
-      recursive: params.recursive ?? false,
-      force: params.force !== false,
-    });
     await this.backend.removeRemotePath(target.containerPath, {
       recursive: params.recursive ?? false,
       signal: params.signal,
       allowFailure: params.force !== false,
+    });
+    await fsPromises.rm(hostPath, {
+      recursive: params.recursive ?? false,
+      force: params.force !== false,
     });
   }
 
@@ -168,9 +168,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
       allowMissingLeaf: true,
       allowFinalSymlinkForUnlink: false,
     });
+    await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal);
     await fsPromises.mkdir(path.dirname(toHostPath), { recursive: true });
     await movePathWithCopyFallback({ from: fromHostPath, to: toHostPath });
-    await this.backend.renameRemotePath(from.containerPath, to.containerPath, params.signal);
   }
 
   async stat(params: {

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -140,11 +140,8 @@ class OpenShellFsBridge implements SandboxFsBridge {
       recursive: params.recursive ?? false,
       force: params.force !== false,
     });
-    await this.backend.runRemoteShellScript({
-      script: params.recursive
-        ? 'rm -rf -- "$1"'
-        : 'if [ -d "$1" ] && [ ! -L "$1" ]; then rmdir -- "$1"; elif [ -e "$1" ] || [ -L "$1" ]; then rm -f -- "$1"; fi',
-      args: [target.containerPath],
+    await this.backend.removeRemotePath(target.containerPath, {
+      recursive: params.recursive ?? false,
       signal: params.signal,
       allowFailure: params.force !== false,
     });

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -532,6 +532,7 @@ function createMirrorBackendMock(): OpenShellSandboxBackend {
     }),
     mkdirpRemotePath: vi.fn().mockResolvedValue(undefined),
     renameRemotePath: vi.fn().mockResolvedValue(undefined),
+    removeRemotePath: vi.fn().mockResolvedValue(undefined),
     syncLocalPathToRemote: vi.fn().mockResolvedValue(undefined),
   } as unknown as OpenShellSandboxBackend;
 }
@@ -575,6 +576,15 @@ describe("openshell fs bridges", () => {
         "payload",
       );
       await expectPathMissing(path.join(outsideDir, "escaped.txt"));
+
+      await fs.writeFile(path.join(remoteRoot, "victim.txt"), "delete me", "utf8");
+      expect(runPinnedMutation(["removefile", remoteRoot, "alias", "victim.txt"]).status).not.toBe(
+        0,
+      );
+      await expect(fs.readFile(path.join(remoteRoot, "victim.txt"), "utf8")).resolves.toBe(
+        "delete me",
+      );
+      await expectPathMissing(path.join(outsideDir, "victim.txt"));
     },
   );
 
@@ -651,6 +661,32 @@ describe("openshell fs bridges", () => {
       "/sandbox/nested/target.txt",
       undefined,
     );
+    expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
+  });
+
+  it("removes remote mirror paths through the pinned backend operation", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    await fs.writeFile(path.join(workspaceDir, "target.txt"), "payload", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    await bridge.remove({ filePath: "target.txt", force: true });
+
+    await expectPathMissing(path.join(workspaceDir, "target.txt"));
+    expect(backend["removeRemotePath"]).toHaveBeenCalledWith("/sandbox/target.txt", {
+      recursive: false,
+      signal: undefined,
+      allowFailure: true,
+    });
     expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
   });
 

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -1,4 +1,5 @@
 // Openshell tests cover openshell core plugin behavior.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -529,11 +530,54 @@ function createMirrorBackendMock(): OpenShellSandboxBackend {
       stderr: Buffer.alloc(0),
       code: 0,
     }),
+    mkdirpRemotePath: vi.fn().mockResolvedValue(undefined),
+    renameRemotePath: vi.fn().mockResolvedValue(undefined),
     syncLocalPathToRemote: vi.fn().mockResolvedValue(undefined),
   } as unknown as OpenShellSandboxBackend;
 }
 
 describe("openshell fs bridges", () => {
+  it.runIf(process.platform !== "win32")(
+    "rejects remote-only symlink parents in pinned mirror mutations",
+    async () => {
+      const stateDir = await makeTempDir("openclaw-openshell-remote-pin-");
+      const remoteRoot = path.join(stateDir, "sandbox");
+      const outsideDir = path.join(stateDir, "outside");
+      await fs.mkdir(remoteRoot, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(path.join(remoteRoot, "source.txt"), "payload", "utf8");
+      await fs.symlink(outsideDir, path.join(remoteRoot, "alias"));
+
+      const { PINNED_REMOTE_PATH_MUTATION_SCRIPT } = await import("./backend.js");
+      const runPinnedMutation = (args: string[]) =>
+        spawnSync("sh", ["-c", PINNED_REMOTE_PATH_MUTATION_SCRIPT, "openshell-test", ...args], {
+          encoding: "utf8",
+        });
+
+      expect(runPinnedMutation(["mkdirp", remoteRoot, "safe/nested"]).status).toBe(0);
+      await expect(fs.stat(path.join(remoteRoot, "safe", "nested"))).resolves.toBeDefined();
+
+      expect(runPinnedMutation(["mkdirp", remoteRoot, "alias/escaped"]).status).not.toBe(0);
+      await expectPathMissing(path.join(outsideDir, "escaped"));
+
+      expect(
+        runPinnedMutation([
+          "rename",
+          remoteRoot,
+          "",
+          "source.txt",
+          remoteRoot,
+          "alias",
+          "escaped.txt",
+        ]).status,
+      ).not.toBe(0);
+      await expect(fs.readFile(path.join(remoteRoot, "source.txt"), "utf8")).resolves.toBe(
+        "payload",
+      );
+      await expectPathMissing(path.join(outsideDir, "escaped.txt"));
+    },
+  );
+
   it("writes locally and syncs the file to the remote workspace", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
     const backend = createMirrorBackendMock();
@@ -559,6 +603,55 @@ describe("openshell fs bridges", () => {
       path.join(workspaceDir, "nested", "file.txt"),
       "/sandbox/nested/file.txt",
     );
+  });
+
+  it("creates remote mirror directories through the pinned backend operation", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    await bridge.mkdirp({ filePath: "nested/dir" });
+
+    await expect(fs.stat(path.join(workspaceDir, "nested", "dir"))).resolves.toBeDefined();
+    expect(backend["mkdirpRemotePath"]).toHaveBeenCalledWith("/sandbox/nested/dir", undefined);
+    expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
+  });
+
+  it("renames remote mirror paths through the pinned backend operation", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    await fs.writeFile(path.join(workspaceDir, "source.txt"), "payload", "utf8");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+    await bridge.rename({ from: "source.txt", to: "nested/target.txt" });
+
+    await expect(
+      fs.readFile(path.join(workspaceDir, "nested", "target.txt"), "utf8"),
+    ).resolves.toBe("payload");
+    expect(backend["renameRemotePath"]).toHaveBeenCalledWith(
+      "/sandbox/source.txt",
+      "/sandbox/nested/target.txt",
+      undefined,
+    );
+    expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
   });
 
   it("rejects symlink-parent writes instead of escaping the local mount root", async () => {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -584,6 +584,12 @@ describe("openshell fs bridges", () => {
       expect(runPinnedMutation(["removefile", remoteRoot, "alias", "victim.txt"]).status).not.toBe(
         0,
       );
+      expect(
+        runPinnedMutation(["removefile", remoteRoot, "missing-parent", "victim.txt", "1"]).status,
+      ).toBe(0);
+      expect(
+        runPinnedMutation(["removefile", remoteRoot, "alias", "victim.txt", "1"]).status,
+      ).not.toBe(0);
       await expect(fs.readFile(path.join(remoteRoot, "victim.txt"), "utf8")).resolves.toBe(
         "delete me",
       );
@@ -688,7 +694,7 @@ describe("openshell fs bridges", () => {
     expect(backend["removeRemotePath"]).toHaveBeenCalledWith("/sandbox/target.txt", {
       recursive: false,
       signal: undefined,
-      allowFailure: true,
+      ignoreMissing: true,
     });
     expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
   });

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -558,6 +558,9 @@ describe("openshell fs bridges", () => {
       expect(runPinnedMutation(["mkdirp", remoteRoot, "safe/nested"]).status).toBe(0);
       await expect(fs.stat(path.join(remoteRoot, "safe", "nested"))).resolves.toBeDefined();
 
+      expect(runPinnedMutation(["mkdirp", remoteRoot, "..cache/file"]).status).toBe(0);
+      await expect(fs.stat(path.join(remoteRoot, "..cache", "file"))).resolves.toBeDefined();
+
       expect(runPinnedMutation(["mkdirp", remoteRoot, "alias/escaped"]).status).not.toBe(0);
       await expectPathMissing(path.join(outsideDir, "escaped"));
 
@@ -688,6 +691,76 @@ describe("openshell fs bridges", () => {
       allowFailure: true,
     });
     expect(backend["runRemoteShellScript"]).not.toHaveBeenCalled();
+  });
+
+  it("keeps local mirror state unchanged when remote pinned mkdir is rejected", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const backend = createMirrorBackendMock();
+    backend["mkdirpRemotePath"] = vi.fn().mockRejectedValue(new Error("remote rejected"));
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(bridge.mkdirp({ filePath: "alias/escaped" })).rejects.toThrow("remote rejected");
+    await expectPathMissing(path.join(workspaceDir, "alias"));
+  });
+
+  it("keeps local mirror state unchanged when remote pinned remove is rejected", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const targetPath = path.join(workspaceDir, "target.txt");
+    await fs.writeFile(targetPath, "payload", "utf8");
+    const backend = createMirrorBackendMock();
+    backend["removeRemotePath"] = vi.fn().mockRejectedValue(new Error("remote rejected"));
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(bridge.remove({ filePath: "target.txt", force: true })).rejects.toThrow(
+      "remote rejected",
+    );
+    await expect(fs.readFile(targetPath, "utf8")).resolves.toBe("payload");
+  });
+
+  it("keeps local mirror state unchanged when remote pinned rename is rejected", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const sourcePath = path.join(workspaceDir, "source.txt");
+    const targetPath = path.join(workspaceDir, "nested", "target.txt");
+    await fs.writeFile(sourcePath, "payload", "utf8");
+    const backend = createMirrorBackendMock();
+    backend["renameRemotePath"] = vi.fn().mockRejectedValue(new Error("remote rejected"));
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(bridge.rename({ from: "source.txt", to: "nested/target.txt" })).rejects.toThrow(
+      "remote rejected",
+    );
+    await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("payload");
+    await expectPathMissing(targetPath);
   });
 
   it("rejects symlink-parent writes instead of escaping the local mount root", async () => {


### PR DESCRIPTION
## Summary

Pin OpenShell mirror-mode remote filesystem mutations to the configured remote workspace roots before creating, moving, deleting, or uploading paths.

## Changes

- Add an OpenShell-local pinned remote path mutation script that walks from the configured `/sandbox` or `/agent` root and rejects symlinked directory components.
- Route mirror-mode `mkdirp()`, `rename()`, and `remove()` through backend pinned remote operations instead of raw full remote path shell commands.
- Run pinned remote mutation before local mirror mutation for mkdir, rename, and remove so remote safety rejection leaves local mirror state unchanged.
- Preserve forced delete semantics for missing remote paths without swallowing pinned path-safety failures.
- Reuse the same pinned remote parent handling for mirror sync delete and upload-parent creation paths.
- Add focused OpenShell tests for remote-only symlink parents, direct bridge delete routing, local mirror consistency after remote rejection, missing forced deletes, and valid dot-prefixed in-root paths.

## Validation

- `node scripts/run-vitest.mjs extensions/openshell/src/openshell-core.test.ts` (31 tests passed)
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` (clean, no accepted/actionable findings)

## Notes

Behavior addressed: OpenShell mirror remote filesystem mutations now stay pinned to the managed remote roots, including direct bridge delete and forced-delete missing-target handling.
Real environment tested: local Linux checkout running the actual shell mutation helper against real filesystem directories and symlinks.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/openshell/src/openshell-core.test.ts`.
Evidence after fix: regression tests verify safe mkdir succeeds, valid `/sandbox/..cache/file` remains allowed, missing forced delete succeeds, and symlink-parent mkdir, rename, and forced/non-forced removefile do not create, move, or delete files outside the remote root.
Observed result after fix: focused OpenShell suite passed with 31 tests.
What was not tested: live NVIDIA OpenShell sandbox over SSH.

No `CHANGELOG.md` update.
