### PR TITLE
fix(feishu): enforce account tool family gates

### DIFF
--- a/extensions/feishu/src/docx.account-selection.test.ts
+++ b/extensions/feishu/src/docx.account-selection.test.ts
@@ -5,6 +5,14 @@ import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.fn((creds: { appId?: string } | undefined) => ({
   __appId: creds?.appId,
+  application: {
+    scope: {
+      list: vi.fn(async () => ({
+        code: 0,
+        data: { scopes: [] },
+      })),
+    },
+  },
 }));
 
 function feishuClientAppId(callIndex: number): string | undefined {
@@ -61,6 +69,28 @@ describe("feishu_doc account selection", () => {
     } as OpenClawPluginApi["config"];
   }
 
+  function createMixedToolConfig(): OpenClawPluginApi["config"] {
+    return {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            a: {
+              appId: "app-a",
+              appSecret: "sec-a", // pragma: allowlist secret
+              tools: { doc: false, scopes: false },
+            },
+            b: {
+              appId: "app-b",
+              appSecret: "sec-b", // pragma: allowlist secret
+              tools: { doc: true, scopes: true },
+            },
+          },
+        },
+      },
+    } as OpenClawPluginApi["config"];
+  }
+
   test("uses agentAccountId context when params omit accountId", async () => {
     const cfg = createDocEnabledConfig();
 
@@ -92,5 +122,45 @@ describe("feishu_doc account selection", () => {
     });
 
     expect(feishuClientAppId(-1)).toBe("app-a");
+  });
+
+  test("rejects a disabled contextual account when another account enables docs", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createMixedToolConfig());
+    registerFeishuDocTools(api);
+
+    const docTool = resolveTool("feishu_doc", { agentAccountId: "a" });
+    const result = await docTool.execute("call-disabled", {
+      action: "list_blocks",
+      doc_token: "d",
+    });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Doc tools are disabled for account "a"');
+  });
+
+  test("rejects an explicit disabled account override for docs", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createMixedToolConfig());
+    registerFeishuDocTools(api);
+
+    const docTool = resolveTool("feishu_doc", { agentAccountId: "b" });
+    const result = await docTool.execute("call-disabled", {
+      action: "list_blocks",
+      doc_token: "d",
+      accountId: "a",
+    });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Doc tools are disabled for account "a"');
+  });
+
+  test("rejects a disabled contextual account when another account enables app scopes", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createMixedToolConfig());
+    registerFeishuDocTools(api);
+
+    const scopesTool = resolveTool("feishu_app_scopes", { agentAccountId: "a" });
+    const result = await scopesTool.execute("call-disabled", {});
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu App Scopes tools are disabled for account "a"');
   });
 });

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1384,14 +1384,23 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   type FeishuDocExecuteParams = FeishuDocParams & { accountId?: string };
 
   const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
-    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+    createFeishuToolClient({
+      api,
+      executeParams: params,
+      defaultAccountId,
+      requiredTool: { family: "doc", label: "Doc" },
+    });
 
   const getMediaMaxBytes = (
     params: { accountId?: string } | undefined,
     defaultAccountId?: string,
   ) =>
-    (resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId }).config
-      ?.mediaMaxMb ?? 30) *
+    (resolveFeishuToolAccount({
+      api,
+      executeParams: params,
+      defaultAccountId,
+      requiredTool: { family: "doc", label: "Doc" },
+    }).config?.mediaMaxMb ?? 30) *
     1024 *
     1024;
 
