### PR TITLE
[codex] Honor npm registry in update checks

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -44,14 +44,17 @@ describe("compareSemverStrings", () => {
 
 describe("resolveNpmChannelTag", () => {
   let versionByTag: Record<string, string | null>;
+  let fetchedUrls: string[];
 
   beforeEach(() => {
     versionByTag = {};
+    fetchedUrls = [];
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         const url =
           typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        fetchedUrls.push(url);
         const tag = decodeURIComponent(url.split("/").pop() ?? "");
         const version = versionByTag[tag] ?? null;
         return {
@@ -68,6 +71,7 @@ describe("resolveNpmChannelTag", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("falls back to latest when beta is older", async () => {
@@ -104,6 +108,21 @@ describe("resolveNpmChannelTag", () => {
       tag: "latest",
       version: "1.0.3",
     });
+  });
+
+  it("uses the configured npm registry for package target fetches", async () => {
+    vi.stubEnv("npm_config_registry", "https://registry.npmmirror.com");
+    versionByTag.latest = "1.0.4";
+
+    await expect(
+      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
+    ).resolves.toEqual({
+      target: "latest",
+      version: "1.0.4",
+      nodeEngine: ">=22.19.0",
+    });
+
+    expect(fetchedUrls).toEqual(["https://registry.npmmirror.com/openclaw/latest"]);
   });
 
   it("exposes tag fetch helpers for success and http failures", async () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -10,6 +10,8 @@ import { channelToNpmTag, type UpdateChannel } from "./update-channels.js";
 
 export type PackageManager = "pnpm" | "bun" | "npm" | "unknown";
 
+const DEFAULT_NPM_REGISTRY_URL = "https://registry.npmjs.org/";
+
 export type GitUpdateStatus = {
   root: string;
   sha: string | null;
@@ -329,11 +331,16 @@ export async function fetchNpmPackageTargetStatus(params: {
   const timeoutMs = params.timeoutMs ?? 3500;
   const target = params.target;
   try {
-    const res = await fetchWithTimeout(
-      `https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`,
-      {},
-      Math.max(250, timeoutMs),
-    );
+    const registryUrl =
+      process.env.npm_config_registry?.trim() ||
+      process.env.NPM_CONFIG_REGISTRY?.trim() ||
+      DEFAULT_NPM_REGISTRY_URL;
+    const registryBaseUrl = registryUrl.endsWith("/") ? registryUrl : `${registryUrl}/`;
+    const packageTargetUrl = new URL(
+      `openclaw/${encodeURIComponent(target)}`,
+      registryBaseUrl,
+    ).toString();
+    const res = await fetchWithTimeout(packageTargetUrl, {}, Math.max(250, timeoutMs));
     if (!res.ok) {
       return { target, version: null, nodeEngine: null, error: `HTTP ${res.status}` };
     }


### PR DESCRIPTION
Closes #79140.

Summary:
- Build update-check registry URLs from the package-manager registry environment when present.
- Fall back to the official npm registry only when no registry is configured.

## Real behavior proof
Behavior addressed: update checks can fetch OpenClaw package metadata from a configured npm mirror instead of always using `registry.npmjs.org`.
Real environment tested: local OpenClaw source checkout on macOS with Node v24.15.0 and a local HTTP registry stub.
Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` in the patched source checkout to start a local HTTP registry, set `npm_config_registry` to that registry, and call the real `fetchNpmPackageTargetStatus({ target: "latest" })` helper.
Evidence after fix: Copied live terminal output from that command:
```text
registry request: GET /openclaw/latest
OpenClaw update registry proof
npm_config_registry: http://127.0.0.1:60077
requested path: /openclaw/latest
fetch result: {"target":"latest","version":"2026.5.3-1","nodeEngine":">=22.19.0"}
```
Observed result after fix: The live request went to the configured registry server at `/openclaw/latest`; the helper returned package metadata from that server, proving the update checker did not use the hardcoded npmjs registry URL.
What was not tested: A live network request to `registry.npmmirror.com`; the command used a local registry stub to prove the update checker honors the configured registry URL without depending on external network availability.
