### PR TITLE
fix(guards): allow auth profile sqlite reader

### DIFF
--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -45,6 +45,7 @@ const rawSqliteAllowPathGroups = {
     "src/state/sqlite-schema-shape.test-support.ts",
   ],
   "backup snapshot maintenance": ["src/commands/backup-verify.ts", "src/infra/backup-create.ts"],
+  "agent auth profile read-only bootstrap": ["src/agents/auth-profiles/sqlite.ts"],
   "doctor legacy state migration": ["src/infra/state-migrations.ts"],
   "Kysely-backed stores that own a DatabaseSync boundary": [
     "src/acp/event-ledger.ts",


### PR DESCRIPTION
## Summary

Allow `src/agents/auth-profiles/sqlite.ts` through the raw SQLite/Kysely guardrail under a named read-only bootstrap owner.

The auth profile reader opens a short-lived read-only `DatabaseSync` and immediately wraps reads through the existing Kysely sync helpers. CI was failing `check-additional-runtime-topology-architecture` because the file was not on the raw SQLite allowlist.

## Verification

- `node scripts/check-kysely-guardrails.mjs`
- Architecture chain progressed through import cycles, madge cycles, deprecated API/JSDoc checks, generated Kysely verification, and Kysely guardrails locally; the final legacy-store guard hit local Node heap limits on this Mac and is unrelated to this one-line allowlist.
