### PR TITLE
fix: honor configured default model for embedded agents

### DIFF
--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import "./test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   buildEmbeddedRunnerAssistant,
   cleanupEmbeddedAgentRunnerTestWorkspace,
@@ -321,6 +322,73 @@ function firstRunEmbeddedAttemptParams(): { sessionKey?: string } {
 }
 
 describe("runEmbeddedAgent", () => {
+  it("uses configured default model when provider and model are omitted", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          anthropic: {
+            api: "anthropic-messages",
+            apiKey: "sk-ant-test",
+            baseUrl: "https://example.com/anthropic",
+            models: [
+              {
+                id: "claude-sonnet-4-6",
+                name: "Mock Claude Sonnet 4.6",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 16_000,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    };
+    runEmbeddedAttemptMock.mockResolvedValueOnce(
+      makeEmbeddedRunnerAttempt({
+        assistantTexts: ["ok"],
+        lastAssistant: buildEmbeddedRunnerAssistant({
+          provider: "anthropic",
+          api: "anthropic-messages",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "ok" }],
+        }),
+      }),
+    );
+
+    await runEmbeddedAgent({
+      sessionId: "configured-default-model",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("configured-default-model"),
+      enqueue: immediateEnqueue,
+    });
+
+    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      "anthropic",
+      "claude-sonnet-4-6",
+      agentDir,
+      cfg,
+      expect.any(Object),
+    );
+    expect(firstRunEmbeddedAttemptParams()).toMatchObject({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+  });
+
   it("skips models.json generation when dynamic model resolution succeeds", async () => {
     const sessionFile = nextSessionFile();
     const cfg = createEmbeddedAgentRunnerOpenAiConfig([]);

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -98,6 +98,7 @@ import {
   resolveAuthProfileOrder,
   shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
+import { resolveDefaultModelForAgent } from "../model-selection.js";
 import { resolveThinkingDefault } from "../model-thinking-default.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
@@ -744,10 +745,20 @@ async function runEmbeddedAgentInternal(
       startupStages.mark("runtime-plugins");
       notifyExecutionPhase("runtime_plugins");
 
-      let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir =
         params.agentDir ?? resolveAgentDir(params.config ?? {}, workspaceResolution.agentId);
+      const hasExplicitProvider = Boolean(params.provider?.trim());
+      const hasExplicitModel = Boolean(params.model?.trim());
+      const defaultModelRef =
+        hasExplicitProvider || hasExplicitModel
+          ? { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL }
+          : resolveDefaultModelForAgent({
+              cfg: params.config ?? {},
+              agentId: workspaceResolution.agentId,
+              allowPluginNormalization: true,
+            });
+      let provider = (params.provider ?? defaultModelRef.provider).trim() || DEFAULT_PROVIDER;
+      let modelId = (params.model ?? defaultModelRef.model).trim() || DEFAULT_MODEL;
       const normalizedSessionKey = params.sessionKey?.trim();
       const fallbackConfigured = hasEmbeddedRunConfiguredModelFallbacks({
         cfg: params.config,


### PR DESCRIPTION
## Summary
- honor `agents.defaults.model` for embedded agent runs when no explicit `provider`/`model` override is supplied
- keep explicit or partial provider/model overrides on the previous fallback path
- add an e2e regression covering a non-OpenAI configured default model

Fixes #93419

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/embedded-agent-runner.e2e.test.ts`
- `pnpm check:test-types`
