### PR TITLE
fix(agents): drop partialJson streaming artifacts from session history repair

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -784,6 +784,107 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     expect(ids).toEqual(expectedIds);
   });
 
+  it("keeps finalized OpenAI Responses blocks and drops interrupted partialJson artifacts", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          // complete tool call — kept as-is
+          { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
+          // Finalized OpenAI Responses blocks keep parsed arguments plus
+          // partialJson in persisted history; repair should strip only
+          // partialJson and keep the finished tool call.
+          {
+            type: "toolCall",
+            id: "call_partial|fc_123",
+            name: "Bash",
+            arguments: { command: "ls" },
+            partialJson: '{"command": "ls"}',
+          },
+          // Anthropic can persist initialized tool calls with arguments: {}
+          // plus partialJson if the stream aborts before content_block_stop.
+          // Those incomplete artifacts must be dropped.
+          {
+            type: "toolCall",
+            id: "toolu_123",
+            name: "Bash",
+            arguments: {},
+            partialJson: '{"command":',
+          },
+          // Missing required input is also an interrupted artifact and should drop.
+          {
+            type: "toolUse",
+            id: "call_partial2",
+            name: "read",
+            input: null,
+            partialJson: '{"path":',
+          },
+        ],
+      },
+      { role: "user", content: "retry" },
+    ]);
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out);
+    const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
+    expect(ids).toEqual(["call_ok", "call_partial|fc_123"]);
+    const keptPartial = toolCalls.find((t) => (t as { id?: unknown }).id === "call_partial|fc_123");
+    expect(keptPartial).not.toHaveProperty("partialJson");
+  });
+
+  it("strips partialJson and preserves sessions_spawn attachment content", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_spawn|fc_456",
+            name: "sessions_spawn",
+            arguments: { attachments: [{ content: "secret data" }] },
+            partialJson: '{"attachments":[{"content":"secret data"}]}',
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out);
+    expect(toolCalls).toHaveLength(1);
+    const spawn = toolCalls[0] as { id?: unknown; arguments?: unknown };
+    // partialJson must be stripped
+    expect(spawn).not.toHaveProperty("partialJson");
+    // sessions_spawn attachment content must be preserved on current main.
+    const args = spawn.arguments as { attachments?: Array<{ content?: unknown }> };
+    expect(args?.attachments?.[0]?.content).toBe("secret data");
+  });
+
+  it.each(["aborted", "error"] as const)(
+    "drops OpenAI Responses partialJson blocks on %s assistant turns",
+    (stopReason) => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          stopReason,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_partial|fc_123",
+              name: "Bash",
+              arguments: { command: "ls" },
+              partialJson: '{"command":"ls"',
+            },
+          ],
+        },
+        { role: "user", content: "retry" },
+      ]);
+
+      const out = sanitizeToolCallInputs(input);
+      expect(getAssistantToolCallBlocks(out)).toHaveLength(0);
+    },
+  );
+
   it("keeps valid tool calls and preserves text blocks", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -784,23 +784,29 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     expect(ids).toEqual(expectedIds);
   });
 
