### PR TITLE
fix(mattermost): keep message tool replies in threads

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -278,8 +278,19 @@ describe("mattermostPlugin", () => {
           threadId: "other-thread",
         }),
       ).toEqual({
-        replyToId: "post-parent",
-        threadId: "post-parent",
+        replyToId: "other-thread",
+        threadId: "other-thread",
+      });
+      expect(
+        resolveReplyTransport({
+          cfg: {},
+          replyToId: "child-post",
+          replyToIsExplicit: true,
+          threadId: "root-post",
+        }),
+      ).toEqual({
+        replyToId: "root-post",
+        threadId: "root-post",
       });
       expect(
         resolveReplyTransport({

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -284,6 +284,17 @@ describe("mattermostPlugin", () => {
       expect(
         resolveReplyTransport({
           cfg: {},
+          replyToId: "child-post",
+          replyToIsExplicit: false,
+          threadId: "root-post",
+        }),
+      ).toEqual({
+        replyToId: "root-post",
+        threadId: "root-post",
+      });
+      expect(
+        resolveReplyTransport({
+          cfg: {},
           threadId: 42,
         }),
       ).toEqual({

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -74,6 +74,14 @@ function requireMattermostReplyToModeResolver() {
   return resolveReplyToMode;
 }
 
+function requireMattermostThreadTargetMatcher() {
+  const matchesToolContextTarget = mattermostPlugin.threading?.matchesToolContextTarget;
+  if (!matchesToolContextTarget) {
+    throw new Error("mattermost threading.matchesToolContextTarget missing");
+  }
+  return matchesToolContextTarget;
+}
+
 function requireMattermostSendText() {
   const sendText = mattermostPlugin.outbound?.sendText;
   if (!sendText) {
@@ -235,6 +243,27 @@ describe("mattermostPlugin", () => {
         expect(context?.replyToMode).toBe(replyToMode);
       },
     );
+
+    it("matches bare Mattermost channel ids against the active channel target", () => {
+      const matchesToolContextTarget = requireMattermostThreadTargetMatcher();
+
+      expect(
+        matchesToolContextTarget({
+          target: "tqfek9psh7fw8mpa5berwyytqw",
+          toolContext: {
+            currentChannelId: "channel:tqfek9psh7fw8mpa5berwyytqw",
+          },
+        }),
+      ).toBe(true);
+      expect(
+        matchesToolContextTarget({
+          target: "tqfek9psh7fw8mpa5berwyytqw",
+          toolContext: {
+            currentChannelId: "channel:kqfek9psh7fw8mpa5berwyytqw",
+          },
+        }),
+      ).toBe(false);
+    });
 
     it("exposes the effective reply root as the transport thread", () => {
       const resolveReplyTransport = mattermostPlugin.threading?.resolveReplyTransport;
@@ -402,6 +431,17 @@ describe("mattermostPlugin", () => {
           },
         }),
       ).toBeUndefined();
+      expect(
+        resolveAutoThreadId({
+          cfg: {},
+          to: "tqfek9psh7fw8mpa5berwyytqw",
+          toolContext: {
+            currentChannelId: "channel:tqfek9psh7fw8mpa5berwyytqw",
+            currentThreadTs: "root-1",
+            replyToMode: "all",
+          },
+        }),
+      ).toBe("root-1");
       expect(
         resolveAutoThreadId({
           cfg: {},
@@ -714,7 +754,7 @@ describe("mattermostPlugin", () => {
       expect(options.replyToId).toBe("post-root");
     });
 
-    it("keeps explicit reply precedence when threadId is also provided", async () => {
+    it("uses threadId as the Mattermost root when generic replyTo names a child post", async () => {
       const cfg = createMattermostTestConfig();
 
       await mattermostPlugin.actions?.handleAction?.(
@@ -732,7 +772,29 @@ describe("mattermostPlugin", () => {
       );
 
       const options = expectSingleMattermostSend("channel:CHAN1", "hello");
-      expect(options.replyToId).toBe("child-post");
+      expect(options.replyToId).toBe("post-root");
+    });
+
+    it("keeps explicit replyToId precedence when threadId is also provided", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            replyToId: "explicit-root",
+            threadId: "post-root",
+            replyTo: "child-post",
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.replyToId).toBe("explicit-root");
     });
 
     it("routes filePath send actions through Mattermost media upload options", async () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -928,7 +928,9 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
             ? replyToIsExplicit
               ? (replyToId ?? ambientThreadId)
               : (ambientThreadId ?? replyToId ?? undefined)
-            : (replyToId ?? ambientThreadId);
+            : replyToIsExplicit === false
+              ? (ambientThreadId ?? replyToId)
+              : (replyToId ?? ambientThreadId);
       return {
         replyToId: replyDelivery?.chatType === "direct" ? null : resolvedThreadId,
         threadId: resolvedThreadId ?? null,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -928,9 +928,7 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
             ? replyToIsExplicit
               ? (replyToId ?? ambientThreadId)
               : (ambientThreadId ?? replyToId ?? undefined)
-            : replyToIsExplicit === false
-              ? (ambientThreadId ?? replyToId)
-              : (replyToId ?? ambientThreadId);
+            : (ambientThreadId ?? replyToId);
       return {
         replyToId: replyDelivery?.chatType === "direct" ? null : resolvedThreadId,
         threadId: resolvedThreadId ?? null,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -258,10 +258,8 @@ function resolveMattermostAutoThreadId(params: {
     typeof context?.currentMessageId === "number"
       ? String(context.currentMessageId)
       : normalizeOptionalString(context?.currentMessageId);
-  const currentTarget = context?.currentChannelId
-    ? normalizeMattermostMessagingTarget(context.currentChannelId)
-    : undefined;
-  if (currentThreadId && currentTarget === normalizeMattermostMessagingTarget(params.to)) {
+  const currentTarget = normalizeMattermostThreadTarget(context?.currentChannelId);
+  if (currentThreadId && currentTarget === normalizeMattermostThreadTarget(params.to)) {
     if (replyToId === currentMessageId) {
       return currentThreadId;
     }
@@ -274,6 +272,28 @@ function resolveMattermostAutoThreadId(params: {
     }
   }
   return replyToId;
+}
+
+function normalizeMattermostThreadTarget(raw: string | undefined): string | undefined {
+  const normalized = raw ? normalizeMattermostMessagingTarget(raw) : undefined;
+  if (normalized) {
+    return normalized;
+  }
+  const trimmed = normalizeOptionalString(raw);
+  return trimmed && /^[a-z0-9]{26}$/i.test(trimmed) ? `channel:${trimmed}` : undefined;
+}
+
+function matchesMattermostToolContextTarget(params: {
+  target: string;
+  toolContext: ChannelThreadingToolContext;
+}): boolean {
+  const target = normalizeMattermostThreadTarget(params.target);
+  if (!target) {
+    return false;
+  }
+  return [params.toolContext.currentChannelId, params.toolContext.currentMessagingTarget].some(
+    (currentTarget) => normalizeMattermostThreadTarget(currentTarget) === target,
+  );
 }
 
 function normalizeMattermostThreadId(value: string | number | undefined): string | undefined {
@@ -420,12 +440,13 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       : typeof params.message === "string"
         ? params.message
         : "";
-    // Match the shared runner semantics: trim empty reply IDs away before
-    // falling back from replyToId to replyTo on direct plugin calls.
+    // Mattermost post root_id is the thread root. A generic replyTo can name
+    // the current child post, so prefer threadId unless the caller supplied the
+    // Mattermost-specific replyToId root directly.
     const replyToId =
       normalizeOptionalString(params.replyToId) ??
-      normalizeOptionalString(params.replyTo) ??
-      normalizeOptionalString(params.threadId);
+      normalizeOptionalString(params.threadId) ??
+      normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
     const attachmentMedia = collectMattermostAttachmentMedia(params);
@@ -896,6 +917,8 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
     },
     resolveAutoThreadId: ({ to, replyToId, toolContext }) =>
       resolveMattermostAutoThreadId({ to, replyToId, toolContext }),
+    matchesToolContextTarget: ({ target, toolContext }) =>
+      matchesMattermostToolContextTarget({ target, toolContext }),
     resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit, replyDelivery }) => {
       const ambientThreadId = threadId != null ? String(threadId) : undefined;
       const resolvedThreadId =

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -924,11 +924,11 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
       const resolvedThreadId =
         replyDelivery?.chatType === "direct"
           ? undefined
-          : replyToIsExplicit
-            ? (replyToId ?? ambientThreadId)
-            : replyDelivery
-              ? (ambientThreadId ?? replyToId ?? undefined)
-              : (replyToId ?? ambientThreadId);
+          : replyDelivery
+            ? replyToIsExplicit
+              ? (replyToId ?? ambientThreadId)
+              : (ambientThreadId ?? replyToId ?? undefined)
+            : (replyToId ?? ambientThreadId);
       return {
         replyToId: replyDelivery?.chatType === "direct" ? null : resolvedThreadId,
         threadId: resolvedThreadId ?? null,

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -237,7 +237,7 @@ describe("runMessageAction core send routing", () => {
     expect(payload.dryRun).toBe(true);
   });
 
-  it("sends with the provider-canonical reply root", async () => {
+  it("preserves an explicit provider reply target with its canonical thread root", async () => {
     const sendText = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "m1",
@@ -312,7 +312,7 @@ describe("runMessageAction core send routing", () => {
     });
 
     expect(firstMockArg(sendText, "send text")).toMatchObject({
-      replyToId: "root-1",
+      replyToId: "child-1",
       threadId: "root-1",
     });
   });

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -191,7 +191,7 @@ describe("message action threading helpers", () => {
     expect(resolveAutoThreadId).not.toHaveBeenCalled();
   });
 
-  it("canonicalizes explicit threadId and replyTo for one-root providers", () => {
+  it("canonicalizes an explicit thread root through Slack-style reply transport", () => {
     const actionParams: Record<string, unknown> = {
       channel: "forum",
       target: "forum:123",
@@ -206,9 +206,9 @@ describe("message action threading helpers", () => {
       to: "forum:123",
       toolContext: defaultForumToolContext,
       resolveAutoThreadId,
-      resolveReplyTransport: ({ replyToId }) => ({
-        replyToId,
-        threadId: replyToId,
+      resolveReplyTransport: ({ threadId, replyToId }) => ({
+        replyToId: threadId ?? replyToId,
+        threadId: null,
       }),
     });
 

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -191,6 +191,33 @@ describe("message action threading helpers", () => {
     expect(resolveAutoThreadId).not.toHaveBeenCalled();
   });
 
+  it("canonicalizes explicit threadId and replyTo for one-root providers", () => {
+    const actionParams: Record<string, unknown> = {
+      channel: "forum",
+      target: "forum:123",
+      message: "hi",
+      threadId: "root-42",
+      replyTo: "child-777",
+    };
+
+    const resolveAutoThreadId = vi.fn(() => "unexpected");
+    const resolved = resolveAndApplyOutboundThreadId(actionParams, {
+      cfg: forumConfig,
+      to: "forum:123",
+      toolContext: defaultForumToolContext,
+      resolveAutoThreadId,
+      resolveReplyTransport: ({ replyToId }) => ({
+        replyToId,
+        threadId: replyToId,
+      }),
+    });
+
+    expect(actionParams.threadId).toBe("root-42");
+    expect(actionParams.replyTo).toBe("root-42");
+    expect(resolved).toBe("root-42");
+    expect(resolveAutoThreadId).not.toHaveBeenCalled();
+  });
+
   it.each([
     { name: "threadId null", params: { threadId: null } },
     { name: "topLevel true", params: { topLevel: true } },

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -119,7 +119,7 @@ describe("message action threading helpers", () => {
       agentId: "main",
       resolveAutoThreadId: () => "root-42",
       resolveReplyTransport: ({ threadId }) => ({
-        replyToId: threadId,
+        replyToId: threadId == null ? threadId : String(threadId),
         threadId: threadId ?? null,
       }),
       resolveOutboundSessionRoute,
@@ -234,7 +234,7 @@ describe("message action threading helpers", () => {
       toolContext: defaultForumToolContext,
       replyToIsExplicit: false,
       resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit }) => ({
-        replyToId: replyToIsExplicit ? replyToId : threadId,
+        replyToId: replyToIsExplicit || threadId == null ? replyToId : String(threadId),
         threadId: threadId ?? null,
       }),
     });
@@ -303,7 +303,7 @@ describe("message action threading helpers", () => {
       toolContext: defaultForumToolContext,
       resolveAutoThreadId: () => "root-42",
       resolveReplyTransport: ({ threadId }) => ({
-        replyToId: threadId,
+        replyToId: threadId == null ? threadId : String(threadId),
         threadId: threadId ?? null,
       }),
     });

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -118,9 +118,9 @@ describe("message action threading helpers", () => {
       toolContext: defaultForumToolContext,
       agentId: "main",
       resolveAutoThreadId: () => "root-42",
-      resolveReplyTransport: ({ replyToId }) => ({
-        replyToId,
-        threadId: replyToId,
+      resolveReplyTransport: ({ threadId }) => ({
+        replyToId: threadId,
+        threadId: threadId ?? null,
       }),
       resolveOutboundSessionRoute,
       ensureOutboundSessionEntry,
@@ -191,7 +191,7 @@ describe("message action threading helpers", () => {
     expect(resolveAutoThreadId).not.toHaveBeenCalled();
   });
 
-  it("canonicalizes an explicit thread root through Slack-style reply transport", () => {
+  it("preserves an explicit reply target through Slack-style reply transport", () => {
     const actionParams: Record<string, unknown> = {
       channel: "forum",
       target: "forum:123",
@@ -206,16 +206,41 @@ describe("message action threading helpers", () => {
       to: "forum:123",
       toolContext: defaultForumToolContext,
       resolveAutoThreadId,
-      resolveReplyTransport: ({ threadId, replyToId }) => ({
-        replyToId: threadId ?? replyToId,
+      replyToIsExplicit: true,
+      resolveReplyTransport: ({ replyToId }) => ({
+        replyToId,
         threadId: null,
       }),
     });
 
     expect(actionParams.threadId).toBe("root-42");
-    expect(actionParams.replyTo).toBe("root-42");
+    expect(actionParams.replyTo).toBe("child-777");
     expect(resolved).toBe("root-42");
     expect(resolveAutoThreadId).not.toHaveBeenCalled();
+  });
+
+  it("canonicalizes an inherited reply target through a one-root transport", () => {
+    const actionParams: Record<string, unknown> = {
+      channel: "forum",
+      target: "forum:123",
+      message: "hi",
+      threadId: "root-42",
+      replyTo: "child-777",
+    };
+
+    resolveAndApplyOutboundThreadId(actionParams, {
+      cfg: forumConfig,
+      to: "forum:123",
+      toolContext: defaultForumToolContext,
+      replyToIsExplicit: false,
+      resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit }) => ({
+        replyToId: replyToIsExplicit ? replyToId : threadId,
+        threadId: threadId ?? null,
+      }),
+    });
+
+    expect(actionParams.threadId).toBe("root-42");
+    expect(actionParams.replyTo).toBe("root-42");
   });
 
   it.each([
@@ -277,9 +302,9 @@ describe("message action threading helpers", () => {
       to: "forum:123",
       toolContext: defaultForumToolContext,
       resolveAutoThreadId: () => "root-42",
-      resolveReplyTransport: ({ replyToId }) => ({
-        replyToId,
-        threadId: replyToId,
+      resolveReplyTransport: ({ threadId }) => ({
+        replyToId: threadId,
+        threadId: threadId ?? null,
       }),
     });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1049,6 +1049,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     agentId,
   });
 
+  const replyToIsExplicit = Boolean(readStringParam(params, "replyTo"));
   resolveAndApplyOutboundReplyToId(params, {
     channel,
     toolContext: input.toolContext,
@@ -1067,6 +1068,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     resolvedTarget,
     resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
     resolveReplyTransport: getChannelPlugin(channel)?.threading?.resolveReplyTransport,
+    replyToIsExplicit,
     resolveOutboundSessionRoute,
     ensureOutboundSessionEntry,
   });

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -61,7 +61,7 @@ export function resolveAndApplyOutboundThreadId(
     })?.replyToId;
     // Providers that use one canonical root for reply and thread routing opt in
     // through resolveReplyTransport. Other transports keep message replies intact.
-    if (replyToId && canonicalReplyToId && replyToId !== canonicalReplyToId) {
+    if (canonicalReplyToId && replyToId !== canonicalReplyToId) {
       actionParams.replyTo = canonicalReplyToId;
     }
   }

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -51,11 +51,13 @@ export function resolveAndApplyOutboundThreadId(
   const resolvedThreadId = threadId ?? autoResolvedThreadId;
   if (autoResolvedThreadId && !actionParams.threadId) {
     actionParams.threadId = autoResolvedThreadId;
+  }
+  if (replyToId && resolvedThreadId) {
     const canonicalReplyToId = context.resolveReplyTransport?.({
       cfg: context.cfg,
       accountId: context.accountId,
-      threadId: autoResolvedThreadId,
-      replyToId: autoResolvedThreadId,
+      threadId: resolvedThreadId,
+      replyToId: resolvedThreadId,
     })?.replyToId;
     // Providers that use one canonical root for reply and thread routing opt in
     // through resolveReplyTransport. Other transports keep message replies intact.

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -31,6 +31,7 @@ export function resolveAndApplyOutboundThreadId(
     toolContext?: ChannelThreadingToolContext;
     resolveAutoThreadId?: ResolveAutoThreadId;
     resolveReplyTransport?: ResolveReplyTransport;
+    replyToIsExplicit?: boolean;
   },
 ): string | undefined {
   const threadId = readStringParam(actionParams, "threadId");
@@ -57,7 +58,8 @@ export function resolveAndApplyOutboundThreadId(
       cfg: context.cfg,
       accountId: context.accountId,
       threadId: resolvedThreadId,
-      replyToId: resolvedThreadId,
+      replyToId,
+      replyToIsExplicit: context.replyToIsExplicit,
     })?.replyToId;
     // Providers that use one canonical root for reply and thread routing opt in
     // through resolveReplyTransport. Other transports keep message replies intact.
@@ -174,6 +176,7 @@ export async function prepareOutboundMirrorRoute(params: {
   resolvedTarget?: ResolvedMessagingTarget;
   resolveAutoThreadId?: ResolveAutoThreadId;
   resolveReplyTransport?: ResolveReplyTransport;
+  replyToIsExplicit?: boolean;
   resolveOutboundSessionRoute: (
     params: ResolveOutboundSessionRouteParams,
   ) => Promise<OutboundSessionRoute | null>;
@@ -194,6 +197,7 @@ export async function prepareOutboundMirrorRoute(params: {
     toolContext: params.toolContext,
     resolveAutoThreadId: params.resolveAutoThreadId,
     resolveReplyTransport: params.resolveReplyTransport,
+    replyToIsExplicit: params.replyToIsExplicit,
   });
   const replyToId = readStringParam(params.actionParams, "replyTo");
   const outboundRoute =


### PR DESCRIPTION
## Summary

- Keep Mattermost message-tool sends in the thread root when generic `replyTo` names a child post and `threadId` carries the root.
- Normalize bare 26-character Mattermost channel IDs for auto-threading and same-target matching, including `replyToMode: "first"` consumption.
- Canonicalize message-action reply/thread metadata for one-root transports before outbound session mirroring.

## Verification

- `node scripts/run-vitest.mjs extensions/mattermost/src/channel.test.ts extensions/mattermost/src/session-route.test.ts`
- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.threading.test.ts`
- `git diff --check -- extensions/mattermost/src/channel.ts extensions/mattermost/src/channel.test.ts extensions/mattermost/src/session-route.ts extensions/mattermost/src/session-route.test.ts src/infra/outbound/message-action-threading.ts src/infra/outbound/message-action-runner.threading.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Testbox-through-Crabbox: `tbx_01kv6n3vr04nnkjc1rs255kdhj`, Actions run https://github.com/openclaw/openclaw/actions/runs/27579510410, ran `node scripts/run-vitest.mjs extensions/mattermost/src/channel.test.ts extensions/mattermost/src/session-route.test.ts src/infra/outbound/message-action-runner.threading.test.ts` with 75 tests passing.
- Tested end to end against local Mattermost
<img width="374" height="330" alt="image" src="https://github.com/user-attachments/assets/56a0be5a-9da5-4322-ba9b-6392c1252010" />