@@ -1584,7 +1593,13 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
         parameters: Type.Object({}),
         async execute() {
           try {
-            const result = await listAppScopes(getClient(undefined, ctx.agentAccountId));
+            const result = await listAppScopes(
+              createFeishuToolClient({
+                api,
+                defaultAccountId: ctx.agentAccountId,
+                requiredTool: { family: "scopes", label: "App Scopes" },
+              }),
+            );
             return json(result);
           } catch (err) {
             return json({ error: formatErrorMessage(err) });

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -765,6 +765,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
               api,
               executeParams: p,
               defaultAccountId,
+              requiredTool: { family: "drive", label: "Drive" },
             });
             switch (p.action) {
               case "list":

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -145,6 +145,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
               api,
               executeParams: p,
               defaultAccountId,
+              requiredTool: { family: "perm", label: "Perm" },
             });
             switch (p.action) {
               case "list":

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -236,6 +236,22 @@ describe("feishu tool account routing", () => {
     expect(lastClientAppId()).toBe("app-b");
   });
 
+  test("perm tool rejects a disabled contextual account when another account enables it", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { perm: false },
+        toolsB: { perm: true },
+      }),
+    );
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm", { agentAccountId: "a" });
+    const result = await tool.execute("call", { action: "unknown_action" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Perm tools are disabled for account "a"');
+  });
+
   test("perm tool rejects an explicit disabled account override", async () => {
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -119,6 +119,21 @@ describe("feishu tool account routing", () => {
     expect(lastClientAppId()).toBe("app-b");
   });
 
+  test("wiki tool implicit fallback selects an account with wiki enabled", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { drive: true, wiki: false },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki");
+    await tool.execute("call", { action: "search" });
+
+    expect(lastClientAppId()).toBe("app-b");
+  });
+
   test("wiki tool prefers the active contextual account over configured defaultAccount", async () => {
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
@@ -190,6 +205,22 @@ describe("feishu tool account routing", () => {
     expect(lastClientAppId()).toBe("app-b");
   });
 
+  test("drive tool rejects a disabled contextual account when another account enables it", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { drive: false },
+        toolsB: { drive: true },
+      }),
+    );
+    registerFeishuDriveTools(api);
+
+    const tool = resolveTool("feishu_drive", { agentAccountId: "a" });
+    const result = await tool.execute("call", { action: "unknown_action" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Drive tools are disabled for account "a"');
+  });
+
   test("perm tool registers when only second account enables it and routes to agentAccountId", async () => {
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
@@ -203,6 +234,22 @@ describe("feishu tool account routing", () => {
     await tool.execute("call", { action: "unknown_action" });
 
     expect(lastClientAppId()).toBe("app-b");
+  });
+
+  test("perm tool rejects an explicit disabled account override", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { perm: false },
+        toolsB: { perm: true },
+      }),
+    );
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm", { agentAccountId: "b" });
+    const result = await tool.execute("call", { action: "unknown_action", accountId: "a" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Perm tools are disabled for account "a"');
   });
 
   test("bitable tool registers when only second account enables it and routes to agentAccountId", async () => {
@@ -384,6 +431,22 @@ describe("feishu tool account routing", () => {
     await tool.execute("call", { action: "search" });
 
     expect(lastClientAppId()).toBe("app-a");
+  });
+
+  test("wiki tool rejects an explicit disabled account override", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { wiki: false },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "b" });
+    const result = await tool.execute("call", { action: "search", accountId: "a" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toBe('Feishu Wiki tools are disabled for account "a"');
   });
 
   test("does not silently fall back when the contextual account is real but uses non-env SecretRefs", async () => {

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -12,11 +12,17 @@ import { resolveToolsConfig } from "./tools-config.js";
 import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
 
 type AccountAwareParams = { accountId?: string };
+type FeishuToolFamily = keyof FeishuToolsConfig;
+type FeishuToolRequirement = {
+  family: FeishuToolFamily;
+  label: string;
+};
 
 function resolveImplicitToolAccountId(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
+  requiredTool?: FeishuToolRequirement;
 }): string | undefined {
   const explicitAccountId = normalizeOptionalString(params.executeParams?.accountId);
   if (explicitAccountId) {
@@ -45,6 +51,19 @@ function resolveImplicitToolAccountId(params: {
     return configuredDefaultAccountId;
   }
 
+  if (params.requiredTool && params.api.config) {
+    for (const accountId of listFeishuAccountIds(params.api.config)) {
+      const account = resolveFeishuAccount({ cfg: params.api.config, accountId });
+      if (
+        account.enabled &&
+        account.configured &&
+        resolveToolsConfig(account.config.tools)[params.requiredTool.family]
+      ) {
+        return accountId;
+      }
+    }
+  }
+
   return undefined;
 }
 
@@ -52,20 +71,31 @@ export function resolveFeishuToolAccount(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
+  requiredTool?: FeishuToolRequirement;
 }): ResolvedFeishuAccount {
   if (!params.api.config) {
     throw new Error("Feishu config unavailable");
   }
-  return resolveFeishuRuntimeAccount({
+  const account = resolveFeishuRuntimeAccount({
     cfg: params.api.config,
     accountId: resolveImplicitToolAccountId(params),
   });
+  if (
+    params.requiredTool &&
+    !resolveToolsConfig(account.config.tools)[params.requiredTool.family]
+  ) {
+    throw new Error(
+      `Feishu ${params.requiredTool.label} tools are disabled for account "${account.accountId}"`,
+    );
+  }
+  return account;
 }
 
 export function createFeishuToolClient(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
+  requiredTool?: FeishuToolRequirement;
 }): Lark.Client {
   return createFeishuClient(resolveFeishuToolAccount(params));
 }

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -208,6 +208,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
                 api,
                 executeParams: p,
                 defaultAccountId,
+                requiredTool: { family: "wiki", label: "Wiki" },
               });
             switch (p.action) {
               case "spaces":


### PR DESCRIPTION
## Summary

Enforces the selected Feishu account's own tool-family settings before creating clients for account-routed Feishu tools.

## Changes

- Threads required Feishu tool-family metadata through account resolution and client creation.
- Rejects disabled selected accounts for doc, app scopes, drive, wiki, and permission tools before SDK client creation.
- Keeps implicit fallback account selection working by choosing an account that enables the requested family when no explicit/contextual/default account is set.
- Adds regression coverage for contextual account routing, explicit account overrides, and implicit fallback selection.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/tool-account-routing.test.ts extensions/feishu/src/docx.account-selection.test.ts extensions/feishu/src/tool-account.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/tool-account-routing.test.ts --reporter=verbose`
- `corepack pnpm test:extension feishu`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

AI-assisted patch. `USER.md` was updated locally with the requested worklog and intentionally left uncommitted. `CHANGELOG.md` was not changed.

Real behavior proof:
Behavior addressed: Feishu account-routed tools now enforce the resolved account's own tool-family gate before Feishu client creation. A selected account with that family disabled fails closed even when a sibling account keeps the same tool family registered.

Real environment tested: local OpenClaw checkout at current PR head `09a46df5d5b30f2220020c3192ff2f5e0a4ee8e0`, with Feishu plugin tools registered through the real plugin `registerTool` path and invoked through the actual `tool.execute(...)` functions using redacted local config and dummy Feishu credentials. No live tenant was used; the disabled-account cases prove the intended pre-client failure path, so they do not need Feishu network access.

Exact steps or command run after this patch: see the redacted runtime proof script in https://github.com/openclaw/openclaw/pull/93363#issuecomment-4712049749. The script registers the real Feishu doc, drive, permission, and wiki tools, resolves tools with disabled contextual or explicit account `a`, and executes each real `tool.execute(...)` path.

Evidence after fix:

```json
{
  "registeredTools": 5,
  "results": [
    { "label": "doc contextual disabled", "tool": "feishu_doc", "error": "Feishu Doc tools are disabled for account \"a\"" },
    { "label": "doc explicit disabled", "tool": "feishu_doc", "error": "Feishu Doc tools are disabled for account \"a\"" },
    { "label": "scopes contextual disabled", "tool": "feishu_app_scopes", "error": "Feishu App Scopes tools are disabled for account \"a\"" },
    { "label": "drive contextual disabled", "tool": "feishu_drive", "error": "Feishu Drive tools are disabled for account \"a\"" },
    { "label": "perm contextual disabled", "tool": "feishu_perm", "error": "Feishu Perm tools are disabled for account \"a\"" },
    { "label": "perm explicit disabled", "tool": "feishu_perm", "error": "Feishu Perm tools are disabled for account \"a\"" },
    { "label": "wiki explicit disabled", "tool": "feishu_wiki", "error": "Feishu Wiki tools are disabled for account \"a\"" },
    { "label": "wiki implicit fallback enabled", "tool": "feishu_wiki", "error": "Unknown action: unknown_action" }
  ]
}
```

Observed result after fix: selected disabled accounts fail with the matching disabled-tool error for doc, app scopes, drive, permission, and wiki. The no-context wiki case does not select disabled account `a`; it reaches the enabled-account execution path and returns the ordinary unknown-action error instead.

Supporting validation:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/tool-account-routing.test.ts extensions/feishu/src/docx.account-selection.test.ts --reporter=verbose
```

Result: 2 files passed, 29 tests passed. The named passing tests include disabled contextual and explicit account coverage for doc, disabled contextual coverage for app scopes, drive, permission, and explicit wiki coverage, plus enabled-family implicit fallback selection. The follow-up permission regression command also passed with 1 file and 24 tests.

Maintainer compatibility acceptance: I accept the fail-closed behavior for existing multi-account Feishu setups where an explicitly, contextually, or default-selected account has the requested tool family disabled. Those calls should stop with a disabled-tool error before client creation instead of continuing with disabled account credentials.

What was not tested: live Feishu SaaS API calls were not run. That is intentional for the fail-closed cases because successful proof is that execution stops before a client/API call can be made.
