### PR TITLE
fix(model-fallback): classify Codex/OpenAI auth failures

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -4,7 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { formatAssistantErrorText, isLikelyContextOverflowError } from "./errors.js";
+import {
+  classifyAssistantFailoverReason,
+  formatAssistantErrorText,
+  isAuthAssistantError,
+  isFailoverAssistantError,
+  isLikelyContextOverflowError,
+} from "./errors.js";
 
 const { toolPolicyAuditInfo } = vi.hoisted(() => ({
   toolPolicyAuditInfo: vi.fn(),
@@ -105,5 +111,20 @@ describe("isLikelyContextOverflowError", () => {
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       ),
     ).toBe(true);
+  });
+});
+
+describe("assistant failover classification", () => {
+  it("classifies structured auth error types without raw errorMessage text", () => {
+    const assistant = {
+      stopReason: "error",
+      errorType: "authentication_error",
+      provider: "openai",
+      model: "gpt-5.5",
+    };
+
+    expect(classifyAssistantFailoverReason(assistant as never)).toBe("auth");
+    expect(isAuthAssistantError(assistant as never)).toBe(true);
+    expect(isFailoverAssistantError(assistant as never)).toBe(true);
   });
 });

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1306,7 +1306,7 @@ function buildAssistantFailoverSignal(
     errorType: msg.errorType,
     message: msg.errorMessage?.trim() || undefined,
     provider: opts?.provider ?? msg.provider,
-    details: extractFailoverSignalDetails(msg.errorBody),
+    details: extractFailoverSignalDetails(msg.errorCode, msg.errorType, msg.errorBody),
   };
 }
 
@@ -1706,7 +1706,9 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   if (!msg || msg.stopReason !== "error") {
     return false;
   }
