### PR TITLE
fix(config): resolve duplicate password export in configure.shared

### DIFF
--- a/src/commands/configure.shared.password.test.ts
+++ b/src/commands/configure.shared.password.test.ts
@@ -1,0 +1,47 @@
+// Regression guard for the deduped `password` prompt wrapper in
+// configure.shared. A merge collision once landed two identical
+// `export const password` declarations (a build-breaking redeclare). These
+// tests pin the single surviving wrapper and prove it still routes secrets
+// through clack's masked password prompt instead of a cleartext text prompt.
+import type { PasswordOptions } from "@clack/prompts";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clackPassword: vi.fn<(opts: PasswordOptions) => Promise<string>>(async () => "CAPTURED"),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  password: mocks.clackPassword,
+  text: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+  intro: vi.fn(),
+  outro: vi.fn(),
+}));
+
+import * as configureShared from "./configure.shared.js";
+
+describe("configure.shared password wrapper", () => {
+  it("exposes exactly one password export", () => {
+    const passwordExports = Object.keys(configureShared).filter((k) => k === "password");
+    expect(passwordExports).toHaveLength(1);
+    expect(typeof configureShared.password).toBe("function");
+  });
+
+  it("routes input through clack's masked password prompt, forwarding params", async () => {
+    mocks.clackPassword.mockClear();
+    // A caller-supplied mask character; clack masks input with it (default •),
+    // so the secret is never rendered in cleartext.
+    const result = await configureShared.password({ message: "Gateway password", mask: "•" });
+
+    // The secret goes through the password prompt, not a cleartext text prompt.
+    expect(mocks.clackPassword).toHaveBeenCalledTimes(1);
+    const args = mocks.clackPassword.mock.calls[0]![0];
+    // The mask character is forwarded untouched.
+    expect(args.mask).toBe("•");
+    // The message survives the wrapper (styled in rich TTY, identity otherwise).
+    expect(args.message).toContain("Gateway password");
+    // The wrapper passes through the underlying prompt result.
+    expect(result).toBe("CAPTURED");
+  });
+});

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -111,9 +111,3 @@ export const select = <T>(params: Parameters<typeof clackSelect<T>>[0]) =>
       opt.hint === undefined ? opt : { ...opt, hint: stylePromptHint(opt.hint) },
     ),
   });
-/** Styled password prompt wrapper. */
-export const password = (params: Parameters<typeof clackPassword>[0]) =>
-  clackPassword({
-    ...params,
-    message: stylePromptMessage(params.message),
-  });


### PR DESCRIPTION
## Summary

`src/commands/configure.shared.ts` currently declares `export const password`
**twice**, which is a build-breaking redeclare on `main`. Two PRs — the gateway
token-masking change and the gateway password-masking change (#90571) — each
added an identical `password` prompt wrapper. After both merged, the same
block-scoped binding is declared twice and TypeScript rejects the module:

```
src/commands/configure.shared.ts(94,14): error TS2451: Cannot redeclare block-scoped variable 'password'.
src/commands/configure.shared.ts(115,14): error TS2451: Cannot redeclare block-scoped variable 'password'.
```

This is a merge collision already present on `main` — `git diff upstream/main`
for this file before my change is empty (the duplicate is upstream, not
introduced by this branch).

## What changed

The two declarations were **byte-for-byte identical** wrappers:

```ts
export const password = (params: Parameters<typeof clackPassword>[0]) =>
  clackPassword({
    ...params,
    message: stylePromptMessage(params.message),
  });
```

Both spread `...params` into `clackPassword` and style `message`, so removing
either copy changes **no runtime behavior**. I keep the earlier-positioned copy,
which carries the more descriptive doc comment
(`Echoes bullets so secrets never appear in cleartext.`) and drop the duplicate.

The single surviving wrapper still forwards every param — including the `mask`
character used by clack to hide input (default `•`) — to the underlying
`clackPassword` prompt, so secrets continue to flow through the **masked
password prompt**, never a cleartext text prompt. The only runtime consumer,
`src/commands/configure.gateway.ts` (`import { confirm, password, select, text }`),
calls a single `password` import, so deduping does not change any call site.

## Real behavior proof

**`node scripts/run-tsgo.mjs` before the fix** (build-breaking redeclare):

```
src/commands/configure.shared.ts(94,14): error TS2451: Cannot redeclare block-scoped variable 'password'.
src/commands/configure.shared.ts(115,14): error TS2451: Cannot redeclare block-scoped variable 'password'.
(exit code 2)
```

**`node scripts/run-tsgo.mjs` after the fix** (clean):

```
(exit code 0)
```

**Real-runtime test** — the added vitest mocks `@clack/prompts`, imports the
real `password` export from `configure.shared`, drives it, and asserts the
wrapper (a) is the single `password` export, (b) forwards the `mask` character,
(c) forwards the styled `message`, and (d) passes through the prompt result:

```
✓ src/commands/configure.shared.password.test.ts (2 tests)
  Test Files  1 passed (1)
       Tests  2 passed (2)
```

**Negative control** — temporarily dropping `...params` from the surviving
wrapper (so `mask` is no longer forwarded) makes the test fail with
`expected undefined to be '•'`, confirming the test actually guards the
secret-mask forwarding rather than passing vacuously. Reverted afterward.

The real consumer suite `configure.gateway.test.ts` continues to pass alongside
the new test (13 tests passed total).

## Tests

- Added `src/commands/configure.shared.password.test.ts` as a regression guard:
  pins a single `password` export and proves the wrapper forwards the secret
  mask + message to the underlying clack password prompt.

## Risk checklist

- **Behavior change:** none — the two removed-vs-kept wrappers were identical.
- **Scope:** one source file (1 dup wrapper removed) + one new test file.
- **API surface:** `password` export signature unchanged; single consumer
  (`configure.gateway.ts`) unaffected.
- **Build:** restores type-checking (`tsgo` 2 errors → 0).
- **Not a product decision:** these were duplicate masking wrappers from two
  merges, not two intentional UI paths.
