### PR TITLE
fix(browser): name Chrome 136+ IPv6 CDP binding in WSL2 portproxy hint

### DIFF
--- a/docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
+++ b/docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md
@@ -90,6 +90,28 @@ curl http://127.0.0.1:9222/json/list
 
 If this fails on Windows, OpenClaw is not the problem yet.
 
+#### Chrome 136+ binds CDP to IPv6 loopback
+
+Chrome 136 and later ignore `--remote-debugging-address` and bind the CDP listener to `[::1]:9222` (IPv6 loopback) instead of `127.0.0.1:9222`. A `v4tov4` portproxy that forwards to `127.0.0.1:9222` then reaches nothing, and the WSL2 side gets an empty reply with no error.
+
+Check which family Chrome is listening on:
+
+```powershell
+netstat -ano | findstr :9222
+curl.exe http://127.0.0.1:9222/json/version
+curl.exe http://[::1]:9222/json/version
+```
+
+If `[::1]:9222` answers but `127.0.0.1:9222` returns an empty reply, Chrome bound IPv6 only. Point the portproxy at `::1` with a `v4tov6` rule (PowerShell as Administrator):
+
+```powershell
+netsh interface portproxy reset
+netsh interface portproxy add v4tov6 listenaddress=127.0.0.1 listenport=9222 connectaddress=::1 connectport=9222
+netsh interface portproxy add v4tov6 listenaddress=WINDOWS_HOST_OR_IP listenport=9222 connectaddress=::1 connectport=9222
+```
+
+After this, both `curl.exe http://127.0.0.1:9222/json/version` and the WSL2-reachable address return Chrome JSON.
+
 ### Layer 2: Verify WSL2 can reach that Windows endpoint
 
 From WSL2, test the exact address you plan to use in `cdpUrl`:
@@ -184,6 +206,8 @@ Treat each message as a layer-specific clue:
   - device approval problem
 - `Remote CDP for profile "remote" is not reachable`
   - WSL2 cannot reach the configured `cdpUrl`
