### PR TITLE
fix(agent): restore suppressed answer when before_agent_finalize revision is silent

### DIFF
--- a/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts
@@ -1,8 +1,10 @@
 // Coverage for before_agent_finalize revision handling in embedded runs.
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
+  mockedBuildEmbeddedRunPayloads,
   mockedGlobalHookRunner,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
@@ -101,6 +103,65 @@ describe("runEmbeddedAgent before_agent_finalize", () => {
     expect(attemptCall(1).prompt).toContain("Mention the validated behavior.");
     expect(attemptCall(1).prompt).not.toContain("hello");
     expect(attemptCall(1).suppressNextUserMessagePersistence).toBe(true);
+  });
+
+  // The production payload builder strips a NO_REPLY-only reply to an empty
+  // array, so model these tests on that contract rather than a payload that
+  // still carries the silent token (which the runner never sees).
+  function buildPayloadsStrippingSilentTokens(params: { assistantTexts: string[] }) {
+    return params.assistantTexts
+      .filter((text) => !isSilentReplyText(text, SILENT_REPLY_TOKEN))
+      .map((text) => ({ text }));
+  }
+
+  it("restores the suppressed answer when a group-chat revision pass ends silently", async () => {
+    // Real #93166 path: the model sees its own first answer in the transcript and
+    // ends the revision turn with NO_REPLY; the builder strips it to nothing, so
+    // the group-chat silent reply restores the suppressed answer (#93166).
+    mockedBuildEmbeddedRunPayloads.mockImplementation(buildPayloadsStrippingSilentTokens);
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        finalAnswerAttempt("First answer.", {
+          beforeAgentFinalizeRevisionReason: "Tighten the final wording.",
+        }),
+      )
+      .mockResolvedValueOnce(finalAnswerAttempt("NO_REPLY"));
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-silent-revision",
+      allowEmptyAssistantReplyAsSilent: true,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toEqual([{ text: "First answer." }]);
+    expect(result.meta?.finalAssistantVisibleText).toBe("First answer.");
+  });
+
+  it("delivers the revised answer when the revision pass produces new text", async () => {
+    // A genuine revision replaces the original answer; the restore guard must
+    // not fire when the revision pass returns real text.
+    mockedBuildEmbeddedRunPayloads.mockImplementation(buildPayloadsStrippingSilentTokens);
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        finalAnswerAttempt("First answer.", {
+          beforeAgentFinalizeRevisionReason: "Tighten the final wording.",
+        }),
+      )
+      .mockResolvedValueOnce(finalAnswerAttempt("Revised answer."));
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-before-finalize-revised-delivery",
+      allowEmptyAssistantReplyAsSilent: true,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toEqual([{ text: "Revised answer." }]);
   });
 
   it("keeps finalizing when the attempt accepted a side-effecting revise decision", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1343,6 +1343,14 @@ async function runEmbeddedAgentInternal(
       let emptyResponseRetryAttempts = 0;
       let compactionContinuationRetryAttempts = 0;
       let beforeAgentFinalizeRevisionAttempts = 0;
+      // before_agent_finalize suppresses the original answer's delivery to ask for
+      // a revision; retain it so a revision pass that returns no deliverable reply
+      // (silent token or empty) restores it instead of dropping the turn (#93166).
+      let suppressedBeforeFinalizeRevisionReply: {
+        payloads: NonNullable<EmbeddedAgentRunResult["payloads"]>;
+        visibleText: string | undefined;
+        rawText: string | undefined;
+      } | null = null;
       let sameModelIdleTimeoutRetries = 0;
       // Cost-runaway breaker for #76293. State lives at the run-loop level
       // on purpose so it survives across attempt boundaries and across
@@ -3665,6 +3673,13 @@ async function runEmbeddedAgentInternal(
             !emptyAssistantReplyIsSilent;
           if (beforeAgentFinalizeRevisionReason && shouldHonorBeforeAgentFinalizeRevision) {
             beforeAgentFinalizeRevisionAttempts += 1;
+            if (payloadsForTerminalPath?.length) {
+              suppressedBeforeFinalizeRevisionReply = {
+                payloads: payloadsForTerminalPath,
+                visibleText: finalAssistantVisibleText,
+                rawText: finalAssistantRawText,
+              };
+            }
             nextAttemptPromptOverride = buildBeforeAgentFinalizeRetryPrompt(
               beforeAgentFinalizeRevisionReason,
             );
@@ -3710,9 +3725,25 @@ async function runEmbeddedAgentInternal(
             : attempt.yieldDetected
               ? "end_turn"
               : (sessionLastAssistant?.stopReason as string | undefined);
-          const terminalPayloads = emptyAssistantReplyIsSilent
-            ? [{ text: SILENT_REPLY_TOKEN }]
-            : payloadsForTerminalPath;
+          // A before_agent_finalize revision that produces no new deliverable
+          // reply collapses to a silent turn (the payload builder strips the
+          // model's NO_REPLY-only answer to nothing); restore the suppressed
+          // original rather than dropping the turn entirely (#93166).
+          const restoredRevisionReply =
+            suppressedBeforeFinalizeRevisionReply && emptyAssistantReplyIsSilent
+              ? suppressedBeforeFinalizeRevisionReply
+              : null;
+          const terminalPayloads = restoredRevisionReply
+            ? restoredRevisionReply.payloads
+            : emptyAssistantReplyIsSilent
+              ? [{ text: SILENT_REPLY_TOKEN }]
+              : payloadsForTerminalPath;
+          const terminalVisibleText = restoredRevisionReply
+            ? restoredRevisionReply.visibleText
+            : finalAssistantVisibleText;
+          const terminalRawText = restoredRevisionReply
+            ? restoredRevisionReply.rawText
+            : finalAssistantRawText;
           setTerminalLifecycleMeta({
             replayInvalid,
             livenessState,
@@ -3730,13 +3761,13 @@ async function runEmbeddedAgentInternal(
               aborted,
               systemPromptReport: attempt.systemPromptReport,
               finalPromptText: attempt.finalPromptText,
-              finalAssistantVisibleText,
-              finalAssistantRawText,
+              finalAssistantVisibleText: terminalVisibleText,
+              finalAssistantRawText: terminalRawText,
               replayInvalid,
               livenessState,
               agentHarnessResultClassification: attempt.agentHarnessResultClassification,
               ...(attempt.yieldDetected ? { yielded: true } : {}),
-              ...(emptyAssistantReplyIsSilent
+              ...(emptyAssistantReplyIsSilent && !restoredRevisionReply
                 ? { terminalReplyKind: "silent-empty" as const }
                 : {}),
               // Handle client tool calls (OpenResponses hosted tools)


### PR DESCRIPTION
### Summary

- **Problem**: Issue #93166 reports a data-loss bug in the core response-iteration loop. When a `before_agent_finalize` hook requests a revision, the embedded run loop suppresses delivery of the first (real) answer but leaves it in the session transcript, then re-prompts for a revised answer. In a group-chat context with the `NO_REPLY` silent-response directive, the revision pass sees its own first answer already in the transcript and correctly ends the turn with the silent token. The terminal path then delivers nothing, so the real answer is never sent — the user receives nothing.
- **Root Cause**: `onBeforeTerminalDelivery` (`src/agents/embedded-agent-runner/run/attempt.ts`) suppresses the original answer's channel delivery and records a revision reason; the run loop in `src/agents/embedded-agent-runner/run.ts` then re-prompts with a hidden continuation. On the revision pass the model replies with the silent token; the payload builder strips that `NO_REPLY`-only reply to an empty array (`buildEmbeddedRunPayloads`), so `payloadCount` is `0` and `shouldTreatEmptyAssistantReplyAsSilent` resolves the turn to silent. The original answer is still reachable at the revision-honor point (`payloadsForTerminalPath`), but it is discarded when the loop `continue`s, so a silent revision pass drops the turn entirely.
- **Fix**: Treat a revision that collapses to a silent/empty reply as "keep the original answer." Capture the suppressed original at the revision-honor point, and at the terminal return restore it when the revision pass resolves to a silent turn.
  - At the `before_agent_finalize` honor branch, retain the about-to-be-suppressed `payloadsForTerminalPath` plus its visible/raw text in `suppressedBeforeFinalizeRevisionReply` (only when it actually carries deliverable content).
  - At the terminal return, when a suppressed original exists and the revision pass resolved to a silent turn (`emptyAssistantReplyIsSilent`), deliver the suppressed original instead of the silent token, and mirror its `finalAssistantVisibleText` / `finalAssistantRawText` so downstream consumers (`result-fallback-classifier`, the commitment/raw-assistant text path) stay consistent and the result is not mislabeled `terminalReplyKind: "silent-empty"`.
  - A genuine revision (real revised text) is unaffected: the restore guard only fires on a silent/empty revision pass, so a revised answer still replaces the original.
- **What changed**:
  - `src/agents/embedded-agent-runner/run.ts` — capture the suppressed original at the revision-honor branch; restore it (plus mirrored visible/raw text and `terminalReplyKind`) at the terminal return when the revision pass is silent/empty.
  - `src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts` — two harness cases driven against the production payload-builder contract (a `NO_REPLY`-only reply strips to empty): a group-chat silent revision pass restores the original answer; a real revised answer is delivered (restore guard does not fire).
- **What did NOT change (scope boundary)**:
  - `onBeforeTerminalDelivery` suppression, the revision-reason hook, and the revision-honor decision (`shouldHonorBeforeAgentFinalizeRevision`) are unchanged; the restore runs only at the terminal return after the loop has decided not to revise again.
  - The downstream silent-token suppression in the reply pipeline and the payload builder are unchanged; the fix only changes which payloads the runner returns.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged (no plugin SDK, manifest, `extensions/*` api/runtime-api, registry/loader).
  - Gateway protocol unchanged.
  - Out of scope: the issue's secondary observation that `before_agent_finalize` hooks are not unregistered on `gateway.reload.mode = "hot"` is a separate plugin hook-lifecycle bug and is not addressed here.

### Reproduction

1. Configure a `before_agent_finalize` hook that requests a revision (e.g. a confidence-check plugin).
2. Run a group chat where silent replies are allowed (the `NO_REPLY` directive; `allowEmptyAssistantReplyAsSilent`).
3. Send a message that warrants a response.
4. First pass produces a real answer; the hook requests a revision; the run loop suppresses the first answer's delivery and re-prompts with a hidden continuation.
5. The revision pass sees its own first answer already in the transcript and ends the turn with `NO_REPLY`; the payload builder strips it to an empty reply.
6. **Before this PR**: the terminal path treats the empty revision pass as silent and delivers nothing, the suppressed real answer is never sent, and the user receives nothing.
7. **After this PR**: the silent revision pass restores the suppressed real answer, which is delivered.

### Real behavior proof

**Behavior addressed (#93166)**: a `before_agent_finalize` revision that collapses to a silent reply (the model produced no new deliverable answer) no longer discards the suppressed original; the runner restores and delivers the original instead of dropping the turn, while a genuine revised answer still replaces the original.

**Real environment tested (Linux, Node 22 — Vitest against the production `runEmbeddedAgent` terminal-delivery selection)**: the `run.before-agent-finalize` harness drives the real run-loop revision honor and terminal-return path with mocked per-attempt results, modeling the production payload-builder contract (a `NO_REPLY`-only reply strips to an empty array) and asserting the payloads the runner returns for delivery.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.before-agent-finalize.test.ts`; `pnpm tsgo:core` (prod typecheck); a scoped `tsgo` over the changed test file's import graph; `oxfmt` and `node scripts/run-oxlint.mjs` on both changed files.

**Evidence after fix (Vitest output for the touched test file)**:

```text
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

**Observed result after fix**: with a revision honored on attempt 1 (real "First answer.") and attempt 2 returning a `NO_REPLY`-only reply that strips to empty in a group chat (`allowEmptyAssistantReplyAsSilent`), `result.payloads` carries `[{ text: "First answer." }]` and `result.meta.finalAssistantVisibleText` is `"First answer."`; when attempt 2 instead returns real "Revised answer.", `result.payloads` carries `[{ text: "Revised answer." }]` (the restore guard does not fire).

**What was not tested**: a live gateway end-to-end run with a real `before_agent_finalize` confidence-check plugin and a group channel (e.g. QQBot/Telegram). The run-loop terminal-delivery selection that drops the turn is covered deterministically against the production path; a full gateway round-trip was not driven. The secondary hot-reload hook-lifecycle observation is out of scope.

**Repro confirmation**: the silent-revision test asserts `result.payloads` equals `[{ text: "First answer." }]`; without the restore the terminal path resolves the empty revision pass to the silent token `[{ text: "NO_REPLY" }]`, so the test fails on a pre-fix tree and passes with the fix.

### Risk / Mitigation

- **Risk**: the restore could override an intentional suppression. **Mitigation**: it fires only when a `before_agent_finalize` revision was honored (a suppressed original exists) AND the revision pass collapsed to a silent/empty reply; in a revision context a silent reply means "no change," and a real revised answer is delivered unchanged.
- **Risk**: the result metadata could disagree with the delivered payloads. **Mitigation**: `finalAssistantVisibleText`, `finalAssistantRawText`, and `terminalReplyKind` are restored together with the payloads, so the result reflects the delivered original and downstream classifiers stay consistent.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / runtime

### Linked Issue/PR

Fixes #93166
