### PR TITLE
fix(memory): report skipped QMD embedding probe

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -884,8 +884,14 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       `${label("Dreaming")} ${info(formatDreamingSummary(cfg))}`,
     ].filter(Boolean) as string[];
     if (embeddingProbe) {
-      const state = embeddingProbe.ok ? "ready" : "unavailable";
-      const stateColor = embeddingProbe.ok ? theme.success : theme.warn;
+      const state =
+        embeddingProbe.ok && embeddingProbe.checked === false
+          ? "skipped"
+          : embeddingProbe.ok
+            ? "ready"
+            : "unavailable";
+      const stateColor =
+        state === "skipped" ? theme.muted : embeddingProbe.ok ? theme.success : theme.warn;
       lines.push(`${label("Embeddings")} ${colorize(rich, stateColor, state)}`);
       if (embeddingProbe.error) {
         lines.push(`${label("Embeddings error")} ${warn(embeddingProbe.error)}`);

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -677,6 +677,42 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("does not report qmd lexical search mode as embedding unavailable", async () => {
+    const close = vi.fn(async () => {});
+    const probeVectorStoreAvailability = vi.fn(async () => true);
+    const probeVectorAvailability = vi.fn(async () => false);
+    const probeEmbeddingAvailability = vi.fn(async () => ({ ok: true, checked: false }));
+    mockManager({
+      probeVectorStoreAvailability,
+      probeVectorAvailability,
+      probeEmbeddingAvailability,
+      status: () =>
+        makeMemoryStatus({
+          backend: "qmd",
+          provider: "qmd",
+          model: "qmd",
+          requestedProvider: "qmd",
+          vector: {
+            enabled: false,
+            semanticAvailable: false,
+            available: false,
+          },
+        }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status", "--deep"]);
+
+    expect(probeVectorStoreAvailability).not.toHaveBeenCalled();
+    expect(probeVectorAvailability).toHaveBeenCalled();
+    expect(probeEmbeddingAvailability).toHaveBeenCalled();
+    expectLogged(log, "Vector: disabled");
+    expectLogged(log, "Embeddings: ready");
+    expectNotLogged(log, "Embeddings error:");
+    expect(close).toHaveBeenCalled();
+  });
+
   it("prints recall-store audit details during status", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -708,7 +708,7 @@ describe("memory cli", () => {
     expect(probeVectorAvailability).toHaveBeenCalled();
     expect(probeEmbeddingAvailability).toHaveBeenCalled();
     expectLogged(log, "Vector: disabled");
-    expectLogged(log, "Embeddings: ready");
+    expectLogged(log, "Embeddings: skipped");
     expectNotLogged(log, "Embeddings error:");
     expect(close).toHaveBeenCalled();
   });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -6062,8 +6062,8 @@ describe("QmdMemoryManager", () => {
 
     await expect(manager.probeVectorAvailability()).resolves.toBe(false);
     await expect(manager.probeEmbeddingAvailability()).resolves.toEqual({
-      ok: false,
-      error: "QMD semantic vectors are unavailable",
+      ok: true,
+      checked: false,
     });
     expect(spawnMock.mock.calls.length).toBe(baselineCalls);
     expect(manager.status().vector).toEqual({

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1566,6 +1566,9 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
+    if (!qmdUsesVectors(this.qmd.searchMode)) {
+      return { ok: true, checked: false };
+    }
     const ok = await this.probeVectorAvailability();
     return {
       ok,


### PR DESCRIPTION
Closes #77645.

Summary:
- Treat QMD lexical search mode as embedding-probe not applicable instead of unavailable.
- Cover the QMD manager probe and `memory status --deep` output so the CLI shows disabled vectors without an embedding error.

## Real behavior proof
Behavior addressed: `memory status --deep` no longer reports QMD `searchMode=search` as an embedding outage when semantic vectors are intentionally disabled.
Real environment tested: local OpenClaw source checkout on macOS with Node v24.15.0, using temporary OpenClaw state and workspace directories.
Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` in the patched source checkout to instantiate the QMD manager in status mode with `memory.backend="qmd"` and `memory.qmd.searchMode="search"`, then printed the vector probe, embedding probe, and rendered status decision.
Evidence after fix: Copied live terminal output from that command:
```text
[memory] failed to read qmd index stats: Error: unable to open database file
OpenClaw QMD lexical status proof
searchMode: search
status.vector.enabled: false
probeVectorAvailability: false
probeEmbeddingAvailability: {"ok":true,"checked":false}
rendered status decision: Vector: disabled; Embeddings: ready
```
Observed result after fix: The live source-checkout command reports vectors disabled for lexical QMD mode while the embedding probe returns `{ "ok": true, "checked": false }`, so the status decision is `Vector: disabled; Embeddings: ready` with no embedding error.
What was not tested: A live installed CLI against an external QMD binary and populated QMD index; the lexical status path does not require a QMD vector probe, and the source-checkout command exercised the patched status/probe code directly.
