### PR TITLE
fix: avoid parent group allowlist false positive

### DIFF
--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -1,8 +1,29 @@
 // Doctor channel capability tests cover channel capability inspection and diagnostics.
-import { describe, expect, it } from "vitest";
-import { getDoctorChannelCapabilities } from "./channel-capabilities.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getDoctorChannelCapabilities,
+  listDoctorChannelAccountIds,
+} from "./channel-capabilities.js";
+
+const channelPluginMocks = vi.hoisted(() => ({
+  getBundledChannelPlugin: vi.fn(() => undefined),
+  getChannelPlugin: vi.fn(() => undefined),
+}));
+
+vi.mock("../../channels/plugins/bundled.js", () => ({
+  getBundledChannelPlugin: channelPluginMocks.getBundledChannelPlugin,
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: channelPluginMocks.getChannelPlugin,
+}));
 
 describe("doctor channel capabilities", () => {
+  beforeEach(() => {
+    channelPluginMocks.getBundledChannelPlugin.mockReset().mockReturnValue(undefined);
+    channelPluginMocks.getChannelPlugin.mockReset().mockReturnValue(undefined);
+  });
+
   it("returns nested route semantics from googlechat plugin metadata", () => {
     expect(getDoctorChannelCapabilities("googlechat")).toEqual({
       dmAllowFromMode: "nestedOnly",
@@ -46,5 +67,13 @@ describe("doctor channel capabilities", () => {
       groupAllowFromFallbackToAllowFrom: true,
       warnOnEmptyGroupSenderAllowlist: true,
     });
+  });
+
+  it("falls back conservatively when channel plugin resolution throws", () => {
+    channelPluginMocks.getChannelPlugin.mockImplementation(() => {
+      throw new Error("missing generated bundled module");
+    });
+
+    expect(listDoctorChannelAccountIds("telegram", {})).toBeUndefined();
   });
 });

--- a/src/commands/doctor/channel-capabilities.test.ts
+++ b/src/commands/doctor/channel-capabilities.test.ts
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getDoctorChannelCapabilities,
-  listDoctorChannelAccountIds,
+  resolveDoctorChannelAccountIds,
 } from "./channel-capabilities.js";
 
 const channelPluginMocks = vi.hoisted(() => ({
@@ -74,6 +74,22 @@ describe("doctor channel capabilities", () => {
       throw new Error("missing generated bundled module");
     });
 
-    expect(listDoctorChannelAccountIds("telegram", {})).toBeUndefined();
+    expect(resolveDoctorChannelAccountIds("telegram", {}, [])).toBeUndefined();
+  });
+
+  it("resolves configured and runtime account ids through plugin semantics", () => {
+    channelPluginMocks.getChannelPlugin.mockReturnValue({
+      config: {
+        listAccountIds: () => ["default", "Work"],
+        resolveAccount: (_cfg: unknown, accountId?: string | null) => ({
+          accountId: accountId === "Work" ? "work" : accountId,
+        }),
+      },
+    } as never);
+
+    expect(resolveDoctorChannelAccountIds("signal", {}, ["Work"])).toEqual({
+      configured: ["work"],
+      runtime: ["default", "work"],
+    });
   });
 });

--- a/src/commands/doctor/channel-capabilities.ts
+++ b/src/commands/doctor/channel-capabilities.ts
@@ -68,18 +68,45 @@ export function getDoctorChannelCapabilities(channelName?: string): DoctorChanne
   return mergeDoctorChannelCapabilities(getManifestDoctorCapabilities(channelId));
 }
 
