### PR TITLE
fix(durable-delivery): anchor reply fallback to current inbound message

### DIFF
--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -22,6 +22,7 @@ vi.mock("../message/send.js", async (importOriginal) => {
   };
 });
 
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import {
   deliverInboundReplyWithMessageSendContext,
@@ -101,7 +102,7 @@ describe("durable inbound reply delivery", () => {
 
     expect(
       resolveDurableInboundReplyToId({
-        payload: { text: "plain reply", replyToId: null },
+        payload: { text: "plain reply", replyToId: null } as unknown as ReplyPayload,
         ctxPayload: ctxPayload({
           MessageSidFull: "context-full-message",
           MessageSid: "context-message",

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -93,20 +93,30 @@ describe("durable inbound reply delivery", () => {
         replyToId: null,
         payload: { text: "plain reply" },
         ctxPayload: ctxPayload({
-          ReplyToIdFull: "context-full-reply",
-          ReplyToId: "context-reply",
+          MessageSidFull: "context-full-message",
+          MessageSid: "context-message",
+        }),
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveDurableInboundReplyToId({
+        payload: { text: "plain reply", replyToId: null },
+        ctxPayload: ctxPayload({
+          MessageSidFull: "context-full-message",
+          MessageSid: "context-message",
         }),
       }),
     ).toBeNull();
   });
 
-  it("falls back to payload and context reply targets when no explicit null is provided", () => {
+  it("falls back to payload and current-message context ids when no explicit null is provided", () => {
     expect(
       resolveDurableInboundReplyToId({
         payload: { text: "payload reply", replyToId: "payload-reply" },
         ctxPayload: ctxPayload({
-          ReplyToIdFull: "context-full-reply",
-          ReplyToId: "context-reply",
+          MessageSidFull: "context-full-message",
+          MessageSid: "context-message",
         }),
       }),
     ).toBe("payload-reply");
@@ -115,11 +125,46 @@ describe("durable inbound reply delivery", () => {
       resolveDurableInboundReplyToId({
         payload: { text: "context reply" },
         ctxPayload: ctxPayload({
-          ReplyToIdFull: "context-full-reply",
-          ReplyToId: "context-reply",
+          MessageSidFull: "context-full-message",
+          MessageSid: "context-message",
         }),
       }),
-    ).toBe("context-full-reply");
+    ).toBe("context-full-message");
+
+    expect(
+      resolveDurableInboundReplyToId({
+        payload: { text: "context reply" },
+        ctxPayload: ctxPayload({
+          MessageSid: "context-message",
+        }),
+      }),
+    ).toBe("context-message");
+  });
+
+  it("anchors to the current inbound message id, not an earlier reply-to target", () => {
+    // ReplyToId* can point at the assistant message Moeed replied to; the durable
+    // fallback must anchor to the current inbound message instead.
+    expect(
+      resolveDurableInboundReplyToId({
+        payload: { text: "reply" },
+        ctxPayload: ctxPayload({
+          ReplyToIdFull: "earlier-assistant-message-full",
+          ReplyToId: "earlier-assistant-message",
+          MessageSidFull: "current-message-full",
+          MessageSid: "current-message",
+        }),
+      }),
+    ).toBe("current-message-full");
+
+    expect(
+      resolveDurableInboundReplyToId({
+        payload: { text: "reply" },
+        ctxPayload: ctxPayload({
+          ReplyToIdFull: "earlier-assistant-message-full",
+          ReplyToId: "earlier-assistant-message",
+        }),
+      }),
+    ).toBeUndefined();
   });
 
   it("preserves explicit null thread targets instead of falling back to context thread", async () => {

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -72,8 +72,8 @@ export function resolveDurableInboundReplyToId(
   return (
     normalizeOptionalString(params.replyToId) ??
     normalizeOptionalString(params.payload.replyToId) ??
-    normalizeOptionalString(params.ctxPayload.ReplyToIdFull) ??
-    normalizeOptionalString(params.ctxPayload.ReplyToId)
+    normalizeOptionalString(params.ctxPayload.MessageSidFull) ??
+    normalizeOptionalString(params.ctxPayload.MessageSid)
   );
 }
 


### PR DESCRIPTION
## Summary
- Anchor durable-delivery reply fallback to the current inbound message when no better reply target exists.
- Prevent fallback delivery from reusing stale assistant reply context for current-message replies.

## Real behavior proof

**Behavior or issue addressed:** Durable final delivery should not fall back to a stale Telegram reply context when a current inbound message id is available.

**Real environment tested:** Moeed's local OpenClaw install on the Mac Mini, running OpenClaw 2026.6.6 installed runtime bundle.

**Exact steps or command run after this patch:**
```bash
~/.openclaw/_patches/reply-anchor-current-message-20260613/reapply.sh
node --check /opt/homebrew/lib/node_modules/openclaw/dist/kernel-BdraY_qZ.js
```

**Evidence after fix:** Terminal output from the real installed OpenClaw setup:
```text
reply-anchor-current-message hotfix present: /opt/homebrew/lib/node_modules/openclaw/dist/kernel-BdraY_qZ.js
node --check /opt/homebrew/lib/node_modules/openclaw/dist/kernel-BdraY_qZ.js
# exited 0
```

**Observed result after fix:** The installed runtime contains the durable-delivery current-message fallback patch and the patched bundle parses successfully in the live local OpenClaw installation.

**What was not tested:** No end-to-end Telegram send was performed from this PR branch; local regression tests cover the source behavior and the installed-runtime check proves the live containment is present.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.channels.config.ts src/channels/turn/durable-delivery.test.ts`
- Result: 7 tests passed locally.

## Notes
This is the source version of a local OpenClaw reply-anchor containment fix.
