### PR TITLE
fix(ui): preserve WebChat wheel scroll intent

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3791,6 +3791,7 @@ export function renderApp(state: AppViewState) {
                     void refreshChat(state, { awaitHistory: true, scheduleScroll: false });
                   },
                   onChatScroll: (event) => state.handleChatScroll(event),
+                  onChatWheelIntent: (event) => state.handleChatWheelIntent(event),
                   getDraft: () => state.chatMessage,
                   onDraftChange: (next) => state.handleChatDraftChange(next),
                   onRequestUpdate: requestHostUpdate,

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -1,6 +1,11 @@
 // Control UI tests cover app scroll behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatScroll, scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
+import {
+  handleChatScroll,
+  handleChatWheelIntent,
+  scheduleChatScroll,
+  resetChatScroll,
+} from "./app-scroll.ts";
 import type { ChatAutoScrollMode } from "./storage.ts";
 
 /* ------------------------------------------------------------------ */
@@ -52,6 +57,7 @@ function createScrollHost(
     chatHasAutoScrolled: false,
     chatUserNearBottom: true,
     chatFollowLocked: false,
+    chatSmoothAutoScrolling: false,
     chatHeaderControlsHidden: false,
     chatNewMessagesBelow: false,
     chatIsProgrammaticScroll: false,
@@ -69,6 +75,19 @@ function createScrollEvent(scrollHeight: number, scrollTop: number, clientHeight
   return {
     currentTarget: { scrollHeight, scrollTop, clientHeight },
   } as unknown as Event;
+}
+
+function createWheelEvent(
+  deltaY: number,
+  scrollHeight: number,
+  clientHeight: number,
+  target: EventTarget | null = null,
+) {
+  return {
+    deltaY,
+    target,
+    currentTarget: { scrollHeight, clientHeight },
+  } as unknown as WheelEvent;
 }
 
 /* ------------------------------------------------------------------ */
@@ -146,6 +165,125 @@ describe("handleChatScroll", () => {
     handleChatScroll(host, event);
 
     expect(host.chatHeaderControlsHidden).toBe(false);
+  });
+
+  it("does not treat smooth auto-scroll progress as upward manual scroll intent", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1200;
+
+    handleChatScroll(host, createScrollEvent(2000, 1300, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+  });
+
+  it("releases follow when the user scrolls upward during smooth auto-scroll", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1100, 400));
+
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  handleChatWheelIntent                                              */
+/* ------------------------------------------------------------------ */
+
+describe("handleChatWheelIntent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("locks follow and cancels pending auto-scroll when the user wheels upward", () => {
+    const { host } = createScrollHost({});
+    const cancelFrame = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    host.chatUserNearBottom = true;
+    host.chatSmoothAutoScrolling = true;
+    host.chatScrollFrame = 12;
+    host.chatScrollTimeout = window.setTimeout(() => {}, 100);
+
+    handleChatWheelIntent(host, createWheelEvent(-120, 2000, 400));
+
+    expect(cancelFrame).toHaveBeenCalledWith(12);
+    expect(host.chatScrollFrame).toBeNull();
+    expect(host.chatScrollTimeout).toBeNull();
+    expect(host.chatUserNearBottom).toBe(false);
+    expect(host.chatFollowLocked).toBe(true);
+    expect(host.chatSmoothAutoScrolling).toBe(false);
+  });
+
+  it("does not lock follow for downward wheel intent", () => {
+    const { host } = createScrollHost({});
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, createWheelEvent(120, 2000, 400));
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("does not lock follow when upward wheel cannot move the chat upward", () => {
+    const { host } = createScrollHost({});
+    const container = {
+      clientHeight: 400,
+      scrollHeight: 500,
+      scrollTop: 0,
+    };
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, {
+      deltaY: -120,
+      target: container,
+      currentTarget: container,
+    } as unknown as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
+  });
+
+  it("ignores upward wheel intent inside a nested scrollable element", () => {
+    const { host } = createScrollHost({});
+    const container = document.createElement("div");
+    const nested = document.createElement("div");
+    container.append(nested);
+    Object.defineProperties(container, {
+      clientHeight: { value: 400 },
+      scrollHeight: { value: 2000 },
+    });
+    Object.defineProperties(nested, {
+      clientHeight: { value: 100 },
+      scrollHeight: { value: 300 },
+      scrollTop: { value: 40 },
+    });
+    vi.spyOn(window, "getComputedStyle").mockImplementation((node) => {
+      return {
+        overflowY: node === nested ? "auto" : "visible",
+      } as unknown as CSSStyleDeclaration;
+    });
+    host.chatUserNearBottom = true;
+
+    handleChatWheelIntent(host, {
+      deltaY: -120,
+      target: nested,
+      currentTarget: container,
+    } as unknown as WheelEvent);
+
+    expect(host.chatUserNearBottom).toBe(true);
+    expect(host.chatFollowLocked).toBe(false);
   });
 });
 
