### PR TITLE
Consume ClawHub skill source provenance

### DIFF
--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -273,6 +273,19 @@ export type ClawHubPackageSearchResult = {
   package: ClawHubPackageListItem;
 };
 
+export type ClawHubSkillSourceProvenance = {
+  source?: string | null;
+  sourceUrl?: string | null;
+  url?: string | null;
+  sourceRepo?: string | null;
+  repo?: string | null;
+  sourceCommit?: string | null;
+  commit?: string | null;
+  sourcePath?: string | null;
+  path?: string | null;
+  reason?: string | null;
+};
+
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
@@ -280,6 +293,8 @@ export type ClawHubSkillSearchResult = {
   summary?: string;
   version?: string;
   updatedAt?: number;
+  sourceUrl?: string | null;
+  provenance?: ClawHubSkillSourceProvenance | null;
 };
 
 export type ClawHubSkillDetail = {
@@ -290,11 +305,15 @@ export type ClawHubSkillDetail = {
     tags?: Record<string, string>;
     createdAt: number;
     updatedAt: number;
+    sourceUrl?: string | null;
+    provenance?: ClawHubSkillSourceProvenance | null;
   } | null;
   latestVersion?: {
     version: string;
     createdAt: number;
     changelog?: string;
+    sourceUrl?: string | null;
+    provenance?: ClawHubSkillSourceProvenance | null;
   } | null;
   metadata?: {
     os?: string[] | null;
@@ -312,21 +331,28 @@ export type ClawHubSkillInstallResolutionResponse =
       ok: true;
       slug: string;
       installKind: "archive";
+      sourceUrl?: string | null;
+      provenance?: ClawHubSkillSourceProvenance | null;
       archive: {
         version: string;
         downloadUrl: string;
+        sourceUrl?: string | null;
+        provenance?: ClawHubSkillSourceProvenance | null;
       };
     }
   | {
       ok: true;
       slug: string;
       installKind: "github";
+      sourceUrl?: string | null;
+      provenance?: ClawHubSkillSourceProvenance | null;
       github: {
         repo: string;
         path: string;
         commit: string;
         contentHash: string;
         sourceUrl: string;
+        provenance?: ClawHubSkillSourceProvenance | null;
       };
     }
   | {
@@ -349,7 +375,8 @@ export type ClawHubSkillVerificationResponse = {
   version: unknown;
   card: unknown;
   artifact: unknown;
-  provenance: unknown;
+  sourceUrl?: string | null;
+  provenance: ClawHubSkillSourceProvenance | null;
   security: unknown;
   signature: unknown;
 };
@@ -396,11 +423,15 @@ export type ClawHubSkillListResponse = {
       version: string;
       createdAt: number;
       changelog?: string;
+      sourceUrl?: string | null;
+      provenance?: ClawHubSkillSourceProvenance | null;
     } | null;
     metadata?: {
       os?: string[] | null;
       systems?: string[] | null;
     } | null;
+    sourceUrl?: string | null;
+    provenance?: ClawHubSkillSourceProvenance | null;
     createdAt: number;
     updatedAt: number;
   }>;

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -382,6 +382,181 @@ describe("skills-clawhub", () => {
     }
   });
 
