### PR TITLE
test(cli): isolate daemon install env assertions

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -721,7 +721,11 @@ describe("runDaemonInstall", () => {
     } as never);
 
     const previous = process.env.OPENAI_API_KEY;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_CONFIG_PATH;
     try {
       await runDaemonInstall({ json: true, force: true });
 
@@ -736,6 +740,16 @@ describe("runDaemonInstall", () => {
       expect(env.PATH).not.toContain("/tmp/doctor-bin");
       expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
     } finally {
+      if (previousConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+      }
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
       if (previous === undefined) {
         delete process.env.OPENAI_API_KEY;
       } else {


### PR DESCRIPTION
## Summary
- isolate `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` in the forced reinstall stale-service-env regression test
- keep the assertion focused on not reusing stale service-control env from the installed service, while allowing CI/agent process envs to be present outside this test

## Repro
This failed locally in an environment where `OPENCLAW_STATE_DIR` was set by the test harness/process:

```text
npm exec --yes pnpm@11.2.2 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/daemon-cli/install.test.ts
```

Failure before the fix:

```text
runDaemonInstall > does not reuse stale service control env during forced reinstall
expected env.OPENCLAW_STATE_DIR to be undefined, received a temp .openclaw path
```

## Validation

```text
npm exec --yes pnpm@11.2.2 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/daemon-cli/install.test.ts
✓ 21 tests passed
```