### PR TITLE
feat: add local broker device provisioning

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -27,8 +27,10 @@ import {
   approveDevicePairing,
   formatDevicePairingForbiddenMessage,
   listDevicePairing,
+  provisionLocalDevicePairing,
   summarizeDeviceTokens,
   type PairedDevice as InfraPairedDevice,
+  type ProvisionLocalDevicePairingResult,
 } from "../infra/device-pairing.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../runtime.js";
@@ -52,6 +54,12 @@ type DevicesRpcOpts = {
   yes?: boolean;
   pending?: boolean;
   device?: string;
+  publicKey?: string;
+  displayName?: string;
+  platform?: string;
+  deviceFamily?: string;
+  clientId?: string;
+  clientMode?: string;
   role?: string;
   scope?: string[];
 };
@@ -687,6 +695,29 @@ function resolveRequiredDeviceRole(
   return null;
 }
 
+function redactProvisionLocalResult(result: ProvisionLocalDevicePairingResult) {
+  if (!result.ok) {
+    return result;
+  }
+  return {
+    ...result,
+    device: redactLocalPairedDevice(result.device),
+  };
+}
+
+function formatProvisionLocalFailure(
+  result: Extract<ProvisionLocalDevicePairingResult, { ok: false }>,
+) {
+  switch (result.reason) {
+    case "device-public-key-mismatch":
+      return "Refusing to provision local device: device id is already paired with a different public key.";
+    case "approval-denied":
+      return `Refusing to provision local device: ${result.scope ? `missing scope ${sanitizeForLog(result.scope)}` : "approval denied"}.`;
+    case "approval-missing":
+      return "Refusing to provision local device: generated pairing request was not found.";
+  }
+}
+
 export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void> {
   let list: DevicePairingList;
   try {
@@ -955,6 +986,45 @@ export async function runDevicesRejectCommand(
   }
   const deviceId = (result as { deviceId?: string })?.deviceId;
   defaultRuntime.log(`${theme.warn("Rejected")} ${theme.command(deviceId ?? "ok")}`);
+}
+
+export async function runDevicesProvisionLocalCommand(opts: DevicesRpcOpts): Promise<void> {
+  const deviceId = normalizeStringifiedOptionalString(opts.device) ?? "";
+  const publicKey = normalizeStringifiedOptionalString(opts.publicKey) ?? "";
+  const role = normalizeStringifiedOptionalString(opts.role) ?? "";
+  if (!deviceId || !publicKey || !role) {
+    defaultRuntime.error("--device, --public-key, and --role are required.");
+    defaultRuntime.exit(1);
+    return;
+  }
+
+  const result = await provisionLocalDevicePairing({
+    deviceId,
+    publicKey,
+    displayName: normalizeOptionalString(opts.displayName),
+    platform: normalizeOptionalString(opts.platform),
+    deviceFamily: normalizeOptionalString(opts.deviceFamily),
+    clientId: normalizeOptionalString(opts.clientId),
+    clientMode: normalizeOptionalString(opts.clientMode),
+    role,
+    scopes: Array.isArray(opts.scope) ? opts.scope : undefined,
+  });
+  const redacted = redactProvisionLocalResult(result);
+  if (opts.json) {
+    defaultRuntime.writeJson(redacted);
+  }
+  if (!result.ok) {
+    if (!opts.json) {
+      defaultRuntime.error(formatProvisionLocalFailure(result));
+    }
+    defaultRuntime.exit(1);
+    return;
+  }
+  if (!opts.json) {
+    defaultRuntime.log(
+      `${theme.success("Provisioned")} ${theme.command(result.device.deviceId)} ${theme.muted(`(${result.status})`)}`,
+    );
+  }
 }
 
 export async function runDevicesRotateCommand(opts: DevicesRpcOpts): Promise<void> {

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -716,6 +716,9 @@ function formatProvisionLocalFailure(
     case "approval-missing":
       return "Refusing to provision local device: generated pairing request was not found.";
   }
+  const exhaustiveReason: never = result.reason;
+  void exhaustiveReason;
+  throw new Error("unsupported local device provisioning failure");
 }
 
 export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void> {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   })),
   listDevicePairing: vi.fn(),
   approveDevicePairing: vi.fn(),
+  provisionLocalDevicePairing: vi.fn(),
   summarizeDeviceTokens: vi.fn(),
   withProgress: vi.fn(async (_opts: unknown, fn: () => Promise<unknown>) => await fn()),
 }));
