### PR TITLE
fix(cli): accept --log-level after subcommands

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -16,6 +16,7 @@ import {
   isRootVersionInvocation,
   normalizeGeneratedHelpCommandArgv,
   normalizeRootHelpTargetArgv,
+  normalizeRootLogLevelArgv,
   normalizeRootNoColorArgv,
   shouldMigrateState,
   shouldMigrateStateFromPath,
@@ -225,6 +226,63 @@ describe("argv helpers", () => {
           remainingArgs[noColorIndex - 1] === "--message",
       }),
     ).toEqual(["node", "openclaw", "--no-color", "doctor", "--lint", "--json"]);
+  });
+
+  it.each([
+    {
+      name: "subcommand trailing log-level",
+      argv: ["node", "openclaw", "doctor", "--log-level", "debug", "--json"],
+      expected: ["node", "openclaw", "--log-level", "debug", "doctor", "--json"],
+    },
+    {
+      name: "subcommand trailing log-level equals form",
+      argv: ["node", "openclaw", "doctor", "--log-level=trace", "--json"],
+      expected: ["node", "openclaw", "--log-level=trace", "doctor", "--json"],
+    },
+    {
+      name: "keeps existing root options first",
+      argv: ["node", "openclaw", "--profile", "work", "doctor", "--log-level", "debug"],
+      expected: ["node", "openclaw", "--profile", "work", "--log-level", "debug", "doctor"],
+    },
+    {
+      name: "keeps log-level after possible command option value",
+      argv: ["node", "openclaw", "agent", "--message", "--log-level", "debug"],
+      expected: ["node", "openclaw", "agent", "--message", "--log-level", "debug"],
+    },
+    {
+      name: "flag terminator leaves log-level positional",
+      argv: ["node", "openclaw", "nodes", "run", "--", "--log-level", "debug"],
+      expected: ["node", "openclaw", "nodes", "run", "--", "--log-level", "debug"],
+    },
+    {
+      name: "missing value remains command scoped",
+      argv: ["node", "openclaw", "doctor", "--log-level", "--json"],
+      expected: ["node", "openclaw", "doctor", "--log-level", "--json"],
+    },
+  ])("normalizes root --log-level before command parsing: $name", ({ argv, expected }) => {
+    expect(normalizeRootLogLevelArgv(argv)).toEqual(expected);
+  });
+
+  it("allows final command metadata to lift log-level after boolean command flags", () => {
+    const argv = ["node", "openclaw", "doctor", "--lint", "--json", "--log-level", "debug"];
+
+    expect(
+      normalizeRootLogLevelArgv(argv, {
+        shouldPreserveLogLevel: ({ remainingArgs, logLevelIndex }) =>
+          remainingArgs[logLevelIndex - 1] === "--message",
+      }),
+    ).toEqual(["node", "openclaw", "--log-level", "debug", "doctor", "--lint", "--json"]);
+  });
+
+  it("preserves log-level when final command metadata owns the option", () => {
+    const argv = ["node", "openclaw", "plugin-cmd", "--log-level", "debug"];
+
+    expect(
+      normalizeRootLogLevelArgv(argv, {
+        shouldPreserveLogLevel: ({ remainingArgs, logLevelIndex }) =>
+          remainingArgs[logLevelIndex] === "--log-level",
+      }),
+    ).toEqual(argv);
   });
 
   it.each([

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -260,15 +260,37 @@ export type NormalizeRootNoColorArgvOptions = {
   }) => boolean;
 };
 
