### PR TITLE
fix(memory-core): keep daily ingestion outside session repair

### DIFF
--- a/extensions/memory-core/src/dreaming-repair.test.ts
+++ b/extensions/memory-core/src/dreaming-repair.test.ts
@@ -199,6 +199,10 @@ describe("dreaming artifact repair", () => {
       }),
     ]);
 
+    await expect(
+      auditDreamingArtifacts({ workspaceDir }).then((audit) => audit.sessionIngestionExists),
+    ).resolves.toBe(true);
+
     const repair = await repairDreamingArtifacts({ workspaceDir });
 
     expect(repair.archivedSessionCorpus).toBe(true);
@@ -214,9 +218,12 @@ describe("dreaming artifact repair", () => {
         workspaceDir,
       }),
     ).resolves.toEqual([]);
+    await expect(
+      auditDreamingArtifacts({ workspaceDir }).then((audit) => audit.sessionIngestionExists),
+    ).resolves.toBe(false);
   });
 
-  it("clears sqlite daily ingestion state when archiving session corpus", async () => {
+  it("preserves sqlite daily ingestion state when archiving session corpus", async () => {
     const workspaceDir = await createWorkspace();
     const sessionCorpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
     await fs.mkdir(sessionCorpusDir, { recursive: true });
@@ -240,37 +247,12 @@ describe("dreaming artifact repair", () => {
         namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
         workspaceDir,
       }),
-    ).resolves.toEqual([]);
-  });
-
-  it("re-audit reports ingestion absent after repairing daily-only ingestion state", async () => {
-    const workspaceDir = await createWorkspace();
-    const sessionCorpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
-    await fs.mkdir(sessionCorpusDir, { recursive: true });
-    await fs.writeFile(path.join(sessionCorpusDir, "2026-04-11.txt"), "corpus\n", "utf-8");
-    await writeMemoryCoreWorkspaceEntries({
-      namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
-      workspaceDir,
-      entries: [
-        {
-          key: "2026-06-10",
-          value: { ingestedAt: 1_000, lastDreamingDayIngested: "2026-06-10" },
-        },
-      ],
-    });
-
-    // Before repair the audit treats the migrated daily namespace as ingestion state.
-    await expect(
-      auditDreamingArtifacts({ workspaceDir }).then((audit) => audit.sessionIngestionExists),
-    ).resolves.toBe(true);
-
-    await repairDreamingArtifacts({ workspaceDir });
-
-    // After repair the daily namespace is cleared, so the immediate re-audit performed by
-    // `memory status --fix` no longer reports a phantom ingestion state.
-    await expect(
-      auditDreamingArtifacts({ workspaceDir }).then((audit) => audit.sessionIngestionExists),
-    ).resolves.toBe(false);
+    ).resolves.toEqual([
+      {
+        key: "2026-06-10",
+        value: { ingestedAt: 1_000, lastDreamingDayIngested: "2026-06-10" },
+      },
+    ]);
   });
 
   it("reports ingestion state present from SQLite when legacy JSON is absent", async () => {
@@ -292,7 +274,7 @@ describe("dreaming artifact repair", () => {
     expect(audit.sessionIngestionExists).toBe(true);
   });
 
-  it("reports ingestion state present from SQLite daily namespace", async () => {
+  it("does not report session ingestion from the SQLite daily namespace", async () => {
     const workspaceDir = await createWorkspace();
     // Only daily ingestion namespace has rows
     await writeMemoryCoreWorkspaceEntries({
@@ -308,6 +290,6 @@ describe("dreaming artifact repair", () => {
 
     const audit = await auditDreamingArtifacts({ workspaceDir });
 
-    expect(audit.sessionIngestionExists).toBe(true);
+    expect(audit.sessionIngestionExists).toBe(false);
   });
 });

--- a/extensions/memory-core/src/dreaming-repair.test.ts
+++ b/extensions/memory-core/src/dreaming-repair.test.ts
@@ -216,6 +216,63 @@ describe("dreaming artifact repair", () => {
     ).resolves.toEqual([]);
   });
 
+  it("clears sqlite daily ingestion state when archiving session corpus", async () => {
+    const workspaceDir = await createWorkspace();
+    const sessionCorpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    await fs.mkdir(sessionCorpusDir, { recursive: true });
+    await fs.writeFile(path.join(sessionCorpusDir, "2026-04-11.txt"), "corpus\n", "utf-8");
+    await writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
+      workspaceDir,
+      entries: [
+        {
+          key: "2026-06-10",
+          value: { ingestedAt: 1_000, lastDreamingDayIngested: "2026-06-10" },
+        },
+      ],
+    });
+
+    const repair = await repairDreamingArtifacts({ workspaceDir });
+
+    expect(repair.archivedSessionCorpus).toBe(true);
+    await expect(
+      readMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
+        workspaceDir,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("re-audit reports ingestion absent after repairing daily-only ingestion state", async () => {
+    const workspaceDir = await createWorkspace();
+    const sessionCorpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    await fs.mkdir(sessionCorpusDir, { recursive: true });
+    await fs.writeFile(path.join(sessionCorpusDir, "2026-04-11.txt"), "corpus\n", "utf-8");
+    await writeMemoryCoreWorkspaceEntries({
+      namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
+      workspaceDir,
+      entries: [
+        {
+          key: "2026-06-10",
+          value: { ingestedAt: 1_000, lastDreamingDayIngested: "2026-06-10" },
+        },
+      ],
+    });
+
+    // Before repair the audit treats the migrated daily namespace as ingestion state.
+    await expect(
+      auditDreamingArtifacts({ workspaceDir }).then((audit) => audit.sessionIngestionExists),
+    ).resolves.toBe(true);
+
+    await repairDreamingArtifacts({ workspaceDir });
+
+    // After repair the daily namespace is cleared, so the immediate re-audit performed by
+    // `memory status --fix` no longer reports a phantom ingestion state.
+    await expect(
+      auditDreamingArtifacts({ workspaceDir }).then((audit) => audit.sessionIngestionExists),
+    ).resolves.toBe(false);
+  });
+
   it("reports ingestion state present from SQLite when legacy JSON is absent", async () => {
     const workspaceDir = await createWorkspace();
     // Write SQLite ingestion entries but NO legacy session-ingestion.json

--- a/extensions/memory-core/src/dreaming-repair.ts
+++ b/extensions/memory-core/src/dreaming-repair.ts
@@ -132,6 +132,10 @@ async function moveToArchive(params: {
   return destination;
 }
 
+// Clears every dreaming ingestion namespace tracked by the SQLite migration so a
+// repair fully resets ingestion bookkeeping. The daily-ingestion namespace mirrors
+// the legacy daily-ingestion.json sidecar and must be cleared alongside the session
+// files/seen namespaces (the audit already treats all three as ingestion state).
 async function clearSessionIngestionState(workspaceDir: string): Promise<void> {
   await Promise.all([
     clearMemoryCoreWorkspaceNamespace({
@@ -140,6 +144,10 @@ async function clearSessionIngestionState(workspaceDir: string): Promise<void> {
     }),
     clearMemoryCoreWorkspaceNamespace({
       namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
+      workspaceDir,
+    }),
+    clearMemoryCoreWorkspaceNamespace({
+      namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
       workspaceDir,
     }),
   ]);

--- a/extensions/memory-core/src/dreaming-repair.ts
+++ b/extensions/memory-core/src/dreaming-repair.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { extractErrorCode } from "openclaw/plugin-sdk/error-runtime";
 import {
   clearMemoryCoreWorkspaceNamespace,
-  DREAMING_DAILY_INGESTION_NAMESPACE,
   DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
   DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
   readMemoryCoreWorkspaceEntries,
@@ -132,10 +131,6 @@ async function moveToArchive(params: {
   return destination;
 }
 
-// Clears every dreaming ingestion namespace tracked by the SQLite migration so a
-// repair fully resets ingestion bookkeeping. The daily-ingestion namespace mirrors
-// the legacy daily-ingestion.json sidecar and must be cleared alongside the session
-// files/seen namespaces (the audit already treats all three as ingestion state).
 async function clearSessionIngestionState(workspaceDir: string): Promise<void> {
   await Promise.all([
     clearMemoryCoreWorkspaceNamespace({
@@ -144,10 +139,6 @@ async function clearSessionIngestionState(workspaceDir: string): Promise<void> {
     }),
     clearMemoryCoreWorkspaceNamespace({
       namespace: DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
-      workspaceDir,
-    }),
-    clearMemoryCoreWorkspaceNamespace({
-      namespace: DREAMING_DAILY_INGESTION_NAMESPACE,
       workspaceDir,
     }),
   ]);
@@ -221,10 +212,11 @@ export async function auditDreamingArtifacts(params: {
   // Fall back to SQLite plugin state when the legacy JSON file was archived by migration.
   if (!sessionIngestionExists) {
     try {
+      // Daily ingestion tracks memory/*.md independently; session repair must not
+      // report or clear that healthy bookkeeping when rebuilding the session corpus.
       const ingestionNamespaces = [
         DREAMING_SESSION_INGESTION_FILES_NAMESPACE,
         DREAMING_SESSION_INGESTION_SEEN_NAMESPACE,
-        DREAMING_DAILY_INGESTION_NAMESPACE,
       ] as const;
       for (const namespace of ingestionNamespaces) {
         const entries = await readMemoryCoreWorkspaceEntries({


### PR DESCRIPTION
## What Problem This Solves

The dreaming repair audit mixed two independent bookkeeping domains: session-corpus ingestion and daily-memory ingestion. This made daily-only state look like stale session ingestion and encouraged session repair to delete healthy daily-memory bookkeeping.

This corrects the boundary related to #92017 and #92020 without broadening destructive repair behavior.

## Why This Change Was Made

The original PR direction was reversed after reading the full dreaming pipeline and repair callers. `sessionIngestionExists` now reflects only the session-files and seen-session namespaces. Session repair clears those namespaces while preserving `dreaming-daily-ingestion`, whose lifecycle belongs to daily-memory ingestion.

## User Impact

`openclaw memory status --fix` no longer reports daily-only bookkeeping as session-corpus state and no longer discards healthy daily ingestion records during explicit session repair.

## Evidence

- Blacksmith Testbox `tbx_01kww7ned9gavfc1rtwaghsm8y`: all 8 focused dreaming-repair tests passed against the real SQLite-backed plugin-state store.
- Regression coverage proves daily-only audit is false, session namespaces audit true and are cleared, and daily rows survive session repair.
- Same Testbox: `pnpm check:changed` passed.
- Fresh Codex autoreview: no actionable findings.

Credit: @Alix-007 surfaced and authored the original repair; @vincentkoc provided the corrected session-scope direction.

AI-assisted: yes. Maintainer repair, full owner/caller/sibling review, regression proof, and final validation were performed before landing.
