### PR TITLE
fix(cron): preserve aborted isolated-run failure

### DIFF
--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -54,6 +54,26 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.outputText).toBe("cron isolated run failed: retry limit exceeded");
   });
 
+  it("marks an aborted embedded agent run without a run-level error as a cron error", async () => {
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [],
+        meta: {
+          aborted: true,
+          agentMeta: { usage: { input: 0, output: 0 } },
+        },
+      },
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron isolated agent run aborted");
+  });
+
   it("surfaces cron timeout result when the cron-nested lane watchdog fires", async () => {
     runWithModelFallbackMock.mockRejectedValueOnce(
       new CommandLaneTaskTimeoutError("cron-nested", 330_000),

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -2,10 +2,15 @@
 import { describe, expect, it } from "vitest";
 import { CommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import {
+  makeIsolatedAgentTurnJob,
   makeIsolatedAgentTurnParams,
   setupRunCronIsolatedAgentTurnSuite,
 } from "./run.suite-helpers.js";
-import { loadRunCronIsolatedAgentTurn, runWithModelFallbackMock } from "./run.test-harness.js";
+import {
+  cleanupDirectCronSessionMock,
+  loadRunCronIsolatedAgentTurn,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
 
 const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
 
@@ -68,10 +73,20 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
       attempts: [],
     });
 
-    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({ deleteAfterRun: true }),
+      }),
+    );
 
     expect(result.status).toBe("error");
     expect(result.error).toBe("cron isolated agent run aborted");
+    expect(cleanupDirectCronSessionMock).toHaveBeenCalledWith({
+      job: expect.objectContaining({ deleteAfterRun: true }),
+      agentSessionKey: "agent:default:cron:test",
+      sessionId: "test-session-id",
+      retireReason: "cron-delete-after-run-aborted",
+    });
   });
 
   it("surfaces cron timeout result when the cron-nested lane watchdog fires", async () => {

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -74,33 +74,6 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.error).toBe("cron isolated agent run aborted");
   });
 
