### PR TITLE
fix(google): use stable Gemini image model

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -182,7 +182,7 @@ Notes:
   ```bash
   openclaw infer image providers --json
   openclaw infer image generate \
-    --model google/gemini-3.1-flash-image-preview \
+    --model google/gemini-3.1-flash-image \
     --prompt "Minimal flat test image: one blue square on a white background, no text." \
     --output ./openclaw-infer-image-smoke.png \
     --json

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -371,7 +371,7 @@ Time format in system prompt. Default: `auto` (OS preference).
       },
       imageGenerationModel: {
         primary: "openai/gpt-image-2",
-        fallbacks: ["google/gemini-3.1-flash-image-preview"],
+        fallbacks: ["google/gemini-3.1-flash-image"],
       },
       videoGenerationModel: {
         primary: "qwen/wan2.6-t2v",
@@ -408,7 +408,7 @@ Time format in system prompt. Default: `auto` (OS preference).
   - Prefer explicit `provider/model` refs. Bare IDs are accepted for compatibility; if a bare ID uniquely matches a configured image-capable entry in `models.providers.*.models`, OpenClaw qualifies it to that provider. Ambiguous configured matches require an explicit provider prefix.
 - `imageGenerationModel`: accepts either a string (`"provider/model"`) or an object (`{ primary, fallbacks }`).
   - Used by the shared image-generation capability and any future tool/plugin surface that generates images.
-  - Typical values: `google/gemini-3.1-flash-image-preview` for native Gemini image generation, `fal/fal-ai/flux/dev` for fal, `openai/gpt-image-2` for OpenAI Images, or `openai/gpt-image-1.5` for transparent-background OpenAI PNG/WebP output.
+  - Typical values: `google/gemini-3.1-flash-image` for native Gemini image generation, `fal/fal-ai/flux/dev` for fal, `openai/gpt-image-2` for OpenAI Images, or `openai/gpt-image-1.5` for transparent-background OpenAI PNG/WebP output.
   - If you select a provider/model directly, configure matching provider auth too (for example `GEMINI_API_KEY` or `GOOGLE_API_KEY` for `google/*`, `OPENAI_API_KEY` or OpenAI Codex OAuth for `openai/gpt-image-2` / `openai/gpt-image-1.5`, `FAL_KEY` for `fal/*`).
   - If omitted, `image_generate` can still infer an auth-backed provider default. It tries the current default provider first, then the remaining registered image-generation providers in provider-id order.
 - `musicGenerationModel`: accepts either a string (`"provider/model"`) or an object (`{ primary, fallbacks }`).

--- a/docs/help/testing-live.md
+++ b/docs/help/testing-live.md
@@ -518,7 +518,7 @@ Docker runners below with an explicit `OPENCLAW_PROFILE_FILE`.
 - Optional narrowing:
   - `OPENCLAW_LIVE_IMAGE_GENERATION_PROVIDERS="openai,google,openrouter,xai"`
   - `OPENCLAW_LIVE_IMAGE_GENERATION_PROVIDERS="deepinfra"`
-  - `OPENCLAW_LIVE_IMAGE_GENERATION_MODELS="openai/gpt-image-2,google/gemini-3.1-flash-image-preview,openrouter/google/gemini-3.1-flash-image-preview,xai/grok-imagine-image"`
+  - `OPENCLAW_LIVE_IMAGE_GENERATION_MODELS="openai/gpt-image-2,google/gemini-3.1-flash-image,openrouter/google/gemini-3.1-flash-image,xai/grok-imagine-image"`
   - `OPENCLAW_LIVE_IMAGE_GENERATION_CASES="google:flash-generate,google:pro-edit,openrouter:generate,xai:default-generate,xai:default-edit"`
 - Optional auth behavior:
   - `OPENCLAW_LIVE_REQUIRE_PROFILE_KEYS=1` to force profile-store auth and ignore env-only overrides
@@ -530,7 +530,7 @@ test passes:
 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_INFER_CLI_TEST=1 pnpm test:live -- test/image-generation.infer-cli.live.test.ts
 openclaw infer image providers --json
 openclaw infer image generate \
-  --model google/gemini-3.1-flash-image-preview \
+  --model google/gemini-3.1-flash-image \
   --prompt "Minimal flat test image: one blue square on a white background, no text." \
   --output ./openclaw-infer-image-smoke.png \
   --json

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -197,9 +197,10 @@ instead of sending it.
 ## Image generation
 
 The bundled `google` image-generation provider defaults to
-`google/gemini-3.1-flash-image-preview`.
+`google/gemini-3.1-flash-image`.
 
-- Also supports `google/gemini-3-pro-image-preview`
+- Also supports `google/gemini-3.1-flash-image`
+- Also supports `google/gemini-3-pro-image`
 - Generate: up to 4 images per request
 - Edit mode: enabled, up to 5 input images
 - Geometry controls: `size`, `aspectRatio`, and `resolution`
@@ -211,7 +212,7 @@ To use Google as the default image provider:
   agents: {
     defaults: {
       imageGenerationModel: {
-        primary: "google/gemini-3.1-flash-image-preview",
+        primary: "google/gemini-3.1-flash-image",
       },
     },
   },

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -105,7 +105,7 @@ under `agents.defaults.imageGenerationModel`:
   agents: {
     defaults: {
       imageGenerationModel: {
-        primary: "openrouter/google/gemini-3.1-flash-image-preview",
+        primary: "openrouter/google/gemini-3.1-flash-image",
         timeoutMs: 180_000,
       },
     },

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -73,17 +73,17 @@ internal image endpoints remain blocked by default.
 
 ## Common routes
 
-| Goal                                                 | Model ref                                          | Auth                                   |
-| ---------------------------------------------------- | -------------------------------------------------- | -------------------------------------- |
-| OpenAI image generation with API billing             | `openai/gpt-image-2`                               | `OPENAI_API_KEY`                       |
-| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                               | OpenAI ChatGPT/Codex OAuth             |
-| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                             | `OPENAI_API_KEY` or OpenAI Codex OAuth |
-| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell`       | `DEEPINFRA_API_KEY`                    |
-| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`                 | `FAL_KEY`                              |
-| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image-preview` | `OPENROUTER_API_KEY`                   |
-| LiteLLM image generation                             | `litellm/gpt-image-2`                              | `LITELLM_API_KEY`                      |
-| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`              | `AZURE_OPENAI_API_KEY` or Entra ID     |
-| Google Gemini image generation                       | `google/gemini-3.1-flash-image-preview`            | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
+| Goal                                                 | Model ref                                    | Auth                                   |
+| ---------------------------------------------------- | -------------------------------------------- | -------------------------------------- |
+| OpenAI image generation with API billing             | `openai/gpt-image-2`                         | `OPENAI_API_KEY`                       |
+| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                         | OpenAI ChatGPT/Codex OAuth             |
+| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                       | `OPENAI_API_KEY` or OpenAI Codex OAuth |
+| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell` | `DEEPINFRA_API_KEY`                    |
+| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`           | `FAL_KEY`                              |
+| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image`   | `OPENROUTER_API_KEY`                   |
+| LiteLLM image generation                             | `litellm/gpt-image-2`                        | `LITELLM_API_KEY`                      |
+| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`        | `AZURE_OPENAI_API_KEY` or Entra ID     |
+| Google Gemini image generation                       | `google/gemini-3.1-flash-image`              | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
 
 The same tool handles text-to-image and reference-image editing. Use `image`
 for one reference or `images` for multiple. For Krea 2 models on fal, those
@@ -96,19 +96,19 @@ backend emits it.
 
 ## Supported providers
 
-| Provider          | Default model                           | Edit support                       | Auth                                                  |
-| ----------------- | --------------------------------------- | ---------------------------------- | ----------------------------------------------------- |
-| ComfyUI           | `workflow`                              | Yes (1 image, workflow-configured) | `COMFY_API_KEY` or `COMFY_CLOUD_API_KEY` for cloud    |
-| DeepInfra         | `black-forest-labs/FLUX-1-schnell`      | Yes (1 image)                      | `DEEPINFRA_API_KEY`                                   |
-| fal               | `fal-ai/flux/dev`                       | Yes (model-specific limits)        | `FAL_KEY`                                             |
-| Google            | `gemini-3.1-flash-image-preview`        | Yes (up to 5 images)               | `GEMINI_API_KEY` or `GOOGLE_API_KEY`                  |
-| LiteLLM           | `gpt-image-2`                           | Yes (up to 5 input images)         | `LITELLM_API_KEY`                                     |
-| Microsoft Foundry | `<deployment-name>`                     | Yes (MAI-Image-2.5 models only)    | `AZURE_OPENAI_API_KEY` or Entra ID (`az login`)       |
-| MiniMax           | `image-01`                              | Yes (subject reference)            | `MINIMAX_API_KEY` or MiniMax OAuth (`minimax-portal`) |
-| OpenAI            | `gpt-image-2`                           | Yes (up to 5 images)               | `OPENAI_API_KEY` or OpenAI ChatGPT/Codex OAuth        |
-| OpenRouter        | `google/gemini-3.1-flash-image-preview` | Yes (up to 5 input images)         | `OPENROUTER_API_KEY`                                  |
-| Vydra             | `grok-imagine`                          | No                                 | `VYDRA_API_KEY`                                       |
-| xAI               | `grok-imagine-image`                    | Yes (up to 5 images)               | `XAI_API_KEY`                                         |
+| Provider          | Default model                      | Edit support                       | Auth                                                  |
+| ----------------- | ---------------------------------- | ---------------------------------- | ----------------------------------------------------- |
+| ComfyUI           | `workflow`                         | Yes (1 image, workflow-configured) | `COMFY_API_KEY` or `COMFY_CLOUD_API_KEY` for cloud    |
+| DeepInfra         | `black-forest-labs/FLUX-1-schnell` | Yes (1 image)                      | `DEEPINFRA_API_KEY`                                   |
+| fal               | `fal-ai/flux/dev`                  | Yes (model-specific limits)        | `FAL_KEY`                                             |
+| Google            | `gemini-3.1-flash-image`           | Yes (up to 5 images)               | `GEMINI_API_KEY` or `GOOGLE_API_KEY`                  |
+| LiteLLM           | `gpt-image-2`                      | Yes (up to 5 input images)         | `LITELLM_API_KEY`                                     |
+| Microsoft Foundry | `<deployment-name>`                | Yes (MAI-Image-2.5 models only)    | `AZURE_OPENAI_API_KEY` or Entra ID (`az login`)       |
+| MiniMax           | `image-01`                         | Yes (subject reference)            | `MINIMAX_API_KEY` or MiniMax OAuth (`minimax-portal`) |
+| OpenAI            | `gpt-image-2`                      | Yes (up to 5 images)               | `OPENAI_API_KEY` or OpenAI ChatGPT/Codex OAuth        |
+| OpenRouter        | `google/gemini-3.1-flash-image`    | Yes (up to 5 input images)         | `OPENROUTER_API_KEY`                                  |
+| Vydra             | `grok-imagine`                     | No                                 | `VYDRA_API_KEY`                                       |
+| xAI               | `grok-imagine-image`               | Yes (up to 5 images)               | `XAI_API_KEY`                                         |
 
 Use `action: "list"` to inspect available providers and models at runtime:
 
@@ -208,8 +208,8 @@ translation.
         primary: "openai/gpt-image-2",
         timeoutMs: 180_000,
         fallbacks: [
-          "openrouter/google/gemini-3.1-flash-image-preview",
-          "google/gemini-3.1-flash-image-preview",
+          "openrouter/google/gemini-3.1-flash-image",
+          "google/gemini-3.1-flash-image",
           "fal/fal-ai/flux/dev",
         ],
       },
@@ -388,7 +388,7 @@ support 1.
       agents: {
         defaults: {
           imageGenerationModel: {
-            primary: "openrouter/google/gemini-3.1-flash-image-preview",
+            primary: "openrouter/google/gemini-3.1-flash-image",
           },
         },
       },
@@ -398,8 +398,8 @@ support 1.
     OpenClaw forwards `prompt`, `count`, reference images, and
     Gemini-compatible `aspectRatio` / `resolution` hints to OpenRouter.
     Current built-in OpenRouter image model shortcuts include
-    `google/gemini-3.1-flash-image-preview`,
-    `google/gemini-3-pro-image-preview`, and `openai/gpt-5.4-image-2`. Use
+    `google/gemini-3.1-flash-image`,
+    `google/gemini-3-pro-image`, and `openai/gpt-5.4-image-2`. Use
     `action: "list"` to see what your configured plugin exposes.
 
   </Accordion>

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -131,7 +131,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     const result = await provider.generateImage({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a cat",
       cfg: {},
       size: "1536x1024",
@@ -139,7 +139,7 @@ describe("Google image-generation provider", () => {
 
     const request = fetchRequest(fetchMock);
     expect(request.url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
     );
     expect(request.method).toBe("POST");
     expect(JSON.parse(request.body ?? "")).toEqual({
@@ -165,7 +165,7 @@ describe("Google image-generation provider", () => {
           fileName: "image-1.png",
         },
       ],
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
     });
   });
 
@@ -192,14 +192,14 @@ describe("Google image-generation provider", () => {
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
       finalUrl:
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent",
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
       release: async () => {},
     });
 
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a cat",
       cfg: {},
       ssrfPolicy: { allowRfc2544BenchmarkRange: true },
@@ -221,7 +221,7 @@ describe("Google image-generation provider", () => {
     await expect(
       provider.generateImage({
         provider: "google",
-        model: "gemini-3.1-flash-image-preview",
+        model: "gemini-3.1-flash-image",
         prompt: "draw a cat",
         cfg: {},
       }),
@@ -249,7 +249,7 @@ describe("Google image-generation provider", () => {
     await expect(
       provider.generateImage({
         provider: "google",
-        model: "gemini-3.1-flash-image-preview",
+        model: "gemini-3.1-flash-image",
         prompt: "draw a cat",
         cfg: {},
       }),
@@ -285,7 +285,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     const result = await provider.generateImage({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a dog",
       cfg: {},
     });
@@ -302,7 +302,7 @@ describe("Google image-generation provider", () => {
           fileName: "image-1.jpg",
         },
       ],
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
     });
   });
 
@@ -381,7 +381,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3-pro-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "Change only the sky to a sunset.",
       cfg: {},
       resolution: "4K",
@@ -396,7 +396,7 @@ describe("Google image-generation provider", () => {
 
     const request = fetchRequest(fetchMock);
     expect(request.url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
     );
     expect(request.method).toBe("POST");
     expect(JSON.parse(request.body ?? "")).toEqual({
@@ -430,7 +430,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3-pro-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "portrait photo",
       cfg: {},
       aspectRatio: "9:16",
@@ -438,7 +438,7 @@ describe("Google image-generation provider", () => {
 
     const request = fetchRequest(fetchMock);
     expect(request.url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
     );
     expect(request.method).toBe("POST");
     expect(JSON.parse(request.body ?? "")).toEqual({
@@ -465,7 +465,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a fox",
       cfg: {},
     });
@@ -481,7 +481,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a fox",
       cfg: {
         models: {
@@ -506,7 +506,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3-pro-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a cat",
       cfg: {
         models: {
@@ -522,7 +522,7 @@ describe("Google image-generation provider", () => {
 
     const request = fetchRequest(fetchMock);
     expect(request.url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
     );
     expect(typeof request.method).toBe("string");
   });
@@ -534,7 +534,7 @@ describe("Google image-generation provider", () => {
     const provider = buildGoogleImageGenerationProvider();
     await provider.generateImage({
       provider: "google",
-      model: "gemini-3-pro-image-preview",
+      model: "gemini-3.1-flash-image",
       prompt: "draw a fox",
       cfg: {
         models: {
@@ -550,7 +550,7 @@ describe("Google image-generation provider", () => {
 
     const request = fetchRequest(fetchMock);
     expect(request.url).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
     );
     expect(typeof request.method).toBe("string");
   });

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -25,7 +25,8 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeGoogleModelId, resolveGoogleGenerativeAiHttpRequestConfig } from "./api.js";
 
-const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image-preview";
+const DEFAULT_GOOGLE_IMAGE_MODEL = "gemini-3.1-flash-image";
+const GOOGLE_PRO_IMAGE_MODEL = "gemini-3-pro-image";
 const DEFAULT_IMAGE_TIMEOUT_MS = 180_000;
 const DEFAULT_OUTPUT_MIME = "image/png";
 const GOOGLE_MAX_IMAGE_RESULTS = 4;
@@ -159,7 +160,7 @@ export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
     id: "google",
     label: "Google",
     defaultModel: DEFAULT_GOOGLE_IMAGE_MODEL,
-    models: [DEFAULT_GOOGLE_IMAGE_MODEL, "gemini-3-pro-image-preview"],
+    models: [DEFAULT_GOOGLE_IMAGE_MODEL, GOOGLE_PRO_IMAGE_MODEL],
     isConfigured: ({ cfg, agentDir }) =>
       // generateImage already authenticates from a config apiKey; count a
       // usable one (non-blank literal or secret ref) as configured here too,

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -98,8 +98,8 @@ function createLazyGoogleImageGenerationProvider(): ImageGenerationProvider {
   return {
     id: "google",
     label: "Google",
-    defaultModel: "gemini-3.1-flash-image-preview",
-    models: ["gemini-3.1-flash-image-preview", "gemini-3-pro-image-preview"],
+    defaultModel: "gemini-3.1-flash-image",
+    models: ["gemini-3.1-flash-image", "gemini-3-pro-image"],
     capabilities: {
       generate: {
         maxCount: 4,

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -99,8 +99,9 @@ describe("openrouter image generation provider", () => {
     const provider = buildOpenRouterImageGenerationProvider();
     expect(provider.id).toBe("openrouter");
     expect(provider.label).toBe("OpenRouter");
-    expect(provider.defaultModel).toBe("google/gemini-3.1-flash-image-preview");
-    expect(provider.models).toContain("google/gemini-3-pro-image-preview");
+    expect(provider.defaultModel).toBe("google/gemini-3.1-flash-image");
+    expect(provider.models).toContain("google/gemini-3.1-flash-image");
+    expect(provider.models).toContain("google/gemini-3-pro-image");
     expect(provider.capabilities.generate.maxCount).toBe(4);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.edit.enabled).toBe(true);
@@ -133,7 +134,7 @@ describe("openrouter image generation provider", () => {
     const provider = buildOpenRouterImageGenerationProvider();
     const result = await provider.generateImage({
       provider: "openrouter",
-      model: "google/gemini-3.1-flash-image-preview",
+      model: "google/gemini-3.1-flash-image",
       prompt: "draw a sticker",
       aspectRatio: "16:9",
       resolution: "2K",
@@ -194,7 +195,7 @@ describe("openrouter image generation provider", () => {
       url: "https://custom.openrouter.test/api/v1/chat/completions",
       headers,
       body: {
-        model: "google/gemini-3.1-flash-image-preview",
+        model: "google/gemini-3.1-flash-image",
         messages: [
           {
             role: "user",
@@ -246,7 +247,7 @@ describe("openrouter image generation provider", () => {
     const provider = buildOpenRouterImageGenerationProvider();
     await provider.generateImage({
       provider: "openrouter",
-      model: "google/gemini-3.1-flash-image-preview",
+      model: "google/gemini-3.1-flash-image",
       prompt: "draw a sticker",
       cfg: {},
     });
@@ -284,7 +285,7 @@ describe("openrouter image generation provider", () => {
     const provider = buildOpenRouterImageGenerationProvider();
     const result = await provider.generateImage({
       provider: "openrouter",
-      model: "google/gemini-3.1-flash-image-preview",
+      model: "google/gemini-3.1-flash-image",
       prompt: "turn this into watercolor",
       inputImages: [{ buffer: Buffer.from("source-image"), mimeType: "image/png" }],
       cfg: {},
@@ -317,7 +318,7 @@ describe("openrouter image generation provider", () => {
     await expect(
       provider.generateImage({
         provider: "openrouter",
-        model: "google/gemini-3.1-flash-image-preview",
+        model: "google/gemini-3.1-flash-image",
         prompt: "bad shape",
         cfg: {},
       }),

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -22,15 +22,12 @@ import {
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 
-const DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview";
+const DEFAULT_MODEL = "google/gemini-3.1-flash-image";
+const GOOGLE_PRO_MODEL = "google/gemini-3-pro-image";
 const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_IMAGE_RESULTS = 4;
 const MB = 1024 * 1024;
-const SUPPORTED_MODELS = [
-  DEFAULT_MODEL,
-  "google/gemini-3-pro-image-preview",
-  "openai/gpt-5.4-image-2",
-] as const;
+const SUPPORTED_MODELS = [DEFAULT_MODEL, GOOGLE_PRO_MODEL, "openai/gpt-5.4-image-2"] as const;
 const SUPPORTED_ASPECT_RATIOS = [
   "1:1",
   "2:3",

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -3219,7 +3219,7 @@ describe("resolveModel", () => {
 
   it("preloads OpenRouter capabilities before first async resolve of an unknown model", async () => {
     mockLoadOpenRouterModelCapabilities.mockImplementation(async (modelId) => {
-      if (modelId === "google/gemini-3.1-flash-image-preview") {
+      if (modelId === "google/gemini-3.1-flash-image") {
         mockGetOpenRouterModelCapabilities.mockReturnValue({
           name: "Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)",
           input: ["text", "image"],
@@ -3233,17 +3233,17 @@ describe("resolveModel", () => {
 
     const result = await resolveModelAsyncForTest(
       "openrouter",
-      "google/gemini-3.1-flash-image-preview",
+      "google/gemini-3.1-flash-image",
       "/tmp/agent",
     );
 
     expect(mockLoadOpenRouterModelCapabilities).toHaveBeenCalledWith(
-      "google/gemini-3.1-flash-image-preview",
+      "google/gemini-3.1-flash-image",
     );
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
       provider: "openrouter",
-      id: "google/gemini-3.1-flash-image-preview",
+      id: "google/gemini-3.1-flash-image",
       reasoning: true,
       input: ["text", "image"],
       contextWindow: 65536,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -472,7 +472,7 @@ describe("handleToolExecutionEnd media emission", () => {
         content: [
           {
             type: "text",
-            text: "Generated 1 image with google/gemini-3.1-flash-image-preview.",
+            text: "Generated 1 image with google/gemini-3.1-flash-image.",
           },
         ],
         details: {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -430,7 +430,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         content: [
           {
             type: "text",
-            text: "Generated 1 image with google/gemini-3.1-flash-image-preview.\nMEDIA:/tmp/generated.png",
+            text: "Generated 1 image with google/gemini-3.1-flash-image.\nMEDIA:/tmp/generated.png",
           },
         ],
         details: {
@@ -489,7 +489,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         content: [
           {
             type: "text",
-            text: "Generated 1 image with google/gemini-3.1-flash-image-preview.\nMEDIA:/tmp/generated.png",
+            text: "Generated 1 image with google/gemini-3.1-flash-image.\nMEDIA:/tmp/generated.png",
           },
         ],
         details: {
@@ -543,7 +543,7 @@ describe("subscribeEmbeddedAgentSession", () => {
         content: [
           {
             type: "text",
-            text: "Generated 1 image with google/gemini-3.1-flash-image-preview.\nMEDIA:/tmp/generated.png",
+            text: "Generated 1 image with google/gemini-3.1-flash-image.\nMEDIA:/tmp/generated.png",
           },
         ],
         details: {

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -83,12 +83,13 @@ function hasStubbedImageProviderAuth(providerId: string): boolean {
   return false;
 }
 
-function stubImageGenerationProviders() {
+function stubImageGenerationProviders(params: { googleModels?: string[] } = {}) {
+  const googleModels = params.googleModels ?? ["gemini-3.1-flash-image", "gemini-3-pro-image"];
   vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
     {
       id: "google",
-      defaultModel: "gemini-3.1-flash-image-preview",
-      models: ["gemini-3.1-flash-image-preview", "gemini-3-pro-image-preview"],
+      defaultModel: "gemini-3.1-flash-image",
+      models: googleModels,
       isConfigured: () => hasStubbedImageProviderAuth("google"),
       capabilities: {
         generate: {
@@ -225,7 +226,7 @@ function stubEditedImageFlow(params?: { width?: number; height?: number }) {
   // shaping, provider choice, and saved-media metadata.
   const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
     provider: "google",
-    model: "gemini-3-pro-image-preview",
+    model: "gemini-3.1-flash-image",
     attempts: [],
     ignoredOverrides: [],
     ...(appliedResolution ? { appliedResolution } : {}),
@@ -585,7 +586,7 @@ describe("createImageGenerateTool", () => {
         },
       }),
     ).toEqual({
-      primary: "google/gemini-3.1-flash-image-preview",
+      primary: "google/gemini-3.1-flash-image",
       fallbacks: ["openai/gpt-image-1"],
     });
   });
@@ -1235,7 +1236,7 @@ describe("createImageGenerateTool", () => {
           agents: {
             defaults: {
               imageGenerationModel: {
-                primary: "gemini-3-pro-image-preview",
+                primary: "gemini-3.1-flash-image",
               },
             },
           },
@@ -1280,7 +1281,7 @@ describe("createImageGenerateTool", () => {
     const result = await tool.execute("call-provider-qualified-repeat", {
       prompt: "Already generated proof image",
       filename: "proof.png",
-      model: "google/gemini-3-pro-image-preview",
+      model: "google/gemini-3.1-flash-image",
     });
 
     expect(scheduled).toHaveLength(1);
@@ -1293,7 +1294,9 @@ describe("createImageGenerateTool", () => {
   });
 
   it("does not collapse distinct unqualified explicit image models in recent duplicate keys", async () => {
-    stubImageGenerationProviders();
+    stubImageGenerationProviders({
+      googleModels: ["gemini-3.1-flash-image", "gemini-test-image-model"],
+    });
     vi.stubEnv("GEMINI_API_KEY", "google-test");
     const now = Date.now();
     taskRuntimeMocks.createRunningTaskRun
@@ -1305,7 +1308,7 @@ describe("createImageGenerateTool", () => {
       });
     vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       attempts: [],
       ignoredOverrides: [],
       images: [],
@@ -1317,7 +1320,7 @@ describe("createImageGenerateTool", () => {
           agents: {
             defaults: {
               imageGenerationModel: {
-                primary: "google/gemini-3.1-flash-image-preview",
+                primary: "google/gemini-3.1-flash-image",
               },
             },
           },
@@ -1333,7 +1336,7 @@ describe("createImageGenerateTool", () => {
     await tool.execute("call-first-model", {
       prompt: "Already generated proof image",
       filename: "proof.png",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
     });
     const firstTask = mockCallArg(taskRuntimeMocks.createRunningTaskRun, 0, "createRunningTaskRun");
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
@@ -1359,7 +1362,7 @@ describe("createImageGenerateTool", () => {
     const result = await tool.execute("call-second-model", {
       prompt: "Already generated proof image",
       filename: "proof.png",
-      model: "gemini-3-pro-image-preview",
+      model: "gemini-test-image-model",
     });
 
     expect(scheduled).toHaveLength(2);
@@ -1908,8 +1911,8 @@ describe("createImageGenerateTool", () => {
     vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
       {
         id: "google",
-        defaultModel: "gemini-3.1-flash-image-preview",
-        models: ["gemini-3.1-flash-image-preview"],
+        defaultModel: "gemini-3.1-flash-image",
+        models: ["gemini-3.1-flash-image"],
         capabilities: {
           generate: {
             maxCount: 4,
@@ -1934,7 +1937,7 @@ describe("createImageGenerateTool", () => {
     ]);
     vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       attempts: [],
       ignoredOverrides: [],
       images: [
@@ -1957,7 +1960,7 @@ describe("createImageGenerateTool", () => {
         config: {
           agents: {
             defaults: {
-              imageGenerationModel: { primary: "google/gemini-3.1-flash-image-preview" },
+              imageGenerationModel: { primary: "google/gemini-3.1-flash-image" },
             },
           },
         },
@@ -1981,8 +1984,8 @@ describe("createImageGenerateTool", () => {
     vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
       {
         id: "google",
-        defaultModel: "gemini-3.1-flash-image-preview",
-        models: ["gemini-3.1-flash-image-preview"],
+        defaultModel: "gemini-3.1-flash-image",
+        models: ["gemini-3.1-flash-image"],
         capabilities: {
           generate: {
             maxCount: 4,
@@ -2011,7 +2014,7 @@ describe("createImageGenerateTool", () => {
           agents: {
             defaults: {
               imageGenerationModel: {
-                primary: "google/gemini-3.1-flash-image-preview",
+                primary: "google/gemini-3.1-flash-image",
               },
             },
           },
@@ -2027,7 +2030,7 @@ describe("createImageGenerateTool", () => {
   it.each([2.5, "2cats", null])("rejects malformed image count %s", async (count) => {
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
       provider: "google",
-      model: "gemini-3.1-flash-image-preview",
+      model: "gemini-3.1-flash-image",
       attempts: [],
       ignoredOverrides: [],
       images: [
@@ -2045,7 +2048,7 @@ describe("createImageGenerateTool", () => {
       contentType: "image/png",
     });
 
-    const tool = createToolWithPrimaryImageModel("google/gemini-3.1-flash-image-preview");
+    const tool = createToolWithPrimaryImageModel("google/gemini-3.1-flash-image");
     await expect(
       tool.execute("call-fractional-count", {
         prompt: "A cat wearing sunglasses",
@@ -2057,7 +2060,7 @@ describe("createImageGenerateTool", () => {
 
   it("forwards reference images and inferred resolution for edit mode", async () => {
     const generateImage = stubEditedImageFlow({ width: 3200, height: 1800 });
-    const tool = createToolWithPrimaryImageModel("google/gemini-3-pro-image-preview", {
+    const tool = createToolWithPrimaryImageModel("google/gemini-3.1-flash-image", {
       workspaceDir: process.cwd(),
     });
 
@@ -2081,7 +2084,7 @@ describe("createImageGenerateTool", () => {
 
   it("accepts managed inbound reference images for edit mode", async () => {
     stubEditedImageFlow({ width: 1024, height: 1024 });
-    const tool = createToolWithPrimaryImageModel("google/gemini-3-pro-image-preview", {
+    const tool = createToolWithPrimaryImageModel("google/gemini-3.1-flash-image", {
       workspaceDir: process.cwd(),
     });
 
@@ -2106,7 +2109,7 @@ describe("createImageGenerateTool", () => {
       createImageGenerateTool({
         config: {
           agents: {
-            defaults: { imageGenerationModel: { primary: "google/gemini-3-pro-image-preview" } },
+            defaults: { imageGenerationModel: { primary: "google/gemini-3.1-flash-image" } },
           },
         },
         workspaceDir: process.cwd(),
@@ -2129,7 +2132,7 @@ describe("createImageGenerateTool", () => {
       createImageGenerateTool({
         config: {
           agents: {
-            defaults: { imageGenerationModel: { primary: "google/gemini-3-pro-image-preview" } },
+            defaults: { imageGenerationModel: { primary: "google/gemini-3.1-flash-image" } },
           },
           tools: { web: { fetch: { ssrfPolicy: { allowRfc2544BenchmarkRange: true } } } },
         },
@@ -2165,7 +2168,7 @@ describe("createImageGenerateTool", () => {
           agents: {
             defaults: {
               imageGenerationModel: {
-                primary: "google/gemini-3-pro-image-preview",
+                primary: "google/gemini-3.1-flash-image",
               },
               mediaMaxMb: Number.POSITIVE_INFINITY,
             },
@@ -2272,7 +2275,7 @@ describe("createImageGenerateTool", () => {
 
   it("forwards explicit aspect ratio and supports up to 5 reference images", async () => {
     const generateImage = stubEditedImageFlow();
-    const tool = createToolWithPrimaryImageModel("google/gemini-3-pro-image-preview", {
+    const tool = createToolWithPrimaryImageModel("google/gemini-3.1-flash-image", {
       workspaceDir: process.cwd(),
     });
 
@@ -2493,7 +2496,7 @@ describe("createImageGenerateTool", () => {
           agents: {
             defaults: {
               imageGenerationModel: {
-                primary: "google/gemini-3-pro-image-preview",
+                primary: "google/gemini-3.1-flash-image",
               },
             },
           },
@@ -2517,7 +2520,7 @@ describe("createImageGenerateTool", () => {
           agents: {
             defaults: {
               imageGenerationModel: {
-                primary: "google/gemini-3.1-flash-image-preview",
+                primary: "google/gemini-3.1-flash-image",
               },
             },
           },
@@ -2528,9 +2531,8 @@ describe("createImageGenerateTool", () => {
     const result = await tool.execute("call-list", { action: "list" });
     const text = resultText(result);
 
-    expect(text).toContain("google (default gemini-3.1-flash-image-preview)");
-    expect(text).toContain("gemini-3.1-flash-image-preview");
-    expect(text).toContain("gemini-3-pro-image-preview");
+    expect(text).toContain("google (default gemini-3.1-flash-image)");
+    expect(text).toContain("gemini-3.1-flash-image");
     expect(text).toContain("auth: set GEMINI_API_KEY / GOOGLE_API_KEY to use google/*");
     expect(text).toContain(
       "auth: set OPENAI_API_KEY or configure OpenAI Codex OAuth for openai/gpt-image-2",
@@ -2544,12 +2546,9 @@ describe("createImageGenerateTool", () => {
     if (!googleProvider || !openaiProvider) {
       throw new Error("Expected google and openai provider details");
     }
-    expect(googleProvider.defaultModel).toBe("gemini-3.1-flash-image-preview");
+    expect(googleProvider.defaultModel).toBe("gemini-3.1-flash-image");
     expect(googleProvider.authEnvVars).toEqual(["GEMINI_API_KEY", "GOOGLE_API_KEY"]);
-    expect(googleProvider.models).toEqual([
-      "gemini-3.1-flash-image-preview",
-      "gemini-3-pro-image-preview",
-    ]);
+    expect(googleProvider.models).toEqual(["gemini-3.1-flash-image", "gemini-3-pro-image"]);
     const googleCapabilities = requireRecord(googleProvider.capabilities, "google capabilities");
     expect(googleCapabilities.edit).toEqual({
       enabled: true,

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -213,10 +213,7 @@ describe("normalizeCompatibilityConfigValues", () => {
       },
     });
 
-    expect(res.config.agents?.list).toEqual([
-      { id: "main", workspace: "/main" },
-      { id: "beta" },
-    ]);
+    expect(res.config.agents?.list).toEqual([{ id: "main", workspace: "/main" }, { id: "beta" }]);
     expect(res.changes.some((change) => change.includes("workspace"))).toBe(false);
   });
 
@@ -451,9 +448,9 @@ describe("normalizeCompatibilityConfigValues", () => {
           },
         },
       } as unknown as OpenClawConfig);
-      const channel = (res.config.channels as Record<string, { accounts?: Record<string, unknown> }>)?.[
-        channelId
-      ];
+      const channel = (
+        res.config.channels as Record<string, { accounts?: Record<string, unknown> }>
+      )?.[channelId];
 
       expect(channel?.accounts?.default).toEqual({
         dmPolicy: "allowlist",
@@ -611,7 +608,7 @@ describe("normalizeCompatibilityConfigValues", () => {
     });
 
     expect(res.config.agents?.defaults?.imageGenerationModel).toEqual({
-      primary: "google/gemini-3-pro-image-preview",
+      primary: "google/gemini-3.1-flash-image",
     });
     expect(res.config.models?.providers?.google?.apiKey).toEqual({
       source: "env",
@@ -624,7 +621,7 @@ describe("normalizeCompatibilityConfigValues", () => {
     expect(res.config.models?.providers?.google?.models).toStrictEqual([]);
     expect(res.config.skills?.entries).toBeUndefined();
     expect(res.changes).toEqual([
-      "Moved skills.entries.nano-banana-pro → agents.defaults.imageGenerationModel.primary (google/gemini-3-pro-image-preview).",
+      "Moved skills.entries.nano-banana-pro → agents.defaults.imageGenerationModel.primary (google/gemini-3.1-flash-image).",
       "Moved skills.entries.nano-banana-pro.apiKey → models.providers.google.apiKey.",
       "Removed legacy skills.entries.nano-banana-pro.",
     ]);

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -879,7 +879,7 @@ export function normalizeLegacyNanoBananaSkill(
   changes: string[],
 ): OpenClawConfig {
   const NANO_BANANA_SKILL_KEY = "nano-banana-pro";
-  const NANO_BANANA_MODEL = "google/gemini-3-pro-image-preview";
+  const NANO_BANANA_MODEL = "google/gemini-3.1-flash-image";
   const rawSkills = cfg.skills;
   if (!isRecord(rawSkills)) {
     return cfg;

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2669,6 +2669,47 @@ describe("legacy model compat migrate", () => {
     ]);
   });
 
+  it("upgrades retired Google image generation model refs", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          imageGenerationModel: {
+            primary: "google/gemini-3.1-flash-image-preview",
+            fallbacks: [
+              "gemini-3-pro-image-preview",
+              "google/gemini-3-pro-image-preview",
+              "openrouter/google/gemini-3.1-flash-image-preview",
+              "google/imagen-4.0-generate-001",
+              "google/imagen-4.0-ultra-generate-001",
+              "google/imagen-4.0-fast-generate-001",
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.imageGenerationModel).toEqual({
+      primary: "google/gemini-3.1-flash-image",
+      fallbacks: [
+        "gemini-3-pro-image",
+        "google/gemini-3-pro-image",
+        "openrouter/google/gemini-3.1-flash-image",
+        "google/gemini-3.1-flash-image",
+        "google/gemini-3.1-flash-image",
+        "google/gemini-3.1-flash-image",
+      ],
+    });
+    expectMigrationChangesToIncludeFragments(res.changes, [
+      'config.agents.defaults.imageGenerationModel.primary from "google/gemini-3.1-flash-image-preview" to "google/gemini-3.1-flash-image"',
+      'config.agents.defaults.imageGenerationModel.fallbacks.0 from "gemini-3-pro-image-preview" to "gemini-3-pro-image"',
+      'config.agents.defaults.imageGenerationModel.fallbacks.1 from "google/gemini-3-pro-image-preview" to "google/gemini-3-pro-image"',
+      'config.agents.defaults.imageGenerationModel.fallbacks.2 from "openrouter/google/gemini-3.1-flash-image-preview" to "openrouter/google/gemini-3.1-flash-image"',
+      'config.agents.defaults.imageGenerationModel.fallbacks.3 from "google/imagen-4.0-generate-001" to "google/gemini-3.1-flash-image"',
+      'config.agents.defaults.imageGenerationModel.fallbacks.4 from "google/imagen-4.0-ultra-generate-001" to "google/gemini-3.1-flash-image"',
+      'config.agents.defaults.imageGenerationModel.fallbacks.5 from "google/imagen-4.0-fast-generate-001" to "google/gemini-3.1-flash-image"',
+    ]);
+  });
+
   it("removes unrecognized model compat thinkingFormat values", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -603,6 +603,21 @@ function upgradeRetiredOpenAiModelId(model: string, provider?: string): string |
   return null;
 }
 
+function upgradeRetiredGoogleImageModelId(model: string): string | null {
+  const normalized = normalizeString(model);
+  switch (normalized) {
+    case "gemini-3.1-flash-image-preview":
+    case "imagen-4.0-generate-001":
+    case "imagen-4.0-ultra-generate-001":
+    case "imagen-4.0-fast-generate-001":
+      return "gemini-3.1-flash-image";
+    case "gemini-3-pro-image-preview":
+      return "gemini-3-pro-image";
+    default:
+      return null;
+  }
+}
+
 function hasRetiredVersionPrefix(normalized: string, prefix: string): boolean {
   if (normalized === prefix) {
     return true;
@@ -759,13 +774,22 @@ function upgradeRetiredModelRef(value: string): string | null {
       ? upgradeRetiredGroqModelId(model)
       : normalizedProvider === "xai"
         ? upgradeRetiredXaiModelId(model)
-        : normalizedProvider === "openai" ||
-            normalizedProvider === "openai-codex" ||
-            normalizedProvider === "github-copilot"
-          ? upgradeRetiredOpenAiModelId(model, normalizedProvider)
-          : undefined;
+        : !normalizedProvider || normalizedProvider === "google"
+          ? upgradeRetiredGoogleImageModelId(model)
+          : normalizedProvider === "openrouter" &&
+              normalizedModel === "google/gemini-3.1-flash-image-preview"
+            ? "google/gemini-3.1-flash-image"
+            : normalizedProvider === "openrouter" &&
+                normalizedModel === "google/gemini-3-pro-image-preview"
+              ? "google/gemini-3-pro-image"
+              : normalizedProvider === "openai" ||
+                  normalizedProvider === "openai-codex" ||
+                  normalizedProvider === "github-copilot"
+                ? upgradeRetiredOpenAiModelId(model, normalizedProvider)
+                : undefined;
   if (retiredOwnerModel) {
-    return `${provider}/${retiredOwnerModel}${split.profile ? `@${split.profile}` : ""}`;
+    const upgraded = provider ? `${provider}/${retiredOwnerModel}` : retiredOwnerModel;
+    return `${upgraded}${split.profile ? `@${split.profile}` : ""}`;
   }
 
   if (

--- a/src/config/plugin-auto-enable.core.test.ts
+++ b/src/config/plugin-auto-enable.core.test.ts
@@ -537,7 +537,7 @@ describe("applyPluginAutoEnable core", () => {
           defaults: {
             imageGenerationModel: {
               primary: "openai/gpt-image-1",
-              fallbacks: ["google/gemini-3-pro-image-preview"],
+              fallbacks: ["google/gemini-3.1-flash-image"],
             },
             videoGenerationModel: {
               primary: "openai/sora-2",
@@ -568,7 +568,7 @@ describe("applyPluginAutoEnable core", () => {
     expect(result.config.plugins?.entries?.minimax?.enabled).toBe(true);
     expect(result.config.plugins?.allow).toEqual(["openai", "google", "minimax"]);
     expect(result.changes).toEqual([
-      "google/gemini-3-pro-image-preview model configured, enabled automatically.",
+      "google/gemini-3.1-flash-image model configured, enabled automatically.",
       "minimax/MiniMax-Hailuo-2.3 model configured, enabled automatically.",
     ]);
   });

--- a/src/image-generation/live-test-helpers.test.ts
+++ b/src/image-generation/live-test-helpers.test.ts
@@ -27,11 +27,11 @@ describe("image-generation live-test helpers", () => {
 
   it("parses provider model overrides by provider id", () => {
     expect(
-      parseProviderModelMap("openai/gpt-image-2, google/gemini-3.1-flash-image-preview, invalid"),
+      parseProviderModelMap("openai/gpt-image-2, google/gemini-3.1-flash-image, invalid"),
     ).toEqual(
       new Map([
         ["openai", "openai/gpt-image-2"],
-        ["google", "google/gemini-3.1-flash-image-preview"],
+        ["google", "google/gemini-3.1-flash-image"],
       ]),
     );
   });
@@ -42,7 +42,7 @@ describe("image-generation live-test helpers", () => {
         defaults: {
           imageGenerationModel: {
             primary: "openai/gpt-image-2",
-            fallbacks: ["google/gemini-3.1-flash-image-preview", "invalid"],
+            fallbacks: ["google/gemini-3.1-flash-image", "invalid"],
           },
         },
       },
@@ -51,7 +51,7 @@ describe("image-generation live-test helpers", () => {
     expect(resolveConfiguredLiveImageModels(cfg)).toEqual(
       new Map([
         ["openai", "openai/gpt-image-2"],
-        ["google", "google/gemini-3.1-flash-image-preview"],
+        ["google", "google/gemini-3.1-flash-image"],
       ]),
     );
   });

--- a/src/image-generation/live-test-helpers.ts
+++ b/src/image-generation/live-test-helpers.ts
@@ -16,10 +16,10 @@ export { parseProviderModelMap, redactLiveApiKey };
 export const DEFAULT_LIVE_IMAGE_MODELS: Partial<Record<string, string>> = {
   deepinfra: "deepinfra/black-forest-labs/FLUX-1-schnell",
   fal: "fal/fal-ai/flux/dev",
-  google: "google/gemini-3.1-flash-image-preview",
+  google: "google/gemini-3.1-flash-image",
   minimax: "minimax/image-01",
   openai: "openai/gpt-image-2",
-  openrouter: "openrouter/google/gemini-3.1-flash-image-preview",
+  openrouter: "openrouter/google/gemini-3.1-flash-image",
   vydra: "vydra/grok-imagine",
   xai: "xai/grok-imagine-image",
 };

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -236,7 +236,7 @@ describe("image-generation runtime", () => {
       },
       {
         id: "google",
-        defaultModel: "gemini-3.1-flash-image-preview",
+        defaultModel: "gemini-3.1-flash-image",
         capabilities: {
           generate: {},
           edit: { enabled: true },
@@ -245,7 +245,7 @@ describe("image-generation runtime", () => {
         async generateImage() {
           return {
             images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
-            model: "gemini-3.1-flash-image-preview",
+            model: "gemini-3.1-flash-image",
           };
         },
       },
@@ -257,7 +257,7 @@ describe("image-generation runtime", () => {
     });
 
     expect(result.provider).toBe("google");
-    expect(result.model).toBe("gemini-3.1-flash-image-preview");
+    expect(result.model).toBe("gemini-3.1-flash-image");
     expect(result.attempts).toEqual([
       {
         provider: "openai",

--- a/src/media-generation/runtime-shared.test.ts
+++ b/src/media-generation/runtime-shared.test.ts
@@ -44,14 +44,14 @@ describe("media-generation runtime shared candidates", () => {
     const candidates = resolveCapabilityModelCandidates({
       cfg,
       modelConfig: {
-        primary: "google/gemini-3.1-flash-image-preview",
+        primary: "google/gemini-3.1-flash-image",
         fallbacks: ["fal/fal-ai/flux/dev"],
       },
       parseModelRef,
       listProviders: () => [
         {
           id: "google",
-          defaultModel: "gemini-3.1-flash-image-preview",
+          defaultModel: "gemini-3.1-flash-image",
           isConfigured: () => true,
         },
         {
@@ -68,7 +68,7 @@ describe("media-generation runtime shared candidates", () => {
     });
 
     expect(candidates).toEqual([
-      { provider: "google", model: "gemini-3.1-flash-image-preview" },
+      { provider: "google", model: "gemini-3.1-flash-image" },
       { provider: "fal", model: "fal-ai/flux/dev" },
       { provider: "openai", model: "gpt-image-1" },
       { provider: "minimax", model: "image-01" },
@@ -145,7 +145,7 @@ describe("media-generation runtime shared candidates", () => {
         },
       } as OpenClawConfig,
       modelConfig: {
-        primary: "google/gemini-3.1-flash-image-preview",
+        primary: "google/gemini-3.1-flash-image",
       },
       parseModelRef,
       listProviders: () => {
@@ -160,7 +160,7 @@ describe("media-generation runtime shared candidates", () => {
       },
     });
 
-    expect(candidates).toEqual([{ provider: "google", model: "gemini-3.1-flash-image-preview" }]);
+    expect(candidates).toEqual([{ provider: "google", model: "gemini-3.1-flash-image" }]);
     expect(listProviderCalls).toBe(0);
   });
 
@@ -174,7 +174,7 @@ describe("media-generation runtime shared candidates", () => {
         },
       } as OpenClawConfig,
       modelConfig: {
-        primary: "google/gemini-3.1-flash-image-preview",
+        primary: "google/gemini-3.1-flash-image",
         fallbacks: ["fal/fal-ai/flux/dev"],
       },
       modelOverride: "openai/gpt-image-2",
@@ -182,7 +182,7 @@ describe("media-generation runtime shared candidates", () => {
       listProviders: () => [
         {
           id: "google",
-          defaultModel: "gemini-3.1-flash-image-preview",
+          defaultModel: "gemini-3.1-flash-image",
           isConfigured: () => true,
         },
       ],

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -929,7 +929,7 @@ describe("resolveGatewayStartupPluginIds", () => {
           defaults: {
             imageGenerationModel: {
               primary: "openai/gpt-image-2",
-              fallbacks: ["google/gemini-3-pro-image-preview"],
+              fallbacks: ["google/gemini-3.1-flash-image"],
             },
             videoGenerationModel: {
               primary: "google/veo-3.1-fast-generate-preview",
@@ -948,7 +948,7 @@ describe("resolveGatewayStartupPluginIds", () => {
         channels: {},
         agents: {
           defaults: {
-            imageGenerationModel: { primary: "google/gemini-3-pro-image-preview" },
+            imageGenerationModel: { primary: "google/gemini-3.1-flash-image" },
           },
         },
         plugins: { entries: { google: { enabled: false } } },
@@ -1313,7 +1313,7 @@ describe("resolveGatewayStartupPluginIds", () => {
         channels: {},
         agents: {
           defaults: {
-            imageGenerationModel: { primary: "google/gemini-3-pro-image-preview" },
+            imageGenerationModel: { primary: "google/gemini-3.1-flash-image" },
           },
         },
         plugins: { allow: ["browser"] },

--- a/test/image-generation.infer-cli.live.test.ts
+++ b/test/image-generation.infer-cli.live.test.ts
@@ -33,7 +33,7 @@ describeLive("image generation infer CLI live", () => {
         "image",
         "generate",
         "--model",
-        "google/gemini-3.1-flash-image-preview",
+        "google/gemini-3.1-flash-image",
         "--prompt",
         "Minimal flat test image: one blue square on a white background, no text.",
         "--output",
@@ -53,7 +53,7 @@ describeLive("image generation infer CLI live", () => {
     expect(payload.ok).toBe(true);
     expect(payload.capability).toBe("image.generate");
     expect(payload.provider).toBe("google");
-    expect(payload.model).toBe("gemini-3.1-flash-image-preview");
+    expect(payload.model).toBe("gemini-3.1-flash-image");
     const outputs = payload.outputs as Array<{ path?: string; mimeType?: string; size?: number }>;
     expect(outputs).toHaveLength(1);
     const outputPath = outputs[0]?.path;


### PR DESCRIPTION
Google's preview Gemini image IDs and legacy Imagen 4 IDs are being retired, but OpenClaw still advertised preview/retired IDs across the Google/OpenRouter image-generation defaults and compatibility migration paths. This keeps stable Flash as the default while preserving explicit Pro selections by mapping Pro preview configs and provider catalogs to the stable Pro image IDs.

## Summary
- switch Google and OpenRouter image-generation provider defaults to `gemini-3.1-flash-image`
- preserve stable Pro image models in Google/OpenRouter provider catalogs and lightweight metadata
- migrate Flash preview/Imagen refs to stable Flash, while migrating Pro preview refs to stable Pro
- update image-generation docs, provider/tool tests, and doctor migration coverage

## Real behavior proof

- Behavior addressed: OpenClaw's real image provider/model selection surface should no longer advertise retired Google Gemini preview image IDs or legacy Imagen 4 IDs as defaults, and should not silently collapse explicit Pro image selections to Flash.
- Real environment tested: Local OpenClaw source checkout on macOS at PR commit `c4ba453f55`, using the real source runner and local OpenClaw setup.
- Exact steps or command run after this patch: `CI=true node scripts/run-node.mjs infer image providers --json`
- Evidence after fix: Copied live output from the real provider listing command showed Google and OpenRouter now expose stable Flash defaults plus stable Pro catalog entries:

```json
{
  "id": "google",
  "label": "Google",
  "defaultModel": "gemini-3.1-flash-image",
  "models": [
    "gemini-3.1-flash-image",
    "gemini-3-pro-image"
  ]
}
```

```json
{
  "id": "openrouter",
  "label": "OpenRouter",
  "defaultModel": "google/gemini-3.1-flash-image",
  "models": [
    "google/gemini-3.1-flash-image",
    "google/gemini-3-pro-image",
    "openai/gpt-5.4-image-2"
  ]
}
```

- Observed result after fix: The runtime provider list reports stable Flash defaults while preserving distinct stable Pro image model entries for Google and OpenRouter. The retired `gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`, and Imagen 4 IDs are not advertised in the runtime provider list.
- What was not tested: I did not submit a paid live image generation request to Google/OpenRouter from this PR branch. The provider request paths are covered by the targeted runtime/provider/tool tests listed below.
- Proof limitations or environment constraints: The first `node scripts/run-node.mjs infer image providers --json` attempt failed before execution because stale dist triggered a noninteractive pnpm install prompt. Rerunning with `CI=true` allowed the source runner to rebuild and complete the real provider-list command.
- Before evidence: Before this PR, Google/OpenRouter image defaults were preview IDs. In the first PR revision, Flash defaults were stable but explicit Pro preview refs were incorrectly migrated to Flash and Pro catalog entries were removed. This revision preserves Pro as stable Pro.

## Verification
- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts extensions/google/image-generation-provider.test.ts extensions/openrouter/image-generation-provider.test.ts src/image-generation/runtime.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/agents/tools/image-generate-tool.test.ts src/media-generation/runtime-shared.test.ts src/config/plugin-auto-enable.core.test.ts src/plugins/channel-plugin-ids.test.ts --reporter=verbose`
- `node_modules/.bin/oxfmt --check docs/cli/infer.md docs/gateway/config-agents.md docs/help/testing-live.md docs/providers/google.md docs/providers/openrouter.md docs/tools/image-generation.md extensions/google/image-generation-provider.ts extensions/google/image-generation-provider.test.ts extensions/google/index.ts extensions/openrouter/image-generation-provider.ts extensions/openrouter/image-generation-provider.test.ts src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts src/commands/doctor/shared/legacy-config-migrate.test.ts src/agents/tools/image-generate-tool.test.ts`
- `git diff --check`
- `CI=true node scripts/run-node.mjs infer image providers --json`