@@ -31,6 +32,7 @@ const {
   buildGatewayConnectionDetails,
   listDevicePairing,
   approveDevicePairing,
+  provisionLocalDevicePairing,
   summarizeDeviceTokens,
 } = mocks;
 
@@ -47,6 +49,7 @@ vi.mock("./progress.js", () => ({
 vi.mock("../infra/device-pairing.js", () => ({
   listDevicePairing: mocks.listDevicePairing,
   approveDevicePairing: mocks.approveDevicePairing,
+  provisionLocalDevicePairing: mocks.provisionLocalDevicePairing,
   summarizeDeviceTokens: mocks.summarizeDeviceTokens,
 }));
 
@@ -530,6 +533,108 @@ describe("devices cli clear", () => {
 });
 
 describe("devices cli tokens", () => {
+  it("provisions a local device without calling the gateway", async () => {
+    provisionLocalDevicePairing.mockResolvedValueOnce({
+      ok: true,
+      status: "provisioned",
+      requestId: "req-1",
+      device: {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-1",
+        roles: ["operator"],
+        scopes: ["operator.admin"],
+        approvedScopes: ["operator.admin"],
+        tokens: {
+          operator: {
+            token: "raw-device-token",
+            role: "operator",
+            scopes: ["operator.admin"],
+            createdAtMs: 1,
+          },
+        },
+        createdAtMs: 1,
+        approvedAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValueOnce([
+      { role: "operator", scopes: ["operator.admin"], createdAtMs: 1 },
+    ]);
+
+    await runDevicesCommand([
+      "provision-local",
+      "--device",
+      "broker-device-1",
+      "--public-key",
+      "broker-public-key-1",
+      "--role",
+      "operator",
+      "--scope",
+      "operator.admin",
+      "--display-name",
+      "Runtime Dashboard Broker",
+      "--client-id",
+      "gateway-client",
+      "--client-mode",
+      "backend",
+      "--platform",
+      "linux",
+      "--device-family",
+      "runtime-dashboard-broker",
+      "--json",
+    ]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(provisionLocalDevicePairing).toHaveBeenCalledWith({
+      deviceId: "broker-device-1",
+      publicKey: "broker-public-key-1",
+      displayName: "Runtime Dashboard Broker",
+      clientId: "gateway-client",
+      clientMode: "backend",
+      platform: "linux",
+      deviceFamily: "runtime-dashboard-broker",
+      role: "operator",
+      scopes: ["operator.admin"],
+    });
+    expect(runtime.writeJson).toHaveBeenCalledWith({
+      ok: true,
+      status: "provisioned",
+      requestId: "req-1",
+      device: {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-1",
+        roles: ["operator"],
+        scopes: ["operator.admin"],
+        approvedScopes: ["operator.admin"],
+        tokens: [{ role: "operator", scopes: ["operator.admin"], createdAtMs: 1 }],
+        createdAtMs: 1,
+        approvedAtMs: 1,
+      },
+    });
+    expect(JSON.stringify(runtime.writeJson.mock.calls[0]?.[0])).not.toContain("raw-device-token");
+  });
+
+  it("fails local provisioning when the device id is already paired to another key", async () => {
+    provisionLocalDevicePairing.mockResolvedValueOnce({
+      ok: false,
+      reason: "device-public-key-mismatch",
+      deviceId: "broker-device-1",
+    });
+
+    await runDevicesCommand([
+      "provision-local",
+      "--device",
+      "broker-device-1",
+      "--public-key",
+      "broker-public-key-2",
+      "--role",
+      "operator",
+    ]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(readRuntimeErrorOutput()).toContain("different public key");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it.each([
     {
       label: "rotates a token for a device role",
@@ -1421,5 +1526,10 @@ afterEach(() => {
   });
   listDevicePairing.mockResolvedValue({ pending: [], paired: [] });
   approveDevicePairing.mockResolvedValue(undefined);
+  provisionLocalDevicePairing.mockResolvedValue({
+    ok: false,
+    reason: "approval-missing",
+    deviceId: "device-1",
+  });
   summarizeDeviceTokens.mockReturnValue(undefined);
 });

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -12,6 +12,12 @@ type DevicesRpcOpts = {
   yes?: boolean;
   pending?: boolean;
   device?: string;
+  publicKey?: string;
+  displayName?: string;
+  platform?: string;
+  deviceFamily?: string;
+  clientId?: string;
+  clientMode?: string;
   role?: string;
   scope?: string[];
 };
@@ -97,6 +103,24 @@ export function registerDevicesCli(program: Command) {
         await runDevicesRejectCommand(requestId, opts);
       }),
   );
+
+  devices
+    .command("provision-local")
+    .description("Provision a paired device directly into the local gateway state")
+    .requiredOption("--device <id>", "Device id")
+    .requiredOption("--public-key <key>", "Device public key")
+    .requiredOption("--role <role>", "Role name")
+    .option("--scope <scope...>", "Scopes to approve for the role (repeatable)")
+    .option("--display-name <name>", "Device display name")
+    .option("--client-id <id>", "Client id")
+    .option("--client-mode <mode>", "Client mode")
+    .option("--platform <platform>", "Client platform")
+    .option("--device-family <family>", "Client device family")
+    .option("--json", "Output JSON", false)
+    .action(async (opts: DevicesRpcOpts) => {
+      const { runDevicesProvisionLocalCommand } = await loadDevicesRuntime();
+      await runDevicesProvisionLocalCommand(opts);
+    });
 
   devicesCallOpts(
     devices

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -13,6 +13,7 @@ import {
   hasEffectivePairedDeviceRole,
   listEffectivePairedDeviceRoles,
   listDevicePairing,
+  provisionLocalDevicePairing,
   removePairedDevice,
   requestDevicePairing,
   rejectDevicePairing,
@@ -1116,6 +1117,154 @@ describe("device pairing tokens", () => {
         baseDir,
       }),
     ).resolves.toEqual({ ok: true });
+  });
+
+  test("provisions a local operator device with an active token baseline", async () => {
+    const baseDir = await makeDevicePairingDir();
+
+    const result = await provisionLocalDevicePairing(
+      {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-1",
+        displayName: "Runtime Dashboard Broker",
+        platform: "linux",
+        deviceFamily: "runtime-dashboard-broker",
+        clientId: "gateway-client",
+        clientMode: "backend",
+        role: "operator",
+        scopes: ["operator.admin", "operator.read"],
+      },
+      baseDir,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(`expected provision success, got ${result.reason}`);
+    }
+    expect(result.status).toBe("provisioned");
+    expect(result.device.roles).toContain("operator");
+    expect(result.device.approvedScopes).toEqual([
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+    ]);
+    const token = requireToken(result.device.tokens?.operator?.token);
+    await expect(
+      verifyDeviceToken({
+        deviceId: "broker-device-1",
+        token,
+        role: "operator",
+        scopes: ["operator.write"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  test("keeps local provisioning idempotent when the approved token already covers scopes", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const input = {
+      deviceId: "broker-device-1",
+      publicKey: "broker-public-key-1",
+      role: "operator",
+      scopes: ["operator.admin"],
+    };
+    const first = await provisionLocalDevicePairing(input, baseDir);
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      throw new Error(`expected first provision success, got ${first.reason}`);
+    }
+    const token = requireToken(first.device.tokens?.operator?.token);
+
+    const second = await provisionLocalDevicePairing(input, baseDir);
+
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      throw new Error(`expected second provision success, got ${second.reason}`);
+    }
+    expect(second.status).toBe("already_provisioned");
+    expect(second.device.tokens?.operator?.token).toBe(token);
+    expect(second.device.tokens?.operator?.rotatedAtMs).toBeUndefined();
+  });
+
+  test("updates local provisioning when requested scopes exceed the existing token", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const first = await provisionLocalDevicePairing(
+      {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-1",
+        role: "operator",
+        scopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      throw new Error(`expected first provision success, got ${first.reason}`);
+    }
+    const firstToken = requireToken(first.device.tokens?.operator?.token);
+
+    const second = await provisionLocalDevicePairing(
+      {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-1",
+        role: "operator",
+        scopes: ["operator.admin"],
+      },
+      baseDir,
+    );
+
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      throw new Error(`expected update success, got ${second.reason}`);
+    }
+    expect(second.status).toBe("updated");
+    expect(second.device.approvedScopes).toHaveLength(3);
+    expect(second.device.approvedScopes).toEqual(
+      expect.arrayContaining(["operator.admin", "operator.read", "operator.write"]),
+    );
+    expect(second.device.tokens?.operator?.token).not.toBe(firstToken);
+    await expect(
+      verifyDeviceToken({
+        deviceId: "broker-device-1",
+        token: requireToken(second.device.tokens?.operator?.token),
+        role: "operator",
+        scopes: ["operator.write"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  test("refuses local provisioning when an existing device id has a different public key", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await provisionLocalDevicePairing(
+      {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-1",
+        role: "operator",
+        scopes: ["operator.admin"],
+      },
+      baseDir,
+    );
+
+    const result = await provisionLocalDevicePairing(
+      {
+        deviceId: "broker-device-1",
+        publicKey: "broker-public-key-rotated",
+        role: "operator",
+        scopes: ["operator.admin"],
+      },
+      baseDir,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "device-public-key-mismatch",
+      deviceId: "broker-device-1",
+    });
+    const list = await listDevicePairing(baseDir);
+    expect(list.pending).toEqual([]);
+    expect(list.paired).toHaveLength(1);
+    expect(list.paired[0]?.publicKey).toBe("broker-public-key-1");
   });
 
   test("tags browser tokens minted from shared gateway auth and rejects stale generations", async () => {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -154,6 +154,34 @@ export type ApproveDevicePairingResult =
   | DevicePairingForbiddenResult
   | null;
 
+export type ProvisionLocalDevicePairingInput = {
+  deviceId: string;
+  publicKey: string;
+  displayName?: string;
+  platform?: string;
+  deviceFamily?: string;
+  clientId?: string;
+  clientMode?: string;
+  role: string;
+  scopes?: string[];
+};
+
+export type ProvisionLocalDevicePairingResult =
+  | {
+      ok: true;
+      status: "already_provisioned" | "provisioned" | "updated";
+      requestId?: string;
+      device: PairedDevice;
+    }
+  | {
+      ok: false;
+      reason: "device-public-key-mismatch" | "approval-denied" | "approval-missing";
+      requestId?: string;
+      deviceId?: string;
+      scope?: string;
+      role?: string;
+    };
+
 type DevicePairingStateFile = {
   pendingById: Record<string, DevicePairingPendingRequest>;
   pairedByDeviceId: Record<string, PairedDevice>;
@@ -609,6 +637,179 @@ export async function getPendingDevicePairing(
 ): Promise<DevicePairingPendingRequest | null> {
   const state = await loadState(baseDir);
   return state.pendingById[requestId] ?? null;
+}
+
+function hasActiveDeviceTokenForRequestedScopes(params: {
+  device: PairedDevice;
+  role: string;
+  scopes: readonly string[];
+}): boolean {
+  const entry = params.device.tokens?.[params.role];
+  if (!entry || entry.revokedAtMs) {
+    return false;
+  }
+  if (entry.role !== params.role) {
+    return false;
+  }
+  return roleScopesAllow({
+    role: params.role,
+    requestedScopes: params.scopes,
+    allowedScopes: entry.scopes,
+  });
+}
+
+function localProvisionAlreadySatisfied(params: {
+  existing: PairedDevice;
+  publicKey: string;
+  role: string;
+  scopes: readonly string[];
+}): boolean {
+  if (params.existing.publicKey !== params.publicKey) {
+    return false;
+  }
+  if (!listApprovedPairedDeviceRoles(params.existing).includes(params.role)) {
+    return false;
+  }
+  if (
+    !scopesWithinApprovedDeviceBaseline({
+      role: params.role,
+      scopes: params.scopes,
+      approvedScopes: resolveApprovedDeviceScopeBaseline(params.existing),
+    })
+  ) {
+    return false;
+  }
+  return hasActiveDeviceTokenForRequestedScopes({
+    device: params.existing,
+    role: params.role,
+    scopes: params.scopes,
+  });
+}
+
+/** Provision or update a local paired device using explicit host-owner authority. */
+export async function provisionLocalDevicePairing(
+  input: ProvisionLocalDevicePairingInput,
+  baseDir?: string,
+): Promise<ProvisionLocalDevicePairingResult> {
+  const deviceId = normalizeDeviceId(input.deviceId);
+  if (!deviceId) {
+    throw new Error("deviceId required");
+  }
+  const publicKey = input.publicKey.trim();
+  if (!publicKey) {
+    throw new Error("publicKey required");
+  }
+  const role = normalizeRole(input.role);
+  if (!role) {
+    throw new Error("role required");
+  }
+  const scopes = normalizeDeviceAuthScopes(input.scopes);
+
+  return await withLock(async () => {
+    const state = await loadState(baseDir);
+    const existing = state.pairedByDeviceId[deviceId];
+    if (existing && existing.publicKey !== publicKey) {
+      return {
+        ok: false,
+        reason: "device-public-key-mismatch",
+        deviceId,
+      };
+    }
+    if (
+      existing &&
+      localProvisionAlreadySatisfied({
+        existing,
+        publicKey,
+        role,
+        scopes,
+      })
+    ) {
+      return {
+        ok: true,
+        status: "already_provisioned",
+        device: existing,
+      };
+    }
+
+    const pending = buildPendingDevicePairingRequest({
+      deviceId,
+      isRepair: Boolean(existing),
+      req: {
+        deviceId,
+        publicKey,
+        displayName: input.displayName,
+        platform: input.platform,
+        deviceFamily: input.deviceFamily,
+        clientId: input.clientId,
+        clientMode: input.clientMode,
+        role,
+        scopes,
+        silent: true,
+      },
+    });
+    const requestedRoles = mergeRoles(pending.roles, pending.role) ?? [];
+    const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
+    const roleMismatchScope = resolveScopeOutsideRequestedRoles({
+      requestedRoles,
+      requestedScopes,
+    });
+    if (roleMismatchScope) {
+      return {
+        ok: false,
+        reason: "approval-denied",
+        requestId: pending.requestId,
+        deviceId,
+        scope: roleMismatchScope,
+      };
+    }
+    const now = Date.now();
+    const roles = mergeRoles(existing?.roles, existing?.role, pending.roles, pending.role);
+    const approvedScopes = mergeScopes(
+      existing?.approvedScopes ?? existing?.scopes,
+      pending.scopes,
+    );
+    const tokens = existing?.tokens ? { ...existing.tokens } : {};
+    for (const roleForToken of requestedRoles) {
+      const existingToken = tokens[roleForToken];
+      const nextScopes = resolveApprovedTokenScopes({
+        role: roleForToken,
+        pending,
+        existingToken,
+        approvedScopes,
+        existing,
+      });
+      tokens[roleForToken] = {
+        token: newToken(),
+        role: roleForToken,
+        scopes: nextScopes,
+        createdAtMs: existingToken?.createdAtMs ?? now,
+        rotatedAtMs: existingToken ? now : undefined,
+        revokedAtMs: undefined,
+        lastUsedAtMs: existingToken?.lastUsedAtMs,
+      };
+    }
+    const device = buildApprovedPairedDevice({
+      pending,
+      existing,
+      roles,
+      approvedScopes,
+      tokens,
+      now,
+    });
+    for (const [requestId, request] of Object.entries(state.pendingById)) {
+      if (request.deviceId === deviceId) {
+        delete state.pendingById[requestId];
+      }
+    }
+    state.pairedByDeviceId[device.deviceId] = device;
+    await persistState(state, baseDir, "both");
+    return {
+      ok: true,
+      status: existing ? "updated" : "provisioned",
+      requestId: pending.requestId,
+      device,
+    };
+  });
 }
 
 /** Create or refresh a pending device pairing request for owner approval. */


### PR DESCRIPTION
## Summary
- add `openclaw devices provision-local` for host-owner provisioning of an approved local paired device
- add `provisionLocalDevicePairing` so automation can install a broker-owned device identity without remote gateway auth
- keep output token-safe by returning redacted token summaries in JSON mode

## Why
Platform's runtime dashboard broker needs to connect as a broker-owned approved OpenClaw device. The EC2 host should receive only the broker device public identity, while Platform keeps the private key in Vault and signs upstream connect challenges from the broker.

## Verification
- `CI=true pnpm test src/infra/device-pairing.test.ts src/cli/devices-cli.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: local host-owner provisioning can create or update a paired device with approved operator scopes and active role token state, while rejecting same-device public-key mismatches.
Real environment tested: local OpenClaw checkout on the `release/2026.6.6` lane.
Exact steps or command run after this patch: `CI=true pnpm test src/infra/device-pairing.test.ts src/cli/devices-cli.test.ts` and `git diff --check`.
Evidence after fix: 2 Vitest shards passed, covering 61 infra tests and 45 CLI tests.
Observed result after fix: `openclaw devices provision-local` is covered for JSON output, idempotency, scope provisioning, and mismatch failure behavior.
What was not tested: live EC2 coworker rollout; that requires the Platform broker-device-auth PR and package publication/deployment after this release-lane PR lands.