+- empty CDP reply / `other side closed` on a `v4tov4` portproxy
+  - the portproxy forwards to an address Chrome is not listening on; either a stale self-loop or Chrome 136+ bound CDP to `[::1]` only (see [Chrome 136+ binds CDP to IPv6 loopback](#chrome-136-binds-cdp-to-ipv6-loopback))
 - `Browser attachOnly is enabled and CDP websocket for profile "remote" is not reachable`
   - the HTTP endpoint answered, but the DevTools WebSocket still could not be opened
 - stale viewport / dark-mode / locale / offline overrides after a remote session

--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -267,10 +267,24 @@ export function formatChromeCdpDiagnostic(diagnostic: ChromeCdpDiagnostic): stri
   const websocket = redactedWsUrl ? `; websocket=${redactedWsUrl}` : "";
   const wslPortproxyHint =
     diagnostic.code === "http_unreachable" && isLikelyEmptyHttpReply(diagnostic.message)
-      ? " In WSL2-to-Windows Chrome setups, this can be a stale netsh portproxy self-loop where svchost/iphlpsvc owns the CDP port instead of chrome.exe; verify with tasklist /svc and curl /json/version, then remove any 127.0.0.1:9222 -> 127.0.0.1:9222 portproxy rule."
+      ? WSL_EMPTY_REPLY_PORTPROXY_HINT
       : "";
   return `CDP diagnostic: ${diagnostic.code} after ${diagnostic.elapsedMs}ms; cdp=${redactedCdpUrl}${websocket}; ${diagnostic.message}.${wslPortproxyHint}`;
 }
+
+// An empty CDP reply on WSL2-to-Windows setups means a netsh portproxy forwarded
+// to an address Chrome is not listening on; the transport itself is fine, so the
+// raw error gives no clue which side is misconfigured. Name both known causes so
+// the silent failure points at the right fix: a stale self-loop (#39369) and, on
+// Chrome 136+, remote debugging binding to [::1] (IPv6) only while a v4tov4 rule
+// targets 127.0.0.1 (#54669).
+const WSL_EMPTY_REPLY_PORTPROXY_HINT =
+  " In WSL2-to-Windows Chrome setups an empty CDP reply means a netsh portproxy forwarded to an" +
+  " address Chrome is not listening on. Run `netstat -ano | findstr :9222`: if svchost/iphlpsvc" +
+  " owns the CDP port instead of chrome.exe it is a stale self-loop, so remove any" +
+  " 127.0.0.1:9222 -> 127.0.0.1:9222 portproxy rule; if Chrome listens on [::1] only (Chrome 136+" +
+  " binds remote debugging to IPv6 loopback and ignores --remote-debugging-address), replace the" +
+  " v4tov4 rule with v4tov6 (connectaddress=::1).";
 
 function isLikelyEmptyHttpReply(message: string): boolean {
   return /empty reply|other side closed|socket closed|terminated before response/i.test(message);

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import { createServer } from "node:http";
+import { createServer as createTcpServer } from "node:net";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -649,8 +650,37 @@ describe("browser chrome helpers", () => {
       elapsedMs: 12,
     });
 
+    // Both empty-reply causes must be named: stale self-loop and Chrome 136+
+    // IPv6-only binding (#54669). A v4tov4 rule to 127.0.0.1 reaches nothing
+    // when Chrome listens on [::1] only.
     expect(formatted).toContain("svchost/iphlpsvc owns the CDP port");
     expect(formatted).toContain("127.0.0.1:9222 -> 127.0.0.1:9222");
+    expect(formatted).toContain("[::1] only");
+    expect(formatted).toContain("v4tov6");
+  });
+
+  it("surfaces the IPv6-binding portproxy hint from a real empty-reply CDP probe", async () => {
+    // Reproduce the field report: a v4tov4 portproxy listens on IPv4 but forwards
+    // to an address Chrome no longer serves (Chrome 136+ bound [::1] only), so the
+    // socket is accepted then closed with no body. The diagnostic must classify
+    // this as http_unreachable and point at the IPv6 binding fix, not fail silently.
+    const portproxy = createTcpServer((socket) => socket.destroy());
+    await new Promise<void>((resolve, reject) => {
+      portproxy.listen(0, "127.0.0.1", () => resolve());
+      portproxy.once("error", reject);
+    });
+    try {
+      const addr = portproxy.address() as AddressInfo;
+      const diagnostic = expectFailedChromeCdpDiagnostic(
+        await diagnoseChromeCdp(`http://127.0.0.1:${addr.port}`, 500, 50),
+      );
+      expect(diagnostic.code).toBe("http_unreachable");
+      const formatted = formatChromeCdpDiagnostic(diagnostic);
+      expect(formatted).toContain("v4tov6");
+      expect(formatted).toContain("[::1] only");
+    } finally {
+      await new Promise<void>((resolve) => portproxy.close(() => resolve()));
+    }
   });
 
   it("probes direct ws:// CDP URLs (with /devtools/ path) via handshake instead of HTTP", async () => {


### PR DESCRIPTION
## Summary

In WSL2-to-Windows setups, when a CDP probe gets an empty reply through a `netsh` portproxy, OpenClaw's diagnostic asserted a **single** cause — a stale `127.0.0.1:9222 -> 127.0.0.1:9222` self-loop owned by `svchost/iphlpsvc`. As of Chrome 136+, a second cause produces the identical empty reply: Chrome ignores `--remote-debugging-address` and binds the CDP listener to `[::1]:9222` (IPv6 loopback) only, so a `v4tov4` portproxy forwarding to `127.0.0.1:9222` reaches nothing. Users following the old hint went looking for a self-loop that wasn't there, while the real fix is a `v4tov6` portproxy.

This PR makes the empty-reply hint name **both** causes and tell the user to run `netstat -ano | findstr :9222` to disambiguate, and documents the IPv6-binding case + `v4tov6` remedy in the dedicated WSL2 remote-CDP troubleshooting guide.

### Why guidance, not an auto-probe

Issue suggestion (2) proposed having OpenClaw probe both `127.0.0.1:9222` and `[::1]:9222`. In the reported topology the gateway runs in WSL2 and Chrome runs on Windows behind the portproxy, so `[::1]` from WSL2 is WSL2's own loopback, not Windows Chrome — OpenClaw cannot reach the Windows IPv6 listener to auto-detect this. The actionable improvement OpenClaw can make from the WSL2 side is to stop pointing users at the wrong cause and surface the correct remedy. Suggestion (1), the doc update, is implemented.

### Changed surface

- `extensions/browser/src/browser/chrome.diagnostics.ts` — `formatChromeCdpDiagnostic` empty-reply hint now names both causes (self-loop and Chrome 136+ IPv6 binding) and the `v4tov6` fix. Extracted to a commented `WSL_EMPTY_REPLY_PORTPROXY_HINT` constant.
- `docs/tools/browser-wsl2-windows-remote-cdp-troubleshooting.md` — new "Chrome 136+ binds CDP to IPv6 loopback" section under Layer 1 + a clue in "Common misleading errors".

This is additive diagnostic text + docs. The CDP connection path itself is unchanged.

## Verification

**Real environment tested:** Linux/WSL2; reproduced the field report's IPv4-vs-IPv6 split and the empty-reply diagnostic with real loopback servers (no Windows Chrome required to drive the diagnostic path under test).

**Reproduction of the field-report signature** — a server bound to `[::1]` only (mirroring Chrome 136+) answers on IPv6 but not IPv4, exactly as reported (`curl.exe http://[::1]:9222` 200 vs `127.0.0.1:9222` empty/refused):

```
Chrome (IPv6-only) listening on [::1]:35865
[::1]: HTTP 200
127.0.0.1: FAIL ECONNREFUSED
portproxy empty-reply fetch error message: other side closed
```

**Diagnostic behavior, before → after** — a TCP server that accepts then closes the socket reproduces the portproxy empty-reply. `diagnoseChromeCdp("http://127.0.0.1:<port>")` returns `http_unreachable` ("other side closed"), and `formatChromeCdpDiagnostic` is asserted in a live end-to-end test:

- Before the fix (hint reverted), the real probe emits only the self-loop cause and the new assertions fail:
  ```
  AssertionError: expected 'CDP diagnostic: http_unreachable ... ' to contain 'v4tov6'
  Received: "... stale netsh portproxy self-loop where svchost/iphlpsvc owns the CDP port ... 127.0.0.1:9222 -> 127.0.0.1:9222 portproxy rule."
  ```
- After the fix, the hint names the IPv6 binding cause and `v4tov6` remedy. Existing self-loop substrings preserved.

**Exact commands run after this patch:**

```
pnpm test extensions/browser/src/browser/chrome.test.ts   # 51 passed (incl. new live empty-reply test)
pnpm tsgo:extensions                                       # clean
npx oxfmt --check --threads=1 <changed .ts files>          # clean
node scripts/format-docs.mjs --check <changed doc>         # clean
```

**What was not tested:** I could not exercise the genuine Chrome 136+ Windows binding (no Windows host with Chrome 136+ in this environment); the IPv6-only listener is simulated with a real `[::1]`-bound server that produces the same observable IPv4/IPv6 split and empty-reply diagnostic. `pnpm docs:check-links:anchors` could not run locally (missing `@mintlify/scraping` transitive dep + network); the new same-page anchor `#chrome-136-binds-cdp-to-ipv6-loopback` was verified by hand against the heading slug.

AI-assisted; all proof above was produced by real local runs.

Closes #54669