-/** Resolve the account ids a channel plugin would activate for the current config. */
-export function listDoctorChannelAccountIds(
+type DoctorChannelAccountIds = {
+  configured: string[];
+  runtime: string[];
+};
+
+function readResolvedAccountId(account: unknown): string | undefined {
+  if (!account || typeof account !== "object") {
+    return undefined;
+  }
+  const accountId = (account as { accountId?: unknown }).accountId;
+  return typeof accountId === "string" && accountId ? accountId : undefined;
+}
+
+/** Resolve configured and runtime account ids through the channel plugin's own semantics. */
+export function resolveDoctorChannelAccountIds(
   channelName: string,
   cfg: OpenClawConfig,
-): string[] | undefined {
+  configuredAccountIds: string[],
+): DoctorChannelAccountIds | undefined {
   const channelId = normalizeAnyChannelId(channelName);
   if (!channelId) {
     return undefined;
   }
   try {
     const plugin = getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId);
-    return plugin?.config.listAccountIds(cfg);
+    if (!plugin) {
+      return undefined;
+    }
+    const resolveAccountIds = (accountIds: string[]): string[] | undefined => {
+      const resolved = accountIds.map((accountId) =>
+        readResolvedAccountId(plugin.config.resolveAccount(cfg, accountId)),
+      );
+      return resolved.every((accountId): accountId is string => accountId !== undefined)
+        ? resolved
+        : undefined;
+    };
+    const configured = resolveAccountIds(configuredAccountIds);
+    const runtime = resolveAccountIds(plugin.config.listAccountIds(cfg));
+    return configured && runtime ? { configured, runtime } : undefined;
   } catch {
     // Keep doctor warnings conservative when a plugin cannot inspect its account set.
     return undefined;

--- a/src/commands/doctor/channel-capabilities.ts
+++ b/src/commands/doctor/channel-capabilities.ts
@@ -2,6 +2,7 @@
 import { getBundledChannelPlugin } from "../../channels/plugins/bundled.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { findBundledPackageChannelMetadata } from "../../plugins/bundled-package-channel-metadata.js";
 import type { PluginPackageChannelDoctorCapabilities } from "../../plugins/manifest.js";
 import type { AllowFromMode } from "./shared/allow-from-mode.types.js";
@@ -65,4 +66,22 @@ export function getDoctorChannelCapabilities(channelName?: string): DoctorChanne
     return mergeDoctorChannelCapabilities(pluginDoctor);
   }
   return mergeDoctorChannelCapabilities(getManifestDoctorCapabilities(channelId));
+}
+
+/** Resolve the account ids a channel plugin would activate for the current config. */
+export function listDoctorChannelAccountIds(
+  channelName: string,
+  cfg: OpenClawConfig,
+): string[] | undefined {
+  const channelId = normalizeAnyChannelId(channelName);
+  if (!channelId) {
+    return undefined;
+  }
+  const plugin = getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId);
+  try {
+    return plugin?.config.listAccountIds(cfg);
+  } catch {
+    // Keep doctor warnings conservative when a plugin cannot inspect its account set.
+    return undefined;
+  }
 }

--- a/src/commands/doctor/channel-capabilities.ts
+++ b/src/commands/doctor/channel-capabilities.ts
@@ -77,8 +77,8 @@ export function listDoctorChannelAccountIds(
   if (!channelId) {
     return undefined;
   }
-  const plugin = getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId);
   try {
+    const plugin = getChannelPlugin(channelId) ?? getBundledChannelPlugin(channelId);
     return plugin?.config.listAccountIds(cfg);
   } catch {
     // Keep doctor warnings conservative when a plugin cannot inspect its account set.

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -9,17 +9,29 @@ vi.mock("../channel-capabilities.js", () => ({
     groupAllowFromFallbackToAllowFrom: channelName !== "imessage",
     warnOnEmptyGroupSenderAllowlist: channelName !== "discord",
   }),
-  listDoctorChannelAccountIds: (
+  resolveDoctorChannelAccountIds: (
     channelName: string,
-    cfg: { channels?: Record<string, { accounts?: Record<string, unknown>; baseUrl?: string }> },
+    cfg: {
+      channels?: Record<
+        string,
+        { accounts?: Record<string, unknown>; appId?: string; baseUrl?: string }
+      >;
+    },
+    configuredAccountIds: string[],
   ) => {
     const channel = cfg.channels?.[channelName];
     const ids = Object.keys(channel?.accounts ?? {});
-    const runtimeIds =
-      channelName === "matrix" ? ids.map((accountId) => accountId.toLowerCase()) : ids;
-    return channelName === "qa-channel" && channel?.baseUrl
-      ? ["default", ...runtimeIds]
-      : runtimeIds;
+    const resolveAccountId = (accountId: string) =>
+      channelName === "matrix" || channelName === "signal" ? accountId.toLowerCase() : accountId;
+    const runtimeIds = [
+      ...(channelName === "qa-channel" && channel?.baseUrl ? ["default"] : []),
+      ...(channelName === "qqbot" && channel?.appId ? ["default"] : []),
+      ...ids,
+    ];
+    return {
+      configured: configuredAccountIds.map(resolveAccountId),
+      runtime: runtimeIds.map(resolveAccountId),
+    };
   },
 }));
 
