### PR TITLE
fix(feishu): guard channelRuntime inbound before dispatch fallback (fixes #93453)

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -422,6 +422,7 @@ async function dispatchMessage(params: {
   cfg: ClawdbotConfig;
   currentCfg?: ClawdbotConfig;
   event: FeishuMessageEvent;
+  channelRuntime?: ReturnType<typeof createFeishuBotRuntime>["channel"];
 }) {
   const runtime = createRuntimeEnv();
   const feishuConfig = params.cfg.channels?.feishu;
@@ -443,6 +444,7 @@ async function dispatchMessage(params: {
     cfg,
     event: params.event,
     runtime,
+    ...(params.channelRuntime ? { channelRuntime: params.channelRuntime } : {}),
   });
   return runtime;
 }
@@ -959,6 +961,33 @@ describe("handleFeishuMessage ACP routing", () => {
       0,
     );
     expect(dispatcherOptions.allowReasoningPreview).toBe(true);
+  });
+
+  it("falls back to full runtime channel when partial channelRuntime lacks inbound", async () => {
+    const partialChannelRuntime = {
+      runtimeContexts: {} as PluginRuntime["channel"]["runtimeContexts"],
+    } as PluginRuntime["channel"];
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-partial-runtime",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+      channelRuntime: partialChannelRuntime,
+    });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledTimes(1);
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -734,7 +734,7 @@ export async function handleFeishuMessage(params: {
 
   try {
     const core = {
-      channel: channelRuntime ?? getFeishuRuntime().channel,
+      channel: channelRuntime?.inbound ? channelRuntime : getFeishuRuntime().channel,
     } as ReturnType<typeof getFeishuRuntime>;
     const pairing = createChannelPairingController({
       core,


### PR DESCRIPTION
## Summary

Fixes #93453

After upgrading to 2026.6.6, the Feishu channel dispatch crashes with `TypeError: Cannot read properties of undefined (reading run)` when the gateway provides a partial `channelRuntime` object that lacks the `inbound` sub-property.

## Root Cause

In `bot.ts:737`, the expression `channelRuntime ?? getFeishuRuntime().channel` selects `channelRuntime` when truthy, even if it is a partial object without `inbound`. The `ChannelGatewayContext.channelRuntime` type is `ChannelRuntimeSurface` (only guarantees `runtimeContexts`), but `channel.ts:1326` casts it to `PluginRuntime["channel"]` via `as PluginRuntime["channel"]`. When a partial runtime object without `inbound` reaches the handler, the unsound type assertion becomes a runtime crash at `core.channel.inbound.run()`.

## Fix

Check `channelRuntime?.inbound` before using it; when `inbound` is absent, fall back to `getFeishuRuntime().channel` which always provides the full runtime surface.

```diff
-      channel: channelRuntime ?? getFeishuRuntime().channel,
+      channel: channelRuntime?.inbound ? channelRuntime : getFeishuRuntime().channel,
```

## Real behavior proof

**Behavior or issue addressed:** Feishu channel dispatch no longer crashes with TypeError when `channelRuntime` lacks the `inbound` property.

**Real environment tested:** Linux (WSL2), Node v24.16.0, commit 97259893.

**Exact steps or command run after this patch:** Verified the fix by checking the code change ensures `channelRuntime?.inbound` is truthy before using `channelRuntime`, otherwise falls back to `getFeishuRuntime().channel`.

**Evidence after fix:** Terminal output from code inspection:

```
$ grep -n "channelRuntime?.inbound" extensions/feishu/src/bot.ts
737:      channel: channelRuntime?.inbound ? channelRuntime : getFeishuRuntime().channel,
```

The conditional `channelRuntime?.inbound ? channelRuntime : getFeishuRuntime().channel` ensures:
- If `channelRuntime` has `inbound` → uses `channelRuntime` (same behavior as before)
- If `channelRuntime` is falsy or lacks `inbound` → falls back to `getFeishuRuntime().channel` (always has `inbound`)

**Observed result after fix:** The crash path is eliminated by falling back to the registered runtime when `inbound` is absent. The working path (when `channelRuntime` has `inbound`) is unchanged. This is a purely defensive guard.

**What was not tested:** Actual Feishu channel runtime behavior with partial `channelRuntime` objects in production; the fix is based on code analysis of the type mismatch.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Security Impact

- No new permissions/capabilities
- No secrets/tokens handling changed
- No new/changed network calls
- No command/tool execution surface changed
- No data access scope changed

## Compatibility

- Backward compatible — guard only expands the fallback path
- No config/env changes
- No migration needed

Fixes #93453