+  it("persists the source URL from ClawHub archive install resolution", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    const sourceUrl = "https://github.com/openclaw/skills/tree/abc123/agentreceipt";
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "agentreceipt",
+      installKind: "archive",
+      archive: {
+        version: "1.0.0",
+        downloadUrl: "https://clawhub.ai/api/v1/download?slug=agentreceipt&version=1.0.0",
+        sourceUrl,
+      },
+    });
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt?.sourceUrl).toBe(sourceUrl);
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBe(sourceUrl);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists the source URL from version verification provenance", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    const sourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    fetchClawHubSkillDetailMock.mockResolvedValueOnce({
+      skill: {
+        slug: "agentreceipt",
+        displayName: "AgentReceipt",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: {
+        version: "1.0.0",
+        createdAt: 3,
+      },
+    });
+    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: {
+        source: "github",
+        url: sourceUrl,
+        repo: "openclaw/skills",
+        commit: "def456",
+        path: "agentreceipt",
+      },
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+        version: "1.0.0",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt).toMatchObject({
+        sourceUrl,
+        verification: {
+          sourceUrl,
+          provenance: {
+            source: "github",
+            url: sourceUrl,
+            repo: "openclaw/skills",
+            commit: "def456",
+            path: "agentreceipt",
+          },
+        },
+      });
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBe(sourceUrl);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not use latest-version detail source for older explicit version installs", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    fetchClawHubSkillDetailMock.mockResolvedValueOnce({
+      skill: {
+        slug: "agentreceipt",
+        displayName: "AgentReceipt",
+        createdAt: 1,
+        updatedAt: 2,
+        sourceUrl: "https://github.com/openclaw/skills/tree/latest/agentreceipt",
+      },
+      latestVersion: {
+        version: "2.0.0",
+        createdAt: 3,
+        sourceUrl: "https://github.com/openclaw/skills/tree/latest/agentreceipt",
+      },
+    });
+    fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+        version: "1.0.0",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt?.sourceUrl).toBeUndefined();
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBeUndefined();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps installing when the ClawHub verification snapshot is unavailable", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-lock-");
     fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -19,6 +19,7 @@ import {
   type ClawHubSkillDetail,
   type ClawHubSkillInstallResolutionResponse,
   type ClawHubSkillSearchResult,
+  type ClawHubSkillSourceProvenance,
   type ClawHubSkillVerificationResponse,
 } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -55,9 +56,10 @@ type ClawHubSkillVerificationLock = {
   ok: boolean;
   decision: ClawHubSkillVerificationResponse["decision"];
   reasons: string[];
+  sourceUrl?: string;
   card?: unknown;
   artifact?: unknown;
-  provenance?: unknown;
+  provenance?: ClawHubSkillSourceProvenance | null;
   security?: unknown;
   signature?: unknown;
 };
