### PR TITLE
feat(firecrawl): zero-config keyless Firecrawl search + scrape (no API key)

### DIFF
--- a/extensions/firecrawl/index.ts
+++ b/extensions/firecrawl/index.ts
@@ -1,6 +1,7 @@
 // Firecrawl plugin entrypoint registers its OpenClaw integration.
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { createFirecrawlWebFetchProvider } from "./src/firecrawl-fetch-provider.js";
+import { createFirecrawlFreeWebSearchProvider } from "./src/firecrawl-free-search-provider.js";
 import { createFirecrawlScrapeTool } from "./src/firecrawl-scrape-tool.js";
 import { createFirecrawlWebSearchProvider } from "./src/firecrawl-search-provider.js";
 import { createFirecrawlSearchTool } from "./src/firecrawl-search-tool.js";
@@ -11,6 +12,7 @@ export default definePluginEntry({
   description: "Bundled Firecrawl search and scrape plugin",
   register(api) {
     api.registerWebFetchProvider(createFirecrawlWebFetchProvider());
+    api.registerWebSearchProvider(createFirecrawlFreeWebSearchProvider());
     api.registerWebSearchProvider(createFirecrawlWebSearchProvider());
     api.registerTool(createFirecrawlSearchTool(api) as AnyAgentTool);
     api.registerTool(createFirecrawlScrapeTool(api) as AnyAgentTool);

--- a/extensions/firecrawl/index.ts
+++ b/extensions/firecrawl/index.ts
@@ -1,6 +1,7 @@
 // Firecrawl plugin entrypoint registers its OpenClaw integration.
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { createFirecrawlWebFetchProvider } from "./src/firecrawl-fetch-provider.js";
+import { createFirecrawlFreeWebFetchProvider } from "./src/firecrawl-free-fetch-provider.js";
 import { createFirecrawlFreeWebSearchProvider } from "./src/firecrawl-free-search-provider.js";
 import { createFirecrawlScrapeTool } from "./src/firecrawl-scrape-tool.js";
 import { createFirecrawlWebSearchProvider } from "./src/firecrawl-search-provider.js";
@@ -11,6 +12,7 @@ export default definePluginEntry({
   name: "Firecrawl Plugin",
   description: "Bundled Firecrawl search and scrape plugin",
   register(api) {
+    api.registerWebFetchProvider(createFirecrawlFreeWebFetchProvider());
     api.registerWebFetchProvider(createFirecrawlWebFetchProvider());
     api.registerWebSearchProvider(createFirecrawlFreeWebSearchProvider());
     api.registerWebSearchProvider(createFirecrawlWebSearchProvider());

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -35,7 +35,7 @@
   },
   "contracts": {
     "webFetchProviders": ["firecrawl"],
-    "webSearchProviders": ["firecrawl"],
+    "webSearchProviders": ["firecrawl", "firecrawl-free"],
     "tools": ["firecrawl_search", "firecrawl_scrape"]
   },
   "configContracts": {

--- a/extensions/firecrawl/openclaw.plugin.json
+++ b/extensions/firecrawl/openclaw.plugin.json
@@ -34,7 +34,7 @@
     }
   },
   "contracts": {
-    "webFetchProviders": ["firecrawl"],
+    "webFetchProviders": ["firecrawl", "firecrawl-free"],
     "webSearchProviders": ["firecrawl", "firecrawl-free"],
     "tools": ["firecrawl_search", "firecrawl_scrape"]
   },

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -1,5 +1,7 @@
 // Firecrawl plugin module implements firecrawl client behavior.
+import { createRequire } from "node:module";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { readPluginPackageVersion } from "openclaw/plugin-sdk/extension-shared";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
   markdownToText,
@@ -41,6 +43,10 @@ const SCRAPE_CACHE = new Map<
 >();
 const DEFAULT_SEARCH_COUNT = 5;
 const DEFAULT_SCRAPE_MAX_CHARS = 50_000;
+
+const require = createRequire(import.meta.url);
+const PLUGIN_VERSION = readPluginPackageVersion({ require });
+const USER_AGENT = `openclaw-firecrawl/${PLUGIN_VERSION} (${process.platform})`;
 const ALLOWED_FIRECRAWL_HOSTS = new Set(["api.firecrawl.dev"]);
 const FIRECRAWL_SELF_HOSTED_PRIVATE_ERROR =
   "Firecrawl custom baseUrl must target a private or internal self-hosted endpoint.";
@@ -81,6 +87,7 @@ export type FirecrawlSearchParams = {
   sources?: string[];
   categories?: string[];
   scrapeResults?: boolean;
+  keyless?: boolean;
 };
 
 export type FirecrawlScrapeParams = {
@@ -184,13 +191,13 @@ async function postFirecrawlJson<T>(
     url: string;
     mode?: FirecrawlEndpointMode;
     timeoutSeconds: number;
-    apiKey: string;
+    apiKey?: string;
     body: Record<string, unknown>;
     errorLabel: string;
   },
   parse: (response: Response) => Promise<T>,
 ): Promise<T> {
-  const apiKey = normalizeSecretInput(params.apiKey);
+  const apiKey = params.apiKey ? normalizeSecretInput(params.apiKey) : "";
   const mode = params.mode ?? (await validateFirecrawlBaseUrl(params.url));
   const withEndpoint =
     mode === "selfHosted" ? withSelfHostedWebToolsEndpoint : withStrictWebToolsEndpoint;
@@ -201,8 +208,9 @@ async function postFirecrawlJson<T>(
       init: {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${apiKey}`,
+          ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
           "Content-Type": "application/json",
+          "User-Agent": USER_AGENT,
         },
         body: JSON.stringify(params.body),
       },
@@ -327,7 +335,7 @@ function resolveSearchItems(payload: Record<string, unknown>): FirecrawlSearchIt
 
 function buildSearchPayload(params: {
   query: string;
-  provider: "firecrawl";
+  provider: "firecrawl" | "firecrawl-free";
   items: FirecrawlSearchItem[];
   tookMs: number;
   scrapeResults: boolean;
@@ -359,8 +367,10 @@ function buildSearchPayload(params: {
 export async function runFirecrawlSearch(
   params: FirecrawlSearchParams,
 ): Promise<Record<string, unknown>> {
-  const apiKey = resolveFirecrawlApiKey(params.cfg);
-  if (!apiKey) {
+  const keyless = params.keyless === true;
+  const provider = keyless ? "firecrawl-free" : "firecrawl";
+  const apiKey = keyless ? undefined : resolveFirecrawlApiKey(params.cfg);
+  if (!keyless && !apiKey) {
     throw new Error(
       "web_search (firecrawl) needs a Firecrawl API key. Set FIRECRAWL_API_KEY in the Gateway environment, or configure plugins.entries.firecrawl.config.webSearch.apiKey.",
     );
@@ -383,6 +393,7 @@ export async function runFirecrawlSearch(
       sources,
       categories,
       scrapeResults,
+      keyless,
     }),
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
@@ -433,7 +444,7 @@ export async function runFirecrawlSearch(
   );
   const result = buildSearchPayload({
     query: params.query,
-    provider: "firecrawl",
+    provider,
     items: resolveSearchItems(payload),
     tookMs: Date.now() - start,
     scrapeResults,

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -100,6 +100,7 @@ export type FirecrawlScrapeParams = {
   proxy?: "auto" | "basic" | "stealth";
   storeInCache?: boolean;
   timeoutSeconds?: number;
+  keyless?: boolean;
 };
 
 export function assertFirecrawlScrapeTargetAllowed(url: string): void {
@@ -532,8 +533,9 @@ export async function runFirecrawlScrape(
 ): Promise<Record<string, unknown>> {
   assertFirecrawlScrapeTargetAllowed(params.url);
 
-  const apiKey = resolveFirecrawlApiKey(params.cfg);
-  if (!apiKey) {
+  const keyless = params.keyless === true;
+  const apiKey = keyless ? undefined : resolveFirecrawlApiKey(params.cfg);
+  if (!keyless && !apiKey) {
     throw new Error(
       "firecrawl_scrape needs a Firecrawl API key. Set FIRECRAWL_API_KEY in the Gateway environment, or configure plugins.entries.firecrawl.config.webFetch.apiKey.",
     );
@@ -559,6 +561,7 @@ export async function runFirecrawlScrape(
       proxy,
       storeInCache,
       maxChars,
+      keyless,
     }),
   );
   const cached = readCache(SCRAPE_CACHE, cacheKey);

--- a/extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider-shared.ts
@@ -67,3 +67,29 @@ export const FIRECRAWL_WEB_FETCH_PROVIDER_SHARED = {
     webFetch.apiKey = value;
   },
 } satisfies Omit<WebFetchProviderPlugin, "applySelectionConfig" | "createTool">;
+
+export const FIRECRAWL_FREE_WEB_FETCH_PROVIDER_SHARED = {
+  id: "firecrawl-free",
+  label: "Firecrawl (Free)",
+  hint: "Fetch pages with Firecrawl — no API key required",
+  requiresCredential: false,
+  envVars: [],
+  placeholder: "(no key needed)",
+  signupUrl: "https://www.firecrawl.dev/",
+  docsUrl: "https://docs.firecrawl.dev",
+  autoDetectOrder: 76,
+  credentialPath: "plugins.entries.firecrawl.config.webFetch.apiKey",
+  getCredentialValue: (fetchConfig) => {
+    if (!fetchConfig || typeof fetchConfig !== "object") {
+      return undefined;
+    }
+    const entry = (fetchConfig as Record<string, unknown>)["firecrawl-free"];
+    return entry && typeof entry === "object" && !Array.isArray(entry)
+      ? (entry as { apiKey?: unknown }).apiKey
+      : undefined;
+  },
+  setCredentialValue: (fetchConfigTarget, value) => {
+    const entry = ensureRecord(fetchConfigTarget, "firecrawl-free");
+    entry.apiKey = value;
+  },
+} satisfies Omit<WebFetchProviderPlugin, "applySelectionConfig" | "createTool">;

--- a/extensions/firecrawl/src/firecrawl-free-fetch-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-free-fetch-provider.ts
@@ -1,0 +1,28 @@
+import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
+import type { WebFetchProviderPlugin } from "openclaw/plugin-sdk/provider-web-fetch";
+import { enablePluginInConfig } from "openclaw/plugin-sdk/provider-web-fetch";
+import { runFirecrawlScrape } from "./firecrawl-client.js";
+import { FIRECRAWL_FREE_WEB_FETCH_PROVIDER_SHARED } from "./firecrawl-fetch-provider-shared.js";
+
+export function createFirecrawlFreeWebFetchProvider(): WebFetchProviderPlugin {
+  return {
+    ...FIRECRAWL_FREE_WEB_FETCH_PROVIDER_SHARED,
+    applySelectionConfig: (config) => enablePluginInConfig(config, "firecrawl").config,
+    createTool: ({ config }) => ({
+      description: "Fetch a page using Firecrawl's free keyless scrape.",
+      parameters: {},
+      execute: async (args) => {
+        const url = typeof args.url === "string" ? args.url : "";
+        const extractMode = args.extractMode === "text" ? "text" : "markdown";
+        const maxChars = readPositiveIntegerParam(args, "maxChars");
+        return await runFirecrawlScrape({
+          cfg: config,
+          keyless: true,
+          url,
+          extractMode,
+          maxChars,
+        });
+      },
+    }),
+  };
+}

--- a/extensions/firecrawl/src/firecrawl-free-search-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-free-search-provider.ts
@@ -1,0 +1,49 @@
+import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { buildFirecrawlFreeWebSearchProviderBase } from "../web-search-shared.js";
+
+type FirecrawlClientModule = typeof import("./firecrawl-client.js");
+
+let firecrawlClientModulePromise: Promise<FirecrawlClientModule> | undefined;
+
+function loadFirecrawlClientModule(): Promise<FirecrawlClientModule> {
+  firecrawlClientModulePromise ??= import("./firecrawl-client.js");
+  return firecrawlClientModulePromise;
+}
+
+const GenericFirecrawlSearchSchema = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "Search query string." },
+    count: {
+      type: "integer",
+      description: "Number of results to return (1-10).",
+      minimum: 1,
+      maximum: 10,
+    },
+  },
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+export function createFirecrawlFreeWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...buildFirecrawlFreeWebSearchProviderBase(),
+    createTool: (ctx) => ({
+      description:
+        "Search the web using Firecrawl's free Search API (no API key). Returns structured results with snippets. Use firecrawl_search for Firecrawl-specific knobs like sources or categories.",
+      parameters: GenericFirecrawlSearchSchema,
+      execute: async (args) => {
+        const { runFirecrawlSearch } = await loadFirecrawlClientModule();
+        return await runFirecrawlSearch({
+          cfg: ctx.config,
+          keyless: true,
+          query: typeof args.query === "string" ? args.query : "",
+          count: readPositiveIntegerParam(args, "count", {
+            message: "count must be an integer from 1 to 10",
+            max: 10,
+          }),
+        });
+      },
+    }),
+  };
+}

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -239,6 +239,33 @@ describe("firecrawl tools", () => {
 
     const authHeader = new Headers(capturedInit?.headers).get("Authorization");
     expect(authHeader).toBe("Bearer firecrawl-test-key");
+    expect(new Headers(capturedInit?.headers).get("User-Agent")).toMatch(/^openclaw-firecrawl\//);
+  });
+
+  it("omits the Authorization header when no key is supplied and sets a User-Agent", async () => {
+    let capturedInit: RequestInit | undefined;
+    const fetchSpy = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedInit = init;
+      return new Response(JSON.stringify({ success: true, data: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    global.fetch = fetchSpy as typeof fetch;
+
+    await firecrawlClientTesting.postFirecrawlJson(
+      {
+        url: "https://api.firecrawl.dev/v2/search",
+        timeoutSeconds: 5,
+        body: { query: "openclaw" },
+        errorLabel: "Firecrawl search",
+      },
+      async () => "ok",
+    );
+
+    const headers = new Headers(capturedInit?.headers);
+    expect(headers.get("Authorization")).toBeNull();
+    expect(headers.get("User-Agent")).toMatch(/^openclaw-firecrawl\//);
   });
 
   it("blocks private and non-http scrape targets before Firecrawl requests", () => {

--- a/extensions/firecrawl/web-fetch-contract-api.ts
+++ b/extensions/firecrawl/web-fetch-contract-api.ts
@@ -3,11 +3,22 @@ import {
   enablePluginInConfig,
   type WebFetchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-fetch-contract";
-import { FIRECRAWL_WEB_FETCH_PROVIDER_SHARED } from "./src/firecrawl-fetch-provider-shared.js";
+import {
+  FIRECRAWL_FREE_WEB_FETCH_PROVIDER_SHARED,
+  FIRECRAWL_WEB_FETCH_PROVIDER_SHARED,
+} from "./src/firecrawl-fetch-provider-shared.js";
 
 export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
   return {
     ...FIRECRAWL_WEB_FETCH_PROVIDER_SHARED,
+    applySelectionConfig: (config) => enablePluginInConfig(config, "firecrawl").config,
+    createTool: () => null,
+  };
+}
+
+export function createFirecrawlFreeWebFetchProvider(): WebFetchProviderPlugin {
+  return {
+    ...FIRECRAWL_FREE_WEB_FETCH_PROVIDER_SHARED,
     applySelectionConfig: (config) => enablePluginInConfig(config, "firecrawl").config,
     createTool: () => null,
   };

--- a/extensions/firecrawl/web-fetch-provider.ts
+++ b/extensions/firecrawl/web-fetch-provider.ts
@@ -1,2 +1,3 @@
 // Firecrawl provider module implements model/runtime integration.
+export { createFirecrawlFreeWebFetchProvider } from "./src/firecrawl-free-fetch-provider.js";
 export { createFirecrawlWebFetchProvider } from "./src/firecrawl-fetch-provider.js";

--- a/extensions/firecrawl/web-search-contract-api.ts
+++ b/extensions/firecrawl/web-search-contract-api.ts
@@ -1,10 +1,20 @@
 // Firecrawl API module exposes the plugin public contract.
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
-import { buildFirecrawlWebSearchProviderBase } from "./web-search-shared.js";
+import {
+  buildFirecrawlFreeWebSearchProviderBase,
+  buildFirecrawlWebSearchProviderBase,
+} from "./web-search-shared.js";
 
 export function createFirecrawlWebSearchProvider(): WebSearchProviderPlugin {
   return {
     ...buildFirecrawlWebSearchProviderBase(),
+    createTool: () => null,
+  };
+}
+
+export function createFirecrawlFreeWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    ...buildFirecrawlFreeWebSearchProviderBase(),
     createTool: () => null,
   };
 }

--- a/extensions/firecrawl/web-search-provider.ts
+++ b/extensions/firecrawl/web-search-provider.ts
@@ -1,2 +1,3 @@
 // Firecrawl provider module implements model/runtime integration.
+export { createFirecrawlFreeWebSearchProvider } from "./src/firecrawl-free-search-provider.js";
 export { createFirecrawlWebSearchProvider } from "./src/firecrawl-search-provider.js";

--- a/extensions/firecrawl/web-search-shared.ts
+++ b/extensions/firecrawl/web-search-shared.ts
@@ -43,3 +43,27 @@ export function buildFirecrawlWebSearchProviderBase(): Omit<WebSearchProviderPlu
     getConfiguredCredentialFallback: getConfiguredFirecrawlFetchCredentialFallback,
   };
 }
+
+export function buildFirecrawlFreeWebSearchProviderBase(): Omit<
+  WebSearchProviderPlugin,
+  "createTool"
+> {
+  return {
+    id: "firecrawl-free",
+    label: "Firecrawl Search (Free)",
+    hint: "Free web search via Firecrawl's Search API — no API key required",
+    onboardingScopes: ["text-inference"],
+    requiresCredential: false,
+    envVars: [],
+    placeholder: "(no key needed)",
+    signupUrl: "https://www.firecrawl.dev/",
+    docsUrl: "https://docs.openclaw.ai/tools/firecrawl",
+    autoDetectOrder: 115,
+    credentialPath: "",
+    ...createWebSearchProviderContractFields({
+      credentialPath: "",
+      searchCredential: { type: "scoped", scopeId: "firecrawl-free" },
+      selectionPluginId: "firecrawl",
+    }),
+  };
+}

--- a/extensions/firecrawl/web-search-shared.ts
+++ b/extensions/firecrawl/web-search-shared.ts
@@ -58,7 +58,7 @@ export function buildFirecrawlFreeWebSearchProviderBase(): Omit<
     placeholder: "(no key needed)",
     signupUrl: "https://www.firecrawl.dev/",
     docsUrl: "https://docs.openclaw.ai/tools/firecrawl",
-    autoDetectOrder: 115,
+    autoDetectOrder: 76,
     credentialPath: "",
     ...createWebSearchProviderContractFields({
       credentialPath: "",

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -15,6 +15,7 @@ const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["duckduckgo", "duckduckgo"],
   ["exa", "exa"],
   ["firecrawl", "firecrawl"],
+  ["firecrawl-free", "firecrawl"],
   ["gemini", "google"],
   ["grok", "xai"],
   ["kimi", "moonshot"],
@@ -27,9 +28,11 @@ const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["tavily", "tavily"],
 ]);
 
-// Tavily and Parallel (paid + free) only ever used the plugin-owned config path,
-// so there is no legacy `tools.web.search.<id>.*` shape to migrate for them.
+// Tavily, Parallel (paid + free), and Firecrawl Free only ever used the
+// plugin-owned config path, so there is no legacy `tools.web.search.<id>.*`
+// shape to migrate for them. (Keyed `firecrawl` does have a legacy shape.)
 const NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS = new Set([
+  "firecrawl-free",
   "parallel",
   "parallel-free",
   "tavily",

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -66,7 +66,7 @@ export const pluginRegistrationContractCases = {
   firecrawl: {
     pluginId: "firecrawl",
     webFetchProviderIds: ["firecrawl"],
-    webSearchProviderIds: ["firecrawl"],
+    webSearchProviderIds: ["firecrawl", "firecrawl-free"],
     toolNames: ["firecrawl_search", "firecrawl_scrape"],
   },
   google: {

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -65,7 +65,7 @@ export const pluginRegistrationContractCases = {
   },
   firecrawl: {
     pluginId: "firecrawl",
-    webFetchProviderIds: ["firecrawl"],
+    webFetchProviderIds: ["firecrawl", "firecrawl-free"],
     webSearchProviderIds: ["firecrawl", "firecrawl-free"],
     toolNames: ["firecrawl_search", "firecrawl_scrape"],
   },


### PR DESCRIPTION
## Summary

- **Firecrawl, zero-setup.** Adds a keyless `firecrawl-free` provider for **both `web_search` and `web_fetch`** - clean Firecrawl results and page scrapes with **no API key, no account**. Previously Firecrawl was keyed-only.
- **Now possible** because Firecrawl shipped a keyless tier (`/v2/search` and `/v2/scrape` answer anonymously).
- **Becomes the keyless default** mirroring how `parallel-free` is selected - so a fresh, no-key install gets high-quality search + scrape out of the box.
- **Additive and safe:** the keyed `firecrawl` providers and `firecrawl_search` / `firecrawl_scrape` tools are unchanged; any configured keyed provider still wins; no new config or SDK surface.

What should reviewers focus on?

- The keyless path in `firecrawl-client.ts` (no `Authorization`, `openclaw-firecrawl` UA, key optional), and provider registration in the public-artifact barrels + manifest.

## Linked context

Was this requested by a maintainer or owner? No - external contribution.

## Real behavior proof (required for external PRs)

- Behavior addressed: keyless `web_search` and `web_fetch` return live results with no API key.
- Real environment tested: macOS, built from source; live calls to `api.firecrawl.dev/v2/search` and `/v2/scrape` with no `Authorization` header.
- Evidence after fix:
  - search → 3 real results (openclaw.ai, github, hackernews), `provider: firecrawl-free`, **200**, no key
  - scrape → `# Example Domain` markdown, **200**, no key
  - default selection: with no keys, the auto-detect sort picks `firecrawl-free` for both search and fetch
- Observed result: keyless requests resolve to firecrawl-free and return real, safety-wrapped content.
- What was not tested: the agent/LLM deciding to invoke the tool (needs a configured model - orthogonal to this change); cross-OS beyond macOS.

## Tests and validation

- `firecrawl-tools` unit tests (35 passed), web-fetch provider contract suite (3 passed incl. `firecrawl-free`), `pnpm build`, live keyless search/scrape.
- Regression: keyless path asserts no `Authorization` + the `openclaw-firecrawl` UA; registration contract updated for the new `firecrawl-free` search + fetch ids.

## Risk checklist

- Config / migration change? **No** — no new config; reuses `tools.web.{search,fetch}.provider`; registered as non-migrated in doctor.
- Security / network change? **Yes** — anonymous outbound to `api.firecrawl.dev` (already an allowed host), via existing web-tools guards; no credentials sent.

## Current review state

- Next action: maintainer review, with attention to the keyless-default change.