### PR TITLE
fix(state): archive rollback-journal sidecar during legacy SQLite migration

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -2357,6 +2357,64 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("archives the rollback-journal sidecar when migrating a task registry sidecar", async () => {
+    const root = await makeTempRoot();
+    const { taskRunsPath } = writeLegacyTaskStateSidecars(root);
+    // Simulate an NFS-backed legacy store left under journal_mode=DELETE: after
+    // a committed transaction SQLite truncates the rollback-journal to an empty
+    // sidecar (rather than deleting it on some NFS mounts), so a 0-byte
+    // -journal lingers next to the retired .sqlite.
+    const journalPath = `${taskRunsPath}-journal`;
+    fs.writeFileSync(journalPath, "");
+
+    const result = await autoMigrateLegacyTaskStateSidecars({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 1 task registry sidecar row → shared SQLite state");
+    // The journal sidecar must be archived alongside the database and its
+    // -wal/-shm siblings instead of being stranded at the legacy path.
+    expect(fs.existsSync(journalPath)).toBe(false);
+    expect(fs.existsSync(`${journalPath}.migrated`)).toBe(true);
+    expect(fs.statSync(`${journalPath}.migrated`).size).toBe(0);
+    expect(fs.existsSync(`${taskRunsPath}.migrated`)).toBe(true);
+
+    await withStateDir(root, async () => {
+      expect(loadTaskRegistryStateFromSqlite().tasks.has("legacy-task")).toBe(true);
+    });
+  });
+
+  it("archives the rollback-journal sidecar when migrating a plugin-state sidecar", async () => {
+    const root = await makeTempRoot();
+    const sourcePath = writeLegacyPluginStateSidecar(root);
+    // Simulate the NFS journal_mode=DELETE rollback-journal sidecar left as a
+    // 0-byte file after the last committed transaction.
+    const journalPath = `${sourcePath}-journal`;
+    fs.writeFileSync(journalPath, "");
+
+    const detected = await detectLegacyStateMigrations({
+      cfg: {},
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    const result = await runLegacyStateMigrations({ detected });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toContain("Migrated 1 plugin-state sidecar entry → shared SQLite state");
+    expect(fs.existsSync(journalPath)).toBe(false);
+    expect(fs.existsSync(`${journalPath}.migrated`)).toBe(true);
+    expect(fs.statSync(`${journalPath}.migrated`).size).toBe(0);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+
+    await withStateDir(root, async () => {
+      const store = createPluginStateKeyedStore<{ ok: boolean }>("discord", {
+        namespace: "components",
+        maxEntries: 10,
+      });
+      await expect(store.lookup("interaction:1")).resolves.toEqual({ ok: true });
+    });
+  });
+
   it("auto-migrates task sidecars without config-dependent state moves", async () => {
     const root = await makeTempRoot();
     const { taskRunsPath, flowRunsPath } = writeLegacyTaskStateSidecars(root);

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -175,8 +175,14 @@ type DetectedPluginDoctorStateMigrationPlan = {
   preview: string[];
 };
 
-const PLUGIN_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
-const TASK_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
+// SQLite keeps -shm/-wal sidecars under journal_mode=WAL, but NFS-backed state
+// volumes fall back to journal_mode=DELETE and leave a rollback-journal
+// (-journal) sidecar instead (see avoid-sqlite-wal-on-nfs handling). Archiving
+// the legacy source must cover all three so migration never strands a stale
+// -journal next to the retired .sqlite, which would trigger an erroneous
+// rollback if anything reopened the legacy database path afterwards.
+const PLUGIN_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal", "-journal"] as const;
+const TASK_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal", "-journal"] as const;
 const LEGACY_DELIVERY_QUEUE_DIRS = [
   { label: "outbound delivery queue", queueName: "outbound", dirName: "delivery-queue" },
   { label: "session delivery queue", queueName: "session", dirName: "session-delivery-queue" },


### PR DESCRIPTION
## Summary

Legacy SQLite state-migration archiving missed the rollback-journal (`-journal`) sidecar. When doctor/startup migrates a legacy `*.sqlite` sidecar into the shared `openclaw.sqlite`, it renames the source database and its `-shm`/`-wal` companions to `*.migrated`, but it never archived the `-journal` companion. On NFS-backed state volumes — which OpenClaw deliberately runs under `journal_mode=DELETE` instead of WAL (see #91247) — that leaves a stale `-journal` next to the retired `.sqlite`. If anything later reopens the legacy database path, SQLite treats the stranded journal as an unfinished transaction and attempts a rollback (`attempt to write a readonly database` on read-only opens).

This is the exact symmetric omission already fixed for the memory atomic-reindex path in #93182 / #93295, which expanded `["", "-wal", "-shm"]` to also cover `-journal`. The legacy state-migration archivers were left behind on the same set.

## What changed

`src/infra/state-migrations.ts`: both sidecar-suffix tables used by the legacy archivers now include `-journal`:

```
-const PLUGIN_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
-const TASK_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal"] as const;
+const PLUGIN_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal", "-journal"] as const;
+const TASK_STATE_SQLITE_SIDECAR_SUFFIXES = ["", "-shm", "-wal", "-journal"] as const;
```

These tables drive `archiveLegacyPluginStateSidecar` and `archiveLegacyTaskStateSidecar` (task registry, task flow, and plugin-state migrations). No behavior change on local WAL stores: when no `-journal` exists, the suffix is simply skipped by the existing `fileExists` filter.

## Real behavior proof (real runtime, outside tests)

A standalone script (`node --import tsx`) seeds a legacy `tasks/runs.sqlite`, materializes a 0-byte `runs.sqlite-journal` (the residue a committed `journal_mode=DELETE` transaction leaves on NFS), then drives the **real exported** `autoMigrateLegacyTaskStateSidecars(...)` and reads back across the real disk and the shared SQLite boundary.

Fixed code:

```
--- BEFORE migration ---
runs.sqlite exists        : true
runs.sqlite-journal exists: true
--- migration result ---
changes : ["Migrated 1 task registry sidecar row → shared SQLite state","Archived task registry sidecar legacy source → .../tasks/runs.sqlite.migrated"]
warnings: []
--- AFTER migration (real disk readback) ---
runs.sqlite-journal still at legacy path: false
runs.sqlite-journal.migrated exists     : true
runs.sqlite.migrated exists             : true
archived journal sidecar byte size      : 0
--- shared SQLite readback (cross-DB boundary) ---
shared openclaw.sqlite task_runs[legacy-task] rows: 1
--- VERDICT ---
PASS: journal sidecar archived, no stale -journal stranded, row imported
```

Negative control (same script, suffix tables reverted to `["", "-shm", "-wal"]` via `git stash`):

```
--- AFTER migration (real disk readback) ---
runs.sqlite-journal still at legacy path: true
runs.sqlite-journal.migrated exists     : false
runs.sqlite.migrated exists             : true
archived journal sidecar byte size      : -1
--- VERDICT ---
FAIL
```

The database body is archived in both runs; only the fixed code also archives the `-journal` sidecar instead of stranding it at the legacy path.

## Tests and validation

- `src/commands/doctor-state-migrations.test.ts`: two new regression tests drive the real migration entry points and assert the `-journal` sidecar is archived to `*.migrated` (and removed from the legacy path) for both the task-registry sidecar (`autoMigrateLegacyTaskStateSidecars`) and the plugin-state sidecar (`detectLegacyStateMigrations` + `runLegacyStateMigrations`).
- Negative control: with the suffix tables reverted, both tests fail (the journal is left stranded), confirming the assertions bind to the fix.
- Type check: `node scripts/run-tsgo.mjs` reports no errors for the touched files.

## Risk checklist

- Scope: one production file (suffix tables) + one test file. No public API change.
- No behavior change on local WAL stores (no `-journal` present → suffix skipped).
- Archiving is best-effort and already guarded by `fileExists` and existing-archive conflict checks; adding `-journal` reuses that path.