@@ -149,6 +161,28 @@ describe("doctor empty allowlist policy scan", () => {
     );
 
     expect(warnings).toEqual([]);
+  });
+
+  it("keeps parent warning for a distinct case-sensitive implicit default account", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          qqbot: {
+            appId: "top-level-app",
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              Default: { groupAllowFrom: ["qqbot:group:named"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toContain(
+      '- channels.qqbot.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.qqbot.groupAllowFrom or channels.qqbot.allowFrom, or set groupPolicy to "open".',
+    );
   });
 
   it("allows provider-specific extra warnings without importing providers", () => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -37,6 +37,48 @@ describe("doctor empty allowlist policy scan", () => {
     ]);
   });
 
+  it("does not warn on empty parent groupAllowFrom when active accounts have effective group allowlists", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              primary: { groupAllowFrom: ["telegram:group:primary"] },
+              backup: { allowFrom: ["telegram:group:backup"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("keeps parent groupAllowFrom warning when any active account lacks an effective allowlist", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          telegram: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              primary: { groupAllowFrom: ["telegram:group:primary"] },
+              backup: {},
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toContain(
+      '- channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.telegram.groupAllowFrom or channels.telegram.allowFrom, or set groupPolicy to "open".',
+    );
+  });
+
   it("allows provider-specific extra warnings without importing providers", () => {
     const warnings = scanEmptyAllowlistPolicyWarnings(
       {

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -14,7 +14,7 @@ vi.mock("../channel-capabilities.js", () => ({
     cfg: { channels?: Record<string, { accounts?: Record<string, unknown>; baseUrl?: string }> },
   ) => {
     const channel = cfg.channels?.[channelName];
-    const ids = Object.keys(channel?.accounts ?? {});
+    const ids = Object.keys(channel?.accounts ?? {}).map((accountId) => accountId.toLowerCase());
     return channelName === "qa-channel" && channel?.baseUrl ? ["default", ...ids] : ids;
   },
 }));
@@ -107,6 +107,25 @@ describe("doctor empty allowlist policy scan", () => {
     expect(warnings).toContain(
       '- channels.qa-channel.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.qa-channel.groupAllowFrom or channels.qa-channel.allowFrom, or set groupPolicy to "open".',
     );
+  });
+
+  it("matches canonical runtime account ids to mixed-case config keys", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          matrix: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              Work: { groupAllowFrom: ["matrix:group:work"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toEqual([]);
   });
 
   it("allows provider-specific extra warnings without importing providers", () => {

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -14,8 +14,12 @@ vi.mock("../channel-capabilities.js", () => ({
     cfg: { channels?: Record<string, { accounts?: Record<string, unknown>; baseUrl?: string }> },
   ) => {
     const channel = cfg.channels?.[channelName];
-    const ids = Object.keys(channel?.accounts ?? {}).map((accountId) => accountId.toLowerCase());
-    return channelName === "qa-channel" && channel?.baseUrl ? ["default", ...ids] : ids;
+    const ids = Object.keys(channel?.accounts ?? {});
+    const runtimeIds =
+      channelName === "matrix" ? ids.map((accountId) => accountId.toLowerCase()) : ids;
+    return channelName === "qa-channel" && channel?.baseUrl
+      ? ["default", ...runtimeIds]
+      : runtimeIds;
   },
 }));
 
@@ -118,6 +122,25 @@ describe("doctor empty allowlist policy scan", () => {
             groupAllowFrom: [],
             accounts: {
               Work: { groupAllowFrom: ["matrix:group:work"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("matches raw runtime account ids to canonical config keys", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          signal: {
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              Work: { groupAllowFrom: ["signal:group:work"] },
             },
           },
         },

--- a/src/commands/doctor/shared/empty-allowlist-scan.test.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.test.ts
@@ -9,6 +9,14 @@ vi.mock("../channel-capabilities.js", () => ({
     groupAllowFromFallbackToAllowFrom: channelName !== "imessage",
     warnOnEmptyGroupSenderAllowlist: channelName !== "discord",
   }),
+  listDoctorChannelAccountIds: (
+    channelName: string,
+    cfg: { channels?: Record<string, { accounts?: Record<string, unknown>; baseUrl?: string }> },
+  ) => {
+    const channel = cfg.channels?.[channelName];
+    const ids = Object.keys(channel?.accounts ?? {});
+    return channelName === "qa-channel" && channel?.baseUrl ? ["default", ...ids] : ids;
+  },
 }));
 
 vi.mock("./channel-doctor.js", () => ({
@@ -76,6 +84,28 @@ describe("doctor empty allowlist policy scan", () => {
 
     expect(warnings).toContain(
       '- channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.telegram.groupAllowFrom or channels.telegram.allowFrom, or set groupPolicy to "open".',
+    );
+  });
+
+  it("keeps parent groupAllowFrom warning when an implicit default account is active", () => {
+    const warnings = scanEmptyAllowlistPolicyWarnings(
+      {
+        channels: {
+          "qa-channel": {
+            baseUrl: "http://127.0.0.1:18789",
+            groupPolicy: "allowlist",
+            groupAllowFrom: [],
+            accounts: {
+              work: { groupAllowFrom: ["qa:group:work"] },
+            },
+          },
+        },
+      },
+      { doctorFixCommand: "openclaw doctor --fix" },
+    );
+
+    expect(warnings).toContain(
+      '- channels.qa-channel.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to channels.qa-channel.groupAllowFrom or channels.qa-channel.allowFrom, or set groupPolicy to "open".',
     );
   });
 

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -1,6 +1,7 @@
 // Doctor scanner for empty allowlist policies across configured channels and accounts.
 import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizeAccountId } from "../../../routing/account-id.js";
 import {
   getDoctorChannelCapabilities,
   listDoctorChannelAccountIds,
@@ -101,7 +102,7 @@ export function scanEmptyAllowlistPolicyWarnings(
           Boolean(account && typeof account === "object" && !isDisabledRecord(account)),
         )
       : [];
-    const configuredAccountIds = new Set(Object.keys(accounts ?? {}));
+    const configuredAccountIds = new Set(Object.keys(accounts ?? {}).map(normalizeAccountId));
     const runtimeAccountIds = listDoctorChannelAccountIds(channelName, cfg);
     const hasImplicitActiveAccount =
       runtimeAccountIds === undefined ||

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -1,7 +1,10 @@
 // Doctor scanner for empty allowlist policies across configured channels and accounts.
 import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { getDoctorChannelCapabilities } from "../channel-capabilities.js";
+import {
+  getDoctorChannelCapabilities,
+  listDoctorChannelAccountIds,
+} from "../channel-capabilities.js";
 import type { DoctorAccountRecord, DoctorAllowFromList } from "../types.js";
 import { hasAllowFromEntries } from "./allowlist.js";
 import { collectEmptyAllowlistPolicyWarningsForAccount } from "./empty-allowlist-policy.js";
@@ -98,8 +101,14 @@ export function scanEmptyAllowlistPolicyWarnings(
           Boolean(account && typeof account === "object" && !isDisabledRecord(account)),
         )
       : [];
+    const configuredAccountIds = new Set(Object.keys(accounts ?? {}));
+    const runtimeAccountIds = listDoctorChannelAccountIds(channelName, cfg);
+    const hasImplicitActiveAccount =
+      runtimeAccountIds === undefined ||
+      runtimeAccountIds.some((accountId) => !configuredAccountIds.has(accountId));
     const suppressParentGroupAllowlistWarning =
       activeAccounts.length > 0 &&
+      !hasImplicitActiveAccount &&
       channelConfig.groupPolicy === "allowlist" &&
       activeAccounts.every((account) => {
         const rawGroupAllowFrom =

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -106,7 +106,9 @@ export function scanEmptyAllowlistPolicyWarnings(
     const runtimeAccountIds = listDoctorChannelAccountIds(channelName, cfg);
     const hasImplicitActiveAccount =
       runtimeAccountIds === undefined ||
-      runtimeAccountIds.some((accountId) => !configuredAccountIds.has(accountId));
+      runtimeAccountIds.some(
+        (accountId) => !configuredAccountIds.has(normalizeAccountId(accountId)),
+      );
     const suppressParentGroupAllowlistWarning =
       activeAccounts.length > 0 &&
       !hasImplicitActiveAccount &&

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -1,7 +1,9 @@
 // Doctor scanner for empty allowlist policies across configured channels and accounts.
 import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { getDoctorChannelCapabilities } from "../channel-capabilities.js";
 import type { DoctorAccountRecord, DoctorAllowFromList } from "../types.js";
+import { hasAllowFromEntries } from "./allowlist.js";
 import { collectEmptyAllowlistPolicyWarningsForAccount } from "./empty-allowlist-policy.js";
 import { asObjectRecord } from "./object.js";
 
@@ -37,6 +39,7 @@ export function scanEmptyAllowlistPolicyWarnings(
     prefix: string,
     channelName: string,
     parent?: DoctorAccountRecord,
+    options: { suppressGroupAllowlistWarning?: boolean } = {},
   ) => {
     const accountDm = asObjectRecord(account.dm);
     const parentDm = asObjectRecord(parent?.dm);
@@ -61,8 +64,9 @@ export function scanEmptyAllowlistPolicyWarnings(
         doctorFixCommand: params.doctorFixCommand,
         parent,
         prefix,
-        shouldSkipDefaultEmptyGroupAllowlistWarning:
-          params.shouldSkipDefaultEmptyGroupAllowlistWarning,
+        shouldSkipDefaultEmptyGroupAllowlistWarning: (context) =>
+          options.suppressGroupAllowlistWarning ||
+          Boolean(params.shouldSkipDefaultEmptyGroupAllowlistWarning?.(context)),
       }),
     );
     if (params.extraWarningsForAccount) {
@@ -88,9 +92,43 @@ export function scanEmptyAllowlistPolicyWarnings(
     if (isDisabledRecord(channelConfig)) {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, channelName);
-
     const accounts = asObjectRecord(channelConfig.accounts);
+    const activeAccounts = accounts
+      ? Object.values(accounts).filter((account): account is DoctorAccountRecord =>
+          Boolean(account && typeof account === "object" && !isDisabledRecord(account)),
+        )
+      : [];
+    const suppressParentGroupAllowlistWarning =
+      activeAccounts.length > 0 &&
+      channelConfig.groupPolicy === "allowlist" &&
+      activeAccounts.every((account) => {
+        const rawGroupAllowFrom =
+          (account.groupAllowFrom as DoctorAllowFromList | undefined) ??
+          (channelConfig.groupAllowFrom as DoctorAllowFromList | undefined);
+        const groupAllowFrom = hasAllowFromEntries(rawGroupAllowFrom)
+          ? rawGroupAllowFrom
+          : undefined;
+        if (hasAllowFromEntries(groupAllowFrom)) {
+          return true;
+        }
+        if (!getDoctorChannelCapabilities(channelName).groupAllowFromFallbackToAllowFrom) {
+          return false;
+        }
+        const accountDm = asObjectRecord(account.dm);
+        const parentDm = asObjectRecord(channelConfig.dm);
+        const effectiveAllowFrom =
+          (account.allowFrom as DoctorAllowFromList | undefined) ??
+          (channelConfig.allowFrom as DoctorAllowFromList | undefined) ??
+          (accountDm?.allowFrom as DoctorAllowFromList | undefined) ??
+          (parentDm?.allowFrom as DoctorAllowFromList | undefined) ??
+          undefined;
+        return hasAllowFromEntries(effectiveAllowFrom);
+      });
+
+    checkAccount(channelConfig, `channels.${channelName}`, channelName, undefined, {
+      suppressGroupAllowlistWarning: suppressParentGroupAllowlistWarning,
+    });
+
     if (!accounts) {
       continue;
     }

--- a/src/commands/doctor/shared/empty-allowlist-scan.ts
+++ b/src/commands/doctor/shared/empty-allowlist-scan.ts
@@ -1,10 +1,9 @@
 // Doctor scanner for empty allowlist policies across configured channels and accounts.
 import type { ChannelDoctorEmptyAllowlistAccountContext } from "../../../channels/plugins/types.adapters.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { normalizeAccountId } from "../../../routing/account-id.js";
 import {
   getDoctorChannelCapabilities,
-  listDoctorChannelAccountIds,
+  resolveDoctorChannelAccountIds,
 } from "../channel-capabilities.js";
 import type { DoctorAccountRecord, DoctorAllowFromList } from "../types.js";
 import { hasAllowFromEntries } from "./allowlist.js";
@@ -102,13 +101,15 @@ export function scanEmptyAllowlistPolicyWarnings(
           Boolean(account && typeof account === "object" && !isDisabledRecord(account)),
         )
       : [];
-    const configuredAccountIds = new Set(Object.keys(accounts ?? {}).map(normalizeAccountId));
-    const runtimeAccountIds = listDoctorChannelAccountIds(channelName, cfg);
+    const accountIds = resolveDoctorChannelAccountIds(
+      channelName,
+      cfg,
+      Object.keys(accounts ?? {}),
+    );
+    const configuredAccountIds = new Set(accountIds?.configured);
     const hasImplicitActiveAccount =
-      runtimeAccountIds === undefined ||
-      runtimeAccountIds.some(
-        (accountId) => !configuredAccountIds.has(normalizeAccountId(accountId)),
-      );
+      accountIds === undefined ||
+      accountIds.runtime.some((accountId) => !configuredAccountIds.has(accountId));
     const suppressParentGroupAllowlistWarning =
       activeAccounts.length > 0 &&
       !hasImplicitActiveAccount &&


### PR DESCRIPTION
## Summary
- avoid reporting the parent channel scope as an empty group allowlist when active accounts all have effective group allowlists
- keep the parent warning when any active account would still inherit an empty group allowlist
- add regression coverage for both the false-positive and mixed-account cases

Fixes openclaw/openclaw#92684

## Tests
- `CI=1 NO_COLOR=1 pnpm vitest run --config test/vitest/vitest.commands.config.ts src/commands/doctor/shared/empty-allowlist-scan.test.ts`
- `CI=1 NO_COLOR=1 pnpm vitest run --config test/vitest/vitest.commands.config.ts src/commands/doctor/shared/channel-doctor.test.ts`
- `CI=1 NO_COLOR=1 pnpm vitest run --config test/vitest/vitest.extension-telegram.config.ts telegram/src/doctor.test.ts`
- `pnpm check:test-types`
- `git diff --check`
