### PR TITLE
fix(codex): log app-server compaction completion

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7,6 +7,8 @@ import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-erro
 import { MissingProviderAuthError } from "../../agents/model-auth.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { ModelDefinitionConfig } from "../../config/types.models.js";
+import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
+import { loggingState } from "../../logging/state.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import {
   createUserTurnTranscriptRecorder,
@@ -5140,6 +5142,61 @@ describe("runAgentTurnWithFallback", () => {
     expect(onCompactionStart).toHaveBeenCalledTimes(1);
     expect(onCompactionEnd).toHaveBeenCalledTimes(1);
     expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("logs Codex app-server compaction completion while notices stay silent by default", async () => {
+    const onBlockReply = vi.fn();
+    const consoleLog = vi.fn();
+    setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "compact" });
+    loggingState.rawConsole = {
+      log: consoleLog,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    try {
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+        await params.onAgentEvent?.({
+          stream: "compaction",
+          data: {
+            phase: "start",
+            backend: "codex-app-server",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "compaction-1",
+          },
+        });
+        await params.onAgentEvent?.({
+          stream: "compaction",
+          data: {
+            phase: "end",
+            completed: true,
+            backend: "codex-app-server",
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "compaction-1",
+          },
+        });
+        return { payloads: [{ text: "final" }], meta: {} };
+      });
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback({
+        ...createMinimalRunAgentTurnParams({
+          opts: { onBlockReply },
+        }),
+      });
+
+      expect(result.kind).toBe("success");
+      expect(onBlockReply).not.toHaveBeenCalled();
+      expect(consoleLog.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+        "codex app-server auto-compaction succeeded for anthropic/claude; refreshed session context",
+      );
+    } finally {
+      loggingState.rawConsole = null;
+      setLoggerOverride(null);
+      resetLogger();
+    }
   });
 
   it("emits a compaction start notice when notifyUser is enabled", async () => {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -5155,6 +5155,14 @@ describe("runAgentTurnWithFallback", () => {
       error: vi.fn(),
     };
     try {
+      state.runWithModelFallbackMock.mockImplementationOnce(
+        async (params: FallbackRunnerParams) => ({
+          result: await params.run("openai", "gpt-5.5"),
+          provider: "openai",
+          model: "gpt-5.5",
+          attempts: [{ provider: "anthropic", model: "claude", error: "rate limit" }],
+        }),
+      );
       state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
         await params.onAgentEvent?.({
           stream: "compaction",
@@ -5190,7 +5198,7 @@ describe("runAgentTurnWithFallback", () => {
       expect(result.kind).toBe("success");
       expect(onBlockReply).not.toHaveBeenCalled();
       expect(consoleLog.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
-        "codex app-server auto-compaction succeeded for anthropic/claude; refreshed session context",
+        "codex app-server auto-compaction succeeded for openai/gpt-5.5; refreshed session context",
       );
     } finally {
       loggingState.rawConsole = null;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -2750,10 +2750,7 @@ export async function runAgentTurnWithFallback(params: {
                           if (completed) {
                             attemptCompactionCount += 1;
                             if (backend === CODEX_APP_SERVER_COMPACTION_BACKEND) {
-                              const modelRef = formatCompactionModelRef(
-                                effectiveRun.provider,
-                                effectiveRun.model,
-                              );
+                              const modelRef = formatCompactionModelRef(provider, model);
                               const consoleMessage =
                                 `codex app-server auto-compaction succeeded for ${modelRef}; ` +
                                 "refreshed session context";
@@ -2762,8 +2759,8 @@ export async function runAgentTurnWithFallback(params: {
                                 {
                                   event: "codex_app_server_compaction_succeeded",
                                   backend,
-                                  provider: effectiveRun.provider,
-                                  model: effectiveRun.model,
+                                  provider,
+                                  model,
                                   sessionKey: params.sessionKey,
                                   sessionId: effectiveRun.sessionId,
                                   threadId: readStringValue(evt.data.threadId),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -163,8 +163,25 @@ type AgentTurnTimingSummary = {
 };
 
 const agentTurnTimingLog = createSubsystemLogger("auto-reply/agent-turn-timing");
+const agentCompactionLog = createSubsystemLogger("auto-reply/compaction");
+const CODEX_APP_SERVER_COMPACTION_BACKEND = "codex-app-server";
 const AGENT_TURN_TIMING_WARN_TOTAL_MS = 1_000;
 const AGENT_TURN_TIMING_WARN_STAGE_MS = 500;
+
+function formatCompactionModelRef(provider?: string, model?: string): string {
+  const normalizedProvider = normalizeOptionalString(provider);
+  const normalizedModel = normalizeOptionalString(model);
+  if (normalizedProvider && normalizedModel) {
+    return `${sanitizeForLog(normalizedProvider)}/${sanitizeForLog(normalizedModel)}`;
+  }
+  if (normalizedProvider) {
+    return sanitizeForLog(normalizedProvider);
+  }
+  if (normalizedModel) {
+    return sanitizeForLog(normalizedModel);
+  }
+  return "unknown model";
+}
 
 function createAgentTurnTimingTracker(options: { profilerEnabled?: boolean } = {}): {
   measure: <T>(name: string, run: () => Promise<T> | T) => Promise<T>;
@@ -2710,6 +2727,7 @@ export async function runAgentTurnWithFallback(params: {
                       }
                       if (evt.stream === "compaction") {
                         const phase = readStringValue(evt.data.phase) ?? "";
+                        const backend = readStringValue(evt.data.backend);
                         const hookMessages = readCompactionHookMessages(evt.data.messages);
                         const sendCompactionUserNotices = async (
                           noticePhase: "start" | "end" | "incomplete",
@@ -2731,6 +2749,31 @@ export async function runAgentTurnWithFallback(params: {
                           const completed = evt.data?.completed === true;
                           if (completed) {
                             attemptCompactionCount += 1;
+                            if (backend === CODEX_APP_SERVER_COMPACTION_BACKEND) {
+                              const modelRef = formatCompactionModelRef(
+                                effectiveRun.provider,
+                                effectiveRun.model,
+                              );
+                              const consoleMessage =
+                                `codex app-server auto-compaction succeeded for ${modelRef}; ` +
+                                "refreshed session context";
+                              agentCompactionLog.info(
+                                "codex app-server auto-compaction succeeded",
+                                {
+                                  event: "codex_app_server_compaction_succeeded",
+                                  backend,
+                                  provider: effectiveRun.provider,
+                                  model: effectiveRun.model,
+                                  sessionKey: params.sessionKey,
+                                  sessionId: effectiveRun.sessionId,
+                                  threadId: readStringValue(evt.data.threadId),
+                                  turnId: readStringValue(evt.data.turnId),
+                                  itemId: readStringValue(evt.data.itemId),
+                                  compactionCount: attemptCompactionCount,
+                                  consoleMessage,
+                                },
+                              );
+                            }
                             if (params.opts?.onCompactionEnd) {
                               await params.opts.onCompactionEnd();
                             }


### PR DESCRIPTION
## Summary

- Adds a normal Gateway log signal when the Codex app-server runtime reports a completed context compaction.
- Keeps chat/channel compaction notices behind the existing `notifyUser` opt-in policy.
- Preserves existing compaction count/callback behavior and only adds Codex app-server completion observability.
- Out of scope: changing default Discord/channel notification behavior or broader compaction policy.
- Success means Codex app-server compactions are no longer silent in Gateway logs while default user-channel behavior stays unchanged.

Reviewers should focus on the backend gate, the log text/metadata, and the regression test proving default-silent notices remain silent.

## Linked context

Closes #83932

Related #46641
Related #49380
Related #77561

Was this requested by a maintainer or owner?

Requested by the ClawSweeper issue review on #83932 as a focused queueable fix.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: completed Codex app-server compaction events now emit a Gateway log line.
- Real environment tested: local OpenClaw checkout using the project Vitest runner.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts -- -t compaction`
  - `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts`
  - `git diff --check`
- Evidence after fix: the new regression drives a `stream: "compaction"` event with `backend: "codex-app-server"` and `completed: true`, then asserts the Gateway console log contains `codex app-server auto-compaction succeeded for anthropic/claude; refreshed session context`.
- Observed result after fix: all commands exited successfully.
- What was not tested: live Discord/Codex app-server compaction replay.
- Proof limitations or environment constraints: this is source-level/runtime-harness proof, not a live channel replay.
- Before evidence: existing code incremented compaction count/callbacks but did not emit a Codex app-server Gateway success log.

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts -- -t compaction`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts`
- `git diff --check`

Regression coverage added:

- Added a compaction runner regression that verifies Codex app-server completion logs to Gateway output while `onBlockReply` remains untouched when `notifyUser` is not enabled.

What failed before this fix, if known?

- There was no Codex app-server Gateway success log for completed compaction events.

If no test was added, why not?

- A focused regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, Gateway/operator logs now include a Codex app-server compaction completion line. Chat/channel replies do not change.

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

Log noise or logging a completion for the wrong runtime.

How is that risk mitigated?

The log is gated to `backend: "codex-app-server"` and only fires when the compaction event has `completed: true`.

## Current review state

What is the next action?

Author/user review, then open the PR from the compare branch.

What is still waiting on author, maintainer, CI, or external proof?

Maintainer review and CI. A live Discord/Codex compaction replay was not run.

Which bot or reviewer comments were addressed?

Addresses the ClawSweeper review comment on #83932 requesting narrow Codex app-server compaction success logging without changing the default `notifyUser` policy.