-  return isAuthErrorMessage(msg.errorMessage ?? "");
+  return (
+    isAuthErrorMessage(msg.errorMessage ?? "") || classifyAssistantFailoverReason(msg) === "auth"
+  );
 }
 
 export { isModelNotFoundErrorMessage };

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -100,6 +100,19 @@ describe("Z.ai vendor error codes (#48988)", () => {
     it("auth still classified correctly", () => {
       expect(isAuthErrorMessage("invalid api key provided")).toBe(true);
     });
+
+    it("Codex/OpenAI auth payloads are classified as auth", () => {
+      expect(
+        isAuthErrorMessage(
+          'OpenAI API error (503): 503 auth_unavailable: no auth available (providers=codex, model=gpt-5.5).',
+        ),
+      ).toBe(true);
+      expect(
+        isAuthErrorMessage(
+          '401 {"type":"error","error":{"type":"authentication_error","message":"Your authentication token has been invalidated. Please try signing in again."}}',
+        ),
+      ).toBe(true);
+    });
   });
 });
 

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -24,8 +24,12 @@ const AMBIGUOUS_AUTH_ERROR_PATTERNS = [
 ] as const satisfies readonly ErrorPattern[];
 
 const COMMON_AUTH_ERROR_PATTERNS = [
+  "auth_unavailable",
+  "authentication_error",
   "incorrect api key",
   "invalid token",
+  "token invalidated",
+  "token has been invalidated",
   "authentication",
   "re-authenticate",
   "oauth token refresh failed",

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2901,8 +2901,24 @@ async function runEmbeddedAgentInternal(
           }
 
           const assistantForFailover = currentAttemptAssistant ?? sessionAssistantForCandidate;
+          const formattedAssistantFailoverErrorText = assistantForFailover
+            ? formatAssistantErrorText(assistantForFailover, {
+                cfg: params.config,
+                sessionKey: resolvedSessionKey ?? params.sessionId,
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
+              })?.trim()
+            : undefined;
+          const assistantFailoverErrorText =
+            assistantForFailover?.errorMessage?.trim() || formattedAssistantFailoverErrorText || "";
+          const assistantForFailoverWithErrorText =
+            assistantForFailover &&
+            assistantFailoverErrorText &&
+            !assistantForFailover.errorMessage?.trim()
+              ? { ...assistantForFailover, errorMessage: assistantFailoverErrorText }
+              : assistantForFailover;
           const fallbackThinking = pickFallbackThinkingLevel({
-            message: assistantForFailover?.errorMessage,
+            message: assistantFailoverErrorText,
             attempted: attemptedThinking,
           });
           if (fallbackThinking && !aborted) {
@@ -2913,11 +2929,13 @@ async function runEmbeddedAgentInternal(
             continue;
           }
 
-          const authFailure = isAuthAssistantError(assistantForFailover);
-          const rateLimitFailure = isRateLimitAssistantError(assistantForFailover);
-          const billingFailure = isBillingAssistantError(assistantForFailover);
-          const failoverFailure = isFailoverAssistantError(assistantForFailover);
-          const assistantFailoverReason = classifyAssistantFailoverReason(assistantForFailover);
+          const authFailure = isAuthAssistantError(assistantForFailoverWithErrorText);
+          const rateLimitFailure = isRateLimitAssistantError(assistantForFailoverWithErrorText);
+          const billingFailure = isBillingAssistantError(assistantForFailoverWithErrorText);
+          const failoverFailure = isFailoverAssistantError(assistantForFailoverWithErrorText);
+          const assistantFailoverReason = classifyAssistantFailoverReason(
+            assistantForFailoverWithErrorText,
+          );
           const assistantProviderStarted =
             Boolean(currentAttemptAssistant?.provider) ||
             idleTimedOut ||
@@ -2931,18 +2949,18 @@ async function runEmbeddedAgentInternal(
               providerStarted: assistantProviderStarted,
               transientRateLimit:
                 assistantProfileFailoverReason === "rate_limit" &&
-                isShortWindowRateLimitMessage(assistantForFailover?.errorMessage),
+                isShortWindowRateLimitMessage(assistantFailoverErrorText),
             },
           );
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
           const imageDimensionError = parseImageDimensionError(
-            assistantForFailover?.errorMessage ?? "",
+            assistantFailoverErrorText,
           );
           // The shared runtime wraps interrupted streams as a timeout. Retry that
           // wrapper only for reasoning-only output so ordinary timeouts keep failover.
           const genericUnknownReasoningError =
             assistantFailoverReason === "timeout" &&
-            isGenericUnknownStreamErrorMessage(assistantForFailover?.errorMessage ?? "") &&
+            isGenericUnknownStreamErrorMessage(assistantFailoverErrorText) &&
             Boolean(assistantForFailover && hasOnlyAssistantReasoningContent(assistantForFailover));
           const silentErrorRetryReason =
             assistantFailoverReason === null ||
@@ -2980,7 +2998,7 @@ async function runEmbeddedAgentInternal(
           const logAssistantFailoverDecision = createFailoverDecisionLogger({
             stage: "assistant",
             runId: params.runId,
-            rawError: assistantForFailover?.errorMessage?.trim(),
+            rawError: assistantFailoverErrorText || undefined,
             failoverReason: assistantFailoverReason,
             profileFailureReason: assistantProfileFailureReason,
             provider: activeErrorContext.provider,
@@ -2996,7 +3014,7 @@ async function runEmbeddedAgentInternal(
           if (
             authFailure &&
             (await maybeRefreshRuntimeAuthForAuthError(
-              assistantForFailover?.errorMessage ?? "",
+              assistantFailoverErrorText,
               runtimeAuthRetry,
             ))
           ) {
@@ -3061,7 +3079,7 @@ async function runEmbeddedAgentInternal(
             modelId,
             provider,
             activeErrorContext,
-            lastAssistant: assistantForFailover,
+            lastAssistant: assistantForFailoverWithErrorText,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,
             authFailure,

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -2901,20 +2901,20 @@ async function runEmbeddedAgentInternal(
           }
 
           const assistantForFailover = currentAttemptAssistant ?? sessionAssistantForCandidate;
-          const formattedAssistantFailoverErrorText = assistantForFailover
-            ? formatAssistantErrorText(assistantForFailover, {
-                cfg: params.config,
-                sessionKey: resolvedSessionKey ?? params.sessionId,
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
-              })?.trim()
-            : undefined;
+          const assistantFailoverRawErrorText = assistantForFailover?.errorMessage?.trim();
+          const formattedAssistantFailoverErrorText =
+            assistantForFailover && !assistantFailoverRawErrorText
+              ? formatAssistantErrorText(assistantForFailover, {
+                  cfg: params.config,
+                  sessionKey: resolvedSessionKey ?? params.sessionId,
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                })?.trim()
+              : undefined;
           const assistantFailoverErrorText =
-            assistantForFailover?.errorMessage?.trim() || formattedAssistantFailoverErrorText || "";
-          const assistantForFailoverWithErrorText =
-            assistantForFailover &&
-            assistantFailoverErrorText &&
-            !assistantForFailover.errorMessage?.trim()
+            assistantFailoverRawErrorText || formattedAssistantFailoverErrorText || "";
+          const assistantForFailoverSignal =
+            assistantForFailover && assistantFailoverErrorText && !assistantFailoverRawErrorText
               ? { ...assistantForFailover, errorMessage: assistantFailoverErrorText }
               : assistantForFailover;
           const fallbackThinking = pickFallbackThinkingLevel({
@@ -2929,12 +2929,12 @@ async function runEmbeddedAgentInternal(
             continue;
           }
 
-          const authFailure = isAuthAssistantError(assistantForFailoverWithErrorText);
-          const rateLimitFailure = isRateLimitAssistantError(assistantForFailoverWithErrorText);
-          const billingFailure = isBillingAssistantError(assistantForFailoverWithErrorText);
-          const failoverFailure = isFailoverAssistantError(assistantForFailoverWithErrorText);
+          const authFailure = isAuthAssistantError(assistantForFailoverSignal);
+          const rateLimitFailure = isRateLimitAssistantError(assistantForFailoverSignal);
+          const billingFailure = isBillingAssistantError(assistantForFailoverSignal);
+          const failoverFailure = isFailoverAssistantError(assistantForFailoverSignal);
           const assistantFailoverReason = classifyAssistantFailoverReason(
-            assistantForFailoverWithErrorText,
+            assistantForFailoverSignal,
           );
           const assistantProviderStarted =
             Boolean(currentAttemptAssistant?.provider) ||
@@ -2953,9 +2953,7 @@ async function runEmbeddedAgentInternal(
             },
           );
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(
-            assistantFailoverErrorText,
-          );
+          const imageDimensionError = parseImageDimensionError(assistantFailoverErrorText);
           // The shared runtime wraps interrupted streams as a timeout. Retry that
           // wrapper only for reasoning-only output so ordinary timeouts keep failover.
           const genericUnknownReasoningError =
@@ -3079,7 +3077,8 @@ async function runEmbeddedAgentInternal(
             modelId,
             provider,
             activeErrorContext,
-            lastAssistant: assistantForFailoverWithErrorText,
+            lastAssistant: assistantForFailover,
+            assistantFailoverRawErrorText: assistantFailoverErrorText || undefined,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,
             authFailure,

--- a/src/agents/embedded-agent-runner/run/assistant-failover.formatted-error.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.formatted-error.test.ts
@@ -1,0 +1,77 @@
+// Focused coverage for assistant failover errors with no raw provider errorMessage.
+import { describe, expect, it, vi } from "vitest";
+import { FailoverError } from "../../failover-error.js";
+import { handleAssistantFailover } from "./assistant-failover.js";
+
+type Params = Parameters<typeof handleAssistantFailover>[0];
+type Outcome = Awaited<ReturnType<typeof handleAssistantFailover>>;
+
+function makeParams(overrides: Partial<Params> = {}): Params {
+  const provider = "openai";
+  const model = "gpt-5.5";
+  const defaults: Params = {
+    initialDecision: { action: "surface_error", reason: "auth" },
+    aborted: false,
+    externalAbort: false,
+    fallbackConfigured: false,
+    failoverFailure: true,
+    failoverReason: "auth",
+    timedOut: false,
+    idleTimedOut: false,
+    timedOutDuringCompaction: false,
+    timedOutDuringToolExecution: false,
+    allowSameModelIdleTimeoutRetry: false,
+    allowSameModelRateLimitRetry: true,
+    assistantProfileFailureReason: null,
+    lastProfileId: undefined,
+    modelId: model,
+    provider,
+    activeErrorContext: { provider, model },
+    lastAssistant: undefined,
+    config: undefined,
+    sessionKey: undefined,
+    authFailure: true,
+    rateLimitFailure: false,
+    billingFailure: false,
+    cloudCodeAssistFormatError: false,
+    isProbeSession: false,
+    overloadProfileRotations: 0,
+    overloadProfileRotationLimit: 3,
+    previousRetryFailoverReason: null,
+    logAssistantFailoverDecision: vi.fn(),
+    warn: vi.fn(),
+    maybeMarkAuthProfileFailure: vi.fn(async () => {}),
+    maybeEscalateRateLimitProfileFallback: vi.fn(),
+    maybeRetrySameModelRateLimit: vi.fn(async () => false),
+    maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
+    advanceAuthProfile: vi.fn(async () => false),
+  };
+  return { ...defaults, ...overrides };
+}
+
+function expectThrownFailoverError(outcome: Outcome): FailoverError {
+  expect(outcome.action).toBe("throw");
+  if (outcome.action !== "throw") {
+    throw new Error("expected throw outcome");
+  }
+  expect(outcome.error).toBeInstanceOf(FailoverError);
+  return outcome.error;
+}
+
+describe("handleAssistantFailover formatted assistant errors", () => {
+  it("uses formatted assistant error text as rawError when raw errorMessage is absent", async () => {
+    const outcome = await handleAssistantFailover(
+      makeParams({
+        lastAssistant: {
+          stopReason: "error",
+          provider: "openai",
+          model: "gpt-5.5",
+        } as Params["lastAssistant"],
+      }),
+    );
+
+    const err = expectThrownFailoverError(outcome);
+    expect(err.reason).toBe("auth");
+    expect(err.rawError).toBe("LLM request failed with an unknown error.");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -116,10 +116,15 @@ export function isShortWindowRateLimitMessage(message: string | undefined): bool
 
 function resolveAssistantFailoverRawErrorText(params: {
   lastAssistant: AssistantMessage | undefined;
+  assistantFailoverRawErrorText?: string;
   config: OpenClawConfig | undefined;
   sessionKey?: string;
   activeErrorContext: { provider: string; model: string };
 }): string | undefined {
+  const derivedError = params.assistantFailoverRawErrorText?.trim();
+  if (derivedError) {
+    return derivedError;
+  }
   const rawError = params.lastAssistant?.errorMessage?.trim();
   if (rawError) {
     return rawError;
@@ -158,6 +163,7 @@ export async function handleAssistantFailover(params: {
   provider: string;
   activeErrorContext: { provider: string; model: string };
   lastAssistant: AssistantMessage | undefined;
+  assistantFailoverRawErrorText?: string;
   config: OpenClawConfig | undefined;
   sessionKey?: string;
   authFailure: boolean;
@@ -399,6 +405,7 @@ export async function handleAssistantFailover(params: {
 
 function resolveAssistantFailoverErrorMessage(params: {
   lastAssistant: AssistantMessage | undefined;
+  assistantFailoverRawErrorText?: string;
   config: OpenClawConfig | undefined;
   sessionKey?: string;
   activeErrorContext: { provider: string; model: string };
@@ -411,14 +418,6 @@ function resolveAssistantFailoverErrorMessage(params: {
   const timeoutFailure = params.timedOut || params.idleTimedOut;
   const assistantRawErrorText = resolveAssistantFailoverRawErrorText(params);
   return (
-    (params.lastAssistant
-      ? formatAssistantErrorText(params.lastAssistant, {
-          cfg: params.config,
-          sessionKey: params.sessionKey,
-          provider: params.activeErrorContext.provider,
-          model: params.activeErrorContext.model,
-        })
-      : undefined) ||
     assistantRawErrorText ||
     (timeoutFailure
       ? "LLM request timed out."

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -114,6 +114,26 @@ export function isShortWindowRateLimitMessage(message: string | undefined): bool
   return resolveShortWindowRateLimitRetry(message) !== null;
 }
 
+function resolveAssistantFailoverRawErrorText(params: {
+  lastAssistant: AssistantMessage | undefined;
+  config: OpenClawConfig | undefined;
+  sessionKey?: string;
+  activeErrorContext: { provider: string; model: string };
+}): string | undefined {
+  const rawError = params.lastAssistant?.errorMessage?.trim();
+  if (rawError) {
+    return rawError;
+  }
+  return params.lastAssistant
+    ? formatAssistantErrorText(params.lastAssistant, {
+        cfg: params.config,
+        sessionKey: params.sessionKey,
+        provider: params.activeErrorContext.provider,
+        model: params.activeErrorContext.model,
+      })?.trim()
+    : undefined;
+}
+
 /**
  * Applies an assistant-stage failover decision and returns the next run action.
  * It owns auth-profile rotation, overload/rate-limit escalation, same-model
@@ -169,6 +189,7 @@ export async function handleAssistantFailover(params: {
 }): Promise<AssistantFailoverOutcome> {
   let overloadProfileRotations = params.overloadProfileRotations;
   let decision = params.initialDecision;
+  const assistantFailoverRawErrorText = resolveAssistantFailoverRawErrorText(params);
   const sameModelIdleTimeoutRetry = (): AssistantFailoverOutcome => {
     params.warn(
       `[llm-idle-timeout] ${sanitizeForLog(params.provider)}/${sanitizeForLog(params.modelId)} produced no reply before the idle watchdog; retrying same model`,
@@ -237,7 +258,7 @@ export async function handleAssistantFailover(params: {
               model: params.activeErrorContext.model,
               profileId: params.lastProfileId,
               status,
-              rawError: params.lastAssistant?.errorMessage?.trim(),
+              rawError: assistantFailoverRawErrorText,
             },
           ),
         };
@@ -248,7 +269,7 @@ export async function handleAssistantFailover(params: {
       // Minute-scale RPM windows can clear without spending a profile rotation
       // or model fallback. Keep the retry bounded; once exhausted, continue
       // through the existing rate-limit escalation path.
-      const shortWindowRetry = resolveShortWindowRateLimitRetry(params.lastAssistant?.errorMessage);
+      const shortWindowRetry = resolveShortWindowRateLimitRetry(assistantFailoverRawErrorText);
       if (
         params.allowSameModelRateLimitRetry &&
         shortWindowRetry &&
@@ -332,7 +353,7 @@ export async function handleAssistantFailover(params: {
         model: params.activeErrorContext.model,
         profileId: params.lastProfileId,
         status,
-        rawError: params.lastAssistant?.errorMessage?.trim(),
+        rawError: assistantFailoverRawErrorText,
         suspend: shouldSuspend,
       }),
     };
@@ -363,7 +384,7 @@ export async function handleAssistantFailover(params: {
           model: params.activeErrorContext.model,
           profileId: params.lastProfileId,
           status,
-          rawError: params.lastAssistant?.errorMessage?.trim(),
+          rawError: assistantFailoverRawErrorText,
           suspend: shouldSuspend,
         }),
       };
@@ -388,6 +409,7 @@ function resolveAssistantFailoverErrorMessage(params: {
   authFailure: boolean;
 }): string {
   const timeoutFailure = params.timedOut || params.idleTimedOut;
+  const assistantRawErrorText = resolveAssistantFailoverRawErrorText(params);
   return (
     (params.lastAssistant
       ? formatAssistantErrorText(params.lastAssistant, {
@@ -397,7 +419,7 @@ function resolveAssistantFailoverErrorMessage(params: {
           model: params.activeErrorContext.model,
         })
       : undefined) ||
-    params.lastAssistant?.errorMessage?.trim() ||
+    assistantRawErrorText ||
     (timeoutFailure
       ? "LLM request timed out."
       : params.rateLimitFailure

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -129,14 +129,7 @@ function resolveAssistantFailoverRawErrorText(params: {
   if (rawError) {
     return rawError;
   }
-  return params.lastAssistant
-    ? formatAssistantErrorText(params.lastAssistant, {
-        cfg: params.config,
-        sessionKey: params.sessionKey,
-        provider: params.activeErrorContext.provider,
-        model: params.activeErrorContext.model,
-      })?.trim()
-    : undefined;
+  return undefined;
 }
 
 /**
@@ -342,7 +335,7 @@ export async function handleAssistantFailover(params: {
     // Backoff runs before throwing so the outer fallback model starts after the
     // provider-specific overload delay.
     await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);
-    const message = resolveAssistantFailoverErrorMessage(params);
+    const message = resolveAssistantFailoverErrorMessage(params, assistantFailoverRawErrorText);
     const status =
       resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
     params.logAssistantFailoverDecision("fallback_model", { status });
@@ -359,7 +352,7 @@ export async function handleAssistantFailover(params: {
         model: params.activeErrorContext.model,
         profileId: params.lastProfileId,
         status,
-        rawError: assistantFailoverRawErrorText,
+        rawError: assistantFailoverRawErrorText ?? message,
         suspend: shouldSuspend,
       }),
     };
@@ -374,7 +367,7 @@ export async function handleAssistantFailover(params: {
     // payload synthesis, and stale classified text without failoverFailure
     // keep the normal payload path.
     if (!params.externalAbort && !params.timedOut && params.failoverFailure) {
-      const message = resolveAssistantFailoverErrorMessage(params);
+      const message = resolveAssistantFailoverErrorMessage(params, assistantFailoverRawErrorText);
       const reason = resolveSurfaceErrorReason(decision.reason, params);
       const status =
         resolveFailoverStatus(reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
@@ -390,7 +383,7 @@ export async function handleAssistantFailover(params: {
           model: params.activeErrorContext.model,
           profileId: params.lastProfileId,
           status,
-          rawError: assistantFailoverRawErrorText,
+          rawError: assistantFailoverRawErrorText ?? message,
           suspend: shouldSuspend,
         }),
       };
@@ -403,21 +396,31 @@ export async function handleAssistantFailover(params: {
   };
 }
 
-function resolveAssistantFailoverErrorMessage(params: {
-  lastAssistant: AssistantMessage | undefined;
-  assistantFailoverRawErrorText?: string;
-  config: OpenClawConfig | undefined;
-  sessionKey?: string;
-  activeErrorContext: { provider: string; model: string };
-  timedOut: boolean;
-  idleTimedOut: boolean;
-  rateLimitFailure: boolean;
-  billingFailure: boolean;
-  authFailure: boolean;
-}): string {
+function resolveAssistantFailoverErrorMessage(
+  params: {
+    lastAssistant: AssistantMessage | undefined;
+    assistantFailoverRawErrorText?: string;
+    config: OpenClawConfig | undefined;
+    sessionKey?: string;
+    activeErrorContext: { provider: string; model: string };
+    timedOut: boolean;
+    idleTimedOut: boolean;
+    rateLimitFailure: boolean;
+    billingFailure: boolean;
+    authFailure: boolean;
+  },
+  assistantRawErrorText?: string,
+): string {
   const timeoutFailure = params.timedOut || params.idleTimedOut;
-  const assistantRawErrorText = resolveAssistantFailoverRawErrorText(params);
   return (
+    (params.lastAssistant
+      ? formatAssistantErrorText(params.lastAssistant, {
+          cfg: params.config,
+          sessionKey: params.sessionKey,
+          provider: params.activeErrorContext.provider,
+          model: params.activeErrorContext.model,
+        })
+      : undefined) ||
     assistantRawErrorText ||
     (timeoutFailure
       ? "LLM request timed out."


### PR DESCRIPTION
## Summary

Fix for #93272.

This PR improves model failover for Codex/OpenAI auth-shaped and zero-output assistant failures by:

- classifying `auth_unavailable`, `authentication_error`, and invalidated-token text as auth failures;
- keeping raw assistant error text separate from formatted display text so failover classification and telemetry can use raw details without duplicating user-visible formatting;
- using formatted assistant error text for assistant-stage failover classification, auth refresh, short-window rate-limit checks, image-dimension checks, and decision logging;
- including structured assistant `errorCode` / `errorType` in failover-signal details so `errorType: "authentication_error"` can classify as auth even without raw error text.

## Why

A local OpenClaw v2026.6.6 incident showed a failed primary model request did not advance to the next configured provider when the upstream error text was an auth-shaped Codex/OpenAI payload. The local hotfix was validated against the affected `heme-literature` dashboard session: primary `openai/gpt-5.5` failed, then fallback `bigmodel/glm-5.2` returned `OK`.

## Real behavior proof

- **Behavior or issue addressed**: OpenClaw should automatically continue to the next configured provider when the primary Codex/OpenAI assistant request fails with auth-shaped or structured zero-output error payloads.
- **Real environment tested**: Local installed OpenClaw v2026.6.6 hotfix on the affected `heme-literature` dashboard session `agent:heme-literature:dashboard:3d5a1f06-de8c-45d9-8526-aefc77144cd0`, session id `d01a0fd4-2616-4f64-ba49-66cba90faadb`.
- **Exact steps or command run after this patch**: Applied the same failover changes to the local installed OpenClaw bundle, restarted the local OpenClaw daemon, ran the affected dashboard session through the real OpenClaw runtime, then inspected the generated trajectory records. Secrets, prompts, paths, and config payloads were omitted from the copied output below.
- **Evidence after fix**: Redacted runtime log excerpt from the real OpenClaw trajectory after the hotfix:

```jsonl
{"ts":"2026-06-15T11:16:51.491Z","type":"session.started","runId":"79873b82-1f45-41a0-8fc0-0b19a010c694","provider":"openai","modelId":"gpt-5.5","modelApi":"openai-responses","authProfileId":"openai:api-key"}
{"ts":"2026-06-15T11:17:27.146Z","type":"session.ended","runId":"79873b82-1f45-41a0-8fc0-0b19a010c694","provider":"openai","modelId":"gpt-5.5","modelApi":"openai-responses","status":"error"}
{"ts":"2026-06-15T11:17:28.608Z","type":"session.started","runId":"79873b82-1f45-41a0-8fc0-0b19a010c694","provider":"bigmodel","modelId":"glm-5.2","modelApi":"openai-completions"}
{"ts":"2026-06-15T11:17:45.230Z","type":"trace.artifacts","runId":"79873b82-1f45-41a0-8fc0-0b19a010c694","provider":"bigmodel","modelId":"glm-5.2","modelApi":"openai-completions","status":"success","assistantTexts":["OK"]}
{"ts":"2026-06-15T11:17:45.231Z","type":"session.ended","runId":"79873b82-1f45-41a0-8fc0-0b19a010c694","provider":"bigmodel","modelId":"glm-5.2","modelApi":"openai-completions","status":"success"}
```

- **Observed result after fix**: The real OpenClaw runtime advanced from failed `openai/gpt-5.5` to fallback `bigmodel/glm-5.2` in the same run, and the fallback model produced assistant output `OK`. Additional same-session fallback-chain proof after `bigmodel/glm-5.2` later hit quota: `openai/gpt-5.5` ended `error`, `bigmodel/glm-5.2` ended `error`, and `deepseek/deepseek-v4-pro` ended `success` in run `f13a5676-91e8-4aa8-a818-f4908cad690a`.
- **What was not tested**: No additional gaps for this fallback path. The broader session/model override and auth-order policy details remain tracked in #93272 and are not closed by this PR.

## Tests

- Added matcher regression coverage for Codex/OpenAI auth payloads.
- Added focused assistant-failover coverage for missing raw `errorMessage`.
- Added helper regression coverage for structured `errorType: "authentication_error"` without raw error text.
- `git diff --check` passed locally.
- Focused Vitest passed locally: `pnpm vitest run src/agents/embedded-agent-helpers/failover-matches.test.ts src/agents/embedded-agent-helpers/errors.test.ts src/agents/embedded-agent-runner/run/assistant-failover.formatted-error.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 5 files passed, 38 tests passed.
- CI-regression shard passed locally: `pnpm vitest run src/agents/embedded-agent-runner/run.codex-server-error-fallback.test.ts src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test.ts src/agents/embedded-agent-runner/run/assistant-failover.formatted-error.test.ts --pool=forks --maxWorkers=1 --maxConcurrency=1` -> 6 files passed, 12 tests passed.
- The local installed OpenClaw hotfix was smoke-tested with the affected agent/session as shown above.

## Note

The broader session/model override and auth-order policy details remain tracked in #93272 and should not be considered closed by merging this PR alone.