### PR TITLE
Fix setup-code bootstrap approval for Android nodes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2033,7 +2033,7 @@ class NodeRuntime(
         }
       _nodesDevicesSummary.value =
         GatewayNodesDevicesSummary(
-          nodes = parseGatewayNodes(nodesRoot?.get("nodes") as? JsonArray),
+          nodes = parseGatewayNodeSummaries(nodesRoot?.get("nodes") as? JsonArray),
           pendingDevices = parsePendingDevices(devicesRoot?.get("pending") as? JsonArray),
           pairedDevices = parsePairedDevices(devicesRoot?.get("paired") as? JsonArray),
           devicePairingAvailable = devicesRoot != null,
@@ -2286,25 +2286,6 @@ class NodeRuntime(
       }.orEmpty()
 
   private fun skillMissingCount(missing: JsonObject?): Int = listOf("bins", "env", "config", "os").sumOf { key -> (missing?.get(key) as? JsonArray)?.size ?: 0 }
-
-  private fun parseGatewayNodes(nodes: JsonArray?): List<GatewayNodeSummary> =
-    nodes
-      ?.mapNotNull { item ->
-        val obj = item.asObjectOrNull() ?: return@mapNotNull null
-        val id = obj["nodeId"].asStringOrNull()?.trim().orEmpty()
-        if (id.isEmpty()) return@mapNotNull null
-        GatewayNodeSummary(
-          id = id,
-          displayName = obj["displayName"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
-          remoteIp = obj["remoteIp"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
-          version = obj["version"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
-          deviceFamily = obj["deviceFamily"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
-          paired = obj.boolean("paired"),
-          connected = obj.boolean("connected"),
-          capabilities = parseStringArray(obj["caps"] as? JsonArray),
-          commands = parseStringArray(obj["commands"] as? JsonArray),
-        )
-      }.orEmpty()
 
   private fun parsePendingDevices(devices: JsonArray?): List<GatewayPendingDeviceSummary> =
     devices
@@ -2840,9 +2821,19 @@ data class GatewayNodeSummary(
   val deviceFamily: String?,
   val paired: Boolean,
   val connected: Boolean,
+  val approvalState: GatewayNodeApprovalState = GatewayNodeApprovalState.Unknown,
+  val pendingRequestId: String? = null,
   val capabilities: List<String>,
   val commands: List<String>,
 )
+
+enum class GatewayNodeApprovalState {
+  Approved,
+  PendingApproval,
+  PendingReapproval,
+  Unapproved,
+  Unknown,
+}
 
 data class GatewayPendingDeviceSummary(
   val requestId: String,
@@ -2934,6 +2925,41 @@ data class GatewayLogEntry(
   val subsystem: String?,
   val message: String,
 )
+
+internal fun parseGatewayNodeSummaries(nodes: JsonArray?): List<GatewayNodeSummary> =
+  nodes
+    ?.mapNotNull { item ->
+      val obj = item.asObjectOrNull() ?: return@mapNotNull null
+      val id = obj["nodeId"].asStringOrNull()?.trim().orEmpty()
+      if (id.isEmpty()) return@mapNotNull null
+      GatewayNodeSummary(
+        id = id,
+        displayName = obj["displayName"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+        remoteIp = obj["remoteIp"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+        version = obj["version"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+        deviceFamily = obj["deviceFamily"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+        paired = obj.boolean("paired"),
+        connected = obj.boolean("connected"),
+        approvalState = parseGatewayNodeApprovalState(obj["approvalState"].asStringOrNull()),
+        pendingRequestId = obj["pendingRequestId"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+        capabilities = parseNodeSummaryStringArray(obj["caps"] as? JsonArray),
+        commands = parseNodeSummaryStringArray(obj["commands"] as? JsonArray),
+      )
+    }.orEmpty()
+
+internal fun parseGatewayNodeApprovalState(raw: String?): GatewayNodeApprovalState =
+  when (raw?.trim()) {
+    "approved" -> GatewayNodeApprovalState.Approved
+    "pending-approval" -> GatewayNodeApprovalState.PendingApproval
+    "pending-reapproval" -> GatewayNodeApprovalState.PendingReapproval
+    "unapproved" -> GatewayNodeApprovalState.Unapproved
+    else -> GatewayNodeApprovalState.Unknown
+  }
+
+private fun parseNodeSummaryStringArray(items: JsonArray?): List<String> =
+  items
+    ?.mapNotNull { it.asStringOrNull()?.trim()?.takeIf(String::isNotEmpty) }
+    .orEmpty()
 
 private fun JsonObject?.long(key: String): Long? = (this?.get(key) as? JsonPrimitive)?.content?.trim()?.toLongOrNull()
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -246,10 +246,10 @@ internal fun nodeStatusText(node: GatewayNodeSummary): String =
     GatewayNodeApprovalState.PendingApproval -> "Approval Pending"
     GatewayNodeApprovalState.PendingReapproval -> "Reapproval Pending"
     GatewayNodeApprovalState.Approved ->
-      if (node.paired) {
+      if (node.connected) {
         "Ready"
       } else {
-        onlineOfflineText(node)
+        "Offline"
       }
     GatewayNodeApprovalState.Unapproved ->
       if (node.paired) {
@@ -263,7 +263,7 @@ internal fun nodeStatusText(node: GatewayNodeSummary): String =
 internal fun nodeStatus(node: GatewayNodeSummary): ClawStatus =
   when (node.approvalState) {
     GatewayNodeApprovalState.Approved ->
-      if (node.paired || node.connected) {
+      if (node.connected) {
         ClawStatus.Success
       } else {
         ClawStatus.Warning

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -220,67 +220,77 @@ internal fun GatewayNodesDevicesSummary.pendingApprovalCount(): Int = pendingDev
 internal fun GatewayNodesDevicesSummary.nodeCapabilityAttentionCount(): Int = nodes.count { it.needsCapabilityAttention() }
 
 internal fun GatewayNodeSummary.hasPendingCapabilityApproval(): Boolean =
-  paired &&
-    when (approvalState) {
-      GatewayNodeApprovalState.PendingApproval,
-      GatewayNodeApprovalState.PendingReapproval,
-      -> true
-      GatewayNodeApprovalState.Approved,
-      GatewayNodeApprovalState.Unapproved,
-      GatewayNodeApprovalState.Unknown,
-      -> false
-    }
+  when (approvalState) {
+    GatewayNodeApprovalState.PendingApproval,
+    GatewayNodeApprovalState.PendingReapproval,
+    -> true
+    GatewayNodeApprovalState.Approved,
+    GatewayNodeApprovalState.Unapproved,
+    GatewayNodeApprovalState.Unknown,
+    -> false
+  }
 
 internal fun GatewayNodeSummary.needsCapabilityAttention(): Boolean =
-  paired &&
-    when (approvalState) {
-      GatewayNodeApprovalState.PendingApproval,
-      GatewayNodeApprovalState.PendingReapproval,
-      GatewayNodeApprovalState.Unapproved,
-      -> true
-      GatewayNodeApprovalState.Approved,
-      GatewayNodeApprovalState.Unknown,
-      -> false
-    }
+  when (approvalState) {
+    GatewayNodeApprovalState.PendingApproval,
+    GatewayNodeApprovalState.PendingReapproval,
+    -> true
+    GatewayNodeApprovalState.Unapproved -> paired
+    GatewayNodeApprovalState.Approved,
+    GatewayNodeApprovalState.Unknown,
+    -> false
+  }
 
 internal fun nodeStatusText(node: GatewayNodeSummary): String =
-  if (node.paired) {
-    when (node.approvalState) {
-      GatewayNodeApprovalState.Approved -> "Ready"
-      GatewayNodeApprovalState.PendingApproval -> "Approval Pending"
-      GatewayNodeApprovalState.PendingReapproval -> "Reapproval Pending"
-      GatewayNodeApprovalState.Unapproved -> "Unavailable"
-      GatewayNodeApprovalState.Unknown -> if (node.connected) "Online" else "Offline"
-    }
-  } else {
-    if (node.connected) "Online" else "Offline"
+  when (node.approvalState) {
+    GatewayNodeApprovalState.PendingApproval -> "Approval Pending"
+    GatewayNodeApprovalState.PendingReapproval -> "Reapproval Pending"
+    GatewayNodeApprovalState.Approved ->
+      if (node.paired) {
+        "Ready"
+      } else {
+        onlineOfflineText(node)
+      }
+    GatewayNodeApprovalState.Unapproved ->
+      if (node.paired) {
+        "Unavailable"
+      } else {
+        onlineOfflineText(node)
+      }
+    GatewayNodeApprovalState.Unknown -> if (node.connected) "Online" else "Offline"
   }
 
 internal fun nodeStatus(node: GatewayNodeSummary): ClawStatus =
-  if (node.paired) {
-    when (node.approvalState) {
-      GatewayNodeApprovalState.Approved -> ClawStatus.Success
-      GatewayNodeApprovalState.PendingApproval,
-      GatewayNodeApprovalState.PendingReapproval,
-      GatewayNodeApprovalState.Unapproved,
-      -> ClawStatus.Warning
-      GatewayNodeApprovalState.Unknown -> if (node.connected) ClawStatus.Success else ClawStatus.Warning
-    }
-  } else {
-    if (node.connected) ClawStatus.Success else ClawStatus.Warning
+  when (node.approvalState) {
+    GatewayNodeApprovalState.Approved ->
+      if (node.paired || node.connected) {
+        ClawStatus.Success
+      } else {
+        ClawStatus.Warning
+      }
+    GatewayNodeApprovalState.PendingApproval,
+    GatewayNodeApprovalState.PendingReapproval,
+    -> ClawStatus.Warning
+    GatewayNodeApprovalState.Unapproved ->
+      if (node.paired) {
+        ClawStatus.Warning
+      } else {
+        onlineOfflineStatus(node)
+      }
+    GatewayNodeApprovalState.Unknown -> if (node.connected) ClawStatus.Success else ClawStatus.Warning
   }
 
+private fun onlineOfflineText(node: GatewayNodeSummary): String = if (node.connected) "Online" else "Offline"
+
+private fun onlineOfflineStatus(node: GatewayNodeSummary): ClawStatus = if (node.connected) ClawStatus.Success else ClawStatus.Warning
+
 private fun nodeCapabilityText(node: GatewayNodeSummary): String? =
-  if (!node.paired) {
-    null
-  } else {
-    when (node.approvalState) {
-      GatewayNodeApprovalState.Approved -> "Ready"
-      GatewayNodeApprovalState.PendingApproval -> approvalCommandText(node.pendingRequestId, "Approval pending")
-      GatewayNodeApprovalState.PendingReapproval -> approvalCommandText(node.pendingRequestId, "Reapproval pending")
-      GatewayNodeApprovalState.Unapproved -> "Capabilities unavailable"
-      GatewayNodeApprovalState.Unknown -> null
-    }
+  when (node.approvalState) {
+    GatewayNodeApprovalState.Approved -> if (node.paired) "Ready" else null
+    GatewayNodeApprovalState.PendingApproval -> approvalCommandText(node.pendingRequestId, "Approval pending")
+    GatewayNodeApprovalState.PendingReapproval -> approvalCommandText(node.pendingRequestId, "Reapproval pending")
+    GatewayNodeApprovalState.Unapproved -> if (node.paired) "Capabilities unavailable" else null
+    GatewayNodeApprovalState.Unknown -> null
   }
 
 private fun approvalCommandText(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.GatewayDeviceTokenSummary
+import ai.openclaw.app.GatewayNodeApprovalState
 import ai.openclaw.app.GatewayNodeSummary
 import ai.openclaw.app.GatewayNodesDevicesSummary
 import ai.openclaw.app.GatewayPairedDeviceSummary
@@ -60,7 +61,7 @@ internal fun NodesDevicesSettingsScreen(
           SettingsMetric("Nodes", summary.nodes.size.toString()),
           SettingsMetric("Online", summary.nodes.count { it.connected }.toString()),
           SettingsMetric("Devices", if (summary.devicePairingAvailable) summary.pairedDevices.size.toString() else "Admin"),
-          SettingsMetric("Pending", summary.pendingDevices.size.toString()),
+          SettingsMetric("Pending", summary.pendingApprovalCount().toString()),
         ),
     )
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -155,8 +156,8 @@ private fun NodeRow(node: GatewayNodeSummary) {
     badge = nodeBadge(node.displayName ?: node.id),
     title = node.displayName ?: node.id,
     subtitle = nodeSubtitle(node),
-    statusText = if (node.connected) "Online" else "Offline",
-    status = if (node.connected) ClawStatus.Success else ClawStatus.Warning,
+    statusText = nodeStatusText(node),
+    status = nodeStatus(node),
   )
 }
 
@@ -201,17 +202,94 @@ private fun DeviceListRow(
 /** True when the gateway returned no node or device rows to render. */
 private fun GatewayNodesDevicesSummary.isEmpty(): Boolean = nodes.isEmpty() && pendingDevices.isEmpty() && pairedDevices.isEmpty()
 
-private fun nodeSubtitle(node: GatewayNodeSummary): String {
+internal fun nodeSubtitle(node: GatewayNodeSummary): String {
   val kind = node.deviceFamily ?: "Node host"
   val version = node.version?.let { "OpenClaw $it" }
-  val status = if (node.paired) "Paired" else "Unpaired"
+  val transport = if (node.paired) "Transport paired" else "Transport unpaired"
+  val capability = nodeCapabilityText(node)
   val commands =
     node.commands
       .take(2)
       .joinToString(", ")
       .takeIf { it.isNotBlank() }
-  return listOfNotNull(kind, version, status, commands).joinToString(" · ")
+  return listOfNotNull(kind, version, transport, capability, commands).joinToString(" · ")
 }
+
+internal fun GatewayNodesDevicesSummary.pendingApprovalCount(): Int = pendingDevices.size + nodes.count { it.hasPendingCapabilityApproval() }
+
+internal fun GatewayNodesDevicesSummary.nodeCapabilityAttentionCount(): Int = nodes.count { it.needsCapabilityAttention() }
+
+internal fun GatewayNodeSummary.hasPendingCapabilityApproval(): Boolean =
+  paired &&
+    when (approvalState) {
+      GatewayNodeApprovalState.PendingApproval,
+      GatewayNodeApprovalState.PendingReapproval,
+      -> true
+      GatewayNodeApprovalState.Approved,
+      GatewayNodeApprovalState.Unapproved,
+      GatewayNodeApprovalState.Unknown,
+      -> false
+    }
+
+internal fun GatewayNodeSummary.needsCapabilityAttention(): Boolean =
+  paired &&
+    when (approvalState) {
+      GatewayNodeApprovalState.PendingApproval,
+      GatewayNodeApprovalState.PendingReapproval,
+      GatewayNodeApprovalState.Unapproved,
+      -> true
+      GatewayNodeApprovalState.Approved,
+      GatewayNodeApprovalState.Unknown,
+      -> false
+    }
+
+internal fun nodeStatusText(node: GatewayNodeSummary): String =
+  if (node.paired) {
+    when (node.approvalState) {
+      GatewayNodeApprovalState.Approved -> "Ready"
+      GatewayNodeApprovalState.PendingApproval -> "Approval Pending"
+      GatewayNodeApprovalState.PendingReapproval -> "Reapproval Pending"
+      GatewayNodeApprovalState.Unapproved -> "Unavailable"
+      GatewayNodeApprovalState.Unknown -> if (node.connected) "Online" else "Offline"
+    }
+  } else {
+    if (node.connected) "Online" else "Offline"
+  }
+
+internal fun nodeStatus(node: GatewayNodeSummary): ClawStatus =
+  if (node.paired) {
+    when (node.approvalState) {
+      GatewayNodeApprovalState.Approved -> ClawStatus.Success
+      GatewayNodeApprovalState.PendingApproval,
+      GatewayNodeApprovalState.PendingReapproval,
+      GatewayNodeApprovalState.Unapproved,
+      -> ClawStatus.Warning
+      GatewayNodeApprovalState.Unknown -> if (node.connected) ClawStatus.Success else ClawStatus.Warning
+    }
+  } else {
+    if (node.connected) ClawStatus.Success else ClawStatus.Warning
+  }
+
+private fun nodeCapabilityText(node: GatewayNodeSummary): String? =
+  if (!node.paired) {
+    null
+  } else {
+    when (node.approvalState) {
+      GatewayNodeApprovalState.Approved -> "Ready"
+      GatewayNodeApprovalState.PendingApproval -> approvalCommandText(node.pendingRequestId, "Approval pending")
+      GatewayNodeApprovalState.PendingReapproval -> approvalCommandText(node.pendingRequestId, "Reapproval pending")
+      GatewayNodeApprovalState.Unapproved -> "Capabilities unavailable"
+      GatewayNodeApprovalState.Unknown -> null
+    }
+  }
+
+private fun approvalCommandText(
+  requestId: String?,
+  label: String,
+): String =
+  requestId
+    ?.let { "$label; run openclaw nodes pending, then openclaw nodes approve $it" }
+    ?: "$label; run openclaw nodes pending"
 
 private fun pendingDeviceSubtitle(device: GatewayPendingDeviceSummary): String {
   val roles = formatDeviceList(device.roles, "role")

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -566,7 +566,7 @@ internal fun homeAttentionRows(
     } else {
       null
     },
-    if (nodesDevicesSummary.pendingDevices.isNotEmpty()) {
+    if (nodesDevicesSummary.pendingApprovalCount() > 0 || nodesDevicesSummary.nodeCapabilityAttentionCount() > 0) {
       HomeAttentionRow("Nodes & Devices", nodesDevicesSummaryText(nodesDevicesSummary), Icons.Default.Cloud, Tab.Settings, SettingsRoute.NodesDevices)
     } else {
       null
@@ -995,8 +995,11 @@ private fun skillsStatus(skills: List<GatewaySkillSummary>): Boolean? =
 private fun nodesDevicesSummaryText(summary: GatewayNodesDevicesSummary): String {
   val online = summary.nodes.count { it.connected }
   val devices = summary.pairedDevices.size
+  val pending = summary.pendingApprovalCount()
+  val unavailable = summary.nodeCapabilityAttentionCount() - summary.nodes.count { it.hasPendingCapabilityApproval() }
   return when {
-    summary.pendingDevices.isNotEmpty() -> "${summary.pendingDevices.size} pending"
+    pending > 0 -> "$pending pending"
+    unavailable > 0 -> "$unavailable unavailable"
     summary.nodes.isNotEmpty() -> "$online/${summary.nodes.size} online"
     devices > 0 -> "$devices paired"
     else -> "No devices"
@@ -1006,7 +1009,7 @@ private fun nodesDevicesSummaryText(summary: GatewayNodesDevicesSummary): String
 /** Maps node/device state to a settings status dot, treating pending pairings as attention-needed. */
 private fun nodesDevicesStatus(summary: GatewayNodesDevicesSummary): Boolean? =
   when {
-    summary.pendingDevices.isNotEmpty() -> false
+    summary.pendingApprovalCount() > 0 || summary.nodeCapabilityAttentionCount() > 0 -> false
     summary.nodes.any { it.connected } -> true
     summary.pairedDevices.isNotEmpty() -> true
     else -> null

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayNodeSummaryParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayNodeSummaryParsingTest.kt
@@ -1,0 +1,58 @@
+package ai.openclaw.app
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GatewayNodeSummaryParsingTest {
+  @Test
+  fun parsesNodeApprovalStatesFromNodeList() {
+    val root =
+      Json
+        .parseToJsonElement(
+          """
+          {
+            "nodes": [
+              {
+                "nodeId": "pending-node",
+                "displayName": "Android",
+                "deviceFamily": "Android",
+                "paired": true,
+                "connected": true,
+                "approvalState": "pending-approval",
+                "pendingRequestId": "node-request-1",
+                "caps": ["device"],
+                "commands": []
+              },
+              {
+                "nodeId": "unapproved-node",
+                "paired": true,
+                "connected": false,
+                "approvalState": "unapproved"
+              },
+              {
+                "nodeId": "approved-node",
+                "paired": true,
+                "connected": true,
+                "approvalState": "approved",
+                "commands": ["device.status"]
+              }
+            ]
+          }
+          """.trimIndent(),
+        ).jsonObject
+
+    val nodes = parseGatewayNodeSummaries(root["nodes"] as? JsonArray)
+
+    assertEquals(GatewayNodeApprovalState.PendingApproval, nodes[0].approvalState)
+    assertEquals("node-request-1", nodes[0].pendingRequestId)
+    assertEquals(listOf("device"), nodes[0].capabilities)
+    assertEquals(GatewayNodeApprovalState.Unapproved, nodes[1].approvalState)
+    assertNull(nodes[1].pendingRequestId)
+    assertEquals(GatewayNodeApprovalState.Approved, nodes[2].approvalState)
+    assertEquals(listOf("device.status"), nodes[2].commands)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -137,6 +137,18 @@ class ShellScreenLogicTest {
   }
 
   @Test
+  fun approvedOfflineNodeKeepsOfflineStatus() {
+    val approvedOffline =
+      androidNode(
+        approvalState = GatewayNodeApprovalState.Approved,
+        connected = false,
+      )
+
+    assertEquals("Offline", nodeStatusText(approvedOffline))
+    assertTrue(nodeSubtitle(approvedOffline).contains("Ready"))
+  }
+
+  @Test
   fun homeAttentionRowsSurfaceNodeCapabilityApprovalRequests() {
     val rows =
       homeAttentionRows(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -157,6 +157,35 @@ class ShellScreenLogicTest {
   }
 
   @Test
+  fun homeAttentionRowsSurfacePendingNodeCapabilityWithoutTransportPairing() {
+    val pendingNode =
+      androidNode(
+        paired = false,
+        approvalState = GatewayNodeApprovalState.PendingApproval,
+        pendingRequestId = "node-request-1",
+      )
+
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary =
+          GatewayNodesDevicesSummary(
+            nodes = listOf(pendingNode),
+            pendingDevices = emptyList(),
+            pairedDevices = emptyList(),
+          ),
+        readyProviderCount = 1,
+      )
+
+    assertEquals("Approval Pending", nodeStatusText(pendingNode))
+    assertTrue(nodeSubtitle(pendingNode).contains("openclaw nodes approve node-request-1"))
+    assertEquals(listOf("Nodes & Devices"), rows.map { it.title })
+    assertEquals("1 pending", rows.single().subtitle)
+  }
+
+  @Test
   fun homeAttentionRowsSurfaceUnavailableNodeCapabilitiesSeparatelyFromPendingRequests() {
     val rows =
       homeAttentionRows(
@@ -183,6 +212,7 @@ class ShellScreenLogicTest {
   private fun androidNode(
     approvalState: GatewayNodeApprovalState,
     pendingRequestId: String? = null,
+    paired: Boolean = true,
     connected: Boolean = true,
     commands: List<String> = emptyList(),
   ): GatewayNodeSummary =
@@ -192,7 +222,7 @@ class ShellScreenLogicTest {
       remoteIp = null,
       version = null,
       deviceFamily = "Android",
-      paired = true,
+      paired = paired,
       connected = connected,
       approvalState = approvalState,
       pendingRequestId = pendingRequestId,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -3,6 +3,8 @@ package ai.openclaw.app.ui
 import ai.openclaw.app.AppearanceThemeMode
 import ai.openclaw.app.GatewayChannelSummary
 import ai.openclaw.app.GatewayChannelsSummary
+import ai.openclaw.app.GatewayNodeApprovalState
+import ai.openclaw.app.GatewayNodeSummary
 import ai.openclaw.app.GatewayNodesDevicesSummary
 import ai.openclaw.app.GatewayPendingDeviceSummary
 import org.junit.Assert.assertEquals
@@ -118,7 +120,83 @@ class ShellScreenLogicTest {
     assertEquals(emptyList<String>(), rows.map { it.title })
   }
 
+  @Test
+  fun nodeRowsDistinguishTransportPairingFromCapabilityApproval() {
+    val pending = androidNode(approvalState = GatewayNodeApprovalState.PendingApproval, pendingRequestId = "node-request-1")
+    val unapproved = androidNode(approvalState = GatewayNodeApprovalState.Unapproved, connected = false)
+    val approved = androidNode(approvalState = GatewayNodeApprovalState.Approved, commands = listOf("device.status"))
+
+    assertEquals("Approval Pending", nodeStatusText(pending))
+    assertTrue(nodeSubtitle(pending).contains("Transport paired"))
+    assertTrue(nodeSubtitle(pending).contains("openclaw nodes pending"))
+    assertTrue(nodeSubtitle(pending).contains("openclaw nodes approve node-request-1"))
+    assertEquals("Unavailable", nodeStatusText(unapproved))
+    assertTrue(nodeSubtitle(unapproved).contains("Capabilities unavailable"))
+    assertEquals("Ready", nodeStatusText(approved))
+    assertTrue(nodeSubtitle(approved).contains("Ready"))
+  }
+
+  @Test
+  fun homeAttentionRowsSurfaceNodeCapabilityApprovalRequests() {
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary =
+          GatewayNodesDevicesSummary(
+            nodes = listOf(androidNode(approvalState = GatewayNodeApprovalState.PendingApproval, pendingRequestId = "node-request-1")),
+            pendingDevices = emptyList(),
+            pairedDevices = emptyList(),
+          ),
+        readyProviderCount = 1,
+      )
+
+    assertEquals(listOf("Nodes & Devices"), rows.map { it.title })
+    assertEquals("1 pending", rows.single().subtitle)
+  }
+
+  @Test
+  fun homeAttentionRowsSurfaceUnavailableNodeCapabilitiesSeparatelyFromPendingRequests() {
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary =
+          GatewayNodesDevicesSummary(
+            nodes = listOf(androidNode(approvalState = GatewayNodeApprovalState.Unapproved)),
+            pendingDevices = emptyList(),
+            pairedDevices = emptyList(),
+          ),
+        readyProviderCount = 1,
+      )
+
+    assertEquals(listOf("Nodes & Devices"), rows.map { it.title })
+    assertEquals("1 unavailable", rows.single().subtitle)
+  }
+
   private fun emptyChannels(): GatewayChannelsSummary = GatewayChannelsSummary(channels = emptyList())
 
   private fun emptyNodesDevices(): GatewayNodesDevicesSummary = GatewayNodesDevicesSummary(nodes = emptyList(), pendingDevices = emptyList(), pairedDevices = emptyList())
+
+  private fun androidNode(
+    approvalState: GatewayNodeApprovalState,
+    pendingRequestId: String? = null,
+    connected: Boolean = true,
+    commands: List<String> = emptyList(),
+  ): GatewayNodeSummary =
+    GatewayNodeSummary(
+      id = "android-node",
+      displayName = "Android",
+      remoteIp = null,
+      version = null,
+      deviceFamily = "Android",
+      paired = true,
+      connected = connected,
+      approvalState = approvalState,
+      pendingRequestId = pendingRequestId,
+      capabilities = emptyList(),
+      commands = commands,
+    )
 }

--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -118,6 +118,35 @@ describe("reconcileNodePairingOnConnect", () => {
     );
   });
 
+  it("can auto-approve first-time node surfaces for explicit bootstrap callers", async () => {
+    const requestPairing = makePendingPairingRequest("req-bootstrap");
+    const autoApproveFirstTimePairing = vi.fn(async () => true);
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        caps: ["camera"],
+        commands: [],
+        permissions: { camera: true },
+      }),
+      pairedNode: null,
+      requestPairing,
+      autoApproveFirstTimePairing,
+    });
+
+    expect(autoApproveFirstTimePairing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          requestId: "req-bootstrap",
+        }),
+      }),
+    );
+    expect(result.pendingPairing).toBeUndefined();
+    expect(result.effectiveCaps).toEqual(["camera"]);
+    expect(result.effectiveCommands).toEqual([]);
+    expect(result.effectivePermissions).toEqual({ camera: true });
+  });
+
   it.each([
     ["conflicts with device family", { deviceFamily: "iPhone" }],
     ["omits device family", {}],

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -33,6 +33,10 @@ export type NodeConnectPairingReconcileResult = {
   shouldClearPendingPairings?: boolean;
 };
 
+type AutoApproveFirstTimeNodePairing = (
+  pendingPairing: RequestNodePairingResult,
+) => Promise<boolean>;
+
 function resolveApprovedReconnectCommands(params: {
   pairedCommands: readonly string[] | undefined;
   allowlist: Set<string>;
@@ -116,6 +120,7 @@ export async function reconcileNodePairingOnConnect(params: {
   pairedNode: NodePairingPairedNode | null;
   reportedClientIp?: string;
   requestPairing: (input: NodePairingRequestInput) => Promise<RequestNodePairingResult | null>;
+  autoApproveFirstTimePairing?: AutoApproveFirstTimeNodePairing;
 }): Promise<NodeConnectPairingReconcileResult> {
   const nodeId = params.connectParams.device?.id ?? params.connectParams.client.id;
   const policyNode = {
@@ -147,6 +152,20 @@ export async function reconcileNodePairingOnConnect(params: {
     );
     if (!pendingPairing) {
       throw new Error("node pairing request required");
+    }
+    if (
+      params.autoApproveFirstTimePairing &&
+      (await params.autoApproveFirstTimePairing(pendingPairing))
+    ) {
+      return {
+        nodeId,
+        declaredCaps,
+        effectiveCaps: declaredCaps,
+        declaredCommands: declared,
+        effectiveCommands: declared,
+        declaredPermissions,
+        effectivePermissions: declaredPermissions,
+      };
     }
     return {
       nodeId,

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1062,6 +1062,7 @@ export function registerControlUiAndPairingSuite(): void {
     const { identityPath, identity } = await createOperatorIdentityFixture(
       "openclaw-bootstrap-node-",
     );
+    const { listNodePairing } = await import("../infra/node-pairing.js");
     const client = {
       id: "openclaw-ios",
       version: "2026.3.30",
@@ -1148,6 +1149,50 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      const nodePairing = await listNodePairing();
+      expect(nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId)).toEqual([]);
+      expect(nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId)).toEqual(
+        expect.objectContaining({
+          nodeId: identity.deviceId,
+          platform: client.platform,
+          version: client.version,
+          commands: [],
+        }),
+      );
+
+      const wsOperator = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      try {
+        const operatorConnect = await connectReq(wsOperator, {
+          skipDefaultAuth: true,
+          deviceToken: issuedOperatorToken,
+          role: "operator",
+          scopes: operatorHandoff?.scopes ?? [],
+          client,
+          deviceIdentityPath: identityPath,
+        });
+        expect(operatorConnect.ok).toBe(true);
+        const nodeList = await rpcReq<{
+          nodes?: Array<{
+            nodeId: string;
+            approvalState?: string;
+            pendingRequestId?: string;
+          }>;
+        }>(wsOperator, "node.list", {});
+        expect(nodeList.ok).toBe(true);
+        expect(
+          nodeList.payload?.nodes?.find((entry) => entry.nodeId === identity.deviceId),
+        ).toEqual(
+          expect.objectContaining({
+            nodeId: identity.deviceId,
+            approvalState: "approved",
+          }),
+        );
+        expect(
+          nodeList.payload?.nodes?.find((entry) => entry.nodeId === identity.deviceId),
+        ).not.toHaveProperty("pendingRequestId");
+      } finally {
+        wsOperator.close();
+      }
 
       const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const replay = await connectReq(wsReplay, {

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1274,6 +1274,61 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("qr setup code leaves admin-required node commands pending", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { listNodePairing } = await import("../infra/node-pairing.js");
+    await writeConfigFile({
+      gateway: {
+        nodes: {
+          allowCommands: ["system.run"],
+        },
+      },
+    });
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-node-admin-command-",
+    );
+    const client = {
+      id: "openclaw-ios",
+      version: "2026.3.30",
+      platform: "iOS 26.3.1",
+      mode: "node",
+      deviceFamily: "iPhone",
+    };
+
+    try {
+      const issued = await issueDeviceBootstrapToken();
+      const wsBootstrap = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client,
+        commands: ["system.run"],
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(true);
+      expect((initial.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
+      wsBootstrap.close();
+
+      const nodePairing = await listNodePairing();
+      expect(
+        nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId),
+      ).toBeUndefined();
+      expect(nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId)).toEqual([
+        expect.objectContaining({
+          nodeId: identity.deviceId,
+          commands: ["system.run"],
+        }),
+      ]);
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("qr bootstrap retry keeps bounded operator handoff after paired approval", async () => {
     const { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } =
       await import("../infra/device-bootstrap.js");

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -179,7 +179,7 @@ const DEVICE_CREDENTIAL_INVALIDATING_METHODS = new Set([
   "device.token.revoke",
 ]);
 const unauthorizedHandshakeLogLimiter = new HandshakeAuthLogLimiter();
-const BOOTSTRAP_NODE_APPROVAL_SCOPES = [PAIRING_SCOPE, WRITE_SCOPE, ADMIN_SCOPE];
+const BOOTSTRAP_NODE_APPROVAL_SCOPES = [PAIRING_SCOPE, WRITE_SCOPE];
 
 class NodePairingRateLimitError extends Error {
   constructor(readonly retryAfterMs: number) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -69,6 +69,7 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import {
   beginNodePairingConnect,
+  approveNodePairing,
   finalizeNodePairingCleanupClaim,
   releaseNodePairingCleanupClaim,
   requestNodePairing,
@@ -101,7 +102,7 @@ import { AUTH_RATE_LIMIT_SCOPE_NODE_PAIRING, type AuthRateLimiter } from "../../
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { hasForwardedRequestHeaders, isLocalDirectRequest } from "../../auth.js";
 import { normalizeDeviceMetadataForAuth } from "../../device-auth.js";
-import { ADMIN_SCOPE, APPROVALS_SCOPE } from "../../method-scopes.js";
+import { ADMIN_SCOPE, APPROVALS_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "../../method-scopes.js";
 import type { GatewayMethodRegistry } from "../../methods/registry.js";
 import {
   isLocalishHost,
@@ -178,6 +179,7 @@ const DEVICE_CREDENTIAL_INVALIDATING_METHODS = new Set([
   "device.token.revoke",
 ]);
 const unauthorizedHandshakeLogLimiter = new HandshakeAuthLogLimiter();
+const BOOTSTRAP_NODE_APPROVAL_SCOPES = [PAIRING_SCOPE, WRITE_SCOPE, ADMIN_SCOPE];
 
 class NodePairingRateLimitError extends Error {
   constructor(readonly retryAfterMs: number) {
@@ -1147,6 +1149,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
             : null;
         let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
+        let allowBootstrapNodeAutoApproval = false;
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
           role,
@@ -1354,6 +1357,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               if (approved?.status === "approved") {
                 if (allowSilentBootstrapPairing && boundBootstrapProfile) {
                   handoffBootstrapProfile = boundBootstrapProfile;
+                  allowBootstrapNodeAutoApproval = true;
                 }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
@@ -1587,6 +1591,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 // bootstrap token is restored while the paired device already has
                 // node+operator grants. Preserve the same bounded handoff on retry.
                 handoffBootstrapProfile = retryBootstrapHandoffProfile;
+                allowBootstrapNodeAutoApproval = true;
               }
             }
 
@@ -1689,6 +1694,17 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                   reapprovalCoordinator: nodeReapprovalCoordinator,
                 });
               },
+              autoApproveFirstTimePairing: allowBootstrapNodeAutoApproval
+                ? async (pendingPairing) => {
+                    // Setup-code bootstrap already proved possession of the device key and
+                    // bootstrap token; approve the initial node surface without granting the
+                    // handed-off operator token pairing/admin scope.
+                    const approved = await approveNodePairing(pendingPairing.request.requestId, {
+                      callerScopes: BOOTSTRAP_NODE_APPROVAL_SCOPES,
+                    });
+                    return approved !== null && !("status" in approved);
+                  }
+                : undefined,
             });
           } catch (error) {
             await releasePendingNodePairingCleanup();


### PR DESCRIPTION
### Summary
- Persist setup-code bootstrap node capability approval so Android first-run onboarding lands in an approved node state, not transport-only pairing.
- Keep the setup-code bounded operator token limited: no `operator.pairing`, no `operator.admin`.
- Keep admin-required node commands such as `system.run` pending for explicit approval.
- Teach Android to show node capability approval separately from transport pairing, including pending/unapproved/approved/offline states.

### Why
Setup-code onboarding already auto-approved the Android device/transport pair, but the node capability approval record was not consistently persisted for the bootstrap node path. That could leave Android connected to the gateway while `node.list` still looked unapproved/pending/missing from the capability side.

This patch closes that gap without broadening Android operator powers.

### What Changed
- `src/gateway/node-connect-reconcile.ts`: adds an opt-in bootstrap node auto-approval hook while preserving normal first-time pending behavior.
- `src/gateway/server/ws-connection/message-handler.ts`: wires setup-code bootstrap node approval with safe internal scopes only.
- `apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt`: parses `approvalState` and `pendingRequestId`.
- `apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt`: shows capability approval separately from transport pairing, including pending-without-transport and approved-but-offline states.
- `apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt`: routes home/settings attention through the node capability state.

### Validation
Current PR head after final rebase:
- `HEAD`: `a2456db3915feac1896e4925f98ccdeae15e9843`
- `base`: `origin/main` `7c6ad2327c648a44fa1a4d756654e5f4150c5fc0`

Passed on the current head:

```bash
pnpm test src/gateway/server.auth.control-ui.test.ts src/gateway/node-connect-reconcile.test.ts src/gateway/server.node-pairing-authz.test.ts
# PASS: 8 files, 124 tests

JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.GatewayNodeSummaryParsingTest --tests ai.openclaw.app.ui.ShellScreenLogicTest :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.GatewayNodeSummaryParsingTest --tests ai.openclaw.app.ui.ShellScreenLogicTest :app:assemblePlayDebug :app:assembleThirdPartyDebug
# PASS

git diff --check origin/main...HEAD
# PASS

pnpm exec oxfmt --check --threads=1 src/gateway/server/ws-connection/message-handler.ts src/gateway/node-connect-reconcile.ts src/gateway/server.auth.control-ui.suite.ts src/gateway/node-connect-reconcile.test.ts
# PASS
```

Earlier final-patch review pass also ran `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` cleanly before the last base-only rebase. After `origin/main` moved, I rebased cleanly and reran the targeted gateway + Android proof above on the current head.

Known unrelated caveat: full Android `./gradlew :app:ktlintCheck` still fails on current-main style issues in:
- `apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt`
- `apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt`

Those files are not touched by this PR.

### Live Android Proof
Disposable AVD proof was captured against the same final patch immediately before the last clean base-only rebase. After the rebase, the current head passed the targeted gateway and Android proof commands above.

The proof used a disposable AVD and an isolated source-built gateway. Setup-code/token material was redacted.

![Connected Android proof](https://raw.githubusercontent.com/Solvely-Colin/openclaw/proof/setup-code-bootstrap-avd-20260616/screen-connected-redacted.png)

![Setup-code proof GIF](https://raw.githubusercontent.com/Solvely-Colin/openclaw/proof/setup-code-bootstrap-avd-20260616/setup-code-final-proof-redacted.gif)

Sanitized proof artifacts:
- [Gateway state JSON](https://raw.githubusercontent.com/Solvely-Colin/openclaw/proof/setup-code-bootstrap-avd-20260616/gateway-state-final-sanitized.json)
- [Gateway proof summary](https://raw.githubusercontent.com/Solvely-Colin/openclaw/proof/setup-code-bootstrap-avd-20260616/gateway-proof-summary.json)
- [Redacted gateway log](https://raw.githubusercontent.com/Solvely-Colin/openclaw/proof/setup-code-bootstrap-avd-20260616/gateway-log-final-redacted.txt)
- [Sanitized commands](https://raw.githubusercontent.com/Solvely-Colin/openclaw/proof/setup-code-bootstrap-avd-20260616/commands-used-sanitized.txt)

The live proof showed:
- Android reached `Online and ready`.
- `Nodes & Devices` showed `1/1 online`.
- `Approvals` showed `No pending approvals`.
- Gateway state showed the Android node as `paired=true`, `connected=true`, `approvalState=approved`.
- `pendingRequestId` was absent.
- Node pending count was zero.
- The bounded operator token excluded `operator.pairing` and `operator.admin`.

### Security Boundary
The setup-code bootstrap auto-approval path does not grant Android admin or pairing authority. A regression test covers an admin-required command surface (`system.run`) and keeps that node capability pending instead of silently approving it.
