### PR TITLE
fix: stabilize transcript cache and CLI env isolation

### DIFF
--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -370,34 +370,68 @@ describe("SessionManager.open", () => {
     expect(warmEntry).toMatchObject({ data: { value: "first" } });
   });
 
-  it("validates the transcript prefix after a custom entry is serialized", async () => {
-    const dir = await makeTempDir();
-    const sessionFile = path.join(dir, "session.jsonl");
-    const originalEntry = {
-      type: "message",
-      id: "assistant-1",
-      parentId: null,
-      timestamp: "2026-06-04T00:00:01.000Z",
-      message: buildAssistantMessage("message 1"),
-    };
-    const replacementEntry = {
-      ...originalEntry,
-      message: buildAssistantMessage("changed 1"),
-    };
-    const headerLine = JSON.stringify(buildSessionHeader(dir));
-    await fs.writeFile(sessionFile, `${headerLine}\n${JSON.stringify(originalEntry)}\n`, "utf8");
-
-    const sessionManager = SessionManager.open(sessionFile, dir, dir);
-    await withOwnedSessionTranscriptWrites(
+  it("validates the transcript prefix after extension-owned entries are serialized", async () => {
+    const appenders: Array<{
+      name: string;
+      append: (manager: SessionManager, value: unknown) => void;
+    }> = [
       {
-        sessionFile,
-        canAdvanceSessionEntryCache: () => true,
-        publishSessionFileSnapshot: () => true,
-        withSessionWriteLock: async (run) => await run(),
+        name: "custom",
+        append: (manager, value) =>
+          manager.appendCustomEntry("rewrite-during-serialization", {
+            value,
+          }),
       },
-      async () => {
-        sessionManager.appendCustomEntry("rewrite-during-serialization", {
-          value: {
+      {
+        name: "custom_message",
+        append: (manager, value) =>
+          manager.appendCustomMessageEntry(
+            "rewrite-during-serialization",
+            "extension message",
+            false,
+            { value },
+          ),
+      },
+      {
+        name: "compaction",
+        append: (manager, value) =>
+          manager.appendCompaction("summary", "assistant-1", 1, { value }, true),
+      },
+      {
+        name: "branch_summary",
+        append: (manager, value) =>
+          manager.branchWithSummary("assistant-1", "summary", { value }, true),
+      },
+    ];
+
+    for (const { name, append } of appenders) {
+      const dir = await makeTempDir();
+      const sessionFile = path.join(dir, `${name}.jsonl`);
+      const originalEntry = {
+        type: "message",
+        id: "assistant-1",
+        parentId: null,
+        timestamp: "2026-06-04T00:00:01.000Z",
+        message: buildAssistantMessage("message 1"),
+      };
+      const replacementEntry = {
+        ...originalEntry,
+        message: buildAssistantMessage("changed 1"),
+      };
+      const headerLine = JSON.stringify(buildSessionHeader(dir));
+      await fs.writeFile(sessionFile, `${headerLine}\n${JSON.stringify(originalEntry)}\n`, "utf8");
+
+      const sessionManager = SessionManager.open(sessionFile, dir, dir);
+      const publishSessionFileSnapshot = vi.fn(() => true);
+      await withOwnedSessionTranscriptWrites(
+        {
+          sessionFile,
+          canAdvanceSessionEntryCache: () => true,
+          publishSessionFileSnapshot,
+          withSessionWriteLock: async (run) => await run(),
+        },
+        async () => {
+          append(sessionManager, {
             toJSON() {
               writeFileSync(
                 sessionFile,
@@ -406,17 +440,18 @@ describe("SessionManager.open", () => {
               );
               return "persisted";
             },
-          },
-        });
-      },
-    );
+          });
+        },
+      );
 
-    expect(
-      SessionManager.open(sessionFile, dir, dir)
-        .getEntries()
-        .filter((entry) => entry.type === "message")
-        .map((entry) => readMessageContent(entry)),
-    ).toEqual(["changed 1"]);
+      expect(
+        SessionManager.open(sessionFile, dir, dir)
+          .getEntries()
+          .filter((entry) => entry.type === "message")
+          .map((entry) => readMessageContent(entry)),
+      ).toEqual(["changed 1"]);
+      expect(publishSessionFileSnapshot).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("invalidates incremental repair when append ownership cannot be proven", async () => {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -613,14 +613,31 @@ function rememberAppendedSessionEntry(
   beforeAppendSnapshot: SessionFileSnapshot | undefined,
   serializedAppend: string,
   cacheOwnedAppend: boolean,
-): { snapshot: SessionFileSnapshot | undefined; cacheAdvanced: boolean } {
+  publishOwnedAppend: boolean,
+): {
+  snapshot: SessionFileSnapshot | undefined;
+  cacheAdvanced: boolean;
+  ownedAppendVerified: boolean;
+} {
   const resolvedPath = resolve(filePath);
+  const appendedByteLength = BigInt(Buffer.byteLength(serializedAppend, "utf8"));
+  const isVerifiedOwnedAppend = (snapshot: SessionFileSnapshot | undefined) =>
+    Boolean(
+      publishOwnedAppend &&
+      beforeAppendSnapshot &&
+      snapshot &&
+      snapshot.dev === beforeAppendSnapshot.dev &&
+      snapshot.ino === beforeAppendSnapshot.ino &&
+      snapshot.size === beforeAppendSnapshot.size + appendedByteLength,
+    );
   if (!cacheOwnedAppend) {
     sessionEntriesCache.delete(resolvedPath);
     invalidateSessionFileRepairCache(resolvedPath);
+    const snapshot = readSessionFileSnapshotIfExists(resolvedPath);
     return {
-      snapshot: readSessionFileSnapshotIfExists(resolvedPath),
+      snapshot,
       cacheAdvanced: false,
+      ownedAppendVerified: isVerifiedOwnedAppend(snapshot),
     };
   }
   if (
@@ -633,6 +650,7 @@ function rememberAppendedSessionEntry(
     return {
       snapshot: readSessionFileSnapshotIfExists(resolvedPath),
       cacheAdvanced: false,
+      ownedAppendVerified: false,
     };
   }
 
@@ -641,8 +659,7 @@ function rememberAppendedSessionEntry(
   // Owned transcript writes serialize appenders under the session lock. Full
   // rewrites refresh the cache explicitly, so identity and size are sufficient
   // to advance this append-only snapshot without reading the whole file.
-  const expectedSize =
-    beforeAppendSnapshot.size + BigInt(Buffer.byteLength(serializedAppend, "utf8"));
+  const expectedSize = beforeAppendSnapshot.size + appendedByteLength;
   if (
     !snapshot ||
     !cached ||
@@ -655,11 +672,11 @@ function rememberAppendedSessionEntry(
   ) {
     sessionEntriesCache.delete(resolvedPath);
     invalidateSessionFileRepairCache(resolvedPath);
-    return { snapshot, cacheAdvanced: false };
+    return { snapshot, cacheAdvanced: false, ownedAppendVerified: false };
   }
   if (snapshot.size > MAX_CACHED_SESSION_BYTES) {
     sessionEntriesCache.delete(resolvedPath);
-    return { snapshot, cacheAdvanced: false };
+    return { snapshot, cacheAdvanced: false, ownedAppendVerified: true };
   }
 
   const persistedEntry = JSON.parse(
@@ -671,7 +688,7 @@ function rememberAppendedSessionEntry(
   sessionEntriesCache.delete(resolvedPath);
   sessionEntriesCache.set(resolvedPath, cached);
   trimSessionEntriesCache();
-  return { snapshot, cacheAdvanced: true };
+  return { snapshot, cacheAdvanced: true, ownedAppendVerified: true };
 }
 
 function publishRememberedSessionFileSnapshot(
@@ -686,6 +703,15 @@ function publishRememberedSessionFileSnapshot(
     sessionEntriesCache.delete(resolve(filePath));
     invalidateSessionFileRepairCache(filePath);
   }
+}
+
+function canIncrementallyCacheAppendedEntry(entry: SessionEntry): boolean {
+  return !(
+    entry.type === "custom" ||
+    entry.type === "custom_message" ||
+    entry.type === "compaction" ||
+    entry.type === "branch_summary"
+  );
 }
 
 function readSessionFileSnapshotIfExists(filePath: string): SessionFileSnapshot | undefined {
@@ -1328,13 +1354,16 @@ export class SessionManager {
       // prefix state that immediately precedes the exact bytes being appended.
       const serializedEntry = serializeJsonlEntry(entry);
       const beforeAppendSnapshot = readSessionFileSnapshotIfExists(this.sessionFile);
-      const cacheOwnedAppend = Boolean(
+      const canPublishOwnedAppend = Boolean(
         beforeAppendSnapshot &&
         canAdvanceOwnedSessionEntryCache({
           sessionFile: this.sessionFile,
           snapshot: beforeAppendSnapshot,
         }),
       );
+      // Extension/detail-bearing entries can run arbitrary toJSON code while
+      // serializing, so stat-only append validation is too weak for them.
+      const cacheOwnedAppend = canPublishOwnedAppend && canIncrementallyCacheAppendedEntry(entry);
       const serializedAppend = appendSerializedJsonlEntrySync(this.sessionFile, serializedEntry, {
         prefixNewline: sessionFileNeedsAppendSeparator(this.sessionFile, beforeAppendSnapshot),
       });
@@ -1344,9 +1373,10 @@ export class SessionManager {
         beforeAppendSnapshot,
         serializedAppend,
         cacheOwnedAppend,
+        canPublishOwnedAppend,
       );
       this.sessionFileSnapshot = rememberedAppend.snapshot;
-      if (rememberedAppend.cacheAdvanced) {
+      if (rememberedAppend.ownedAppendVerified) {
         publishRememberedSessionFileSnapshot(this.sessionFile, rememberedAppend.snapshot);
       }
     }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -1445,6 +1445,7 @@ describe("runCli exit behavior", () => {
           OPENCLAW_GATEWAY_TOKEN: undefined,
           OPENCLAW_HOME: homeDir,
           OPENCLAW_STATE_DIR: undefined,
+          NODE_OPTIONS: undefined,
         },
         async () => {
           await runCli(["node", "openclaw", "gateway"]);


### PR DESCRIPTION
## Summary

- prevent selected-state `.env` values from leaking `NODE_OPTIONS` between CLI tests
- stop incrementally advancing the parsed transcript cache for extension/detail-bearing appends whose serialization can mutate earlier transcript bytes
- keep owned append snapshot publication separate from parsed-cache advancement, so owned custom/detail appends still update the write context after the append is verified
- expand session-manager regression coverage for `custom`, `custom_message`, `compaction`, and `branch_summary` entries

## Verification

- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/cli/run-main.exit.test.ts src/cli/daemon-cli/install.test.ts -- --reporter=verbose`
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=agentic-cli OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_NO_OUTPUT_RETRY=0 OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/test-projects.mjs test/vitest/vitest.cli.config.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=agentic-agents-support OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_NO_OUTPUT_RETRY=0 OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/test-projects.mjs test/vitest/vitest.agents-support.config.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_SHARD_NAME=agentic-commands-agent-channel OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_NO_OUTPUT_RETRY=0 OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/test-projects.mjs test/vitest/vitest.commands.config.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-oxlint.mjs src/agents/sessions/session-manager.ts src/agents/sessions/session-manager.test.ts src/cli/run-main.exit.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Post-rebase focused checks also passed:

- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/cli/run-main.exit.test.ts src/cli/daemon-cli/install.test.ts -- --reporter=verbose`
