### PR TITLE
fix(whatsapp): thread authDir through command authorization and owner bypass for LID JID resolution

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -78,12 +78,16 @@ function shouldWarnForGroupDrop(warnKey: string): boolean {
   return true;
 }
 
-function isOwnerSender(baseMentionConfig: MentionConfig, msg: AdmittedWebInboundMessage) {
-  const sender = normalizeE164(getSenderIdentity(msg).e164 ?? "");
+function isOwnerSender(
+  baseMentionConfig: MentionConfig,
+  msg: AdmittedWebInboundMessage,
+  authDir?: string,
+) {
+  const sender = normalizeE164(getSenderIdentity(msg, authDir).e164 ?? "");
   if (!sender) {
     return false;
   }
-  const owners = resolveOwnerList(baseMentionConfig, getSelfIdentity(msg).e164 ?? undefined);
+  const owners = resolveOwnerList(baseMentionConfig, getSelfIdentity(msg, authDir).e164 ?? undefined);
   return owners.includes(sender);
 }
 
@@ -187,7 +191,7 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
     self.e164,
   );
   const activationCommand = parseActivationCommand(commandBody);
-  const owner = isOwnerSender(baseMentionConfig, params.msg);
+  const owner = isOwnerSender(baseMentionConfig, params.msg, params.authDir);
   const shouldBypassMention = owner && hasControlCommand(commandBody, params.cfg);
 
   if (activationCommand.hasCommand && !owner) {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -437,6 +437,7 @@ export async function processMessage(params: {
         cfg: params.cfg,
         msg: params.msg,
         policy: inboundPolicy,
+        authDir: account.authDir,
       })
     : undefined;
   const commandTurn: CommandTurnContext = isTextCommand

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -173,13 +173,14 @@ export async function resolveWhatsAppCommandAuthorized(params: {
   cfg: OpenClawConfig;
   msg: AdmittedWebInboundMessage;
   policy?: ResolvedWhatsAppInboundPolicy;
+  authDir?: string;
 }): Promise<boolean> {
   const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;
   if (!useAccessGroups) {
     return true;
   }
 
-  const self = getSelfIdentity(params.msg);
+  const self = getSelfIdentity(params.msg, params.authDir);
   const admission = requireWhatsAppInboundAdmission(params.msg);
   const policy =
     params.policy ??
@@ -189,7 +190,7 @@ export async function resolveWhatsAppCommandAuthorized(params: {
       selfE164: self.e164 ?? null,
     });
   const isGroup = admission.conversation.kind === "group";
-  const sender = getSenderIdentity(params.msg);
+  const sender = getSenderIdentity(params.msg, params.authDir);
   const dmSender = sender.e164 ?? admission.conversation.id;
   const groupSender = sender.e164 ?? "";
   if (!normalizeE164(isGroup ? groupSender : dmSender)) {

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -1,4 +1,7 @@
 // Whatsapp tests cover access control plugin behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
 import type {
   AcceptedInboundAccessControlResult,
@@ -600,6 +603,52 @@ describe("WhatsApp dmPolicy precedence", () => {
 
     expect(result.allowed).toBe(false);
     expect(result.isSelfChat).toBe(false);
+  });
+
+  it("authorizes group commands when owner sender is a LID JID with authDir (issue #77755)", async () => {
+    const lidDigits = "9876543210";
+    const ownerE164 = "+15550001111";
+    const authDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-lid-77755-"));
+    try {
+      // Write reverse LID mapping so the LID JID resolves to the owner's phone
+      fs.writeFileSync(
+        path.join(authDir, `lid-mapping-${lidDigits}_reverse.json`),
+        JSON.stringify(ownerE164),
+      );
+
+      const cfg = {
+        channels: {
+          whatsapp: {
+            dmPolicy: "allowlist",
+            allowFrom: [ownerE164],
+          },
+        },
+      };
+      setAccessControlTestConfig(cfg);
+
+      const result = await resolveWhatsAppCommandAuthorized({
+        cfg: cfg as never,
+        msg: createTestWebInboundMessage({
+          event: { id: "cmd-group-lid" },
+          payload: { body: "/status" },
+          platform: {
+            chatJid: "120363401234567890@g.us",
+            recipientJid: "+15550009999",
+            senderJid: `${lidDigits}@lid`,
+            selfE164: "+15550009999",
+          },
+          accountId: "default",
+          chatType: "group",
+          from: "120363401234567890@g.us",
+          conversationId: "120363401234567890@g.us",
+        }) as never,
+        authDir,
+      });
+
+      expect(result).toBe(true);
+    } finally {
+      fs.rmSync(authDir, { recursive: true, force: true });
+    }
   });
 
   it("treats same-phone DMs as self-chat only when explicitly configured", async () => {

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -637,10 +637,12 @@ describe("WhatsApp dmPolicy precedence", () => {
             senderJid: `${lidDigits}@lid`,
             selfE164: "+15550009999",
           },
-          accountId: "default",
-          chatType: "group",
-          from: "120363401234567890@g.us",
-          conversationId: "120363401234567890@g.us",
+          admission: {
+            conversation: {
+              id: "120363401234567890@g.us",
+              kind: "group",
+            },
+          },
         }) as never,
         authDir,
       });


### PR DESCRIPTION
## What Problem This Solves

WhatsApp group commands (`/new`, `/stop`, `/status`) are silently ignored when Baileys reports the sender as a LID JID (`@lid`) instead of a phone JID (`@s.whatsapp.net`), even when the sender is the configured owner.

Root cause: `resolveWhatsAppCommandAuthorized()` and `isOwnerSender()` called `getSelfIdentity()`/`getSenderIdentity()` without passing `authDir`, so the LID-to-phone reverse mapping files (`lid-mapping-<lid>_reverse.json`) in the auth directory could not be found. The sender fell through to unauthorized, and the command was dropped.

Fixes #77755

## Why This Change Was Made

Thread `account.authDir` through both command authorization (`resolveWhatsAppCommandAuthorized`) and group owner-bypass identity resolution (`isOwnerSender`), enabling proper LID JID → phone E.164 resolution before owner/allowlist checks.

This is the narrowest fix: the existing `resolveComparableIdentity()` helper already accepts `authDir` and passes it to `jidToE164()` for LID identity resolution. The only gap was the two call sites that weren't forwarding the parameter.

## User Impact

- **Before**: WhatsApp group owner commands silently ignored when Baileys uses LID JID sender format (intermittent, depends on Baileys internal state)
- **After**: Owner commands in WhatsApp groups always authorized, regardless of whether Baileys reports the sender as phone JID or LID JID
- Affected users: WhatsApp channel users whose Baileys session uses LID-based sender identities for group messages

## Evidence

- `pnpm test extensions/whatsapp/src/inbound/access-control.test.ts` — 16/16 passed (including new LID regression test)
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json` — clean
- CI: all checks passing (build, lint, test-types, contracts, boundaries, etc.)
- Autoreview: ClawSweeper reviewed, patch quality 🦞 diamond lobster

### Real behavior proof

Behavior addressed: WhatsApp group commands (e.g. `/status`) from the configured owner are properly authorized when Baileys reports the sender as a LID JID (`<LID>@lid`) instead of a phone JID, via the reverse LID mapping file in the auth directory.

Real environment tested: Linux x86_64, Node 24.13.1, branch `fix/issue-77755-whatsapp-lid-authdir` at commit `f74779fe9a`, production WhatsApp config with real Baileys auth directory containing LID reverse mappings.

Exact steps after this patch:
```bash
# 1. Build and start gateway with PR branch
pnpm build
OPENCLAW_HOME=$HOME OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1 pnpm openclaw gateway

# 2. Send /status from owner's phone in a WhatsApp group
# 3. Observe gateway logs
```

Gateway log evidence — WhatsApp connected and listening:
```
[whatsapp] Listening for WhatsApp inbound messages (DM + all groups; sender allowlist configured).
```

Sending `/status` from owner's phone in WhatsApp group. Gateway received and authorized the command:
```
inbound message
Inbound message <GROUP_JID>@g.us -> REDACTED (group, 101 chars)
Sending message -> sha256:e4c4dd672a3d
Sent message 3EB048CA4F762AB9930161 (875ms)
```

Temporary diagnostic probe confirming LID JID → E.164 resolution path with `authDir`:
```
[PROOF] isOwnerSender authDir=~/.openclaw/credentials/whatsapp/default
        sender.jid=(none) sender.lid=<LID>@lid sender.e164=REDACTED
[PROOF] isOwnerSender => true (owners=["REDACTED"] sender=REDACTED)

[PROOF] resolveWhatsAppCommandAuthorized authDir=~/.openclaw/credentials/whatsapp/default
        sender.jid=(none) sender.lid=<LID>@lid sender.e164=REDACTED isGroup=true
[PROOF] resolveWhatsAppCommandAuthorized => true (senderId=REDACTED)
```

Key facts confirmed by live probe:
- **Baileys reported the sender as LID JID** `<LID>@lid` — no phone JID present
- **authDir was correctly threaded** to `getSenderIdentity()`/`getSelfIdentity()`
- **LID → E.164 reverse mapping succeeded** via `lid-mapping-<LID>_reverse.json` → owner phone
- **Owner authorization passed** in both `isOwnerSender` and `resolveWhatsAppCommandAuthorized` paths
- **Bot replied successfully** (875ms send latency)

Observed result after fix: The owner's `/status` command in a WhatsApp group, where Baileys reports the sender as `<LID>@lid`, is correctly resolved to the owner's phone number via the authDir reverse mapping, authorized as owner, and the bot responds normally.

What was not tested: The "before" (broken) behavior on `main` was not reverted and retested on this live setup, as doing so would disrupt the running gateway. The main-branch gap was confirmed by source inspection (see ClawSweeper review evidence: `inbound-policy.ts:182` and `group-gating.ts:81` on main call `getSenderIdentity(msg)` without `authDir`).
