### PR TITLE
feat(advisor): prepare ClawHub publication

### DIFF
--- a/extensions/advisor/README.md
+++ b/extensions/advisor/README.md
@@ -1,0 +1,50 @@
+# Advisor Plugin
+
+Advisor adds an `advisor` tool to OpenClaw agents. The tool asks an LLM for a
+focused second opinion on a plan, implementation, review, or design tradeoff.
+
+Use it when the agent needs another read before doing something risky or
+ambiguous:
+
+- review a complex plan before execution
+- check edge cases in a proposed implementation
+- get a second opinion on requirements or architecture choices
+- flag likely security issues, side effects, or unsafe assumptions
+
+## Configuration
+
+By default the tool uses the agent's active model. To route advisor calls to a
+specific model, configure `modelRef` and allow model override for this plugin:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "advisor": {
+        "enabled": true,
+        "config": {
+          "modelRef": "lmstudio/google/gemma-4-12b"
+        },
+        "llm": {
+          "allowModelOverride": true
+        }
+      }
+    }
+  },
+  "tools": {
+    "alsoAllow": ["advisor"]
+  }
+}
+```
+
+The advisor only sees the `question` and optional `context` passed into the
+tool call, so include the relevant code, constraints, and current conclusion in
+the request.
+
+## Tool
+
+`advisor`
+
+- `question` - required question, problem, or decision for review.
+- `context` - optional background, code snippets, constraints, or prior
+  conclusions.

--- a/extensions/advisor/index.test.ts
+++ b/extensions/advisor/index.test.ts
@@ -1,0 +1,207 @@
+// Advisor plugin tests cover tool factory behavior and llm.complete integration.
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it, vi } from "vitest";
+import advisorPlugin from "./index.js";
+
+function buildApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi {
+  return createTestPluginApi({
+    runtime: {
+      llm: {
+        complete: vi.fn(async () => ({
+          text: "The approach looks solid.",
+          provider: "test-provider",
+          model: "test-model",
+          agentId: "test-agent",
+          usage: { inputTokens: 10, outputTokens: 5 },
+          audit: { caller: { kind: "plugin" } },
+        })),
+      },
+    } as unknown as OpenClawPluginApi["runtime"],
+    ...overrides,
+  });
+}
+
+describe("advisor plugin", () => {
+  it("registers exactly one tool named advisor", () => {
+    const api = buildApi();
+    const registered: unknown[] = [];
+    const spy = vi.spyOn(api, "registerTool").mockImplementation((t) => {
+      registered.push(t);
+    });
+    advisorPlugin.register(api);
+    expect(spy).toHaveBeenCalledOnce();
+    expect(registered).toHaveLength(1);
+  });
+
+  it("creates advisor tool with correct name and description", () => {
+    const api = buildApi();
+    let toolFactory: ((ctx: object) => unknown) | null = null;
+    vi.spyOn(api, "registerTool").mockImplementation((factory) => {
+      toolFactory = factory as typeof toolFactory;
+    });
+    advisorPlugin.register(api);
+    expect(toolFactory).not.toBeNull();
+    const tool = toolFactory!({ agentId: "agent-1" }) as {
+      name: string;
+      label: string;
+      description: string;
+    };
+    expect(tool.name).toBe("advisor");
+    expect(tool.label).toBe("Advisor");
+    expect(tool.description).toContain("second opinion");
+  });
+
+  it("calls api.runtime.llm.complete with user message on execute", async () => {
+    const completeMock = vi.fn(async (_params: Record<string, unknown>) => ({
+      text: "Looks good.",
+      provider: "test",
+      model: "test-model",
+      agentId: "agent-1",
+      usage: {},
+      audit: { caller: { kind: "plugin" as const } },
+    }));
+    const api = buildApi({
+      runtime: {
+        llm: { complete: completeMock },
+      } as unknown as OpenClawPluginApi["runtime"],
+    });
+
+    let toolFactory: ((ctx: object) => unknown) | null = null;
+    vi.spyOn(api, "registerTool").mockImplementation((factory) => {
+      toolFactory = factory as typeof toolFactory;
+    });
+    advisorPlugin.register(api);
+
+    const tool = toolFactory!({ agentId: "agent-1" }) as {
+      execute: (id: string, params: unknown) => Promise<{ content: { text: string }[] }>;
+    };
+
+    const result = await tool.execute("call-1", {
+      question: "Is this implementation correct?",
+    });
+
+    expect(completeMock).toHaveBeenCalledOnce();
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: "user", content: "Is this implementation correct?" }],
+        purpose: "advisor",
+      }),
+    );
+    expect(result.content[0]?.text).toContain("Looks good.");
+  });
+
+  it("prepends context before question when context is provided", async () => {
+    const completeMock = vi.fn(async (_params: Record<string, unknown>) => ({
+      text: "Context noted.",
+      provider: "test",
+      model: "test-model",
+      agentId: "agent-1",
+      usage: {},
+      audit: { caller: { kind: "plugin" as const } },
+    }));
+    const api = buildApi({
+      runtime: {
+        llm: { complete: completeMock },
+      } as unknown as OpenClawPluginApi["runtime"],
+    });
+
+    let toolFactory: ((ctx: object) => unknown) | null = null;
+    vi.spyOn(api, "registerTool").mockImplementation((factory) => {
+      toolFactory = factory as typeof toolFactory;
+    });
+    advisorPlugin.register(api);
+
+    const tool = toolFactory!({ agentId: "agent-1" }) as {
+      execute: (id: string, params: unknown) => Promise<{ content: { text: string }[] }>;
+    };
+
+    await tool.execute("call-2", {
+      question: "Is this safe?",
+      context: "We are writing to /etc/hosts",
+    });
+
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            role: "user",
+            content: expect.stringContaining("We are writing to /etc/hosts"),
+          }),
+        ],
+      }),
+    );
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: expect.stringContaining("Is this safe?"),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("passes configuredModelRef as model when pluginConfig.modelRef is set", async () => {
+    const completeMock = vi.fn(async (_params: Record<string, unknown>) => ({
+      text: "Model override worked.",
+      provider: "vmlx",
+      model: "gemma-4-26B",
+      agentId: "agent-1",
+      usage: {},
+      audit: { caller: { kind: "plugin" as const } },
+    }));
+    const api = buildApi({
+      pluginConfig: { modelRef: "vmlx/gemma-4-26B" },
+      runtime: {
+        llm: { complete: completeMock },
+      } as unknown as OpenClawPluginApi["runtime"],
+    });
+
+    let toolFactory: ((ctx: object) => unknown) | null = null;
+    vi.spyOn(api, "registerTool").mockImplementation((factory) => {
+      toolFactory = factory as typeof toolFactory;
+    });
+    advisorPlugin.register(api);
+
+    const tool = toolFactory!({ agentId: "agent-1" }) as {
+      execute: (id: string, params: unknown) => Promise<unknown>;
+    };
+    await tool.execute("call-3", { question: "Any issues?" });
+
+    expect(completeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "vmlx/gemma-4-26B" }),
+    );
+  });
+
+  it("omits model from complete call when pluginConfig.modelRef is not set", async () => {
+    const completeMock = vi.fn(async (_params: Record<string, unknown>) => ({
+      text: "Default model response.",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      agentId: "agent-1",
+      usage: {},
+      audit: { caller: { kind: "plugin" as const } },
+    }));
+    const api = buildApi({
+      runtime: {
+        llm: { complete: completeMock },
+      } as unknown as OpenClawPluginApi["runtime"],
+    });
+
+    let toolFactory: ((ctx: object) => unknown) | null = null;
+    vi.spyOn(api, "registerTool").mockImplementation((factory) => {
+      toolFactory = factory as typeof toolFactory;
+    });
+    advisorPlugin.register(api);
+
+    const tool = toolFactory!({ agentId: "agent-1" }) as {
+      execute: (id: string, params: unknown) => Promise<unknown>;
+    };
+    await tool.execute("call-4", { question: "Any issues?" });
+
+    expect(completeMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ model: expect.anything() }),
+    );
+  });
+});

--- a/extensions/advisor/index.test.ts
+++ b/extensions/advisor/index.test.ts
@@ -88,6 +88,9 @@ describe("advisor plugin", () => {
         purpose: "advisor",
       }),
     );
+    expect(completeMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: expect.anything() }),
+    );
     expect(result.content[0]?.text).toContain("Looks good.");
   });
 

--- a/extensions/advisor/index.ts
+++ b/extensions/advisor/index.ts
@@ -19,6 +19,6 @@ export default definePluginEntry({
     restartPrefixes: ["plugins.entries.advisor"],
   },
   register(api) {
-    api.registerTool((ctx) => createAdvisorTool(ctx, api));
+    api.registerTool((ctx) => createAdvisorTool(ctx, api), { name: "advisor" });
   },
 });

--- a/extensions/advisor/index.ts
+++ b/extensions/advisor/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Advisor plugin — model-agnostic second-opinion tool for agent sessions.
+ *
+ * By default uses the agent's active model. To route to a different model
+ * (e.g. a local Gemma via vMLX), set in agent config:
+ *
+ *   plugins.entries.advisor.config.modelRef = "vmlx/gemma-4-26B"
+ *   plugins.entries.advisor.llm.allowModelOverride = true
+ */
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createAdvisorTool } from "./src/tool.js";
+
+export default definePluginEntry({
+  id: "advisor",
+  name: "Advisor",
+  description:
+    "Model-agnostic advisor tool that provides expert second opinions during agent sessions using any configured LLM provider.",
+  reload: {
+    restartPrefixes: ["plugins.entries.advisor"],
+  },
+  register(api) {
+    api.registerTool((ctx) => createAdvisorTool(ctx, api));
+  },
+});

--- a/extensions/advisor/npm-shrinkwrap.json
+++ b/extensions/advisor/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/advisor-plugin",
+  "version": "2026.6.5",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/advisor-plugin",
+      "version": "2026.6.5"
+    }
+  }
+}

--- a/extensions/advisor/openclaw.plugin.json
+++ b/extensions/advisor/openclaw.plugin.json
@@ -1,0 +1,22 @@
+{
+  "id": "advisor",
+  "name": "Advisor",
+  "description": "Model-agnostic advisor tool for expert second opinions using any configured LLM.",
+  "activation": {
+    "onStartup": true
+  },
+  "enabledByDefault": false,
+  "contracts": {
+    "tools": ["advisor"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "modelRef": {
+        "type": "string",
+        "description": "Model ref to route advisor calls to (e.g. \"vmlx/gemma-4-26B\", \"lmstudio/qwen3-30b\"). Requires plugins.entries.advisor.llm.allowModelOverride: true."
+      }
+    }
+  }
+}

--- a/extensions/advisor/package.json
+++ b/extensions/advisor/package.json
@@ -7,12 +7,6 @@
     "url": "https://github.com/openclaw/openclaw"
   },
   "type": "module",
-  "devDependencies": {
-    "@openclaw/plugin-sdk": "workspace:*"
-  },
-  "dependencies": {
-    "typebox": "1.1.39"
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/advisor/package.json
+++ b/extensions/advisor/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/advisor-plugin",
+  "version": "2026.6.2",
+  "private": true,
+  "description": "OpenClaw model-agnostic advisor plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "dependencies": {
+    "typebox": "1.1.39"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/advisor/package.json
+++ b/extensions/advisor/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@openclaw/advisor-plugin",
-  "version": "2026.6.2",
-  "private": true,
+  "version": "2026.6.5",
   "description": "OpenClaw model-agnostic advisor plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
@@ -13,6 +16,23 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/advisor-plugin",
+      "npmSpec": "@openclaw/advisor-plugin",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.2"
+    },
+    "build": {
+      "openclawVersion": "2026.6.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
   }
 }

--- a/extensions/advisor/src/tool.ts
+++ b/extensions/advisor/src/tool.ts
@@ -4,22 +4,29 @@ import type {
   OpenClawPluginApi,
   OpenClawPluginToolContext,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { Type, type Static } from "typebox";
 
-const AdvisorToolSchema = Type.Object({
-  question: Type.String({
-    description:
-      "The question, problem, or decision to get expert review on. Include all relevant context inline — the advisor only sees what you pass here, not the surrounding conversation.",
-  }),
-  context: Type.Optional(
-    Type.String({
+const AdvisorToolSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["question"],
+  properties: {
+    question: {
+      type: "string",
+      description:
+        "The question, problem, or decision to get expert review on. Include all relevant context inline — the advisor only sees what you pass here, not the surrounding conversation.",
+    },
+    context: {
+      type: "string",
       description:
         "Additional background context, code snippets, relevant constraints, or prior conclusions that the advisor needs to give a useful answer.",
-    }),
-  ),
-});
+    },
+  },
+} as const;
 
-type AdvisorParams = Static<typeof AdvisorToolSchema>;
+type AdvisorParams = {
+  question: string;
+  context?: string;
+};
 
 const ADVISOR_SYSTEM_PROMPT = `You are a senior expert advisor providing a second opinion during an AI agent session.
 
