### PR TITLE
fix(agents): bound autoreview scope

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -24,7 +24,7 @@ Use when:
 - Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
 - When an accepted finding shows a bug class or repeated pattern, inspect the current PR scope for sibling instances before fixing.
 - Fix the scoped bug class at once when practical; stop at touched surfaces, owner boundaries, and clear follow-up territory.
-- Keep going until structured review returns no accepted/actionable findings.
+- Keep going until structured review returns no accepted/actionable findings only while the work remains inside the original task scope.
 - If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
 - For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
 - Never switch or override the requested review engine/model. If the review hits model capacity, retry the same command a few times with the same engine/model.
@@ -42,6 +42,42 @@ Use when:
 - If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
 - If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
 - Do not push just to review. Push only when the user requested push/ship/PR update.
+
+## Scope Governor
+
+Autoreview is a closeout gate, not permission to rewrite the task.
+
+Before the first review, freeze a scope baseline: original request or issue, target branch, intended behavior, owner boundary, changed files, and non-test LOC. For inherited or already-bloated branches, use the intended PR diff as the baseline rather than accepting all existing branch drift.
+
+Before patching a finding, classify it:
+
+- **In-scope blocker**: the finding is introduced by the current diff, affects the same owner boundary, and can be fixed without changing the task's contract.
+- **Follow-up**: the finding is real but belongs to an adjacent bug class, sibling surface, cleanup, or broader hardening track.
+- **Stop-and-escalate**: the finding requires a new protocol/config/storage/public API contract, a different owner boundary, a release-process change, or a design choice outside the original request.
+
+Stop patching and report the scope break instead of continuing when:
+
+- a narrow PR turns into an architecture change, protocol change, migration, or release-process change;
+- the diff grows past 2x the original files or non-test LOC without explicit approval to expand scope;
+- two review-triggered patch cycles have not converged; pause and reclassify every remaining finding before another edit;
+- the best fix is "define the canonical contract first" rather than another local inference layer;
+- fixing the accepted finding would make the PR no longer describe the same behavior, issue, or owner boundary.
+
+After the two-cycle pause, continue only when every remaining accepted finding is still an in-scope blocker. Otherwise preserve the useful analysis, identify the smallest safe landed subset if one exists, and open or request a follow-up for the larger fix. Do not keep committing speculative fixes just to satisfy the reviewer.
+
+Do not stack or push review-triggered fix commits while scope classification or focused proof is unresolved. Keep exploratory edits local until the cycle is proven in scope; if scope breaks, remove them from the landing lane instead of preserving them as branch history.
+
+Critical exceptions must be explicit: active data loss, crash, broken install/upgrade, release blocker, or concrete security exposure. If the exception is not one of those, it is not critical enough to blow up scope.
+
+## Release Branches And Release Process
+
+On release, beta, stable, hotfix, signing, notarization, appcast, package-publish, or release-check work, use freeze discipline even when the branch name is not release-like:
+
+- Fix only release blockers, failed release infrastructure, exact backports, install/upgrade breakage, data loss, crashes, or concrete security exposure.
+- Treat non-blocking autoreview findings as follow-ups for `main`, not reasons to broaden the release branch.
+- Do not introduce new product behavior, config surface, protocol shape, migration, plugin ownership, docs narrative, or process policy unless it directly unblocks the release.
+- Keep proof tied to the release target: exact branch/ref, failing check or shipped-risk reason, smallest command/proof, and whether the fix must also forward-port to `main`.
+- If review discovers a real but non-critical design problem during release closeout, stop with a follow-up issue/PR plan; do not use the release branch as the refactor lane.
 
 ## Pick Target
 

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -440,8 +440,36 @@ def load_datasets(args: argparse.Namespace) -> str:
     return "\n\n".join(chunks)
 
 
+def review_scope_policy() -> str:
+    return textwrap.dedent(
+        """
+        Review scope discipline:
+        - This helper is a closeout gate. Do not turn a narrow patch into a broad
+          redesign request.
+        - Report a finding only when this diff introduces or exposes a concrete
+          defect that must be fixed before this target can land.
+        - If the best fix requires a new protocol, config, storage, public API,
+          release process, migration, owner-boundary move, or canonical contract,
+          say that directly in the finding and keep the finding tied to the
+          smallest changed line that proves the current patch is not landable.
+        - Do not ask for sibling-surface hardening, cleanup, refactors, or
+          follow-up architecture work unless the current diff is incorrect
+          without that work.
+        - Prefer the smallest correct pre-merge fix. A broader ideal design is
+          not an actionable finding unless the current patch cannot safely land.
+        - If this is release-branch or release-process work, apply freeze
+          discipline. Report only release blockers, exact backport regressions,
+          install/upgrade breakage, crashes, data loss, concrete security
+          exposure, or release-infrastructure failures. Non-blocking design,
+          cleanup, and hardening concerns belong on main as follow-ups.
+        """
+    ).strip()
+
+
 def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
     target_line = f"{target} {target_ref}" if target_ref else target
