### PR TITLE
fix(agents): honor embedded run default model

### DIFF
--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -312,6 +312,43 @@ const runDefaultEmbeddedTurn = async (sessionFile: string, prompt: string, sessi
   });
 };
 
+const addAnthropicProvider = (
+  cfg: ReturnType<typeof createEmbeddedAgentRunnerOpenAiConfig>,
+  modelIds: string[],
+) => ({
+  ...cfg,
+  models: {
+    providers: {
+      ...cfg.models?.providers,
+      anthropic: {
+        api: "anthropic-messages" as const,
+        apiKey: "sk-test",
+        baseUrl: "https://example.com",
+        models: modelIds.map((id) => ({
+          id,
+          name: `Mock ${id}`,
+          reasoning: false,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 16_000,
+          maxTokens: 2048,
+        })),
+      },
+    },
+  },
+});
+
+const mockSuccessfulEmbeddedAttempt = () => {
+  runEmbeddedAttemptMock.mockResolvedValueOnce(
+    makeEmbeddedRunnerAttempt({
+      assistantTexts: ["ok"],
+      lastAssistant: buildEmbeddedRunnerAssistant({
+        content: [{ type: "text", text: "ok" }],
+      }),
+    }),
+  );
+};
+
 function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
   const call = mock.mock.calls[0];
   if (!call) {
@@ -338,14 +375,7 @@ describe("runEmbeddedAgent", () => {
         list: [{ id: "research", model: "openrouter/research-default" }],
       },
     };
-    runEmbeddedAttemptMock.mockResolvedValueOnce(
-      makeEmbeddedRunnerAttempt({
-        assistantTexts: ["ok"],
-        lastAssistant: buildEmbeddedRunnerAssistant({
-          content: [{ type: "text", text: "ok" }],
-        }),
-      }),
-    );
+    mockSuccessfulEmbeddedAttempt();
 
     await runEmbeddedAgent({
       sessionId: "configured-default-model",
@@ -383,14 +413,7 @@ describe("runEmbeddedAgent", () => {
       },
     };
     setRuntimeConfigSnapshot(cfg);
-    runEmbeddedAttemptMock.mockResolvedValueOnce(
-      makeEmbeddedRunnerAttempt({
-        assistantTexts: ["ok"],
-        lastAssistant: buildEmbeddedRunnerAssistant({
-          content: [{ type: "text", text: "ok" }],
-        }),
-      }),
-    );
+    mockSuccessfulEmbeddedAttempt();
 
     await runEmbeddedAgent({
       sessionId: "runtime-config-default-model",
@@ -413,6 +436,85 @@ describe("runEmbeddedAgent", () => {
       cfg,
       expect.objectContaining({ skipAgentDiscovery: true }),
     );
+  });
+
+  it("uses the session-key agent default when agentId is inferred", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = {
+      ...addAnthropicProvider(createEmbeddedAgentRunnerOpenAiConfig(["mock-1"]), [
+        "claude-opus-4-7",
+      ]),
+      agents: {
+        defaults: {
+          model: { primary: "openai/mock-1" },
+        },
+        list: [
+          {
+            id: "research",
+            model: { primary: "anthropic/claude-opus-4-7" },
+          },
+        ],
+      },
+    };
+    mockSuccessfulEmbeddedAttempt();
+
+    await runEmbeddedAgent({
+      sessionId: "session-key-agent-default",
+      sessionKey: "agent:research:embedded:session-key-agent-default",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("session-key-agent-default"),
+      enqueue: immediateEnqueue,
+    });
+
+    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      "anthropic",
+      "claude-opus-4-7",
+      agentDir,
+      cfg,
+      expect.objectContaining({ skipAgentDiscovery: true }),
+    );
+    expect(
+      (firstRunEmbeddedAttemptParams() as { model?: { provider?: string; id?: string } }).model,
+    ).toEqual(expect.objectContaining({ provider: "anthropic", id: "claude-opus-4-7" }));
+  });
+
+  it("resolves model-only provider refs instead of prefixing the default provider", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = addAnthropicProvider(createEmbeddedAgentRunnerOpenAiConfig(["mock-1"]), [
+      "claude-sonnet-4-6",
+    ]);
+    mockSuccessfulEmbeddedAttempt();
+
+    await runEmbeddedAgent({
+      sessionId: "model-only-provider-ref",
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      model: "anthropic/claude-sonnet-4-6",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("model-only-provider-ref"),
+      enqueue: immediateEnqueue,
+    });
+
+    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      "anthropic",
+      "claude-sonnet-4-6",
+      agentDir,
+      cfg,
+      expect.objectContaining({ skipAgentDiscovery: true }),
+    );
+    expect(
+      (firstRunEmbeddedAttemptParams() as { model?: { provider?: string; id?: string } }).model,
+    ).toEqual(expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4-6" }));
   });
 
   it("skips models.json generation when dynamic model resolution succeeds", async () => {

--- a/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test.ts
+++ b/src/agents/embedded-agent-runner/run.cross-provider-fallback-error-context.test.ts
@@ -132,6 +132,9 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
       runId: "run-cross-provider-fallback-error-context",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",
+      provider: "deepseek",
+      model: "deepseek-chat",
+      modelFallbacksOverride: ["deepseek/deepseek-chat"],
     });
 
     await expectDeepseekFallbackError(promise, getLastFormattedAssistant);
@@ -167,6 +170,9 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
       runId: "run-compaction-fallback-error-context",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",
+      provider: "anthropic",
+      model: "test-model",
+      modelFallbacksOverride: ["deepseek/deepseek-chat"],
     });
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
@@ -203,6 +209,9 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
       runId: "run-stale-session-assistant-timeout",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",
