### PR TITLE
fix(ci): allowlist auth-profiles/sqlite.ts in Kysely raw-SQLite guardrail

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -48,6 +48,7 @@ const rawSqliteAllowPathGroups = {
   "doctor legacy state migration": ["src/infra/state-migrations.ts"],
   "Kysely-backed stores that own a DatabaseSync boundary": [
     "src/acp/event-ledger.ts",
+    "src/agents/auth-profiles/sqlite.ts",
     "src/agents/subagent-registry.store.ts",
     "src/cron/run-log.ts",
     "src/cron/run-log/sqlite-store.ts",


### PR DESCRIPTION
## Summary

`scripts/check-kysely-guardrails.mjs` (the `check:architecture` shard / `lint:kysely`) is **failing on current `main`** and therefore on every open PR:

```
Kysely guardrail violations:
- src/agents/auth-profiles/sqlite.ts:103: new raw node:sqlite access requires Kysely or an explicit raw SQLite allowlist entry
```

## Root cause

`src/agents/auth-profiles/sqlite.ts` owns a legitimate Kysely-backed `DatabaseSync` boundary: `readAuthProfileJsonCellReadOnly` opens a short-lived read-only `new sqlite.DatabaseSync(...)` and drives it through `getAuthProfileKysely(db)`. The file was never added to the raw-SQLite allowlist.

Commit `0ef8620746` ("fix(auth): wait through SQLite read contention") added:

```ts
db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
```

to that reader. The guardrail flags `.exec`/`.prepare` calls on a sqlite receiver in any file with SQLite context that is not allowlisted, so this correct `db.exec` turned `check:architecture` red.

## Fix

Add `src/agents/auth-profiles/sqlite.ts` to the existing **"Kysely-backed stores that own a DatabaseSync boundary"** allowlist group, matching how the other Kysely + raw-boundary owners are handled (`src/state/openclaw-agent-db.ts`, `src/acp/event-ledger.ts`, etc.). No runtime behavior change; guardrail-only.

## Real behavior proof

**Behavior or issue addressed:** `check:architecture` / `lint:kysely` is red on current `main` because the Kysely raw-SQLite guardrail reports `src/agents/auth-profiles/sqlite.ts:103` as unallowlisted raw `node:sqlite` access.

**Real environment tested:** Clean OpenClaw checkout of current `main` at `fd806ada64`, Node 24.

**Exact steps or command run after this patch:**

```bash
node scripts/check-kysely-guardrails.mjs
pnpm lint:kysely
```

**Evidence after fix:** Terminal output from the clean checkout after this PR:

```text
$ node scripts/check-kysely-guardrails.mjs
Kysely guardrails OK
$ pnpm lint:kysely
Kysely guardrails OK
```

**Observed result after fix:** The same guardrail violation that reproduced on `main` no longer appears after this one-line allowlist addition; both the direct guardrail command and `pnpm lint:kysely` report `Kysely guardrails OK`.

**What was not tested:** Runtime auth-profile behavior was not changed or separately exercised because this PR only updates the architecture guard allowlist.

**Before evidence:**

```text
$ node scripts/check-kysely-guardrails.mjs
Kysely guardrail violations:
- src/agents/auth-profiles/sqlite.ts:103: new raw node:sqlite access requires Kysely or an explicit raw SQLite allowlist entry
(exit 1 under CI wrapper)
```

## Test plan

- Coverage: architecture guardrail script (`check:architecture` shard)
- `node scripts/check-kysely-guardrails.mjs` -> `Kysely guardrails OK`
- `pnpm lint:kysely` -> `Kysely guardrails OK`
- This unblocks `main` CI and every open PR currently failing the runtime-topology-architecture shard.
