### PR TITLE
fix(memory): abort orphaned qmd search subprocess when memory_search times out

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -2874,6 +2874,107 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("aborts the in-flight mcporter search subprocess when the caller signal aborts", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    // The mcporter `call` child never closes on its own, so the only way the
+    // search can settle is the caller-owned abort signal reaching the mcporter
+    // subprocess via runMcporter -> runCliCommand and killing it.
+    let mcporterCallKill: ReturnType<typeof vi.fn> | undefined;
+    let mcporterCallChild: MockChild | undefined;
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        const child = createMockChild({ autoClose: false });
+        const kill = vi.fn(() => {
+          // Mirror a real child exiting after SIGKILL so the close handler runs.
+          queueMicrotask(() => child.emit("close", null));
+        });
+        Object.assign(child, { kill });
+        mcporterCallKill = kill;
+        mcporterCallChild = child;
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+
+    const searchPromise = manager.search("test", {
+      sessionKey: "agent:main:slack:dm:u123",
+      signal: controller.signal,
+    });
+    searchPromise.catch(() => undefined);
+
+    await waitUntil(() => mcporterCallKill !== undefined);
+    expect(mcporterCallChild).toBeDefined();
+
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
+    expect(mcporterCallKill).toHaveBeenCalledWith("SIGKILL");
+    await manager.close();
+  });
+
+  it("rejects the mcporter search before spawning a call subprocess when the caller signal is already aborted", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        emitAndClose(child, "stdout", JSON.stringify({ results: [] }));
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    const callsBefore = spawnMock.mock.calls.filter(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])?.[0] === "call",
+    ).length;
+
+    await expect(
+      manager.search("test", {
+        sessionKey: "agent:main:slack:dm:u123",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("memory_search timed out after 15s");
+
+    const callsAfter = spawnMock.mock.calls.filter(
+      (call: unknown[]) => isMcporterCommand(call[0]) && (call[1] as string[])?.[0] === "call",
+    ).length;
+    expect(callsAfter).toBe(callsBefore);
+    await manager.close();
+  });
+
   it("does not pass --no-rerank to direct query fallback from search mode", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -2809,6 +2809,71 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("aborts the in-flight grouped qmd search subprocess when the caller signal aborts", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          sessions: { enabled: true },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    // Mixed memory/session sources route the search through
+    // runQueryAcrossCollectionGroups. The first grouped search child never
+    // closes on its own, so the only way the search can settle is the
+    // caller-owned abort signal reaching the grouped subprocess and killing it.
+    let groupedChildKill: ReturnType<typeof vi.fn> | undefined;
+    let groupedChild: MockChild | undefined;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "--help") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          "-c, --collection <name>    Filter by one or more collections",
+        );
+        return child;
+      }
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        const kill = vi.fn(() => {
+          // Mirror a real child exiting after SIGKILL so the close handler runs.
+          queueMicrotask(() => child.emit("close", null));
+        });
+        Object.assign(child, { kill });
+        if (!groupedChildKill) {
+          groupedChildKill = kill;
+          groupedChild = child;
+        }
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+
+    const searchPromise = manager.search("test", {
+      sessionKey: "agent:main:slack:dm:u123",
+      signal: controller.signal,
+    });
+    searchPromise.catch(() => undefined);
+
+    await waitUntil(() => groupedChildKill !== undefined);
+    expect(groupedChild).toBeDefined();
+
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
+    expect(groupedChildKill).toHaveBeenCalledWith("SIGKILL");
+    await manager.close();
+  });
+
   it("does not pass --no-rerank to direct query fallback from search mode", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -2874,6 +2874,60 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("aborts the multi-collection capability probe without caching a failure", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "workspace" },
+            { path: path.join(workspaceDir, "notes"), pattern: "**/*.md", name: "notes" },
+          ],
+        },
+      },
+    } as OpenClawConfig;
+
+    let helpChildKill: ReturnType<typeof vi.fn> | undefined;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "--help") {
+        const child = createMockChild({ autoClose: false });
+        const kill = vi.fn(() => {
+          queueMicrotask(() => child.emit("close", null));
+        });
+        Object.assign(child, { kill });
+        helpChildKill = kill;
+        return child;
+      }
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(child, "stdout", "[]");
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+    const searchPromise = manager.search("test", {
+      sessionKey: "agent:main:slack:dm:u123",
+      signal: controller.signal,
+    });
+    searchPromise.catch(() => undefined);
+
+    await waitUntil(() => helpChildKill !== undefined);
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
+    expect(helpChildKill).toHaveBeenCalledWith("SIGKILL");
+    expect(
+      spawnMock.mock.calls.some((call: unknown[]) => (call[1] as string[])?.[0] === "search"),
+    ).toBe(false);
+    await manager.close();
+  });
+
   it("aborts the in-flight mcporter search subprocess when the caller signal aborts", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -2721,6 +2721,94 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("aborts the in-flight qmd search subprocess when the caller signal aborts", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    // The query child never closes on its own so the only way the search can
+    // settle is the caller-owned abort signal killing the subprocess.
+    let queryChildKill: ReturnType<typeof vi.fn> | undefined;
+    let queryChild: MockChild | undefined;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "query") {
+        const child = createMockChild({ autoClose: false });
+        const kill = vi.fn(() => {
+          // Mirror a real child exiting after SIGKILL so the close handler runs.
+          queueMicrotask(() => child.emit("close", null));
+        });
+        Object.assign(child, { kill });
+        queryChildKill = kill;
+        queryChild = child;
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+
+    const searchPromise = manager.search("test", {
+      sessionKey: "agent:main:slack:dm:u123",
+      signal: controller.signal,
+    });
+    searchPromise.catch(() => undefined);
+
+    await waitUntil(() => queryChildKill !== undefined);
+    expect(queryChild).toBeDefined();
+
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(searchPromise).rejects.toThrow("memory_search timed out after 15s");
+    expect(queryChildKill).toHaveBeenCalledWith("SIGKILL");
+    await manager.close();
+  });
+
+  it("rejects the qmd search before spawning when the caller signal is already aborted", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const { manager } = await createManager();
+    const controller = new AbortController();
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    const callsBefore = spawnMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
+    ).length;
+
+    await expect(
+      manager.search("test", {
+        sessionKey: "agent:main:slack:dm:u123",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("memory_search timed out after 15s");
+
+    const callsAfter = spawnMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as string[])?.[0] === "query",
+    ).length;
+    expect(callsAfter).toBe(callsBefore);
+    await manager.close();
+  });
+
   it("does not pass --no-rerank to direct query fallback from search mode", async () => {
     cfg = {
       ...cfg,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1398,6 +1398,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             limit,
             collectionGroups,
             qmdSearchCommand,
+            searchSignal,
           );
         }
         const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
@@ -1425,6 +1426,7 @@ export class QmdMemoryManager implements MemorySearchManager {
                 limit,
                 collectionGroups,
                 "query",
+                searchSignal,
               );
             }
             const fallbackArgs = this.buildSearchArgs("query", trimmed, limit);
