### PR TITLE
fix(telegram): use native rich drafts for live previews

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -663,7 +663,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext() });
 
-    const params = expectDraftStreamParams({});
+    const params = expectDraftStreamParams({ preferNativeDraft: false });
     const renderText = params.renderText as ((text: string) => Record<string, unknown>) | undefined;
     expect(renderText?.("# Heading")).toEqual({
       text: "Heading",
@@ -694,7 +694,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { richMessages: true },
     });
 
-    const params = expectDraftStreamParams({ richMessages: true });
+    const params = expectDraftStreamParams({ richMessages: true, preferNativeDraft: true });
     const renderText = params.renderText as ((text: string) => Record<string, unknown>) | undefined;
     const preview = renderText?.("| A | B |\n| --- | --- |\n| 1 | 2 |");
     expect(preview?.richMessage).toEqual(
@@ -2568,7 +2568,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith({
       text: "Cracking\n\n`🛠️ Exec`\n`🛠️ git rev-parse --abbrev-ref HEAD`",
       richMessage: {
-        html: "<b>Cracking</b><br><b>🛠️ Exec</b><br><b>🛠️ Exec</b> <code>git rev-parse --abbrev-ref HEAD</code>",
+        html: "<b>Cracking</b><br><b>🛠️ Exec</b><br><b>🛠️ Exec</b><br> <code>git rev-parse --abbrev-ref HEAD</code>",
         skip_entity_detection: true,
       },
     });
@@ -2936,7 +2936,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
       text: "Shelling\n\n`🛠️ exit 2; command false`",
       richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>command false</code> <i>exit 2</i>",
+        html: "<b>Shelling</b><br><b>🛠️ Exec</b><br> <i>exit 2</i>; <code>command false</code>",
         skip_entity_detection: true,
       },
     });
@@ -2979,7 +2979,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.updatePreview).toHaveBeenLastCalledWith({
       text: "Shelling\n\n`🛠️ exit 2`",
       richMessage: {
-        html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>exit 2</code>",
+        html: "<b>Shelling</b><br><b>🛠️ Exec</b><br> <code>exit 2</code>",
         skip_entity_detection: true,
       },
     });
