### PR TITLE
fix(cron): emit isolated model usage diagnostics

### DIFF
--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -288,6 +288,55 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
     expect(usageEvents).toEqual([]);
   });
 
+  it("emits billed model usage when the cron run is aborted before finalization", async () => {
+    const abortController = new AbortController();
+    const usageEvents: Array<{
+      type: string;
+      sessionId?: string;
+      usage?: { input?: number; output?: number; total?: number };
+    }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((evt) => {
+      if (evt.type === "model.usage") {
+        usageEvents.push(evt);
+      }
+    });
+
+    runWithModelFallbackMock.mockImplementationOnce(async () => {
+      abortController.abort("cron: job execution timed out");
+      return {
+        result: {
+          payloads: [{ text: "late output" }],
+          meta: {
+            agentMeta: {
+              sessionId: "late-session",
+              usage: { input: 50, output: 10, total: 60 },
+            },
+          },
+        },
+        provider: "openai",
+        model: "gpt-5.4",
+      };
+    });
+
+    try {
+      const result = await runCronIsolatedAgentTurn({
+        ...makeParams(),
+        abortSignal: abortController.signal,
+      });
+      expect(result.status).toBe("error");
+      expect(result.error).toBe("cron: job execution timed out");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      type: "model.usage",
+      sessionId: "test-session-id",
+      usage: { input: 50, output: 10, total: 60 },
+    });
+  });
+
   it("preserves total-only model usage in cron diagnostics", async () => {
     const usageEvents: Array<{
       type: string;

--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -228,7 +228,7 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
             sessionFile: "/tmp/cron-usage-session.jsonl",
             provider: "test-provider",
             model: "test-model",
-            usage: { input: 50, output: 100, cacheRead: 7, cacheWrite: 3 },
+            usage: { input: 50, output: 100, cacheRead: 7, cacheWrite: 3, total: 55 },
             lastCallUsage: { input: 40, output: 5, cacheRead: 6, cacheWrite: 4 },
           },
         },

--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -292,6 +292,7 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
     const usageEvents: Array<{
       type: string;
       usage?: { input?: number; output?: number; promptTokens?: number; total?: number };
+      costUsd?: number;
     }> = [];
     const unsubscribe = onInternalDiagnosticEvent((evt) => {
       if (evt.type === "model.usage") {
@@ -326,5 +327,6 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
       promptTokens: 0,
       total: 42,
     });
+    expect(usageEvents[0]?.costUsd).toBeUndefined();
   });
 });

--- a/src/cron/isolated-agent/run.diagnostic-events.test.ts
+++ b/src/cron/isolated-agent/run.diagnostic-events.test.ts
@@ -1,6 +1,10 @@
 // Run diagnostic event tests cover emitted diagnostics from isolated cron runs.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { onDiagnosticEvent, resetDiagnosticEventsForTest } from "../../infra/diagnostic-events.js";