+      provider: "deepseek",
+      model: "deepseek-chat",
+      modelFallbacksOverride: ["deepseek/deepseek-chat"],
     });
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
@@ -236,6 +245,9 @@ describe("runEmbeddedAgent cross-provider fallback error handling", () => {
       runId: "run-stale-session-assistant-non-timeout",
       config: makeCrossProviderFallbackConfig(),
       agentHarnessRuntimeOverride: "openclaw",
+      provider: "deepseek",
+      model: "deepseek-chat",
+      modelFallbacksOverride: ["deepseek/deepseek-chat"],
     });
 
     expect(mockedIsFailoverAssistantError).toHaveBeenCalledWith(undefined);

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -100,7 +100,11 @@ import {
   resolveAuthProfileOrder,
   shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
-import { resolveDefaultModelForAgent } from "../model-selection.js";
+import {
+  buildModelAliasIndex,
+  resolveDefaultModelForAgent,
+  resolveModelRefFromString,
+} from "../model-selection.js";
 import { resolveThinkingDefault } from "../model-thinking-default.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
@@ -528,6 +532,49 @@ function buildHandledReplyPayloads(reply?: ReplyPayload) {
   ];
 }
 
+function resolveInitialEmbeddedRunModel(params: {
+  config: RunEmbeddedAgentParams["config"];
+  agentId?: string;
+  provider?: string;
+  model?: string;
+}): { provider: string; modelId: string } {
+  const cfg = params.config ?? {};
+  const configuredDefault = resolveDefaultModelForAgent({
+    cfg,
+    agentId: params.agentId,
+  });
+  const explicitProvider = normalizeOptionalString(params.provider);
+  const explicitModel = normalizeOptionalString(params.model);
+  const defaultProvider = configuredDefault.provider || DEFAULT_PROVIDER;
+
+  if (explicitProvider && explicitModel) {
+    return { provider: explicitProvider, modelId: explicitModel };
+  }
+
+  if (explicitModel) {
+    const provider = explicitProvider ?? defaultProvider;
+    const aliasIndex = buildModelAliasIndex({
+      cfg,
+      defaultProvider: provider,
+    });
+    const resolved = resolveModelRefFromString({
+      cfg,
+      raw: explicitModel,
+      defaultProvider: provider,
+      aliasIndex,
+    });
+    return {
+      provider: explicitProvider ?? resolved?.ref.provider ?? provider,
+      modelId: resolved?.ref.model ?? explicitModel,
+    };
+  }
+
+  return {
+    provider: explicitProvider ?? defaultProvider,
+    modelId: configuredDefault.model || DEFAULT_MODEL,
+  };
+}
+
 export function runEmbeddedAgent(
   paramsInput: RunEmbeddedAgentParams,
 ): Promise<EmbeddedAgentRunResult> {
@@ -758,17 +805,12 @@ async function runEmbeddedAgentInternal(
       startupStages.mark("runtime-plugins");
       notifyExecutionPhase("runtime_plugins");
 
-      const requestedProvider = normalizeOptionalString(params.provider);
-      const requestedModel = normalizeOptionalString(params.model);
-      const configuredDefault =
-        !requestedProvider && !requestedModel
-          ? resolveDefaultModelForAgent({
-              cfg: params.config ?? {},
-              agentId: workspaceResolution.agentId,
-            })
-          : undefined;
-      let provider = requestedProvider ?? configuredDefault?.provider ?? DEFAULT_PROVIDER;
-      let modelId = requestedModel ?? configuredDefault?.model ?? DEFAULT_MODEL;
+      let { provider, modelId } = resolveInitialEmbeddedRunModel({
+        config: params.config,
+        agentId: workspaceResolution.agentId,
+        provider: params.provider,
+        model: params.model,
+      });
       const agentDir =
         params.agentDir ?? resolveAgentDir(params.config ?? {}, workspaceResolution.agentId);
       const normalizedSessionKey = params.sessionKey?.trim();


### PR DESCRIPTION
## Summary

Fixes #93419.

- Honor `agents.defaults.model.primary` and per-agent `model.primary` when embedded agent runs omit both `provider` and `model`.
- Resolve model-only provider refs such as `anthropic/claude-sonnet-4-6` before model resolution so they no longer become `openai` + `anthropic/claude-sonnet-4-6`.
- Add embedded-runner regressions for global defaults, session-key inferred agent defaults, and model-only provider refs.

## Root Cause

`runEmbeddedAgent` initialized omitted model inputs with `DEFAULT_PROVIDER` and `DEFAULT_MODEL` before consulting the configured model defaults. That made plugin-triggered embedded runs route to `openai/gpt-5.5` even when `agents.defaults.model.primary` or the inferred agent config selected another provider/model.

## Release Note

User-facing fix: embedded OpenClaw runs started without explicit provider/model now follow the configured agent model default instead of silently falling back to OpenAI.

## Real behavior proof

- Behavior or issue addressed: Embedded agent runs started without explicit provider/model now use configured agent model defaults, and provider-qualified model-only refs keep their provider instead of falling through to `openai/gpt-5.5`.
- Real environment tested: Local OpenClaw source checkout on macOS with Node 22.22.3 and a throwaway state directory; captured the embedded-runner model-routing decision before provider dispatch.
- Exact steps or command run after this patch: Ran a `node --import tsx --input-type=module` terminal probe in the checkout that imports the production model-selection helpers used by `runEmbeddedAgent`, applies a config with `agents.defaults.model.primary = openai/gpt-5.5` and `agents.list[research].model.primary = anthropic/claude-opus-4-7`, then resolves the two embedded-runner cases before dispatch.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
OpenClaw embedded run routing capture
default constants: openai/gpt-5.5
scenario: session-key inferred agent default, request omits provider/model
{
  "provider": "anthropic",
  "modelId": "claude-opus-4-7"
}
scenario: model-only provider ref, request omits provider
{
  "provider": "anthropic",
  "modelId": "claude-sonnet-4-6"
}
```

- Observed result after fix: The routing output resolves omitted embedded model inputs to `anthropic/claude-opus-4-7` and resolves the model-only provider ref to `anthropic/claude-sonnet-4-6`; neither path falls back to `openai/gpt-5.5`.
- What was not tested: Live Anthropic provider network execution was not run; verification stopped before provider dispatch so no live credentials were required.
- Proof limitations or environment constraints: The capture proves the local OpenClaw routing decision before provider dispatch; focused regression coverage remains supplemental validation below.

## Review

Claude autoreview reported: `autoreview clean: no accepted/actionable findings reported`.
