### PR TITLE
fix(whatsapp): stop markdownToWhatsApp dropping code spans followed by a digit

### DIFF
--- a/extensions/whatsapp/src/targets-runtime.ts
+++ b/extensions/whatsapp/src/targets-runtime.ts
@@ -8,6 +8,9 @@ import { CONFIG_DIR, resolveUserPath } from "openclaw/plugin-sdk/text-utility-ru
 
 const WHATSAPP_FENCE_PLACEHOLDER = "\x00FENCE";
 const WHATSAPP_INLINE_CODE_PLACEHOLDER = "\x00CODE";
+// Terminates the numeric index in a placeholder so the restore regex cannot
+// absorb a digit from adjacent user text (e.g. `code`5) into the index.
+const WHATSAPP_PLACEHOLDER_TERMINATOR = "\x00";
 
 export type WebChannel = "web";
 
@@ -197,25 +200,26 @@ export function markdownToWhatsApp(text: string): string {
   const fences: string[] = [];
   let result = text.replace(/```[\s\S]*?```/g, (match) => {
     fences.push(match);
-    return `${WHATSAPP_FENCE_PLACEHOLDER}${fences.length - 1}`;
+    return `${WHATSAPP_FENCE_PLACEHOLDER}${fences.length - 1}${WHATSAPP_PLACEHOLDER_TERMINATOR}`;
   });
 
   const inlineCodes: string[] = [];
   result = result.replace(/`[^`\n]+`/g, (match) => {
     inlineCodes.push(match);
-    return `${WHATSAPP_INLINE_CODE_PLACEHOLDER}${inlineCodes.length - 1}`;
+    return `${WHATSAPP_INLINE_CODE_PLACEHOLDER}${inlineCodes.length - 1}${WHATSAPP_PLACEHOLDER_TERMINATOR}`;
   });
 
   result = result.replace(/\*\*(.+?)\*\*/g, "*$1*");
   result = result.replace(/__(.+?)__/g, "*$1*");
   result = result.replace(/~~(.+?)~~/g, "~$1~");
 
+  const terminator = escapeRegExp(WHATSAPP_PLACEHOLDER_TERMINATOR);
   result = result.replace(
-    new RegExp(`${escapeRegExp(WHATSAPP_INLINE_CODE_PLACEHOLDER)}(\\d+)`, "g"),
+    new RegExp(`${escapeRegExp(WHATSAPP_INLINE_CODE_PLACEHOLDER)}(\\d+)${terminator}`, "g"),
     (_, idx) => inlineCodes[Number(idx)] ?? "",
   );
   result = result.replace(
-    new RegExp(`${escapeRegExp(WHATSAPP_FENCE_PLACEHOLDER)}(\\d+)`, "g"),
+    new RegExp(`${escapeRegExp(WHATSAPP_FENCE_PLACEHOLDER)}(\\d+)${terminator}`, "g"),
     (_, idx) => fences[Number(idx)] ?? "",
   );
   return result;

--- a/extensions/whatsapp/src/text-runtime.test.ts
+++ b/extensions/whatsapp/src/text-runtime.test.ts
@@ -41,12 +41,23 @@ describe("markdownToWhatsApp", () => {
     ["returns empty string for empty input", "", ""],
     ["returns plain text unchanged", "no formatting here", "no formatting here"],
     ["handles bold inside a sentence", "This is **very** important", "This is *very* important"],
+    // Regression: a digit immediately after an inline-code span must not be
+    // absorbed into the placeholder index (which previously dropped both).
+    ["preserves inline code immediately followed by a digit", "`a`5", "`a`5"],
+    ["preserves inline code followed by a number", "`status`200 done", "`status`200 done"],
+    ["preserves two adjacent code+digit spans", "`x`1 and `y`2", "`x`1 and `y`2"],
+    ["preserves inline code with a space before a digit", "`a` 5", "`a` 5"],
   ] as const)("handles markdown-to-whatsapp conversion: %s", (_name, input, expected) => {
     expect(markdownToWhatsApp(input)).toBe(expected);
   });
 
   it("preserves fenced code blocks", () => {
     const input = "```\nconst x = **bold**;\n```";
+    expect(markdownToWhatsApp(input)).toBe(input);
+  });
+
+  it("preserves a fenced code block immediately followed by a digit", () => {
+    const input = "```code```7 done";
     expect(markdownToWhatsApp(input)).toBe(input);
   });
 


### PR DESCRIPTION
## Summary

- `markdownToWhatsApp` silently dropped inline-code / fenced-code spans (and adjacent digits) from outbound WhatsApp text whenever a digit immediately followed the span — e.g. `` `status`200 `` or `` `a`5 ``.
- Root cause: code spans are swapped for `\x00CODE<index>` / `\x00FENCE<index>` placeholders, then restored by matching `placeholder(\d+)`. The `(\d+)` is greedy and unterminated, so a trailing user digit gets absorbed into the index, which then resolves to `undefined` and `?? ""` deletes the whole thing.
- Fix: terminate the placeholder index with the same `\x00` marker the placeholders already use, so the index boundary is unambiguous and adjacent user digits are preserved.
- Out of scope: no change to which markdown is converted; only the placeholder round-trip is made digit-safe.

## Linked context

Closes # (none — found by inspection)
Related # (none)
Requested by a maintainer/owner: no

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** outbound WhatsApp text loses inline-code/fenced spans (and the adjacent digit) when a digit immediately follows the span. `markdownToWhatsApp` is applied to all outbound text in `send.ts` and `auto-reply/deliver-reply.ts`.
- **Real environment tested:** OpenClaw checkout on macOS (Darwin arm64, Node v22), running the actual `markdownToWhatsApp` from `extensions/whatsapp/src/targets-runtime.ts` via `node --import tsx` — before and after the patch, same inputs.
- **Exact steps or command run after this patch:** `node --import tsx repro-md.mts` (calls the real exported function on representative inputs).
- **Evidence after fix (console output):**

```console
# BEFORE (origin/main) — content silently destroyed
in : "`a`5"               out: ""
in : "`status`200 done"   out: " done"
in : "port `8080`9 open"  out: "port  open"
in : "```code```7 done"   out: " done"

# AFTER (this branch) — content preserved
in : "`a`5"               out: "`a`5"
in : "`status`200 done"   out: "`status`200 done"
in : "port `8080`9 open"  out: "port `8080`9 open"
in : "```code```7 done"   out: "```code```7 done"
in : "`a` 5"              out: "`a` 5"          (control, unchanged)
in : "**bold** and `code` here" out: "*bold* and `code` here"  (control, unchanged)
```

- **Observed result after fix:** the code span and the adjacent digit are both preserved; conversions with no adjacent digit are unaffected.
- **What was not tested:** end-to-end send to a live device. The full `pnpm test:extension whatsapp` lane was not run from the isolated git worktree (pnpm wanted to purge a shared `node_modules`); validated instead via the function's own vitest file and direct before/after execution of the real module (CI runs the full lanes).
- **Proof limitations or environment constraints:** transcript above is copied live output from the real module, not a mock.

## Tests and validation

- `node_modules/.bin/vitest run extensions/whatsapp/src/text-runtime.test.ts` → **34 passed** (5 new regression cases added for digit-adjacent code/fence spans).
- Regression coverage added in `text-runtime.test.ts`: inline code + digit, inline code + number, two adjacent code+digit spans, code + space + digit, fenced block + digit.
- What failed before: the new regression cases fail on `main` (content dropped); they pass with this change.

## Risk checklist

- User-visible behavior change? **Yes** — outbound text that was being corrupted is now correct.
- Config / env / migration change? No.
- Security / auth / secrets / network / tool-execution change? No.
- Highest-risk area: the placeholder restore regex. Mitigated by reusing the existing `\x00` marker convention (no new assumptions about user input) and by the adjacent-placeholder regression test.

## Current review state

- Next action: review.
- Waiting on: CI + maintainer review.
- Bot/reviewer comments addressed: none yet.
- Note on red checks: the two failing checks (`checks-node-agentic-cli`, `checks-node-agentic-agents-support`) fail in `src/cli/daemon-cli/install.test.ts` ("does not reuse stale service control env during forced reinstall") and `src/agents/sessions/session-manager.test.ts` — subsystems this PR does not touch. This diff changes only the WhatsApp markdown converter (`extensions/whatsapp/src/targets-runtime.ts`) and its test, so those failures appear unrelated to this change. The WhatsApp test lane and the real-behavior-proof check pass.

## AI-Assisted PR Checklist

- [x] Marked as AI-assisted
- [x] Human-run real behavior proof included above (before/after live output, not test/CI-only)
- [x] Code reviewed and understood — root cause confirmed by reading and reproducing
- [x] Backwards compatible — pure-string conversion, no signature change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