+import {
+  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../../infra/diagnostic-events.js";
 import { resetDiagnosticStateForTest } from "../../logging/diagnostic.js";
 
 vi.mock("../../agents/auth-profiles/source-check.js", () => ({
@@ -181,5 +185,146 @@ describe("runCronIsolatedAgentTurn diagnostic events", () => {
       { type: "session.state", state: "idle", sessionId: "persisted-run-session" },
       { type: "message.processed", sessionId: "persisted-run-session" },
     ]);
+  });
+
+  it("emits model.usage for cron runs with billed aggregate usage", async () => {
+    const usageEvents: Array<{
+      type: string;
+      sessionKey?: string;
+      sessionId?: string;
+      channel?: string;
+      agentId?: string;
+      provider?: string;
+      model?: string;
+      usage?: {
+        input?: number;
+        output?: number;
+        cacheRead?: number;
+        cacheWrite?: number;
+        promptTokens?: number;
+        total?: number;
+      };
+      lastCallUsage?: {
+        input?: number;
+        output?: number;
+        cacheRead?: number;
+        cacheWrite?: number;
+      };
+      context?: { limit?: number; used?: number };
+      durationMs?: number;
+    }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((evt) => {
+      if (evt.type === "model.usage") {
+        usageEvents.push(evt);
+      }
+    });
+
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "test output" }],
+        meta: {
+          agentMeta: {
+            sessionId: "cron-usage-session",
+            sessionFile: "/tmp/cron-usage-session.jsonl",
+            provider: "test-provider",
+            model: "test-model",
+            usage: { input: 50, output: 100, cacheRead: 7, cacheWrite: 3 },
+            lastCallUsage: { input: 40, output: 5, cacheRead: 6, cacheWrite: 4 },
+          },
+        },
+      },
+      provider: "fallback-provider",
+      model: "fallback-model",
+    });
+
+    try {
+      const result = await runCronIsolatedAgentTurn(makeParams());
+      expect(result.status).toBe("ok");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]).toMatchObject({
+      type: "model.usage",
+      sessionKey: "agent:default:cron:diag-events:run:test-session-id",
+      sessionId: "cron-usage-session",
+      channel: "cron",
+      agentId: "default",
+      provider: "test-provider",
+      model: "test-model",
+      usage: {
+        input: 50,
+        output: 100,
+        cacheRead: 7,
+        cacheWrite: 3,
+        promptTokens: 60,
+        total: 160,
+      },
+      lastCallUsage: { input: 40, output: 5, cacheRead: 6, cacheWrite: 4 },
+      context: { limit: 128000, used: 50 },
+    });
+    expect(usageEvents[0]?.durationMs).toEqual(expect.any(Number));
+    expect(usageEvents[0]?.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not emit model.usage when diagnostics are disabled", async () => {
+    const usageEvents: Array<{ type: string }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((evt) => {
+      if (evt.type === "model.usage") {
+        usageEvents.push(evt);
+      }
+    });
+
+    try {
+      const params = makeParams();
+      params.cfg = { diagnostics: { enabled: false } } as never;
+      const result = await runCronIsolatedAgentTurn(params);
+      expect(result.status).toBe("ok");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(usageEvents).toEqual([]);
+  });
+
+  it("preserves total-only model usage in cron diagnostics", async () => {
+    const usageEvents: Array<{
+      type: string;
+      usage?: { input?: number; output?: number; promptTokens?: number; total?: number };
+    }> = [];
+    const unsubscribe = onInternalDiagnosticEvent((evt) => {
+      if (evt.type === "model.usage") {
+        usageEvents.push(evt);
+      }
+    });
+
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "test output" }],
+        meta: {
+          agentMeta: {
+            usage: { total: 42 },
+          },
+        },
+      },
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+
+    try {
+      const result = await runCronIsolatedAgentTurn(makeParams());
+      expect(result.status).toBe("ok");
+    } finally {
+      unsubscribe();
+    }
+
+    expect(usageEvents).toHaveLength(1);
+    expect(usageEvents[0]?.usage).toMatchObject({
+      input: 0,
+      output: 0,
+      promptTokens: 0,
+      total: 42,
+    });
   });
 });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -457,9 +457,20 @@ function resetRunConfigMocks(): void {
   resolveAgentTimeoutMsMock.mockReturnValue(60_000);
   deriveSessionTotalTokensMock.mockReturnValue(30);
   hasNonzeroUsageMock.mockImplementation(
-    (usage: { input?: unknown; output?: unknown } | undefined) =>
-      (typeof usage?.input === "number" && usage.input > 0) ||
-      (typeof usage?.output === "number" && usage.output > 0),
+    (
+      usage:
+        | {
+            input?: unknown;
+            output?: unknown;
+            cacheRead?: unknown;
+            cacheWrite?: unknown;
+            total?: unknown;
+          }
+        | undefined,
+    ) =>
+      [usage?.input, usage?.output, usage?.cacheRead, usage?.cacheWrite, usage?.total].some(
+        (value) => typeof value === "number" && Number.isFinite(value) && value > 0,
+      ),
   );
   ensureAgentWorkspaceMock.mockResolvedValue({ dir: "/tmp/workspace" });
   normalizeThinkLevelMock.mockImplementation((value: unknown) => value);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1009,6 +1009,11 @@ async function finalizeCronRun(params: {
     const output = usage.output ?? 0;
     const cacheRead = usage.cacheRead ?? 0;
     const cacheWrite = usage.cacheWrite ?? 0;
+    const hasBillableUsageBuckets =
+      usage.input !== undefined ||
+      usage.output !== undefined ||
+      usage.cacheRead !== undefined ||
+      usage.cacheWrite !== undefined;
     const lastCallTotalTokens = deriveSessionTotalTokens({
       usage: lastCallUsage,
       contextTokens,
@@ -1097,7 +1102,9 @@ async function finalizeCronRun(params: {
           limit: contextTokens,
           ...(contextUsedTokens !== undefined ? { used: contextUsedTokens } : {}),
         },
-        costUsd: runEstimatedCostUsd,
+        ...(hasBillableUsageBuckets && runEstimatedCostUsd !== undefined
+          ? { costUsd: runEstimatedCostUsd }
+          : {}),
         durationMs: execution.runEndedAt - execution.runStartedAt,
       });
     }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -959,16 +959,21 @@ async function finalizeCronRun(params: {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
   const payloads = finalRunResult.payloads ?? [];
+  // Late aborted results may still contain billable usage, but their session,
+  // model, and CLI binding metadata must not replace the active run identity.
+  const abortedBeforeFinalize = params.isAborted();
   let telemetry: CronRunTelemetry | undefined;
 
-  if (finalRunResult.meta?.systemPromptReport) {
-    prepared.cronSession.sessionEntry.systemPromptReport = finalRunResult.meta.systemPromptReport;
+  if (!abortedBeforeFinalize) {
+    if (finalRunResult.meta?.systemPromptReport) {
+      prepared.cronSession.sessionEntry.systemPromptReport = finalRunResult.meta.systemPromptReport;
+    }
+    adoptCronRunSessionMetadata({
+      entry: prepared.cronSession.sessionEntry,
+      sessionKey: prepared.agentSessionKey,
+      runMeta: finalRunResult.meta?.agentMeta,
+    });
   }
-  adoptCronRunSessionMetadata({
-    entry: prepared.cronSession.sessionEntry,
-    sessionKey: prepared.agentSessionKey,
-    runMeta: finalRunResult.meta?.agentMeta,
-  });
   const usage = finalRunResult.meta?.agentMeta?.usage;
   const lastCallUsage = finalRunResult.meta?.agentMeta?.lastCallUsage;
   const promptTokens = finalRunResult.meta?.agentMeta?.promptTokens;
@@ -988,19 +993,21 @@ async function finalizeCronRun(params: {
     resolvePositiveContextTokens(prepared.cronSession.sessionEntry.contextTokens) ??
     DEFAULT_CONTEXT_TOKENS;
 
-  setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
-    provider: providerUsed,
-    model: modelUsed,
-  });
-  prepared.cronSession.sessionEntry.contextTokens = contextTokens;
-  if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
-    const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
-    if (finalRunResult.meta?.agentMeta?.clearCliSessionBinding === true) {
-      const { clearCliSession } = await loadCliRunnerRuntime();
-      clearCliSession(prepared.cronSession.sessionEntry, providerUsed);
-    } else if (cliSessionId) {
-      const { setCliSessionId } = await loadCliRunnerRuntime();
-      setCliSessionId(prepared.cronSession.sessionEntry, providerUsed, cliSessionId);
+  if (!abortedBeforeFinalize) {
+    setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
+      provider: providerUsed,
+      model: modelUsed,
+    });
+    prepared.cronSession.sessionEntry.contextTokens = contextTokens;
+    if (isCliProvider(providerUsed, prepared.cfgWithAgentDefaults)) {
+      const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
+      if (finalRunResult.meta?.agentMeta?.clearCliSessionBinding === true) {
+        const { clearCliSession } = await loadCliRunnerRuntime();
+        clearCliSession(prepared.cronSession.sessionEntry, providerUsed);
+      } else if (cliSessionId) {
+        const { setCliSessionId } = await loadCliRunnerRuntime();
+        setCliSessionId(prepared.cronSession.sessionEntry, providerUsed, cliSessionId);
+      }
     }
   }
   if (hasNonzeroUsage(usage)) {
@@ -1475,15 +1482,6 @@ export async function runCronIsolatedAgentTurn(params: {
       runTimeoutOverrideMs: prepared.context.runTimeoutOverrideMs,
       suppressExecNotifyOnExit: prepared.context.suppressExecNotifyOnExit,
     });
-    if (isAborted()) {
-      outcome = "error";
-      outcomeError = abortReason();
-      return prepared.context.withRunSession({
-        status: "error",
-        error: abortReason(),
-        diagnostics: createCronRunDiagnosticsFromError("cron-setup", abortReason()),
-      });
-    }
     const finalized = await finalizeCronRun({
       prepared: prepared.context,
       execution,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1040,6 +1040,8 @@ async function finalizeCronRun(params: {
       output_tokens: output,
     };
     const bucketTotalTokens = input + output + cacheRead + cacheWrite;
+    // Embedded runs accumulate billing buckets across calls, while usage.total
+    // may be replaced with the final provider-call total for context tracking.
     const aggregateTotalTokens =
       typeof usage.total === "number" && Number.isFinite(usage.total)
         ? Math.max(bucketTotalTokens, usage.total)

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -5,6 +5,7 @@ import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { expandToolGroups, normalizeToolName } from "../../agents/tool-policy.js";
+import { deriveContextPromptTokens } from "../../agents/usage.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import {
@@ -22,7 +23,11 @@ import {
   getAgentRunContext,
   releaseAgentRunContext,
 } from "../../infra/agent-events.js";
-import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import {
+  createChildDiagnosticTraceContext,
+  freezeDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
 import {
   createSourceDeliveryPlan,
   resolveSourceDeliveryOutcome,
@@ -1002,6 +1007,8 @@ async function finalizeCronRun(params: {
     const { estimateUsageCost, resolveModelCostConfig } = await loadUsageFormatRuntime();
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
+    const cacheRead = usage.cacheRead ?? 0;
+    const cacheWrite = usage.cacheWrite ?? 0;
     const lastCallTotalTokens = deriveSessionTotalTokens({
       usage: lastCallUsage,
       contextTokens,
@@ -1027,7 +1034,11 @@ async function finalizeCronRun(params: {
       input_tokens: input,
       output_tokens: output,
     };
-    const aggregateTotalTokens = input + output + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+    const bucketTotalTokens = input + output + cacheRead + cacheWrite;
+    const aggregateTotalTokens =
+      typeof usage.total === "number" && Number.isFinite(usage.total)
+        ? Math.max(bucketTotalTokens, usage.total)
+        : bucketTotalTokens;
     if (aggregateTotalTokens > 0) {
       telemetryUsage.total_tokens = aggregateTotalTokens;
     }
@@ -1038,8 +1049,8 @@ async function finalizeCronRun(params: {
       prepared.cronSession.sessionEntry.totalTokens = undefined;
       prepared.cronSession.sessionEntry.totalTokensFresh = false;
     }
-    prepared.cronSession.sessionEntry.cacheRead = usage.cacheRead ?? 0;
-    prepared.cronSession.sessionEntry.cacheWrite = usage.cacheWrite ?? 0;
+    prepared.cronSession.sessionEntry.cacheRead = cacheRead;
+    prepared.cronSession.sessionEntry.cacheWrite = cacheWrite;
     // Snapshot cost like tokens (runEstimatedCostUsd is already computed from
     // cumulative run usage, so assign directly instead of accumulating).
     // Fixes #69347: cost was inflated 1x-72x by accumulating on every persist.
@@ -1051,6 +1062,45 @@ async function finalizeCronRun(params: {
       provider: providerUsed,
       usage: telemetryUsage,
     };
+    if (isDiagnosticsEnabled(prepared.cfgWithAgentDefaults)) {
+      const usagePromptTokens = input + cacheRead + cacheWrite;
+      const contextUsedTokens = deriveContextPromptTokens({
+        lastCallUsage,
+        promptTokens,
+        usage,
+      });
+      emitTrustedDiagnosticEvent({
+        type: "model.usage",
+        ...(finalRunResult.diagnosticTrace
+          ? {
+              trace: freezeDiagnosticTraceContext(
+                createChildDiagnosticTraceContext(finalRunResult.diagnosticTrace),
+              ),
+            }
+          : {}),
+        sessionKey: prepared.runSessionKey,
+        sessionId: prepared.currentRunSessionId(),
+        channel: "cron",
+        agentId: prepared.agentId,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead,
+          cacheWrite,
+          promptTokens: usagePromptTokens,
+          total: aggregateTotalTokens,
+        },
+        lastCallUsage,
+        context: {
+          limit: contextTokens,
+          ...(contextUsedTokens !== undefined ? { used: contextUsedTokens } : {}),
+        },
+        costUsd: runEstimatedCostUsd,
+        durationMs: execution.runEndedAt - execution.runStartedAt,
+      });
+    }
   } else {
     telemetry = { model: modelUsed, provider: providerUsed };
   }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -959,12 +959,11 @@ async function finalizeCronRun(params: {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
   const payloads = finalRunResult.payloads ?? [];
-  // Late aborted results may still contain billable usage, but their session,
-  // model, and CLI binding metadata must not replace the active run identity.
-  const abortedBeforeFinalize = params.isAborted();
   let telemetry: CronRunTelemetry | undefined;
 
-  if (!abortedBeforeFinalize) {
+  // Late aborted results may still contain billable usage. Recheck before each
+  // metadata mutation because lazy runtime loads below can yield to the timeout.
+  if (!params.isAborted()) {
     if (finalRunResult.meta?.systemPromptReport) {
       prepared.cronSession.sessionEntry.systemPromptReport = finalRunResult.meta.systemPromptReport;
     }
@@ -993,7 +992,7 @@ async function finalizeCronRun(params: {
     resolvePositiveContextTokens(prepared.cronSession.sessionEntry.contextTokens) ??
     DEFAULT_CONTEXT_TOKENS;
 
-  if (!abortedBeforeFinalize) {
+  if (!params.isAborted()) {
     setSessionRuntimeModel(prepared.cronSession.sessionEntry, {
       provider: providerUsed,
       model: modelUsed,


### PR DESCRIPTION
## Summary

- emit `model.usage` diagnostics from isolated cron run finalization when cron model usage is nonzero
- keep billed aggregate usage separate from session/context token snapshots, including total-only usage payloads
- extend cron diagnostic tests and align the isolated-run test harness usage mock with production usage buckets

Fixes #92338.

## Verification

- `git diff --check upstream/main..HEAD`
- `pnpm exec oxfmt --check src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.diagnostic-events.test.ts src/cron/isolated-agent/run.test-harness.ts`
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.diagnostic-events.test.ts`
- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.usage-accounting.test.ts`
- `pnpm tsgo:core`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof

Behavior addressed: Cron-isolated agent runs already persisted nonzero model usage into cron telemetry/session state, but did not emit the `model.usage` diagnostic event consumed by diagnostics exporters such as `diagnostics-prometheus` and `diagnostics-otel`.

Real environment tested: Local OpenClaw source checkout on macOS with a temporary isolated OpenClaw state/config, a loopback Gateway, Claude CLI backend (`claude-sonnet-4-6` through `claude-cli`), and the bundled `diagnostics-prometheus` plugin enabled. The temporary CLI device was paired only inside that temporary state so cron write RPCs could run against the loopback Gateway.

Exact steps or command run after this patch:

```bash
pnpm openclaw gateway run --port 18765 --auth none --bind loopback --allow-unconfigured --cli-backend-logs
pnpm openclaw cron create --at '+10m' --message 'Reply exactly OK' --name 'issue-92338-prometheus-proof' --session isolated --light-context --no-deliver --agent main --model anthropic/claude-sonnet-4-6 --json
pnpm openclaw cron run b5628201-e509-419e-b2b8-6467eec24fe0 --wait --wait-timeout 5m --poll-interval 2s
pnpm openclaw gateway call cron.runs --params '{"id":"b5628201-e509-419e-b2b8-6467eec24fe0","limit":1}' --json
curl -fsS http://127.0.0.1:18765/api/diagnostics/prometheus | rg 'openclaw_model_tokens_total|openclaw_model_usage_duration_seconds|openclaw_gen_ai_client_token_usage'
```

Evidence after fix:

```text
"status": "ok",
"summary": "OK",
"model": "claude-sonnet-4-6",
"provider": "claude-cli",
"usage": {
  "input_tokens": 15980,
  "output_tokens": 144,
  "total_tokens": 40316
},
"sessionKey": "agent:main:cron:b5628201-e509-419e-b2b8-6467eec24fe0:run:dc4f276b-0932-45d7-9f6c-be4cfdf789f1"
```

```text
openclaw_model_tokens_total{agent="main",channel="cron",model="claude-sonnet-4-6",provider="claude-cli",token_type="cache_read"} 24192
openclaw_model_tokens_total{agent="main",channel="cron",model="claude-sonnet-4-6",provider="claude-cli",token_type="input"} 15980
openclaw_model_tokens_total{agent="main",channel="cron",model="claude-sonnet-4-6",provider="claude-cli",token_type="output"} 144
openclaw_model_tokens_total{agent="main",channel="cron",model="claude-sonnet-4-6",provider="claude-cli",token_type="prompt"} 40172
openclaw_model_tokens_total{agent="main",channel="cron",model="claude-sonnet-4-6",provider="claude-cli",token_type="total"} 40316
openclaw_model_usage_duration_seconds_count{agent="main",channel="cron",model="claude-sonnet-4-6",provider="claude-cli"} 1
```

Observed result after fix: A real isolated cron agent run completed through the Claude CLI backend, persisted nonzero cron run usage, and the Prometheus diagnostics exporter recorded `model.usage` metrics with `channel="cron"`, `provider="claude-cli"`, `model="claude-sonnet-4-6"`, and the same total token count as the cron run log.

What was not tested: An external OTLP backend was not configured. `diagnostics-prometheus` was used for real exporter proof because it subscribes to the same trusted diagnostic event bus as `diagnostics-otel` and exposes the resulting `model.usage` metrics locally.