-  it("keeps finalized OpenAI Responses blocks and drops interrupted partialJson artifacts", () => {
+  it("keeps finalized OpenAI Responses calls and drops partialJson streaming artifacts", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
-        stopReason: "stop",
+        stopReason: "toolUse",
         content: [
           // complete tool call — kept as-is
           { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
-          // Finalized OpenAI Responses blocks keep parsed arguments plus
-          // partialJson in persisted history; repair should strip only
-          // partialJson and keep the finished tool call.
+          // Legacy generic Responses transport persisted finalized toolUse
+          // turns with partialJson; repair strips the scratch field.
           {
             type: "toolCall",
             id: "call_partial|fc_123",
             name: "Bash",
             arguments: { command: "ls" },
             partialJson: '{"command": "ls"}',
+          },
+          {
+            type: "toolCall",
+            id: "call_empty|fc_789",
+            name: "session_status",
+            arguments: {},
+            partialJson: "",
           },
           // Anthropic can persist initialized tool calls with arguments: {}
           // plus partialJson if the stream aborts before content_block_stop.
@@ -811,6 +817,15 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
             name: "Bash",
             arguments: {},
             partialJson: '{"command":',
+          },
+          // An OpenAI-shaped id and parsed partial arguments do not prove that
+          // response.output_item.done arrived.
+          {
+            type: "toolCall",
+            id: "call_truncated|fc_456",
+            name: "Bash",
+            arguments: { command: "ls" },
+            partialJson: '{"command":"ls"',
           },
           // Missing required input is also an interrupted artifact and should drop.
           {
@@ -827,16 +842,16 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const out = sanitizeToolCallInputs(input);
     const toolCalls = getAssistantToolCallBlocks(out);
     const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
-    expect(ids).toEqual(["call_ok", "call_partial|fc_123"]);
-    const keptPartial = toolCalls.find((t) => (t as { id?: unknown }).id === "call_partial|fc_123");
-    expect(keptPartial).not.toHaveProperty("partialJson");
+    expect(ids).toEqual(["call_ok", "call_partial|fc_123", "call_empty|fc_789"]);
+    expect(toolCalls[1]).not.toHaveProperty("partialJson");
+    expect(toolCalls[2]).not.toHaveProperty("partialJson");
   });
 
-  it("strips partialJson and preserves sessions_spawn attachment content", () => {
+  it("strips finalized partialJson without rewriting sessions_spawn arguments", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
-        stopReason: "stop",
+        stopReason: "toolUse",
         content: [
           {
             type: "toolCall",
@@ -852,15 +867,13 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const out = sanitizeToolCallInputs(input);
     const toolCalls = getAssistantToolCallBlocks(out);
     expect(toolCalls).toHaveLength(1);
-    const spawn = toolCalls[0] as { id?: unknown; arguments?: unknown };
-    // partialJson must be stripped
-    expect(spawn).not.toHaveProperty("partialJson");
-    // sessions_spawn attachment content must be preserved on current main.
-    const args = spawn.arguments as { attachments?: Array<{ content?: unknown }> };
-    expect(args?.attachments?.[0]?.content).toBe("secret data");
+    expect(toolCalls[0]).not.toHaveProperty("partialJson");
+    expect((toolCalls[0] as { arguments?: unknown }).arguments).toEqual({
+      attachments: [{ content: "secret data" }],
+    });
   });
 
-  it.each(["aborted", "error"] as const)(
+  it.each(["stop", "aborted", "error", "length"] as const)(
     "drops OpenAI Responses partialJson blocks on %s assistant turns",
     (stopReason) => {
       const input = castAgentMessages([
@@ -873,7 +886,7 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
               id: "call_partial|fc_123",
               name: "Bash",
               arguments: { command: "ls" },
-              partialJson: '{"command":"ls"',
+              partialJson: '{"command":"ls"}',
             },
           ],
         },
@@ -930,6 +943,36 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
 
     const out = sanitizeToolCallInputs(input, {
       allowedToolNames: ["read"],
+      allowProviderOwnedThinkingReplay: true,
+    });
+
+    expect(out).toStrictEqual([]);
+  });
+
+  it("drops signed-thinking assistant turns with partialJson tool calls", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Let me run a command.",
+            thinkingSignature: "sig_partial",
+          },
+          {
+            type: "toolCall",
+            id: "call_partial|fc_123",
+            name: "exec",
+            arguments: {},
+            partialJson: '{"command":"ls"}',
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input, {
+      allowedToolNames: ["exec"],
       allowProviderOwnedThinkingReplay: true,
     });
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -457,21 +457,19 @@ function repairToolCallInputs(
               messageChanged = true;
             }
             nextContent.push(sanitized as typeof block);
-          } else {
-            if (typeof (workBlock as { name?: unknown }).name === "string") {
-              const rawName = (workBlock as { name: string }).name;
-              const trimmedName = rawName.trim();
-              if (rawName !== trimmedName && trimmedName) {
-                const renamed = { ...(workBlock as object), name: trimmedName } as typeof block;
-                nextContent.push(renamed);
-                changed = true;
-                messageChanged = true;
-              } else {
-                nextContent.push(workBlock);
-              }
+          } else if (typeof (workBlock as { name?: unknown }).name === "string") {
+            const rawName = (workBlock as { name: string }).name;
+            const trimmedName = rawName.trim();
+            if (rawName !== trimmedName && trimmedName) {
+              const renamed = { ...(workBlock as object), name: trimmedName } as typeof block;
+              nextContent.push(renamed);
+              changed = true;
+              messageChanged = true;
             } else {
               nextContent.push(workBlock);
             }
+          } else {
+            nextContent.push(workBlock);
           }
           continue;
         }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -5,6 +5,7 @@
  */
 import {
   hasNonEmptyString as hasNonEmptyStringField,
+  normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
@@ -27,6 +28,7 @@ type RawToolCallBlock = {
   name?: unknown;
   input?: unknown;
   arguments?: unknown;
+  partialJson?: unknown;
 };
 
 const RAW_TOOL_CALL_BLOCK_TYPES = new Set([
@@ -70,6 +72,31 @@ function hasToolCallId(block: RawToolCallBlock): boolean {
     hasNonEmptyStringField(block.tool_call_id) ||
     hasNonEmptyStringField(block.tool_use_id)
   );
+}
+
+function hasPartialJson(
+  block: RawToolCallBlock,
+): block is RawToolCallBlock & { partialJson: string } {
+  return typeof block.partialJson === "string";
+}
+
+function isFinalizedOpenAIResponsesToolCall(block: RawToolCallBlock): boolean {
+  if (!hasPartialJson(block) || typeof block.id !== "string" || "input" in block) {
+    return false;
+  }
+
+  const separator = block.id.indexOf("|");
+  if (separator <= 0 || separator === block.id.length - 1) {
+    return false;
+  }
+
+  return "arguments" in block && block.arguments !== undefined && block.arguments !== null;
+}
+function isInterruptedAssistantTurn(message: AgentMessage): boolean {
+  if (message.role !== "assistant" || !("stopReason" in message)) {
+    return false;
+  }
+  return message.stopReason === "aborted" || message.stopReason === "error";
 }
 
 function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
@@ -382,31 +409,74 @@ function repairToolCallInputs(
     let messageChanged = false;
 
     for (const block of msg.content) {
-      if (
-        isRawToolCallBlock(block) &&
-        (!hasToolCallInput(block) ||
-          !hasToolCallId(block) ||
-          !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames))
-      ) {
-        droppedToolCalls += 1;
-        droppedInMessage += 1;
-        changed = true;
-        messageChanged = true;
-        continue;
-      }
       if (isRawToolCallBlock(block)) {
-        if (RAW_TOOL_CALL_BLOCK_TYPES.has((block as { type?: string }).type ?? "")) {
-          const sanitized = sanitizeToolCallBlock(block);
-          if (sanitized !== block) {
-            changed = true;
-            messageChanged = true;
-          }
-          nextContent.push(sanitized as typeof block);
+        // Drop genuinely incomplete streaming artifacts (missing required fields).
+        if (
+          !hasToolCallInput(block) ||
+          !hasToolCallId(block) ||
+          !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames)
+        ) {
+          droppedToolCalls += 1;
+          droppedInMessage += 1;
+          changed = true;
+          messageChanged = true;
           continue;
         }
-      } else {
-        nextContent.push(block);
       }
+      let workBlock = block;
+      if (isRawToolCallBlock(block) && hasPartialJson(block)) {
+        if (isInterruptedAssistantTurn(msg) || !isFinalizedOpenAIResponsesToolCall(block)) {
+          droppedToolCalls += 1;
+          droppedInMessage += 1;
+          changed = true;
+          messageChanged = true;
+          continue;
+        }
+
+        // OpenAI Responses persists finalized function calls with both parsed
+        // arguments and the original partialJson bytes. Strip only the
+        // redundant partialJson field so replay keeps the finalized call.
+        const stripped = { ...block };
+        delete (stripped as RawToolCallBlock & { partialJson?: unknown }).partialJson;
+        workBlock = stripped;
+        changed = true;
+        messageChanged = true;
+      }
+      if (isRawToolCallBlock(workBlock)) {
+        if (RAW_TOOL_CALL_BLOCK_TYPES.has((workBlock as { type?: string }).type ?? "")) {
+          // Only sanitize (redact) sessions_spawn blocks; all others are passed through
+          // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).
+          const blockName =
+            typeof (workBlock as { name?: unknown }).name === "string"
+              ? (workBlock as { name: string }).name.trim()
+              : undefined;
+          if (normalizeLowercaseStringOrEmpty(blockName) === "sessions_spawn") {
+            const sanitized = sanitizeToolCallBlock(workBlock);
+            if (sanitized !== workBlock) {
+              changed = true;
+              messageChanged = true;
+            }
+            nextContent.push(sanitized as typeof block);
+          } else {
+            if (typeof (workBlock as { name?: unknown }).name === "string") {
+              const rawName = (workBlock as { name: string }).name;
+              const trimmedName = rawName.trim();
+              if (rawName !== trimmedName && trimmedName) {
+                const renamed = { ...(workBlock as object), name: trimmedName } as typeof block;
+                nextContent.push(renamed);
+                changed = true;
+                messageChanged = true;
+              } else {
+                nextContent.push(workBlock);
+              }
+            } else {
+              nextContent.push(workBlock);
+            }
+          }
+          continue;
+        }
+      }
+      nextContent.push(workBlock);
     }
 
     if (droppedInMessage > 0) {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -80,23 +80,37 @@ function hasPartialJson(
   return typeof block.partialJson === "string";
 }
 
-function isFinalizedOpenAIResponsesToolCall(block: RawToolCallBlock): boolean {
-  if (!hasPartialJson(block) || typeof block.id !== "string" || "input" in block) {
+function isCompleteJsonObject(value: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
+function isFinalizedOpenAIResponsesToolCall(
+  message: AgentMessage,
+  block: RawToolCallBlock,
+): boolean {
+  if (
+    message.role !== "assistant" ||
+    !("stopReason" in message) ||
+    message.stopReason !== "toolUse" ||
+    !hasPartialJson(block) ||
+    typeof block.id !== "string" ||
+    "input" in block ||
+    !block.arguments ||
+    typeof block.arguments !== "object" ||
+    Array.isArray(block.arguments) ||
+    (!isCompleteJsonObject(block.partialJson) &&
+      (block.partialJson.trim() !== "" || Object.keys(block.arguments).length > 0))
+  ) {
     return false;
   }
 
   const separator = block.id.indexOf("|");
-  if (separator <= 0 || separator === block.id.length - 1) {
-    return false;
-  }
-
-  return "arguments" in block && block.arguments !== undefined && block.arguments !== null;
-}
-function isInterruptedAssistantTurn(message: AgentMessage): boolean {
-  if (message.role !== "assistant" || !("stopReason" in message)) {
-    return false;
-  }
-  return message.stopReason === "aborted" || message.stopReason === "error";
+  return separator > 0 && separator < block.id.length - 1;
 }
 
 function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
@@ -143,6 +157,7 @@ function isReplaySafeThinkingAssistantTurn(
     const toolCallId = typeof block.id === "string" ? block.id.trim() : "";
     if (
       !hasToolCallInput(block) ||
+      hasPartialJson(block) ||
       !toolCallId ||
       seenToolCallIds.has(toolCallId) ||
       !isAllowedToolCallName(block.name, allowedToolNames)
@@ -425,7 +440,7 @@ function repairToolCallInputs(
       }
       let workBlock = block;
       if (isRawToolCallBlock(block) && hasPartialJson(block)) {
-        if (isInterruptedAssistantTurn(msg) || !isFinalizedOpenAIResponsesToolCall(block)) {
+        if (!isFinalizedOpenAIResponsesToolCall(msg, block)) {
           droppedToolCalls += 1;
           droppedInMessage += 1;
           changed = true;
@@ -433,9 +448,9 @@ function repairToolCallInputs(
           continue;
         }
 
-        // OpenAI Responses persists finalized function calls with both parsed
-        // arguments and the original partialJson bytes. Strip only the
-        // redundant partialJson field so replay keeps the finalized call.
+        // Legacy generic Responses transport persisted successful toolUse turns
+        // with the scratch buffer intact. Strip it only when terminal state and
+        // the provider-specific finalized shape both prove completion.
         const stripped = { ...block };
         delete (stripped as RawToolCallBlock & { partialJson?: unknown }).partialJson;
         workBlock = stripped;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Transcript repair was treating any tool call with non-null `arguments` as complete, then stripping `partialJson` without checking whether the remaining block was a finalized OpenAI Responses call or an interrupted Anthropic artifact.

Why does this matter now?

- That leaves interrupted Anthropic artifacts replayable in repaired history, which can corrupt later tool-result repair and preserve bad session state.

What is the intended outcome?

- Drop interrupted Anthropic `partialJson` artifacts, keep finalized OpenAI Responses tool calls, and preserve retained `sessions_spawn` attachment content on kept blocks.

What is intentionally out of scope?

- This PR does not claim to fix the upstream Kimi transport ordering problem itself, and it does not change provider transport handling outside transcript repair.

What does success look like?

- Interrupted Anthropic artifacts are removed during transcript repair, finalized OpenAI Responses calls remain usable after `partialJson` stripping, and existing `sessions_spawn` attachment preservation still works.

What should reviewers focus on?

- The keep/drop split in `repairToolCallInputs()` and the matching regression coverage in `src/agents/session-transcript-repair.test.ts`.

## Linked context

Which issue does this close?

- None claimed.

Which issues, PRs, or discussions are related?

- Related #57523
- Supersedes #61151

Was this requested by a maintainer or owner?

- No.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: interrupted Anthropic tool-call artifacts that still have `id`, `name`, `arguments: {}`, and `partialJson` should be dropped, while finalized OpenAI Responses tool calls should keep valid arguments, lose `partialJson`, and preserve retained `sessions_spawn` attachment content.
- Real environment tested: local OpenClaw checkout on Windows 11 with Node 22.
- Exact steps or command run after this patch:
  1. Ran a temporary TypeScript proof script through `pnpm exec tsx` that imports `sanitizeToolCallInputs()` from `src/agents/session-transcript-repair.ts`.
  2. Fed that script one finalized OpenAI-style `sessions_spawn` block (`call_spawn|fc_456`) plus one interrupted Anthropic-style block (`toolu_123` with `arguments: {}` and `partialJson`).
  3. Printed the repaired assistant content from the current PR head.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "droppedAnthropicArtifact": true,
  "assistantContent": [
    {
      "type": "toolCall",
      "id": "call_spawn|fc_456",
      "name": "sessions_spawn",
      "arguments": {
        "attachments": [
          {
            "content": "secret data",
            "name": "a.txt"
          }
        ]
      }
    }
  ],
  "sessionsSpawnAttachmentContent": "secret data"
}
```

- Observed result after fix: the interrupted Anthropic artifact was removed, the finalized OpenAI-style `sessions_spawn` block stayed, `partialJson` was removed from the retained block, and attachment content was preserved.
- What was not tested: a live remote-provider replay round-trip against Anthropic or OpenAI Responses in this environment.
- Proof limitations or environment constraints: no live provider credentials or remote replay harness were available in this environment, so proof is limited to direct transcript-repair execution plus focused regression tests.
- Before evidence (optional but encouraged): the previous branch behavior kept the initialized Anthropic shape after deleting `partialJson`, which is the blocker called out in prior review.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/session-transcript-repair.test.ts --run`
- `node scripts/run-vitest.mjs src/agents/session-transcript-repair.attachments.test.ts --run`
- `pnpm check:changed`

What regression coverage was added or updated?

- `src/agents/session-transcript-repair.test.ts` now locks in the keep/drop split between finalized OpenAI Responses tool calls and interrupted Anthropic `partialJson` artifacts.

What failed before this fix, if known?

- The initialized Anthropic `id + name + arguments: {} + partialJson` shape survived cleanup as a replayable tool call after `partialJson` removal.

If no test was added, why not?

- N/A

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- Yes. Transcript repair now drops interrupted Anthropic `partialJson` artifacts instead of replaying them as valid tool calls.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- Misclassifying a valid non-OpenAI tool call that still carries `partialJson`.

How is that risk mitigated?

- Current source only persists `partialJson` on Anthropic streaming artifacts and finalized OpenAI Responses blocks, and the updated regression tests pin the intended split and preserved `sessions_spawn` payload path.

## Current review state

What is the next action?

- Wait for CI and maintainer review on the fresh replacement PR.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on GitHub CI and maintainer review. No additional author-side code change is planned unless CI or maintainer feedback finds a concrete regression.

Which bot or reviewer comments were addressed?

- Reworded the PR body to remove the over-claiming `fully tested` footer.
- Narrowed `#57523` from a closing claim to related context only, because this PR repairs transcript fallout rather than claiming to fix the upstream Kimi transport ordering bug itself.

AI-assisted: drafted with Copilot.
