### PR TITLE
fix(tui): show activity indicator for system-injected runs

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -220,6 +220,56 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).toHaveBeenCalledTimes(1);
   });
 
+  it("shows running for a system-injected run that never went through submit", () => {
+    const { state, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleAgentEvent({
+      runId: "run-bridge",
+      stream: "lifecycle",
+      sessionKey: state.currentSessionKey,
+      data: { phase: "start" },
+    });
+
+    expect(setActivityStatus).toHaveBeenCalledWith("running");
+    expect(state.activeChatRunId).toBe("run-bridge");
+    expect(tui.requestRender).toHaveBeenCalled();
+  });
+
+  it("does not adopt a system-injected lifecycle start from another session", () => {
+    const { state, tui, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleAgentEvent({
+      runId: "run-other",
+      stream: "lifecycle",
+      sessionKey: "agent:other:other",
+      data: { phase: "start" },
+    });
+
+    expect(setActivityStatus).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBeNull();
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
+  it("does not let a system-injected run steal a concurrent active run", () => {
+    const { state, setActivityStatus, handleAgentEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-user" },
+    });
+
+    handleAgentEvent({
+      runId: "run-bridge",
+      stream: "lifecycle",
+      sessionKey: state.currentSessionKey,
+      data: { phase: "start" },
+    });
+
+    expect(state.activeChatRunId).toBe("run-user");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("running");
+  });
+
   it("renders terminal lifecycle errors after retry grace and clears the active run", () => {
     vi.useFakeTimers();
     const { state, chatLog, tui, setActivityStatus, loadHistory, handleAgentEvent } =

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -265,9 +265,45 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       sessionKey: state.currentSessionKey,
       data: { phase: "start" },
     });
+    handleAgentEvent({
+      runId: "run-bridge",
+      stream: "lifecycle",
+      sessionKey: state.currentSessionKey,
+      data: { phase: "finishing" },
+    });
+    handleAgentEvent({
+      runId: "run-bridge",
+      stream: "lifecycle",
+      sessionKey: state.currentSessionKey,
+      data: { phase: "end" },
+    });
 
     expect(state.activeChatRunId).toBe("run-user");
     expect(setActivityStatus).not.toHaveBeenCalledWith("running");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("finishing context");
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+  });
+
+  it("promotes a remaining system-injected run when the active run finishes", () => {
+    const { state, setActivityStatus, handleAgentEvent, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: "run-user" },
+    });
+
+    handleAgentEvent({
+      runId: "run-bridge",
+      stream: "lifecycle",
+      sessionKey: state.currentSessionKey,
+      data: { phase: "start" },
+    });
+    handleChatEvent({
+      runId: "run-user",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "done" }], stopReason: "stop" },
+    });
+
+    expect(state.activeChatRunId).toBe("run-bridge");
+    expect(setActivityStatus).toHaveBeenLastCalledWith("running");
   });
 
   it("renders terminal lifecycle errors after retry grace and clears the active run", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -301,6 +301,30 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
   };
 