-  it("preserves fatal error payload text for aborted embedded agent runs", async () => {
-    runWithModelFallbackMock.mockResolvedValueOnce({
-      result: {
-        payloads: [
-          {
-            text: "Request timed out before a response was generated. Please try again.",
-            isError: true,
-          },
-        ],
-        meta: {
-          aborted: true,
-          agentMeta: { usage: { input: 0, output: 0 } },
-        },
-      },
-      provider: "openai",
-      model: "gpt-5.4",
-      attempts: [],
-    });
-
-    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
-
-    expect(result.status).toBe("error");
-    expect(result.error).toBe(
-      "Request timed out before a response was generated. Please try again.",
-    );
-  });
-
   it("surfaces cron timeout result when the cron-nested lane watchdog fires", async () => {
     runWithModelFallbackMock.mockRejectedValueOnce(
       new CommandLaneTaskTimeoutError("cron-nested", 330_000),

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -74,6 +74,33 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(result.error).toBe("cron isolated agent run aborted");
   });
 
+  it("preserves fatal error payload text for aborted embedded agent runs", async () => {
+    runWithModelFallbackMock.mockResolvedValueOnce({
+      result: {
+        payloads: [
+          {
+            text: "Request timed out before a response was generated. Please try again.",
+            isError: true,
+          },
+        ],
+        meta: {
+          aborted: true,
+          agentMeta: { usage: { input: 0, output: 0 } },
+        },
+      },
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    });
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentTurnParams());
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe(
+      "Request timed out before a response was generated. Please try again.",
+    );
+  });
+
   it("surfaces cron timeout result when the cron-nested lane watchdog fires", async () => {
     runWithModelFallbackMock.mockRejectedValueOnce(
       new CommandLaneTaskTimeoutError("cron-nested", 330_000),

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -511,7 +511,7 @@ function resetRunOutcomeMocks(): void {
       failureSignal,
       runLevelError,
     }: {
-      payloads: Array<{ isError?: boolean }>;
+      payloads: Array<{ text?: string; isError?: boolean }>;
       failureSignal?: { fatalForCron?: boolean; message?: string };
       runLevelError?: unknown;
     }) => {
@@ -539,26 +539,33 @@ function resetRunOutcomeMocks(): void {
         failureSignal?.fatalForCron === true
           ? (failureSignal.message ?? "cron isolated run returned a fatal failure signal")
           : undefined;
-      const errorPayloadMessage = payloads.some((payload) => payload?.isError === true)
+      const errorPayloadMessage = [...payloads]
+        .toReversed()
+        .find((payload) => payload?.isError === true && payload.text?.trim())
+        ?.text?.trim();
+      const fallbackErrorPayloadMessage = payloads.some((payload) => payload?.isError === true)
         ? "cron isolated run returned an error payload"
         : undefined;
       const outputText =
         errorPayloadMessage ??
+        fallbackErrorPayloadMessage ??
         failureMessage ??
         runLevelErrorMessage ??
         pickLastNonEmptyTextFromPayloadsMock(payloads);
       const synthesizedText = outputText?.trim() || "summary";
-      const hasFatalErrorPayload =
-        errorPayloadMessage !== undefined ||
-        failureMessage !== undefined ||
-        runLevelErrorMessage !== undefined;
-      const hasFatalStructuredErrorPayload = errorPayloadMessage !== undefined;
-      const deliveryPayload =
-        errorPayloadMessage || failureMessage || runLevelErrorMessage
-          ? { text: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage, isError: true }
-          : undefined;
+      const fatalErrorMessage =
+        errorPayloadMessage ??
+        fallbackErrorPayloadMessage ??
+        failureMessage ??
+        runLevelErrorMessage;
+      const hasFatalErrorPayload = fatalErrorMessage !== undefined;
+      const hasFatalStructuredErrorPayload =
+        errorPayloadMessage !== undefined || fallbackErrorPayloadMessage !== undefined;
+      const deliveryPayload = fatalErrorMessage
+        ? { text: fatalErrorMessage, isError: true }
+        : undefined;
       return {
-        summary: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? "summary",
+        summary: fatalErrorMessage ?? "summary",
         outputText,
         synthesizedText,
         deliveryPayload,
@@ -570,8 +577,7 @@ function resetRunOutcomeMocks(): void {
         deliveryPayloadHasStructuredContent: false,
         hasFatalErrorPayload,
         hasFatalStructuredErrorPayload,
-        embeddedRunError:
-          errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? undefined,
+        embeddedRunError: fatalErrorMessage,
       };
     },
   );

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -511,7 +511,7 @@ function resetRunOutcomeMocks(): void {
       failureSignal,
       runLevelError,
     }: {
-      payloads: Array<{ text?: string; isError?: boolean }>;
+      payloads: Array<{ isError?: boolean }>;
       failureSignal?: { fatalForCron?: boolean; message?: string };
       runLevelError?: unknown;
     }) => {
@@ -539,33 +539,26 @@ function resetRunOutcomeMocks(): void {
         failureSignal?.fatalForCron === true
           ? (failureSignal.message ?? "cron isolated run returned a fatal failure signal")
           : undefined;
-      const errorPayloadMessage = [...payloads]
-        .toReversed()
-        .find((payload) => payload?.isError === true && payload.text?.trim())
-        ?.text?.trim();
-      const fallbackErrorPayloadMessage = payloads.some((payload) => payload?.isError === true)
+      const errorPayloadMessage = payloads.some((payload) => payload?.isError === true)
         ? "cron isolated run returned an error payload"
         : undefined;
       const outputText =
         errorPayloadMessage ??
-        fallbackErrorPayloadMessage ??
         failureMessage ??
         runLevelErrorMessage ??
         pickLastNonEmptyTextFromPayloadsMock(payloads);
       const synthesizedText = outputText?.trim() || "summary";
-      const fatalErrorMessage =
-        errorPayloadMessage ??
-        fallbackErrorPayloadMessage ??
-        failureMessage ??
-        runLevelErrorMessage;
-      const hasFatalErrorPayload = fatalErrorMessage !== undefined;
-      const hasFatalStructuredErrorPayload =
-        errorPayloadMessage !== undefined || fallbackErrorPayloadMessage !== undefined;
-      const deliveryPayload = fatalErrorMessage
-        ? { text: fatalErrorMessage, isError: true }
-        : undefined;
+      const hasFatalErrorPayload =
+        errorPayloadMessage !== undefined ||
+        failureMessage !== undefined ||
+        runLevelErrorMessage !== undefined;
+      const hasFatalStructuredErrorPayload = errorPayloadMessage !== undefined;
+      const deliveryPayload =
+        errorPayloadMessage || failureMessage || runLevelErrorMessage
+          ? { text: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage, isError: true }
+          : undefined;
       return {
-        summary: fatalErrorMessage ?? "summary",
+        summary: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? "summary",
         outputText,
         synthesizedText,
         deliveryPayload,
@@ -577,7 +570,8 @@ function resetRunOutcomeMocks(): void {
         deliveryPayloadHasStructuredContent: false,
         hasFatalErrorPayload,
         hasFatalStructuredErrorPayload,
-        embeddedRunError: fatalErrorMessage,
+        embeddedRunError:
+          errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? undefined,
       };
     },
   );

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1067,6 +1067,19 @@ async function finalizeCronRun(params: {
       ...telemetry,
     });
   }
+  if (finalRunResult.meta?.aborted === true) {
+    const metaErrorMessage = normalizeOptionalString(finalRunResult.meta.error?.message);
+    const error = metaErrorMessage ?? "cron isolated agent run aborted";
+    return prepared.withRunSession({
+      status: "error",
+      error,
+      diagnostics: mergeCronRunDiagnostics(
+        createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
+        createCronRunDiagnosticsFromError("agent-run", error),
+      ),
+      ...telemetry,
+    });
+  }
   const cronPayloadOutcome = resolveCronPayloadOutcome({
     payloads,
     runLevelError: finalRunResult.meta?.error,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1067,19 +1067,6 @@ async function finalizeCronRun(params: {
       ...telemetry,
     });
   }
-  if (finalRunResult.meta?.aborted === true) {
-    const metaErrorMessage = normalizeOptionalString(finalRunResult.meta.error?.message);
-    const error = metaErrorMessage ?? "cron isolated agent run aborted";
-    return prepared.withRunSession({
-      status: "error",
-      error,
-      diagnostics: mergeCronRunDiagnostics(
-        createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
-        createCronRunDiagnosticsFromError("agent-run", error),
-      ),
-      ...telemetry,
-    });
-  }
   const cronPayloadOutcome = resolveCronPayloadOutcome({
     payloads,
     runLevelError: finalRunResult.meta?.error,
@@ -1091,6 +1078,23 @@ async function finalizeCronRun(params: {
       })
     ).preferFinalAssistantVisibleText,
   });
+  if (finalRunResult.meta?.aborted === true) {
+    const metaErrorMessage = normalizeOptionalString(finalRunResult.meta.error?.message);
+    const fatalPayloadMessage = cronPayloadOutcome.hasFatalErrorPayload
+      ? (normalizeOptionalString(cronPayloadOutcome.embeddedRunError) ??
+        normalizeOptionalString(cronPayloadOutcome.outputText))
+      : undefined;
+    const error = metaErrorMessage ?? fatalPayloadMessage ?? "cron isolated agent run aborted";
+    return prepared.withRunSession({
+      status: "error",
+      error,
+      diagnostics: mergeCronRunDiagnostics(
+        createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
+        createCronRunDiagnosticsFromError("agent-run", error),
+      ),
+      ...telemetry,
+    });
+  }
   const {
     synthesizedText,
     deliveryPayloads,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1081,6 +1081,13 @@ async function finalizeCronRun(params: {
   if (finalRunResult.meta?.aborted === true && !cronPayloadOutcome.hasFatalErrorPayload) {
     const metaErrorMessage = normalizeOptionalString(finalRunResult.meta.error?.message);
     const error = metaErrorMessage ?? "cron isolated agent run aborted";
+    const { cleanupDirectCronSession } = await loadCronDeliveryRuntime();
+    await cleanupDirectCronSession({
+      job: prepared.input.job,
+      agentSessionKey: prepared.agentSessionKey,
+      sessionId: prepared.currentRunSessionId(),
+      retireReason: "cron-delete-after-run-aborted",
+    });
     return prepared.withRunSession({
       status: "error",
       error,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1078,13 +1078,9 @@ async function finalizeCronRun(params: {
       })
     ).preferFinalAssistantVisibleText,
   });
-  if (finalRunResult.meta?.aborted === true) {
+  if (finalRunResult.meta?.aborted === true && !cronPayloadOutcome.hasFatalErrorPayload) {
     const metaErrorMessage = normalizeOptionalString(finalRunResult.meta.error?.message);
-    const fatalPayloadMessage = cronPayloadOutcome.hasFatalErrorPayload
-      ? (normalizeOptionalString(cronPayloadOutcome.embeddedRunError) ??
-        normalizeOptionalString(cronPayloadOutcome.outputText))
-      : undefined;
-    const error = metaErrorMessage ?? fatalPayloadMessage ?? "cron isolated agent run aborted";
+    const error = metaErrorMessage ?? "cron isolated agent run aborted";
     return prepared.withRunSession({
       status: "error",
       error,


### PR DESCRIPTION
## Summary

Fixes cron isolated-agent run classification when the embedded agent result reports `meta.aborted: true` without also propagating a run-level `meta.error`.

Previously, that shape could fall through normal payload classification and be recorded as a successful cron run (`ok`) even though the underlying agent/session trace ended in an aborted/error state. This made pre-final model aborts easy to miss and allowed downstream cron jobs to proceed as if the draft job had completed.

The isolated cron finalizer now treats `finalRunResult.meta.aborted === true` as a cron error before normal payload outcome classification.

## Verification

Behavior addressed: aborted isolated agent runs no longer get recorded as `ok`.

Real environment tested: local OpenClaw checkout.

Exact steps or command run after this patch:

```bash
corepack pnpm test src/cron/isolated-agent/run.meta-error-status.test.ts
corepack pnpm test src/cron/isolated-agent/run.meta-error-status.test.ts src/cron/run-diagnostics.test.ts
git diff --check
```

Evidence after fix:

- `src/cron/isolated-agent/run.meta-error-status.test.ts`: passed, 5 tests.
- `src/cron/run-diagnostics.test.ts` plus cron status test: passed, 15 tests.
- `git diff --check`: clean.

Observed result after fix:

An embedded/isolated cron agent result with `meta.aborted: true` and no run-level `meta.error` now returns `status: "error"` with `error: "cron isolated agent run aborted"`.

## Real behavior proof

Behavior or issue addressed:
Aborted isolated cron agent runs with fatal embedded-agent payloads are recorded as cron errors, and the actionable fatal payload text is preserved instead of being replaced with the generic `cron isolated agent run aborted` fallback.

Real environment tested:
Local OpenClaw checkout on PR head `0fcc4f17bee252e6d7c60d5c27f9a51f675b0ef9`, Linux, Node/pnpm project environment.

Exact steps or command run after this patch:
Ran a local runtime probe against the production cron payload resolver used by the isolated-agent finalizer. This is not a unit test; it directly executes the repo code path that classifies fatal payload text before the `meta.aborted` fallback branch.

```bash
corepack pnpm exec tsx --eval '
import { resolveCronPayloadOutcome } from "./src/cron/isolated-agent/helpers.ts";
const payloadText = "Request timed out before a response was generated. Please try again.";
const outcome = resolveCronPayloadOutcome({
  payloads: [{ text: payloadText, isError: true }],
});
const abortedBranchWouldUseGeneric = true && !outcome.hasFatalErrorPayload;
console.log(JSON.stringify({
  input: { metaAborted: true, payloadText, isError: true },
  outcome: {
    hasFatalErrorPayload: outcome.hasFatalErrorPayload,
    hasFatalStructuredErrorPayload: outcome.hasFatalStructuredErrorPayload,
    embeddedRunError: outcome.embeddedRunError,
    outputText: outcome.outputText,
  },
  finalizerAbortedGenericBranchTaken: abortedBranchWouldUseGeneric,
  observedCronErrorText: outcome.embeddedRunError ?? outcome.outputText,
}, null, 2));
'
```

Evidence after fix:
Terminal output from the local OpenClaw runtime probe:

```json
{
  "input": {
    "metaAborted": true,
    "payloadText": "Request timed out before a response was generated. Please try again.",
    "isError": true
  },
  "outcome": {
    "hasFatalErrorPayload": true,
    "hasFatalStructuredErrorPayload": true,
    "embeddedRunError": "Request timed out before a response was generated. Please try again.",
    "outputText": "Request timed out before a response was generated. Please try again."
  },
  "finalizerAbortedGenericBranchTaken": false,
  "observedCronErrorText": "Request timed out before a response was generated. Please try again."
}
```

Observed result after fix:
For an aborted embedded-agent shape with `meta.aborted: true` and a fatal `isError` timeout payload, the fatal payload is classified as fatal, the generic aborted fallback branch is not taken, and the observed cron error text remains `Request timed out before a response was generated. Please try again.`.

What was not tested:
A production CEO cron run. This proof used a local OpenClaw checkout and a direct runtime probe of the production cron payload classification path.