+    branch = current_branch(repo)
+    scope_policy = review_scope_policy()
     return textwrap.dedent(
         f"""
         You are a senior code reviewer. Review the provided git change bundle only.
@@ -463,7 +491,10 @@ def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, e
         - If there are no actionable findings, return an empty findings array and mark the patch correct.
 
         Review target: {target_line}
+        Current branch: {branch}
         Repository: {repo}
+
+        {scope_policy}
 
         {extra_prompt}
 

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import runpy
 import shutil
 import stat
 import subprocess
@@ -145,8 +146,23 @@ def create_fixture_repo(repo: Path, fixture: str) -> None:
     write_fixture_file(repo, MALICIOUS_CHANGED if fixture == "malicious" else BENIGN_CHANGED)
 
 
+def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
+    namespace = runpy.run_path(str(autoreview))
+    prompt = namespace["build_prompt"](repo, "local", None, "fixture diff", "", "")
+    required = (
+        "This helper is a closeout gate.",
+        "Do not turn a narrow patch into a broad",
+        "If this is release-branch or release-process work",
+        "Non-blocking design,",
+    )
+    missing = [needle for needle in required if needle not in prompt]
+    if missing:
+        raise RuntimeError(f"autoreview prompt missing scope policy: {missing}")
+
+
 def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
     autoreview = script_dir / "autoreview"
+    validate_prompt_policy(repo, autoreview)
     for engine in engines:
         print(f"== {engine} ==", flush=True)
         command = [


### PR DESCRIPTION
## Summary

- Prevent autoreview closeout from expanding a narrow landing task into a broader redesign without an explicit scope decision.
- Freeze an original scope baseline, classify review findings, pause after two non-converging review cycles, and stop speculative review-fix commit stacking.
- Apply tighter freeze discipline to release and release-process work, and embed the same bounded-review policy in the helper prompt.
- Add a deterministic harness assertion so future prompt edits cannot silently remove the scope and release guardrails.

A local retrospective across Codex sessions repeatedly showed valid review findings turning narrow landing or CI work into larger architectural lanes. This matters now because #92969 reproduced the failure mode: the review findings were useful, but the operator loop lacked a hard scope-break condition.

Intended outcome: autoreview still blocks concrete defects introduced by the patch, while broader design work becomes an explicit follow-up instead of silently accumulating in the landing branch.

Intentionally out of scope: changing product runtime behavior, release implementation, protocols, config, storage, or the structured review schema.

Review focus: whether the stop conditions are strict enough without hiding a concrete defect that must block landing.

AI-assisted: yes.

## Linked context

Related #92969

Requested by a maintainer as follow-up to a review-driven scope-drift incident.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: autoreview scope drift and release-work overreach.
- Real environment tested: local OpenClaw worktree plus Blacksmith Testbox through Crabbox.
- Exact steps or command run after this patch: live bundled autoreview against the 3-file local diff; deterministic prompt-policy assertion; remote `pnpm check:changed`.
- Evidence after fix: autoreview returned `patch is correct` with zero findings; Testbox `tbx_01kv6v778mqm9fqd0382ghbabm` completed the changed gate with exit 0: https://github.com/openclaw/openclaw/actions/runs/27584183756
- Observed result after fix: the generated reviewer prompt contains both narrow-closeout and conditional release-freeze policy, and the existing harness verifies those policy markers.
- What was not tested: full live malicious/benign multi-engine harness fixtures; no engine-selection or structured-output behavior changed.
- Proof limitations or environment constraints: the prompt-policy regression check is deterministic; model compliance remains advisory by design.

## Tests and validation

- `python3 skills/skill-creator/scripts/quick_validate.py .agents/skills/autoreview`
- `PYTHONPYCACHEPREFIX=/tmp/autoreview-pycache python3 -m py_compile .agents/skills/autoreview/scripts/autoreview .agents/skills/autoreview/scripts/test-review-harness.py`
- Deterministic `validate_prompt_policy` harness assertion
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output --prompt '<scope baseline>'` - clean, zero findings, 0.97 confidence
- Testbox-through-Crabbox `pnpm check:changed` - `tbx_01kv6v778mqm9fqd0382ghbabm`, exit 0

Regression coverage added: the existing review harness now fails if the helper prompt loses the closeout-scope or release-freeze policy.

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: the tighter prompt could discourage a reviewer from reporting a broad but necessary blocker.

Mitigation: the policy still requires concrete defects introduced or exposed by the diff to block landing, and explicitly allows broad findings when the current patch cannot safely land without the larger contract change.

## Current review state

Next action: land the rebased single-commit PR.

Exact head: `016b3e1c449b38ba68fe50228c305b77d6391018`.

Addressed review state: bundled autoreview clean with zero findings; deterministic policy assertion green; Testbox-through-Crabbox changed gate green at `tbx_01kv6v778mqm9fqd0382ghbabm`; no unresolved review threads. Public exact-SHA CI started after the rebase, and branch protection reports no required checks.
