### PR TITLE
Fix Telegram rich progress command output

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2523,7 +2523,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(answerDraftStream.updatePreview).not.toHaveBeenCalledWith(
-      expect.stringContaining("stdout line one"),
+      expect.objectContaining({ text: expect.stringContaining("stdout line one") }),
     );
     expect(answerDraftStream.updatePreview).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -2758,6 +2758,92 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
+  it("renders command status without command output in Telegram progress draft previews", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({
+        name: "exec",
+        phase: "start",
+        toolCallId: "exec-1",
+        args: { command: "false" },
+      });
+      await replyOptions?.onCommandOutput?.({
+        phase: "end",
+        title: "command false",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "No such file or directory",
+        exitCode: 2,
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "Shelling", commandText: "raw" },
+        },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
+      text: "Shelling\n\n`🛠️ exit 2; command false`",
+      richMessage: {
+        html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
+        skip_entity_detection: true,
+      },
+    });
+  });
+
+  it("hides command titles in Telegram status-only progress draft previews", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({
+        name: "exec",
+        phase: "start",
+        toolCallId: "exec-1",
+        args: { command: "curl -H 'Authorization: token' https://example.test" },
+      });
+      await replyOptions?.onCommandOutput?.({
+        phase: "end",
+        title: "curl -H 'Authorization: token' https://example.test",
+        name: "exec",
+        toolCallId: "exec-1",
+        output: "secret response",
+        exitCode: 2,
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "Shelling", commandText: "status" },
+        },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
+      text: "Shelling\n\n`🛠️ exit 2`",
+      richMessage: {
+        html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>exit 2</code>",
+        skip_entity_detection: true,
+      },
+    });
+  });
+
   it("composes streamed reasoning with tool progress in Telegram progress drafts", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -2842,9 +2928,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(draftStream.updatePreview).not.toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining("Checking recent") }),