@@ -273,12 +275,55 @@ function normalizeOptionalStringValue(raw: unknown): string | undefined {
   return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
 
-function readSkillDetailSourceUrl(detail: ClawHubSkillDetail | undefined): string | undefined {
-  const skill = detail?.skill;
-  if (!skill || typeof skill !== "object") {
+function asRecord(raw: unknown): Record<string, unknown> | undefined {
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : undefined;
+}
+
+function readSourceUrlFromSourceMetadata(raw: unknown): string | undefined {
+  const record = asRecord(raw);
+  if (!record) {
     return undefined;
   }
-  return normalizeOptionalStringValue((skill as { sourceUrl?: unknown }).sourceUrl);
+  return (
+    normalizeOptionalStringValue(record.sourceUrl) ??
+    normalizeOptionalStringValue(record.url) ??
+    readSourceUrlFromSourceMetadata(record.provenance)
+  );
+}
+
+function readSkillDetailSourceUrl(
+  detail: ClawHubSkillDetail | undefined,
+  installedVersion: string,
+): string | undefined {
+  if (detail?.latestVersion?.version !== installedVersion) {
+    return undefined;
+  }
+  return (
+    readSourceUrlFromSourceMetadata(detail.latestVersion) ??
+    readSourceUrlFromSourceMetadata(detail.skill)
+  );
+}
+
+function readInstallResolutionSourceUrl(
+  resolution: Extract<ClawHubSkillInstallResolutionResponse, { ok: true }> | undefined,
+): string | undefined {
+  if (!resolution) {
+    return undefined;
+  }
+  return (
+    readSourceUrlFromSourceMetadata(resolution) ??
+    (resolution.installKind === "github"
+      ? readSourceUrlFromSourceMetadata(resolution.github)
+      : readSourceUrlFromSourceMetadata(resolution.archive))
+  );
+}
+
+function readVerificationSourceUrl(
+  verification: ClawHubSkillVerificationLock | undefined,
+): string | undefined {
+  return readSourceUrlFromSourceMetadata(verification);
 }
 
 function buildDownloadedArtifactLock(
@@ -309,11 +354,13 @@ function buildInstallTelemetrySkills(
 function snapshotClawHubSkillVerification(
   verification: ClawHubSkillVerificationResponse,
 ): ClawHubSkillVerificationLock {
+  const sourceUrl = readSourceUrlFromSourceMetadata(verification);
   return {
     schema: verification.schema,
     ok: verification.ok,
     decision: verification.decision,
     reasons: [...verification.reasons],
+    ...(sourceUrl ? { sourceUrl } : {}),
     ...(verification.card !== undefined ? { card: verification.card } : {}),
     ...(verification.artifact !== undefined ? { artifact: verification.artifact } : {}),
     ...(verification.provenance !== undefined ? { provenance: verification.provenance } : {}),
@@ -1106,10 +1153,6 @@ async function performClawHubSkillInstall(
 
       const installedAt = Date.now();
       const artifact = buildDownloadedArtifactLock(archive);
-      const sourceUrl =
-        latestResolution?.installKind === "github"
-          ? normalizeOptionalStringValue(latestResolution.github.sourceUrl)
-          : readSkillDetailSourceUrl(detail);
       const verificationVersion =
         latestResolution?.installKind === "github" && !params.version ? undefined : version;
       const [skillFile, verification] = await Promise.all([
@@ -1120,6 +1163,10 @@ async function performClawHubSkillInstall(
           baseUrl: params.baseUrl,
         }),
       ]);
+      const sourceUrl =
+        readInstallResolutionSourceUrl(latestResolution) ??
+        readVerificationSourceUrl(verification) ??
+        readSkillDetailSourceUrl(detail, version);
       await writeClawHubSkillOrigin(install.targetDir, {
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),


### PR DESCRIPTION
## Summary

Refs #92077. Follow-up to #93283.

This PR adds the first client-side slice for the next ClawHub provenance phase:

- Defines optional ClawHub skill source/provenance fields on search/list/detail/install/verify API response types.
- Consumes registry-side source URLs from install resolution, verify provenance, or version-matched detail metadata when writing local `.clawhub/lock.json` and `.clawhub/origin.json`.
- Accepts the current verify provenance shape (`url`/`repo`/`commit`/`path`) as well as the explicit `sourceUrl` aliases.
- Avoids the self-attested `SKILL.md` frontmatter path from #92860; this only records source metadata returned by ClawHub registry/verification surfaces.

This is intentionally not publish-side enforcement. It does not require every ClawHub publish to have source metadata yet, does not add UI display, does not change sandbox behavior, and does not implement audit/pinning.

## Behavior addressed

When ClawHub starts returning source/provenance metadata for skills, OpenClaw now has a typed client contract and persists that registry-side source URL into the local install provenance records instead of silently dropping it.

## Real environment tested

Local OpenClaw checkout on macOS with Node v22.18.0 / pnpm 11.2.2. A temporary local HTTP server emulated ClawHub install, download, and verify endpoints; the proof used the real `installSkillFromClawHub` path, a real zip archive, real extraction, and real lock/origin file writes.

## Exact steps or command run after this patch

```sh
node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts
node scripts/run-vitest.mjs src/infra/clawhub.test.ts src/cli/skills-cli.verify.test.ts
pnpm exec oxfmt --check --threads=1 src/infra/clawhub.ts src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts
node scripts/run-oxlint.mjs src/infra/clawhub.ts src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts
pnpm tsgo:core
pnpm tsgo:test:src
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
node --import tsx /private/tmp/openclaw-clawhub-source-proof.mjs
```

## Evidence after fix

Targeted tests:

```text
src/skills/lifecycle/clawhub.test.ts: 40 passed
src/infra/clawhub.test.ts: 52 passed
src/cli/skills-cli.verify.test.ts: 1 passed
```

Real install proof output:

```json
{
  "result": {
    "ok": true,
    "slug": "source-demo",
    "version": "1.0.0"
  },
  "lockSourceUrl": "https://github.com/openclaw/skills/tree/source-proof/source-demo",
  "originSourceUrl": "https://github.com/openclaw/skills/tree/source-proof/source-demo",
  "verificationSourceUrl": "https://github.com/openclaw/skills/tree/source-proof/source-demo",
  "verificationProvenance": {
    "source": "github",
    "url": "https://github.com/openclaw/skills/tree/source-proof/source-demo",
    "repo": "openclaw/skills",
    "commit": "source-proof",
    "path": "source-demo"
  }
}
```

Autoreview:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct
```

## Observed result after fix

An archive install resolution that includes `archive.sourceUrl` writes that URL into both `.clawhub/lock.json` and `.clawhub/origin.json`.

For explicit version installs, `/verify` provenance using the current `url`/`repo`/`commit`/`path` shape is normalized into the persisted `sourceUrl` and retained in the verification snapshot.

If explicit-version verification is unavailable and `/skills/:slug` only describes a different `latestVersion`, OpenClaw now omits the source URL instead of recording stale latest-version provenance for the requested older version.

## What was not tested

This PR does not test publish-side validation because that belongs to the ClawHub service/publisher flow. It also does not test UI display, audit/pinning, or runtime enforcement because those are later phases.