@@ -3204,7 +3204,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.updatePreview).toHaveBeenCalledWith({
       text: "Shelling\n\n`🔎 Web Search: docs lookup`\n• `tests passed`",
       richMessage: {
-        html: "<b>Shelling</b><br><b>🔎 Web Search</b> <code>docs lookup</code><br><b>Update</b> <code>tests passed</code>",
+        html: "<b>Shelling</b><br><b>🔎 Web Search</b><br> <code>docs lookup</code><br><b>Update</b><br> <code>tests passed</code>",
         skip_entity_detection: true,
       },
     });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -448,20 +448,24 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
     return renderTelegramProgressStringLine(line.text);
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
-  const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
+  const labelHtml = `<b>${escapeTelegramProgressHtml(label)}</b>`;
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
-  if (detail) {
-    parts.push(`<code>${escapeTelegramProgressHtml(clipProgressMarkdownText(detail))}</code>`);
-  } else {
-    const text = line.text.trim();
-    if (text && text !== label) {
-      parts.push(renderTelegramProgressStringLine(text));
-    }
+  const clippedDetail = detail ? clipProgressMarkdownText(detail) : undefined;
+  const status = line.status && line.status !== line.detail ? line.status : undefined;
+  if (clippedDetail && status) {
+    return `${labelHtml}<br> <i>${escapeTelegramProgressHtml(status)}</i>; <code>${escapeTelegramProgressHtml(clippedDetail)}</code>`;
   }
-  if (line.status && line.status !== line.detail) {
-    parts.push(`<i>${escapeTelegramProgressHtml(line.status)}</i>`);
+  if (clippedDetail) {
+    return `${labelHtml}<br> <code>${escapeTelegramProgressHtml(clippedDetail)}</code>`;
   }
-  return parts.join(" ");
+  if (status) {
+    return `${labelHtml}<br> <i>${escapeTelegramProgressHtml(status)}</i>`;
+  }
+  const text = line.text.trim();
+  if (text && text !== label) {
+    return `${labelHtml}<br> ${renderTelegramProgressStringLine(text)}`;
+  }
+  return labelHtml;
 }
 
 function renderTelegramProgressDraftPreview(
@@ -1002,6 +1006,7 @@ export const dispatchTelegramMessage = async ({
           richMessages: telegramCfg.richMessages,
           minInitialChars: draftMinInitialChars,
           renderText: renderStreamText,
+          preferNativeDraft: telegramCfg.richMessages === true,
           onSupersededPreview: (superseded) => {
             if (superseded.retain) {
               lanes[laneName].activeChunkIndex += 1;

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -2,7 +2,7 @@
 import type { Bot } from "grammy";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTelegramDraftStream } from "./draft-stream.js";
-import type { TelegramInputRichMessage } from "./rich-message.js";
+import { buildTelegramRichMarkdown, type TelegramInputRichMessage } from "./rich-message.js";
 
 type TelegramDraftStreamParams = Parameters<typeof createTelegramDraftStream>[0];
 
@@ -308,7 +308,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.sendRichMessageDraft).toHaveBeenCalledWith({
       chat_id: 123,
       draft_id: expect.any(Number),
-      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+      rich_message: buildTelegramRichMarkdown("Hello"),
       message_thread_id: 42,
     });
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
@@ -347,11 +347,11 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.sendRichMessageDraft).toHaveBeenCalledWith({
       chat_id: 123,
       draft_id: expect.any(Number),
-      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+      rich_message: buildTelegramRichMarkdown("Hello"),
     });
     expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
       chat_id: 123,
-      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+      rich_message: buildTelegramRichMarkdown("Hello"),
     });
   });
 
@@ -373,7 +373,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.sendRichMessageDraft).toHaveBeenCalledTimes(1);
     expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
       chat_id: 123,
-      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+      rich_message: buildTelegramRichMarkdown("Hello"),
     });
     expect(warn.mock.calls[0]?.[0]).toContain("falling back to preview message");
   });
