### PR TITLE
fix: dedupe codex commentary across event lanes

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1082,6 +1082,53 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.replayMetadata).toEqual({ hadPotentialSideEffects: false, replaySafe: true });
   });
 
+  it("dedupes matching commentary emitted by typed and raw response lanes", async () => {
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "agentMessage",
+          id: "typed-commentary",
+          phase: "commentary",
+          text: "",
+        },
+      }),
+    );
+    await projector.handleNotification(
+      agentMessageDelta("Checking the app-server stream", "typed-commentary"),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("rawResponseItem/completed", {
+        item: {
+          id: "raw-commentary",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Checking the app-server stream" }],
+        },
+      }),
+    );
+
+    const progressEvents = onAgentEvent.mock.calls
+      .map((call) => call[0])
+      .filter((event) => event.stream === "item" && event.data.kind === "preamble");
+
+    expect(progressEvents.map((event) => event.data)).toEqual([
+      {
+        itemId: "typed-commentary",
+        kind: "preamble",
+        title: "Preamble",
+        phase: "update",
+        progressText: "Checking the app-server stream",
+        source: "codex-app-server",
+      },
+    ]);
+  });
+
   it("streams commentary agent messages as keyed progress events", async () => {
     const onAgentEvent = vi.fn();
     const onPartialReply = vi.fn();

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -149,6 +149,7 @@ export class CodexAppServerEventProjector {
   private readonly assistantItemOrder: string[] = [];
   private readonly assistantPhaseByItem = new Map<string, string>();
   private readonly lastCommentaryProgressTextByItem = new Map<string, string>();
+  private readonly commentaryProgressItemByText = new Map<string, string>();
   private readonly reasoningTextByGroup = new Map<string, ReasoningTextGroup>();
   private readonly reasoningItemOrder = new Map<string, number>();
   private readonly planTextByItem = new Map<string, string>();
@@ -1065,7 +1066,12 @@ export class CodexAppServerEventProjector {
     ) {
       return;
     }
+    const previousItemId = this.commentaryProgressItemByText.get(progressText);
+    if (previousItemId && previousItemId !== params.itemId) {
+      return;
+    }
     this.lastCommentaryProgressTextByItem.set(params.itemId, progressText);
+    this.commentaryProgressItemByText.set(progressText, params.itemId);
     this.emitAgentEvent({
       stream: "item",
       data: {


### PR DESCRIPTION
## Summary
- dedupe Codex app-server commentary progress across typed agentMessage and raw response item lanes
- keep same-item commentary snapshot updates intact
- add a regression test for matching commentary text emitted under different item id namespaces

Fixes #93296

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts codex/src/app-server/event-projector.test.ts`
- `pnpm check:test-types`