@@ -33,7 +40,7 @@ Your role:
 Respond in plain text. No pleasantries — focus on substance.`;
 
 export function createAdvisorTool(
-  ctx: OpenClawPluginToolContext,
+  _ctx: OpenClawPluginToolContext,
   api: OpenClawPluginApi,
 ): AnyAgentTool {
   const configuredModelRef =

--- a/extensions/advisor/src/tool.ts
+++ b/extensions/advisor/src/tool.ts
@@ -1,0 +1,89 @@
+// Advisor tool: wraps api.runtime.llm.complete to provide a model-agnostic second opinion.
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { Type, type Static } from "typebox";
+
+const AdvisorToolSchema = Type.Object({
+  question: Type.String({
+    description:
+      "The question, problem, or decision to get expert review on. Include all relevant context inline — the advisor only sees what you pass here, not the surrounding conversation.",
+  }),
+  context: Type.Optional(
+    Type.String({
+      description:
+        "Additional background context, code snippets, relevant constraints, or prior conclusions that the advisor needs to give a useful answer.",
+    }),
+  ),
+});
+
+type AdvisorParams = Static<typeof AdvisorToolSchema>;
+
+const ADVISOR_SYSTEM_PROMPT = `You are a senior expert advisor providing a second opinion during an AI agent session.
+
+Your role:
+- Catch errors, oversights, or unsafe assumptions in the proposed approach
+- Suggest concrete improvements or alternatives where relevant
+- Flag potential side effects, edge cases, or risks
+- Be direct, specific, and concise — prioritize the highest-impact insights
+- If the approach looks solid, say so briefly with the key reason why
+
+Respond in plain text. No pleasantries — focus on substance.`;
+
+export function createAdvisorTool(
+  ctx: OpenClawPluginToolContext,
+  api: OpenClawPluginApi,
+): AnyAgentTool {
+  const configuredModelRef =
+    typeof api.pluginConfig?.modelRef === "string" ? api.pluginConfig.modelRef : undefined;
+
+  const modelLabel = configuredModelRef
+    ? `configured advisor model (${configuredModelRef})`
+    : "the agent's active model";
+
+  return {
+    name: "advisor",
+    label: "Advisor",
+    description: `Get an expert second opinion from ${modelLabel}.
+
+Use this tool when you need to:
+- Verify a complex plan before executing it
+- Check whether your solution correctly handles edge cases
+- Get a second read on ambiguous requirements or design tradeoffs
+- Catch potential errors or security issues in a proposed implementation
+
+Pass rich context in \`question\` — the advisor only sees what you provide here.${
+      configuredModelRef
+        ? `\n\nNote: requires \`plugins.entries.advisor.llm.allowModelOverride: true\` in agent config to use the override model.`
+        : ""
+    }`,
+    parameters: AdvisorToolSchema,
+    execute: async (_toolCallId, rawParams, signal) => {
+      const params = rawParams as AdvisorParams;
+      const userContent = params.context
+        ? `${params.context}\n\n---\n\n${params.question}`
+        : params.question;
+
+      const result = await api.runtime.llm.complete({
+        messages: [{ role: "user", content: userContent }],
+        systemPrompt: ADVISOR_SYSTEM_PROMPT,
+        ...(configuredModelRef ? { model: configuredModelRef } : {}),
+        agentId: ctx.agentId,
+        signal,
+        purpose: "advisor",
+      });
+
+      const attribution = `[Advisor: ${result.provider}/${result.model}]`;
+      return {
+        content: [{ type: "text" as const, text: `${result.text}\n\n${attribution}` }],
+        details: {
+          provider: result.provider,
+          model: result.model,
+          usage: result.usage,
+        },
+      };
+    },
+  } satisfies AnyAgentTool;
+}

--- a/extensions/advisor/src/tool.ts
+++ b/extensions/advisor/src/tool.ts
@@ -70,7 +70,6 @@ Pass rich context in \`question\` — the advisor only sees what you provide her
         messages: [{ role: "user", content: userContent }],
         systemPrompt: ADVISOR_SYSTEM_PROMPT,
         ...(configuredModelRef ? { model: configuredModelRef } : {}),
-        agentId: ctx.agentId,
         signal,
         purpose: "advisor",
       });

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "!dist/plugin-sdk/src/test-utils/**",
     "!dist/plugin-sdk/src/plugin-sdk/test-helpers/**",
     "!dist/extensions/acpx/**",
+    "!dist/extensions/advisor/**",
     "!dist/extensions/amazon-bedrock/**",
     "!dist/extensions/amazon-bedrock-mantle/**",
     "!dist/extensions/anthropic-vertex/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,15 +331,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
-  extensions/advisor:
-    dependencies:
-      typebox:
-        specifier: 1.1.39
-        version: 1.1.39
-    devDependencies:
-      '@openclaw/plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/plugin-sdk
+  extensions/advisor: {}
 
   extensions/alibaba:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/advisor:
+    dependencies:
+      typebox:
+        specifier: 1.1.39
+        version: 1.1.39
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/alibaba:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -1,5 +1,6 @@
 // Test routing roots for miscellaneous provider/tool extension suites.
 export const miscExtensionTestRoots = [
+  "extensions/advisor",
   "extensions/arcee",
   "extensions/brave",
   "extensions/device-pair",


### PR DESCRIPTION
## Summary
- adds ClawHub/npm publication metadata and docs for the advisor plugin
- registers the advisor tool with an explicit tool name for plugin discovery
- fixes advisor LLM completion by relying on the active session binding instead of passing an explicit agentId
- removes the extra runtime dependency by using a plain JSON schema and adds the required package shrinkwrap

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the advisor plugin registers an `advisor` tool and can be called by an OpenClaw agent for second-opinion review; plugin LLM completion must not fail on target-agent override.
- Real environment tested: local OpenClaw CLI on Marco's MacBook Pro using `localgateway/local` through LM Studio Gemma 12B QAT, 120k context.
- Exact steps or command run after this patch:

```bash
openclaw agent --local --model localgateway/local --session-key agent:default:advisor-e2e-jsonschema-12b --message "Call advisor once, then answer. advisor question: Review this change for risks: edit a model config and restart local gateway. advisor context: end-to-end plugin test using plain JSON schema after removing the extra dependency. After the tool result, reply in one sentence with the top risk." --thinking off --timeout 300 --json
```

- Evidence after fix:

```json
{
  "durationMs": 175261,
  "provider": "localgateway",
  "model": "local",
  "toolSummary": {
    "calls": 1,
    "tools": ["advisor"],
    "failures": 0
  },
  "finalAssistantVisibleText": "The top risk is that an invalid schema format in the edited model config could cause the local gateway to fail to initialize or enter a crash loop upon restart."
}
```

- Observed result after fix: the agent called `advisor` exactly once; the advisor completed; the final answer used the advisor result.
- Before evidence: an earlier real local run reached the advisor tool but failed with `Plugin LLM completion cannot override the target agent`; removing the explicit `agentId` from the advisor LLM call fixed that runtime error.
- What was not tested: upstream ClawHub workflow dispatch, because this fork account only has read permission on `openclaw/openclaw`; first-time ClawHub publication still requires maintainer bootstrap after merge.
- Proof limitations/environment constraints: local model generation is slow; the proof uses localgateway/LM Studio; logs are summarized and redacted where appropriate.

## Validation
- `node scripts/run-vitest.mjs run extensions/advisor/index.test.ts` — 6 tests passed
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false` — passed
- `node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/advisor --check` — passed
- `node --import tsx scripts/plugin-clawhub-release-check.ts -- --plugins @openclaw/advisor-plugin` — passed
- `node --import tsx scripts/plugin-npm-release-check.ts -- --plugins @openclaw/advisor-plugin` — passed
- `node --import tsx scripts/plugin-clawhub-release-plan.ts --selection-mode selected --plugins @openclaw/advisor-plugin` — reports `@openclaw/advisor-plugin@2026.6.5` as a bootstrap candidate
- `git diff --check` — passed
- `/tmp/advisor-plugin-clawhub`: `npm test && npm run build` — passed
- local OpenClaw agent E2E above: advisor tool called once with 0 tool failures via `localgateway/local`

## ClawHub
The release plan reports `@openclaw/advisor-plugin@2026.6.5` as a bootstrap candidate, so after this lands on a trusted branch it should be published through `plugin-clawhub-new.yml` before normal OIDC release publishing.

## Dependency Guard Note
The follow-up commit removed the new third-party dependency (`typebox`) and the package-level SDK devDependency. The remaining dependency-review surface is the unavoidable new publishable package metadata, minimal empty `pnpm-lock.yaml` importer, and package-local `npm-shrinkwrap.json` required by CI.
