### PR TITLE
test(telegram): keep live polling leases protected

### DIFF
--- a/extensions/telegram/src/polling-lease.test.ts
+++ b/extensions/telegram/src/polling-lease.test.ts
@@ -28,6 +28,31 @@ describe("Telegram polling lease", () => {
     first.release();
   });
 
+  it("refuses an old active duplicate poller for the same bot token", async () => {
+    vi.useFakeTimers();
+    try {
+      const abort = new AbortController();
+      const first = await acquireTelegramPollingLease({
+        token: "123:abc",
+        accountId: "default",
+        abortSignal: abort.signal,
+      });
+
+      await vi.advanceTimersByTimeAsync(6 * 60 * 1_000);
+
+      await expect(
+        acquireTelegramPollingLease({
+          token: "123:abc",
+          accountId: "ops",
+        }),
+      ).rejects.toThrow('refusing duplicate poller for account "ops"');
+
+      first.release();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("allows concurrent pollers for different bot tokens", async () => {
     const first = await acquireTelegramPollingLease({
       token: "123:abc",


### PR DESCRIPTION
## Summary

Keep Telegram's same-token polling lease protection intact and add regression coverage for the reviewed failure mode.

This no longer claims to fix #93375. The attempted lease-age recovery was removed because a healthy Telegram poller can hold a non-aborted lease for longer than five minutes, so lease age is not a safe owner-death signal.

## What changed

- Removed the five-minute active-lease replacement path.
- Added a regression test proving an old but still-active same-token lease continues to reject a duplicate poller.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/polling-lease.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/polling-lease.ts extensions/telegram/src/polling-lease.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/polling-lease.ts extensions/telegram/src/polling-lease.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Scope: PR 93378 maintainer cleanup. Removed unsafe age-based Telegram polling lease replacement, added one focused regression test that old non-aborted same-token leases still reject duplicates. Please review only extensions/telegram/src/polling-lease.ts and polling-lease.test.ts changes."`

## Not fixed

#93375 remains open. The recovery fix should use explicit stopped/aborted lifecycle state or gateway task cleanup, with real Telegram or equivalent runtime proof.
