### PR TITLE
fix: show reachable gateway auth diagnostic for remaining gateway CLI calls

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvOverride } from "../config/test-helpers.js";
+import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
 import { GatewayLockError } from "../infra/gateway-lock.js";
 import { registerGatewayCli } from "./gateway-cli.js";
 
@@ -34,6 +35,9 @@ const discoverGatewayBeacons = vi.fn<(opts: unknown) => Promise<DiscoveredBeacon
 const gatewayStatusCommand = vi.fn<(opts: unknown) => Promise<void>>(async () => {});
 const inspectPortUsage = vi.fn(async (_port: number) => ({ status: "free" as const }));
 const formatPortDiagnostics = vi.fn((_diagnostics: unknown) => [] as string[]);
+const emitReachableGatewayAuthDiagnostic =
+  vi.fn<(params: Record<string, unknown>) => Promise<boolean>>(async () => false);
+const readBestEffortConfig = vi.fn<() => Promise<Record<string, unknown>>>(async () => ({}));
 
 const mocks = await vi.hoisted(async () => {
   const { createCliRuntimeMock } = await import("./test-runtime-mock.js");
@@ -118,6 +122,19 @@ vi.mock("../infra/ports.js", () => ({
   formatPortDiagnostics: (diagnostics: unknown) => formatPortDiagnostics(diagnostics),
 }));
 
+vi.mock("../commands/health.js", async () => ({
+  ...(await vi.importActual<typeof import("../commands/health.js")>("../commands/health.js")),
+  emitReachableGatewayAuthDiagnostic: (params: Record<string, unknown>) =>
+    emitReachableGatewayAuthDiagnostic(params),
+}));
+
+vi.mock("../config/read-best-effort-config.runtime.js", async () => ({
+  ...(await vi.importActual<typeof import("../config/read-best-effort-config.runtime.js")>(
+    "../config/read-best-effort-config.runtime.js",
+  )),
+  readBestEffortConfig: () => readBestEffortConfig(),
+}));
+
 let gatewayProgram: Command;
 
 function createGatewayProgram() {
@@ -158,6 +175,10 @@ describe("gateway-cli coverage", () => {
     formatPortDiagnostics.mockClear();
     formatGatewayTransportErrorJson.mockReset();
     formatGatewayTransportErrorJson.mockReturnValue(null);
+    emitReachableGatewayAuthDiagnostic.mockReset();
+    emitReachableGatewayAuthDiagnostic.mockResolvedValue(false);
+    readBestEffortConfig.mockReset();
+    readBestEffortConfig.mockResolvedValue({});
   });
 
   it("registers call/health commands and routes to callGateway", async () => {
@@ -547,5 +568,85 @@ describe("gateway-cli coverage", () => {
       expect(startCall?.[0]).toBe(19001);
       expect(typeof startCall?.[1]).toBe("object");
     });
+  });
+
+  it("emits the reachable-gateway auth diagnostic for usage-cost when SecretRefs are unavailable", async () => {
+    callGateway.mockClear();
+    callGateway.mockRejectedValueOnce(
+      new GatewaySecretRefUnavailableError("gateway.auth.password"),
+    );
+    emitReachableGatewayAuthDiagnostic.mockResolvedValueOnce(true);
+
+    await runGatewayCommand([
+      "gateway",
+      "usage-cost",
+      "--days",
+      "7",
+      "--token",
+      "diag-token",
+      "--password",
+      "diag-pass",
+    ]);
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
+    const diagArg = firstMockArg(emitReachableGatewayAuthDiagnostic) as {
+      token?: string;
+      password?: string;
+      timeoutMs?: number;
+      error?: unknown;
+    };
+    expect(diagArg.token).toBe("diag-token");
+    expect(diagArg.password).toBe("diag-pass");
+    expect(diagArg.error).toBeInstanceOf(GatewaySecretRefUnavailableError);
+    // Diagnostic handled the failure: no raw error leaked to stderr.
+    expect(runtimeErrors.join("\n")).not.toContain("Gateway usage cost failed");
+    expect(runtimeErrors.join("\n")).not.toContain("SecretRefUnavailable");
+  });
+
+  it("rethrows raw usage-cost errors when the gateway is not reachable", async () => {
+    callGateway.mockClear();
+    callGateway.mockRejectedValueOnce(
+      new GatewaySecretRefUnavailableError("gateway.auth.password"),
+    );
+    emitReachableGatewayAuthDiagnostic.mockResolvedValueOnce(false);
+
+    await expectGatewayExit(["gateway", "usage-cost"]);
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
+    expect(runtimeErrors.join("\n")).toContain("Gateway usage cost failed");
+  });
+
+  it("emits the reachable-gateway auth diagnostic for gateway call when SecretRefs are unavailable", async () => {
+    callGateway.mockClear();
+    callGateway.mockRejectedValueOnce(
+      new GatewaySecretRefUnavailableError("gateway.auth.token"),
+    );
+    emitReachableGatewayAuthDiagnostic.mockResolvedValueOnce(true);
+
+    await runGatewayCommand([
+      "gateway",
+      "call",
+      "system-presence",
+      "--token",
+      "diag-token",
+    ]);
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
+    const diagArg = firstMockArg(emitReachableGatewayAuthDiagnostic) as { token?: string };
+    expect(diagArg.token).toBe("diag-token");
+    expect(runtimeErrors.join("\n")).not.toContain("Gateway call failed");
+  });
+
+  it("rethrows raw gateway call errors when the gateway is not reachable", async () => {
+    callGateway.mockClear();
+    callGateway.mockRejectedValueOnce(
+      new GatewaySecretRefUnavailableError("gateway.auth.token"),
+    );
+    emitReachableGatewayAuthDiagnostic.mockResolvedValueOnce(false);
+
+    await expectGatewayExit(["gateway", "call", "system-presence"]);
+
+    expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
+    expect(runtimeErrors.join("\n")).toContain("Gateway call failed");
   });
 });

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -594,10 +594,16 @@ describe("gateway-cli coverage", () => {
       password?: string;
       timeoutMs?: number;
       error?: unknown;
+      credentialsRequiredMessage?: string;
     };
     expect(diagArg.token).toBe("diag-token");
     expect(diagArg.password).toBe("diag-pass");
     expect(diagArg.error).toBeInstanceOf(GatewaySecretRefUnavailableError);
+    // Non-health callers must request the command-neutral diagnostic wording: it states the
+    // reachable-but-unauthenticated fact without claiming the method is a read-scope health RPC.
+    expect(diagArg.credentialsRequiredMessage).toBeDefined();
+    expect(diagArg.credentialsRequiredMessage).not.toMatch(/health/i);
+    expect(diagArg.credentialsRequiredMessage).toMatch(/OPENCLAW_GATEWAY_TOKEN/);
     // Diagnostic handled the failure: no raw error leaked to stderr.
     expect(runtimeErrors.join("\n")).not.toContain("Gateway usage cost failed");
     expect(runtimeErrors.join("\n")).not.toContain("SecretRefUnavailable");
@@ -632,8 +638,16 @@ describe("gateway-cli coverage", () => {
     ]);
 
     expect(emitReachableGatewayAuthDiagnostic).toHaveBeenCalledTimes(1);
-    const diagArg = firstMockArg(emitReachableGatewayAuthDiagnostic) as { token?: string };
+    const diagArg = firstMockArg(emitReachableGatewayAuthDiagnostic) as {
+      token?: string;
+      credentialsRequiredMessage?: string;
+    };
     expect(diagArg.token).toBe("diag-token");
+    // Generic `gateway call <method>` is not a read-scope health RPC, so the helper must pass
+    // the command-neutral diagnostic message rather than the health-specific wording.
+    expect(diagArg.credentialsRequiredMessage).toBeDefined();
+    expect(diagArg.credentialsRequiredMessage).not.toMatch(/health/i);
+    expect(diagArg.credentialsRequiredMessage).toMatch(/OPENCLAW_GATEWAY_TOKEN/);
     expect(runtimeErrors.join("\n")).not.toContain("Gateway call failed");
   });
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -161,13 +161,13 @@ function parseGatewayRpcTimeoutOption(raw: unknown, fallback = 10_000): number {
  * when the diagnostic was emitted (and the process is exiting); callers should
  * stop processing. Otherwise the raw error is rethrown for the default handler.
  */
-async function callGatewayCliWithAuthDiagnostic<T = unknown>(
+async function callGatewayCliWithAuthDiagnostic(
   method: string,
   rpcOpts: GatewayRpcOpts,
   params?: unknown,
-): Promise<{ handled: true } | { handled: false; result: T }> {
+): Promise<{ handled: true } | { handled: false; result: unknown }> {
   try {
-    const result = (await callGatewayCli(method, rpcOpts, params)) as T;
+    const result = await callGatewayCli(method, rpcOpts, params);
     return { handled: false, result };
   } catch (error) {
     const [

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -170,10 +170,10 @@ async function callGatewayCliWithAuthDiagnostic<T = unknown>(
     const result = (await callGatewayCli(method, rpcOpts, params)) as T;
     return { handled: false, result };
   } catch (error) {
-    const [{ emitReachableGatewayAuthDiagnostic }, { readBestEffortConfig }] = await Promise.all([
-      loadGatewayHealthModule(),
-      loadConfigModule(),
-    ]);
+    const [
+      { emitReachableGatewayAuthDiagnostic, GATEWAY_REACHABLE_CREDENTIALS_REQUIRED_MESSAGE },
+      { readBestEffortConfig },
+    ] = await Promise.all([loadGatewayHealthModule(), loadConfigModule()]);
     const handled = await emitReachableGatewayAuthDiagnostic({
       error,
       config: await readBestEffortConfig(),
@@ -182,6 +182,10 @@ async function callGatewayCliWithAuthDiagnostic<T = unknown>(
       token: rpcOpts.token,
       password: rpcOpts.password,
       json: Boolean(rpcOpts.json),
+      // usage-cost / generic call are not read-scope health RPCs; the pre-dispatch credential
+      // failure is method-agnostic, so emit the command-neutral wording instead of the
+      // health-specific message.
+      credentialsRequiredMessage: GATEWAY_REACHABLE_CREDENTIALS_REQUIRED_MESSAGE,
     });
     if (handled) {
       return { handled: true };

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -153,6 +153,43 @@ function parseGatewayRpcTimeoutOption(raw: unknown, fallback = 10_000): number {
   return fallback;
 }
 
+/**
+ * Calls a Gateway RPC method, but when credential resolution fails before the
+ * method is dispatched (gateway auth SecretRefs are unresolved in this command
+ * path), emit the same reachable-but-unauthenticated diagnostic the `health`
+ * subcommand uses instead of leaking a raw error. Returns `{ handled: true }`
+ * when the diagnostic was emitted (and the process is exiting); callers should
+ * stop processing. Otherwise the raw error is rethrown for the default handler.
+ */
+async function callGatewayCliWithAuthDiagnostic<T = unknown>(
+  method: string,
+  rpcOpts: GatewayRpcOpts,
+  params?: unknown,
+): Promise<{ handled: true } | { handled: false; result: T }> {
+  try {
+    const result = (await callGatewayCli(method, rpcOpts, params)) as T;
+    return { handled: false, result };
+  } catch (error) {
+    const [{ emitReachableGatewayAuthDiagnostic }, { readBestEffortConfig }] = await Promise.all([
+      loadGatewayHealthModule(),
+      loadConfigModule(),
+    ]);
+    const handled = await emitReachableGatewayAuthDiagnostic({
+      error,
+      config: await readBestEffortConfig(),
+      runtime: defaultRuntime,
+      timeoutMs: parseGatewayRpcTimeoutOption(rpcOpts.timeout),
+      token: rpcOpts.token,
+      password: rpcOpts.password,
+      json: Boolean(rpcOpts.json),
+    });
+    if (handled) {
+      return { handled: true };
+    }
+    throw error;
+  }
+}
+
 function resolveGatewayRpcOptions<T extends { token?: string; password?: string }>(
   opts: T,
   command?: Command,
@@ -499,20 +536,27 @@ export function registerGatewayCli(program: Command) {
       .argument("<method>", "Method name (health/status/system-presence/cron.*)")
       .option("--params <json>", "JSON object string for params", "{}")
       .action(async (method, opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const params = JSON.parse(String(opts.params ?? "{}"));
-          const result = await callGatewayCli(method, rpcOpts, params);
-          if (rpcOpts.json) {
+        await runGatewayCommand(
+          async () => {
+            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const params = JSON.parse(String(opts.params ?? "{}"));
+            const outcome = await callGatewayCliWithAuthDiagnostic(method, rpcOpts, params);
+            if (outcome.handled) {
+              return;
+            }
+            const result = outcome.result;
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
+            }
+            const rich = isRich();
+            defaultRuntime.log(
+              `${colorize(rich, theme.heading, "Gateway call")}: ${colorize(rich, theme.muted, String(method))}`,
+            );
             defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          defaultRuntime.log(
-            `${colorize(rich, theme.heading, "Gateway call")}: ${colorize(rich, theme.muted, String(method))}`,
-          );
-          defaultRuntime.writeJson(result);
-        }, "Gateway call failed");
+          },
+          "Gateway call failed",
+        );
       }),
   );
 
@@ -522,20 +566,26 @@ export function registerGatewayCli(program: Command) {
       .description("Fetch usage cost summary from session logs")
       .option("--days <days>", "Number of days to include", "30")
       .action(async (opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const days = parseDaysOption(opts.days);
-          const result = await callGatewayCli("usage.cost", rpcOpts, { days });
-          if (rpcOpts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          const summary = result as CostUsageSummary;
-          for (const line of await renderCostUsageSummaryAsync(summary, days, rich)) {
-            defaultRuntime.log(line);
-          }
-        }, "Gateway usage cost failed");
+        await runGatewayCommand(
+          async () => {
+            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const days = parseDaysOption(opts.days);
+            const outcome = await callGatewayCliWithAuthDiagnostic("usage.cost", rpcOpts, { days });
+            if (outcome.handled) {
+              return;
+            }
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(outcome.result);
+              return;
+            }
+            const rich = isRich();
+            const summary = outcome.result as CostUsageSummary;
+            for (const line of await renderCostUsageSummaryAsync(summary, days, rich)) {
+              defaultRuntime.log(line);
+            }
+          },
+          "Gateway usage cost failed",
+        );
       }),
   );
 

--- a/src/commands/gateway-health-auth-diagnostic.ts
+++ b/src/commands/gateway-health-auth-diagnostic.ts
@@ -8,6 +8,13 @@ export const GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE =
 export const GATEWAY_HEALTH_CREDENTIALS_REQUIRED_TITLE = "Gateway credentials required";
 export const GATEWAY_HEALTH_REACHABLE_LINE = "Gateway: reachable";
 
+// Command-neutral variant for non-health Gateway CLI calls (e.g. `gateway usage-cost`,
+// `gateway call <method>`). The pre-dispatch credential failure is identical regardless of
+// the RPC method, so this states the reachable-but-unauthenticated fact without claiming the
+// invoked method is a read-scope health RPC.
+export const GATEWAY_REACHABLE_CREDENTIALS_REQUIRED_MESSAGE =
+  "Gateway is reachable, but this CLI has no token/password or paired device token to authenticate gateway RPCs. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD.";
+
 /**
  * Detects when a daemon probe reached the gateway even if read-scope auth failed.
  */
@@ -34,14 +41,20 @@ export function gatewayProbeResultSawGateway(status: GatewayProbeReachabilityEvi
 }
 
 /**
- * Builds the health diagnostic emitted when the gateway is reachable but credentials are absent.
+ * Builds the diagnostic emitted when the gateway is reachable but credentials are absent.
+ *
+ * Defaults to the health-specific wording so `gateway health` / doctor behaviour is unchanged.
+ * Non-health callers (usage-cost, generic call) pass a command-neutral message so the output
+ * never claims the invoked method is a read-scope health RPC.
  */
-export function buildCredentialsRequiredHealthDiagnostic() {
+export function buildCredentialsRequiredHealthDiagnostic(
+  message: string = GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+) {
   return {
     ok: false,
     error: {
       type: "gateway_credentials_required",
-      message: GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
+      message,
     },
     gateway: {
       reachable: true,

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -46,8 +46,13 @@ import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
   buildCredentialsRequiredHealthDiagnostic,
   GATEWAY_HEALTH_REACHABLE_LINE,
+  GATEWAY_REACHABLE_CREDENTIALS_REQUIRED_MESSAGE,
   gatewayProbeResultSawGateway,
 } from "./gateway-health-auth-diagnostic.js";
+
+// Re-exported so the gateway CLI helper can request the command-neutral diagnostic wording
+// for non-health calls (usage-cost / generic call) via the already-loaded health module.
+export { GATEWAY_REACHABLE_CREDENTIALS_REQUIRED_MESSAGE };
 import { formatHealthChannelLines } from "./health-format.js";
 import type {
   AgentHealthSummary,
@@ -87,6 +92,12 @@ export async function emitReachableGatewayAuthDiagnostic(params: {
   token?: string;
   password?: string;
   json?: boolean;
+  /**
+   * Optional command-neutral diagnostic message. When omitted, the health-specific wording is
+   * used (preserving `gateway health` / doctor behaviour). Non-health callers pass a neutral
+   * message so the output does not claim the invoked method is a read-scope health RPC.
+   */
+  credentialsRequiredMessage?: string;
 }): Promise<boolean> {
   if (!isGatewayHealthAuthUnavailableError(params.error)) {
     return false;
@@ -109,7 +120,7 @@ export async function emitReachableGatewayAuthDiagnostic(params: {
   if (!gatewayProbeResultSawGateway(probe)) {
     return false;
   }
-  const diagnostic = buildCredentialsRequiredHealthDiagnostic();
+  const diagnostic = buildCredentialsRequiredHealthDiagnostic(params.credentialsRequiredMessage);
   if (params.json) {
     writeRuntimeJson(params.runtime, diagnostic);
     params.runtime.exit(1);


### PR DESCRIPTION
## Summary

`#92290` taught the gateway CLI to recognise when a gateway call fails *before* the
RPC is dispatched because `gateway.auth.token`/`gateway.auth.password` are configured
as SecretRefs that cannot be resolved in this command path. Instead of leaking a raw
`GatewaySecretRefUnavailableError`, the `health` subcommand probes the gateway and,
when it is reachable but the CLI simply has no usable credentials, prints an actionable
diagnostic (`Gateway: reachable` + "set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD").

That fix only wired `gateway health` (plus `browser doctor` and `channels status`). The
two remaining `callGatewayCli(...)` entrypoints in the **same file** —
`gateway usage-cost` and `gateway call <method>` — resolve credentials through the exact
same path (`callGatewayWithScopes`, independent of the RPC method name), so they fail with
the identical error, yet still surface only the raw `String(err)` from `runGatewayCommand`.

This PR closes that symmetric gap: `usage-cost` and `call` now reuse the same reachable
gateway auth diagnostic as `health`, with **command-neutral wording** so the output never
claims a non-health method is a "read-scope health RPC".

## What changed

- `src/cli/gateway-cli/register.ts`
  - Extracted the `health` subcommand's catch-template into a shared helper
    `callGatewayCliWithAuthDiagnostic(method, rpcOpts, params)`. On credential-resolution
    failure it runs the existing `emitReachableGatewayAuthDiagnostic(...)`; if the gateway
    is reachable-but-unauthenticated it emits the diagnostic and returns `{ handled: true }`,
    otherwise it rethrows the raw error for the default handler.
  - `gateway usage-cost` and `gateway call <method>` now route through this helper, requesting
    the **command-neutral** diagnostic message.
- `src/commands/gateway-health-auth-diagnostic.ts`
  - Added `GATEWAY_REACHABLE_CREDENTIALS_REQUIRED_MESSAGE`, a command-neutral variant that
    states the reachable-but-unauthenticated fact without mentioning health/read-scope.
  - `buildCredentialsRequiredHealthDiagnostic(message?)` now takes an optional message and
    **defaults to the existing health-specific wording**, so `gateway health`/doctor behaviour
    is byte-for-byte unchanged.
- `src/commands/health.ts`
  - `emitReachableGatewayAuthDiagnostic(...)` accepts an optional `credentialsRequiredMessage`
    and forwards it to the builder. `gateway health` does not pass it (keeps health wording);
    `usage-cost`/`call` pass the neutral message.

No behaviour change for the reachable/success paths or for non-auth errors.

### Addressing the review's command-neutral / auth-boundary concern

The reused diagnostic is no longer health-specific for the new surfaces: `usage-cost` and
generic `call` now emit a **command-neutral** message and never say "read-scope health RPCs".
The pre-dispatch credential failure is method-agnostic (it happens in
`callGatewayWithScopes` before any RPC is sent), so this states the credential fact accurately
for any method.

This does change the *observable* error output for generic `gateway call <method>` (including
`--json`): a pre-dispatch SecretRef failure now surfaces the actionable reachable-gateway
diagnostic instead of the raw `GatewaySecretRefUnavailableError`. Exit code stays `1` and the
non-reachable / non-auth paths are unchanged. **If maintainers prefer generic `gateway call`
to remain a strict raw/plumbing surface, I can narrow this PR to `usage-cost` only** — the
mechanism and wording are already command-neutral, so the scope choice is yours.

## Real behavior proof (real runtime, real WS boundary, real commands)

A standalone `tsx` script (not a vitest file) drives the **real** `gateway usage-cost` and
`gateway call <method>` commands registered by the real `registerGatewayCli`, through the new
`callGatewayCliWithAuthDiagnostic` wiring, across a **real WebSocket boundary**:

- A real `ws` server listens on a real loopback TCP port and closes the handshake with
  `1008 "pairing required"` (a real reachable-gateway signal).
- A real on-disk config sets `gateway.auth.token` to an env-template SecretRef whose env var
  is intentionally absent, so the **real** credential resolver throws a **real**
  `GatewaySecretRefUnavailableError` before any RPC is dispatched.
- Nothing in the function under test is mocked. The only interception is `process.exit`
  (captured to model its non-returning semantics; its sentinel lines are filtered before the
  "did not leak" assertions so they can never be mistaken for a real leak).

```
$ node --import tsx proof-gateway-cli-auth-diagnostic.mts

== Real `gateway` CLI auth-diagnostic proof (PR #93373) ==

Neutral message constant under test:
  Gateway is reachable, but this CLI has no token/password or paired device token to authenticate gateway RPCs. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD.

== Part A: real `gateway usage-cost` (gateway reachable, SecretRef unresolved) ==
  --- positive captured output ---
    OUT| Gateway: reachable
    OUT| Gateway is reachable, but this CLI has no token/password or paired device token to authenticate gateway RPCs. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD.
    ERR| Gateway usage cost failed: Error: __OPENCLAW_PROOF_EXIT__
    exitCode = 1
  [PASS] usage-cost: prints 'Gateway: reachable'
  [PASS] usage-cost: prints command-neutral credentials diagnostic
  [PASS] usage-cost: diagnostic is command-neutral (no 'read-scope health RPCs')
  [PASS] usage-cost: exit(1) requested -- exitCode=1
  [PASS] usage-cost: did NOT leak raw SecretRef error (no GatewaySecretRefUnavailableError)

== Part B: real `gateway call system-presence` (gateway reachable, SecretRef unresolved) ==
  --- positive captured output ---
    OUT| Gateway: reachable
    OUT| Gateway is reachable, but this CLI has no token/password or paired device token to authenticate gateway RPCs. Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD.
    ERR| Gateway call failed: Error: __OPENCLAW_PROOF_EXIT__
    exitCode = 1
  [PASS] call: prints 'Gateway: reachable'
  [PASS] call: prints command-neutral credentials diagnostic
  [PASS] call: diagnostic is command-neutral (no 'read-scope health RPCs')
  [PASS] call: exit(1) requested -- exitCode=1
  [PASS] call: did NOT leak raw SecretRef error (no GatewaySecretRefUnavailableError)

== Part C: negative control -- gateway closed (dead port) ==
  --- negative captured output (usage-cost) ---
    ERR| Gateway usage cost failed: GatewaySecretRefUnavailableError: gateway.auth.token is configured as a secret reference but is unavailable in this command path.
Fix: set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD, pass explicit --token/--password,
or run a gateway command path that resolves secret references before credential selection.
    exitCode = 1
  [PASS] negative usage-cost: did NOT print reachable diagnostic
  [PASS] negative usage-cost: preserved prior raw-error path ('Gateway usage cost failed')
  --- negative captured output (call) ---
    ERR| Gateway call failed: GatewaySecretRefUnavailableError: gateway.auth.token is configured as a secret reference but is unavailable in this command path.
Fix: set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD, pass explicit --token/--password,
or run a gateway command path that resolves secret references before credential selection.
    exitCode = 1
  [PASS] negative call: did NOT print reachable diagnostic
  [PASS] negative call: preserved prior raw-error path ('Gateway call failed')

ALL PROOF CHECKS PASSED
```

What this proves end to end, against real runtime (no mocks of the code under test):

- **Real commands** — the proof runs `registerGatewayCli(program)` and
  `program.parseAsync(["gateway", "usage-cost", ...])` / `[..., "call", "system-presence"]`,
  i.e. the actual changed CLI commands, not the underlying helper in isolation.
- **Real WS boundary** — the real `GatewayClient` probe connects to a real `ws` server which
  closes with `1008 "pairing required"`; this is recognised as reachability evidence
  (`gatewayProbeResultSawGateway`).
- **Positive (both commands)** — with the gateway reachable but the SecretRef unresolved, each
  command prints `Gateway: reachable` plus the **command-neutral** credentials diagnostic
  (verified to contain neither `read-scope health RPCs` nor the health-specific message),
  requests `exit(1)`, and does **not** leak the raw `GatewaySecretRefUnavailableError`.
- **Negative control** — pointing the same config at a now-dead port makes the probe see no
  gateway, so the helper returns `false`, no diagnostic is printed, and each command falls back
  to the original raw-error path (`Gateway usage cost failed` / `Gateway call failed` with the
  full `GatewaySecretRefUnavailableError`) — exactly the prior behaviour for non-reachable
  failures.

> `__OPENCLAW_PROOF_EXIT__` is the harness's own `process.exit` sentinel (used to model exit's
> non-returning behaviour during capture); those lines are filtered out before the leak
> assertions, so they are not a real raw-error leak.

## Tests and validation

- `src/cli/gateway-cli.coverage.test.ts` — drives the real commander program registered by
  `registerGatewayCli`:
  - `usage-cost` and `call` each emit the reachable-gateway auth diagnostic and request the
    **command-neutral** `credentialsRequiredMessage` (asserted to omit `health`) when credential
    resolution fails and the gateway is reachable, with **no** raw error leaked.
  - Negative cases: when the diagnostic is not handled (gateway not reachable), both commands
    rethrow the raw error and print the original `Gateway usage cost failed` / `Gateway call
    failed` message — proving the prior behaviour is preserved.
- `src/commands/health.test.ts` (14) + `src/commands/doctor-gateway-health.test.ts` (10) stay
  green: `gateway health`/doctor keep the original health-specific wording (unchanged).
- `node scripts/run-vitest.mjs src/cli/gateway-cli.coverage.test.ts` → **24/24 passed**.
- `node scripts/run-tsgo.mjs` → clean for the changed files.

## Risk checklist

- [x] Scope limited to the two `callGatewayCli` entrypoints plus an optional, defaulted message
      parameter on the shared diagnostic; reuses the already-merged
      `emitReachableGatewayAuthDiagnostic` from `#92290`.
- [x] `gateway health`/doctor behaviour is unchanged (the new message parameter defaults to the
      existing health-specific wording; their tests still pass).
- [x] No behaviour change on success/reachable paths or for non-auth errors (the helper only
      acts when the gateway is reachable-but-unauthenticated, otherwise rethrows).
- [x] Output for the new surfaces is command-neutral: it never claims the invoked method
      "requires auth" or is a health RPC; it states the gateway is reachable but the CLI has no
      usable credentials, which is accurate for any pre-dispatch credential failure.
- [x] No new dependencies.