+  const promoteMostRecentSessionRun = (): boolean => {
+    if (state.activeChatRunId || sessionRuns.size === 0) {
+      return false;
+    }
+    let nextRunId: string | undefined;
+    let nextSeenAt = -1;
+    for (const [runId, seenAt] of sessionRuns) {
+      if (seenAt > nextSeenAt) {
+        nextRunId = runId;
+        nextSeenAt = seenAt;
+      }
+    }
+    if (!nextRunId) {
+      return false;
+    }
+    // A concurrent run can outlive the active run. Keep the activity owner on
+    // remaining work so terminal cleanup cannot incorrectly return the TUI idle.
+    state.activeChatRunId = nextRunId;
+    clearStreamingWatchdog();
+    setActivityStatus("running");
+    armStreamingWatchdog(nextRunId);
+    return true;
+  };
+
   const clearStaleStreamingIfNoTrackedRunRemains = () => {
     const activeRunId = state.activeChatRunId;
     // A missing active run is the recovery case; only tracked active runs block cleanup.
@@ -344,15 +368,18 @@ export function createEventHandlers(context: EventHandlerContext) {
   }) => {
     noteFinalizedRun(params.runId, { displayedFinal: params.displayedFinal });
     clearActiveRunIfMatch(params.runId);
+    const promotedRemainingRun = promoteMostRecentSessionRun();
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
-      setActivityStatus(params.status);
-      clearStreamingWatchdog();
-    } else {
-      if (streamingWatchdogRunId === params.runId) {
+    if (!promotedRemainingRun) {
+      if (params.wasActiveRun) {
+        setActivityStatus(params.status);
         clearStreamingWatchdog();
+      } else {
+        if (streamingWatchdogRunId === params.runId) {
+          clearStreamingWatchdog();
+        }
+        clearStaleStreamingIfNoTrackedRunRemains();
       }
-      clearStaleStreamingIfNoTrackedRunRemains();
     }
     void refreshSessionInfo?.();
   };
@@ -367,12 +394,15 @@ export function createEventHandlers(context: EventHandlerContext) {
     streamAssembler.drop(params.runId);
     sessionRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
+    const promotedRemainingRun = promoteMostRecentSessionRun();
     flushPendingHistoryRefreshIfIdle();
-    if (params.wasActiveRun) {
-      setActivityStatus(params.status);
-      clearStreamingWatchdog();
-    } else if (streamingWatchdogRunId === params.runId) {
-      clearStreamingWatchdog();
+    if (!promotedRemainingRun) {
+      if (params.wasActiveRun) {
+        setActivityStatus(params.status);
+        clearStreamingWatchdog();
+      } else if (streamingWatchdogRunId === params.runId) {
+        clearStreamingWatchdog();
+      }
     }
     void refreshSessionInfo?.();
   };
@@ -419,10 +449,7 @@ export function createEventHandlers(context: EventHandlerContext) {
 
   const hasConcurrentActiveRun = (runId: string) => {
     const activeRunId = state.activeChatRunId;
-    if (!activeRunId || activeRunId === runId) {
-      return false;
-    }
-    return sessionRuns.has(activeRunId);
+    return Boolean(activeRunId && activeRunId !== runId);
   };
 
   const maybeRefreshHistoryForRun = (

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -699,6 +699,33 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as AgentEvent;
     syncSessionKey();
+    // System-injected runs (bridge-notify, webhook, cron) never go through the
+    // TUI submit path, so no active/pending run id exists when their lifecycle
+    // "start" arrives — leaving the status bar idle until the response lands.
+    // Adopt such a run for the current session (lifecycle events always carry
+    // sessionKey) so the activity indicator shows work is happening, mirroring
+    // how chat deltas adopt runs in handleChatEvent. Only claim the active slot
+    // when none is held, so a concurrent user run keeps the indicator.
+    const isUntrackedRun =
+      evt.runId !== state.activeChatRunId &&
+      evt.runId !== state.pendingChatRunId &&
+      !sessionRuns.has(evt.runId) &&
+      !finalizedRuns.has(evt.runId);
+    if (
+      isUntrackedRun &&
+      evt.stream === "lifecycle" &&
+      asString(evt.data?.phase, "") === "start" &&
+      !(isLocalBtwRunId?.(evt.runId) ?? false) &&
+      isSameSessionKey(evt.sessionKey, state.currentSessionKey) &&
+      isMatchingGlobalAgentEvent(evt.sessionKey, evt.agentId)
+    ) {
+      noteSessionRun(evt.runId);
+      // Mirror handleChatEvent: side-question (btw) runs never claim the active
+      // slot, so a concurrent btw run cannot hijack the main activity indicator.
+      if (!state.activeChatRunId) {
+        state.activeChatRunId = evt.runId;
+      }
+    }
     // Agent events (tool streaming, lifecycle) are emitted per-run. Filter against the
     // active chat run id, not the session id. Tool results can arrive after the chat
     // final event, so accept finalized runs for tool updates.

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -51,6 +51,11 @@ export type AgentEvent = {
   runId: string;
   stream: string;
   data?: Record<string, unknown>;
+  // Stamped by the gateway on every emitted payload (see infra/agent-events.ts).
+  // Lifecycle events always carry sessionKey, letting the TUI adopt
+  // system-injected runs that never went through the local submit path.
+  sessionKey?: string;
+  agentId?: string;
 };
 
 export type ResponseUsageMode = "on" | "off" | "tokens" | "full";


### PR DESCRIPTION
## Summary

- Fixes the TUI showing no activity indicator (no spinner, elapsed, or "running") while the agent works on a **system-injected** event — bridge-notify, webhook, or cron — even though user-typed messages already show one (fixed earlier in #21549).
- `handleAgentEvent` dropped lifecycle events for any run that was not already active/pending/tracked. System-injected runs never pass through the TUI submit path, so when their lifecycle `start` arrives there is no run id to match and the status bar stays idle until the response lands.
- The fix adopts an untracked lifecycle `start` for the **current session** (lifecycle events always carry `sessionKey`), so the existing `start` → `running` path fires. Local side-question (btw) runs and other sessions are left untouched, and a concurrent user run keeps the active slot.

## Linked context

Closes #51825

Prior art: #21549 fixed the same indicator for user-typed TUI messages; this is the system-injected sibling. The `sessionKey` stamp the fix relies on is produced in `src/infra/agent-events.ts:456` (`preserveSessionKey` is always true for the `lifecycle` stream).

## Real behavior proof

- Behavior or issue addressed: TUI activity indicator stays idle for bridge/webhook/cron-triggered work.
- Real environment tested: local source checkout; the production `createEventHandlers()` event loop driven with the exact gateway event shapes (`src/tui/tui-event-handlers.test.ts`), plus the fake-backend PTY harness running the real `runTui()` loop.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs run src/tui/tui-event-handlers.test.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts`
- Evidence after fix: a `lifecycle`/`start` agent event for an untracked run whose `sessionKey` matches the current session now calls `setActivityStatus("running")` and adopts the run as active. Before the patch the same event produced **0** calls to `setActivityStatus` (verified by reverting the production change and re-running the new test — it fails with `Number of calls: 0`).
- Observed result after fix: 75/75 event-handler tests pass; 13/13 PTY fake-backend tests pass.
- What was not tested: I did not stand up a live gateway with a real bridge/webhook/cron injector against a live TUI. The session-match guard fails closed (no adoption) when `sessionKey` is absent, so there is no behavior change on paths that do not stamp it.
- Proof limitations or environment constraints: no live multi-agent bridge setup available in my checkout; the unit + PTY proof exercises the real handler logic and the real `runTui()` loop with a fake backend.

## Tests and validation

- `git diff --check`
- `node scripts/run-oxlint.mjs src/tui/tui-event-handlers.ts src/tui/tui-types.ts src/tui/tui-event-handlers.test.ts`
- `pnpm format:check <changed files>`
- `pnpm tsgo`
- `node scripts/run-vitest.mjs run src/tui/tui-event-handlers.test.ts` (75 passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` (13 passed)

## Risk checklist

Did user-visible behavior change? `Yes` — the TUI now shows the activity indicator for system-injected runs in the viewed session.

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: wrongly claiming the active-run slot for a run from another session or a side-question (btw) run.

How is that risk mitigated? Adoption is gated on `isSameSessionKey` + `isMatchingGlobalAgentEvent` (the same filters `handleChatEvent` uses) and excludes local btw runs; the active slot is only claimed when none is held, so a concurrent user run is preserved. Control UI is a separate surface and is out of scope.

Current review state: maintainer review and CI.

AI-assisted (Claude Code). Proof above was run manually.
