### PR TITLE
fix(minimax): correct volume range warning to match inclusive max

### DIFF
--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -297,6 +297,19 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(result.warnings).toHaveLength(1);
     });
 
+    it("handles vol=10 (inclusive maximum)", () => {
+      const result = parseDirectiveToken({ key: "vol", value: "10", policy });
+      expect(result.handled).toBe(true);
+      expect(result.warnings).toBeUndefined();
+      expect(result.overrides?.vol).toBe(10);
+    });
+
+    it("warns on vol above the inclusive maximum", () => {
+      const result = parseDirectiveToken({ key: "vol", value: "11", policy });
+      expect(result.handled).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+    });
+
     it("warns on non-decimal volume values", () => {
       const result = parseDirectiveToken({ key: "vol", value: "0x3", policy });
       expect(result.handled).toBe(true);

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -200,7 +200,7 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
         ctx,
         overrideKey: "vol",
         range: { min: 0, minExclusive: true, max: 10 },
-        warning: (value) => `invalid MiniMax volume "${value}" (0-10, exclusive)`,
+        warning: (value) => `invalid MiniMax volume "${value}" (0 exclusive to 10 inclusive)`,
       });
     }
     case "pitch": {


### PR DESCRIPTION
## Summary

The MiniMax T2A `vol` (volume) parameter is documented as the range `(0, 10]`
— exclusive minimum, inclusive maximum (per the [official T2A API docs](https://platform.minimax.io/docs/api-reference/speech-t2a-http):
`exclusiveMinimum: 0`, `maximum: 10`).

The validation in `parseDirectiveToken` already enforces this correctly — it
rejects only `vol <= 0` or `vol > 10`, so `vol=10` is accepted. But the warning
text read `"(0-10, exclusive)"`, which implies `10` is also rejected. That
contradicts both the API spec and the code's own bound, so a user who sees the
warning could wrongly believe `vol=10` is invalid.

This reworks the warning to `"(0 exclusive to 10 inclusive)"` so the message
matches the actual behavior and the documented range. **No behavior change** —
only the warning string is corrected.

## Changes
- `extensions/minimax/speech-provider.ts`: fix the volume warning wording
- `extensions/minimax/speech-provider.test.ts`: add boundary tests
  - `vol=10` is accepted (inclusive maximum, no warning)
  - `vol=11` is rejected (above maximum)

## Test plan
- [x] Added tests covering the upper-bound boundary (`vol=10` accepted, `vol=11` rejected)
- [x] Existing `vol=0` (exclusive minimum) test still passes
- [x] No runtime behavior change — only the warning text and new test coverage