### PR TITLE
fix(cli): honor --log-level in route-first commands

### DIFF
--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -47,6 +47,7 @@ describe("tryRouteCli", () => {
   let loggingState: typeof import("../logging/state.js").loggingState;
   let originalDisableRouteFirst: string | undefined;
   let originalHideBanner: string | undefined;
+  let originalLogLevel: string | undefined;
   let originalForceStderr: boolean;
 
   beforeAll(async () => {
@@ -58,8 +59,10 @@ describe("tryRouteCli", () => {
     vi.clearAllMocks();
     originalDisableRouteFirst = process.env.OPENCLAW_DISABLE_ROUTE_FIRST;
     originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
+    originalLogLevel = process.env.OPENCLAW_LOG_LEVEL;
     delete process.env.OPENCLAW_DISABLE_ROUTE_FIRST;
     delete process.env.OPENCLAW_HIDE_BANNER;
+    delete process.env.OPENCLAW_LOG_LEVEL;
     originalForceStderr = loggingState.forceConsoleToStderr;
     loggingState.forceConsoleToStderr = false;
     findRoutedCommandMock.mockReturnValue({
@@ -81,6 +84,11 @@ describe("tryRouteCli", () => {
       delete process.env.OPENCLAW_HIDE_BANNER;
     } else {
       process.env.OPENCLAW_HIDE_BANNER = originalHideBanner;
+    }
+    if (originalLogLevel === undefined) {
+      delete process.env.OPENCLAW_LOG_LEVEL;
+    } else {
+      process.env.OPENCLAW_LOG_LEVEL = originalLogLevel;
     }
   });
 
@@ -166,6 +174,11 @@ describe("tryRouteCli", () => {
   });
 
   it("routes status when root options precede the command", async () => {
+    const capturedLogLevels: Array<string | undefined> = [];
+    ensureConfigReadyMock.mockImplementationOnce(async () => {
+      capturedLogLevels.push(process.env.OPENCLAW_LOG_LEVEL);
+    });
+
     await expect(tryRouteCli(["node", "openclaw", "--log-level", "debug", "status"])).resolves.toBe(
       true,
     );
@@ -181,6 +194,50 @@ describe("tryRouteCli", () => {
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({
       scope: "channels",
     });
+    expect(capturedLogLevels).toEqual(["debug"]);
+    expect(process.env.OPENCLAW_LOG_LEVEL).toBe("debug");
+  });
+
+  it("applies routed log level options after the command", async () => {
+    const capturedLogLevels: Array<string | undefined> = [];
+    ensureConfigReadyMock.mockImplementationOnce(async () => {
+      capturedLogLevels.push(process.env.OPENCLAW_LOG_LEVEL);
+    });
+
+    await expect(tryRouteCli(["node", "openclaw", "status", "--log-level=trace"])).resolves.toBe(
+      true,
+    );
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
+    expect(runRouteMock).toHaveBeenCalledTimes(1);
+    expect(capturedLogLevels).toEqual(["trace"]);
+    expect(process.env.OPENCLAW_LOG_LEVEL).toBe("trace");
+  });
+
+  it("uses the last valid routed log level option", async () => {
+    await expect(
+      tryRouteCli(["node", "openclaw", "--log-level", "debug", "status", "--log-level=trace"]),
+    ).resolves.toBe(true);
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
+    expect(runRouteMock).toHaveBeenCalledTimes(1);
+    expect(process.env.OPENCLAW_LOG_LEVEL).toBe("trace");
+  });
+
+  it.each([
+    ["invalid value", ["node", "openclaw", "status", "--log-level", "verbose"]],
+    ["missing value", ["node", "openclaw", "status", "--log-level"]],
+    [
+      "later invalid value",
+      ["node", "openclaw", "--log-level", "debug", "status", "--log-level", "verbose"],
+    ],
+  ])("falls back for %s routed log level options before bootstrap", async (_name, argv) => {
+    await expect(tryRouteCli(argv)).resolves.toBe(false);
+
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+    expect(runRouteMock).not.toHaveBeenCalled();
+    expect(process.env.OPENCLAW_LOG_LEVEL).toBeUndefined();
   });
 
   it("respects OPENCLAW_HIDE_BANNER for routed commands", async () => {

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -1,5 +1,7 @@
 // Route-first CLI entry point for commands that can run before full Commander setup.
+import { FLAG_TERMINATOR, isValueToken } from "../infra/cli-root-options.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { type LogLevel, tryParseLogLevel } from "../logging/levels.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 import { hasFlag } from "./argv.js";
@@ -9,6 +11,43 @@ import {
   resolveCliExecutionStartupContext,
 } from "./command-execution-startup.js";
 import { findRoutedCommand } from "./program/routes.js";
+
+const LOG_LEVEL_FLAG = "--log-level";
+const LOG_LEVEL_EQUALS_PREFIX = `${LOG_LEVEL_FLAG}=`;
+
+function resolveRoutedCliLogLevel(argv: string[]): LogLevel | null | undefined {
+  const args = argv.slice(2);
+  let logLevel: LogLevel | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg || arg === FLAG_TERMINATOR) {
+      break;
+    }
+    if (arg === LOG_LEVEL_FLAG) {
+      const value = args[index + 1];
+      if (!isValueToken(value)) {
+        return null;
+      }
+      const parsed = tryParseLogLevel(value);
+      if (!parsed) {
+        return null;
+      }
+      logLevel = parsed;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith(LOG_LEVEL_EQUALS_PREFIX)) {
+      const parsed = tryParseLogLevel(arg.slice(LOG_LEVEL_EQUALS_PREFIX.length));
+      if (!parsed) {
+        return null;
+      }
+      logLevel = parsed;
+    }
+  }
+
+  return logLevel;
+}
 
 async function prepareRoutedCommand(params: {
   argv: string[];
@@ -58,6 +97,14 @@ export async function tryRouteCli(argv: string[]): Promise<boolean> {
   if (route.canRun && !route.canRun(argv)) {
     // Let Commander own unsupported argv shapes so user-facing validation stays centralized.
     return false;
+  }
+  const logLevel = resolveRoutedCliLogLevel(argv);
+  if (logLevel === null) {
+    // Let Commander own the existing user-facing --log-level validation errors.
+    return false;
+  }
+  if (logLevel) {
+    process.env.OPENCLAW_LOG_LEVEL = logLevel;
   }
   await prepareRoutedCommand({
     argv,


### PR DESCRIPTION
## Summary

- Route-first commands can accept root `--log-level <level>` while finding the command path, but they bypass the Commander `preAction` hook that applies the CLI log-level override.
- This PR scans routed argv for `--log-level` before route-first bootstrap, applies the last valid value to `OPENCLAW_LOG_LEVEL`, and falls back to Commander for missing or invalid values.
- This matters for diagnostics on common fast-path commands such as `status`, `health`, `gateway status`, `agents list`, `config get`, `models list/status`, `tasks list/audit`, `channels list/status`, and `plugins list`.
- Out of scope: changing log rendering, changing Commander-path trailing option normalization, or adding broad root-option reordering for route-first commands.
- Success looks like route-first bootstrap seeing the requested log level, while invalid/missing/repeated `--log-level` inputs keep Commander-compatible validation behavior.
- Reviewer focus: the pre-bootstrap ordering in `src/cli/route.ts`, repeated `--log-level` parity with Commander, and the fallback path for invalid or missing values.

## Linked context

Fixes #93457.

Related #93455 covers a separate Commander-path issue where non-route-first commands can reject trailing root `--log-level`.

No maintainer request; this came from source inspection while keeping #93455 intentionally scoped.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: route-first CLI commands accepted `--log-level` for command routing but did not apply the global log-level override because they skipped Commander `preAction`.
- Real environment tested: Windows source checkout on branch `fix/cli-route-log-level`, commit `34077f8737`, Node `v22.22.0`, pnpm `11.2.2`, source rebuilt through `scripts/run-node.mjs`.
- Exact steps or command run after this patch:

```powershell
node scripts/run-node.mjs --log-level debug status --json | Select-String -Pattern '"runtimeVersion"|"branch"|"dirty"|"reachable"' -Context 0,0
```

- Evidence after fix:

```text
"runtimeVersion": "2026.6.2",
"branch": "fix/cli-route-log-level",
"dirty": false,
"reachable": true,
```

- Observed result after fix: the route-first `status --json` path accepts root `--log-level debug`, reaches real status JSON output on the source checkout, and remains on the clean PR branch. Focused route tests additionally capture `OPENCLAW_LOG_LEVEL` inside the routed bootstrap mock as `debug` / `trace`, proving the override is applied before bootstrap.
- What was not tested: full CLI suite, packaged npm install, every routed command, and visual/log-rendering differences for each log level.
- Proof limitations or environment constraints: source checkout proof only, not a packaged release artifact. The source runner printed local config/version warnings because this machine also has a newer beta gateway service installed; the route-first status command still exited successfully and returned status JSON.
- Before evidence (optional but encouraged): source inspection showed `src/cli/program/preaction.ts` sets `process.env.OPENCLAW_LOG_LEVEL` only on Commander paths, while `src/cli/route.ts` ran route-first commands without applying that option. Existing `src/cli/route.test.ts` covered routing with `--log-level` but did not assert the log level took effect.

## Tests and validation

Commands run:

```powershell
node scripts/run-vitest.mjs src/cli/route.test.ts
node scripts/run-oxlint.mjs src\cli\route.ts src\cli\route.test.ts
node_modules\.bin\oxfmt.cmd --check --threads=1 src\cli\route.ts src\cli\route.test.ts
git diff --check
node scripts/run-node.mjs --log-level debug status --json | Select-String -Pattern '"runtimeVersion"|"branch"|"dirty"|"reachable"' -Context 0,0
python -X utf8 .agents\skills\autoreview\scripts\autoreview --mode local
```

Results:

```text
route focused Vitest: 14 passed
run-oxlint: passed
oxfmt --check: passed
git diff --check: passed
route-first real CLI smoke: runtimeVersion 2026.6.2, branch fix/cli-route-log-level, dirty false, gateway reachable true
autoreview: clean, no accepted/actionable findings after addressing repeated --log-level validation parity
```

Regression coverage added:

- Applies `--log-level debug` before routed bootstrap when root options precede the command.
- Applies `--log-level=trace` after a route-first command.
- Uses the last valid repeated log-level value for Commander parity.
- Falls back before bootstrap for missing values, invalid values, and later invalid repeated values.
- Restores `OPENCLAW_LOG_LEVEL` in route tests to avoid environment leakage.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Route-first commands now honor the documented global `--log-level` override.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes, narrowly. When a routed command receives a valid CLI `--log-level`, the route-first path now sets `OPENCLAW_LOG_LEVEL` before startup/bootstrap work, matching Commander-backed commands.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Changing route-first startup ordering or silently diverging from Commander option validation for repeated, invalid, or missing `--log-level` inputs.

How is that risk mitigated?

The change only applies one documented global option, validates every occurrence before routed bootstrap, lets Commander own invalid/missing-value errors by returning `false`, and adds focused route tests for prefix, suffix, repeated, invalid, and missing cases.

## Current review state

What is the next action?

Wait for CI, ClawSweeper, and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI and ClawSweeper are pending after PR creation.

Which bot or reviewer comments were addressed?

Local autoreview initially flagged repeated `--log-level` parity. The patch now scans every routed log-level occurrence, rejects any invalid/missing value before bootstrap, applies the last valid value, and the final autoreview run reported no accepted/actionable findings.