### PR TITLE
fix(bedrock): strip inference profile prefix from model ID in embedding adapter

### DIFF
--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -120,20 +120,26 @@ describe("stripInferenceProfilePrefix", () => {
     expect(testing.stripInferenceProfilePrefix("us.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
   });
 
+  it("strips eu prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("eu.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
+  });
+
+  it("strips ap prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("ap.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
+  });
+
   it("strips apac prefix", () => {
     expect(testing.stripInferenceProfilePrefix("apac.cohere.embed-v4:0")).toBe(
       "cohere.embed-v4:0",
     );
   });
 
-  it("strips eu prefix", () => {
-    expect(testing.stripInferenceProfilePrefix("eu.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
+  it("strips au prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("au.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
   });
 
-  it("strips us-gov prefix", () => {
-    expect(testing.stripInferenceProfilePrefix("us-gov.cohere.embed-v4:0")).toBe(
-      "cohere.embed-v4:0",
-    );
+  it("strips jp prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("jp.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
   });
 
   it("returns unchanged model ID without prefix", () => {

--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -108,3 +108,41 @@ describe("bedrock embedding response parsers", () => {
     ).toThrow("Amazon Bedrock embedding response returned malformed JSON");
   });
 });
+
+describe("stripInferenceProfilePrefix", () => {
+  it("strips global prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("global.cohere.embed-v4:0")).toBe(
+      "cohere.embed-v4:0",
+    );
+  });
+
+  it("strips us prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("us.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
+  });
+
+  it("strips apac prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("apac.cohere.embed-v4:0")).toBe(
+      "cohere.embed-v4:0",
+    );
+  });
+
+  it("strips eu prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("eu.cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
+  });
+
+  it("strips us-gov prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("us-gov.cohere.embed-v4:0")).toBe(
+      "cohere.embed-v4:0",
+    );
+  });
+
+  it("returns unchanged model ID without prefix", () => {
+    expect(testing.stripInferenceProfilePrefix("cohere.embed-v4:0")).toBe("cohere.embed-v4:0");
+  });
+
+  it("returns unchanged model ID for amazon.titan-embed-text-v2:0", () => {
+    expect(testing.stripInferenceProfilePrefix("amazon.titan-embed-text-v2:0")).toBe(
+      "amazon.titan-embed-text-v2:0",
+    );
+  });
+});

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -69,12 +69,18 @@ const MODELS: Record<string, ModelSpec> = {
   "twelvelabs.marengo-embed-3-0-v1:0": { maxTokens: 512, dims: 512, family: "twelvelabs" },
 };
 
+/** Strip AWS inference profile prefix (global., us., apac., eu., us-gov.) from model ID. */
+function stripInferenceProfilePrefix(modelId: string): string {
+  return modelId.replace(/^(us-gov|us|global|apac|eu)\./, "");
+}
+
 /** Resolve spec, stripping throughput suffixes like `:2:8k` or `:0:512`. */
 function resolveSpec(modelId: string): ModelSpec | undefined {
-  if (MODELS[modelId]) {
-    return MODELS[modelId];
+  const bare = stripInferenceProfilePrefix(modelId);
+  if (MODELS[bare]) {
+    return MODELS[bare];
   }
-  const parts = modelId.split(":");
+  const parts = bare.split(":");
   for (let i = parts.length - 1; i >= 1; i--) {
     const spec = MODELS[parts.slice(0, i).join(":")];
     if (spec) {
@@ -86,7 +92,7 @@ function resolveSpec(modelId: string): ModelSpec | undefined {
 
 /** Infer family from model ID prefix when not in catalog. */
 function inferFamily(modelId: string): Family {
-  const id = normalizeLowercaseStringOrEmpty(modelId);
+  const id = normalizeLowercaseStringOrEmpty(stripInferenceProfilePrefix(modelId));
   if (id.startsWith("amazon.titan-embed-text-v2")) {
     return "titan-v2";
   }
@@ -312,6 +318,7 @@ function parseCohereBatch(family: Family, raw: string): number[][] {
 export const testing = {
   parseCohereBatch,
   parseSingle,
+  stripInferenceProfilePrefix,
 };
 
 // ---------------------------------------------------------------------------

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -69,9 +69,9 @@ const MODELS: Record<string, ModelSpec> = {
   "twelvelabs.marengo-embed-3-0-v1:0": { maxTokens: 512, dims: 512, family: "twelvelabs" },
 };
 
-/** Strip AWS inference profile prefix (global., us., apac., eu., us-gov.) from model ID. */
+/** Strip AWS inference profile prefix (us., eu., ap., apac., au., jp., global.) from model ID. */
 function stripInferenceProfilePrefix(modelId: string): string {
-  return modelId.replace(/^(us-gov|us|global|apac|eu)\./, "");
+  return modelId.replace(/^(?:us|eu|ap|apac|au|jp|global)\./, "");
 }
 
 /** Resolve spec, stripping throughput suffixes like `:2:8k` or `:0:512`. */


### PR DESCRIPTION
## Summary

Fixes #79212

The Bedrock embedding adapter fails with `ValidationException: Malformed request` when configured with an inference-profile-prefixed model id (e.g. `global.cohere.embed-v4:0`), because `resolveSpec()` and `inferFamily()` do not strip the `global.`/`us.`/`apac.`/`eu.`/`us-gov.` prefix before catalog lookup, causing the family to silently fall back to `titan-v1` and the wrong request body to be built.

## Changes

- Add `stripInferenceProfilePrefix(modelId)` helper that strips AWS inference profile prefixes (`global.`, `us.`, `apac.`, `eu.`, `us-gov.`) from model IDs
- Use it in `resolveSpec()` to correctly look up model specs from the catalog
- Use it in `inferFamily()` to correctly infer the family from model ID prefix
- Add unit tests for `stripInferenceProfilePrefix` covering all prefix variants

## Verification

All 19 tests in `extensions/amazon-bedrock/embedding-provider.test.ts` pass:

```
✓ extension-providers extensions/amazon-bedrock/embedding-provider.test.ts (19 tests) 34ms
Test Files  1 passed (1)
     Tests  19 passed (19)
```

## What this does NOT change

- `InvokeModelCommand.modelId` continues to use the full prefixed id so Bedrock resolves the inference profile correctly
- No changes to request/response parsing logic beyond the model ID resolution
- No CHANGELOG changes (per contributing guidelines)