@@ -386,7 +386,7 @@ describe("createTelegramDraftStream", () => {
     await stream.flush();
 
     expect(api.raw.sendRichMessageDraft).not.toHaveBeenCalled();
-    expectRichSend(api, "Hello", { message_thread_id: 99 });
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello", { message_thread_id: 99 });
   });
 
   it("deletes message preview on clear after finalization", async () => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -317,6 +317,21 @@ describe("createTelegramDraftStream", () => {
     expect(stream.temporary?.()).toBe(true);
   });
 
+  it("does not report a temporary native draft before debounce delivers it", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      preferNativeDraft: true,
+      minInitialChars: 10,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessageDraft).not.toHaveBeenCalled();
+    expect(stream.messageId()).toBeUndefined();
+    expect(stream.temporary?.()).toBe(false);
+  });
+
   it("materializes native temporary rich drafts with sendRichMessage", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -8,6 +8,7 @@ type TelegramDraftStreamParams = Parameters<typeof createTelegramDraftStream>[0]
 
 function createMockDraftApi(sendMessageImpl?: () => Promise<{ message_id: number }>) {
   const sendRichMessage = vi.fn(sendMessageImpl ?? (async () => ({ message_id: 17 })));
+  const sendRichMessageDraft = vi.fn().mockResolvedValue(true);
   const editRichMessageText = vi.fn().mockResolvedValue(true);
   return {
     sendMessage: vi.fn(sendMessageImpl ?? (async () => ({ message_id: 17 }))),
@@ -15,6 +16,7 @@ function createMockDraftApi(sendMessageImpl?: () => Promise<{ message_id: number
     deleteMessage: vi.fn().mockResolvedValue(true),
     raw: {
       sendRichMessage,
+      sendRichMessageDraft,
       editMessageText: editRichMessageText,
     },
   };
@@ -290,6 +292,86 @@ describe("createTelegramDraftStream", () => {
     expect(materializedId).toBe(17);
     expect(api.sendMessage).toHaveBeenCalledTimes(1);
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses native temporary rich drafts only for supported private chats", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      richMessages: true,
+      thread: { id: 42, scope: "dm" },
+      preferNativeDraft: true,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessageDraft).toHaveBeenCalledWith({
+      chat_id: 123,
+      draft_id: expect.any(Number),
+      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+      message_thread_id: 42,
+    });
+    expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
+    expect(api.raw.editMessageText).not.toHaveBeenCalled();
+    expect(stream.messageId()).toBeUndefined();
+    expect(stream.temporary?.()).toBe(true);
+  });
+
+  it("materializes native temporary rich drafts with sendRichMessage", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      richMessages: true,
+      preferNativeDraft: true,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+    const materializedId = await stream.materialize?.();
+
+    expect(materializedId).toBe(17);
+    expect(api.raw.sendRichMessageDraft).toHaveBeenCalledWith({
+      chat_id: 123,
+      draft_id: expect.any(Number),
+      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+    });
+    expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+    });
+  });
+
+  it("falls back to rich preview messages when native drafts are unsupported", async () => {
+    const api = createMockDraftApi();
+    api.raw.sendRichMessageDraft.mockRejectedValueOnce(
+      new Error("400: Bad Request: chat_id must be a private chat"),
+    );
+    const warn = vi.fn();
+    const stream = createDraftStream(api, {
+      richMessages: true,
+      preferNativeDraft: true,
+      warn,
+    });
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessageDraft).toHaveBeenCalledTimes(1);
+    expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: { html: markdownToTelegramRichHtml("Hello") },
+    });
+    expect(warn.mock.calls[0]?.[0]).toContain("falling back to preview message");
+  });
+
+  it("does not use native drafts for forum targets", async () => {
+    const api = createMockDraftApi();
+    const stream = createForumDraftStream(api);
+
+    stream.update("Hello");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessageDraft).not.toHaveBeenCalled();
+    expectRichSend(api, "Hello", { message_thread_id: 99 });
   });
 
   it("deletes message preview on clear after finalization", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -53,6 +53,8 @@ export type TelegramDraftStream = {
   materialize?: () => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /** True when this stream uses Telegram's native temporary draft surface. */
+  temporary?: () => boolean;
   /** True when a preview sendMessage was attempted but the response was lost. */
   sendMayHaveLanded?: () => boolean;
 };
@@ -161,6 +163,28 @@ function findTelegramDraftChunkLength(
   return best;
 }
 
+let nextTelegramNativeDraftId = 1;
+
+function allocateTelegramNativeDraftId(): number {
+  const draftId = nextTelegramNativeDraftId;
+  nextTelegramNativeDraftId =
+    nextTelegramNativeDraftId >= 0x7fffffff ? 1 : nextTelegramNativeDraftId + 1;
+  return draftId;
+}
+
+function normalizePrivateTelegramChatId(
+  chatId: Parameters<Bot["api"]["sendMessage"]>[0],
+): number | undefined {
+  if (typeof chatId === "number") {
+    return Number.isInteger(chatId) && chatId > 0 ? chatId : undefined;
+  }
+  if (typeof chatId === "string" && /^\d+$/u.test(chatId)) {
+    const parsed = Number(chatId);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
 export function createTelegramDraftStream(params: {
   api: Bot["api"];
   chatId: Parameters<Bot["api"]["sendMessage"]>[0];
@@ -173,6 +197,8 @@ export function createTelegramDraftStream(params: {
   minInitialChars?: number;
   /** Optional preview renderer (e.g. markdown -> HTML + parse mode). */
   renderText?: (text: string) => TelegramDraftPreview;
+  /** Prefer Bot API native temporary rich drafts when the target supports them. */
+  preferNativeDraft?: boolean;
   /** Called when a late send resolves after forceNewMessage() switched generations. */
   onSupersededPreview?: (preview: SupersededTelegramPreview) => void;
   log?: (message: string) => void;
@@ -184,6 +210,8 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
+  const nativeDraftChatId = normalizePrivateTelegramChatId(chatId);
+  const nativeDraftId = allocateTelegramNativeDraftId();
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
   const sendMessageParams =
@@ -220,13 +248,23 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
+  let nativeDraftActive = false;
+  let nativeDraftDisabled = false;
+  const richRawApi = () => getTelegramRichRawApi(params.api);
+  const canUseNativeDraft = () =>
+    params.preferNativeDraft === true &&
+    richMessages &&
+    !nativeDraftDisabled &&
+    nativeDraftChatId !== undefined &&
+    params.thread?.scope !== "forum" &&
+    typeof richRawApi().sendRichMessageDraft === "function";
   type PreviewSendParams = {
     preview: TelegramDraftPreview;
     sendGeneration: number;
   };
   const sendRenderedMessage = async (preview: TelegramDraftPreview) => {
     if (richMessages) {
-      return await getTelegramRichRawApi(params.api).sendRichMessage({
+      return await richRawApi().sendRichMessage({
         chat_id: chatId,
         rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
         ...richMessageParams,
@@ -250,15 +288,40 @@ export function createTelegramDraftStream(params: {
       return await sendPlain();
     }
   };
+  const sendRenderedNativeDraft = async (preview: TelegramDraftPreview): Promise<boolean> => {
+    if (!canUseNativeDraft() || nativeDraftChatId === undefined) {
+      return false;
+    }
+    await richRawApi().sendRichMessageDraft?.({
+      chat_id: nativeDraftChatId,
+      draft_id: nativeDraftId,
+      rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
+      ...threadParams,
+    });
+    nativeDraftActive = true;
+    streamVisibleSinceMs ??= Date.now();
+    return true;
+  };
   const sendMessageTransportPreview = async ({
     preview,
     sendGeneration,
   }: PreviewSendParams): Promise<boolean> => {
+    if (canUseNativeDraft()) {
+      try {
+        return await sendRenderedNativeDraft(preview);
+      } catch (err) {
+        nativeDraftDisabled = true;
+        nativeDraftActive = false;
+        params.warn?.(
+          `telegram native stream draft failed; falling back to preview message: ${formatErrorMessage(err)}`,
+        );
+      }
+    }
     const transportPreview = normalizeTelegramDraftTransportPreview(preview);
     if (typeof streamMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
       if (richMessages) {
-        await getTelegramRichRawApi(params.api).editMessageText({
+        await richRawApi().editMessageText({
           chat_id: chatId,
           message_id: streamMessageId,
           rich_message: preview.richMessage ?? buildTelegramRichMarkdown(preview.text),
@@ -507,6 +570,7 @@ export function createTelegramDraftStream(params: {
     messageSendAttempted = false;
     streamMessageId = undefined;
     streamVisibleSinceMs = undefined;
+    nativeDraftActive = false;
     lastSentPreviewKey = "";
     if (options?.resetOffset !== false) {
       deliveredTextOffset = 0;
@@ -535,10 +599,12 @@ export function createTelegramDraftStream(params: {
         params.warn?.(`telegram stream preview cleanup failed: ${formatErrorMessage(err)}`);
       }
     }
+    nativeDraftActive = false;
   };
 
   const discard = async () => {
     await stopForClear();
+    nativeDraftActive = false;
   };
 
   const forceNewMessage = () => {
@@ -547,6 +613,22 @@ export function createTelegramDraftStream(params: {
 
   const materialize = async (): Promise<number | undefined> => {
     await stop();
+    if (nativeDraftActive && typeof streamMessageId !== "number") {
+      const finalText = lastRequestedText.trimEnd();
+      const preview =
+        lastRequestedPreview?.text.trimEnd() === finalText
+          ? { ...lastRequestedPreview, text: finalText }
+          : renderTelegramDraftPreview(finalText, params.renderText);
+      if (preview.text.trimEnd()) {
+        const sent = await sendRenderedMessage(preview);
+        const sentMessageId = sent?.message_id;
+        if (typeof sentMessageId === "number" && Number.isFinite(sentMessageId)) {
+          streamMessageId = Math.trunc(sentMessageId);
+          streamVisibleSinceMs ??= Date.now();
+        }
+      }
+      nativeDraftActive = false;
+    }
     return streamMessageId;
   };
 
@@ -565,6 +647,8 @@ export function createTelegramDraftStream(params: {
     discard,
     materialize,
     forceNewMessage,
-    sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
+    temporary: () => canUseNativeDraft() || nativeDraftActive,
+    sendMayHaveLanded: () =>
+      !nativeDraftActive && messageSendAttempted && typeof streamMessageId !== "number",
   };
 }

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -647,7 +647,7 @@ export function createTelegramDraftStream(params: {
     discard,
     materialize,
     forceNewMessage,
-    temporary: () => canUseNativeDraft() || nativeDraftActive,
+    temporary: () => nativeDraftActive,
     sendMayHaveLanded: () =>
       !nativeDraftActive && messageSendAttempted && typeof streamMessageId !== "number",
   };

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -364,7 +364,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     };
 
     const candidateTexts = [stream.lastDeliveredText?.(), lane.lastPartialText];
-    if (useFinalTextRecovery && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)) {
+    if (
+      useFinalTextRecovery &&
+      remainingChunks.length === 0 &&
+      isPotentialTruncatedFinal(activeFullText)
+    ) {
       const resolvedFullCandidate = await params.resolveFinalTextCandidate?.({
         finalText: text,
         laneName,
@@ -379,7 +383,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     const retainedPreview =
-      useFinalTextRecovery && remainingChunks.length === 0 && isPotentialTruncatedFinal(activeFullText)
+      useFinalTextRecovery &&
+      remainingChunks.length === 0 &&
+      isPotentialTruncatedFinal(activeFullText)
         ? selectLongerFinalText({
             finalText: activeFullText,
             candidateTexts,
@@ -443,7 +449,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     } else {
       await params.flushDraftLane(lane);
     }
-    const activeChunkIndexAfterStop = useFinalTextRecovery ? clampActiveChunkIndex() : activeChunkIndex;
+    const activeChunkIndexAfterStop = useFinalTextRecovery
+      ? clampActiveChunkIndex()
+      : activeChunkIndex;
     const activeChunkAfterStop = chunks[activeChunkIndexAfterStop] ?? activeChunk;
     const remainingChunksAfterStop = chunks.slice(activeChunkIndexAfterStop + 1);
 
@@ -453,6 +461,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         lane.finalized = true;
         params.markDelivered();
         return result("preview-retained");
+      }
+      if (!finalizePreview && stream.temporary?.()) {
+        params.markDelivered();
+        return result("preview-updated");
       }
       if (!finalizePreview) {
         await discardUnmaterializedStream(lane);

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -72,6 +72,14 @@ export type TelegramSendRichMessageParams = {
   reply_markup?: TelegramRichMessageReplyMarkup;
 };
 
+export type TelegramSendRichMessageDraftParams = {
+  business_connection_id?: string;
+  chat_id: number;
+  message_thread_id?: number;
+  draft_id: number;
+  rich_message: TelegramInputRichMessage;
+};
+
 export type TelegramRichMessageContextParams = Pick<
   TelegramSendRichMessageParams,
   "disable_notification" | "message_thread_id" | "reply_parameters"
@@ -88,6 +96,7 @@ export type TelegramEditRichMessageTextParams = {
 
 type TelegramRichRawApi = {
   sendRichMessage: (params: TelegramSendRichMessageParams) => Promise<Message>;
+  sendRichMessageDraft?: (params: TelegramSendRichMessageDraftParams) => Promise<true>;
   editMessageText: (params: TelegramEditRichMessageTextParams) => Promise<Message | true>;
 };
 


### PR DESCRIPTION
## Summary
- Recreated the closed PR #93416 from a clean branch based on current `main`.
- Rebased after #93279 and again onto latest `main`; kept the readable default path intact.
- Add Bot API 10.1 native `sendRichMessageDraft` support for Telegram live previews only when the selected account has `richMessages` enabled.
- Preserve the standard `sendMessage` / `editMessageText` fallback when rich transport is disabled or when native drafts are rejected.
- Keep final replies on the existing persistent rich-message path; this PR changes live preview behavior, not final-answer persistence.
- Fix the prior review blocker: `stream.temporary?.()` now reports true only after a native draft has actually been delivered, so debounce-delayed flushes without a message id still preserve fallback delivery.
- Improve Telegram progress rich HTML line breaks so tool label, status, process, and command details display as readable separate lines.

## Clean-branch scope
- Supersedes #93416.
- This branch intentionally includes only Telegram live-preview/progress source and test changes.
- No dependency, lockfile, workflow, daemon, session-cache, or unrelated CI-hardening changes are included.

## Validation
- `node scripts/run-vitest.mjs run extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/lane-delivery.test.ts --reporter=dot`
  - Result after latest rebase: 3 files passed, 218 tests passed.
- `node scripts/run-vitest.mjs run test/scripts/openclaw-cross-os-release-checks.test.ts --config test/vitest/vitest.tooling.config.ts --reporter=verbose`
  - Result after latest rebase: 1 file passed, 89 tests passed.
- `git diff --check origin/main...HEAD` plus conflict-marker scan
  - Result after latest rebase: no whitespace errors and no conflict markers.

## Real behavior proof
- **Behavior or issue addressed:** Supported private Telegram chats use native `sendRichMessageDraft` for temporary live previews only when rich messages are enabled for the selected account, rich-disabled or rejected native-draft paths stay on the standard send/edit preview fallback, and final reply persistence remains unchanged.
- **Real environment tested:** Local Linux OpenClaw checkout on exact rebased PR head `c2dccb728891d70ada68acc6b8d1d6a5eec339cd`.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs run extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/lane-delivery.test.ts --reporter=dot` and `node scripts/run-vitest.mjs run test/scripts/openclaw-cross-os-release-checks.test.ts --config test/vitest/vitest.tooling.config.ts --reporter=verbose`.
- **Evidence after fix:** Terminal output captured after the rebase showed `Test Files 3 passed (3)`, `Tests 218 passed (218)`, followed by `Test Files 1 passed (1)` and `Tests 89 passed (89)`. The same checkout reported no conflict markers and the diff remains limited to the six Telegram live-preview/progress source/test files.
- **Observed result after fix:** The rich opt-in/native-draft fallback coverage passed on the exact rebased head: native drafts are gated by selected-account rich messages, rejected native drafts fall back to preview messages, and delayed native drafts are not treated as temporary until delivered. The tooling reproducer also passed locally.
- **What was not tested:** Live Telegram client exact-head proof was not rerun in this cycle; the latest inspected upstream Mantis attempt failed before candidate capture because the baseline Telegram session did not receive a bot reply.


## Current CI note
- Latest inspected `CI` run on this head has unrelated failures outside the Telegram diff: `extensions/codex/src/app-server/bounded-turn.ts` type errors, prompt snapshot drift, and plugin SDK surface budget drift. I reproduced the bounded-turn TypeScript error locally with `pnpm tsgo:extensions`; the PR diff remains limited to the six Telegram live-preview/progress files.

## Risk / rollback
- Risk is limited to Telegram private-chat live-preview behavior and progress rich HTML layout.
- Unsupported targets and accounts without rich messages enabled retain the standard send/edit preview path.
- Rollback: revert this PR to disable native temporary rich drafts while keeping the current final-answer rich-message behavior.


