### PR TITLE
fix(status): usage follows session model after switch

### DIFF
--- a/src/auto-reply/model-runtime.ts
+++ b/src/auto-reply/model-runtime.ts
@@ -78,12 +78,17 @@ export function resolveSelectedAndActiveModel(params: {
   selectedProvider: string;
   selectedModel: string;
   sessionEntry?: Pick<SessionEntry, "modelProvider" | "model">;
+  parseSelectedProvider?: boolean;
 }): {
   selected: ModelRef;
   active: ModelRef;
   activeDiffers: boolean;
 } {
-  const selected = normalizeModelRef(params.selectedModel, params.selectedProvider);
+  const selected = normalizeModelRef(
+    params.selectedModel,
+    params.selectedProvider,
+    params.parseSelectedProvider,
+  );
   const runtimeModel = normalizeOptionalString(params.sessionEntry?.model);
   const runtimeProvider = normalizeOptionalString(params.sessionEntry?.modelProvider);
 

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1249,6 +1249,155 @@ describe("buildStatusReply subagent summary", () => {
     });
   });
 
+  it("uses active fallback provider usage for legacy fallback notices", async () => {
+    const fallbackModel: ModelDefinitionConfig = {
+      id: "MiniMax-M2.7",
+      name: "MiniMax M2.7",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 32_000,
+    };
+    const selectedModel: ModelDefinitionConfig = {
+      id: "mimo-v2-flash",
+      name: "MiMo V2 Flash",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_048_576,
+      maxTokens: 32_000,
+    };
+    providerUsageMock.loadProviderUsageSummary.mockImplementation(async (options) => ({
+      updatedAt: Date.now(),
+      providers:
+        options?.providers?.includes("minimax") === true
+          ? [
+              {
+                provider: "minimax",
+                displayName: "MiniMax",
+                windows: [{ label: "day", usedPercent: 20 }],
+              },
+            ]
+          : [],
+    }));
+
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        models: {
+          providers: {
+            "minimax-portal": {
+              baseUrl: "https://api.minimax.test/v1",
+              models: [fallbackModel],
+            },
+            xiaomi: {
+              baseUrl: "https://api.xiaomi.test/v1",
+              models: [selectedModel],
+            },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-legacy-fallback-usage",
+        updatedAt: 0,
+        providerOverride: "xiaomi",
+        modelOverride: "mimo-v2-flash",
+        modelProvider: "minimax-portal",
+        model: "MiniMax-M2.7",
+        fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
+        fallbackNoticeReason: "model not allowed",
+        totalTokens: 49_000,
+        totalTokensFresh: true,
+        contextTokens: 1_048_576,
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      provider: "xiaomi",
+      model: "mimo-v2-flash",
+      contextTokens: 1_048_576,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
+    expect(normalized).toContain("Context: 49k/200k");
+    expect(normalized).toContain("Usage: day 80% left");
+    expect(providerUsageMock.loadProviderUsageSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: ["minimax"] }),
+    );
+  });
+
+  it("uses live runtime context for unresolved active fallback notices", async () => {
+    const selectedModel: ModelDefinitionConfig = {
+      id: "mimo-v2-flash",
+      name: "MiMo V2 Flash",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_048_576,
+      maxTokens: 32_000,
+    };
+
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        models: {
+          providers: {
+            xiaomi: {
+              baseUrl: "https://api.xiaomi.test/v1",
+              models: [selectedModel],
+            },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-unresolved-fallback-context",
+        updatedAt: 0,
+        providerOverride: "xiaomi",
+        modelOverride: "mimo-v2-flash",
+        modelProvider: "custom-runtime",
+        model: "unknown-fallback-model",
+        fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
+        fallbackNoticeActiveModel: "custom-runtime/unknown-fallback-model",
+        fallbackNoticeReason: "model not allowed",
+        totalTokens: 49_000,
+        totalTokensFresh: true,
+        contextTokens: 1_048_576,
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "mobilechat",
+      provider: "xiaomi",
+      model: "mimo-v2-flash",
+      contextTokens: 123_456,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "api-key",
+      activeModelAuthOverride: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Fallback: custom-runtime/unknown-fallback-model");
+    expect(normalized).toContain("Context: 49k/123k");
+    expect(normalized).not.toContain("Context: 49k/1.0m");
+  });
+
   it("shows DeepSeek balance summaries in /status output", async () => {
     providerUsageMock.loadProviderUsageSummary.mockResolvedValue({
       updatedAt: Date.now(),
@@ -1295,6 +1444,241 @@ describe("buildStatusReply subagent summary", () => {
       throw new Error("expected provider usage summary call for deepseek");
     }
     expect(providerUsageCall[0]?.providers).toEqual(["deepseek"]);
+  });
+
+  it("uses the session-selected model provider for /status usage", async () => {
+    const usageResetBase = Math.floor(Date.now() / 1000);
+    providerUsageMock.loadProviderUsageSummary.mockImplementation(
+      async ({ providers = [] } = {}) => ({
+        updatedAt: Date.now(),
+        providers: providers.map((provider) =>
+          provider === "openai"
+            ? {
+                provider: "openai",
+                displayName: "OpenAI",
+                windows: [
+                  {
+                    label: "5h",
+                    usedPercent: 9,
+                    resetAt: (usageResetBase + 60 * 60) * 1000,
+                  },
+                ],
+              }
+            : {
+                provider,
+                displayName: "DeepSeek",
+                windows: [],
+                summary: "Balance ¥42.50",
+              },
+        ),
+      }),
+    );
+
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        agents: {
+          defaults: {
+            model: "deepseek/deepseek-v4-flash",
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-session-selected-usage",
+        updatedAt: 0,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "telegram",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 1_000_000,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "oauth (openai:status)",
+      activeModelAuthOverride: "oauth (openai:status)",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: openai/gpt-5.5");
+    expect(normalized).toContain("pinned session; config primary deepseek/deepseek-v4-flash");
+    expect(normalized).toContain("clear /model default");
+    expect(normalized).toContain("Usage: 5h 91% left");
+    expect(normalized).not.toContain("Usage: Balance ¥42.50");
+    expect(providerUsageMock.loadProviderUsageSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: ["openai"] }),
+    );
+  });
+
+  it("uses the session-selected provider for /status usage when runtime state is stale", async () => {
+    const usageResetBase = Math.floor(Date.now() / 1000);
+    providerUsageMock.loadProviderUsageSummary.mockImplementation(
+      async ({ providers = [] } = {}) => ({
+        updatedAt: Date.now(),
+        providers: providers.map((provider) =>
+          provider === "openai"
+            ? {
+                provider: "openai",
+                displayName: "OpenAI",
+                windows: [
+                  {
+                    label: "5h",
+                    usedPercent: 9,
+                    resetAt: (usageResetBase + 60 * 60) * 1000,
+                  },
+                ],
+              }
+            : {
+                provider,
+                displayName: "DeepSeek",
+                windows: [],
+                summary: "Balance ¥42.50",
+              },
+        ),
+      }),
+    );
+
+    const text = await buildStatusText({
+      cfg: {
+        ...baseCfg,
+        agents: {
+          defaults: {
+            model: "deepseek/deepseek-v4-flash",
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "sess-status-stale-runtime-selected-usage",
+        updatedAt: 0,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.5",
+        modelOverrideSource: "user",
+        modelProvider: "deepseek",
+        model: "deepseek-v4-flash",
+      },
+      sessionKey: "agent:main:main",
+      parentSessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      statusChannel: "telegram",
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+      contextTokens: 1_000_000,
+      resolvedFastMode: false,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      modelAuthOverride: "oauth (openai:status)",
+      activeModelAuthOverride: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: openai/gpt-5.5");
+    expect(normalized).toContain("pinned session; config primary deepseek/deepseek-v4-flash");
+    expect(normalized).toContain("clear /model default");
+    expect(normalized).toContain("Usage: 5h 91% left");
+    expect(normalized).not.toContain("Usage: Balance ¥42.50");
+    expect(providerUsageMock.loadProviderUsageSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: ["openai"] }),
+    );
+  });
+
+  it("uses provider-qualified model overrides for /status usage lookup", async () => {
+    await withTempHome(
+      async (dir) => {
+        saveStatusTestAuthProfile({ dir, profileId: "openai:status", provider: "openai" });
+
+        const usageResetBase = Math.floor(Date.now() / 1000);
+        providerUsageMock.loadProviderUsageSummary.mockImplementation(
+          async ({ providers = [] } = {}) => ({
+            updatedAt: Date.now(),
+            providers: providers.map((provider) =>
+              provider === "openai"
+                ? {
+                    provider: "openai",
+                    displayName: "OpenAI",
+                    windows: [
+                      {
+                        label: "5h",
+                        usedPercent: 9,
+                        resetAt: (usageResetBase + 60 * 60) * 1000,
+                      },
+                    ],
+                  }
+                : {
+                    provider,
+                    displayName: "DeepSeek",
+                    windows: [],
+                    summary: "Balance ¥42.50",
+                  },
+            ),
+          }),
+        );
+
+        const text = await buildStatusText({
+          cfg: {
+            ...baseCfg,
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://chatgpt.com/backend-api/codex",
+                  models: [{ ...codexStatusModel, contextWindow: 258_000, contextTokens: 258_000 }],
+                },
+              },
+            },
+            agents: {
+              defaults: {
+                model: "deepseek/deepseek-v4-flash",
+              },
+            },
+            auth: {
+              order: {
+                openai: ["openai:status"],
+              },
+            },
+          },
+          sessionEntry: {
+            sessionId: "sess-status-qualified-session-selected-usage",
+            updatedAt: 0,
+            modelOverride: "openai/gpt-5.5",
+          },
+          sessionKey: "agent:main:main",
+          parentSessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          statusChannel: "telegram",
+          provider: "deepseek",
+          model: "deepseek-v4-flash",
+          contextTokens: 1_000_000,
+          resolvedFastMode: false,
+          resolvedVerboseLevel: "off",
+          resolvedReasoningLevel: "off",
+          resolveDefaultThinkingLevel: async () => undefined,
+          isGroup: false,
+          defaultGroupActivation: () => "mention",
+        });
+
+        const normalized = normalizeTestText(text);
+        expect(normalized).toContain("Model: openai/gpt-5.5");
+        expect(normalized).toContain("pinned session; config primary deepseek/deepseek-v4-flash");
+        expect(normalized).toContain("clear /model default");
+        expect(normalized).toContain("oauth (openai:status)");
+        expect(normalized).toContain("Context: ?/258k");
+        expect(normalized).toContain("Usage: 5h 91% left");
+        expect(normalized).not.toContain("Usage: Balance ¥42.50");
+        expect(providerUsageMock.loadProviderUsageSummary).toHaveBeenCalledWith(
+          expect.objectContaining({ providers: ["openai"] }),
+        );
+      },
+      { env: { OPENAI_API_KEY: undefined } },
+    );
   });
 
   it("uses Codex OAuth auth labels for explicit OpenAI OpenClaw auth order", async () => {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -593,11 +593,17 @@ export function buildStatusMessage(args: StatusArgs): string {
   });
   const selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
   const selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  const parseSelectedProvider = Boolean(
+    entry?.modelOverride?.trim() && !entry?.providerOverride?.trim(),
+  );
   const modelRefs = resolveSelectedAndActiveModel({
     selectedProvider,
     selectedModel,
     sessionEntry: entry,
+    parseSelectedProvider,
   });
+  const selectedLookupProvider = modelRefs.selected.provider || selectedProvider;
+  const selectedLookupModel = modelRefs.selected.model || selectedModel;
   const initialFallbackState = resolveActiveFallbackState({
     selectedModelRef: modelRefs.selected.label || "unknown",
     activeModelRef: modelRefs.active.label || "unknown",
@@ -718,8 +724,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   const runtimeDiffersFromSelected = activeModelLabel !== (modelRefs.selected.label || "unknown");
   const selectedContextTokens = resolveContextTokensForModel({
     cfg: contextConfig,
-    provider: selectedProvider,
-    model: selectedModel,
+    provider: selectedLookupProvider,
+    model: selectedLookupModel,
     allowAsyncLoad: false,
   });
   const explicitRuntimeContextTokens =
@@ -740,8 +746,8 @@ export function buildStatusMessage(args: StatusArgs): string {
   const channelModelNote = resolveChannelModelNote({
     config: args.config,
     entry,
-    selectedProvider,
-    selectedModel,
+    selectedProvider: selectedLookupProvider,
+    selectedModel: selectedLookupModel,
     parentSessionKey: args.parentSessionKey,
   });
   const persistedContextTokens =
@@ -1007,7 +1013,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     { config: args.config },
   );
   const selectedAuthMode =
-    normalizeAuthMode(args.modelAuth) ?? resolveModelAuthMode(selectedProvider, args.config);
+    normalizeAuthMode(args.modelAuth) ?? resolveModelAuthMode(selectedLookupProvider, args.config);
   const rawSelectedAuthLabelValue =
     selectedAuthMode && selectedAuthMode !== "unknown"
       ? (args.modelAuth ?? selectedAuthMode)

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -441,16 +441,16 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     // labels differ; prefer the active auth label so status matches execution.
     selectedModelAuth = activeModelAuth;
   }
-  const usageShouldFollowActiveRuntime =
+  const activeRuntimeIsAuthoritative =
     !modelRefs.activeDiffers ||
     fallbackState.active ||
     hasSessionAutoModelFallbackProvenance(sessionEntry) ||
     runtimeAliasModelEquivalent;
-  const usageAuthLabel = usageShouldFollowActiveRuntime ? activeModelAuth : selectedModelAuth;
-  const usageStatusProvider = usageShouldFollowActiveRuntime
+  const usageAuthLabel = activeRuntimeIsAuthoritative ? activeModelAuth : selectedModelAuth;
+  const usageStatusProvider = activeRuntimeIsAuthoritative
     ? activeStatusProvider
     : selectedStatusProvider;
-  const usageProvider = usageShouldFollowActiveRuntime ? activeProvider : selectedLookupProvider;
+  const usageProvider = activeRuntimeIsAuthoritative ? activeProvider : selectedLookupProvider;
   const selectedUsageCredentialType = resolveUsageCredentialType(usageAuthLabel);
   const useCodexSyntheticUsage =
     shouldUseCodexSyntheticUsage({
@@ -616,22 +616,15 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     provider: selectedStatusProvider,
     model: modelRefs.selected.model || selectedLookupModel,
   });
-  const runtimeSnapshotHasFallbackProvenance =
-    !modelRefs.activeDiffers ||
-    fallbackState.active ||
-    hasSessionAutoModelFallbackProvenance(sessionEntry) ||
-    areRuntimeModelRefsEquivalent(modelRefs.active.label, modelRefs.selected.label, {
-      config: cfg,
-    });
   const statusAgentContextTokens =
     typeof contextTokens === "number" &&
     contextTokens > 0 &&
-    (runtimeSnapshotHasFallbackProvenance ||
+    (activeRuntimeIsAuthoritative ||
       contextTokens === configuredContextTokens ||
       contextTokens === selectedContextTokens)
       ? contextTokens
       : undefined;
-  const statusRuntimeContextTokens = runtimeSnapshotHasFallbackProvenance
+  const statusRuntimeContextTokens = activeRuntimeIsAuthoritative
     ? (runtimeContextTokens ??
       (fallbackState.active && typeof contextTokens === "number" && contextTokens > 0
         ? contextTokens

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -49,6 +49,7 @@ import {
   formatTaskStatusDetail,
   formatTaskStatusTitle,
 } from "../tasks/task-status.js";
+import { resolveActiveFallbackState } from "./fallback-notice-state.js";
 import { formatCompactPluginHealthLine } from "./status-plugin-health.js";
 import type { BuildStatusTextParams } from "./status-text.types.js";
 
@@ -352,27 +353,35 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     params.workspaceDir ??
     sessionEntry?.spawnedWorkspaceDir ??
     resolveAgentWorkspaceDir(cfg, statusAgentId);
+  const selectedProvider = sessionEntry?.providerOverride?.trim() ?? provider;
+  const selectedModel = sessionEntry?.modelOverride?.trim() ?? model;
+  const parseSelectedProvider = Boolean(
+    sessionEntry?.modelOverride?.trim() && !sessionEntry?.providerOverride?.trim(),
+  );
   const modelRefs = resolveSelectedAndActiveModel({
-    selectedProvider: provider,
-    selectedModel: model,
+    selectedProvider,
+    selectedModel,
     sessionEntry,
+    parseSelectedProvider,
   });
+  const selectedLookupProvider = modelRefs.selected.provider || selectedProvider || provider;
+  const selectedLookupModel = modelRefs.selected.model || selectedModel || model;
   const effectiveHarness =
     params.resolvedHarness ??
     (await resolveStatusHarnessId({
       cfg,
-      provider,
-      model,
+      provider: selectedLookupProvider,
+      model: selectedLookupModel,
       agentId: statusAgentId,
       sessionKey,
       sessionEntry,
     }));
   const selectedStatusProvider = resolveStatusRuntimeProvider({
-    provider,
+    provider: selectedLookupProvider,
     effectiveHarness,
   });
   const selectedAuthProviders = listOpenAIAuthProfileProvidersForAgentRuntime({
-    provider,
+    provider: selectedLookupProvider,
     harnessRuntime: effectiveHarness,
     config: cfg,
   });
@@ -415,6 +424,12 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     modelRefs.active.label,
     { config: cfg },
   );
+  const fallbackState = resolveActiveFallbackState({
+    selectedModelRef: modelRefs.selected.label || "unknown",
+    activeModelRef: modelRefs.active.label || "unknown",
+    config: cfg,
+    state: sessionEntry,
+  });
   if (
     shouldPreferActiveRuntimeAliasAuthLabel({
       runtimeAliasModelEquivalent,
@@ -426,11 +441,20 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     // labels differ; prefer the active auth label so status matches execution.
     selectedModelAuth = activeModelAuth;
   }
-  const usageAuthLabel = modelRefs.activeDiffers ? activeModelAuth : selectedModelAuth;
+  const usageShouldFollowActiveRuntime =
+    !modelRefs.activeDiffers ||
+    fallbackState.active ||
+    hasSessionAutoModelFallbackProvenance(sessionEntry) ||
+    runtimeAliasModelEquivalent;
+  const usageAuthLabel = usageShouldFollowActiveRuntime ? activeModelAuth : selectedModelAuth;
+  const usageStatusProvider = usageShouldFollowActiveRuntime
+    ? activeStatusProvider
+    : selectedStatusProvider;
+  const usageProvider = usageShouldFollowActiveRuntime ? activeProvider : selectedLookupProvider;
   const selectedUsageCredentialType = resolveUsageCredentialType(usageAuthLabel);
   const useCodexSyntheticUsage =
     shouldUseCodexSyntheticUsage({
-      provider: activeStatusProvider,
+      provider: usageStatusProvider,
       effectiveHarness,
     }) &&
     (selectedUsageCredentialType === "oauth" || selectedUsageCredentialType === "token");
@@ -443,8 +467,8 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     : undefined;
   const usageCredentialType = useCodexSyntheticUsage ? "token" : selectedUsageCredentialType;
   const currentUsageProvider =
-    resolveUsageProviderId(activeStatusProvider, { credentialType: usageCredentialType }) ??
-    resolveUsageProviderId(activeProvider, { credentialType: usageCredentialType });
+    resolveUsageProviderId(usageStatusProvider, { credentialType: usageCredentialType }) ??
+    resolveUsageProviderId(usageProvider, { credentialType: usageCredentialType });
   let usageLine: string | null = null;
   if (
     currentUsageProvider &&
@@ -590,10 +614,11 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
   const selectedContextTokens = resolveStatusRuntimeContextTokens({
     cfg,
     provider: selectedStatusProvider,
-    model,
+    model: modelRefs.selected.model || selectedLookupModel,
   });
   const runtimeSnapshotHasFallbackProvenance =
     !modelRefs.activeDiffers ||
+    fallbackState.active ||
     hasSessionAutoModelFallbackProvenance(sessionEntry) ||
     areRuntimeModelRefsEquivalent(modelRefs.active.label, modelRefs.selected.label, {
       config: cfg,
@@ -607,7 +632,10 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
       ? contextTokens
       : undefined;
   const statusRuntimeContextTokens = runtimeSnapshotHasFallbackProvenance
-    ? runtimeContextTokens
+    ? (runtimeContextTokens ??
+      (fallbackState.active && typeof contextTokens === "number" && contextTokens > 0
+        ? contextTokens
+        : undefined))
     : undefined;
   return buildStatusMessage({
     config: cfg,


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Fixes an issue where a session pinned with `/model openai/gpt-5.5` could show OpenAI as the selected model while `/status` still resolved usage, auth, harness, and context metadata through the configured default DeepSeek provider. It also fixes the stale-runtime path where persisted runtime state can still reference DeepSeek after a manual session model switch; usage now follows the selected session model unless the active runtime is authoritative through explicit automatic model handoff provenance, an existing active fallback notice, or an equivalent runtime alias. Active fallback notices now also keep the live runtime context window when the fallback model is not resolvable from config, instead of falling back to a stale selected-model context window. The root cause was that status lookup treated the configured or stale active provider/model as the source for provider-specific metadata after the session had a selected-model override; this PR moves the resolver boundary to the selected session model and explicit runtime provenance instead of patching the rendered status text downstream.

Why does this matter now?

This PR was already carrying the selected-model status routing fix, and the first blocker was introduced by this PR's new regression fixture: the OpenAI provider config used by the provider-qualified override test omitted the required `ModelProviderConfig.baseUrl`. After that was fixed, ClawSweeper identified one remaining author-side gap: `/status` usage could still query the stale active runtime provider when `sessionEntry.modelProvider/model` lagged behind a user-pinned session model.

What is the intended outcome?

Root-cause fix. `/status` should keep the configured default visible for new or unpinned sessions, but provider-specific lookup for a pinned session should use the selected provider/model. If active runtime differs because of a real automatic model handoff, an existing active runtime-handoff notice, or an equivalent runtime alias, status can still use active-runtime usage/auth and context metadata. If active runtime differs only because stored runtime state is stale after a manual switch, usage follows the selected session provider. When an active runtime-handoff notice points at a runtime model that is not in config, `/status` now trusts the live runtime context snapshot instead of a stale selected-model context window. The typecheck blocker is fixed at the canonical fixture boundary by giving the new OpenAI provider fixture the same required `baseUrl` shape used by the existing OpenAI/Codex provider config, not by weakening types or changing runtime behavior.

What is intentionally out of scope?

Out of scope: changing model selection semantics, provider credentials, config defaults, migrations, automatic runtime handoff behavior, external usage APIs, schema shape, or compatibility defaults. This update does not add a new public contract; it keeps the existing public contract surface for session overrides and model provider config intact.

What does success look like?

A pinned direct session can run `/model openai/gpt-5.5` and then `/status`; the status card shows `Configured default: deepseek/deepseek-v4-flash`, `Session selected: openai/gpt-5.5`, OpenAI context metadata, and no DeepSeek balance text. A stale runtime snapshot with selected OpenAI and active DeepSeek also loads usage for `openai`, not `deepseek`. An unresolved active fallback notice with live `contextTokens: 123456` and stale persisted selected-window `contextTokens: 1048576` renders `Context: 49k/123k`, not `Context: 49k/1.0m`. `pnpm check:test-types` passes on the current head.

What should reviewers focus on?

Review the source-of-truth boundary: selected session model resolution should happen before status usage/auth/context lookup, not as a renderer-only post-process. Also review the stale-runtime distinction: active-runtime usage and context metadata are preserved for explicit automatic handoff provenance, active fallback notices, or equivalent runtime aliases, while manual selected-model overrides are not overwritten by stale `sessionEntry.modelProvider/model` state. The only config fixture correction is the required `baseUrl` on the OpenAI test provider. Related #93829 also touches status model/provider resolution; this update keeps #93384 scoped to the existing #93322 selected-session status routing path and does not broaden the resolver contract.

## Linked context

Which issue does this close?

Closes #93322

Which issues, PRs, or discussions are related?

Related #93384

Related #93829 (overlapping open PR noted; this PR stays scoped to #93322's selected-session status routing fix and avoids broad resolver-contract changes).

Was this requested by a maintainer or owner?

ClawSweeper flagged the status routing risk, stale-runtime usage gap, CI/typecheck state, and optional visible `/model` then `/status` proof; this update addresses those author-side items.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `/status` now keeps the configured default line on DeepSeek while resolving the session-selected model, context metadata, and usage/provider decision from OpenAI after a session is pinned to `openai/gpt-5.5`.
- Real environment tested: Existing before-fix Telegram direct session evidence from #93322 on `OpenClaw 2026.6.6`; retained after-fix Node status-renderer proof against the patched source; and current-head after-fix qa-channel proof using qa-channel + qa-lab bus + real OpenClaw gateway child + mock-openai provider with configured default `deepseek/deepseek-v4-flash` and session selection `openai/gpt-5.5`.
- Exact steps or command run after this patch: Retained renderer proof: `OPENAI_API_KEY= DEEPSEEK_API_KEY= node --import tsx --input-type=module <status-renderer proof script>`. Current channel proof: `daily_fix run-validation --name qa-channel-model-status-proof-round2 -- pnpm exec tsx <qa-channel-model-status-proof.ts>`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  Evidence after fix (qa-channel-model-status-proof):
  - Started qa-channel + qa-lab bus + real gateway child + mock-openai provider.
  - Injected /model openai/gpt-5.5, then /status in the same direct conversation.
  - /model ack: Model set to openai/gpt-5.5 for this session.
  - /status excerpt:
    🧠 Configured default: deepseek/deepseek-v4-flash
    📌 Session selected: openai/gpt-5.5 · 🔑 api-key (models.json)
    📚 Context: ?/258k · 🧹 Compactions: 0
  - Verified /status did not include DeepSeek balance text.
  ```

  Retained renderer proof excerpt from the existing PR body:

  ```text
  🦞 OpenClaw 2026.6.2 (da92615)
  ⏱️ Uptime: gateway 50s · system 9h 37m
  🧠 Configured default: deepseek/deepseek-v4-flash
  📌 Session selected: openai/gpt-5.5
  ⚠️ Reason: session override
  ⚠️ This session is pinned to openai/gpt-5.5; config primary deepseek/deepseek-v4-flash will apply to new/unpinned sessions.
  ↩️ Clear with: /model default
  📚 Context: ?/258k · 🧹 Compactions: 0
  🧵 Session: agent:main:main • updated just now
  ⚙️ Execution: direct · Runtime: OpenClaw Default · Think: off · Fast: off · Text: low · elevated
  🪢 Queue: steer (depth 0)

  CHECKS
  selectedOpenAI=true
  configuredDeepSeek=true
  deepSeekBalanceShown=false
  openAIContextShown=true
  ```

- Observed result after fix: current-head after-fix proof shows `Session selected: openai/gpt-5.5`, keeps `Configured default: deepseek/deepseek-v4-flash`, resolves OpenAI context metadata as `/258k`, and verifies DeepSeek balance text is not shown for the OpenAI-selected session.
- What was not tested: after-fix proof was not rerun in native Telegram Desktop; the original Telegram direct session report remains the before-fix evidence, and the current qa-channel run exercises the channel plugin boundary with a deterministic transcript and real gateway child.
- Proof limitations or environment constraints: the new provider is `mock-openai`, so it proves routing and visible status selection without spending live provider quota. The retained renderer proof intentionally avoids a live external OpenAI balance request; regression tests separately assert the provider usage loader receives `openai` rather than `deepseek`, including when runtime state is stale.
- Before evidence (optional but encouraged):

  ```text
  OpenClaw 2026.6.6 (8c802aa)
  Channel: Telegram direct session
  Session: agent:main:main
  Session selected model: openai/gpt-5.5
  Configured default model: deepseek/deepseek-v4-flash

  🧠 Model: openai/gpt-5.5 · 🔑 api-key (models.json) (default: deepseek/deepseek-v4-flash)
  📊 Usage: Balance ¥22.75
  ```

  That `Balance ¥22.75` was the DeepSeek provider balance while the same status card showed the session model as OpenAI.

## Tests and validation

Which commands did you run?

- `daily_fix run-validation --name status-requested-focused-run-vitest -- node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts -t "uses the session-selected model provider for /status usage"` — passed; 1 test passed.
- `daily_fix run-validation --name status-requested-run-vitest-suite -- node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts src/agents/openclaw-tools.session-status.test.ts` — passed; 2 Vitest shards passed, 93 tests passed.
- `daily_fix run-validation --name check-test-types-round2 -- pnpm check:test-types` — passed.
- `daily_fix run-validation --name qa-channel-model-status-proof-round2 -- pnpm exec tsx <qa-channel-model-status-proof.ts>` — passed; drives `/model openai/gpt-5.5` then `/status` through qa-channel and a real gateway child.
- `daily_fix run-validation --name ci-boundary-no-extension-test-core-imports -- pnpm run lint:plugins:no-extension-test-core-imports` — passed after syncing current main; confirms the prior Feishu extension boundary blocker is no longer present on the updated branch.
- `daily_fix run-validation --name ci-core-support-boundary-isolated-tmp -- env TMPDIR=<isolated task temp> NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.full-core-support-boundary.config.ts` — passed; 12 test files and 97 tests passed.
- `daily_fix run-validation --name ci-core-tooling-test-projects -- env NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts src/scripts/test-projects.test.ts --reporter=verbose` — passed; 83 tests passed.
- `daily_fix run-validation --name focused-status-regression -- env NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/reply/commands-status.test.ts --reporter=verbose` — passed; 33 status regression tests passed, including selected-provider and stale-runtime cases.
- `daily_fix run-validation --name ci-core-tooling-cross-os-release-checks -- env NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/openclaw-cross-os-release-checks.test.ts --reporter=verbose` — passed; 95 process-cleanup and cross-OS release-check tests passed.
- `daily_fix run-validation --name legacy-fallback-usage-green-typesafe -- env NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/reply/commands-status.test.ts -t "uses active fallback provider usage for legacy fallback notices" --reporter=verbose` — passed; the legacy runtime-handoff notice case now keeps `Fallback: minimax-portal/MiniMax-M2.7`, uses the active MiniMax context window, and loads usage through `minimax`.
- `daily_fix run-validation --name check-test-types-after-fallback-fix -- pnpm check:test-types` — passed after the legacy fallback-notice usage guard was added.
- `daily_fix run-validation --name focused-status-regression-after-fallback-fix-typesafe -- env NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/reply/commands-status.test.ts --reporter=verbose` — passed; 34 status regression tests passed, including selected-provider, stale-runtime, and legacy fallback-notice usage routing cases.
- `daily_fix run-validation --name focused-status-regression-after-sync -- env NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 pnpm exec node scripts/test-projects.mjs src/auto-reply/reply/commands-status.test.ts -- --reporter=verbose` — passed after syncing current main; 1 auto-reply Vitest shard passed, 34 status regression tests passed.
- `daily_fix run-validation --name fallback-context-status-regression -- bash -lc 'OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts && OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/status/status-text.test.ts src/status/status-message.test.ts src/auto-reply/status.test.ts'` — passed; 35 status command tests, 2 status-text tests, 5 status-message tests, and 84 auto-reply status tests passed.

What regression coverage was added or updated?

Regression coverage was added in `commands-status.test.ts` for selected-provider usage/auth/context lookup so `/status` does not keep querying DeepSeek after the session is pinned to OpenAI. The scenarios lock in separate `providerOverride: "openai"` + `modelOverride: "gpt-5.5"`, provider-qualified `modelOverride: "openai/gpt-5.5"`, stale-runtime state where the selected session provider is OpenAI but `sessionEntry.modelProvider/model` still points at DeepSeek, legacy active fallback usage routing, and unresolved active fallback context routing where the live runtime window must win over a stale persisted selected-model window.

What failed before this fix, if known?

The PR-introduced typecheck blocker failed because the new OpenAI provider fixture did not satisfy the `ModelProviderConfig` contract: `baseUrl` is required. The original behavior regression was that a selected OpenAI session could still show DeepSeek usage/balance data in `/status`. The stale-runtime regression test also failed before the latest status routing fix because `/status` still rendered `Usage: Balance ¥42.50` and queried `deepseek` when the selected session model was `openai/gpt-5.5`. The unresolved active fallback regression failed before the final context fix because `/status` rendered `Context: 49k/1.0m` from stale persisted selected-model state instead of the live runtime `Context: 49k/123k` snapshot.

If no test was added, why not?

Not applicable. Focused regression tests were added, and the smallest reliable guardrail is the status command test because it reaches the resolver, usage/auth/context lookup, and rendered status output without broadening provider or config behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. `/status` now reports and looks up session-selected model details for pinned sessions while still showing the configured default for unpinned/new-session context.

Did config, environment, or migration behavior change? (`Yes/No`)

No. The public config/default/compatibility contract is unchanged; the test fixture now includes the required OpenAI `baseUrl`, and no migration, default, or backward-compatibility behavior changed.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, narrowly in status lookup routing: auth and usage labels are resolved against the selected provider for a pinned session unless active runtime is authoritative through automatic handoff provenance or equivalent runtime alias. This does not add credentials, secrets, migrations, tools, or new network surfaces.

What is the highest-risk area?

Pinned-session status could query or display the wrong provider if selected/default/active model references are resolved incorrectly. The contract surface is provider routing for status metadata, not model execution or stored config schema.

How is that risk mitigated?

The root-cause boundary is covered by focused regression tests for both override shapes, stale runtime state, active fallback usage routing, and unresolved active fallback context routing. The retained renderer proof shows the selected OpenAI status output, and the current-head qa-channel proof shows the visible `/model` then `/status` transcript using the selected OpenAI model while the configured DeepSeek default remains visible. Patch quality warnings are addressed by keeping the diff scoped to resolver/status lookup and the required test fixture config, rather than adding downstream guards, compatibility branches, or renderer string filtering.

## Current review state

What is the next action?

High confidence: ready for maintainer review after the updated branch and PR body are submitted.

What is still waiting on author, maintainer, CI, or external proof?

Author-side typecheck, stale-runtime usage, legacy runtime-handoff usage, unresolved fallback runtime context, ClawSweeper review, and proof items are addressed locally. The current-head CI failures investigated here are in unrelated test-infrastructure shards, not in the status files changed by this PR; remote checks need to rerun and settle on the updated branch. The native Telegram Desktop proof remains external-environment limited; the deterministic qa-channel proof and status regression suite cover the fixed `/model` then `/status` behavior.

Which bot or reviewer comments were addressed?

- RF-001: current-head CI was investigated. The failing jobs point at unrelated test infrastructure paths (`cli-runner.spawn.test.ts`, `test-projects.test.ts`, `bench-gateway-restart.test.ts`, and `resolve-openclaw-ref.test.ts`), while the synced status regression suite passed on this branch.
- RF-002: disclosed the overlap with #93829 in the reviewer-focus section so maintainers can choose one canonical resolver path.
- RF-003: `/status` no longer shows or queries stale DeepSeek usage when a user-selected session retains old runtime model fields; the regression asserts `providers: ["openai"]` and rejects `Usage: Balance ¥42.50`.
- RF-004: disclosed the overlapping open fix candidate risk and kept this PR scoped to the existing status routing implementation rather than creating or bypassing a competing canonical path.
- RF-005: kept the repair narrow: one status usage-provider selection change plus a focused stale-runtime regression, without deciding new product direction.
- RF-006: `src/status/status-text.ts` now uses selected usage when runtime state is stale, while preserving active-provider usage for automatic handoff provenance, existing active runtime-handoff notices, and equivalent runtime aliases.
- ClawSweeper runtime-handoff usage finding: added a focused legacy notice regression and routed `/status` usage through the active provider when the stored notice still matches the selected and active model refs. This is a root-cause source-of-truth boundary fix: it reuses the existing active runtime-handoff state to distinguish intentional active runtime from stale manual override state, instead of masking rendered text or adding a new compatibility fallback.
- ClawSweeper fallback context finding: added an unresolved active fallback regression and now passes the live runtime context snapshot through when an active fallback notice is present but the fallback model cannot be resolved from config, so `/status` shows `Context: 49k/123k` instead of stale `Context: 49k/1.0m`.
- RF-007: ran `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts -t "uses the session-selected model provider for /status usage"`; passed.
- RF-008: ran `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts`; covered by the requested status suite command and passed.
- RF-009: ran `node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts src/agents/openclaw-tools.session-status.test.ts`; passed.
- Local commit review: `daily_fix clawsweeper-commit-review` passed on the submitted head.
