### PR TITLE
AGT-80 AGT-81 Fix Discord ingress ack ordering

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -852,6 +852,39 @@ describe("processDiscordMessage ack reactions", () => {
     });
   });
 
+  it("records accepted mention ingress before acking and dispatching", async () => {
+    const events: string[] = [];
+    recordInboundSession.mockImplementationOnce(async () => {
+      events.push("record");
+    });
+    sendMocks.reactMessageDiscord.mockImplementationOnce(async () => {
+      events.push("ack");
+    });
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      events.push("dispatch");
+      return createNoQueuedDispatchResult();
+    });
+    const ctx = await createAutomaticSourceDeliveryContext({
+      accountId: "ops",
+      shouldRequireMention: true,
+      effectiveWasMentioned: true,
+      route: {
+        agentId: "main",
+        channel: "discord",
+        accountId: "ops",
+        sessionKey: "agent:main:discord:channel:c1",
+        mainSessionKey: "agent:main:main",
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(events).toEqual(["record", "ack", "dispatch"]);
+    expect(recordInboundSession).toHaveBeenCalledTimes(1);
+    expect(sendMocks.reactMessageDiscord).toHaveBeenCalled();
+    expect(dispatchInboundMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("uses preflight-resolved messageChannelId when message.channelId is missing", async () => {
     const ctx = await createAutomaticSourceDeliveryContext({
       message: {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -415,14 +415,24 @@ async function processDiscordMessageInner(
     statusReactionsActive = true;
     void statusReactions.setQueued();
   };
-  queueInitialDiscordAckReaction({
-    enabled: statusReactionsEnabled,
-    shouldSendAckReaction,
-    ackReaction,
-    statusReactions,
-    reactionAdapter: discordAdapter,
-    target: `${messageChannelId}/${message.id}`,
-  });
+  let initialAckReactionQueued = false;
+  const queueInitialAckReactionAfterRecord = () => {
+    if (initialAckReactionQueued) {
+      return;
+    }
+    initialAckReactionQueued = true;
+    if (statusReactionsEnabled) {
+      statusReactionsActive = true;
+    }
+    queueInitialDiscordAckReaction({
+      enabled: statusReactionsEnabled,
+      shouldSendAckReaction,
+      ackReaction,
+      statusReactions,
+      reactionAdapter: discordAdapter,
+      target: `${messageChannelId}/${message.id}`,
+    });
+  };
   const processContext = await buildDiscordMessageProcessContext({
     ctx,
     text,
@@ -953,6 +963,7 @@ async function processDiscordMessageInner(
       storePath: turn.storePath,
       ctxPayload,
       recordInboundSession,
+      afterRecord: queueInitialAckReactionAfterRecord,
       dispatchReplyWithBufferedBlockDispatcher,
       dispatcherOptions: {
         ...replyPipeline,

--- a/extensions/discord/src/monitor/threading.auto-thread.test.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.test.ts
@@ -126,7 +126,56 @@ describe("maybeCreateDiscordAutoThread", () => {
 
   it("creates auto-thread if channelType is GuildText", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     const result = await maybeCreateDiscordAutoThread(createBaseParams());
+    expect(result).toBe("thread1");
+    expect(postMock).toHaveBeenCalled();
+  });
+
+  it("reuses an existing message thread before creating a new one", async () => {
+    getMock.mockResolvedValueOnce({ thread: { id: "existing-thread" } });
+    const result = await maybeCreateDiscordAutoThread(createBaseParams());
+
+    expect(result).toBe("existing-thread");
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing message thread before skipping bot-authored messages", async () => {
+    getMock.mockResolvedValueOnce({ thread: { id: "existing-thread" } });
+    const result = await maybeCreateDiscordAutoThread(
+      createBaseParams({
+        message: {
+          ...mockMessage,
+          author: { bot: true },
+        } as Parameters<MaybeCreateDiscordAutoThreadFn>[0]["message"],
+      }),
+    );
+
+    expect(result).toBe("existing-thread");
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("skips creating new auto-threads for bot-authored messages", async () => {
+    getMock.mockResolvedValueOnce({});
+    const result = await maybeCreateDiscordAutoThread(
+      createBaseParams({
+        message: {
+          ...mockMessage,
+          author: { bot: true },
+        } as Parameters<MaybeCreateDiscordAutoThreadFn>[0]["message"],
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("still creates an auto-thread when the existing-thread lookup fails", async () => {
+    getMock.mockRejectedValueOnce(new Error("transient fetch failure"));
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+
+    const result = await maybeCreateDiscordAutoThread(createBaseParams());
+
     expect(result).toBe("thread1");
     expect(postMock).toHaveBeenCalled();
   });
@@ -135,6 +184,7 @@ describe("maybeCreateDiscordAutoThread", () => {
 describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
   it("uses configured autoArchiveDuration", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     await maybeCreateDiscordAutoThread(
       createBaseParams({
         channelConfig: { allowed: true, autoThread: true, autoArchiveDuration: "10080" },
@@ -145,6 +195,7 @@ describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
 
   it("accepts numeric autoArchiveDuration", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     await maybeCreateDiscordAutoThread(
       createBaseParams({
         channelConfig: { allowed: true, autoThread: true, autoArchiveDuration: 4320 },
@@ -155,6 +206,7 @@ describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
 
   it("defaults to 60 when autoArchiveDuration not set", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     await maybeCreateDiscordAutoThread(createBaseParams());
     expectRestBodyField(postMock, "auto_archive_duration", 60);
   });
@@ -163,6 +215,7 @@ describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
 describe("maybeCreateDiscordAutoThread autoThreadName", () => {
   it("renames created thread when generated mode is enabled", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     patchMock.mockResolvedValueOnce({});
     generateThreadTitleMock.mockResolvedValueOnce("Deploy rollout summary");
 
@@ -193,6 +246,7 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
 
   it("does not block thread creation while title summary is pending", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     patchMock.mockResolvedValueOnce({});
     let resolveTitle: ((value: string | null) => void) | undefined;
     generateThreadTitleMock.mockReturnValueOnce(
@@ -219,6 +273,7 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
 
   it("uses channel-specific thread override for generated title model", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     patchMock.mockResolvedValueOnce({});
     generateThreadTitleMock.mockResolvedValueOnce("Deploy rollout summary");
 
@@ -248,6 +303,7 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
 
   it("falls back to parent channel override for generated title model", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     patchMock.mockResolvedValueOnce({});
     generateThreadTitleMock.mockResolvedValueOnce("Deploy rollout summary");
 
@@ -277,6 +333,7 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
 
   it("skips summarization when cfg or agentId is missing", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     await maybeCreateDiscordAutoThread(
       createBaseParams({
         channelConfig: { allowed: true, autoThread: true, autoThreadName: "generated" },
@@ -289,6 +346,7 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
 
   it("does not rename when autoThreadName is not set", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     await maybeCreateDiscordAutoThread(
       createBaseParams({
         channelConfig: { allowed: true, autoThread: true },
@@ -301,6 +359,7 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
 
   it("does not rename when generated title sanitizes to fallback thread name", async () => {
     postMock.mockResolvedValueOnce({ id: "thread1" });
+    getMock.mockResolvedValueOnce({});
     generateThreadTitleMock.mockResolvedValueOnce("<@123456789012345678> <#987654321098765432>");
 
     const cfg = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } } as OpenClawConfig;

--- a/extensions/discord/src/monitor/threading.auto-thread.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.ts
@@ -147,6 +147,28 @@ export async function maybeCreateDiscordAutoThread(
     return undefined;
   }
   try {
+    try {
+      const existingThreadId = (
+        (await getChannelMessage(params.client.rest, messageChannelId, params.message.id)) as {
+          thread?: { id?: string };
+        }
+      )?.thread?.id;
+      if (existingThreadId) {
+        logVerbose(
+          `discord: autoThread reusing existing thread ${existingThreadId} on ${messageChannelId}/${params.message.id}`,
+        );
+        return existingThreadId;
+      }
+    } catch {
+      // Best effort only. A failed message refetch must not block creating the thread.
+    }
+    if (params.message.author?.bot) {
+      logVerbose(
+        `discord: autoThread skipped for bot-authored message ${messageChannelId}/${params.message.id}`,
+      );
+      return undefined;
+    }
+
     const rawThreadSource = params.baseText || params.combinedBody || "Thread";
     const threadName = sanitizeDiscordThreadName(rawThreadSource, params.message.id);
     const archiveDuration = params.channelConfig?.autoArchiveDuration

--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -965,6 +965,47 @@ describe("channel turn kernel", () => {
     ]);
   });
 
+  it("runs afterRecord only after session recording succeeds and before dispatch", async () => {
+    const events: string[] = [];
+    await runPreparedChannelTurn({
+      channel: "test",
+      routeSessionKey: "agent:main:test:peer",
+      storePath: "/tmp/sessions.json",
+      ctxPayload: createCtx(),
+      recordInboundSession: createRecordInboundSession(events),
+      afterRecord: vi.fn(async () => {
+        events.push("afterRecord");
+      }),
+      runDispatch: vi.fn(async () => {
+        events.push("dispatch");
+        return { visibleReplySent: true };
+      }),
+    });
+
+    expect(events).toEqual(["record", "afterRecord", "dispatch"]);
+  });
+
+  it("does not run afterRecord when session recording fails", async () => {
+    const recordError = new Error("session store failed");
+    const afterRecord = vi.fn();
+
+    await expect(
+      runPreparedChannelTurn({
+        channel: "test",
+        routeSessionKey: "agent:main:test:peer",
+        storePath: "/tmp/sessions.json",
+        ctxPayload: createCtx(),
+        recordInboundSession: vi.fn(async () => {
+          throw recordError;
+        }) as unknown as RecordInboundSession,
+        afterRecord,
+        runDispatch: vi.fn(),
+      }),
+    ).rejects.toThrow(recordError);
+
+    expect(afterRecord).not.toHaveBeenCalled();
+  });
+
   it("normalizes visible dispatch checks", () => {
     expect(hasVisibleChannelTurnDispatch(undefined)).toBe(false);
     expect(

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -372,6 +372,7 @@ export async function dispatchAssembledChannelTurn(
       storePath: params.storePath,
       ctxPayload: params.ctxPayload,
       recordInboundSession: params.recordInboundSession,
+      afterRecord: params.afterRecord,
       record: params.record,
       history: params.history,
       admission: params.admission,
@@ -512,6 +513,7 @@ async function runPreparedChannelTurnCoreInTrace<
         admission: admission.kind,
       },
     });
+    await params.afterRecord?.();
   } catch (err) {
     emit({
       ...params,

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -385,6 +385,7 @@ export type AssembledChannelTurn = {
   storePath: string;
   ctxPayload: FinalizedMsgContext;
   recordInboundSession: RecordInboundSession;
+  afterRecord?: () => void | Promise<void>;
   dispatchReplyWithBufferedBlockDispatcher: DispatchReplyWithBufferedBlockDispatcher;
   delivery: ChannelEventDeliveryAdapter;
   replyPipeline?: ChannelTurnReplyPipelineOptions;
@@ -408,6 +409,7 @@ export type PreparedChannelTurn<TDispatchResult = DispatchFromConfigResult> = {
   storePath: string;
   ctxPayload: FinalizedMsgContext;
   recordInboundSession: RecordInboundSession;
+  afterRecord?: () => void | Promise<void>;
   record?: ChannelTurnRecordOptions;
   history?: ChannelTurnHistoryFinalizeOptions;
   onPreDispatchFailure?: (err: unknown) => void | Promise<void>;

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -27,10 +27,17 @@ describe("createPluginRuntimeMock", () => {
       id: raw.id,
       rawText: "hello",
     }));
-    const recordInboundSession = vi.fn();
-    const runDispatch = vi.fn(async () => ({
-      visibleReplySent: true,
-    }));
+    const events: string[] = [];
+    const recordInboundSession = vi.fn(() => {
+      events.push("record");
+    });
+    const afterRecord = vi.fn(() => {
+      events.push("afterRecord");
+    });
+    const runDispatch = vi.fn(async () => {
+      events.push("dispatch");
+      return { visibleReplySent: true };
+    });
     const resolveTurn = vi.fn(async () => ({
       channel,
       storePath: "/tmp/openclaw-test",
@@ -41,6 +48,7 @@ describe("createPluginRuntimeMock", () => {
         SessionKey: "agent:main:test:direct:u1",
       },
       recordInboundSession,
+      afterRecord,
       runDispatch,
     }));
 
@@ -65,6 +73,7 @@ describe("createPluginRuntimeMock", () => {
         sessionKey: "agent:main:test:direct:u1",
       }),
     );
+    expect(events).toEqual(["record", "afterRecord", "dispatch"]);
     expect(runDispatch).toHaveBeenCalled();
     expect(result).toEqual(
       expect.objectContaining({

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -190,6 +190,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       onRecordError: record?.onRecordError ?? (() => undefined),
       trackSessionMetaTask: record?.trackSessionMetaTask,
     });
+    await (params.afterRecord as (() => void | Promise<void>) | undefined)?.();
     const dispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
       ctx: ctxPayload,
       cfg: params.cfg,
@@ -224,6 +225,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           onRecordError: params.record?.onRecordError ?? (() => undefined),
           trackSessionMetaTask: params.record?.trackSessionMetaTask,
         });
+        await params.afterRecord?.();
       } catch (err) {
         try {
           await params.onPreDispatchFailure?.(err);


### PR DESCRIPTION
## Summary
- Queue Discord initial ack/status reactions only after inbound session recording succeeds.
- Add a generic channel-turn `afterRecord` lifecycle hook and wire Discord acking through it.
- Reuse existing Discord message threads before skipping bot-authored auto-thread creation, while preserving thread creation when the prefetch fails.
- Add regression coverage for accepted mention ingress ordering and auto-thread reuse/fallback behavior.

## Verification
- `node scripts/run-vitest.mjs src/channels/turn/kernel.test.ts extensions/discord/src/monitor/threading.auto-thread.test.ts extensions/discord/src/monitor/message-handler.process.test.ts` passed.
- `git diff --check` passed.
- `~/.agents/skills/autoreview/scripts/autoreview --mode local` initially found one P1 prefetch regression; fixed it and reran clean.

## Real behavior proof
- Local installed OpenClaw runtime 2026.6.6 was patched and validated before source PR handoff.
- `openclaw config validate` passed.
- `openclaw doctor --fix` completed with only known housekeeping warnings.
- Gateway was restarted and verified live at `http://127.0.0.1:18789/health` after the local runtime patch.
- Focused source tests later passed for the ported behavior: `node scripts/run-vitest.mjs src/channels/turn/kernel.test.ts extensions/discord/src/monitor/threading.auto-thread.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`.

## Notes
- This ports the local installed-runtime AGT-80/AGT-81 hotfix into source.
- The acked-without-run watchdog query is not included here; this PR covers ordering and regression smoke, not the production detector.