+export type NormalizeRootLogLevelArgvOptions = {
+  shouldPreserveLogLevel?: (params: {
+    remainingArgs: readonly string[];
+    logLevelIndex: number;
+    consumed: number;
+  }) => boolean;
+};
+
 function isPossibleCommandOptionValue(
   remainingArgs: readonly string[],
-  noColorIndex: number,
+  optionIndex: number,
 ): boolean {
-  const previous = remainingArgs[noColorIndex - 1];
+  const previous = remainingArgs[optionIndex - 1];
   if (!previous?.startsWith("-") || previous === FLAG_TERMINATOR) {
     return false;
   }
   return !previous.includes("=");
+}
+
+function consumeRootLogLevelToken(args: readonly string[], index: number): number {
+  const arg = args[index];
+  if (!arg || arg === FLAG_TERMINATOR) {
+    return 0;
+  }
+  if (arg.startsWith("--log-level=")) {
+    return arg.slice("--log-level=".length).trim() ? 1 : 0;
+  }
+  if (arg === "--log-level") {
+    return isValueToken(args[index + 1]) ? 2 : 0;
+  }
+  return 0;
 }
 
 export function normalizeRootNoColorArgv(
@@ -321,6 +343,62 @@ export function normalizeRootNoColorArgv(
     return argv;
   }
   return [...prefix, ...rootPrefix, ...movedNoColorArgs, ...nextArgs];
+}
+
+export function normalizeRootLogLevelArgv(
+  argv: string[],
+  options: NormalizeRootLogLevelArgvOptions = {},
+): string[] {
+  const prefix = argv.slice(0, 2);
+  const args = argv.slice(2);
+  let rootPrefixEnd = 0;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    const consumed = consumeRootOptionToken(args, index);
+    if (consumed <= 0) {
+      break;
+    }
+    rootPrefixEnd = index + consumed;
+    index += consumed - 1;
+  }
+
+  const rootPrefix = args.slice(0, rootPrefixEnd);
+  const remainingArgs = args.slice(rootPrefixEnd);
+  const movedLogLevelArgs: string[] = [];
+  const nextArgs: string[] = [];
+  for (let index = 0; index < remainingArgs.length; index += 1) {
+    const arg = remainingArgs[index];
+    if (arg === FLAG_TERMINATOR) {
+      nextArgs.push(...remainingArgs.slice(index));
+      break;
+    }
+    const consumed = consumeRootLogLevelToken(remainingArgs, index);
+    if (consumed > 0) {
+      const shouldPreserve =
+        options.shouldPreserveLogLevel?.({
+          remainingArgs,
+          logLevelIndex: index,
+          consumed,
+        }) ?? isPossibleCommandOptionValue(remainingArgs, index);
+      const tokens = remainingArgs.slice(index, index + consumed);
+      if (shouldPreserve) {
+        nextArgs.push(...tokens);
+      } else {
+        movedLogLevelArgs.push(...tokens);
+      }
+      index += consumed - 1;
+      continue;
+    }
+    nextArgs.push(arg);
+  }
+
+  if (movedLogLevelArgs.length === 0) {
+    return argv;
+  }
+  return [...prefix, ...rootPrefix, ...movedLogLevelArgs, ...nextArgs];
 }
 
 export function getFlagValue(argv: string[], name: string): string | null | undefined {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -18,6 +18,7 @@ import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import {
   normalizeGeneratedHelpCommandArgv,
   normalizeRootHelpTargetArgv,
+  normalizeRootLogLevelArgv,
   normalizeRootNoColorArgv,
 } from "./argv.js";
 import {
@@ -425,10 +426,52 @@ function isNoColorConsumedAsCommandOptionValue(
   return pendingValue;
 }
 
+function isLogLevelConsumedAsCommandOption(
+  program: CommanderCommand,
+  remainingArgs: readonly string[],
+  logLevelIndex: number,
+): boolean {
+  let command = program;
+  let pendingValue = false;
+  for (let index = 0; index < logLevelIndex; index += 1) {
+    const arg = remainingArgs[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      return false;
+    }
+    if (pendingValue) {
+      pendingValue = false;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      const option = findCommandOption(command, arg);
+      if (!option && index === logLevelIndex - 1 && !arg.includes("=")) {
+        return true;
+      }
+      pendingValue = shouldOptionConsumeFollowingToken(option, arg, remainingArgs[index + 1]);
+      continue;
+    }
+    command = findSubcommand(command, arg) ?? command;
+  }
+
+  if (pendingValue) {
+    return true;
+  }
+
+  const arg = remainingArgs[logLevelIndex];
+  return command !== program && arg !== undefined && findCommandOption(command, arg) !== undefined;
+}
+
 function normalizeRootNoColorArgvForProgram(argv: string[], program: CommanderCommand): string[] {
   return normalizeRootNoColorArgv(argv, {
     shouldPreserveNoColor: ({ remainingArgs, noColorIndex }) =>
       isNoColorConsumedAsCommandOptionValue(program, remainingArgs, noColorIndex),
+  });
+}
+
+function normalizeRootLogLevelArgvForProgram(argv: string[], program: CommanderCommand): string[] {
+  return normalizeRootLogLevelArgv(argv, {
+    shouldPreserveLogLevel: ({ remainingArgs, logLevelIndex }) =>
+      isLogLevelConsumedAsCommandOption(program, remainingArgs, logLevelIndex),
   });
 }
 
@@ -1051,7 +1094,10 @@ export async function runCli(argv: string[] = process.argv) {
         }
       }
 
-      parseArgv = normalizeRootNoColorArgvForProgram(parseArgv, program);
+      parseArgv = normalizeRootLogLevelArgvForProgram(
+        normalizeRootNoColorArgvForProgram(parseArgv, program),
+        program,
+      );
       stopStartupProgress();
 
       try {


### PR DESCRIPTION
﻿## Summary

- Root `--log-level <level>` is accepted before a subcommand, but Commander-owned command paths can reject it when callers append it after the subcommand, for example `openclaw doctor --lint --json --log-level debug`.
- This is the value-option sibling of the already-landed `--no-color` normalization in #93324.
- This PR normalizes valid trailing `--log-level <level>` and `--log-level=<level>` tokens back into the root option prefix before the final Commander parse.
- Out of scope: changing log rendering, route-first logging behavior, or broadly reordering every root value option after subcommands.
- Success looks like real subcommands accepting trailing `--log-level` while command-owned `--log-level`, required option values, missing values, and `--` positionals stay command-scoped.
- Reviewer focus: value-option normalization around `--`, required option values such as `agent --message --log-level`, and the final Commander-metadata pass that avoids stealing command-owned `--log-level` options.

## Linked context

No separate issue. This is a small follow-up to the CLI parser behavior fixed in #93324.

## Real behavior proof (required for external PRs)

- Behavior addressed: root `--log-level <level>` after a subcommand could be parsed as an unknown command option instead of the root log-level override on final Commander command paths.
- Real environment tested: Windows source checkout on branch `fix/cli-log-level-subcommands`, commit `6d39dd1760`, Node `v22.22.0`, pnpm `11.2.2`, source rebuilt through `scripts/run-node.mjs`.
- Exact steps or command run after this patch:

```powershell
node scripts/run-node.mjs doctor --lint --json --log-level debug --severity-min error
```

- Evidence after fix:

```json
{"ok":true,"checksRun":22,"checksSkipped":0,"findings":[]}
```

- Observed result after fix: the command accepts `--log-level debug` after `doctor` boolean flags and reaches doctor lint JSON output; Commander no longer rejects it as an unknown command option.
- What was not tested: full CLI suite, packaged npm install, route-first log-level application, every subcommand/plugin command combination.
- Proof limitations or environment constraints: source checkout proof only, not a packaged release artifact. The source checkout warned that the local config was written by `2026.6.8-beta.1` while the source package version is `2026.6.2`; the doctor lint proof still completed successfully.

## Tests and validation

Commands run:

```powershell
node scripts/run-vitest.mjs src/cli/argv.test.ts
node scripts/run-oxlint.mjs src\cli\argv.ts src\cli\run-main.ts src\cli\argv.test.ts
node_modules\.bin\oxfmt.cmd --check --threads=1 src\cli\argv.ts src\cli\run-main.ts src\cli\argv.test.ts
node_modules\.bin\oxlint.cmd src\cli\argv.ts src\cli\run-main.ts src\cli\argv.test.ts --threads=1
git diff --check
node scripts/run-node.mjs doctor --lint --json --log-level debug --severity-min error
python -X utf8 .agents\skills\autoreview\scripts\autoreview --mode local
```

Results:

```text
argv focused Vitest: 125 passed
run-oxlint: passed
oxfmt --check: passed
plain oxlint: passed
git diff --check: passed
doctor real CLI proof: {"ok":true,"checksRun":22,"checksSkipped":0,"findings":[]}
autoreview: clean, no accepted/actionable findings
```

Regression coverage added:

- Moves `--log-level <level>` and `--log-level=<level>` from unambiguous subcommand positions to the root option prefix.
- Preserves existing root option prefixes such as `--profile work`.
- Leaves `--log-level` after `--` positional.
- Leaves missing-value `--log-level` command-scoped.
- Preserves literal required-option values such as `agent --message --log-level debug`.
- Lets final Commander command metadata lift `--log-level` after boolean command flags without stealing command-owned `--log-level` options.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The CLI now accepts root `--log-level <level>` after subcommands in valid unambiguous positions.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Accidentally treating a command-owned `--log-level` or a required option value as the root log-level override.

How is that risk mitigated?

The early normalization remains conservative, the final parse uses Commander command metadata, and tests cover required-option values, command-owned option preservation, missing values, and the `--` terminator.

## Current review state

What is the next action?

Wait for CI, ClawSweeper, and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and ClawSweeper are pending after PR creation.

Which bot or reviewer comments were addressed?

Local autoreview was run before opening and reported no accepted/actionable findings.
