### PR TITLE
fix(gateway): log websocket handshake phase

### DIFF
--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -262,7 +262,7 @@ describe("attachGatewayWsConnectionHandler", () => {
     ).toBe(true);
     handlerParams.setHandshakeState("connected");
     handlerParams.advanceHandshakePhase("session_attached");
-    handlerParams.advanceHandshakePhase("subscriptions_registered");
+    handlerParams.advanceHandshakePhase("hello_payload_prepared");
     handlerParams.advanceHandshakePhase("ready");
 
     socket.emit("close", 1000, Buffer.from("done"));

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -4,6 +4,7 @@ import type { ResolvedGatewayAuth } from "../auth.js";
 import { MAX_BUFFERED_BYTES } from "../server-constants.js";
 import {
   attachGatewayWsForTest,
+  createGatewayWsTestLogger,
   createGatewayWsTestRequestContext,
   createGatewayWsTestSocket,
   createResolvedGatewayTokenAuth,
@@ -47,18 +48,20 @@ async function connectTestWs(
     options?: Partial<Parameters<typeof attachGatewayWsConnectionHandler>[0]>;
   } = {},
 ) {
+  const logWsControl = createGatewayWsTestLogger();
   const connected = attachGatewayWsForTest({
     attach: attachGatewayWsConnectionHandler,
     clients: params.clients,
     headers: params.headers,
     host: params.host,
-    options: params.options,
+    options: { ...params.options, logWsControl: logWsControl as never },
     socket: params.socket,
   });
   await waitForLazyMessageHandler();
 
   return {
     clients: connected.clients,
+    logWsControl,
     socket: connected.socket,
     passed: firstAttachedHandlerParams(),
   };
@@ -195,6 +198,76 @@ describe("attachGatewayWsConnectionHandler", () => {
 
     expect(socket.send).not.toHaveBeenCalled();
     expect(socket.close).toHaveBeenCalledWith(1008, "slow consumer");
+  });
+
+  it("keeps handshake phase advancement monotonic", async () => {
+    const { socket, logWsControl, passed } = await connectTestWs();
+    const handlerParams = passed as {
+      advanceHandshakePhase: (phase: string) => void;
+    };
+
+    handlerParams.advanceHandshakePhase("auth_credentials_received");
+    handlerParams.advanceHandshakePhase("auth_validated");
+    handlerParams.advanceHandshakePhase("auth_credentials_received");
+    socket.emit("close", 1006, Buffer.from("client disappeared"));
+
+    const [message, context] = logWsControl.warn.mock.calls[0] as [string, { phase?: string }];
+    expect(message).toContain("phase=auth_validated");
+    expect(context).toMatchObject({ phase: "auth_validated" });
+  });
+
+  it("includes the last completed handshake phase in pre-connect close logs", async () => {
+    const { socket, logWsControl } = await connectTestWs();
+
+    socket.emit("close", 1006, Buffer.from("client disappeared"));
+
+    expect(logWsControl.warn).toHaveBeenCalled();
+    const [message, context] = logWsControl.warn.mock.calls[0] as [string, { phase?: string }];
+    expect(message).toContain("closed before connect");
+    expect(message).toContain("phase=ws_upgrade_started");
+    expect(context).toMatchObject({ phase: "ws_upgrade_started" });
+  });
+
+  it("includes the last completed handshake phase on preauth timeout logs", async () => {
+    vi.useFakeTimers();
+    const { logWsControl } = await connectTestWs({
+      options: { preauthHandshakeTimeoutMs: 100 },
+    });
+
+    vi.advanceTimersByTime(150);
+
+    expect(logWsControl.warn).toHaveBeenCalledWith(expect.stringContaining("handshake timeout"));
+    expect(logWsControl.warn).toHaveBeenCalledWith(
+      expect.stringContaining("phase=ws_upgrade_started"),
+    );
+  });
+
+  it("omits handshake phase metadata after the connection is ready", async () => {
+    const { socket, logWsControl, passed } = await connectTestWs();
+    const handlerParams = passed as {
+      advanceHandshakePhase: (phase: string) => void;
+      setClient: (client: never) => boolean;
+      setHandshakeState: (state: "pending" | "connected" | "failed") => void;
+    };
+
+    handlerParams.advanceHandshakePhase("auth_credentials_received");
+    handlerParams.advanceHandshakePhase("auth_validated");
+    expect(
+      handlerParams.setClient({
+        socket,
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+        connId: "ready-client",
+        usesSharedGatewayAuth: false,
+      } as never),
+    ).toBe(true);
+    handlerParams.setHandshakeState("connected");
+    handlerParams.advanceHandshakePhase("session_attached");
+    handlerParams.advanceHandshakePhase("subscriptions_registered");
+    handlerParams.advanceHandshakePhase("ready");
+
+    socket.emit("close", 1000, Buffer.from("done"));
+
+    expect(logWsControl.warn).not.toHaveBeenCalled();
   });
 
   it("skips node presence disconnects for stale reconnected sockets", async () => {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -44,7 +44,7 @@ import type {
   WsOriginCheckMetrics,
 } from "./ws-connection/message-handler.js";
 import { resolveSharedGatewaySessionGeneration } from "./ws-shared-generation.js";
-import type { GatewayWsClient } from "./ws-types.js";
+import { WS_HANDSHAKE_PHASES, type GatewayWsClient, type WsHandshakePhase } from "./ws-types.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
@@ -289,12 +289,19 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
 
     logWs("in", "open", { connId, remoteAddr, remotePort, localAddr, localPort, endpoint });
     let handshakeState: "pending" | "connected" | "failed" = "pending";
+    let lastHandshakePhase: WsHandshakePhase = "tcp_accepted";
     let holdsPreauthBudget = true;
     let closeCause: string | undefined;
     let closeMeta: Record<string, unknown> = {};
     let lastFrameType: string | undefined;
     let lastFrameMethod: string | undefined;
     let lastFrameId: string | undefined;
+
+    const advanceHandshakePhase = (next: WsHandshakePhase) => {
+      if (WS_HANDSHAKE_PHASES.indexOf(next) > WS_HANDSHAKE_PHASES.indexOf(lastHandshakePhase)) {
+        lastHandshakePhase = next;
+      }
+    };
 
     const setCloseCause = (cause: string, meta?: Record<string, unknown>) => {
       if (!closeCause) {
@@ -331,9 +338,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         setCloseCause("handshake-timeout", {
           handshakeMs: Date.now() - openedAt,
           endpoint,
+          phase: lastHandshakePhase,
         });
         logWsControl.warn(
-          `handshake timeout conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"}`,
+          `handshake timeout conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} phase=${lastHandshakePhase}`,
         );
         close();
       }
@@ -390,6 +398,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       event: "connect.challenge",
       payload: { nonce: connectNonce, ts: Date.now() },
     });
+    advanceHandshakePhase("ws_upgrade_started");
 
     socket.once("error", (err) => {
       if (isWsPayloadLimitError(err)) {
@@ -414,9 +423,11 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       const logHost = sanitizeLogValue(requestHost);
       const logUserAgent = sanitizeLogValue(requestUserAgent);
       const logReason = sanitizeLogValue(reason?.toString());
+      const handshakeIncomplete = lastHandshakePhase !== "ready";
       const closeContext = {
         cause: closeCause,
         handshake: handshakeState,
+        ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
         durationMs,
         lastFrameType,
         lastFrameMethod,
@@ -467,7 +478,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
               ? ` suppressed=${closeLogDecision.suppressedSinceLastLog}`
               : "";
           logFn(
-            `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}${suppressedText}`,
+            `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"} phase=${lastHandshakePhase}${suppressedText}`,
             closeContext,
           );
         }
@@ -506,6 +517,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         durationMs,
         cause: closeCause,
         handshake: handshakeState,
+        ...(handshakeIncomplete ? { phase: lastHandshakePhase } : {}),
         lastFrameType,
         lastFrameMethod,
         lastFrameId,
@@ -567,6 +579,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       setHandshakeState: (next) => {
         handshakeState = next;
       },
+      advanceHandshakePhase,
       setCloseCause,
       setLastFrameMeta,
       originCheckMetrics,

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -212,6 +212,7 @@ function attachGatewayHarness(options: {
     mode: "none",
     allowTailscale: false,
   };
+  const advanceHandshakePhase = vi.fn();
   attachGatewayWsMessageHandler({
     socket,
     upgradeReq: {
@@ -244,7 +245,7 @@ function attachGatewayHarness(options: {
       return true;
     },
     setHandshakeState: vi.fn(),
-    advanceHandshakePhase: vi.fn(),
+    advanceHandshakePhase,
     setCloseCause: options.setCloseCause ?? createSetCloseCauseMock(),
     setLastFrameMeta: vi.fn(),
     originCheckMetrics: { hostHeaderFallbackAccepted: 0 },
@@ -257,6 +258,7 @@ function attachGatewayHarness(options: {
   }
   const sendMessage = onMessage;
   return {
+    advanceHandshakePhase,
     socketSend,
     sendRequest: (id: string, method: string, params: Record<string, unknown> = {}) => {
       sendMessage(
@@ -583,6 +585,46 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     });
     expect(JSON.stringify(captured.events)).not.toContain("wrong-token");
     expect(JSON.stringify(captured.events)).not.toContain("gateway-token");
+  });
+
+  it("records credential and hello preparation phases during connect", async () => {
+    const harness = attachGatewayHarness({
+      connId: "conn-phases",
+      connectNonce: "nonce-phases",
+      resolvedAuth: {
+        mode: "token",
+        token: "gateway-token",
+        allowTailscale: false,
+      },
+    });
+
+    harness.sendConnect("connect-phases", {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: "backend",
+      },
+      role: "operator",
+      scopes: [],
+      caps: [],
+      auth: {
+        token: "gateway-token",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.socketSend).toHaveBeenCalled();
+    });
+    expect(harness.advanceHandshakePhase.mock.calls.map(([phase]) => phase)).toEqual([
+      "auth_credentials_received",
+      "auth_validated",
+      "session_attached",
+      "hello_payload_prepared",
+      "ready",
+    ]);
   });
 
   it("does not mark local backend self-pairing clients as approval runtimes", async () => {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -244,6 +244,7 @@ function attachGatewayHarness(options: {
       return true;
     },
     setHandshakeState: vi.fn(),
+    advanceHandshakePhase: vi.fn(),
     setCloseCause: options.setCloseCause ?? createSetCloseCauseMock(),
     setLastFrameMeta: vi.fn(),
     originCheckMetrics: { hostHeaderFallbackAccepted: 0 },

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -930,6 +930,14 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           deviceRaw,
         });
         const device = controlUiAuthPolicy.device;
+        const hasRawHandshakeCredentials =
+          hasSharedAuth ||
+          Boolean(connectParams.auth?.bootstrapToken) ||
+          Boolean(connectParams.auth?.deviceToken) ||
+          Boolean(device);
+        if (hasRawHandshakeCredentials) {
+          advanceHandshakePhase("auth_credentials_received");
+        }
         const connectAuthState = await resolveConnectAuthState({
           resolvedAuth,
           connectAuth: connectParams.auth,
@@ -946,9 +954,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           deviceTokenCandidate,
           deviceTokenCandidateSource,
         } = connectAuthState;
-        if (hasSharedAuth || bootstrapTokenCandidate || deviceTokenCandidate || device) {
-          advanceHandshakePhase("auth_credentials_received");
-        }
         let { authResult, authOk, authMethod } = connectAuthState;
         const rejectUnauthorized = (failedAuth: GatewayAuthResult) => {
           const { authProvided, canRetryWithDeviceToken, recommendedNextStep } =
@@ -2153,7 +2158,6 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             );
         }
 
-        advanceHandshakePhase("subscriptions_registered");
         const snapshot = buildGatewaySnapshot({
           includeSensitive: scopes.includes(ADMIN_SCOPE),
         });
@@ -2198,6 +2202,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             tickIntervalMs: TICK_INTERVAL_MS,
           },
         };
+        advanceHandshakePhase("hello_payload_prepared");
 
         let revokedBootstrapTokenRecord:
           | Awaited<ReturnType<typeof revokeDeviceBootstrapToken>>["record"]

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -157,7 +157,7 @@ import {
   incrementPresenceVersion,
 } from "../health-state.js";
 import { resolveSharedGatewaySessionGeneration } from "../ws-shared-generation.js";
-import type { GatewayWsClient } from "../ws-types.js";
+import type { GatewayWsClient, WsHandshakePhase } from "../ws-types.js";
 import { resolveConnectAuthDecision, resolveConnectAuthState } from "./auth-context.js";
 import { formatGatewayAuthFailureMessage } from "./auth-messages.js";
 import {
@@ -493,6 +493,7 @@ export type GatewayWsMessageHandlerParams = {
   getClient: () => GatewayWsClient | null;
   setClient: (next: GatewayWsClient) => boolean;
   setHandshakeState: (state: "pending" | "connected" | "failed") => void;
+  advanceHandshakePhase: (phase: WsHandshakePhase) => void;
   setCloseCause: (cause: string, meta?: Record<string, unknown>) => void;
   setLastFrameMeta: (meta: { type?: string; method?: string; id?: string }) => void;
   originCheckMetrics: WsOriginCheckMetrics;
@@ -538,6 +539,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     getClient,
     setClient,
     setHandshakeState,
+    advanceHandshakePhase,
     setCloseCause,
     setLastFrameMeta,
     originCheckMetrics,
@@ -944,6 +946,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           deviceTokenCandidate,
           deviceTokenCandidateSource,
         } = connectAuthState;
+        if (hasSharedAuth || bootstrapTokenCandidate || deviceTokenCandidate || device) {
+          advanceHandshakePhase("auth_credentials_received");
+        }
         let { authResult, authOk, authMethod } = connectAuthState;
         const rejectUnauthorized = (failedAuth: GatewayAuthResult) => {
           const { authProvided, canRetryWithDeviceToken, recommendedNextStep } =
@@ -1272,6 +1277,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           rejectUnauthorized(authResult);
           return;
         }
+        advanceHandshakePhase("auth_validated");
         const usesSharedGatewayAuth =
           authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy";
         const sharedGatewaySessionGeneration = usesSharedGatewayAuth
@@ -2051,6 +2057,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           return;
         }
         setHandshakeState("connected");
+        advanceHandshakePhase("session_attached");
         logWs("in", "connect", {
           connId,
           client: connectParams.client.id,
@@ -2146,6 +2153,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             );
         }
 
+        advanceHandshakePhase("subscriptions_registered");
         const snapshot = buildGatewaySnapshot({
           includeSensitive: scopes.includes(ADMIN_SCOPE),
         });
@@ -2257,6 +2265,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           clientMode: connectParams.client.mode,
           deviceId: device?.id,
         });
+        advanceHandshakePhase("ready");
         if (pendingNodePairingCleanup) {
           const context = buildRequestContext();
           const cleanupClaim = pendingNodePairingCleanup;

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -26,3 +26,15 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   invalidated?: boolean;
   invalidatedReason?: string;
 };
+
+export const WS_HANDSHAKE_PHASES = [
+  "tcp_accepted",
+  "ws_upgrade_started",
+  "auth_credentials_received",
+  "auth_validated",
+  "session_attached",
+  "subscriptions_registered",
+  "ready",
+] as const;
+
+export type WsHandshakePhase = (typeof WS_HANDSHAKE_PHASES)[number];

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -33,7 +33,7 @@ export const WS_HANDSHAKE_PHASES = [
   "auth_credentials_received",
   "auth_validated",
   "session_attached",
-  "subscriptions_registered",
+  "hello_payload_prepared",
   "ready",
 ] as const;
 


### PR DESCRIPTION
## Summary

- Adds a Gateway WebSocket handshake phase tracker so failure logs report the last completed phase instead of only the terminal outcome.
- Emits `phase=<value>` on preauth handshake timeout and pre-connect close logs, with matching structured metadata.
- Keeps the change scoped to Gateway diagnostics: no protocol, auth, config, migration, provider, or network behavior changes.
- Uses credential-neutral `auth_credentials_received` and only advances that phase when a shared/device/bootstrap credential is actually present.
- Review focus: whether the phase transitions match the existing WebSocket handshake owner boundary and whether failure-only log shape is acceptable.

## Linked context

Closes #79603

Related #79654, the older closed attempt that mixed in extra surfaces and initially lacked contributor real behavior proof.

This follows the issue's latest requested narrow replacement shape: Gateway WebSocket handshake diagnostics only.

## Real behavior proof (required for external PRs)

- Behavior addressed: Gateway WebSocket `handshake timeout` and `closed before connect` logs now include the last completed phase, so operators can distinguish a connection that only reached the WebSocket upgrade/challenge stage from later auth/session phases.
- Real environment tested: Local macOS source checkout, Node.js via `node --import tsx`, real `node:http` server, real `ws` `WebSocketServer`, real `ws` client, temporary empty OpenClaw config and state dir.
- Exact steps or command run after this patch: Started a real in-process Gateway WebSocket connection handler from `src/gateway/server/ws-connection.ts`, configured `preauthHandshakeTimeoutMs: 250`, opened `ws://127.0.0.1:<port>`, did not send a `connect` request, and waited for the production preauth timer to close the socket.
- Evidence after fix:

```text
[repro] gateway listening on ws://127.0.0.1:52169
[repro] preauth handshake timeout = 250ms
[warn] gateway/ws: handshake timeout conn=411b0bce-066a-4be3-86c6-dd68d11ae164 peer=127.0.0.1:52170->127.0.0.1:52169 remote=127.0.0.1 phase=ws_upgrade_started
[repro] received: {"type":"event","event":"connect.challenge","payload":{"nonce":"a7f8c1a1-e76c-478a-9bc5-fab064d8af54","ts":1781549788029}}
[repro] ws opened, idling so server preauth timer fires...
[warn] gateway/ws: closed before connect conn=411b0bce-066a-4be3-86c6-dd68d11ae164 peer=127.0.0.1:52170->127.0.0.1:52169 remote=127.0.0.1 fwd=n/a origin=n/a host=127.0.0.1:52169 ua=n/a code=1000 reason=n/a phase=ws_upgrade_started {"cause":"handshake-timeout","handshake":"failed","phase":"ws_upgrade_started","durationMs":1333,"host":"127.0.0.1:52169","remoteAddr":"127.0.0.1","remotePort":52170,"localAddr":"127.0.0.1","localPort":52169,"endpoint":"127.0.0.1:52170->127.0.0.1:52169","handshakeMs":1325}
[repro] OK: phase log emitted (2 matching warning(s))
```

- Observed result after fix: Both runtime warn paths contain `phase=ws_upgrade_started`, and the structured close context includes `"phase":"ws_upgrade_started"`.
- What was not tested: Windows 11 runtime from the original report; the changed logic is platform-independent TypeScript in the Gateway WebSocket handler.
- Proof limitations or environment constraints: The focused runtime proof exercises the reported preauth timeout path with loopback networking, not a packaged npm install or deployed Gateway service.
- Before evidence (optional but encouraged): Current main did not carry `phase` in the timeout or pre-connect close contexts; #79603 and the ClawSweeper issue review identify that source-level gap.

## Tests and validation

- `git diff --check` — passed after rebase conflict resolution.
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection.test.ts` — passed, Gateway shard selected 4 files / 44 tests.
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts` — passed, Gateway shard selected 4 files / 92 tests.
- `node_modules/.bin/oxfmt --check src/gateway/server/ws-connection.test.ts src/gateway/server/ws-connection.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/server/ws-connection/message-handler.ts src/gateway/server/ws-types.ts` — passed.
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm tsgo:core` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` — clean, no accepted/actionable findings.
- Runtime repro command described above — previously passed and emitted `phase=ws_upgrade_started` in both warn lines.

Note: a combined two-file local Vitest invocation hit the harness timeout before useful output, so the same two directly relevant files were rerun separately and both passed.

Regression coverage added in `src/gateway/server/ws-connection.test.ts` for monotonic phase advancement, pre-connect close log metadata, timeout log metadata, and omitting phase metadata after a connection reaches `ready`.

Known validation limitation: the full CI matrix is left to GitHub after this push; local proof stayed focused on the touched Gateway surface.

## Risk checklist

Did user-visible behavior change? `Yes` — failure logs gain a low-cardinality `phase` token and structured field.

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area? Misleading diagnostics if phase advancement does not match the actual handshake path.

How is that risk mitigated? Phase values are a closed enum, advancement is monotonic, credential receipt only advances when credentials are actually present, and tests lock the timeout/pre-connect/ready cases.

## Current review state

Next action: waiting for CI, ClawSweeper review, and maintainer review.

Author-side work complete for the narrow fix. The earlier autoreview finding about `auth_token_received` being misleading was addressed by switching to `auth_credentials_received` and gating it on actual credential presence.

