### PR TITLE
Fix diagnostics OTEL runtime install trust

### DIFF
--- a/src/plugins/gateway-effective-trust.test.ts
+++ b/src/plugins/gateway-effective-trust.test.ts
@@ -1,0 +1,168 @@
+/** Proves Gateway pre-service plugin metadata preserves diagnostics trust provenance. */
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { writePersistedInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
+import { loadOpenClawPlugins } from "./loader.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function makeTempDir(): string {
+  return makeTrackedTempDir("openclaw-gateway-effective-trust", tempDirs);
+}
+
+function writeDiagnosticsOtelPlugin(rootDir: string): void {
+  fs.mkdirSync(rootDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(rootDir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: "diagnostics-otel",
+        configSchema: { type: "object" },
+        activation: { onStartup: true },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "package.json"),
+    JSON.stringify({ name: "@openclaw/diagnostics-otel", version: "2026.5.28" }, null, 2),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    path.join(rootDir, "index.cjs"),
+    "module.exports = { id: 'diagnostics-otel', register() {} };\n",
+    "utf-8",
+  );
+}
+
+function createDiagnosticsOtelInstallRecord(installPath: string): PluginInstallRecord {
+  return {
+    source: "npm",
+    spec: "@openclaw/diagnostics-otel",
+    installPath,
+    resolvedName: "@openclaw/diagnostics-otel",
+    resolvedVersion: "2026.5.28",
+    resolvedSpec: "@openclaw/diagnostics-otel@2026.5.28",
+  };
+}
+
+function createDiagnosticsOtelConfig(params: {
+  installRecord: PluginInstallRecord;
+  pluginRoot: string;
+}): OpenClawConfig {
+  return {
+    plugins: {
+      enabled: true,
+      allow: ["diagnostics-otel"],
+      load: { paths: [params.pluginRoot] },
+      entries: { "diagnostics-otel": { enabled: true } },
+      installs: { "diagnostics-otel": params.installRecord },
+    },
+  };
+}
+
+function loadGatewayPreServiceDiagnosticsTrust(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  workspaceDir: string;
+}): {
+  manifestTrustedOfficialInstall: boolean;
+  loaderTrustedOfficialInstall: boolean;
+  loaderStatus: string | undefined;
+} {
+  const metadata = resolvePluginMetadataSnapshot({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    allowCurrent: false,
+    allowWorkspaceScopedCurrent: false,
+  });
+  const manifestRecord = metadata.manifestRegistry.plugins.find(
+    (entry) => entry.id === "diagnostics-otel",
+  );
+  const registry = loadOpenClawPlugins({
+    cache: false,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    onlyPluginIds: ["diagnostics-otel"],
+    manifestRegistry: metadata.manifestRegistry,
+  });
+  const loaderRecord = registry.plugins.find((entry) => entry.id === "diagnostics-otel");
+  return {
+    manifestTrustedOfficialInstall: manifestRecord?.trustedOfficialInstall === true,
+    loaderTrustedOfficialInstall: loaderRecord?.trustedOfficialInstall === true,
+    loaderStatus: loaderRecord?.status,
+  };
+}
+
+describe("Gateway diagnostics-otel effective trust path", () => {
+  it("keeps config-authored diagnostics-otel installs untrusted on the precomputed Gateway path", () => {
+    const rootDir = makeTempDir();
+    const stateDir = path.join(rootDir, "state");
+    const workspaceDir = path.join(rootDir, "workspace");
+    const pluginRoot = path.join(rootDir, "usr-lib-node-modules", "@openclaw", "diagnostics-otel");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    writeDiagnosticsOtelPlugin(pluginRoot);
+
+    const installRecord = createDiagnosticsOtelInstallRecord(pluginRoot);
+    const config = createDiagnosticsOtelConfig({ installRecord, pluginRoot });
+    const env = {
+      ...process.env,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "true",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.5.28",
+      VITEST: "true",
+    } as NodeJS.ProcessEnv;
+
+    const result = loadGatewayPreServiceDiagnosticsTrust({ config, env, workspaceDir });
+
+    expect(result.loaderStatus).toBe("loaded");
+    expect(result.manifestTrustedOfficialInstall).toBe(false);
+    expect(result.loaderTrustedOfficialInstall).toBe(false);
+  });
+
+  it("trusts persisted diagnostics-otel installs before Gateway services start", () => {
+    const rootDir = makeTempDir();
+    const stateDir = path.join(rootDir, "state");
+    const workspaceDir = path.join(rootDir, "workspace");
+    const pluginRoot = path.join(rootDir, "usr-lib-node-modules", "@openclaw", "diagnostics-otel");
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    writeDiagnosticsOtelPlugin(pluginRoot);
+
+    const installRecord = createDiagnosticsOtelInstallRecord(pluginRoot);
+    const config = createDiagnosticsOtelConfig({ installRecord, pluginRoot });
+    const env = {
+      ...process.env,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "true",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_VERSION: "2026.5.28",
+      VITEST: "true",
+    } as NodeJS.ProcessEnv;
+    writePersistedInstalledPluginIndexInstallRecordsSync(
+      { "diagnostics-otel": installRecord },
+      { stateDir, env },
+    );
+
+    const result = loadGatewayPreServiceDiagnosticsTrust({ config, env, workspaceDir });
+
+    expect(result.loaderStatus).toBe("loaded");
+    expect(result.manifestTrustedOfficialInstall).toBe(true);
+    expect(result.loaderTrustedOfficialInstall).toBe(true);
+  });
+});

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1364,6 +1364,48 @@ describe("loadOpenClawPlugins", () => {
     expect(record?.rootDir).toBe(fs.realpathSync.native(plugin.dir));
   });
 
