### PR TITLE
fix: add compact mode to cron list tool

### DIFF
--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -160,6 +160,8 @@ import {
   type CronGetParams,
   CronGetParamsSchema,
   type CronJob,
+  type CronJobCompact,
+  CronJobCompactSchema,
   CronJobSchema,
   type CronListParams,
   CronListParamsSchema,

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -450,10 +450,26 @@ export const CronJobSchema = Type.Object(
   { additionalProperties: false },
 );
 
+/** Compact cron job summary (6 fields only). */
+export const CronJobCompactSchema = Type.Object(
+  {
+    id: NonEmptyString,
+    name: NonEmptyString,
+    enabled: Type.Boolean(),
+    nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    scheduleKind: Type.Union([Type.Literal("at"), Type.Literal("every"), Type.Literal("cron")]),
+    lastRunStatus: Type.Optional(
+      Type.Union([Type.Literal("ok"), Type.Literal("error"), Type.Literal("skipped"), Type.Null()]),
+    ),
+  },
+  { additionalProperties: false },
+);
+
 /** Query params for listing cron jobs with filters and pagination. */
 export const CronListParamsSchema = Type.Object(
   {
     includeDisabled: Type.Optional(Type.Boolean()),
+    compact: Type.Optional(Type.Boolean()),
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200 })),
     offset: Type.Optional(Type.Integer({ minimum: 0 })),
     query: Type.Optional(Type.String()),

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -307,6 +307,7 @@ export function createCronToolSchema(): TSchema {
       action: stringEnum(CRON_ACTIONS),
       ...gatewayCallOptionSchemaProperties(),
       includeDisabled: Type.Optional(Type.Boolean()),
+      compact: Type.Optional(Type.Boolean({ description: 'Return lightweight 6-field summaries for "list" action' })),
       job: createCronJobObjectSchema(),
       jobId: Type.Optional(Type.String()),
       id: Type.Optional(Type.String()),
@@ -759,7 +760,7 @@ Main cron => system events for heartbeat. Isolated cron => background task in \`
 
 ACTIONS:
 - status: scheduler status
-- list: jobs; includeDisabled true includes disabled; agentId filter auto-filled from session
+- list: jobs; includeDisabled true includes disabled; agentId filter auto-filled from session; compact true returns lightweight 6-field summaries (id/name/enabled/nextRunAtMs/scheduleKind/lastRunStatus) to reduce tokens with 10+ jobs
 - get: one job; needs jobId
 - add: create job; needs job object
 - update: patch job; needs jobId + patch
@@ -864,9 +865,11 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
           let offset = 0;
           let result: unknown;
           let shouldContinue = true;
+          const compact = Boolean(params.compact);
           while (shouldContinue) {
             result = await callGateway("cron.list", gatewayOpts, {
               includeDisabled,
+              compact,
               agentId: listAgentId,
               ...(selfRemoveOnlyJobId ? { limit: 200, offset } : {}),
             });

--- a/src/cron/service/list-page-types.ts
+++ b/src/cron/service/list-page-types.ts
@@ -19,6 +19,8 @@ export type CronSortDir = "asc" | "desc";
 /** Input contract for filtered, sorted, offset-based cron job pages. */
 export type CronListPageOptions = {
   includeDisabled?: boolean;
+  /** Return lightweight 6-field summaries instead of full CronJob objects. */
+  compact?: boolean;
   limit?: number;
   offset?: number;
   query?: string;
@@ -31,7 +33,7 @@ export type CronListPageOptions = {
 };
 
 /** Offset-page result returned by cron listPage callers. */
-export type CronListPageResult<TJobs extends readonly CronJob[] = CronJob[]> = {
+export type CronListPageResult<TJobs extends readonly unknown[] = CronJob[]> = {
   jobs: TJobs;
   total: number;
   offset: number;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -43,6 +43,27 @@ import type {
   CronListPageResult,
   CronSortDir,
 } from "./list-page-types.js";
+
+/** Lightweight cron job summary (6 fields). */
+export type CronJobCompact = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  nextRunAtMs: number | null;
+  scheduleKind: "at" | "every" | "cron";
+  lastRunStatus: "ok" | "error" | "skipped" | null;
+};
+
+function compactJob(job: CronJob): CronJobCompact {
+  return {
+    id: job.id,
+    name: job.name,
+    enabled: job.enabled,
+    nextRunAtMs: typeof job.state.nextRunAtMs === "number" ? job.state.nextRunAtMs : null,
+    scheduleKind: job.schedule.kind,
+    lastRunStatus: job.state.lastRunStatus ?? job.state.lastStatus ?? null,
+  };
+}
 import { locked } from "./locked.js";
 import { normalizeOptionalAgentId } from "./normalize.js";
 import type { CronServiceState, CronWakeMode } from "./state.js";
@@ -423,6 +444,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const enabledFilter = resolveEnabledFilter(opts);
     const scheduleKindFilter = resolveScheduleKindFilter(opts);
     const lastRunStatusFilter = resolveLastRunStatusFilter(opts);
+    const compact = opts?.compact === true;
     const sortBy = opts?.sortBy ?? "nextRunAtMs";
     const sortDir = opts?.sortDir ?? "asc";
     const requestedAgentId = normalizeOptionalAgentId(opts?.agentId);
@@ -459,8 +481,9 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
     const defaultLimit = total === 0 ? 50 : total;
     const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
-    const jobs = sorted.slice(offset, offset + limit);
-    const nextOffset = offset + jobs.length;
+    const sliced = sorted.slice(offset, offset + limit);
+    const jobs = compact ? sliced.map((job) => compactJob(job)) : sliced;
+    const nextOffset = offset + sliced.length;
     return {
       jobs,
       total,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -320,6 +320,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     }
     const p = params as {
       includeDisabled?: boolean;
+      compact?: boolean;
       limit?: number;
       offset?: number;
       query?: string;
@@ -332,6 +333,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     };
     const page = await context.cron.listPage({
       includeDisabled: p.includeDisabled,
+      compact: p.compact,
       limit: p.limit,
       offset: p.offset,
       query: p.query,


### PR DESCRIPTION
## Summary

- Add optional `compact: true` parameter to `cron(action="list")` gateway endpoint and agent tool
- When set, each job is reduced to 6 lightweight fields: id, name, enabled, nextRunAtMs, scheduleKind, lastRunStatus
- Default behavior unchanged — existing callers get full CronJob objects as before
- Fixes truncation/hallucination issues when agents have 10+ cron jobs

Closes #93366

## Test plan

- [ ] `cron(action="list")` returns full objects (default)
- [ ] `cron(action="list", compact=true)` returns compact 6-field summaries
- [ ] Pagination and filters (enabled, scheduleKind, lastRunStatus, query, agentId) work with compact mode
- [ ] Existing callers unaffected

🤖 AI-assisted fix.