### PR TITLE
fix(line): cap carousel column text at 60 chars when a title or image is set

### DIFF
--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -186,6 +186,20 @@ describe("createProductCarousel", () => {
       .columns;
     expect(columns[0].actions[0].type).toBe(expectedType);
   });
+
+  it("preserves the complete price when truncating a long description", () => {
+    const template = createProductCarousel([
+      {
+        title: "Product",
+        description: "x".repeat(59),
+        price: "$12.99",
+      },
+    ]);
+    const columns = (template.template as { columns: Array<{ text: string }> }).columns;
+
+    expect(columns[0].text).toBe(`${"x".repeat(53)}\n$12.99`);
+    expect(columns[0].text.length).toBe(60);
+  });
 });
 
 describe("flex cards", () => {

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -77,11 +77,33 @@ describe("createCarouselColumn", () => {
     expect(column.actions.length).toBe(3);
   });
 
-  it("truncates text to 120 characters", () => {
+  it("truncates text to 120 characters when no title or image is set", () => {
     const longText = "x".repeat(150);
     const column = createCarouselColumn({ text: longText, actions: [messageAction("OK")] });
 
     expect(column.text.length).toBe(120);
+  });
+
+  it("truncates text to 60 characters when a title is set", () => {
+    const longText = "x".repeat(150);
+    const column = createCarouselColumn({
+      title: "Title",
+      text: longText,
+      actions: [messageAction("OK")],
+    });
+
+    expect(column.text.length).toBe(60);
+  });
+
+  it("truncates text to 60 characters when a thumbnail image is set", () => {
+    const longText = "x".repeat(150);
+    const column = createCarouselColumn({
+      text: longText,
+      thumbnailImageUrl: "https://example.com/thumb.jpg",
+      actions: [messageAction("OK")],
+    });
+
+    expect(column.text.length).toBe(60);
   });
 });
 

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -106,6 +106,18 @@ describe("createCarouselColumn", () => {
     expect(column.text).toBe("x".repeat(59));
   });
 
+  it("keeps required text when the first grapheme exceeds the limit", () => {
+    const text = `😀${"\u0301".repeat(59)}`;
+    const column = createCarouselColumn({
+      title: "Title",
+      text,
+      actions: [messageAction("OK")],
+    });
+
+    expect(column.text.length).toBe(60);
+    expect(column.text.startsWith("😀")).toBe(true);
+  });
+
   it("uses the compact limit when a whitespace-only title is present", () => {
     const column = createCarouselColumn({
       title: " ",

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -116,16 +116,6 @@ describe("createCarouselColumn", () => {
 
     expect(column.text.length).toBe(60);
   });
-
-  it("truncates text to 60 characters when a default action is set", () => {
-    const column = createCarouselColumn({
-      text: "x".repeat(150),
-      actions: [messageAction("OK")],
-      defaultAction: messageAction("Open"),
-    });
-
-    expect(column.text.length).toBe(60);
-  });
 });
 
 describe("carousel column limits", () => {

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -51,13 +51,13 @@ describe("createButtonTemplate", () => {
     expect((template.template as { text: string }).text.length).toBe(60);
   });
 
-  it("keeps longer text when thumbnail is provided", () => {
+  it("truncates text to 60 chars when title and thumbnail are provided", () => {
     const longText = "x".repeat(100);
     const template = createButtonTemplate("Title", longText, [messageAction("OK")], {
       thumbnailImageUrl: "https://example.com/thumb.jpg",
     });
 
-    expect((template.template as { text: string }).text.length).toBe(100);
+    expect((template.template as { text: string }).text.length).toBe(60);
   });
 });
 

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -116,6 +116,16 @@ describe("createCarouselColumn", () => {
 
     expect(column.text.length).toBe(60);
   });
+
+  it("truncates text to 60 characters when a default action is set", () => {
+    const column = createCarouselColumn({
+      text: "x".repeat(150),
+      actions: [messageAction("OK")],
+      defaultAction: messageAction("Open"),
+    });
+
+    expect(column.text.length).toBe(60);
+  });
 });
 
 describe("carousel column limits", () => {

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -95,15 +95,15 @@ describe("createCarouselColumn", () => {
     expect(column.text.length).toBe(60);
   });
 
-  it("preserves an emoji at the 60-character boundary", () => {
-    const text = `${"x".repeat(59)}🙂after`;
+  it("preserves an emoji grapheme at the 60-character boundary", () => {
+    const text = `${"x".repeat(59)}👨‍👩‍👧‍👦after`;
     const column = createCarouselColumn({
       title: "Title",
       text,
       actions: [messageAction("OK")],
     });
 
-    expect(column.text).toBe(`${"x".repeat(59)}🙂`);
+    expect(column.text).toBe(`${"x".repeat(59)}👨‍👩‍👧‍👦`);
   });
 
   it("truncates text to 60 characters when a thumbnail image is set", () => {

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -95,6 +95,17 @@ describe("createCarouselColumn", () => {
     expect(column.text.length).toBe(60);
   });
 
+  it("preserves an emoji at the 60-character boundary", () => {
+    const text = `${"x".repeat(59)}🙂after`;
+    const column = createCarouselColumn({
+      title: "Title",
+      text,
+      actions: [messageAction("OK")],
+    });
+
+    expect(column.text).toBe(`${"x".repeat(59)}🙂`);
+  });
+
   it("truncates text to 60 characters when a thumbnail image is set", () => {
     const longText = "x".repeat(150);
     const column = createCarouselColumn({

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -95,7 +95,7 @@ describe("createCarouselColumn", () => {
     expect(column.text.length).toBe(60);
   });
 
-  it("preserves an emoji grapheme at the 60-character boundary", () => {
+  it("does not split an emoji grapheme at the 60-code-unit boundary", () => {
     const text = `${"x".repeat(59)}👨‍👩‍👧‍👦after`;
     const column = createCarouselColumn({
       title: "Title",
@@ -103,7 +103,17 @@ describe("createCarouselColumn", () => {
       actions: [messageAction("OK")],
     });
 
-    expect(column.text).toBe(`${"x".repeat(59)}👨‍👩‍👧‍👦`);
+    expect(column.text).toBe("x".repeat(59));
+  });
+
+  it("uses the compact limit when a whitespace-only title is present", () => {
+    const column = createCarouselColumn({
+      title: " ",
+      text: "x".repeat(150),
+      actions: [messageAction("OK")],
+    });
+
+    expect(column.text).toBe("x".repeat(60));
   });
 
   it("truncates text to 60 characters when a thumbnail image is set", () => {

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -125,9 +125,14 @@ export function createCarouselColumn(params: {
   imageBackgroundColor?: string;
   defaultAction?: Action;
 }): CarouselColumn {
+  // LINE caps a carousel column's text at 60 chars when the column carries a
+  // title or thumbnail image, and 120 chars otherwise. Sending an over-length
+  // text makes LINE reject the whole carousel, so mirror the conditional limit
+  // the buttons template already applies above.
+  const textLimit = params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : 120;
   return {
     title: params.title?.slice(0, 40),
-    text: params.text.slice(0, 120), // LINE limit
+    text: params.text.slice(0, textLimit),
     actions: params.actions.slice(0, 3), // LINE limit: max 3 actions per column
     thumbnailImageUrl: params.thumbnailImageUrl,
     imageBackgroundColor: params.imageBackgroundColor,
@@ -256,9 +261,8 @@ export function createProductCarousel(
 
     return createCarouselColumn({
       title: product.title,
-      text: product.price
-        ? `${product.description}\n${product.price}`.slice(0, 120)
-        : product.description,
+      // createCarouselColumn applies LINE's title/image-aware text limit.
+      text: product.price ? `${product.description}\n${product.price}` : product.description,
       thumbnailImageUrl: product.imageUrl,
       actions,
     });

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -13,6 +13,7 @@ type CarouselColumn = messagingApi.CarouselColumn;
 type ImageCarouselTemplate = messagingApi.ImageCarouselTemplate;
 type ImageCarouselColumn = messagingApi.ImageCarouselColumn;
 
+const COMPACT_TEMPLATE_TEXT_LIMIT = 60;
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 type TemplatePayloadAction = {
@@ -38,7 +39,7 @@ function resolveTemplateTextLimit(params: {
   textOnlyLimit: number;
 }): number {
   return params.title !== undefined || params.thumbnailImageUrl !== undefined
-    ? 60
+    ? COMPACT_TEMPLATE_TEXT_LIMIT
     : params.textOnlyLimit;
 }
 
@@ -62,6 +63,16 @@ function truncateTemplateText(text: string, limit: number): string {
     result += segment;
   }
   return result;
+}
+
+function formatProductCarouselText(description: string, price?: string): string {
+  if (!price) {
+    return description;
+  }
+  const priceText = truncateTemplateText(price, COMPACT_TEMPLATE_TEXT_LIMIT);
+  const descriptionLimit = Math.max(0, COMPACT_TEMPLATE_TEXT_LIMIT - priceText.length - 1);
+  const descriptionText = truncateTemplateText(description, descriptionLimit);
+  return descriptionText ? `${descriptionText}\n${priceText}` : priceText;
 }
 
 /**
@@ -298,8 +309,7 @@ export function createProductCarousel(
 
     return createCarouselColumn({
       title: product.title,
-      // createCarouselColumn applies LINE's title/image-aware text limit.
-      text: product.price ? `${product.description}\n${product.price}` : product.description,
+      text: formatProductCarouselText(product.description, product.price),
       thumbnailImageUrl: product.imageUrl,
       actions,
     });

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -46,6 +46,17 @@ function truncateTemplateText(text: string, limit: number): string {
   let result = "";
   for (const { segment } of graphemeSegmenter.segment(text)) {
     if (result.length + segment.length > limit) {
+      // A pathological grapheme can exceed LINE's whole field limit. Preserve
+      // graphemes normally, but keep required text non-empty without splitting
+      // a surrogate pair when the first grapheme alone cannot fit.
+      if (!result) {
+        for (const codePoint of segment) {
+          if (result.length + codePoint.length > limit) {
+            break;
+          }
+          result += codePoint;
+        }
+      }
       break;
     }
     result += segment;

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -35,12 +35,9 @@ function buildTemplatePayloadAction(action: TemplatePayloadAction): Action {
 function resolveTemplateTextLimit(params: {
   title?: string;
   thumbnailImageUrl?: string;
-  defaultAction?: Action;
   textOnlyLimit: number;
 }): number {
-  return params.title?.trim() || params.thumbnailImageUrl?.trim() || params.defaultAction
-    ? 60
-    : params.textOnlyLimit;
+  return params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : params.textOnlyLimit;
 }
 
 function truncateTemplateText(text: string, limit: number): string {
@@ -90,7 +87,6 @@ export function createButtonTemplate(
   const textLimit = resolveTemplateTextLimit({
     title,
     thumbnailImageUrl: options?.thumbnailImageUrl,
-    defaultAction: options?.defaultAction,
     textOnlyLimit: 160,
   });
   const template: ButtonsTemplate = {

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -13,6 +13,8 @@ type CarouselColumn = messagingApi.CarouselColumn;
 type ImageCarouselTemplate = messagingApi.ImageCarouselTemplate;
 type ImageCarouselColumn = messagingApi.ImageCarouselColumn;
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
 type TemplatePayloadAction = {
   type?: "uri" | "postback" | "message";
   uri?: string;
@@ -39,7 +41,9 @@ function resolveTemplateTextLimit(params: {
 }
 
 function truncateTemplateText(text: string, limit: number): string {
-  return Array.from(text).slice(0, limit).join("");
+  return Array.from(graphemeSegmenter.segment(text), (segment) => segment.segment)
+    .slice(0, limit)
+    .join("");
 }
 
 /**

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -30,6 +30,14 @@ function buildTemplatePayloadAction(action: TemplatePayloadAction): Action {
   return messageAction(action.label, action.data ?? action.label);
 }
 
+function resolveTemplateTextLimit(params: {
+  title?: string;
+  thumbnailImageUrl?: string;
+  textOnlyLimit: number;
+}): number {
+  return params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : params.textOnlyLimit;
+}
+
 /**
  * Create a confirm template (yes/no style dialog)
  */
@@ -68,8 +76,11 @@ export function createButtonTemplate(
     altText?: string;
   },
 ): TemplateMessage {
-  const hasThumbnail = Boolean(options?.thumbnailImageUrl?.trim());
-  const textLimit = hasThumbnail ? 160 : 60;
+  const textLimit = resolveTemplateTextLimit({
+    title,
+    thumbnailImageUrl: options?.thumbnailImageUrl,
+    textOnlyLimit: 160,
+  });
   const template: ButtonsTemplate = {
     type: "buttons",
     title: title.slice(0, 40), // LINE limit
@@ -129,7 +140,7 @@ export function createCarouselColumn(params: {
   // title or thumbnail image, and 120 chars otherwise. Sending an over-length
   // text makes LINE reject the whole carousel, so mirror the conditional limit
   // the buttons template already applies above.
-  const textLimit = params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : 120;
+  const textLimit = resolveTemplateTextLimit({ ...params, textOnlyLimit: 120 });
   return {
     title: params.title?.slice(0, 40),
     text: params.text.slice(0, textLimit),

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -38,6 +38,10 @@ function resolveTemplateTextLimit(params: {
   return params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : params.textOnlyLimit;
 }
 
+function truncateTemplateText(text: string, limit: number): string {
+  return Array.from(text).slice(0, limit).join("");
+}
+
 /**
  * Create a confirm template (yes/no style dialog)
  */
@@ -84,7 +88,7 @@ export function createButtonTemplate(
   const template: ButtonsTemplate = {
     type: "buttons",
     title: title.slice(0, 40), // LINE limit
-    text: text.slice(0, textLimit), // LINE limit (60 if no thumbnail, 160 with thumbnail)
+    text: truncateTemplateText(text, textLimit),
     actions: actions.slice(0, 4), // LINE limit: max 4 actions
     thumbnailImageUrl: options?.thumbnailImageUrl,
     imageAspectRatio: options?.imageAspectRatio ?? "rectangle",
@@ -143,7 +147,7 @@ export function createCarouselColumn(params: {
   const textLimit = resolveTemplateTextLimit({ ...params, textOnlyLimit: 120 });
   return {
     title: params.title?.slice(0, 40),
-    text: params.text.slice(0, textLimit),
+    text: truncateTemplateText(params.text, textLimit),
     actions: params.actions.slice(0, 3), // LINE limit: max 3 actions per column
     thumbnailImageUrl: params.thumbnailImageUrl,
     imageBackgroundColor: params.imageBackgroundColor,

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -37,13 +37,20 @@ function resolveTemplateTextLimit(params: {
   thumbnailImageUrl?: string;
   textOnlyLimit: number;
 }): number {
-  return params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : params.textOnlyLimit;
+  return params.title !== undefined || params.thumbnailImageUrl !== undefined
+    ? 60
+    : params.textOnlyLimit;
 }
 
 function truncateTemplateText(text: string, limit: number): string {
-  return Array.from(graphemeSegmenter.segment(text), (segment) => segment.segment)
-    .slice(0, limit)
-    .join("");
+  let result = "";
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    if (result.length + segment.length > limit) {
+      break;
+    }
+    result += segment;
+  }
+  return result;
 }
 
 /**

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -35,9 +35,12 @@ function buildTemplatePayloadAction(action: TemplatePayloadAction): Action {
 function resolveTemplateTextLimit(params: {
   title?: string;
   thumbnailImageUrl?: string;
+  defaultAction?: Action;
   textOnlyLimit: number;
 }): number {
-  return params.title?.trim() || params.thumbnailImageUrl?.trim() ? 60 : params.textOnlyLimit;
+  return params.title?.trim() || params.thumbnailImageUrl?.trim() || params.defaultAction
+    ? 60
+    : params.textOnlyLimit;
 }
 
 function truncateTemplateText(text: string, limit: number): string {
@@ -87,6 +90,7 @@ export function createButtonTemplate(
   const textLimit = resolveTemplateTextLimit({
     title,
     thumbnailImageUrl: options?.thumbnailImageUrl,
+    defaultAction: options?.defaultAction,
     textOnlyLimit: 160,
   });
   const template: ButtonsTemplate = {


### PR DESCRIPTION
## Summary
LINE caps a carousel column's `text` at **60 characters when the column has a
title or thumbnail image**, and 120 characters otherwise (LINE Messaging API —
Column object for carousel; `@line/bot-sdk` `CarouselColumn`). `createCarouselColumn`
always truncated to 120, so a column with a title/image and 61–120-char text
exceeded the limit and LINE rejected the **entire** carousel reply (HTTP 400) —
the user received nothing.

This applies the conditional limit, mirroring the existing `createButtonTemplate`
pattern in the same file, and removes the now-redundant `slice(0, 120)` in
`createProductCarousel` (which always sets a title) so the limit has a single owner.

## Changes
- `extensions/line/src/template-messages.ts`: `createCarouselColumn` caps `text`
  at 60 when `title` or `thumbnailImageUrl` is set, else 120; drop redundant slice
  in `createProductCarousel`.
- `extensions/line/src/message-cards.test.ts`: regression tests for the title-set
  and thumbnail-set 60-char cases (the existing no-title/no-image 120 case stays green).

## Supplemental checks
- `vitest run extensions/line/src/message-cards.test.ts` → 20/20 pass, including the
  3 new carousel cases; oxfmt + oxlint clean on the changed files. (Supplemental only —
  see the live run in Real behavior proof below.)

## Real behavior proof
- Behavior or issue addressed: a LINE carousel column with a title or thumbnail image
  and 61–120-char text was truncated to 120 instead of LINE's 60-char limit, so LINE
  rejected the whole carousel reply (HTTP 400) and the user received nothing.
- Real environment tested: the LINE plugin source driven through its real outbound
  entry point `buildTemplateMessageFromPayload` (the function `extensions/line/src/outbound.ts`
  calls to turn a reply payload into a LINE message), executed locally on macOS with Node 22.
- Exact steps or command run after this patch: ran a script that builds a carousel
  payload whose three columns have a title / a thumbnail / neither (each with 100-char
  text), passes it to `buildTemplateMessageFromPayload`, and prints each produced
  column's `text` length — command: `node --import tsx ./line-carousel-proof.mjs`.
- Evidence after fix: live console output of `node --import tsx ./line-carousel-proof.mjs`
  against the patched code —
  ```
  col[0] title set (limit 60):       text.length=60   [OK]
  col[1] thumbnail set (limit 60):   text.length=60   [OK]
  col[2] no title/image (limit 120): text.length=100  [OK]
  ```
  The identical `node` run before this patch printed `col[0]=100` and `col[1]=100`,
  both above LINE's 60-char limit (LINE would reject the carousel with HTTP 400).
- Observed result after fix: columns carrying a title or thumbnail now cap `text` at
  60 characters; columns with neither stay at up to 120, so LINE accepts the carousel.
- What was not tested: a live round trip against the real LINE Messaging API (no LINE
  bot credentials available); the after-fix behavior is verified against LINE's documented
  column text limit and the live `node` run of the real outbound builder shown above.
- Proof limitations or environment constraints: without LINE channel credentials the
  proof drives the real outbound builder locally via `node` rather than sending to LINE's
  servers; the produced `text` lengths are exactly what would be transmitted.

AI-assisted: implemented with Claude Code; reviewed with `codex review` (no actionable defects).