+  it("keeps user-authored diagnostics-otel config install records untrusted during plugin load", () => {
+    useNoBundledPlugins();
+    const stateDir = makeTempDir();
+    const plugin = writePlugin({
+      id: "diagnostics-otel",
+      filename: "index.cjs",
+      body: `module.exports = { id: "diagnostics-otel", register() {} };`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "package.json"),
+      JSON.stringify({ name: "@openclaw/diagnostics-otel", version: "2026.5.28" }),
+      "utf-8",
+    );
+
+    const registry = withEnv({ OPENCLAW_STATE_DIR: stateDir }, () =>
+      loadOpenClawPlugins({
+        cache: false,
+        config: {
+          plugins: {
+            load: { paths: [plugin.dir] },
+            entries: { "diagnostics-otel": { enabled: true } },
+            installs: {
+              "diagnostics-otel": {
+                source: "npm",
+                spec: "@openclaw/diagnostics-otel",
+                installPath: plugin.dir,
+                resolvedName: "@openclaw/diagnostics-otel",
+                resolvedVersion: "2026.5.28",
+                resolvedSpec: "@openclaw/diagnostics-otel@2026.5.28",
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const record = registry.plugins.find((entry) => entry.id === "diagnostics-otel");
+    expect(record?.status).toBe("loaded");
+    expect(record?.origin).toBe("config");
+    expect(record?.trustedOfficialInstall).toBeFalsy();
+  });
+
   it("refreshes bundled plugin-sdk aliases without deleting the shared alias directory", () => {
     const distRoot = makeTempDir();
     const pluginSdkDir = path.join(distRoot, "plugin-sdk");

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1307,9 +1307,13 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const preferBuiltPluginArtifacts = options.preferBuiltPluginArtifacts === true;
   const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = resolveCoreGatewayMethodNames(options);
+  const trustedInstallRecords =
+    options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env });
   const installRecords = {
-    ...(options.installRecords ?? loadInstalledPluginIndexInstallRecordsSync({ env })),
+    // Legacy config records may point discovery at a managed plugin path, but only
+    // the persisted/index records are trusted to grant official-plugin privileges.
     ...cfg.plugins?.installs,
+    ...trustedInstallRecords,
   };
   const devSourceRoot = resolveOpenClawDevSourceRoot(env);
   const cacheKey = buildCacheKey({
@@ -1357,6 +1361,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     shouldLoadModules: options.loadModules !== false,
     runtimeSubagentMode,
     installRecords,
+    trustedInstallRecords,
     devSourceRoot,
     cacheKey,
   };
@@ -1754,6 +1759,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     cacheKey,
     runtimeSubagentMode,
     installRecords,
+    trustedInstallRecords,
     devSourceRoot,
   } = resolvePluginLoadCacheContext(options);
   const logger = options.logger ?? defaultLogger();
@@ -1937,6 +1943,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         candidates: discovery.candidates,
         diagnostics: discovery.diagnostics,
         installRecords: Object.keys(installRecords).length > 0 ? installRecords : undefined,
+        trustedInstallRecords,
       });
     pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
     warnWhenAllowlistIsOpen({
@@ -2875,6 +2882,7 @@ export async function loadOpenClawPluginCliRegistry(
     onlyPluginIds,
     cacheKey,
     installRecords,
+    trustedInstallRecords,
     devSourceRoot,
   } = resolvePluginLoadCacheContext({
     ...options,
@@ -2911,6 +2919,7 @@ export async function loadOpenClawPluginCliRegistry(
     candidates: discovery.candidates,
     diagnostics: discovery.diagnostics,
     installRecords: Object.keys(installRecords).length > 0 ? installRecords : undefined,
+    trustedInstallRecords,
   });
   pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
   warnWhenAllowlistIsOpen({

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   readPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndex,
@@ -73,6 +74,55 @@ function createIndex(rootDir: string): InstalledPluginIndex {
       },
     ],
     diagnostics: [],
+  };
+}
+
+type TestInstalledPluginOrigin = InstalledPluginIndex["plugins"][number]["origin"];
+
+function createIndexForPlugin(params: {
+  rootDir: string;
+  pluginId: string;
+  origin?: TestInstalledPluginOrigin;
+  packageName?: string;
+  packageVersion?: string;
+  installRecord?: PluginInstallRecord;
+}): InstalledPluginIndex {
+  const index = createIndex(params.rootDir);
+  const record = index.plugins[0];
+  if (!record) {
+    throw new Error("expected index record");
+  }
+  return {
+    ...index,
+    installRecords: params.installRecord
+      ? { ...index.installRecords, [params.pluginId]: params.installRecord }
+      : index.installRecords,
+    plugins: [
+      {
+        ...record,
+        pluginId: params.pluginId,
+        origin: params.origin ?? "config",
+        ...(params.packageName ? { packageName: params.packageName } : {}),
+        ...(params.packageVersion ? { packageVersion: params.packageVersion } : {}),
+      },
+    ],
+  };
+}
+
+type DiagnosticsInstallRecordOverrides = Partial<PluginInstallRecord>;
+
+function createDiagnosticsOtelInstallRecord(
+  rootDir: string,
+  installRecordOverrides: DiagnosticsInstallRecordOverrides = {},
+): PluginInstallRecord {
+  return {
+    source: "npm",
+    spec: "@openclaw/diagnostics-otel",
+    installPath: rootDir,
+    resolvedName: "@openclaw/diagnostics-otel",
+    resolvedVersion: "2026.5.28",
+    resolvedSpec: "@openclaw/diagnostics-otel@2026.5.28",
+    ...installRecordOverrides,
   };
 }
 
@@ -338,6 +388,164 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(registry.plugins[0]?.modelSupport).toEqual({
       modelPrefixes: ["installed-"],
     });
+  });
+
+  it("marks persisted diagnostics-otel install records trusted on the installed-index path", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "diagnostics-otel", "diagnostics-otel-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndexForPlugin({
+        rootDir,
+        pluginId: "diagnostics-otel",
+        origin: "config",
+        packageName: "@openclaw/diagnostics-otel",
+        packageVersion: "2026.5.28",
+        installRecord: createDiagnosticsOtelInstallRecord(rootDir),
+      }),
+      env: {
+        OPENCLAW_VERSION: "2026.5.28",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.origin).toBe("config");
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
+  });
+
+  it("keeps package-name spoofed diagnostics-otel install records untrusted", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "diagnostics-otel", "diagnostics-otel-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndexForPlugin({
+        rootDir,
+        pluginId: "diagnostics-otel",
+        origin: "config",
+        packageName: "@spoof/diagnostics-otel",
+        packageVersion: "2026.5.28",
+        installRecord: createDiagnosticsOtelInstallRecord(rootDir),
+      }),
+      env: {
+        OPENCLAW_VERSION: "2026.5.28",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeFalsy();
+  });
+
+  it("keeps mismatched-spec diagnostics-otel install records untrusted", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "diagnostics-otel", "diagnostics-otel-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndexForPlugin({
+        rootDir,
+        pluginId: "diagnostics-otel",
+        origin: "config",
+        packageName: "@openclaw/diagnostics-otel",
+        packageVersion: "2026.5.28",
+        installRecord: createDiagnosticsOtelInstallRecord(rootDir, {
+          spec: "@spoof/diagnostics-otel",
+          resolvedName: "@spoof/diagnostics-otel",
+          resolvedSpec: "@spoof/diagnostics-otel@2026.5.28",
+        }),
+      }),
+      env: {
+        OPENCLAW_VERSION: "2026.5.28",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeFalsy();
+  });
+
+  it("keeps wrong-path diagnostics-otel install records untrusted", () => {
+    const rootDir = makeTempDir();
+    const otherRoot = makeTempDir();
+    writePlugin(rootDir, "diagnostics-otel", "diagnostics-otel-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndexForPlugin({
+        rootDir,
+        pluginId: "diagnostics-otel",
+        origin: "config",
+        packageName: "@openclaw/diagnostics-otel",
+        packageVersion: "2026.5.28",
+        installRecord: createDiagnosticsOtelInstallRecord(rootDir, { installPath: otherRoot }),
+      }),
+      env: {
+        OPENCLAW_VERSION: "2026.5.28",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeFalsy();
+  });
+
+  it("keeps non-official install records untrusted", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "not-official-diagnostics", "not-official-diagnostics-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndexForPlugin({
+        rootDir,
+        pluginId: "not-official-diagnostics",
+        origin: "config",
+        packageName: "@openclaw/not-official-diagnostics",
+        packageVersion: "2026.5.28",
+        installRecord: {
+          source: "npm",
+          spec: "@openclaw/not-official-diagnostics",
+          installPath: rootDir,
+          resolvedName: "@openclaw/not-official-diagnostics",
+          resolvedVersion: "2026.5.28",
+          resolvedSpec: "@openclaw/not-official-diagnostics@2026.5.28",
+        },
+      }),
+      env: {
+        OPENCLAW_VERSION: "2026.5.28",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeFalsy();
+  });
+
+  it("keeps non-npm diagnostics-otel install records untrusted", () => {
+    const rootDir = makeTempDir();
+    writePlugin(rootDir, "diagnostics-otel", "diagnostics-otel-");
+
+    const registry = loadPluginManifestRegistryForInstalledIndex({
+      index: createIndexForPlugin({
+        rootDir,
+        pluginId: "diagnostics-otel",
+        origin: "config",
+        packageName: "@openclaw/diagnostics-otel",
+        packageVersion: "2026.5.28",
+        installRecord: createDiagnosticsOtelInstallRecord(rootDir, { source: "marketplace" }),
+      }),
+      env: {
+        OPENCLAW_VERSION: "2026.5.28",
+        VITEST: "true",
+      },
+      includeDisabled: true,
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeFalsy();
   });
 
   it("reconstructs bundle candidates with their bundle manifest format", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -731,6 +731,47 @@ describe("loadPluginManifestRegistry", () => {
     });
   });
 
+  it("keeps user-authored diagnostics-otel config installs untrusted", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
+    writeTextFile(
+      dir,
+      "package.json",
+      JSON.stringify({ name: "@openclaw/diagnostics-otel", version: "2026.5.28" }),
+    );
+    writeTextFile(dir, "index.ts", "export {};\n");
+
+    const registry = loadPluginManifestRegistry({
+      config: {
+        plugins: {
+          load: { paths: [dir] },
+          entries: { "diagnostics-otel": { enabled: true } },
+          installs: {
+            "diagnostics-otel": {
+              source: "npm",
+              spec: "@openclaw/diagnostics-otel",
+              installPath: dir,
+              resolvedName: "@openclaw/diagnostics-otel",
+              resolvedVersion: "2026.5.28",
+              resolvedSpec: "@openclaw/diagnostics-otel@2026.5.28",
+            },
+          },
+        },
+      },
+      env: hermeticEnv({
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "true",
+        OPENCLAW_HOME: makeTempDir(),
+        OPENCLAW_VERSION: "2026.5.28",
+      }),
+    });
+
+    expect(registry.plugins).toHaveLength(1);
+    expectRecordFields(registry.plugins[0], "plugin", {
+      origin: "config",
+    });
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeFalsy();
+  });
+
   it("preserves trusted official installs when a config path selects the installed package", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "diagnostics-prometheus", configSchema: { type: "object" } });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -806,6 +806,25 @@ function npmSpecMatchesPackage(value: string | undefined, packageName: string): 
   return normalized.startsWith(`${packageName}@`);
 }
 
