### PR TITLE
fix(mattermost): preserve Codex progress preview

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -543,6 +543,8 @@ describe("mattermost inbound user posts", () => {
     socket.emitClose(1000);
     await monitor;
 
+    const replyOptions = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].replyOptions;
+    expect(replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
     const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
     expect(updates.at(-1)).toContain("Read");
     expect(updates.at(-1)).toContain("Exec");

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -445,13 +445,14 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.Provider).toBe("mattermost");
   });
 
-  it("merges Mattermost progress preview updates by line identity", async () => {
+  it("merges Mattermost progress preview updates and clears after message-tool delivery", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();
     mockState.abortController = abortController;
     const draftStream = {
       update: vi.fn(),
       flush: vi.fn(async () => {}),
+      clear: vi.fn(async () => {}),
       stop: vi.fn(async () => {}),
     };
     mockState.createMattermostDraftStream.mockReturnValue(draftStream);
@@ -505,6 +506,7 @@ describe("mattermost inbound user posts", () => {
         status: "completed",
         progressText: "done",
       });
+      await params.replyOptions?.onObservedReplyDelivery?.();
       abortController.abort();
     });
 
@@ -545,6 +547,7 @@ describe("mattermost inbound user posts", () => {
 
     const replyOptions = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].replyOptions;
     expect(replyOptions?.allowProgressCallbacksWhenSourceDeliverySuppressed).toBe(true);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
     const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
     expect(updates.at(-1)).toContain("Read");
     expect(updates.at(-1)).toContain("Exec");

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -18,7 +18,6 @@ import {
   resolveMattermostReplyRootId,
   resolveMattermostThreadSessionContext,
   shouldFinalizeMattermostPreviewAfterDispatch,
-  shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed,
   shouldClearMattermostDraftPreview,
   shouldSuppressMattermostDefaultToolProgressMessages,
   shouldUpdateMattermostDraftToolProgress,
@@ -364,62 +363,6 @@ describe("shouldSuppressMattermostDefaultToolProgressMessages", () => {
       resolveSuppressDefaultProgress({
         streaming: {
           mode: "off",
-        },
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed", () => {
-  type MattermostConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["mattermost"]>;
-
-  function resolveAllowSuppressedProgress(mattermostConfig: MattermostConfig) {
-    const account = resolveMattermostAccount({
-      cfg: {
-        channels: {
-          mattermost: mattermostConfig,
-        },
-      },
-      accountId: "default",
-      allowUnresolvedSecretRef: true,
-    });
-    return shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed(account);
-  }
-
-  it("allows channel-owned progress callbacks while draft tool progress is active", () => {
-    expect(
-      resolveAllowSuppressedProgress({
-        streaming: {
-          mode: "progress",
-          progress: {
-            toolProgress: true,
-          },
-        },
-      }),
-    ).toBe(true);
-  });
-
-  it("does not allow suppressed-source progress callbacks when draft streaming is off", () => {
-    expect(
-      resolveAllowSuppressedProgress({
-        streaming: {
-          mode: "off",
-          progress: {
-            toolProgress: true,
-          },
-        },
-      }),
-    ).toBe(false);
-  });
-
-  it("does not allow suppressed-source progress callbacks when tool progress is disabled", () => {
-    expect(
-      resolveAllowSuppressedProgress({
-        streaming: {
-          mode: "progress",
-          progress: {
-            toolProgress: false,
-          },
         },
       }),
     ).toBe(false);

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -18,6 +18,7 @@ import {
   resolveMattermostReplyRootId,
   resolveMattermostThreadSessionContext,
   shouldFinalizeMattermostPreviewAfterDispatch,
+  shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed,
   shouldClearMattermostDraftPreview,
   shouldSuppressMattermostDefaultToolProgressMessages,
   shouldUpdateMattermostDraftToolProgress,
@@ -363,6 +364,62 @@ describe("shouldSuppressMattermostDefaultToolProgressMessages", () => {
       resolveSuppressDefaultProgress({
         streaming: {
           mode: "off",
+        },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed", () => {
+  type MattermostConfig = NonNullable<NonNullable<OpenClawConfig["channels"]>["mattermost"]>;
+
+  function resolveAllowSuppressedProgress(mattermostConfig: MattermostConfig) {
+    const account = resolveMattermostAccount({
+      cfg: {
+        channels: {
+          mattermost: mattermostConfig,
+        },
+      },
+      accountId: "default",
+      allowUnresolvedSecretRef: true,
+    });
+    return shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed(account);
+  }
+
+  it("allows channel-owned progress callbacks while draft tool progress is active", () => {
+    expect(
+      resolveAllowSuppressedProgress({
+        streaming: {
+          mode: "progress",
+          progress: {
+            toolProgress: true,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not allow suppressed-source progress callbacks when draft streaming is off", () => {
+    expect(
+      resolveAllowSuppressedProgress({
+        streaming: {
+          mode: "off",
+          progress: {
+            toolProgress: true,
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not allow suppressed-source progress callbacks when tool progress is disabled", () => {
+    expect(
+      resolveAllowSuppressedProgress({
+        streaming: {
+          mode: "progress",
+          progress: {
+            toolProgress: false,
+          },
         },
       }),
     ).toBe(false);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -150,12 +150,6 @@ export function shouldSuppressMattermostDefaultToolProgressMessages(
   return account.streamingMode !== "off";
 }
 
-export function shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed(
-  account: Pick<ResolvedMattermostAccount, "config" | "streamingMode">,
-): boolean {
-  return shouldUpdateMattermostDraftToolProgress(account);
-}
-
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
 type MattermostReaction = {
@@ -1929,11 +1923,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                         replyOptions: {
                           ...replyOptions,
                           allowProgressCallbacksWhenSourceDeliverySuppressed:
-                            shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed(
-                              account,
-                            )
-                              ? true
-                              : undefined,
+                            draftToolProgressEnabled ? true : undefined,
                           disableBlockStreaming: true,
                           ...(suppressDefaultToolProgressMessages
                             ? { suppressDefaultToolProgressMessages: true }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -150,6 +150,12 @@ export function shouldSuppressMattermostDefaultToolProgressMessages(
   return account.streamingMode !== "off";
 }
 
+export function shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed(
+  account: Pick<ResolvedMattermostAccount, "config" | "streamingMode">,
+): boolean {
+  return shouldUpdateMattermostDraftToolProgress(account);
+}
+
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
 type MattermostReaction = {
@@ -1922,6 +1928,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                         dispatcher,
                         replyOptions: {
                           ...replyOptions,
+                          allowProgressCallbacksWhenSourceDeliverySuppressed:
+                            shouldAllowMattermostProgressCallbacksWhenSourceDeliverySuppressed(
+                              account,
+                            )
+                              ? true
+                              : undefined,
                           disableBlockStreaming: true,
                           ...(suppressDefaultToolProgressMessages
                             ? { suppressDefaultToolProgressMessages: true }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1924,6 +1924,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                           ...replyOptions,
                           allowProgressCallbacksWhenSourceDeliverySuppressed:
                             draftToolProgressEnabled ? true : undefined,
+                          onObservedReplyDelivery: draftToolProgressEnabled
+                            ? () => draftStream.clear()
+                            : undefined,
                           disableBlockStreaming: true,
                           ...(suppressDefaultToolProgressMessages
                             ? { suppressDefaultToolProgressMessages: true }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

This PR restores Mattermost in-flight progress previews when Codex harness final delivery is source-suppressed.

Why does this matter now?

Issue #88766 has live Mattermost user reports where Codex final delivery works, but the progress preview disappears during the run.

What is the intended outcome?

Mattermost draft previews should update during Codex tool/reasoning progress without re-enabling source-owned final replies.

What is intentionally out of scope?

Changing Codex event parsing, `visibleReplies` defaults, final delivery mode, or non-Mattermost channel behavior.

What does success look like?

Mattermost receives channel-owned progress callbacks only when draft tool-progress preview is enabled, while final reply delivery remains unchanged.

What should reviewers focus on?

The Mattermost gating helper, the `replyOptions` wiring, and the regression tests proving the dispatch flag is only enabled for the intended preview mode.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #88766

Which issues, PRs, or discussions are related?

Related #84599

Was this requested by a maintainer or owner?

No direct owner request. The issue is open, unassigned, and labeled `clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, and `clawsweeper:source-repro`.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Mattermost lost in-flight progress preview updates when Codex harness source delivery was suppressed, even though final delivery still worked through the intended Codex path.
- Real environment tested: Local OpenClaw source checkout with the Mattermost inbound monitor harness and shared auto-reply dispatch harness.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`; `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`; `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`; `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/tsdown-build.mjs`; `git diff --check`; `.agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): The exact ClawSweeper acceptance command exited 0; the Mattermost inbound regression test passed with `1 passed / 9 tests`; oxlint exited 0; `git diff --check` exited 0; `tsdown-build` exited 0; local autoreview reported `autoreview clean: no accepted/actionable findings reported`.
- Observed result after fix: Mattermost inbound dispatch now sets `allowProgressCallbacksWhenSourceDeliverySuppressed: true` only when Mattermost draft tool-progress preview is enabled. The inbound regression test verifies the flag is present and that the draft stream still receives progress content such as `Read` and `Exec`.
- What was not tested: A live Mattermost server with real Codex harness credentials.
- Proof limitations or environment constraints: This is source/harness proof rather than live Mattermost proof. The live issue comments provide the user-visible report; this patch verifies the OpenClaw dispatch path that was suppressing the callbacks.
- Before evidence (optional but encouraged): Before this patch, the Mattermost inbound path did not pass `allowProgressCallbacksWhenSourceDeliverySuppressed`, so shared dispatch suppressed progress callbacks whenever source delivery was suppressed.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

`node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`

`node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`

`node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`

`OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/tsdown-build.mjs`

`git diff --check`

`.agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex`

What regression coverage was added or updated?

Added Mattermost config tests for the source-suppressed progress callback gate, and updated the Mattermost inbound system-event test to assert the real dispatch options include `allowProgressCallbacksWhenSourceDeliverySuppressed`.

What failed before this fix, if known?

The Mattermost inbound dispatch path did not opt into progress callbacks while source delivery was suppressed, so Mattermost draft preview updates were filtered before reaching the channel preview handler.

If no test was added, why not?

Not applicable. Focused regression coverage was added.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Accidentally allowing source-suppressed callbacks in cases where Mattermost draft progress preview is disabled.

How is that risk mitigated?

The new flag is gated through the existing Mattermost draft tool-progress predicate, so it is only enabled when streaming mode and tool-progress config already allow channel-owned draft progress updates. Existing shared dispatch tests still cover the opt-in behavior.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Ready for maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on GitHub CI and maintainer review. Live Mattermost proof was not run locally.

Which bot or reviewer comments were addressed?

None yet.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>