@@ -3376,6 +3378,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     limit: number,
     collectionGroups: string[][],
     command: "query" | "search" | "vsearch",
+    signal?: AbortSignal,
   ): Promise<QmdQueryResult[]> {
     log.debug(
       `qmd ${command} multi-source collection grouping active (${collectionGroups.length} groups)`,
@@ -3384,7 +3387,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     for (const collectionNames of collectionGroups) {
       const args = this.buildSearchArgs(command, query, limit);
       args.push(...this.buildCollectionFilterArgs(collectionNames));
-      const parsed = await this.runQmdSearch(args, command);
+      const parsed = await this.runQmdSearch(args, command, signal);
       for (const entry of parsed) {
         const defaultCollection = collectionNames.length === 1 ? collectionNames[0] : undefined;
         const normalizedHints = this.normalizeDocHints({

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -342,6 +342,7 @@ type QmdMcporterSearchParams =
       minScore: number;
       collection?: string;
       timeoutMs: number;
+      signal?: AbortSignal;
     }
   | {
       mcporter: ResolvedQmdMcporterConfig;
@@ -353,6 +354,7 @@ type QmdMcporterSearchParams =
       minScore: number;
       collection?: string;
       timeoutMs: number;
+      signal?: AbortSignal;
     };
 type QmdMcporterAcrossCollectionsParams =
   | {
@@ -363,6 +365,7 @@ type QmdMcporterAcrossCollectionsParams =
       limit: number;
       minScore: number;
       collectionNames: string[];
+      signal?: AbortSignal;
     }
   | {
       tool: BuiltinQmdMcpTool;
@@ -372,6 +375,7 @@ type QmdMcporterAcrossCollectionsParams =
       limit: number;
       minScore: number;
       collectionNames: string[];
+      signal?: AbortSignal;
     };
 
 export class QmdMemoryManager implements MemorySearchManager {
@@ -1353,6 +1357,7 @@ export class QmdMemoryManager implements MemorySearchManager {
                 limit,
                 minScore,
                 collectionNames,
+                signal: searchSignal,
               });
             }
             return await this.runQmdSearchViaMcporter({
@@ -1365,6 +1370,7 @@ export class QmdMemoryManager implements MemorySearchManager {
               minScore,
               collection: collectionNames[0],
               timeoutMs: this.qmd.limits.timeoutMs,
+              signal: searchSignal,
             });
           }
           const tool = this.resolveQmdMcpTool(qmdSearchCommand);
@@ -1377,6 +1383,7 @@ export class QmdMemoryManager implements MemorySearchManager {
               limit,
               minScore,
               collectionNames,
+              signal: searchSignal,
             });
           }
           return await this.runQmdSearchViaMcporter({
@@ -1389,6 +1396,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             minScore,
             collection: collectionNames[0],
             timeoutMs: this.qmd.limits.timeoutMs,
+            signal: searchSignal,
           });
         }
         const collectionGroups = await this.resolveCollectionSearchGroups(collectionNames);
@@ -2336,7 +2344,7 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private async runMcporter(
     args: string[],
-    opts?: { timeoutMs?: number },
+    opts?: { timeoutMs?: number; signal?: AbortSignal },
   ): Promise<{ stdout: string; stderr: string }> {
     const spawnInvocation = resolveCliSpawnInvocation({
       command: "mcporter",
@@ -2352,12 +2360,16 @@ export class QmdMemoryManager implements MemorySearchManager {
       cwd: this.workspaceDir,
       timeoutMs: opts?.timeoutMs,
       maxOutputChars: this.maxQmdOutputChars,
+      signal: opts?.signal,
     });
   }
 
   private async runQmdSearchViaMcporter(
     params: QmdMcporterSearchParams,
   ): Promise<QmdQueryResult[]> {
+    if (params.signal?.aborted) {
+      throw asAbortError(params.signal);
+    }
     await this.ensureMcporterDaemonStarted(params.mcporter);
 
     // If the version is already known as v1 but we received a stale "query" tool name
@@ -2414,7 +2426,10 @@ export class QmdMemoryManager implements MemorySearchManager {
           "--timeout",
           String(Math.max(0, params.timeoutMs)),
         ],
-        { timeoutMs: resolveQmdMcporterSearchProcessTimeoutMs(params.timeoutMs) },
+        {
+          timeoutMs: resolveQmdMcporterSearchProcessTimeoutMs(params.timeoutMs),
+          signal: params.signal,
+        },
       );
       // If we got here with the v2 "query" tool, confirm v2 for future calls.
       if (useUnifiedQueryTool && this.qmdMcpToolVersion === null) {
@@ -2443,6 +2458,7 @@ export class QmdMemoryManager implements MemorySearchManager {
           minScore: params.minScore,
           collection: params.collection,
           timeoutMs: params.timeoutMs,
+          signal: params.signal,
         });
       }
       throw err;
@@ -3470,6 +3486,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             minScore: params.minScore,
             collection: collectionName,
             timeoutMs: this.qmd.limits.timeoutMs,
+            signal: params.signal,
           })
         : await this.runQmdSearchViaMcporter({
             mcporter: this.qmd.mcporter,
@@ -3481,6 +3498,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             minScore: params.minScore,
             collection: collectionName,
             timeoutMs: this.qmd.limits.timeoutMs,
+            signal: params.signal,
           });
       for (const entry of parsed) {
         if (typeof entry.docid !== "string" || !entry.docid.trim()) {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -90,6 +90,23 @@ type SqliteDatabase = import("node:sqlite").DatabaseSync;
 
 const log = createSubsystemLogger("memory");
 
+/**
+ * Normalize an already-aborted search signal into the error thrown before any
+ * qmd work starts. Prefers the caller-supplied abort reason (so a deadline
+ * message such as "memory_search timed out after 15s" survives) and falls back
+ * to a stable abort error.
+ */
+function asAbortError(signal: AbortSignal): Error {
+  const reason = signal.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  if (typeof reason === "string" && reason.length > 0) {
+    return new Error(reason);
+  }
+  return new Error("qmd search aborted");
+}
+
 const SNIPPET_HEADER_RE = /@@\s*-([0-9]+),([0-9]+)/;
 const SEARCH_PENDING_UPDATE_WAIT_MS = 500;
 const MAX_QMD_OUTPUT_CHARS = 200_000;
@@ -1280,11 +1297,22 @@ export class QmdMemoryManager implements MemorySearchManager {
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
+      /**
+       * Caller-owned cancellation. When the caller stops waiting (e.g. the
+       * memory_search tool deadline fires), abort kills the in-flight qmd
+       * subprocess instead of leaving it running orphaned for the full qmd
+       * timeout.
+       */
+      signal?: AbortSignal;
     },
   ): Promise<MemorySearchResult[]> {
     if (!this.isScopeAllowed(opts?.sessionKey)) {
       this.logScopeDenied(opts?.sessionKey);
       return [];
+    }
+    const searchSignal = opts?.signal;
+    if (searchSignal?.aborted) {
+      throw asAbortError(searchSignal);
     }
     const trimmed = query.trim();
     if (!trimmed) {
@@ -1374,7 +1402,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         }
         const args = this.buildSearchArgs(qmdSearchCommand, trimmed, limit);
         args.push(...this.buildCollectionFilterArgs(collectionGroups[0] ?? collectionNames));
-        return await this.runQmdSearch(args, qmdSearchCommand);
+        return await this.runQmdSearch(args, qmdSearchCommand, searchSignal);
       } catch (err) {
         if (allowMissingCollectionRepair && this.isMissingCollectionSearchError(err)) {
           throw err;
@@ -1403,7 +1431,7 @@ export class QmdMemoryManager implements MemorySearchManager {
             fallbackArgs.push(
               ...this.buildCollectionFilterArgs(collectionGroups[0] ?? collectionNames),
             );
-            return await this.runQmdSearch(fallbackArgs, "query");
+            return await this.runQmdSearch(fallbackArgs, "query", searchSignal);
           } catch (fallbackErr) {
             log.warn(`qmd query fallback failed: ${String(fallbackErr)}`);
             throw fallbackErr instanceof Error ? fallbackErr : new Error(String(fallbackErr));
@@ -2137,7 +2165,7 @@ export class QmdMemoryManager implements MemorySearchManager {
 
   private async runQmd(
     args: string[],
-    opts?: { timeoutMs?: number; discardOutput?: boolean },
+    opts?: { timeoutMs?: number; discardOutput?: boolean; signal?: AbortSignal },
   ): Promise<{ stdout: string; stderr: string }> {
     return await runCliCommand({
       commandSummary: `qmd ${args.join(" ")}`,
@@ -2153,15 +2181,17 @@ export class QmdMemoryManager implements MemorySearchManager {
       maxOutputChars: this.maxQmdOutputChars,
       // Large `qmd update` runs can easily exceed the output cap; keep only stderr.
       discardStdout: opts?.discardOutput,
+      signal: opts?.signal,
     });
   }
 
   private async runQmdSearch(
     args: string[],
     command: "query" | "search" | "vsearch",
+    signal?: AbortSignal,
   ): Promise<QmdQueryResult[]> {
     try {
-      const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
+      const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs, signal });
       return parseQmdQueryJson(result.stdout, result.stderr);
     } catch (err) {
       const recovered = this.parseFailedQmdSearchJson(err, command);

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1399,7 +1399,10 @@ export class QmdMemoryManager implements MemorySearchManager {
             signal: searchSignal,
           });
         }
-        const collectionGroups = await this.resolveCollectionSearchGroups(collectionNames);
+        const collectionGroups = await this.resolveCollectionSearchGroups(
+          collectionNames,
+          searchSignal,
+        );
         if (collectionGroups.length > 1) {
           return await this.runQueryAcrossCollectionGroups(
             trimmed,
@@ -1427,7 +1430,10 @@ export class QmdMemoryManager implements MemorySearchManager {
             `qmd ${qmdSearchCommand} does not support configured flags; retrying search with qmd query`,
           );
           try {
-            const collectionGroups = await this.resolveCollectionSearchGroups(collectionNames);
+            const collectionGroups = await this.resolveCollectionSearchGroups(
+              collectionNames,
+              searchSignal,
+            );
             if (collectionGroups.length > 1) {
               return await this.runQueryAcrossCollectionGroups(
                 trimmed,
@@ -3361,28 +3367,39 @@ export class QmdMemoryManager implements MemorySearchManager {
     ]);
   }
 
-  private async resolveCollectionSearchGroups(collectionNames: string[]): Promise<string[][]> {
+  private async resolveCollectionSearchGroups(
+    collectionNames: string[],
+    signal?: AbortSignal,
+  ): Promise<string[][]> {
     if (collectionNames.length <= 1) {
       return [collectionNames];
     }
-    if (!(await this.supportsQmdMultiCollectionFilters())) {
+    if (!(await this.supportsQmdMultiCollectionFilters(signal))) {
       return collectionNames.map((collectionName) => [collectionName]);
     }
     return this.groupCollectionNamesBySource(collectionNames);
   }
 
-  private async supportsQmdMultiCollectionFilters(): Promise<boolean> {
+  private async supportsQmdMultiCollectionFilters(signal?: AbortSignal): Promise<boolean> {
+    if (signal?.aborted) {
+      throw asAbortError(signal);
+    }
     if (this.multiCollectionFilterSupported !== null) {
       return this.multiCollectionFilterSupported;
     }
     try {
       const result = await this.runQmd(["--help"], {
         timeoutMs: Math.min(this.qmd.limits.timeoutMs, 5_000),
+        signal,
       });
       const helpText = `${result.stdout}\n${result.stderr}`;
       this.multiCollectionFilterSupported =
         /\b(?:one or more collections|collection\(s\)|multiple -c flags)\b/i.test(helpText);
     } catch (err) {
+      // Cancellation says nothing about QMD capabilities; leave the probe uncached.
+      if (signal?.aborted) {
+        throw asAbortError(signal);
+      }
       this.multiCollectionFilterSupported = false;
       log.debug(`qmd multi-collection filter probe failed: ${String(err)}`);
     }

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -328,6 +328,29 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock.mock.calls).toHaveLength(1);
   });
 
+  it("keeps the cached QMD manager active when the caller cancels a search", async () => {
+    const agentId = "cancelled-search";
+    const cfg = createQmdCfg(agentId);
+    const controller = new AbortController();
+    const abortError = new Error("memory_search timed out after 15s");
+    mockPrimary.search.mockImplementationOnce(async () => {
+      controller.abort(abortError);
+      throw abortError;
+    });
+
+    const first = await getMemorySearchManager({ cfg, agentId });
+    const firstManager = requireManager(first);
+    await expect(firstManager.search("hello", { signal: controller.signal })).rejects.toBe(
+      abortError,
+    );
+
+    expect(mockPrimary.close).not.toHaveBeenCalled();
+    expect(fallbackSearch).not.toHaveBeenCalled();
+    const second = await getMemorySearchManager({ cfg, agentId });
+    expect(second.manager).toBe(first.manager);
+    expect(createQmdManagerMock).toHaveBeenCalledTimes(1);
+  });
+
   it("evicts failed qmd wrapper so next call retries qmd", async () => {
     const retryAgentId = "retry-agent";
     const {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -475,6 +475,7 @@ class FallbackMemoryManager implements MemorySearchManager {
       qmdSearchModeOverride?: "query" | "search" | "vsearch";
       onDebug?: (debug: MemorySearchRuntimeDebug) => void;
       sources?: MemorySource[];
+      signal?: AbortSignal;
     },
   ) {
     this.ensureOpen();
@@ -482,6 +483,11 @@ class FallbackMemoryManager implements MemorySearchManager {
       try {
         return await this.deps.primary.search(query, opts);
       } catch (err) {
+        // Caller cancellation is request-scoped, not a QMD health failure.
+        // Keep the shared manager active for concurrent and later searches.
+        if (opts?.signal?.aborted) {
+          throw err;
+        }
         this.primaryFailed = true;
         this.lastError = formatErrorMessage(err);
         log.warn(`qmd memory failed; switching to builtin index: ${this.lastError}`);

--- a/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
@@ -71,7 +71,9 @@ function killProcessTree(parentPid: number): void {
     );
     return;
   }
-  process.kill(-parentPid, "SIGKILL");
+  // The production abort path already force-kills the group. Cleanup after a
+  // failed assertion starts gracefully so it cannot kill a reused group id.
+  process.kill(-parentPid, "SIGTERM");
 }
 
 describe("runCliCommand real process lifecycle", () => {

--- a/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.real.test.ts
@@ -1,0 +1,141 @@
+// Memory Host SDK real-process tests cover QMD process-tree cleanup.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCliCommand } from "./qmd-process.js";
+
+type ProcessTreePids = {
+  parent: number;
+  grandchild: number;
+};
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function waitUntil(params: {
+  condition: () => boolean | Promise<boolean>;
+  description: string;
+  timeoutMs?: number;
+}): Promise<void> {
+  const deadline = Date.now() + (params.timeoutMs ?? 5_000);
+  while (!(await params.condition())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${params.description}`);
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+}
+
+async function readProcessTreePids(pidFile: string): Promise<ProcessTreePids> {
+  let pids: ProcessTreePids | undefined;
+  await waitUntil({
+    description: "the process-tree PID file",
+    condition: async () => {
+      try {
+        pids = JSON.parse(await fs.readFile(pidFile, "utf8")) as ProcessTreePids;
+        return Number.isInteger(pids.parent) && Number.isInteger(pids.grandchild);
+      } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+          return false;
+        }
+        throw error;
+      }
+    },
+  });
+  if (!pids) {
+    throw new Error("process-tree PID file was not populated");
+  }
+  return pids;
+}
+
+function killProcessTree(parentPid: number): void {
+  if (process.platform === "win32") {
+    const systemRoot = process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows";
+    spawnSync(
+      path.win32.join(systemRoot, "System32", "taskkill.exe"),
+      ["/PID", String(parentPid), "/T", "/F"],
+      { stdio: "ignore", windowsHide: true },
+    );
+    return;
+  }
+  process.kill(-parentPid, "SIGKILL");
+}
+
+describe("runCliCommand real process lifecycle", () => {
+  it("kills the command and its descendant when the caller aborts", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-abort-"));
+    const pidFile = path.join(tempDir, "pids.json");
+    const controller = new AbortController();
+    const abortError = new Error("memory_search timed out after 15s");
+    let pending: ReturnType<typeof runCliCommand> | undefined;
+    let pids: ProcessTreePids | undefined;
+
+    const childScript = `
+        const { spawn } = require("node:child_process");
+        const { renameSync, writeFileSync } = require("node:fs");
+        const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+          stdio: "ignore",
+        });
+        const pidFile = process.argv[1];
+        const temporaryPidFile = pidFile + ".tmp";
+        writeFileSync(temporaryPidFile, JSON.stringify({
+          parent: process.pid,
+          grandchild: grandchild.pid,
+        }));
+        renameSync(temporaryPidFile, pidFile);
+        setInterval(() => {}, 1000);
+      `;
+
+    try {
+      pending = runCliCommand({
+        commandSummary: "real qmd process-tree fixture",
+        spawnInvocation: { command: process.execPath, argv: ["-e", childScript, pidFile] },
+        env: process.env,
+        cwd: tempDir,
+        timeoutMs: 60_000,
+        maxOutputChars: 10_000,
+        signal: controller.signal,
+      });
+
+      pids = await readProcessTreePids(pidFile);
+      expect(isProcessRunning(pids.parent)).toBe(true);
+      expect(isProcessRunning(pids.grandchild)).toBe(true);
+
+      controller.abort(abortError);
+      await expect(pending).rejects.toBe(abortError);
+      await waitUntil({
+        description: "the detached process tree to exit",
+        condition: () =>
+          pids !== undefined &&
+          !isProcessRunning(pids.parent) &&
+          !isProcessRunning(pids.grandchild),
+      });
+    } finally {
+      if (!controller.signal.aborted) {
+        controller.abort(abortError);
+      }
+      await pending?.catch(() => undefined);
+      if (pids?.parent && isProcessRunning(pids.parent)) {
+        try {
+          killProcessTree(pids.parent);
+        } catch {
+          // Best-effort cleanup when an assertion failed after the child exited.
+        }
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -277,7 +277,6 @@ describe("checkQmdBinaryAvailability", () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_SAFE_TIMEOUT_DELAY_MS);
   });
-
   it("kills timed-out availability probes by process group on POSIX", async () => {
     platformSpy?.mockReturnValue("linux");
     const killProcess = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -427,6 +426,52 @@ describe("runCliCommand", () => {
     }).catch(() => undefined);
 
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_SAFE_TIMEOUT_DELAY_MS);
+  });
+
+  it("kills aborted cli command process groups on POSIX and rejects with the abort reason", async () => {
+    platformSpy?.mockReturnValue("linux");
+    const killProcess = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const child = createMockChild({ pid: 7654 });
+    spawnMock.mockReturnValueOnce(child);
+    const controller = new AbortController();
+
+    try {
+      const pending = runCliCommand({
+        commandSummary: "qmd query slow",
+        spawnInvocation: { command: "qmd", argv: ["query", "slow", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+        timeoutMs: 60_000,
+        signal: controller.signal,
+      });
+
+      controller.abort(new Error("memory_search timed out after 15s"));
+
+      await expect(pending).rejects.toThrow("memory_search timed out after 15s");
+      expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({ detached: true });
+      expect(killProcess).toHaveBeenCalledWith(-7654, "SIGKILL");
+      expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      killProcess.mockRestore();
+    }
+  });
+
+  it("rejects immediately without spawning when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("memory_search timed out after 15s"));
+
+    await expect(
+      runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("memory_search timed out after 15s");
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("kills timed-out cli command process groups on POSIX", async () => {

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -156,6 +156,22 @@ function validateQmdProbeCwd(cwd: string): QmdBinaryAvailability | null {
   }
 }
 
+/**
+ * Normalize an aborted signal into the error used to reject a killed command.
+ * Prefers the caller-supplied abort reason (so a deadline message survives) and
+ * falls back to a stable per-command abort error.
+ */
+function abortReason(signal: AbortSignal | undefined, commandSummary: string): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  if (typeof reason === "string" && reason.length > 0) {
+    return new Error(reason);
+  }
+  return new Error(`${commandSummary} aborted`);
+}
+
 export async function runCliCommand(params: {
   commandSummary: string;
   spawnInvocation: CliSpawnInvocation;
@@ -164,8 +180,20 @@ export async function runCliCommand(params: {
   timeoutMs?: number;
   maxOutputChars: number;
   discardStdout?: boolean;
+  /**
+   * Caller-owned cancellation. When the signal aborts, the spawned child is
+   * killed immediately and the call rejects, so a caller that already stopped
+   * waiting (for example after its own deadline) does not leave an orphaned
+   * process running for the full command timeout.
+   */
+  signal?: AbortSignal;
 }): Promise<{ stdout: string; stderr: string }> {
   return await new Promise((resolve, reject) => {
+    const { signal } = params;
+    if (signal?.aborted) {
+      reject(abortReason(signal, params.commandSummary));
+      return;
+    }
     const child = spawn(params.spawnInvocation.command, params.spawnInvocation.argv, {
       env: params.env,
       cwd: params.cwd,
@@ -177,15 +205,34 @@ export async function runCliCommand(params: {
     let stderr = "";
     let stdoutTruncated = false;
     let stderrTruncated = false;
+    let settled = false;
     const discardStdout = params.discardStdout === true;
     const timeoutMs =
       params.timeoutMs === undefined ? undefined : resolveSafeTimeoutDelayMs(params.timeoutMs);
     const timer = timeoutMs
       ? setTimeout(() => {
           signalQmdProcessTree(child, "SIGKILL");
-          reject(new Error(`${params.commandSummary} timed out after ${timeoutMs}ms`));
+          settle(() =>
+            reject(new Error(`${params.commandSummary} timed out after ${timeoutMs}ms`)),
+          );
         }, timeoutMs)
       : null;
+    const onAbort = () => {
+      signalQmdProcessTree(child, "SIGKILL");
+      settle(() => reject(abortReason(signal, params.commandSummary)));
+    };
+    function settle(run: () => void): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      signal?.removeEventListener("abort", onAbort);
+      run();
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
     child.stdout.on("data", (data) => {
       if (discardStdout) {
         return;
@@ -203,33 +250,35 @@ export async function runCliCommand(params: {
       if (timer) {
         clearTimeout(timer);
       }
-      reject(err);
+      settle(() => reject(err));
     });
-    child.on("close", (code, signal) => {
+    child.on("close", (code, closeSignal) => {
       if (timer) {
         clearTimeout(timer);
       }
-      if (!discardStdout && (stdoutTruncated || stderrTruncated)) {
-        reject(
-          new Error(
-            `${params.commandSummary} produced too much output (limit ${params.maxOutputChars} chars)`,
-          ),
-        );
-        return;
-      }
-      if (code === 0) {
-        resolve({ stdout, stderr });
-      } else {
-        reject(
-          new CliCommandError({
-            commandSummary: params.commandSummary,
-            code,
-            signal: signal ?? null,
-            stdout,
-            stderr,
-          }),
-        );
-      }
+      settle(() => {
+        if (!discardStdout && (stdoutTruncated || stderrTruncated)) {
+          reject(
+            new Error(
+              `${params.commandSummary} produced too much output (limit ${params.maxOutputChars} chars)`,
+            ),
+          );
+          return;
+        }
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          reject(
+            new CliCommandError({
+              commandSummary: params.commandSummary,
+              code,
+              signal: closeSignal ?? null,
+              stdout,
+              stderr,
+            }),
+          );
+        }
+      });
     });
   });
 }


### PR DESCRIPTION
## What Problem This Solves

The `memory_search` tool enforces a 15s deadline, but with the **QMD** memory backend that deadline only stops the *caller* — the spawned `qmd query`/`qmd search` subprocess keeps running for the full QMD command timeout (`memory.qmd.limits.timeoutMs`, whose embed-heavy default was raised to 600s in PR #87572). So after the agent has already given up and moved on, an orphaned `qmd` process keeps churning for up to ~10 minutes, leaking CPU/memory on every timed-out search. PR #91742 fixed exactly this orphaned-work leak for the **builtin** backend by wiring an `AbortSignal` through `MemorySearchManager.search()`, but the QMD manager — the other backend behind the same interface — silently ignored the signal, so the leak was still live for QMD users. This PR closes that gap so every supported QMD search path kills its subprocess when the caller's deadline fires.

## Evidence

Proven against the **real exported `runCliCommand`** (the single spawn point for all qmd search subprocesses) via `node --import tsx` against a real OS subprocess on PR head `6ee870e0ca`:

```
[B] child OS pid: 598162 alive before abort: true
[B] runCliCommand rejected after 17 ms with: "memory_search timed out after 15s"
[B] child pid 598162 alive AFTER abort: false
RESULT: PASS - abort killed the real subprocess and rejected promptly (no orphan).
```

The real OS process is confirmed alive before abort and dead after abort (via `process.kill(pid, 0)`), and `runCliCommand` rejects in **17ms** (not 600s) with the caller's deadline message preserved.

- **Tests:** `qmd-process.test.ts` 16/16 pass (SIGKILL + reject-on-abort, and reject-before-spawn when already aborted); `qmd-manager.test.ts -t abort` → 3/3 abort tests pass (132 total) covering single-collection **and** grouped multi-collection paths, asserted via the child `kill("SIGKILL")` spy. Typecheck (`run-tsgo.mjs -p tsconfig.extensions.json`) clean; memory-host-sdk typecheck passes.
- **Negative control:** reverting *only* the grouped-path signal propagation makes the grouped abort test fail — the qmd child survives the caller abort and dies only at the qmd command timeout (`...timed out after 4000ms` instead of being killed promptly), confirming the wiring is load-bearing on the grouped path.

---

## Summary

PR #91742 ("abort orphaned embedding work when memory_search times out") added an `AbortSignal` to `MemorySearchManager.search()` so that when the 15s `memory_search` tool deadline fires, in-flight embedding work is cancelled instead of running orphaned. That fix wired the signal through the **builtin** manager, but the **QMD** manager — the other backend behind the exact same `MemorySearchManager.search` interface — silently ignored it.

With the QMD backend, `memory_search` returns "timed out after 15s" to the agent after 15s, but the spawned `qmd query`/`qmd search` subprocess keeps running for the full QMD command timeout (`memory.qmd.limits.timeoutMs`, whose embed-heavy default was raised to 600s in PR #87572). So the orphaned-work leak that #91742 fixed for the builtin backend was still present for QMD users: the agent has already moved on, but a `qmd` process keeps churning for up to ~10 minutes.

## What changed

- `packages/memory-host-sdk/src/host/qmd-process.ts`: `runCliCommand` now accepts an optional `signal: AbortSignal`. When the signal aborts (or is already aborted on entry), the spawned child is `SIGKILL`ed immediately and the call rejects with the abort reason (preserving the caller's deadline message). Resolution/rejection is funneled through a single `settle()` guard so abort, timeout, `error`, and `close` cannot double-settle.
- `extensions/memory-core/src/memory/qmd-manager.ts`: `QmdMemoryManager.search()` accepts `opts.signal` (matching the builtin manager and the `MemorySearchManager` interface added in #91742). It fast-fails if the signal is already aborted, and threads the signal through `runQmdSearch` → `runQmd` → `runCliCommand` across **all** direct-`qmd` subprocess search paths:
  - the single-collection direct path and its `query` fallback, **and**
  - the **grouped multi-collection path** `runQueryAcrossCollectionGroups` (plus its unsupported-option `query` fallback), which multi-collection or mixed memory/session configs route through.

  The grouped helper previously called `runQmdSearch(args, command)` without the caller signal, so the central subprocess leak remained on that supported path (flagged in review). It now receives and forwards the same signal.

When the caller's deadline fires, the qmd subprocess is killed on every supported search path instead of left orphaned. The optional mcporter bridge is short-circuited by the universal pre-flight abort guard before it spawns anything.

## Real behavior proof (real runtime, outside tests)

`runCliCommand` is the single spawn point for **all** qmd search subprocesses (single-collection and grouped), so proving abort kills the real child there covers every path that forwards the signal. Ran the **real exported `runCliCommand`** via `node --import tsx` against a real OS subprocess (PR head `6ee870e0ca`):

```
$ TSX_TSCONFIG_PATH=tsconfig.json node --import tsx ./abort-proof.mts
[A] normal completion stdout: "hello-from-child"
[B] child OS pid: 598162 alive before abort: true
[B] runCliCommand rejected after 17 ms with: "memory_search timed out after 15s"
[B] child pid 598162 alive AFTER abort: false

RESULT: PASS - abort killed the real subprocess and rejected promptly (no orphan).
```

The proof script spawns a child that records its own PID and `sleep 30`s, with `timeoutMs: 600_000` (mimicking the qmd embed timeout). It confirms via `process.kill(pid, 0)` that the real OS process is **alive before abort** and **dead after abort**, that `runCliCommand` rejects in **17ms** (not 600s) with the caller's deadline message, and that a no-signal short command still completes normally (Case A).

**Grouped-path wiring (negative control):** the new grouped multi-collection abort regression drives `QmdMemoryManager.search({ signal })` through `runQueryAcrossCollectionGroups` (mixed memory/session sources) and asserts the spawned qmd child is `SIGKILL`ed when the caller aborts. Reverting *only* the grouped-path signal propagation makes that test fail, with the qmd child surviving the caller abort and dying only at the qmd command timeout:

```
AssertionError: expected [Function] to throw error including 'memory_search timed out after 15s'
  but got 'qmd search test --json -n 4 -c workspace-main timed out after 4000ms'
```

i.e. without this fix the grouped qmd child is left running until the qmd command timeout (4000ms in the test) instead of being killed promptly — the exact leak this PR closes, now confirmed on the grouped path too.

## Tests and validation

- `packages/memory-host-sdk/src/host/qmd-process.test.ts`: `runCliCommand` kills the child with `SIGKILL` and rejects with the abort reason when the signal aborts mid-run; and rejects immediately without spawning when already aborted. 16/16 pass.
- `extensions/memory-core/src/memory/qmd-manager.test.ts` (added grouped abort test → 3 abort tests total): single-collection **and** grouped multi-collection `qmd` searches both kill the in-flight subprocess (asserted via the child `kill("SIGKILL")` spy) when the caller aborts, and reject before spawning when already aborted. `-t abort` → 3 passed / 132 total.
- **Negative control**: reverting the grouped-path signal propagation makes the grouped abort test fail (child survives to the qmd command timeout), as shown above.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` clean; memory-host-sdk typecheck passes.

## Risk checklist

- Behavior is unchanged when no `signal` is passed (all parameters/opts fields are optional; existing callers are unaffected).
- `settle()` guard prevents double resolve/reject across abort/timeout/error/close; the abort listener is removed on settle to avoid leaks.
- The abort reason prefers the caller-supplied error so the existing "memory_search timed out after 15s" message is preserved end to end.
- No public API removed; only optional `signal` fields added. No config or schema changes.

<!-- codex-rescue-machine-readable-real-behavior-proof -->
## Real behavior proof

Behavior addressed: memory_search enforces a 15s deadline, but QMD search subprocesses could continue running until the much longer qmd command timeout after the caller had already aborted. This patch threads AbortSignal through the QMD paths so the spawned subprocess is killed promptly instead of becoming orphaned work.

Real environment tested: Local Linux runtime with Node v22 and node --import tsx, driving the real exported runCliCommand from packages/memory-host-sdk/src/host/qmd-process.ts against a real OS subprocess. runCliCommand is the central spawn point for qmd subprocesses; qmd-manager tests also cover signal forwarding through single-collection and grouped multi-collection search paths.

Exact steps or command run after this patch: In PR head fix/qmd-search-abort-orphaned, ran TSX_TSCONFIG_PATH=tsconfig.json node --import tsx ./abort-proof.mts, then ran packages/memory-host-sdk/src/host/qmd-process.test.ts and extensions/memory-core/src/memory/qmd-manager.test.ts -t abort. Also ran node scripts/run-tsgo.mjs -p tsconfig.extensions.json.

Evidence after fix: Live terminal output from the real OS subprocess proof:
```text
$ TSX_TSCONFIG_PATH=tsconfig.json node --import tsx ./abort-proof.mts
[A] normal completion stdout: "hello-from-child"
[B] child OS pid: 598162 alive before abort: true
[B] runCliCommand rejected after 17 ms with: "memory_search timed out after 15s"
[B] child pid 598162 alive AFTER abort: false
RESULT: PASS - abort killed the real subprocess and rejected promptly (no orphan).
```
Grouped-path negative control reverting only grouped-path signal propagation made the grouped abort regression fail with qmd timing out after 4000ms instead of rejecting with memory_search timed out after 15s, showing the child survived until qmd timeout without the fix.

Observed result after fix: The real child process is alive before abort and dead after abort, verified via process.kill(pid, 0). runCliCommand rejects in 17ms with the caller deadline message rather than waiting for the qmd timeout. The qmd-process abort tests passed 16/16 and qmd-manager abort tests passed 3/3 across single and grouped paths.

What was not tested: This proof does not run a live external qmd binary with real embeddings for the full 600s default timeout. It validates the process lifecycle and signal propagation through the shared spawn point and covered manager paths.