-    );
+    expect(
+      draftStream.updatePreview.mock.calls.every(
+        ([preview]) => !preview.text.includes("Checking recent"),
+      ),
+    ).toBe(true);
   });
 
   it("keeps the progress draft label when tool progress lines are hidden", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2434,7 +2434,7 @@ export const dispatchTelegramMessage = async ({
                       return;
                     }
                     await pushStreamToolProgress(
-                      buildChannelProgressDraftLine({
+                      buildChannelProgressDraftLineForEntry(telegramCfg, {
                         event: "command-output",
                         itemId: payload.itemId,
                         toolCallId: payload.toolCallId,

--- a/src/channels/streaming.test.ts
+++ b/src/channels/streaming.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { buildChannelProgressDraftLine } from "./streaming.js";
+
+describe("buildChannelProgressDraftLine", () => {
+  it("keeps command status and title in raw command progress lines", () => {
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        toolCallId: "exec-1",
+        phase: "end",
+        title: "command false",
+        name: "exec",
+        exitCode: 2,
+      },
+      { commandText: "raw" },
+    );
+
+    expect(line).toMatchObject({
+      kind: "command-output",
+      id: "exec-1",
+      text: "🛠️ exit 2; command false",
+      detail: "command false",
+      status: "exit 2",
+    });
+  });
+
+  it("keeps only command status in status-only progress lines", () => {
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "command-output",
+        phase: "end",
+        title: "command false",
+        name: "exec",
+        exitCode: 2,
+      },
+      { commandText: "status" },
+    );
+
+    expect(line).toMatchObject({
+      kind: "command-output",
+      text: "🛠️ exit 2",
+      detail: "exit 2",
+      status: "exit 2",
+    });
+    expect(line?.text).not.toContain("command false");
+  });
+});

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -329,9 +329,13 @@ function buildNamedProgressLine(
   });
   const display = resolveToolDisplay({ name: normalizedName });
   const prefix = `${display.emoji} ${display.label}`;
-  const compactCommandPrefix =
+  const compactCommandDetail =
     (display.name === "exec" || display.name === "bash") && text.startsWith(`${display.emoji} `)
       ? text.slice(display.emoji.length + 1).trim()
+      : undefined;
+  const compactCommandPrefix =
+    compactCommandDetail && compactCommandDetail !== display.label
+      ? compactCommandDetail
       : undefined;
   const detail = text.startsWith(`${prefix}: `)
     ? text.slice(prefix.length + 2).trim()
@@ -421,6 +425,39 @@ function isEmptyReasoningProgressItem(
 function patchMetas(input: Extract<ChannelProgressDraftLineInput, { event: "patch" }>): string[] {
   const fileMetas = [...(input.added ?? []), ...(input.modified ?? []), ...(input.deleted ?? [])];
   return compactStrings([input.summary, ...fileMetas, input.title]);
+}
+
+function buildCommandOutputProgressLine(
+  input: Extract<ChannelProgressDraftLineInput, { event: "command-output" }>,
+  status: string | undefined,
+  options?: ChannelProgressLineOptions,
+): ChannelProgressDraftLine | undefined {
+  const name = input.name ?? "exec";
+  const correlationKey = resolveCommandProgressCorrelationKey(input);
+  const detail = options?.commandText === "status" ? [] : compactStrings([input.title]);
+  const line = buildNamedProgressLine(input.event, name, detail, options, {
+    correlationKey,
+    id: resolveProgressDraftLineId(input, { useToolCallIdFallback: true }),
+    status,
+  });
+  if (!line || !status) {
+    return line;
+  }
+  if (!line.detail || line.detail === status) {
+    const statusLine = {
+      ...line,
+      detail: status,
+      text: formatToolAggregate(name, [status], { markdown: options?.markdown }),
+    };
+    setProgressDraftLineCorrelationKey(statusLine, correlationKey);
+    return statusLine;
+  }
+  const statusLine = {
+    ...line,
+    text: formatToolAggregate(name, [status, line.detail], { markdown: options?.markdown }),
+  };
+  setProgressDraftLineCorrelationKey(statusLine, correlationKey);
+  return statusLine;
 }
 
 function shouldPrefixProgressLine(line: string): boolean {
@@ -571,17 +608,7 @@ export function buildChannelProgressDraftLine(
           : input.exitCode != null
             ? `exit ${input.exitCode}`
             : input.status;
-      return buildNamedProgressLine(
-        input.event,
-        input.name ?? "exec",
-        [status, input.title],
-        options,
-        {
-          correlationKey: resolveCommandProgressCorrelationKey(input),
-          id: resolveProgressDraftLineId(input, { useToolCallIdFallback: true }),
-          status,
-        },
-      );
+      return buildCommandOutputProgressLine(input, status, options);
     }
     case "patch": {
       if (input.phase !== undefined && input.phase !== "end") {
@@ -1027,15 +1054,22 @@ function getProgressDraftLineText(line: string | ChannelProgressDraftLine): stri
   const prefix = icon ? `${icon} ` : "";
   const label = line.label.trim();
   const detail = line.detail?.trim();
+  const status = line.status?.trim();
   if (detail) {
     const compactCommandLine =
       line.toolName === "exec" || line.toolName === "bash" || line.toolName === "shell";
+    if (line.kind === "command-output" && status && detail !== status) {
+      const outputDetail = detail.startsWith(`${status};`) ? detail : `${status}; ${detail}`;
+      if (compactCommandLine) {
+        return `${prefix}${outputDetail}`;
+      }
+      return label ? `${prefix}${label}: ${outputDetail}` : `${prefix}${outputDetail}`;
+    }
     if (line.kind !== "patch" && label && !compactCommandLine) {
       return `${prefix}${label}: ${detail}`;
     }
     return `${prefix}${detail}`;
   }
-  const status = line.status?.trim();
   if (status) {
     if (label) {
       return `${prefix}${label}: ${status}`;
@@ -1054,7 +1088,8 @@ export function normalizeChannelProgressDraftLineIdentity(
   line: string | ChannelProgressDraftLine | undefined,
 ): string {
   const text = typeof line === "string" ? line : line?.text;
-  return text?.replace(/\s+/g, " ").trim() ?? "";
+  const status = typeof line === "object" ? line.status : undefined;
+  return compactStrings([text, status]).join(" ");
 }
 
 export function mergeChannelProgressDraftLine<TLine extends string | ChannelProgressDraftLine>(


### PR DESCRIPTION
Summary
- Route Telegram command-output progress through the channel-aware progress renderer.
- Preserve command-output status/detail while merging command start/output updates into one progress line.
- Keep stdout/stderr out of progress drafts; `commandText: "status"` also hides command titles.

Verification
- node scripts/run-vitest.mjs src/channels/progress-draft-compositor.test.ts src/channels/streaming.test.ts
- node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts
- git diff --check

Review
- Distill pass done before commit shaping.
- Codex autoreview found privacy/status regressions during review; both were fixed with regression tests. Final rerun was blocked by Codex usage limit before producing a result.