+function npmInstallRecordMatchesPackage(params: {
+  installRecord: PluginInstallRecord;
+  candidatePackageName?: string;
+  packageName: string;
+}): boolean {
+  const recordPackageRefs = [
+    params.installRecord.resolvedName,
+    params.installRecord.spec,
+    params.installRecord.resolvedSpec,
+  ];
+  if (recordPackageRefs.some((value) => npmSpecMatchesPackage(value, params.packageName))) {
+    return true;
+  }
+  const hasRecordPackageRef = recordPackageRefs.some((value) => value?.trim());
+  return (
+    !hasRecordPackageRef && npmSpecMatchesPackage(params.candidatePackageName, params.packageName)
+  );
+}
+
 function isTrustedOfficialPluginInstall(params: {
   pluginId: string;
   candidate: PluginCandidate;
@@ -839,12 +858,11 @@ function isTrustedOfficialPluginInstall(params: {
   if (
     installRecord.source === "npm" &&
     officialInstall?.npmSpec === packageName &&
-    [
-      installRecord.resolvedName,
-      installRecord.spec,
-      installRecord.resolvedSpec,
-      params.candidate.packageName,
-    ].some((value) => npmSpecMatchesPackage(value, packageName))
+    npmInstallRecordMatchesPackage({
+      installRecord,
+      candidatePackageName: params.candidate.packageName,
+      packageName,
+    })
   ) {
     return true;
   }
@@ -958,6 +976,7 @@ export function loadPluginManifestRegistry(
     candidates?: PluginCandidate[];
     diagnostics?: PluginDiagnostic[];
     installRecords?: Record<string, PluginInstallRecord>;
+    trustedInstallRecords?: Record<string, PluginInstallRecord>;
     bundledChannelConfigCollector?: BundledChannelConfigCollector;
     discovery?: PluginDiscoveryResult;
   } = {},
@@ -974,6 +993,8 @@ export function loadPluginManifestRegistry(
     }
     return installRecords ?? {};
   };
+  const getTrustedInstallRecords = (): Record<string, PluginInstallRecord> =>
+    params.trustedInstallRecords ?? getInstallRecords();
 
   const discovery = params.candidates
     ? {
@@ -1115,7 +1136,7 @@ export function loadPluginManifestRegistry(
             pluginId: manifest.id,
             candidate,
             env,
-            installRecords: getInstallRecords(),
+            installRecords: getTrustedInstallRecords(),
           }),
           ...(params.bundledChannelConfigCollector
             ? { bundledChannelConfigCollector: params.bundledChannelConfigCollector }

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -212,6 +212,51 @@ describe("resolvePluginRuntimeLoadContext", () => {
     });
   });
 
+  it("passes runtime config install records into the metadata snapshot", () => {
+    const installRecords = {
+      "diagnostics-otel": {
+        source: "npm" as const,
+        spec: "@openclaw/diagnostics-otel",
+        installPath: "/usr/lib/node_modules/@openclaw/diagnostics-otel",
+        resolvedName: "@openclaw/diagnostics-otel",
+        resolvedVersion: "2026.5.28",
+        resolvedSpec: "@openclaw/diagnostics-otel@2026.5.28",
+      },
+    };
+    const rawConfig = {
+      plugins: {
+        load: { paths: ["/usr/lib/node_modules/@openclaw/diagnostics-otel"] },
+        entries: { "diagnostics-otel": { enabled: true } },
+        installs: installRecords,
+      },
+    };
+    const snapshotWithRecords = {
+      ...metadataSnapshot,
+      index: {
+        installRecords,
+        plugins: [],
+        policyHash: "policy",
+      },
+    };
+    loadPluginMetadataSnapshotMock.mockReturnValueOnce(snapshotWithRecords);
+    const env = { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
+
+    const context = resolvePluginRuntimeLoadContext({
+      config: rawConfig,
+      env,
+    });
+
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+      allowWorkspaceScopedCurrent: true,
+      config: rawConfig,
+      env,
+      installRecords,
+      workspaceDir: "/resolved-workspace",
+    });
+    expect(context.installRecords).toEqual(installRecords);
+    expect(buildPluginRuntimeLoadOptions(context).installRecords).toEqual(installRecords);
+  });
+
   it("builds plugin load options from the shared runtime context", () => {
     const context = resolvePluginRuntimeLoadContext({
       config: { plugins: {} },

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -73,6 +73,7 @@ export function resolvePluginRuntimeLoadContext(
   const rawConfig = options?.config ?? getRuntimeConfig();
   const rawWorkspaceDir =
     options?.workspaceDir ?? resolveAgentWorkspaceDir(rawConfig, resolveDefaultAgentId(rawConfig));
+  const runtimeInstallRecords = rawConfig.plugins?.installs;
   const metadataSnapshot = options?.manifestRegistry
     ? undefined
     : resolvePluginMetadataSnapshot({
@@ -80,6 +81,9 @@ export function resolvePluginRuntimeLoadContext(
         env,
         workspaceDir: rawWorkspaceDir,
         allowWorkspaceScopedCurrent: true,
+        ...(runtimeInstallRecords && Object.keys(runtimeInstallRecords).length > 0
+          ? { installRecords: runtimeInstallRecords }
+          : {}),
       });
   const manifestRegistry = options?.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
   const installRecords = metadataSnapshot


### PR DESCRIPTION
## Summary

Fixes the remaining OpenClaw Gateway diagnostics OTEL trust propagation gap.

After Lobster PR #2858 deployed to FRE301 in OpenClaw builds `26.162.04`, `26.162.05`, and `26.162.06`, Kusto still showed fresh Gateway startups with:

- `diagnostics-otel` plugin loaded
- Gateway ready
- zero `OpenClaw Gateway OTEL batch forwarded` rows
- persistent `diagnostics-otel: internal diagnostics capability unavailable`

RCA: Gateway runtime load context retained `plugins.installs` for discovery, but did not pass those runtime install records into the plugin metadata snapshot. The lower-level loader correctly keeps raw config-authored install records untrusted, so the diagnostics plugin could load but never receive `internalDiagnostics` and therefore never forward Gateway OTEL batches.

This PR:

- threads runtime config install records into `resolvePluginMetadataSnapshot` from `resolvePluginRuntimeLoadContext`
- preserves the safety boundary: direct user-authored config install records remain untrusted unless they are in the trusted installed-index/runtime context
- adds Gateway-effective trust coverage proving trusted/persisted records make `diagnostics-otel` trusted before services start
- keeps spoofed/wrong-path/non-official install records untrusted

## Verification

RED/GREEN:

- RED: `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/runtime/load-context.test.ts -t "passes runtime config install records into the metadata snapshot"`
  - failed because `installRecords` was not passed to `resolvePluginMetadataSnapshot`
- GREEN: same command passed after the fix

Focused validation on final branch:

```bash
git diff --check origin/main...HEAD
pnpm exec oxfmt --check --threads=1 \
  src/plugins/loader.test.ts \
  src/plugins/loader.ts \
  src/plugins/manifest-registry-installed.test.ts \
  src/plugins/manifest-registry.test.ts \
  src/plugins/manifest-registry.ts \
  src/plugins/runtime/load-context.test.ts \
  src/plugins/runtime/load-context.ts \
  src/plugins/gateway-effective-trust.test.ts

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/runtime/load-context.test.ts \
  src/plugins/gateway-effective-trust.test.ts

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/manifest-registry.test.ts \
  -t "diagnostics-otel|trusted official|user-authored"

node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts \
  src/plugins/manifest-registry-installed.test.ts \
  -t "diagnostics-otel|official|untrusted"

OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include-loader.json \
  node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts \
  -t "keeps user-authored diagnostics-otel config install records untrusted during plugin load"
```

All commands above passed after the fix.

## Real behavior proof

Ran a source-checkout proof against this PR head (`8528831716f0ce7fcbbe8422edccf8f0585c6906`) using actual OpenClaw runtime metadata/loader APIs (not mocks):

- creates a real temp `@openclaw/diagnostics-otel` package directory with `openclaw.plugin.json`, `package.json`, and module entrypoint
- writes a persisted installed-plugin-index install record for that package
- calls `resolvePluginMetadataSnapshot(...)`
- calls `loadOpenClawPlugins(...)` with the precomputed manifest registry, matching the Gateway pre-service path
- verifies the diagnostics plugin is loaded and `trustedOfficialInstall === true` at both manifest and loader levels

Command:

```bash
node --import tsx /tmp/openclaw-real-proof.mjs
```

Output:

```json
{
  "proof": "diagnostics-otel-runtime-trust",
  "branchHead": "8528831716f0ce7fcbbe8422edccf8f0585c6906",
  "pluginRoot": "<temp-root>/usr-lib-node-modules/@openclaw/diagnostics-otel",
  "manifestOrigin": "config",
  "manifestTrustedOfficialInstall": true,
  "loaderStatus": "loaded",
  "loaderOrigin": "config",
  "loaderTrustedOfficialInstall": true,
  "installRecordSource": "npm",
  "installRecordSpec": "@openclaw/diagnostics-otel"
}
```

This is the behavior that was missing in FRE: diagnostics-otel loaded, but was not trusted and therefore did not receive `internalDiagnostics`.

## Real behavior proof (structured)

- **Behavior or issue addressed**: Gateway diagnostics-otel loaded from a config path must be treated as a trusted official diagnostics exporter when the runtime has persisted npm install metadata for `@openclaw/diagnostics-otel`; otherwise it loads but does not receive `internalDiagnostics`, matching the FRE failure mode.
- **Real environment tested**: Local OpenClaw source checkout at PR head `8528831716f0ce7fcbbe8422edccf8f0585c6906`, running the actual plugin metadata snapshot and plugin loader runtime APIs with a real temporary `@openclaw/diagnostics-otel` package directory and persisted installed-plugin-index record.
- **Exact steps or command run after this patch**: Ran `node --import tsx /tmp/openclaw-real-proof.mjs` from the OpenClaw checkout after this patch. The script creates a temp diagnostics-otel package, writes persisted install metadata, calls `resolvePluginMetadataSnapshot(...)`, then calls `loadOpenClawPlugins(...)` with the precomputed manifest registry.
- **Evidence after fix**: Terminal output from the source-checkout proof command:

  ```json
  {
    "proof": "diagnostics-otel-runtime-trust",
    "branchHead": "8528831716f0ce7fcbbe8422edccf8f0585c6906",
    "pluginRoot": "<temp-root>/usr-lib-node-modules/@openclaw/diagnostics-otel",
    "manifestOrigin": "config",
    "manifestTrustedOfficialInstall": true,
    "loaderStatus": "loaded",
    "loaderOrigin": "config",
    "loaderTrustedOfficialInstall": true,
    "installRecordSource": "npm",
    "installRecordSpec": "@openclaw/diagnostics-otel"
  }
  ```

- **Observed result after fix**: The actual runtime metadata path marks the config-path diagnostics-otel package trusted (`manifestTrustedOfficialInstall: true`), and the actual loader path loads it as trusted (`loaderStatus: loaded`, `loaderTrustedOfficialInstall: true`). This is the trust bit required for `startPluginServices(...)` to grant `internalDiagnostics` to diagnostics-otel.
- **What was not tested**: FRE Kusto end-to-end batch forwarding is not yet tested for this OpenClaw patch because it must merge, publish in an OpenClaw official build, deploy to FRE, and receive fresh OpenClaw Gateway traffic before Kusto can show `OpenClaw Gateway OTEL batch forwarded` rows.