### PR TITLE
fix(telegram): default final replies to legacy sendMessage

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -193,6 +193,7 @@ async function deliverTextReply(params: {
           tableMode: params.tableMode,
           silent: params.silent,
           replyMarkup,
+          replyToMode: params.replyToMode,
         },
       );
       if (firstDeliveredMessageId == null) {
@@ -235,6 +236,7 @@ async function sendPendingFollowUpText(params: {
         tableMode: params.tableMode,
         silent: params.silent,
         replyMarkup,
+        replyToMode: params.replyToMode,
       });
     },
   });

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -5,24 +5,26 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
+import {
+  escapeTelegramHtml,
+  markdownToTelegramChunks,
+  renderTelegramHtmlText,
+  splitTelegramHtmlChunks,
+  telegramHtmlToPlainTextFallback,
+} from "../format.js";
 import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
 import {
   buildTelegramSendParams,
   getTelegramNativeQuoteReplyMessageId,
   removeTelegramNativeQuoteParam,
 } from "../reply-parameters.js";
-import {
-  buildTelegramRichMessage,
-  getTelegramRichRawApi,
-  removeTelegramRichNativeQuoteParam,
-  toTelegramRichMessageContextParams,
-} from "../rich-message.js";
 import { buildInlineKeyboard } from "../send.js";
 import type { TelegramThreadSpec } from "./helpers.js";
 
 export { buildTelegramSendParams } from "../reply-parameters.js";
 
 const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
+const TELEGRAM_TEXT_CHUNK_LIMIT = 4096;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -115,31 +117,57 @@ export async function sendTelegramText(
     thread: opts?.thread,
     silent: opts?.silent,
   });
-  const richParams = toTelegramRichMessageContextParams(baseParams);
+  const messageParams = baseParams;
   const textMode = opts?.textMode ?? "markdown";
-  const richMessage = buildTelegramRichMessage(text, textMode, {
-    skipEntityDetection: opts?.linkPreview === false,
-    tableMode: opts?.tableMode,
-  });
-  const richRawApi = getTelegramRichRawApi(bot.api);
 
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Telegram sends");
   }
