### PR TITLE
fix(cron): emit model.usage diagnostic events for cron-isolated agent runs (fixes #92338)

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -22,7 +22,7 @@ import {
   getAgentRunContext,
   releaseAgentRunContext,
 } from "../../infra/agent-events.js";
-import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
   createSourceDeliveryPlan,
   resolveSourceDeliveryOutcome,
@@ -1045,6 +1045,35 @@ async function finalizeCronRun(params: {
     // Fixes #69347: cost was inflated 1x-72x by accumulating on every persist.
     if (runEstimatedCostUsd !== undefined) {
       prepared.cronSession.sessionEntry.estimatedCostUsd = runEstimatedCostUsd;
+    }
+    // Emit model.usage diagnostic event so OTel subscribers see cron-fired
+    // spend alongside auto-reply spend (#92338).
+    if (isDiagnosticsEnabled(prepared.cfgWithAgentDefaults)) {
+      const usagePromptTokens = input + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+      const totalUsageTokens = totalTokens ?? usagePromptTokens + output;
+      emitTrustedDiagnosticEvent({
+        type: "model.usage",
+        sessionKey: prepared.agentSessionKey,
+        sessionId: prepared.runSessionId,
+        agentId: prepared.agentId,
+        provider: providerUsed,
+        model: modelUsed,
+        usage: {
+          input,
+          output,
+          cacheRead: usage.cacheRead ?? 0,
+          cacheWrite: usage.cacheWrite ?? 0,
+          promptTokens: usagePromptTokens,
+          total: totalUsageTokens,
+        },
+        lastCallUsage,
+        context: {
+          contextTokens,
+          promptTokens,
+        },
+        costUsd: runEstimatedCostUsd,
+        durationMs: finalRunResult.meta?.durationMs,
+      });
     }
     telemetry = {
       model: modelUsed,


### PR DESCRIPTION
### Summary

- **Problem**: `model.usage` diagnostic events are emitted only from the auto-reply pipeline (`src/auto-reply/reply/agent-runner.ts`). The cron-isolated pipeline (`src/cron/isolated-agent/run.ts`) computes the same token usage data but never emits the diagnostic event, making OTel subscribers blind to all cron-fired model spend.
- **Root Cause**: `finalizeCronRun` in `run.ts` imports `isDiagnosticsEnabled` and computes usage data (input/output/cache/cost), but never calls `emitTrustedDiagnosticEvent({ type: "model.usage", ... })`.
- **Fix**: Add the `emitTrustedDiagnosticEvent({ type: "model.usage", ... })` call inside the existing `if (hasNonzeroUsage(usage))` block, gated by `isDiagnosticsEnabled`, mirroring the auto-reply emission in `agent-runner.ts:2167-2188`.
- **What changed**:
  - `src/cron/isolated-agent/run.ts` — import `emitTrustedDiagnosticEvent`; add diagnostic emission with sessionKey, sessionId, agentId, provider, model, usage, lastCallUsage, context (contextTokens + promptTokens), costUsd, and durationMs.
- **What did NOT change (scope boundary)**:
  - No changes to the auto-reply pipeline (`agent-runner.ts`).
  - No changes to the cron run log format or persistence layer.
  - No changes to the diagnostics-otel plugin or any OTel configuration.

### Reproduction

1. Configure `diagnostics-otel` to a Prometheus/OTLP backend.
2. Define a cron job that uses a model distinct from interactive traffic (e.g., `claude-haiku-4-5` for cron, `claude-opus-4-7` for Slack).
3. Let the cron run for a few cycles; have the interactive agent receive a Slack @mention.
4. **Before this PR**: Query Prometheus `openclaw_tokens_total` — only the interactive model appears; cron-fired model is absent despite real API spend.
5. **After this PR**: Both models appear in the metric, reflecting total spend across interactive and scheduled agent activity.

### Real behavior proof

**Behavior or issue addressed (#92338)**: Cron-isolated agent runs now emit `model.usage` diagnostic events so OTel subscribers can observe cron-fired token consumption alongside interactive (auto-reply) spend.

**Real environment tested**: Linux, Node 22 — in-memory test harness against `finalizeCronRun` with the cron test configuration.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/cron/isolated-agent.model-formatting.test.ts src/cron/isolated-agent.hook-content-wrapping.test.ts src/cron/run-diagnostics.test.ts`

**Evidence after fix**:
```text
Test Files  3 passed (3)
     Tests  48 passed (48)

Files:
  isolated-agent.model-formatting.test.ts         1 file  | 23 tests
  isolated-agent.hook-content-wrapping.test.ts    1 file  | 15 tests
  run-diagnostics.test.ts                         1 file  | 10 tests
```

**Observed result after fix**: The `finalizeCronRun` function now calls `emitTrustedDiagnosticEvent({ type: "model.usage", ... })` with the same usage shape as the auto-reply pipeline — input/output/cacheRead/cacheWrite/promptTokens/total, plus lastCallUsage, context tokens, costUsd, and durationMs. The emission is gated by `isDiagnosticsEnabled` so it is only active when diagnostics subscribers are configured. All 48 existing cron-related tests continue to pass with no regressions.

**What was not tested**: A live cron job cycle with a real OTel backend was not driven. The diagnostic event shape was verified against the auto-reply emission in `agent-runner.ts` to ensure structural parity.

**Repro confirmation**: Code-path analysis confirms the gap: `src/cron/isolated-agent/run.ts` computed `input`, `output`, `cacheRead`, `cacheWrite`, `runEstimatedCostUsd`, and `totalTokens` inside the `if (hasNonzeroUsage(usage))` block at line 1001, but never called `emitTrustedDiagnosticEvent`. After the patch, the emission is added inside the same block, gated by `isDiagnosticsEnabled(prepared.cfgWithAgentDefaults)`.

### Risk / Mitigation

- **Risk**: The diagnostic event adds a synchronous call to subscriber hooks inside the usage-persistence hot path.
  **Mitigation**: The emission is gated by `isDiagnosticsEnabled` so the overhead is zero when no diagnostics subscribers are configured. When enabled, the call pattern is identical to the auto-reply pipeline which already emits the same event on every interactive turn.
- **Risk**: The event shape may diverge from the auto-reply emission over time.
  **Mitigation**: The emission mirrors the existing `agent-runner.ts:2167-2188` pattern with the same field names and types. Future changes to the auto-reply emission should be reflected here.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] cron (isolated agent run diagnostics)

### Regression Test Plan

- `node scripts/run-vitest.mjs src/cron/isolated-agent.model-formatting.test.ts`
- `node scripts/run-vitest.mjs src/cron/isolated-agent.hook-content-wrapping.test.ts`
- `node scripts/run-vitest.mjs src/cron/run-diagnostics.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #92338
