### PR TITLE
fix(agents): handle string assistant message content

### DIFF
--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -780,6 +780,9 @@ function hasOwnProperty(value: object, key: string): boolean {
 }
 
 function hasAssistantToolCallArguments(message: Extract<Message, { role: "assistant" }>): boolean {
+  if (!Array.isArray(message.content)) {
+    return false;
+  }
   return message.content.some(
     (part) => part.type === "toolCall" && hasOwnProperty(part, "arguments"),
   );


### PR DESCRIPTION
## Summary

- Fixes an inherited `SessionManager.appendMessage` crash when assistant messages carry legacy/plain string content.
- Keeps the tool-call argument scan limited to array content parts; string content cannot contain structured tool-call argument parts.
- Unblocks the current core/gateway CI failure seen on Clownfish PRs that do not touch this code path.
- Out of scope: changing message serialization shape or adding compat paths beyond this narrow guard.

## Linked context

Related open Clownfish PRs blocked by this main failure:

- https://github.com/openclaw/openclaw/pull/93441
- https://github.com/openclaw/openclaw/pull/93443

Was this requested by a maintainer or owner?

- Maintainer-side CI unblock while scaling ProjectClownfish cleanup.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: assistant string content no longer crashes the assistant tool-call argument scan.
- Real environment tested: local OpenClaw Codex worktree using the repo test wrapper.
- Exact steps or command run after this patch: `node scripts/test-projects-serial.mjs src/agents/session-tool-result-guard.test.ts src/gateway/session-compaction-checkpoints.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): unit-fast shard passed 1 file / 35 tests; gateway shard passed 4 files / 44 tests.
- Observed result after fix: both previously failing suites completed without `message.content.some is not a function`.
- What was not tested: full changed gate did not start locally because this shell has no `pnpm`, and `check:changed` delegates to Testbox via `pnpm crabbox:run`.
- Proof limitations or environment constraints: local shell is missing `pnpm`; CI should run the normal hosted gate.
- Before evidence: Clownfish PR CI failed `checks-node-core-fast` and `checks-node-agentic-gateway-core` with `TypeError: message.content.some is not a function` in `src/agents/sessions/session-manager.ts`.

## Tests and validation

- `node scripts/test-projects-serial.mjs src/agents/session-tool-result-guard.test.ts src/gateway/session-compaction-checkpoints.test.ts`
- `git diff --check`
- `node scripts/check-changed.mjs` attempted, but failed before running the gate because `pnpm` is not installed in this local shell.

Regression coverage was already present in the failing suites; this PR fixes the implementation path those tests exercise.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes, narrowly: assistant string content is accepted again instead of crashing during append.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- Message serialization around assistant tool-call content.

How is that risk mitigated?

- The guard only bypasses structured part scanning for non-array content, where structured `toolCall` parts cannot exist.

## Current review state

What is the next action?

- Wait for CI. If clean, squash merge to unblock the two Clownfish PRs.

What is still waiting on author, maintainer, CI, or external proof?

- Hosted CI / changed gate.

Which bot or reviewer comments were addressed?

- None yet.