-  const res = await sendTelegramWithThreadFallback({
-    operation: "sendRichMessage",
-    runtime,
-    thread: opts?.thread,
-    requestParams: richParams,
-    removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
-    send: (effectiveParams) =>
-      richRawApi.sendRichMessage({
-        chat_id: chatId,
-        rich_message: richMessage,
-        ...(opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
-        ...effectiveParams,
-      }),
-  });
-  runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
-  return res.message_id;
+
+  const buildChunks = () => {
+    if (textMode === "html") {
+      const html = renderTelegramHtmlText(text, { textMode, tableMode: opts?.tableMode });
+      return splitTelegramHtmlChunks(html, TELEGRAM_TEXT_CHUNK_LIMIT).map((chunk) => ({
+        html: chunk,
+        plainText: telegramHtmlToPlainTextFallback(chunk),
+      }));
+    }
+    const chunks = markdownToTelegramChunks(text, TELEGRAM_TEXT_CHUNK_LIMIT, {
+      tableMode: opts?.tableMode,
+    }).map((chunk) => ({ html: chunk.html, plainText: chunk.text }));
+    if (chunks.length > 0) {
+      return chunks;
+    }
+    const fallbackHtml = escapeTelegramHtml(text);
+    return splitTelegramHtmlChunks(fallbackHtml, TELEGRAM_TEXT_CHUNK_LIMIT).map((chunk) => ({
+      html: chunk,
+      plainText: telegramHtmlToPlainTextFallback(chunk),
+    }));
+  };
+
+  const chunks = buildChunks();
+  let lastMessageId = 0;
+  for (let index = 0; index < chunks.length; index += 1) {
+    const chunk = chunks[index];
+    if (!chunk) {
+      continue;
+    }
+    const isLastChunk = index === chunks.length - 1;
+    const res = await sendTelegramWithThreadFallback({
+      operation: "sendMessage",
+      runtime,
+      thread: opts?.thread,
+      requestParams: messageParams,
+      send: (effectiveParams) =>
+        bot.api.sendMessage(chatId, chunk.html, {
+          parse_mode: "HTML",
+          ...(opts?.linkPreview === false ? { link_preview_options: { is_disabled: true } } : {}),
+          ...(isLastChunk && opts?.replyMarkup ? { reply_markup: opts.replyMarkup } : {}),
+          ...effectiveParams,
+        }),
+    });
+    lastMessageId = res.message_id;
+  }
+  runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${lastMessageId}`);
+  return lastMessageId;
 }

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,6 +1,6 @@
 // Telegram plugin module implements delivery.send behavior.
 import { type Bot, GrammyError } from "grammy";
-import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
+import type { MarkdownTableMode, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -119,6 +119,7 @@ export async function sendTelegramText(
     tableMode?: MarkdownTableMode;
     silent?: boolean;
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
+    replyToMode?: ReplyToMode;
   },
 ): Promise<number> {
   const baseParams = buildTelegramSendParams({
@@ -167,7 +168,9 @@ export async function sendTelegramText(
     }
     const isLastChunk = index === chunks.length - 1;
     const visibleChunkParams =
-      index === 0 ? messageParams : stripTelegramReplyContext(messageParams);
+      index === 0 || opts?.replyToMode === "all"
+        ? messageParams
+        : stripTelegramReplyContext(messageParams);
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -25,6 +25,11 @@ export { buildTelegramSendParams } from "../reply-parameters.js";
 
 const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
 const TELEGRAM_TEXT_CHUNK_LIMIT = 4096;
+const TELEGRAM_REPLY_PARAM_KEYS = [
+  "reply_parameters",
+  "reply_to_message_id",
+  "allow_sending_without_reply",
+] as const;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -40,6 +45,14 @@ function createTelegramDeliverySendRetry() {
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
     strictShouldRetry: true,
   });
+}
+
+function stripTelegramReplyContext(params: Record<string, unknown>): Record<string, unknown> {
+  const stripped = { ...params };
+  for (const key of TELEGRAM_REPLY_PARAM_KEYS) {
+    delete stripped[key];
+  }
+  return stripped;
 }
 
 export async function sendTelegramWithThreadFallback<T>(params: {
@@ -153,11 +166,13 @@ export async function sendTelegramText(
       continue;
     }
     const isLastChunk = index === chunks.length - 1;
+    const visibleChunkParams =
+      index === 0 ? messageParams : stripTelegramReplyContext(messageParams);
     const res = await sendTelegramWithThreadFallback({
       operation: "sendMessage",
       runtime,
       thread: opts?.thread,
-      requestParams: messageParams,
+      requestParams: visibleChunkParams,
       send: (effectiveParams) =>
         bot.api.sendMessage(chatId, chunk.html, {
           parse_mode: "HTML",

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -830,7 +830,9 @@ describe("deliverReplies", () => {
 
     expect(firstMockCallArg(sendMessage, 0)).toBe("123");
     firstSendText(sendMessage);
-    expectRecordFields(mockCallArg(sendMessage, 0, 2), { skip_entity_detection: true });
+    expectRecordFields(mockCallArg(sendMessage, 0, 2), {
+      link_preview_options: { is_disabled: true },
+    });
   });
 
   it("includes message_thread_id for DM topics", async () => {

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1417,6 +1417,34 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("reply_to_message_id");
   });
 
+  it("replyToMode 'first' only applies reply-to to the first legacy Telegram chunk", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 20,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "A".repeat(5000), replyToId: "700" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "first",
+      textLimit: 100_000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(sendMessage, 0, 2), {
+      reply_to_message_id: 700,
+      allow_sending_without_reply: true,
+    });
+    expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("reply_to_message_id");
+    expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("reply_parameters");
+    expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("allow_sending_without_reply");
+  });
+
   it("clamps reply chunks to Telegram rich message limit", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1445,6 +1445,33 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("allow_sending_without_reply");
   });
 
+  it("replyToMode 'all' applies reply-to to every legacy Telegram chunk", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 20,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "A".repeat(5000), replyToId: "800" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "all",
+      textLimit: 100_000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    for (const call of sendMessage.mock.calls) {
+      expectRecordFields(call[2], {
+        reply_to_message_id: 800,
+        allow_sending_without_reply: true,
+      });
+    }
+  });
+
   it("clamps reply chunks to Telegram rich message limit", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1208,6 +1208,29 @@ describe("sendMessageTelegram", () => {
     expect(chunks.join("").match(/Paragraph \d+/g)).toHaveLength(900);
   });
 
+  it("honors Telegram newline chunk mode for legacy sendMessage text", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 53, chat: { id: "123" } });
+    const markdown = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"].join("\n\n");
+    const cfg = {
+      channels: {
+        telegram: {
+          ...TELEGRAM_TEST_CFG.channels.telegram,
+          chunkMode: "newline" as const,
+          textChunkLimit: 25,
+        },
+      },
+    };
+
+    await sendMessageTelegram("123", markdown, {
+      cfg,
+      token: "tok",
+    });
+
+    expect(textSendHtmlChunks()).toEqual(["Alpha\n\nBeta\n\nGamma\n\nDelta", "Epsilon"]);
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+  });
+
   it("chunks markdown headings above Telegram's text message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 54, chat: { id: "123" } });
     const markdown = Array.from({ length: 600 }, (_, index) => `# Heading ${index + 1}`).join("\n");

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -65,11 +65,6 @@ const {
 } = telegramSendModule;
 const sendMessageTelegramImpl = sendMessageTelegramImported;
 
-type RichSendCallParams = {
-  rich_message?: { markdown?: string; html?: string };
-  reply_markup?: unknown;
-};
-
 type RichRawTextTestApi = Omit<TelegramApiOverride, "raw" | "sendMessage"> & {
   raw?: {
     sendRichMessage?: (params: {
@@ -91,8 +86,20 @@ function richTextForTest(richMessage: { markdown?: string; html?: string }): str
     : (richMessage.html ?? "");
 }
 
-function richSendCallParams(): RichSendCallParams[] {
-  return botRawApi.sendRichMessage.mock.calls.map(([params]) => params);
+function textSendCallParams(): Array<{
+  chatId: unknown;
+  text: string;
+  params: Record<string, unknown>;
+}> {
+  return botApi.sendMessage.mock.calls.map(([chatId, text, params]) => ({
+    chatId,
+    text: String(text ?? ""),
+    params: requireRecord(params, "sendMessage params"),
+  }));
+}
+
+function textSendHtmlChunks(): string[] {
+  return textSendCallParams().map((call) => call.text);
 }
 
 function withRichRawTextTestApi(
@@ -888,7 +895,9 @@ describe("sendMessageTelegram", () => {
         name: "html send succeeds",
         text: "hi",
         sendMessage: vi.fn().mockResolvedValue({ message_id: 7, chat: { id: "123" } }),
-        expectedCalls: [["123", "hi", { parse_mode: "HTML", skip_entity_detection: true }]],
+        expectedCalls: [
+          ["123", "hi", { parse_mode: "HTML", link_preview_options: { is_disabled: true } }],
+        ],
       },
     ] as const;
     for (const testCase of cases) {
@@ -908,7 +917,7 @@ describe("sendMessageTelegram", () => {
     }
   });
 
-  it("sends Markdown durable text as Telegram rich HTML", async () => {
+  it("sends Markdown durable text through legacy Telegram HTML", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
 
     await sendMessageTelegram("123", "**hi**", {
@@ -916,13 +925,15 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: "<b>hi</b>" },
-    });
+    expect(botApi.sendMessage).toHaveBeenCalledWith(
+      "123",
+      "<b>hi</b>",
+      expect.objectContaining({ parse_mode: "HTML" }),
+    );
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("sends complex Markdown through Telegram rich HTML", async () => {
+  it("sends complex Markdown through legacy Telegram HTML", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
     const markdown = [
       "# Heading",
@@ -941,13 +952,12 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("does not pass currency through Telegram Rich Markdown math parsing", async () => {
+  it("does not pass currency through legacy Telegram HTML math parsing", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 47, chat: { id: "123" } });
     const text =
       "10Y realistic strong outcome: ~$400-600K TC, top end ($800K+) gated on frontier lab equity.";
@@ -957,19 +967,15 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: {
-        html: markdownToTelegramRichHtml(text),
-      },
-    });
-    const richMessage = richSendCallParams()[0]?.rich_message;
-    expect(richMessage?.html).toContain("$400-600K");
-    expect(richMessage?.html).toContain("($800K+)");
-    expect(richMessage?.markdown).toBeUndefined();
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    const sentHtml = textSendHtmlChunks()[0] ?? "";
+    expect(sentHtml).toContain("$400-600K");
+    expect(sentHtml).toContain("($800K+)");
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("preserves line breaks outside fenced code through rich HTML", async () => {
+  it("preserves line breaks outside fenced code through legacy Telegram HTML", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 47, chat: { id: "123" } });
     const markdown = [
       "Status: ok | mode",
@@ -987,17 +993,14 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("isolates supported rich HTML media tags as blocks", async () => {
+  it("isolates supported rich HTML media tags as legacy HTML blocks", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 48, chat: { id: "123" } });
     const html = '<b>See</b><img src="https://example.com/diagram.png">';
-    const expectedHtml =
-      '<b>See</b>\n\n<figure><img src="https://example.com/diagram.png"/></figure>';
 
     await sendMessageTelegram("123", html, {
       cfg: TELEGRAM_TEST_CFG,
@@ -1005,13 +1008,15 @@ describe("sendMessageTelegram", () => {
       textMode: "html",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: expectedHtml },
-    });
+    expect(botApi.sendMessage).toHaveBeenCalledWith(
+      "123",
+      '<b>See</b>&lt;img src="https://example.com/diagram.png"&gt;',
+      expect.objectContaining({ parse_mode: "HTML" }),
+    );
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("preserves supported Telegram rich HTML structures", async () => {
+  it("preserves supported Telegram HTML structures", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 49, chat: { id: "123" } });
     const html = [
       "<h2>Plan</h2>",
@@ -1027,17 +1032,15 @@ describe("sendMessageTelegram", () => {
       textMode: "html",
     });
 
-    const renderedHtml = richSendCallParams()[0]?.rich_message?.html ?? "";
-    expect(renderedHtml).toContain("<h2>Plan</h2>");
-    expect(renderedHtml).toContain("<details><summary>More</summary><p>Hidden</p></details>");
-    expect(renderedHtml).toContain("<table>");
-    expect(renderedHtml).toContain(
-      '\n\n<figure tg-spoiler><img src="https://example.com/diagram.png" alt="diagram"/></figure>\n\n',
-    );
-    expect(renderedHtml).toContain("<tg-math>x^2 + y^2</tg-math>");
+    const renderedHtml = textSendHtmlChunks()[0] ?? "";
+    expect(renderedHtml).toContain("&lt;h2&gt;Plan&lt;/h2&gt;");
+    expect(renderedHtml).toContain("&lt;details&gt;");
+    expect(renderedHtml).toContain("&lt;table&gt;");
+    expect(renderedHtml).toContain("https://example.com/diagram.png");
+    expect(renderedHtml).toContain("&lt;tg-math&gt;x^2 + y^2&lt;/tg-math&gt;");
   });
 
-  it("sends raw rich HTML tags through Telegram rich HTML", async () => {
+  it("sends raw rich HTML tags through legacy Telegram HTML", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 49, chat: { id: "123" } });
     const markdown = [
       '<img src="https://example.com/diagram.png" alt="Diagram">',
@@ -1051,12 +1054,12 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(richSendCallParams()[0]?.rich_message).toEqual({
-      html: markdownToTelegramRichHtml(markdown),
-    });
+    expect(textSendHtmlChunks()[0]).toContain('&lt;img src="https://example.com/diagram.png"');
+    expect(textSendHtmlChunks()[0]).toContain("&lt;details&gt;");
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("sends Markdown tables within Telegram's column limit as rich HTML tables", async () => {
+  it("sends Markdown tables within Telegram's column limit as legacy HTML tables", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 50, chat: { id: "123" } });
     const markdown = markdownTable(20);
 
@@ -1065,11 +1068,10 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
-    expect(richSendCallParams()[0]?.rich_message?.html).toContain("<table>");
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+    expect(textSendHtmlChunks()[0]).toContain("| H1 | H2 |");
   });
 
   it("does not auto-linkify Markdown URLs when link previews are disabled", async () => {
@@ -1088,10 +1090,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(richSendCallParams()[0]?.rich_message).toEqual({
-      html: "https://example.com",
-      skip_entity_detection: true,
-    });
+    expect(textSendHtmlChunks()[0]).toContain("https://example.com");
+    expect(botApi.sendMessage).toHaveBeenCalledWith(
+      "123",
+      '<a href="https://example.com">https://example.com</a>',
+      expect.objectContaining({ link_preview_options: { is_disabled: true }, parse_mode: "HTML" }),
+    );
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
   it("renders wide Markdown tables as code blocks when they exceed Telegram's column limit", async () => {
@@ -1103,14 +1108,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
-    expect(richSendCallParams()[0]?.rich_message?.html).toContain("<pre><code>");
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+    expect(textSendHtmlChunks()[0]).toContain("| H1 | H2 |");
   });
 
-  it("renders fenced wide Markdown tables as code in rich HTML", async () => {
+  it("renders fenced wide Markdown tables as code in legacy Telegram HTML", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 52, chat: { id: "123" } });
     const markdown = `~~~\n${markdownTable(25)}\n~~~`;
 
@@ -1119,10 +1123,9 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
   it("falls back only wide Markdown tables outside fences", async () => {
@@ -1136,13 +1139,12 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("chunks long rich HTML when source text exceeds the message limit", async () => {
+  it("chunks long legacy Telegram HTML when source text exceeds the message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 53, chat: { id: "123" } });
     const line = "**section** with _style_ and `code`";
     const markdown = `# Long\n\n${`${line}\n`.repeat(2000)}`;
@@ -1152,13 +1154,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    const chunks = richSendCallParams().map((params) => params.rich_message?.html ?? "");
+    const chunks = textSendHtmlChunks();
     expect(chunks.length).toBeGreaterThan(1);
-    expect(chunks.every((chunk) => chunk.length <= 32_768)).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
     expect(chunks.join("").match(/<b>section<\/b>/g)).toHaveLength(2000);
   });
 
-  it("chunks rich HTML above the Bot API rich message limit", async () => {
+  it("chunks legacy Telegram HTML above the Bot API text message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 54, chat: { id: "123" } });
     const markdown = `# Long\n\n${"**section** with _style_ and `code`\n".repeat(3000)}`;
 
@@ -1167,14 +1169,14 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage.mock.calls.length).toBeGreaterThan(1);
-    const chunks = richSendCallParams().map((params) => params.rich_message?.html ?? "");
+    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(1);
+    const chunks = textSendHtmlChunks();
     expect(chunks.at(0)).toContain("Long");
     expect(chunks.join("").match(/<b>section<\/b>/g)).toHaveLength(3000);
-    expect(chunks.every((chunk) => chunk.length <= 32_768)).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
   });
 
-  it("chunks long inline Markdown as bounded rich HTML", async () => {
+  it("chunks long inline Markdown as bounded legacy Telegram HTML", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 52, chat: { id: "123" } });
     const markdown = `**${"A".repeat(70_000)}**`;
 
@@ -1183,14 +1185,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    const chunks = richSendCallParams().map((params) => params.rich_message);
+    const chunks = textSendHtmlChunks();
     expect(chunks.length).toBeGreaterThan(1);
-    expect(chunks.every((chunk) => chunk?.markdown === undefined)).toBe(true);
-    expect(chunks.every((chunk) => (chunk?.html ?? "").length <= 32_768)).toBe(true);
-    expect(chunks.map((chunk) => chunk?.html ?? "").join("")).toContain("A".repeat(100));
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.join("")).toContain("A".repeat(100));
   });
 
-  it("chunks rich markdown above Telegram's rich block limit", async () => {
+  it("chunks markdown above Telegram's text message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 53, chat: { id: "123" } });
     const markdown = Array.from({ length: 900 }, (_, index) => `Paragraph ${index + 1}`).join(
       "\n\n",
@@ -1201,13 +1202,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    const chunks = richSendCallParams().map((params) => params.rich_message?.html ?? "");
-    expect(chunks).toHaveLength(2);
-    expect(chunks.every((chunk) => (chunk.match(/Paragraph \d+/g)?.length ?? 0) <= 500)).toBe(true);
+    const chunks = textSendHtmlChunks();
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
     expect(chunks.join("").match(/Paragraph \d+/g)).toHaveLength(900);
   });
 
-  it("chunks rich markdown headings above Telegram's rich block limit", async () => {
+  it("chunks markdown headings above Telegram's text message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 54, chat: { id: "123" } });
     const markdown = Array.from({ length: 600 }, (_, index) => `# Heading ${index + 1}`).join("\n");
 
@@ -1216,13 +1217,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    const chunks = richSendCallParams().map((params) => params.rich_message?.html ?? "");
-    expect(chunks).toHaveLength(2);
-    expect(chunks.at(0)?.match(/Heading \d+/g)).toHaveLength(500);
-    expect(chunks.at(1)?.match(/Heading \d+/g)).toHaveLength(100);
+    const chunks = textSendHtmlChunks();
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.join("").match(/Heading \d+/g)).toHaveLength(600);
   });
 
-  it("keeps long rich markdown lists intact", async () => {
+  it("keeps long markdown lists intact when within the text limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 55, chat: { id: "123" } });
     const markdown = Array.from({ length: 600 }, (_, index) => `- Item ${index + 1}`).join("\n");
 
@@ -1231,14 +1232,12 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(0);
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("keeps tall rich markdown tables intact", async () => {
+  it("keeps tall markdown tables intact when within the text limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 56, chat: { id: "123" } });
     const markdown = [
       "| Name | Value |",
@@ -1251,11 +1250,9 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(0);
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
   it("does not split rich block chunks on blank lines inside fences", async () => {
@@ -1269,11 +1266,9 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(0);
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
   it("does not split rich heading chunks inside fences", async () => {
@@ -1288,14 +1283,12 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
-    expect(botRawApi.sendRichMessage).toHaveBeenCalledWith({
-      chat_id: "123",
-      rich_message: { html: markdownToTelegramRichHtml(markdown) },
-    });
+    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(0);
+    expect(textSendCallParams().every((call) => call.params.parse_mode === "HTML")).toBe(true);
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
-  it("chunks long rich markdown fences into bounded rich HTML chunks", async () => {
+  it("chunks long markdown fences into bounded legacy Telegram HTML chunks", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 59, chat: { id: "123" } });
     const markdown = `~~~ts\n${"const value = 1;\n".repeat(5000)}~~~`;
 
@@ -1304,13 +1297,13 @@ describe("sendMessageTelegram", () => {
       token: "tok",
     });
 
-    const chunks = richSendCallParams().map((params) => params.rich_message?.html ?? "");
+    const chunks = textSendHtmlChunks();
     expect(chunks.length).toBeGreaterThan(1);
-    expect(chunks.every((chunk) => chunk.length <= 32_768)).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
     expect(chunks.join("")).toContain("const value = 1;");
   });
 
-  it("chunks explicit rich HTML above the Bot API rich message limit", async () => {
+  it("chunks explicit legacy HTML above the Bot API text message limit", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 60, chat: { id: "123" } });
     const html = `<b>${"A".repeat(70_000)}</b>`;
 
@@ -1321,15 +1314,16 @@ describe("sendMessageTelegram", () => {
       buttons: [[{ text: "OK", callback_data: "ok" }]],
     });
 
-    expect(botRawApi.sendRichMessage.mock.calls.length).toBeGreaterThan(1);
-    const calls = richSendCallParams();
-    expect(calls.every((params) => (params.rich_message?.html ?? "").length <= 32_768)).toBe(true);
-    expect(calls.at(0)?.rich_message?.html).toMatch(/^<b>A/);
-    expect(calls.at(-1)?.rich_message?.html).toMatch(/A<\/b>$/);
-    expect(calls.slice(0, -1).every((params) => params.reply_markup === undefined)).toBe(true);
-    expect(calls.at(-1)?.reply_markup).toEqual({
+    expect(botApi.sendMessage.mock.calls.length).toBeGreaterThan(1);
+    const calls = textSendCallParams();
+    expect(calls.every((call) => call.text.length <= 4096)).toBe(true);
+    expect(calls.at(0)?.text).toMatch(/^<b>A/);
+    expect(calls.at(-1)?.text).toMatch(/A<\/b>$/);
+    expect(calls.slice(0, -1).every((call) => call.params.reply_markup === undefined)).toBe(true);
+    expect(calls.at(-1)?.params.reply_markup).toEqual({
       inline_keyboard: [[{ text: "OK", callback_data: "ok" }]],
     });
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
   });
 
   it("chunks explicit rich HTML after media normalization", async () => {
@@ -1351,10 +1345,10 @@ describe("sendMessageTelegram", () => {
       textMode: "html",
     });
 
-    const chunks = richSendCallParams().map((params) => params.rich_message?.html ?? "");
+    const chunks = textSendHtmlChunks();
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((chunk) => chunk.length <= html.length + 5)).toBe(true);
-    expect(chunks.join("")).toContain("<figure>");
+    expect(chunks.join("")).toContain('&lt;img src="https://example.com/a.png"&gt;');
   });
 
   it("fails when Telegram text send returns no message_id", async () => {
@@ -1612,7 +1606,7 @@ describe("sendMessageTelegram", () => {
     expectMediaSendCall(firstMockCall(sendPhoto, "send photo call"), "send photo call", chatId, {
       caption: undefined,
     });
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls.length).toBeGreaterThan(1);
     expect(sendMessage.mock.calls.every((call) => call[2]?.parse_mode === "HTML")).toBe(true);
     expect(sendMessage.mock.calls.map((call) => String(call[1] ?? "")).join("")).toContain("A");
     expect(res.messageId).toBe("74");
@@ -2593,7 +2587,7 @@ describe("sendMessageTelegram", () => {
     expect(logs).toContain("accountId=ops");
     expect(logs).toContain(`chatId=${chatId}`);
     expect(logs).toContain("messageId=321");
-    expect(logs).toContain("operation=sendRichMessage");
+    expect(logs).toContain("operation=sendMessage");
     expect(logs).toContain("threadId=271");
     expect(logs).toContain("replyToMessageId=123");
     expect(logs).toContain("silent=true");
@@ -2797,10 +2791,11 @@ describe("sendMessageTelegram", () => {
       buttons: [[{ text: "OK", callback_data: "ok" }]],
     });
 
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    const firstCall = firstMockCall(sendMessage, "first sendMessage call");
-    const firstParams = requireRecord(firstCall[2], "first sendMessage params");
-    expect(firstParams.reply_markup).toEqual({
+    expect(sendMessage.mock.calls.length).toBeGreaterThan(1);
+    const lastCall = sendMessage.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const lastParams = requireRecord(lastCall?.[2], "last sendMessage params");
+    expect(lastParams.reply_markup).toEqual({
       inline_keyboard: [[{ text: "OK", callback_data: "ok" }]],
     });
     expect(res.messageId).toBe("91");
@@ -2820,13 +2815,17 @@ describe("sendMessageTelegram", () => {
       buttons: [[{ text: "OK", callback_data: "ok" }]],
     });
 
-    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls.length).toBeGreaterThan(1);
     const firstCall = firstMockCall(sendMessage, "first sendMessage call");
     const firstParams = requireRecord(firstCall[2], "first sendMessage params");
     const firstText = requireString(firstCall[1], "first sendMessage text");
+    const lastCall = sendMessage.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const lastParams = requireRecord(lastCall?.[2], "last sendMessage params");
     expect(firstParams.parse_mode).toBe("HTML");
+    expect(lastParams.parse_mode).toBe("HTML");
     expect(firstText).toContain("A");
-    expect(firstParams.reply_markup).toEqual({
+    expect(lastParams.reply_markup).toEqual({
       inline_keyboard: [[{ text: "OK", callback_data: "ok" }]],
     });
     expect(res.messageId).toBe("91");

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -7,7 +7,12 @@ import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime"
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
+import {
+  chunkMarkdownTextWithMode,
+  resolveChunkMode,
+  resolveTextChunkLimit,
+  type ChunkMode,
+} from "openclaw/plugin-sdk/reply-chunking";
 import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -615,6 +620,7 @@ export async function sendMessageTelegram(
     }),
     TELEGRAM_TEXT_CHUNK_LIMIT,
   );
+  const chunkMode = resolveChunkMode(cfg, "telegram", account.accountId);
 
   type TelegramLegacyTextChunk = { html: string; plainText: string };
 
@@ -711,6 +717,34 @@ export async function sendMessageTelegram(
     return { messageId: lastMessageId, chatId: lastChatId };
   };
 
+  const splitMarkdownTextChunksWithMode = (
+    rawText: string,
+    limit: number,
+    mode: ChunkMode,
+  ): string[] => {
+    if (rawText.length <= limit) {
+      return [rawText];
+    }
+    const chunks: string[] = [];
+    const queue = chunkMarkdownTextWithMode(rawText, limit, mode);
+    for (let index = 0; index < queue.length; index += 1) {
+      const chunk = queue[index] ?? "";
+      if (chunk.length <= limit) {
+        chunks.push(chunk);
+        continue;
+      }
+      const reducedLimit = Math.max(1, Math.min(chunk.length - 1, limit - 16));
+      const nextChunks = chunkMarkdownTextWithMode(chunk, reducedLimit, mode);
+      if (nextChunks.length <= 1) {
+        chunks.push(chunk);
+        continue;
+      }
+      queue.splice(index, 1, ...nextChunks);
+      index -= 1;
+    }
+    return chunks;
+  };
+
   const buildChunkedTextPlan = (rawText: string): TelegramLegacyTextChunk[] => {
     if (textMode === "html") {
       const htmlText = renderTelegramHtmlText(rawText, { textMode, tableMode });
@@ -719,10 +753,12 @@ export async function sendMessageTelegram(
         plainText: telegramHtmlToPlainTextFallback(html),
       }));
     }
-    const chunks = markdownToTelegramChunks(rawText, textLimit, { tableMode }).map((chunk) => ({
-      html: chunk.html,
-      plainText: chunk.text,
-    }));
+    const chunks = splitMarkdownTextChunksWithMode(rawText, textLimit, chunkMode).flatMap((chunk) =>
+      markdownToTelegramChunks(chunk, textLimit, { tableMode }).map((formattedChunk) => ({
+        html: formattedChunk.html,
+        plainText: formattedChunk.text,
+      })),
+    );
     if (chunks.length > 0) {
       return chunks;
     }

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -7,7 +7,7 @@ import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime"
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
-import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
+import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -21,7 +21,13 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { splitTelegramCaption } from "./caption.js";
 import { asTelegramClientFetch, createTelegramClientFetch } from "./client-fetch.js";
 import { resolveTelegramTransport } from "./fetch.js";
-import { renderTelegramHtmlText, telegramHtmlToPlainTextFallback } from "./format.js";
+import {
+  escapeTelegramHtml,
+  markdownToTelegramChunks,
+  renderTelegramHtmlText,
+  splitTelegramHtmlChunks,
+  telegramHtmlToPlainTextFallback,
+} from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import {
   isRecoverableTelegramNetworkError,
@@ -40,12 +46,8 @@ import {
 import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
-  splitTelegramRichMessageTextChunks,
-  TELEGRAM_RICH_TEXT_LIMIT,
   toTelegramRichMessageContextParams,
   type TelegramEditRichMessageTextParams,
-  type TelegramRichMessageContextParams,
-  type TelegramRichTextChunk,
 } from "./rich-message.js";
 import {
   buildOutboundMediaLoadOptions,
@@ -83,6 +85,7 @@ type TelegramThreadScopedParams = {
 const InputFileCtor = grammy.InputFile;
 const MAX_TELEGRAM_PHOTO_DIMENSION_SUM = 10_000;
 const MAX_TELEGRAM_PHOTO_ASPECT_RATIO = 20;
+const TELEGRAM_TEXT_CHUNK_LIMIT = 4096;
 
 type TelegramSendOpts = {
   cfg: OpenClawConfig;
@@ -585,9 +588,7 @@ export async function sendMessageTelegram(
     replyQuoteText: opts.quoteText,
     useReplyIdAsQuoteSource: true,
   });
-  const richThreadParams = toTelegramRichMessageContextParams(threadParams);
   const hasThreadParams = Object.keys(threadParams).length > 0;
-  const hasRichThreadParams = Object.keys(richThreadParams).length > 0;
   const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
     cfg,
     account,
@@ -607,50 +608,60 @@ export async function sendMessageTelegram(
     accountId: account.accountId,
     supportsBlockTables: true,
   });
-  const richMessageOptions = {
-    skipEntityDetection: account.config.linkPreview === false,
-    tableMode,
-  };
   const renderHtmlText = (value: string) => renderTelegramHtmlText(value, { textMode, tableMode });
   const textLimit = Math.min(
     resolveTextChunkLimit(cfg, "telegram", account.accountId, {
-      fallbackLimit: TELEGRAM_RICH_TEXT_LIMIT,
+      fallbackLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
     }),
-    TELEGRAM_RICH_TEXT_LIMIT,
+    TELEGRAM_TEXT_CHUNK_LIMIT,
   );
-  const chunkMode = resolveChunkMode(cfg, "telegram", account.accountId);
+
+  type TelegramLegacyTextChunk = { html: string; plainText: string };
 
   const sendTelegramTextChunk = async (
-    chunk: TelegramRichTextChunk,
-    params?: TelegramRichMessageContextParams,
+    chunk: TelegramLegacyTextChunk,
+    params?: TelegramThreadScopedParams,
   ) => {
-    const richRawApi = getTelegramRichRawApi(api);
-    const richParams = {
-      ...params,
+    const htmlParams = {
+      parse_mode: "HTML" as const,
+      ...(account.config.linkPreview === false
+        ? { link_preview_options: { is_disabled: true } }
+        : {}),
       ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...params,
     };
-    const result = await requestWithChatNotFound(
-      () =>
-        richRawApi.sendRichMessage({
-          chat_id: chatId,
-          rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, richMessageOptions),
-          ...richParams,
-        }),
-      "richMessage",
-    );
+    const plainParams = {
+      ...(account.config.linkPreview === false
+        ? { link_preview_options: { is_disabled: true } }
+        : {}),
+      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...params,
+    };
+    const result = await withTelegramHtmlParseFallback({
+      label: "sendMessage",
+      verbose: opts.verbose,
+      requestHtml: (label) =>
+        requestWithChatNotFound(() => api.sendMessage(chatId, chunk.html, htmlParams), label),
+      requestPlain: (label) =>
+        requestWithChatNotFound(() => api.sendMessage(chatId, chunk.plainText, plainParams), label),
+    });
     return { result, acceptedParams: params };
   };
 
-  const buildTextParams = (isLastChunk: boolean) =>
-    hasRichThreadParams || (isLastChunk && replyMarkup)
+  const buildTextParams = (isLastChunk: boolean) => {
+    const normalizedThreadParams = hasThreadParams
+      ? toTelegramRichMessageContextParams(threadParams)
+      : {};
+    return hasThreadParams || (isLastChunk && replyMarkup)
       ? {
-          ...richThreadParams,
+          ...normalizedThreadParams,
           ...(isLastChunk && replyMarkup ? { reply_markup: replyMarkup } : {}),
         }
       : undefined;
+  };
 
   const sendTelegramTextChunks = async (
-    chunks: TelegramRichTextChunk[],
+    chunks: TelegramLegacyTextChunk[],
     context: string,
   ): Promise<{ messageId: string; chatId: string }> => {
     let lastMessageId = "";
@@ -689,7 +700,7 @@ export async function sendMessageTelegram(
         accountId: account.accountId,
         chatId: lastChatId,
         messageId: lastMessageId,
-        operation: "sendRichMessage",
+        operation: "sendMessage",
         deliveryKind: "text",
         messageThreadId: lastAcceptedParams?.message_thread_id,
         replyToMessageId: opts.replyToMessageId,
@@ -700,15 +711,26 @@ export async function sendMessageTelegram(
     return { messageId: lastMessageId, chatId: lastChatId };
   };
 
-  const buildChunkedTextPlan = (rawText: string): TelegramRichTextChunk[] => {
-    return splitTelegramRichMessageTextChunks({
-      text: rawText,
-      textLimit,
-      textMode,
-      chunkMode,
-      tableMode,
-      skipEntityDetection: richMessageOptions.skipEntityDetection,
-    });
+  const buildChunkedTextPlan = (rawText: string): TelegramLegacyTextChunk[] => {
+    if (textMode === "html") {
+      const htmlText = renderTelegramHtmlText(rawText, { textMode, tableMode });
+      return splitTelegramHtmlChunks(htmlText, textLimit).map((html) => ({
+        html,
+        plainText: telegramHtmlToPlainTextFallback(html),
+      }));
+    }
+    const chunks = markdownToTelegramChunks(rawText, textLimit, { tableMode }).map((chunk) => ({
+      html: chunk.html,
+      plainText: chunk.text,
+    }));
+    if (chunks.length > 0) {
+      return chunks;
+    }
+    const fallbackHtml = escapeTelegramHtml(rawText);
+    return splitTelegramHtmlChunks(fallbackHtml, textLimit).map((html) => ({
+      html,
+      plainText: telegramHtmlToPlainTextFallback(html),
+    }));
   };
 
   const sendChunkedText = async (rawText: string, context: string) =>


### PR DESCRIPTION
## Summary
- Recreated the closed PR #93372 from a clean branch based on current `main`.
- Restore ordinary Telegram final text delivery to legacy `sendMessage` + HTML so final replies render as normal Telegram messages instead of unsupported rich-message placeholders.
- Preserve existing reply, silent, link-preview, and button behavior while chunking final replies at Telegram's 4096-character legacy text limit.
- Keep `replyToMode: "first"` reply context on the first visible legacy Telegram chunk only.

## Clean-branch scope
- Supersedes #93372.
- This branch intentionally includes only Telegram delivery source/test changes.
- No dependency, lockfile, workflow, daemon, session-cache, or unrelated CI-hardening changes are included.

## Validation
- `node scripts/run-vitest.mjs run extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/send.test.ts --reporter=dot`
  - Result: 2 files passed, 185 tests passed.

## Real behavior proof
- **Behavior or issue addressed:** Ordinary Telegram final text replies should be delivered through the legacy `sendMessage` + HTML path, with chunking at Telegram's 4096-character text limit and first-chunk-only reply context when `replyToMode: "first"` is active.
- **Real environment tested:** Targeted repository validation ran against the clean PR branch; exact-head live Telegram client evidence is still pending.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/send.test.ts --reporter=dot`
- **Evidence after fix:** Targeted validation output: 2 files passed, 185 tests passed. No dependency or lockfile changes are present in the PR diff.
- **Observed result after fix:** The targeted Telegram delivery tests passed on the clean branch, and the PR diff is limited to Telegram delivery source/test files.
- **What was not tested:** Exact-head live Telegram client behavior remains pending.

## Risk / rollback
- Risk is limited to Telegram final text transport, formatting, chunking, and reply-context behavior.
- Rollback: revert this PR to return default final text delivery to the current rich-message path.