@@ -435,6 +573,7 @@ describe("resetChatScroll", () => {
     host.chatHasAutoScrolled = true;
     host.chatUserNearBottom = false;
     host.chatFollowLocked = true;
+    host.chatSmoothAutoScrolling = true;
     host.chatLastScrollTop = 300;
     host.chatHeaderControlsHidden = true;
 
@@ -443,6 +582,7 @@ describe("resetChatScroll", () => {
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
     expect(host.chatFollowLocked).toBe(false);
+    expect(host.chatSmoothAutoScrolling).toBe(false);
     expect(host.chatLastScrollTop).toBe(0);
     expect(host.chatHeaderControlsHidden).toBe(false);
     expect(host.chatIsProgrammaticScroll).toBe(false);

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -6,6 +6,7 @@ const NEAR_BOTTOM_THRESHOLD = 450;
 const FOLLOW_REACQUIRE_THRESHOLD = 8;
 const HEADER_HIDE_SCROLL_DELTA = 12;
 const HEADER_SHOW_TOP_THRESHOLD = 24;
+const MANUAL_SCROLL_RELEASE_THRESHOLD = 24;
 
 type ScrollHost = {
   updateComplete: Promise<unknown>;
@@ -17,6 +18,7 @@ type ScrollHost = {
   chatHasAutoScrolled: boolean;
   chatUserNearBottom: boolean;
   chatFollowLocked: boolean;
+  chatSmoothAutoScrolling: boolean;
   chatHeaderControlsHidden: boolean;
   chatNewMessagesBelow: boolean;
   chatIsProgrammaticScroll: boolean;
@@ -40,19 +42,54 @@ type ChatScrollOptions = {
   source?: "auto" | "manual";
 };
 
+function cancelPendingChatScroll(host: ScrollHost) {
+  if (host.chatScrollFrame) {
+    cancelAnimationFrame(host.chatScrollFrame);
+    host.chatScrollFrame = null;
+  }
+  if (host.chatScrollTimeout != null) {
+    clearTimeout(host.chatScrollTimeout);
+    host.chatScrollTimeout = null;
+  }
+}
+
+function canConsumeVerticalWheelDelta(node: HTMLElement, deltaY: number) {
+  const overflowY = getComputedStyle(node).overflowY;
+  const hasVerticalScrollRange = node.scrollHeight - node.clientHeight > 1;
+  const canScrollVertically =
+    (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+    hasVerticalScrollRange;
+  if (!canScrollVertically) {
+    return false;
+  }
+  if (deltaY < 0) {
+    return node.scrollTop > 1;
+  }
+  return node.scrollTop + node.clientHeight < node.scrollHeight - 1;
+}
+
+function hasNestedScrollableAncestor(
+  target: EventTarget | null,
+  container: HTMLElement,
+  deltaY: number,
+) {
+  let node = target instanceof HTMLElement ? target : null;
+  while (node && node !== container) {
+    if (canConsumeVerticalWheelDelta(node, deltaY)) {
+      return true;
+    }
+    node = node.parentElement;
+  }
+  return false;
+}
+
 export function scheduleChatScroll(
   host: ScrollHost,
   force = false,
   smooth = false,
   options: ChatScrollOptions = {},
 ) {
-  if (host.chatScrollFrame) {
-    cancelAnimationFrame(host.chatScrollFrame);
-  }
-  if (host.chatScrollTimeout != null) {
-    clearTimeout(host.chatScrollTimeout);
-    host.chatScrollTimeout = null;
-  }
+  cancelPendingChatScroll(host);
   const pickScrollTarget = () => {
     const container = queryHost(host, ".chat-thread") as HTMLElement | null;
     if (container) {
@@ -117,6 +154,7 @@ export function scheduleChatScroll(
         host.chatIsProgrammaticScroll = false;
       });
       host.chatUserNearBottom = true;
+      host.chatSmoothAutoScrolling = smoothEnabled;
       host.chatNewMessagesBelow = false;
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
@@ -144,6 +182,7 @@ export function scheduleChatScroll(
           host.chatIsProgrammaticScroll = false;
         });
         host.chatUserNearBottom = true;
+        host.chatSmoothAutoScrolling = false;
       }, retryDelay);
     });
   });
@@ -204,7 +243,6 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   }
   const scrollTop = Math.max(0, container.scrollTop);
   const delta = scrollTop - host.chatLastScrollTop;
-  host.chatLastScrollTop = scrollTop;
   // Ignore scroll events that we ourselves triggered — they must not flip
   // chatUserNearBottom to false while streaming content grows the page.
   // Only suppress if scrollTop is still at or above the position we scrolled to;
@@ -217,10 +255,18 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
     !isUserScrollUp &&
     container.scrollTop >= host.chatProgrammaticScrollTarget - container.clientHeight
   ) {
+    host.chatLastScrollTop = scrollTop;
     return;
   }
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-  if (isUserScrollUp && distanceFromBottom > FOLLOW_REACQUIRE_THRESHOLD) {
+  if (host.chatSmoothAutoScrolling) {
+    if (isUserScrollUp && distanceFromBottom > MANUAL_SCROLL_RELEASE_THRESHOLD) {
+      host.chatSmoothAutoScrolling = false;
+      host.chatFollowLocked = true;
+    } else if (!isUserScrollUp || distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD) {
+      host.chatSmoothAutoScrolling = false;
+    }
+  } else if (isUserScrollUp && distanceFromBottom > FOLLOW_REACQUIRE_THRESHOLD) {
     host.chatFollowLocked = true;
   } else if (distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD) {
     host.chatFollowLocked = false;
@@ -240,6 +286,30 @@ export function handleChatScroll(host: ScrollHost, event: Event) {
   if (host.chatUserNearBottom) {
     host.chatNewMessagesBelow = false;
   }
+  host.chatLastScrollTop = scrollTop;
+}
+
+export function handleChatWheelIntent(host: ScrollHost, event: WheelEvent) {
+  if (event.deltaY >= 0) {
+    return;
+  }
+  const container = event.currentTarget as HTMLElement | null;
+  if (!container || container.scrollHeight - container.clientHeight <= 1) {
+    return;
+  }
+  if (container.scrollTop <= 1) {
+    return;
+  }
+  if (hasNestedScrollableAncestor(event.target, container, event.deltaY)) {
+    return;
+  }
+  if (!host.chatUserNearBottom && host.chatFollowLocked) {
+    return;
+  }
+  cancelPendingChatScroll(host);
+  host.chatSmoothAutoScrolling = false;
+  host.chatUserNearBottom = false;
+  host.chatFollowLocked = true;
 }
 
 export function handleLogsScroll(host: ScrollHost, event: Event) {
@@ -264,6 +334,7 @@ export function resetChatScroll(host: ScrollHost) {
   host.chatHasAutoScrolled = false;
   host.chatUserNearBottom = true;
   host.chatFollowLocked = false;
+  host.chatSmoothAutoScrolling = false;
   host.chatLastScrollTop = 0;
   host.chatHeaderControlsHidden = false;
   host.chatNewMessagesBelow = false;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -539,6 +539,7 @@ export type AppViewState = {
     removeQueuedMessage: (id: string) => void;
     retryQueuedChatMessage: (id: string) => Promise<void>;
     handleChatScroll: (event: Event) => void;
+    handleChatWheelIntent: (event: WheelEvent) => void;
     resetToolStream: () => void;
     resetChatScroll: () => void;
     exportLogs: (lines: string[], label: string) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -52,6 +52,7 @@ import {
   exportLogs as exportLogsInternal,
   handleActivityScroll as handleActivityScrollInternal,
   handleChatScroll as handleChatScrollInternal,
+  handleChatWheelIntent as handleChatWheelIntentInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleActivityScroll as scheduleActivityScrollInternal,
@@ -698,6 +699,7 @@ export class OpenClawApp extends LitElement {
   chatHasAutoScrolled = false;
   chatUserNearBottom = true;
   chatFollowLocked = false;
+  chatSmoothAutoScrolling = false;
   chatIsProgrammaticScroll = false;
   chatProgrammaticScrollTarget = 0;
   @state() chatNewMessagesBelow = false;
@@ -879,6 +881,13 @@ export class OpenClawApp extends LitElement {
   handleChatScroll(event: Event) {
     handleChatScrollInternal(
       this as unknown as Parameters<typeof handleChatScrollInternal>[0],
+      event,
+    );
+  }
+
+  handleChatWheelIntent(event: WheelEvent) {
+    handleChatWheelIntentInternal(
+      this as unknown as Parameters<typeof handleChatWheelIntentInternal>[0],
       event,
     );
   }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -191,6 +191,7 @@ export type ChatProps = {
   onCloseSidebar?: () => void;
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
+  onChatWheelIntent?: (event: WheelEvent) => void;
   basePath?: string;
   composerControls?: TemplateResult | typeof nothing | ReturnType<typeof guard>;
   sessionWorkspace?: {
@@ -2038,6 +2039,7 @@ export function renderChat(props: ChatProps) {
         );
       })}
       @scroll=${handleChatThreadScroll}
+      @wheel=${props.onChatWheelIntent}
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">


### PR DESCRIPTION
## Summary

- Preserves WebChat upward wheel intent during streaming by locking auto-follow before a pending auto-scroll retry can pull the user back to the bottom.
- Adds a small smooth auto-scroll guard so browser-generated smooth-scroll progress is not mistaken for user takeover, while real upward movement still releases follow.
- Ignores downward wheel intent, upward wheel events when the chat cannot scroll upward, and wheel events inside nested scrollable message content.
- Intentionally keeps the already-merged #92622 follow-lock behavior intact; this PR only covers the remaining wheel/smooth-scroll edge cases.

## Linked context

Closes #

Related #72957
Related #92622
Related #37500

Was this requested by a maintainer or owner?

No direct maintainer request. This is a follow-up split from the superseded #72957 after #92622 landed the narrower central follow-lock fix.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: WebChat should preserve explicit upward wheel intent during streaming/smooth auto-scroll and avoid snapping the thread back to the bottom after the user starts scrolling upward.
- Real environment tested: Local OpenClaw checkout on macOS, focused Control UI scroll helper tests and UI type/lint/format checks.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs ui/src/ui/app-scroll.test.ts
node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/app-scroll.ts ui/src/ui/app-scroll.test.ts ui/src/ui/app.ts ui/src/ui/app-render.ts ui/src/ui/app-view-state.ts ui/src/ui/views/chat.ts
node scripts/run-oxlint.mjs ui/src/ui/app-scroll.ts ui/src/ui/app-scroll.test.ts ui/src/ui/app.ts ui/src/ui/app-render.ts ui/src/ui/app-view-state.ts ui/src/ui/views/chat.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo
git diff --check
```

- Evidence after fix: `ui/src/ui/app-scroll.test.ts` passed with 37 tests, covering upward wheel lock, downward wheel no-op, top-of-thread no-op, nested scrollable no-op, smooth auto-scroll progress, and real upward scroll during smooth auto-scroll.
- Observed result after fix: Upward wheel intent on the chat thread cancels pending auto-scroll, sets `chatFollowLocked=true`, clears smooth auto-scroll state, and prevents the next streaming scroll tick from snapping the view down. Downward wheel intent and nested scrollable content do not release chat follow.
- What was not tested: Full browser/manual gateway-backed streaming session and multi-browser matrix.
- Proof limitations or environment constraints: The proof is deterministic unit-level coverage of the actual Control UI scroll helper and wiring type surface, not live model streaming.
- Before evidence: #92622 fixed the core follow-lock path, but current main still did not wire a wheel-intent handler for the chat thread.

## Tests and validation

- `node scripts/run-vitest.mjs ui/src/ui/app-scroll.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/app-scroll.ts ui/src/ui/app-scroll.test.ts ui/src/ui/app.ts ui/src/ui/app-render.ts ui/src/ui/app-view-state.ts ui/src/ui/views/chat.ts`
- `node scripts/run-oxlint.mjs ui/src/ui/app-scroll.ts ui/src/ui/app-scroll.test.ts ui/src/ui/app.ts ui/src/ui/app-render.ts ui/src/ui/app-view-state.ts ui/src/ui/views/chat.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `git diff --check`

Regression coverage added in `ui/src/ui/app-scroll.test.ts`:

- Upward wheel intent locks follow and cancels pending auto-scroll.
- Downward wheel intent does not lock follow.
- Upward wheel at the top of a slightly scrollable chat does not lock follow.
- Upward wheel inside nested scrollable content is ignored.
- Smooth auto-scroll progress is not treated as user takeover.
- Real upward scroll during smooth auto-scroll releases follow.

What failed before this fix:

- The new wheel-intent and smooth-scroll guard tests failed before implementation.
- A follow-up regression test for upward wheel at `scrollTop=0` failed before the top-of-thread guard was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. WebChat now treats upward wheel intent as immediate user takeover during streaming.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Chat auto-scroll ergonomics in the Control UI.

How is that risk mitigated?

The handler only responds to upward wheel intent when the chat thread itself can scroll upward, ignores nested scrollables, leaves downward wheel intent unchanged, and is covered by focused scroll-helper regression tests.

## Current review state

What is the next action?

Ready for maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer review. A live browser/gateway streaming proof was not run locally.

Which bot or reviewer comments were addressed?

Local autoreview initially reported no accepted/actionable findings, but surfaced an ignored edge case for upward wheel at the top of the chat. That edge case was accepted, fixed, and covered by a regression test. The autoreview rerun after that fix was blocked by local approval policy, so focused tests, lint, format, and UI typecheck were rerun instead.
