### PR TITLE
fix(ui): add agent selector to skills page

### DIFF
--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -323,6 +323,7 @@ export const SkillsUploadCommitParamsSchema = Type.Object(
 export const SkillsInstallParamsSchema = Type.Union([
   Type.Object(
     {
+      agentId: Type.Optional(NonEmptyString),
       name: NonEmptyString,
       installId: NonEmptyString,
       dangerouslyForceUnsafeInstall: Type.Optional(
@@ -338,6 +339,7 @@ export const SkillsInstallParamsSchema = Type.Union([
   ),
   Type.Object(
     {
+      agentId: Type.Optional(NonEmptyString),
       source: Type.Literal("clawhub"),
       slug: NonEmptyString,
       version: Type.Optional(NonEmptyString),
@@ -348,6 +350,7 @@ export const SkillsInstallParamsSchema = Type.Union([
   ),
   Type.Object(
     {
+      agentId: Type.Optional(NonEmptyString),
       source: Type.Literal("upload"),
       uploadId: NonEmptyString,
       slug: NonEmptyString,
@@ -372,6 +375,7 @@ export const SkillsUpdateParamsSchema = Type.Union([
   ),
   Type.Object(
     {
+      agentId: Type.Optional(NonEmptyString),
       source: Type.Literal("clawhub"),
       slug: Type.Optional(NonEmptyString),
       all: Type.Optional(Type.Boolean()),

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -4,9 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { callGatewayHandler } from "./skills.test-helpers.js";
 
 const loadConfigMock = vi.fn(() => ({}));
-const listAgentIdsMock = vi.fn(() => ["main"]);
+const listAgentIdsMock = vi.fn<(_cfg: unknown) => string[]>(() => ["main"]);
 const resolveDefaultAgentIdMock = vi.fn(() => "main");
-const resolveAgentWorkspaceDirMock = vi.fn(() => "/tmp/workspace");
+const resolveAgentWorkspaceDirMock = vi.fn<(_cfg: unknown, _agentId: string) => string>(
+  () => "/tmp/workspace",
+);
 const buildWorkspaceSkillStatusMock = vi.fn();
 const readLocalSkillCardContentSyncMock = vi.fn();
 const fetchClawHubSkillSecurityVerdictsMock = vi.fn();
@@ -20,10 +22,11 @@ vi.mock("../../config/config.js", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  listAgentIds: (...args: unknown[]) => listAgentIdsMock(...args),
+  listAgentIds: (cfg: unknown) => listAgentIdsMock(cfg),
   resolveAgentConfig: vi.fn(() => undefined),
-  resolveDefaultAgentId: (...args: unknown[]) => resolveDefaultAgentIdMock(...args),
-  resolveAgentWorkspaceDir: (...args: unknown[]) => resolveAgentWorkspaceDirMock(...args),
+  resolveDefaultAgentId: () => resolveDefaultAgentIdMock(),
+  resolveAgentWorkspaceDir: (cfg: unknown, agentId: string) =>
+    resolveAgentWorkspaceDirMock(cfg, agentId),
   resolveSessionAgentId: vi.fn(() => undefined),
 }));
 

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -107,6 +107,26 @@ describe("skills gateway handlers (clawhub)", () => {
     await expectEmptySecurityVerdictsWithoutFetch();
   });
 
+  it("builds status with the selected agent filter", async () => {
+    listAgentIdsMock.mockReturnValue(["main", "research"]);
+    resolveAgentWorkspaceDirMock.mockImplementation((_cfg, agentId) =>
+      agentId === "research" ? "/tmp/research-workspace" : "/tmp/workspace",
+    );
+
+    const { ok, error } = await callSkillsHandler("skills.status", { agentId: "research" });
+
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+    expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith(
+      "/tmp/research-workspace",
+      expect.objectContaining({
+        agentId: "research",
+        config: {},
+        eligibility: expect.any(Object),
+      }),
+    );
+  });
+
   it("fetches one bulk ClawHub verdict batch for linked installed skills", async () => {
     buildWorkspaceSkillStatusMock.mockReturnValue({
       workspaceDir: "/tmp/workspace",

--- a/src/gateway/server-methods/skills.clawhub.test.ts
+++ b/src/gateway/server-methods/skills.clawhub.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { callGatewayHandler } from "./skills.test-helpers.js";
 
 const loadConfigMock = vi.fn(() => ({}));
+const listAgentIdsMock = vi.fn(() => ["main"]);
 const resolveDefaultAgentIdMock = vi.fn(() => "main");
 const resolveAgentWorkspaceDirMock = vi.fn(() => "/tmp/workspace");
 const buildWorkspaceSkillStatusMock = vi.fn();
@@ -19,10 +20,10 @@ vi.mock("../../config/config.js", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  listAgentIds: vi.fn(() => ["main"]),
+  listAgentIds: (...args: unknown[]) => listAgentIdsMock(...args),
   resolveAgentConfig: vi.fn(() => undefined),
-  resolveDefaultAgentId: () => resolveDefaultAgentIdMock(),
-  resolveAgentWorkspaceDir: () => resolveAgentWorkspaceDirMock(),
+  resolveDefaultAgentId: (...args: unknown[]) => resolveDefaultAgentIdMock(...args),
+  resolveAgentWorkspaceDir: (...args: unknown[]) => resolveAgentWorkspaceDirMock(...args),
   resolveSessionAgentId: vi.fn(() => undefined),
 }));
 
@@ -82,6 +83,7 @@ async function expectEmptySecurityVerdictsWithoutFetch(): Promise<void> {
 describe("skills gateway handlers (clawhub)", () => {
   beforeEach(() => {
     loadConfigMock.mockReset();
+    listAgentIdsMock.mockReset();
     resolveDefaultAgentIdMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     buildWorkspaceSkillStatusMock.mockReset();
@@ -92,6 +94,7 @@ describe("skills gateway handlers (clawhub)", () => {
     updateSkillsFromClawHubMock.mockReset();
 
     loadConfigMock.mockReturnValue({});
+    listAgentIdsMock.mockReturnValue(["main"]);
     resolveDefaultAgentIdMock.mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     buildWorkspaceSkillStatusMock.mockReturnValue(emptySkillStatusReport());
@@ -260,6 +263,37 @@ describe("skills gateway handlers (clawhub)", () => {
     expect(result?.message).toBe("Installed calendar@1.2.3");
     expect(result?.slug).toBe("calendar");
     expect(result?.version).toBe("1.2.3");
+  });
+
+  it("routes explicit agent ClawHub installs through that agent workspace", async () => {
+    listAgentIdsMock.mockReturnValue(["main", "research"]);
+    resolveAgentWorkspaceDirMock.mockImplementation((_cfg, agentId) =>
+      agentId === "research" ? "/tmp/research-workspace" : "/tmp/workspace",
+    );
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      version: "1.2.3",
+      targetDir: "/tmp/research-workspace/skills/calendar",
+    });
+
+    const { ok, error } = await callSkillsHandler("skills.install", {
+      agentId: "research",
+      source: "clawhub",
+      slug: "calendar",
+      version: "1.2.3",
+    });
+
+    expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith({}, "research");
+    expect(installSkillFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/research-workspace",
+      slug: "calendar",
+      version: "1.2.3",
+      force: false,
+      config: {},
+    });
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
   });
 
   it("accepts deprecated unsafe override without forwarding it to skill installs", async () => {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -523,8 +523,13 @@ export const skillsHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateSkillsInstallParams, "skills.install", respond)) {
       return;
     }
-    const cfg = context.getRuntimeConfig();
-    const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+    const resolved = resolveSkillsAgentWorkspace(params, context);
+    if (!resolved.ok) {
+      respond(false, undefined, resolved.error);
+      return;
+    }
+    const cfg = resolved.cfg;
+    const workspaceDirRaw = resolved.workspaceDir;
     // Skill installs are intentionally routed by source; each source owns its
     // validation, provenance checks, and result payload shape.
     if (params && typeof params === "object" && "source" in params && params.source === "clawhub") {
@@ -575,7 +580,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
         sha256: p.sha256,
         timeoutMs: p.timeoutMs,
         workspaceDir: workspaceDirRaw,
-        config: context.getRuntimeConfig(),
+        config: cfg,
         log: context.logGateway,
       });
       const errorCode =
@@ -643,12 +648,15 @@ export const skillsHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-      const cfg = context.getRuntimeConfig();
-      const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+      const resolved = resolveSkillsAgentWorkspace(params, context);
+      if (!resolved.ok) {
+        respond(false, undefined, resolved.error);
+        return;
+      }
       const results = await updateSkillsFromClawHub({
-        workspaceDir,
+        workspaceDir: resolved.workspaceDir,
         slug: p.slug,
-        config: cfg,
+        config: resolved.cfg,
       });
       const errors = results.filter((result) => !result.ok);
       respond(

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -102,6 +102,7 @@ function buildRemoteAwareWorkspaceSkillStatus(resolved: ResolvedSkillsWorkspace)
   // not only the workspace contents, so status reports include live eligibility.
   return buildWorkspaceSkillStatus(resolved.workspaceDir, {
     config: resolved.cfg,
+    agentId: resolved.agentId,
     eligibility: {
       remote: getRemoteSkillEligibility({
         advertiseExecNode: canExecRequestNode({

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -146,6 +146,7 @@ import {
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
+  setSkillsAgentId,
   updateSkillEdit,
   updateSkillEnabled,
 } from "./controllers/skills.ts";
@@ -3479,6 +3480,8 @@ export function renderApp(state: AppViewState) {
                 connected: state.connected,
                 loading: state.skillsLoading,
                 report: state.skillsReport,
+                agentsList: state.agentsList,
+                selectedAgentId: state.skillsAgentId ?? state.agentsList?.defaultId ?? null,
                 error: state.skillsError,
                 filter: state.skillsFilter,
                 statusFilter: state.skillsStatusFilter,
@@ -3503,9 +3506,16 @@ export function renderApp(state: AppViewState) {
                 clawhubDetailError: state.clawhubDetailError,
                 clawhubInstallSlug: state.clawhubInstallSlug,
                 clawhubInstallMessage: state.clawhubInstallMessage,
+                onAgentChange: (agentId) => {
+                  setSkillsAgentId(state, agentId);
+                  void loadSkills(state, { clearMessages: true });
+                },
                 onFilterChange: (next) => (state.skillsFilter = next),
                 onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
-                onRefresh: () => void loadSkills(state, { clearMessages: true }),
+                onRefresh: () => {
+                  void loadAgents(state);
+                  void loadSkills(state, { clearMessages: true });
+                },
                 onToggle: (key, enabled) => void updateSkillEnabled(state, key, enabled),
                 onEdit: (key, value) => updateSkillEdit(state, key, value),
                 onSaveKey: (key) => void saveSkillApiKey(state, key),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -143,6 +143,7 @@ import {
   installSkill,
   loadClawHubDetail,
   loadSkills,
+  reconcileSkillsAgentId,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
@@ -3513,8 +3514,11 @@ export function renderApp(state: AppViewState) {
                 onFilterChange: (next) => (state.skillsFilter = next),
                 onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
                 onRefresh: () => {
-                  void loadAgents(state);
-                  void loadSkills(state, { clearMessages: true });
+                  void (async () => {
+                    await loadAgents(state);
+                    reconcileSkillsAgentId(state, state.agentsList);
+                    await loadSkills(state, { clearMessages: true });
+                  })();
                 },
                 onToggle: (key, enabled) => void updateSkillEnabled(state, key, enabled),
                 onEdit: (key, value) => updateSkillEdit(state, key, value),

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -359,6 +359,16 @@ describe("refreshActiveTab", () => {
     });
   });
 
+  it("loads agents before rendering the Skills tab agent selector", async () => {
+    const host = createHost();
+    host.tab = "skills";
+
+    await refreshActiveTab(host as never);
+
+    expect(mocks.loadAgentsMock).toHaveBeenCalledWith(host);
+    expect(mocks.loadSkillsMock).toHaveBeenCalledWith(host);
+  });
+
   it("starts node polling on Nodes tab entry and clears pending session reloads on tab changes", () => {
     vi.useFakeTimers();
     const host = createHost();

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
   loadPresenceMock: vi.fn(async () => {}),
   loadSessionsMock: vi.fn(async () => {}),
   loadSkillsMock: vi.fn(async () => {}),
+  reconcileSkillsAgentIdMock: vi.fn(),
   loadUsageMock: vi.fn(async () => {}),
   loadWorkboardMock: vi.fn(async () => {}),
   startDebugPollingMock: vi.fn(),
@@ -136,6 +137,7 @@ vi.mock("./controllers/sessions.ts", () => ({
 }));
 vi.mock("./controllers/skills.ts", () => ({
   loadSkills: mocks.loadSkillsMock,
+  reconcileSkillsAgentId: mocks.reconcileSkillsAgentIdMock,
 }));
 vi.mock("./controllers/usage.ts", () => ({
   loadUsage: mocks.loadUsageMock,
@@ -362,10 +364,22 @@ describe("refreshActiveTab", () => {
   it("loads agents before rendering the Skills tab agent selector", async () => {
     const host = createHost();
     host.tab = "skills";
+    const calls: string[] = [];
+    mocks.loadAgentsMock.mockImplementationOnce(async () => {
+      calls.push("agents");
+    });
+    mocks.reconcileSkillsAgentIdMock.mockImplementationOnce(() => {
+      calls.push("reconcile");
+    });
+    mocks.loadSkillsMock.mockImplementationOnce(async () => {
+      calls.push("skills");
+    });
 
     await refreshActiveTab(host as never);
 
+    expect(calls).toEqual(["agents", "reconcile", "skills"]);
     expect(mocks.loadAgentsMock).toHaveBeenCalledWith(host);
+    expect(mocks.reconcileSkillsAgentIdMock).toHaveBeenCalledWith(host, host.agentsList);
     expect(mocks.loadSkillsMock).toHaveBeenCalledWith(host);
   });
 

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -57,7 +57,7 @@ import {
   loadSkillWorkshopProposals,
   type SkillWorkshopState,
 } from "./controllers/skill-workshop.ts";
-import { loadSkills, type SkillsState } from "./controllers/skills.ts";
+import { loadSkills, reconcileSkillsAgentId, type SkillsState } from "./controllers/skills.ts";
 import { loadUsage, type UsageState } from "./controllers/usage.ts";
 import { loadWorkboard } from "./controllers/workboard.ts";
 import { resolveCronJobLastRunStatus } from "./cron-status.ts";
@@ -469,7 +469,9 @@ export async function refreshActiveTab(host: SettingsHost, opts?: { chatStartup?
         await loadCron(host);
         break;
       case "skills":
-        await Promise.all([loadAgents(app), loadSkills(app)]);
+        await loadAgents(app);
+        reconcileSkillsAgentId(app, app.agentsList);
+        await loadSkills(app);
         break;
       case "skillWorkshop":
         await loadSkillWorkshopProposals(app, { force: true });

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -469,7 +469,7 @@ export async function refreshActiveTab(host: SettingsHost, opts?: { chatStartup?
         await loadCron(host);
         break;
       case "skills":
-        await loadSkills(app);
+        await Promise.all([loadAgents(app), loadSkills(app)]);
         break;
       case "skillWorkshop":
         await loadSkillWorkshopProposals(app, { force: true });

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -402,6 +402,7 @@ export type AppViewState = {
 > &
   Pick<CronModelSuggestionsState, "cronModelSuggestions"> & {
     skillsLoading: boolean;
+    skillsAgentId: string | null;
     skillsReport: SkillStatusReport | null;
     skillsError: string | null;
     skillsFilter: string;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -403,6 +403,7 @@ export type AppViewState = {
   Pick<CronModelSuggestionsState, "cronModelSuggestions"> & {
     skillsLoading: boolean;
     skillsAgentId: string | null;
+    skillsAgentRevision: number;
     skillsReport: SkillStatusReport | null;
     skillsError: string | null;
     skillsFilter: string;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -607,6 +607,7 @@ export class OpenClawApp extends LitElement {
   @state() overviewLogCursor = 0;
 
   @state() skillsLoading = false;
+  @state() skillsAgentId: string | null = null;
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;
   @state() skillsFilter = "";

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -608,6 +608,7 @@ export class OpenClawApp extends LitElement {
 
   @state() skillsLoading = false;
   @state() skillsAgentId: string | null = null;
+  skillsAgentRevision = 0;
   @state() skillsReport: SkillStatusReport | null = null;
   @state() skillsError: string | null = null;
   @state() skillsFilter = "";

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -685,6 +685,53 @@ describe("skill mutations", () => {
     expect(state.skillsBusyKey).toBeNull();
   });
 
+  it("refreshes the current agent after a stale global config mutation succeeds", async () => {
+    const { state, request } = createState();
+    const pendingRequests: Array<{
+      method: string;
+      payload: unknown;
+      resolve: (value: unknown) => void;
+    }> = [];
+    request.mockImplementation(
+      (method, payload) =>
+        new Promise((resolve) => {
+          pendingRequests.push({ method, payload, resolve });
+        }),
+    );
+    state.skillsAgentId = "alpha";
+
+    const mutation = updateSkillEnabled(state, "github", true);
+    await Promise.resolve();
+    setSkillsAgentId(state, "beta");
+    const betaLoad = loadSkills(state);
+    await Promise.resolve();
+    pendingRequests[1].resolve({
+      workspaceDir: "/tmp/beta-before-update",
+      managedSkillsDir: "/tmp/skills",
+      skills: [],
+    });
+    await betaLoad;
+
+    pendingRequests[0].resolve({});
+    await vi.waitFor(() => {
+      expect(pendingRequests).toHaveLength(3);
+    });
+    pendingRequests[2].resolve({
+      workspaceDir: "/tmp/beta-after-update",
+      managedSkillsDir: "/tmp/skills",
+      skills: [],
+    });
+    await mutation;
+
+    expect(pendingRequests.map(({ method, payload }) => [method, payload])).toEqual([
+      ["skills.update", { skillKey: "github", enabled: true }],
+      ["skills.status", { agentId: "beta" }],
+      ["skills.status", { agentId: "beta" }],
+    ]);
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta-after-update");
+    expect(state.skillMessages).toEqual({});
+  });
+
   it("routes selected agent installs through the selected workspace", async () => {
     const { state, request } = createState();
     state.skillsAgentId = "research";

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover skills behavior.
 import { describe, expect, it, vi } from "vitest";
 import {
+  installFromClawHub,
   installSkill,
   loadSkills,
   loadSkillCard,
@@ -8,6 +9,7 @@ import {
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
+  setSkillsAgentId,
   updateSkillEnabled,
   type SkillsState,
 } from "./skills.ts";
@@ -21,12 +23,15 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn<T
       request,
     } as unknown as SkillsState["client"],
     connected: true,
+    skillsAgentId: null,
     skillsLoading: false,
     skillsReport: null,
     skillsError: null,
     skillsBusyKey: null,
     skillEdits: {},
     skillMessages: {},
+    skillsDetailKey: null,
+    skillsDetailTab: "overview",
     clawhubSearchQuery: "github",
     clawhubSearchResults: [
       {
@@ -164,6 +169,98 @@ describe("loadSkills", () => {
     expect(state.clawhubVerdictsError).toBeNull();
   });
 
+  it("loads selected agent skills and verdicts with the agent id", async () => {
+    const { state, request } = createState();
+    state.skillsAgentId = "research";
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.status") {
+        return {
+          workspaceDir: "/tmp/research",
+          managedSkillsDir: "/tmp/skills",
+          skills: [
+            {
+              name: "AgentReceipt",
+              skillKey: "agentreceipt",
+              source: "workspace",
+              clawhub: {
+                status: "linked",
+                valid: true,
+                registry: "https://clawhub.ai",
+                slug: "agentreceipt",
+                installedVersion: "1.2.3",
+                installedAt: 123,
+              },
+            },
+          ],
+        };
+      }
+      if (method === "skills.securityVerdicts") {
+        return {
+          schema: "openclaw.skills.security-verdicts.v1",
+          items: [],
+        };
+      }
+      return {};
+    });
+
+    await loadSkills(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "skills.status", { agentId: "research" });
+    expect(request).toHaveBeenNthCalledWith(2, "skills.securityVerdicts", {
+      agentId: "research",
+    });
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/research");
+  });
+
+  it("ignores stale skill reports after switching agents mid-request", async () => {
+    const { state, request } = createState();
+    const pendingRequests: Array<{
+      method: string;
+      payload: unknown;
+      resolve: (value: unknown) => void;
+    }> = [];
+    request.mockImplementation(
+      (method, payload) =>
+        new Promise((resolve) => {
+          pendingRequests.push({ method, payload, resolve });
+        }),
+    );
+
+    state.skillsAgentId = "alpha";
+    state.skillEdits = { shared: "stale-secret" };
+    const firstLoad = loadSkills(state);
+    await Promise.resolve();
+
+    setSkillsAgentId(state, "beta");
+    expect(state.skillEdits).toEqual({});
+    const secondLoad = loadSkills(state);
+    await Promise.resolve();
+
+    expect(pendingRequests.map(({ method, payload }) => [method, payload])).toEqual([
+      ["skills.status", { agentId: "alpha" }],
+      ["skills.status", { agentId: "beta" }],
+    ]);
+
+    pendingRequests[1].resolve({
+      workspaceDir: "/tmp/beta",
+      managedSkillsDir: "/tmp/skills",
+      skills: [{ name: "Beta", skillKey: "beta", source: "workspace" }],
+    });
+    await secondLoad;
+
+    pendingRequests[0].resolve({
+      workspaceDir: "/tmp/alpha",
+      managedSkillsDir: "/tmp/skills",
+      skills: [{ name: "Alpha", skillKey: "alpha", source: "workspace" }],
+    });
+    await firstLoad;
+
+    expect(state.skillsAgentId).toBe("beta");
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta");
+    expect(state.skillsReport?.skills.map((skill) => skill.name)).toEqual(["Beta"]);
+    expect(state.skillsLoading).toBe(false);
+  });
+
   it("does not keep skills loading while the optional verdict refresh is pending", async () => {
     const { state, request } = createState();
     let resolveVerdicts: (value: unknown) => void = () => {
@@ -253,6 +350,7 @@ describe("loadSkills", () => {
 describe("loadSkillCard", () => {
   it("loads local Skill Card content on demand", async () => {
     const { state, request } = createState();
+    state.skillsAgentId = "research";
     request.mockResolvedValueOnce({
       schema: "openclaw.skills.skill-card.v1",
       skillKey: "agentreceipt",
@@ -290,7 +388,10 @@ describe("loadSkillCard", () => {
 
     await loadSkillCard(state, "agentreceipt");
 
-    expect(request).toHaveBeenCalledWith("skills.skillCard", { skillKey: "agentreceipt" });
+    expect(request).toHaveBeenCalledWith("skills.skillCard", {
+      agentId: "research",
+      skillKey: "agentreceipt",
+    });
     expect(state.skillCardContents.agentreceipt).toBe("# AgentReceipt\n\nLocal trust card.\n");
     expect(state.skillCardContentKeys.agentreceipt).toBe(
       "/tmp/workspace/skills/agentreceipt/skill-card.md\u000034\u0000",
@@ -546,5 +647,39 @@ describe("skill mutations", () => {
       message: "skills update failed",
     });
     expect(state.skillsBusyKey).toBeNull();
+  });
+
+  it("routes selected agent installs through the selected workspace", async () => {
+    const { state, request } = createState();
+    state.skillsAgentId = "research";
+    mockSkillMutationRequests(request, "Installed from registry");
+
+    await installSkill(state, "github", "GitHub", "install-123", true);
+
+    expect(request).toHaveBeenCalledWith("skills.install", {
+      agentId: "research",
+      name: "GitHub",
+      installId: "install-123",
+      dangerouslyForceUnsafeInstall: true,
+      timeoutMs: 120000,
+    });
+  });
+
+  it("routes selected agent ClawHub installs through the selected workspace", async () => {
+    const { state, request } = createState();
+    state.skillsAgentId = "research";
+    request.mockResolvedValue({});
+
+    await installFromClawHub(state, "github");
+
+    expect(request).toHaveBeenCalledWith("skills.install", {
+      agentId: "research",
+      source: "clawhub",
+      slug: "github",
+    });
+    expect(state.clawhubInstallMessage).toEqual({
+      kind: "success",
+      text: "Installed github",
+    });
   });
 });

--- a/ui/src/ui/controllers/skills.test.ts
+++ b/ui/src/ui/controllers/skills.test.ts
@@ -6,6 +6,7 @@ import {
   loadSkills,
   loadSkillCard,
   loadClawHubDetail,
+  reconcileSkillsAgentId,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
@@ -24,6 +25,7 @@ function createState(): { state: SkillsState; request: ReturnType<typeof vi.fn<T
     } as unknown as SkillsState["client"],
     connected: true,
     skillsAgentId: null,
+    skillsAgentRevision: 0,
     skillsLoading: false,
     skillsReport: null,
     skillsError: null,
@@ -258,6 +260,40 @@ describe("loadSkills", () => {
     expect(state.skillsAgentId).toBe("beta");
     expect(state.skillsReport?.workspaceDir).toBe("/tmp/beta");
     expect(state.skillsReport?.skills.map((skill) => skill.name)).toEqual(["Beta"]);
+    expect(state.skillsLoading).toBe(false);
+  });
+
+  it("ignores stale skill reports after switching away and back to the same agent", async () => {
+    const { state, request } = createState();
+    const queue = createDeferredRequestQueue(request);
+    state.skillsAgentId = "alpha";
+
+    const firstLoad = loadSkills(state);
+    await Promise.resolve();
+    setSkillsAgentId(state, "beta");
+    setSkillsAgentId(state, "alpha");
+    const secondLoad = loadSkills(state);
+    await Promise.resolve();
+
+    queue.resolveNext({
+      workspaceDir: "/tmp/stale-alpha",
+      managedSkillsDir: "/tmp/skills",
+      skills: [{ name: "Stale Alpha", skillKey: "stale-alpha", source: "workspace" }],
+    });
+    await firstLoad;
+
+    expect(state.skillsReport).toBeNull();
+    expect(state.skillsLoading).toBe(true);
+
+    queue.resolveNext({
+      workspaceDir: "/tmp/current-alpha",
+      managedSkillsDir: "/tmp/skills",
+      skills: [{ name: "Current Alpha", skillKey: "current-alpha", source: "workspace" }],
+    });
+    await secondLoad;
+
+    expect(state.skillsReport?.workspaceDir).toBe("/tmp/current-alpha");
+    expect(state.skillsReport?.skills.map((skill) => skill.name)).toEqual(["Current Alpha"]);
     expect(state.skillsLoading).toBe(false);
   });
 
@@ -681,5 +717,72 @@ describe("skill mutations", () => {
       kind: "success",
       text: "Installed github",
     });
+  });
+
+  it.each([
+    {
+      name: "legacy install",
+      run: (state: SkillsState) => installSkill(state, "github", "GitHub", "install-123"),
+      expectedRequest: {
+        agentId: "alpha",
+        name: "GitHub",
+        installId: "install-123",
+        dangerouslyForceUnsafeInstall: false,
+        timeoutMs: 120000,
+      },
+    },
+    {
+      name: "ClawHub install",
+      run: (state: SkillsState) => installFromClawHub(state, "github"),
+      expectedRequest: {
+        agentId: "alpha",
+        source: "clawhub",
+        slug: "github",
+      },
+    },
+  ])("ignores $name completion after switching agents", async ({ run, expectedRequest }) => {
+    const { state, request } = createState();
+    const queue = createDeferredRequestQueue(request);
+    state.skillsAgentId = "alpha";
+
+    const pending = run(state);
+    await Promise.resolve();
+    setSkillsAgentId(state, "beta");
+    queue.resolveNext({ message: "Installed" });
+    await pending;
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("skills.install", expectedRequest);
+    expect(state.skillsAgentId).toBe("beta");
+    expect(state.skillsReport).toBeNull();
+    expect(state.skillMessages).toEqual({});
+    expect(state.clawhubInstallMessage).toBeNull();
+    expect(state.skillsBusyKey).toBeNull();
+    expect(state.clawhubInstallSlug).toBeNull();
+  });
+});
+
+describe("reconcileSkillsAgentId", () => {
+  it("resets a deleted selected agent to the current default scope", () => {
+    const { state } = createState();
+    state.skillsAgentId = "deleted";
+    state.skillsReport = {
+      workspaceDir: "/tmp/deleted",
+      managedSkillsDir: "/tmp/skills",
+      skills: [],
+    };
+    state.clawhubInstallSlug = "calendar";
+
+    reconcileSkillsAgentId(state, {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "project",
+      agents: [{ id: "main" }],
+    });
+
+    expect(state.skillsAgentId).toBeNull();
+    expect(state.skillsAgentRevision).toBe(1);
+    expect(state.skillsReport).toBeNull();
+    expect(state.clawhubInstallSlug).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -63,12 +63,15 @@ export type ClawHubSkillSecurityVerdict = {
 export type SkillsState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
+  skillsAgentId: string | null;
   skillsLoading: boolean;
   skillsReport: SkillStatusReport | null;
   skillsError: string | null;
   skillsBusyKey: string | null;
   skillEdits: Record<string, string>;
   skillMessages: SkillMessageMap;
+  skillsDetailKey: string | null;
+  skillsDetailTab: "overview" | "card";
   clawhubSearchQuery: string;
   clawhubSearchResults: ClawHubSearchResult[] | null;
   clawhubSearchLoading: boolean;
@@ -136,6 +139,11 @@ function currentSkillCardCacheKey(state: SkillsState, skillKey: string): string 
   return skill ? skillCardCacheKey(skill) : undefined;
 }
 
+function skillsAgentParams(state: Pick<SkillsState, "skillsAgentId">): { agentId?: string } {
+  const agentId = state.skillsAgentId?.trim();
+  return agentId ? { agentId } : {};
+}
+
 async function runStaleAwareRequest<T>(
   isCurrent: () => boolean,
   request: () => Promise<T>,
@@ -166,6 +174,30 @@ export function setClawHubSearchQuery(state: SkillsState, query: string) {
   state.clawhubSearchLoading = false;
 }
 
+export function setSkillsAgentId(state: SkillsState, agentId: string | null) {
+  const nextAgentId = agentId?.trim() || null;
+  if (state.skillsAgentId === nextAgentId) {
+    return;
+  }
+  state.skillsAgentId = nextAgentId;
+  state.skillsLoading = false;
+  state.skillsReport = null;
+  state.skillsError = null;
+  state.skillsBusyKey = null;
+  state.skillEdits = {};
+  state.skillMessages = {};
+  state.skillsDetailKey = null;
+  state.skillsDetailTab = "overview";
+  state.clawhubInstallMessage = null;
+  state.clawhubVerdicts = {};
+  state.clawhubVerdictsLoading = false;
+  state.clawhubVerdictsError = null;
+  state.skillCardContents = {};
+  state.skillCardContentKeys = {};
+  state.skillCardLoadingKey = null;
+  state.skillCardErrors = {};
+}
+
 export async function loadSkills(state: SkillsState, options?: { clearMessages?: boolean }) {
   if (options?.clearMessages && Object.keys(state.skillMessages).length > 0) {
     state.skillMessages = {};
@@ -173,19 +205,32 @@ export async function loadSkills(state: SkillsState, options?: { clearMessages?:
   if (!state.client || !state.connected || state.skillsLoading) {
     return;
   }
+  const requestedAgentId = state.skillsAgentId;
+  const requestParams = skillsAgentParams(state);
   state.skillsLoading = true;
   state.skillsError = null;
   try {
-    const res = await state.client.request<SkillStatusReport | undefined>("skills.status", {});
+    const res = await state.client.request<SkillStatusReport | undefined>(
+      "skills.status",
+      requestParams,
+    );
+    if (state.skillsAgentId !== requestedAgentId) {
+      return;
+    }
     if (res && Array.isArray(res.skills)) {
       state.skillsReport = res;
       pruneSkillCardState(state, res);
       void loadClawHubSecurityVerdicts(state, res);
     }
   } catch (err) {
+    if (state.skillsAgentId !== requestedAgentId) {
+      return;
+    }
     state.skillsError = getErrorMessage(err);
   } finally {
-    state.skillsLoading = false;
+    if (state.skillsAgentId === requestedAgentId) {
+      state.skillsLoading = false;
+    }
   }
 }
 
@@ -227,6 +272,8 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
   if (!cacheKey) {
     return;
   }
+  const requestedAgentId = state.skillsAgentId;
+  const requestParams = { ...skillsAgentParams(state), skillKey };
   state.skillCardLoadingKey = skillKey;
   const { [skillKey]: _previousError, ...nextErrors } = state.skillCardErrors;
   state.skillCardErrors = nextErrors;
@@ -237,8 +284,9 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
       path: string;
       sizeBytes: number;
       content: string;
-    }>("skills.skillCard", { skillKey });
+    }>("skills.skillCard", requestParams);
     if (
+      state.skillsAgentId === requestedAgentId &&
       response?.skillKey === skillKey &&
       typeof response.content === "string" &&
       currentSkillCardCacheKey(state, skillKey) === cacheKey
@@ -247,9 +295,11 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
       state.skillCardContentKeys = { ...state.skillCardContentKeys, [skillKey]: cacheKey };
     }
   } catch (err) {
-    state.skillCardErrors = { ...state.skillCardErrors, [skillKey]: getErrorMessage(err) };
+    if (state.skillsAgentId === requestedAgentId) {
+      state.skillCardErrors = { ...state.skillCardErrors, [skillKey]: getErrorMessage(err) };
+    }
   } finally {
-    if (state.skillCardLoadingKey === skillKey) {
+    if (state.skillsAgentId === requestedAgentId && state.skillCardLoadingKey === skillKey) {
       state.skillCardLoadingKey = null;
     }
   }
@@ -257,6 +307,7 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
 
 async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
   const client = state.client;
+  const requestedAgentId = state.skillsAgentId;
   if (!client || !state.connected || !reportHasLinkedClawHubSkills(report)) {
     state.clawhubVerdicts = {};
     state.clawhubVerdictsLoading = false;
@@ -269,7 +320,10 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
     const response = await client.request<{
       schema: "openclaw.skills.security-verdicts.v1";
       items: ClawHubSkillSecurityVerdict[];
-    }>("skills.securityVerdicts", {});
+    }>("skills.securityVerdicts", skillsAgentParams(state));
+    if (state.skillsAgentId !== requestedAgentId) {
+      return;
+    }
     state.clawhubVerdicts = Object.fromEntries(
       (response?.items ?? []).map((item) => [
         clawhubVerdictKey({
@@ -281,10 +335,15 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
       ]),
     );
   } catch (err) {
+    if (state.skillsAgentId !== requestedAgentId) {
+      return;
+    }
     state.clawhubVerdicts = {};
     state.clawhubVerdictsError = getErrorMessage(err);
   } finally {
-    state.clawhubVerdictsLoading = false;
+    if (state.skillsAgentId === requestedAgentId) {
+      state.clawhubVerdictsLoading = false;
+    }
   }
 }
 
@@ -349,6 +408,7 @@ export async function installSkill(
 ) {
   await runSkillMutation(state, skillKey, async (client) => {
     const result = await client.request<{ message?: string }>("skills.install", {
+      ...skillsAgentParams(state),
       name,
       installId,
       dangerouslyForceUnsafeInstall,
@@ -434,7 +494,11 @@ export async function installFromClawHub(state: SkillsState, slug: string) {
   state.clawhubInstallSlug = slug;
   state.clawhubInstallMessage = null;
   try {
-    await state.client.request("skills.install", { source: "clawhub", slug });
+    await state.client.request("skills.install", {
+      ...skillsAgentParams(state),
+      source: "clawhub",
+      slug,
+    });
     await loadSkills(state);
     state.clawhubInstallMessage = { kind: "success", text: `Installed ${slug}` };
   } catch (err) {

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -397,6 +397,7 @@ async function runSkillMutation(
   state: SkillsState,
   skillKey: string,
   run: (client: GatewayBrowserClient) => Promise<SkillMessage>,
+  options?: { refreshCurrentScopeOnStaleSuccess?: boolean },
 ) {
   const client = state.client;
   if (!client || !state.connected) {
@@ -408,6 +409,9 @@ async function runSkillMutation(
   try {
     const message = await run(client);
     if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      if (options?.refreshCurrentScopeOnStaleSuccess) {
+        await loadSkills(state);
+      }
       return;
     }
     await loadSkills(state);
@@ -433,24 +437,34 @@ async function runSkillMutation(
 }
 
 export async function updateSkillEnabled(state: SkillsState, skillKey: string, enabled: boolean) {
-  await runSkillMutation(state, skillKey, async (client) => {
-    await client.request("skills.update", { skillKey, enabled });
-    return {
-      kind: "success",
-      message: enabled ? "Skill enabled" : "Skill disabled",
-    };
-  });
+  await runSkillMutation(
+    state,
+    skillKey,
+    async (client) => {
+      await client.request("skills.update", { skillKey, enabled });
+      return {
+        kind: "success",
+        message: enabled ? "Skill enabled" : "Skill disabled",
+      };
+    },
+    { refreshCurrentScopeOnStaleSuccess: true },
+  );
 }
 
 export async function saveSkillApiKey(state: SkillsState, skillKey: string) {
-  await runSkillMutation(state, skillKey, async (client) => {
-    const apiKey = state.skillEdits[skillKey] ?? "";
-    await client.request("skills.update", { skillKey, apiKey });
-    return {
-      kind: "success",
-      message: `API key saved — stored in openclaw.json (skills.entries.${skillKey})`,
-    };
-  });
+  await runSkillMutation(
+    state,
+    skillKey,
+    async (client) => {
+      const apiKey = state.skillEdits[skillKey] ?? "";
+      await client.request("skills.update", { skillKey, apiKey });
+      return {
+        kind: "success",
+        message: `API key saved — stored in openclaw.json (skills.entries.${skillKey})`,
+      };
+    },
+    { refreshCurrentScopeOnStaleSuccess: true },
+  );
 }
 
 export async function installSkill(

--- a/ui/src/ui/controllers/skills.ts
+++ b/ui/src/ui/controllers/skills.ts
@@ -1,6 +1,11 @@
 // Control UI controller manages skills gateway state.
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { SkillClawHubLink, SkillStatusEntry, SkillStatusReport } from "../types.ts";
+import type {
+  AgentsListResult,
+  SkillClawHubLink,
+  SkillStatusEntry,
+  SkillStatusReport,
+} from "../types.ts";
 
 export type ClawHubSearchResult = {
   score: number;
@@ -64,6 +69,7 @@ export type SkillsState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
   skillsAgentId: string | null;
+  skillsAgentRevision: number;
   skillsLoading: boolean;
   skillsReport: SkillStatusReport | null;
   skillsError: string | null;
@@ -144,6 +150,27 @@ function skillsAgentParams(state: Pick<SkillsState, "skillsAgentId">): { agentId
   return agentId ? { agentId } : {};
 }
 
+type SkillsAgentScope = {
+  agentId: string | null;
+  revision: number;
+};
+
+function captureSkillsAgentScope(
+  state: Pick<SkillsState, "skillsAgentId" | "skillsAgentRevision">,
+): SkillsAgentScope {
+  return {
+    agentId: state.skillsAgentId,
+    revision: state.skillsAgentRevision,
+  };
+}
+
+function isSkillsAgentScopeCurrent(
+  state: Pick<SkillsState, "skillsAgentId" | "skillsAgentRevision">,
+  scope: SkillsAgentScope,
+): boolean {
+  return state.skillsAgentId === scope.agentId && state.skillsAgentRevision === scope.revision;
+}
+
 async function runStaleAwareRequest<T>(
   isCurrent: () => boolean,
   request: () => Promise<T>,
@@ -180,6 +207,7 @@ export function setSkillsAgentId(state: SkillsState, agentId: string | null) {
     return;
   }
   state.skillsAgentId = nextAgentId;
+  state.skillsAgentRevision++;
   state.skillsLoading = false;
   state.skillsReport = null;
   state.skillsError = null;
@@ -188,6 +216,7 @@ export function setSkillsAgentId(state: SkillsState, agentId: string | null) {
   state.skillMessages = {};
   state.skillsDetailKey = null;
   state.skillsDetailTab = "overview";
+  state.clawhubInstallSlug = null;
   state.clawhubInstallMessage = null;
   state.clawhubVerdicts = {};
   state.clawhubVerdictsLoading = false;
@@ -198,6 +227,19 @@ export function setSkillsAgentId(state: SkillsState, agentId: string | null) {
   state.skillCardErrors = {};
 }
 
+export function reconcileSkillsAgentId(
+  state: SkillsState,
+  agentsList: AgentsListResult | null | undefined,
+) {
+  if (
+    agentsList &&
+    state.skillsAgentId &&
+    !agentsList.agents.some((agent) => agent.id === state.skillsAgentId)
+  ) {
+    setSkillsAgentId(state, null);
+  }
+}
+
 export async function loadSkills(state: SkillsState, options?: { clearMessages?: boolean }) {
   if (options?.clearMessages && Object.keys(state.skillMessages).length > 0) {
     state.skillMessages = {};
@@ -205,7 +247,7 @@ export async function loadSkills(state: SkillsState, options?: { clearMessages?:
   if (!state.client || !state.connected || state.skillsLoading) {
     return;
   }
-  const requestedAgentId = state.skillsAgentId;
+  const agentScope = captureSkillsAgentScope(state);
   const requestParams = skillsAgentParams(state);
   state.skillsLoading = true;
   state.skillsError = null;
@@ -214,7 +256,7 @@ export async function loadSkills(state: SkillsState, options?: { clearMessages?:
       "skills.status",
       requestParams,
     );
-    if (state.skillsAgentId !== requestedAgentId) {
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;
     }
     if (res && Array.isArray(res.skills)) {
@@ -223,12 +265,12 @@ export async function loadSkills(state: SkillsState, options?: { clearMessages?:
       void loadClawHubSecurityVerdicts(state, res);
     }
   } catch (err) {
-    if (state.skillsAgentId !== requestedAgentId) {
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;
     }
     state.skillsError = getErrorMessage(err);
   } finally {
-    if (state.skillsAgentId === requestedAgentId) {
+    if (isSkillsAgentScopeCurrent(state, agentScope)) {
       state.skillsLoading = false;
     }
   }
@@ -272,7 +314,7 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
   if (!cacheKey) {
     return;
   }
-  const requestedAgentId = state.skillsAgentId;
+  const agentScope = captureSkillsAgentScope(state);
   const requestParams = { ...skillsAgentParams(state), skillKey };
   state.skillCardLoadingKey = skillKey;
   const { [skillKey]: _previousError, ...nextErrors } = state.skillCardErrors;
@@ -286,7 +328,7 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
       content: string;
     }>("skills.skillCard", requestParams);
     if (
-      state.skillsAgentId === requestedAgentId &&
+      isSkillsAgentScopeCurrent(state, agentScope) &&
       response?.skillKey === skillKey &&
       typeof response.content === "string" &&
       currentSkillCardCacheKey(state, skillKey) === cacheKey
@@ -295,11 +337,11 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
       state.skillCardContentKeys = { ...state.skillCardContentKeys, [skillKey]: cacheKey };
     }
   } catch (err) {
-    if (state.skillsAgentId === requestedAgentId) {
+    if (isSkillsAgentScopeCurrent(state, agentScope)) {
       state.skillCardErrors = { ...state.skillCardErrors, [skillKey]: getErrorMessage(err) };
     }
   } finally {
-    if (state.skillsAgentId === requestedAgentId && state.skillCardLoadingKey === skillKey) {
+    if (isSkillsAgentScopeCurrent(state, agentScope) && state.skillCardLoadingKey === skillKey) {
       state.skillCardLoadingKey = null;
     }
   }
@@ -307,7 +349,7 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
 
 async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
   const client = state.client;
-  const requestedAgentId = state.skillsAgentId;
+  const agentScope = captureSkillsAgentScope(state);
   if (!client || !state.connected || !reportHasLinkedClawHubSkills(report)) {
     state.clawhubVerdicts = {};
     state.clawhubVerdictsLoading = false;
@@ -321,7 +363,7 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
       schema: "openclaw.skills.security-verdicts.v1";
       items: ClawHubSkillSecurityVerdict[];
     }>("skills.securityVerdicts", skillsAgentParams(state));
-    if (state.skillsAgentId !== requestedAgentId) {
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;
     }
     state.clawhubVerdicts = Object.fromEntries(
@@ -335,13 +377,13 @@ async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStat
       ]),
     );
   } catch (err) {
-    if (state.skillsAgentId !== requestedAgentId) {
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
       return;
     }
     state.clawhubVerdicts = {};
     state.clawhubVerdictsError = getErrorMessage(err);
   } finally {
-    if (state.skillsAgentId === requestedAgentId) {
+    if (isSkillsAgentScopeCurrent(state, agentScope)) {
       state.clawhubVerdictsLoading = false;
     }
   }
@@ -360,13 +402,23 @@ async function runSkillMutation(
   if (!client || !state.connected) {
     return;
   }
+  const agentScope = captureSkillsAgentScope(state);
   state.skillsBusyKey = skillKey;
   state.skillsError = null;
   try {
     const message = await run(client);
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      return;
+    }
     await loadSkills(state);
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      return;
+    }
     setSkillMessage(state, skillKey, message);
   } catch (err) {
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      return;
+    }
     const message = getErrorMessage(err);
     state.skillsError = message;
     setSkillMessage(state, skillKey, {
@@ -374,7 +426,9 @@ async function runSkillMutation(
       message,
     });
   } finally {
-    state.skillsBusyKey = null;
+    if (isSkillsAgentScopeCurrent(state, agentScope) && state.skillsBusyKey === skillKey) {
+      state.skillsBusyKey = null;
+    }
   }
 }
 
@@ -491,6 +545,7 @@ export async function installFromClawHub(state: SkillsState, slug: string) {
   if (!state.client || !state.connected) {
     return;
   }
+  const agentScope = captureSkillsAgentScope(state);
   state.clawhubInstallSlug = slug;
   state.clawhubInstallMessage = null;
   try {
@@ -499,11 +554,21 @@ export async function installFromClawHub(state: SkillsState, slug: string) {
       source: "clawhub",
       slug,
     });
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      return;
+    }
     await loadSkills(state);
+    if (!isSkillsAgentScopeCurrent(state, agentScope)) {
+      return;
+    }
     state.clawhubInstallMessage = { kind: "success", text: `Installed ${slug}` };
   } catch (err) {
-    state.clawhubInstallMessage = { kind: "error", text: getErrorMessage(err) };
+    if (isSkillsAgentScopeCurrent(state, agentScope)) {
+      state.clawhubInstallMessage = { kind: "error", text: getErrorMessage(err) };
+    }
   } finally {
-    state.clawhubInstallSlug = null;
+    if (isSkillsAgentScopeCurrent(state, agentScope) && state.clawhubInstallSlug === slug) {
+      state.clawhubInstallSlug = null;
+    }
   }
 }

--- a/ui/src/ui/views/skills-shared.ts
+++ b/ui/src/ui/views/skills-shared.ts
@@ -19,7 +19,14 @@ export function computeSkillReasons(skill: SkillStatusEntry): string[] {
   if (skill.blockedByAllowlist) {
     reasons.push("blocked by allowlist");
   }
+  if (skill.blockedByAgentFilter) {
+    reasons.push("blocked by agent filter");
+  }
   return reasons;
+}
+
+export function isSkillAvailable(skill: SkillStatusEntry): boolean {
+  return skill.eligible && !skill.blockedByAgentFilter;
 }
 
 export function renderSkillStatusChips(params: {
@@ -27,13 +34,14 @@ export function renderSkillStatusChips(params: {
   showBundledBadge?: boolean;
 }) {
   const skill = params.skill;
+  const available = isSkillAvailable(skill);
   const showBundledBadge = Boolean(params.showBundledBadge);
   return html`
     <div class="chip-row" style="margin-top: 6px;">
       <span class="chip">${skill.source}</span>
       ${showBundledBadge ? html` <span class="chip">bundled</span> ` : nothing}
-      <span class="chip ${skill.eligible ? "chip-ok" : "chip-warn"}">
-        ${skill.eligible ? "eligible" : "blocked"}
+      <span class="chip ${available ? "chip-ok" : "chip-warn"}">
+        ${available ? "eligible" : "blocked"}
       </span>
       ${skill.disabled ? html` <span class="chip chip-warn">disabled</span> ` : nothing}
     </div>

--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -26,6 +26,7 @@ function createSkill(overrides: Partial<SkillStatusEntry> = {}): SkillStatusEntr
     always: false,
     disabled: false,
     blockedByAllowlist: false,
+    blockedByAgentFilter: false,
     eligible: true,
     requirements: {
       bins: [],
@@ -194,6 +195,39 @@ describe("renderSkills", () => {
     const updatedToggles = container.querySelectorAll<HTMLInputElement>(".skill-toggle");
     expect(updatedToggles).toHaveLength(1);
     expect(updatedToggles[0].checked).toBe(false);
+  });
+
+  it("treats skills blocked by the selected agent filter as needing setup", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    installDialogMethod("showModal", function (this: HTMLDialogElement) {
+      this.setAttribute("open", "");
+    });
+    const report: SkillStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/skills",
+      skills: [createSkill({ blockedByAgentFilter: true })],
+    };
+
+    render(renderSkills(createProps({ report, statusFilter: "ready" })), container);
+    await Promise.resolve();
+
+    expect(container.querySelectorAll(".list-item")).toHaveLength(0);
+    expect(normalizeText(container)).toContain("Ready0");
+    expect(normalizeText(container)).toContain("Needs Setup1");
+
+    render(
+      renderSkills(createProps({ report, statusFilter: "needs-setup", detailKey: "repo-skill" })),
+      container,
+    );
+    await Promise.resolve();
+
+    expect(container.querySelector(".list-item .statusDot")?.classList.contains("warn")).toBe(true);
+    expect(normalizeText(container)).toContain("Reason: blocked by agent filter");
+    expect(
+      Array.from(container.querySelectorAll(".chip")).map((chip) => normalizeText(chip)),
+    ).toContain("blocked");
   });
 
   it("defers detail dialog opening until the dialog is connected", async () => {

--- a/ui/src/ui/views/skills.test.ts
+++ b/ui/src/ui/views/skills.test.ts
@@ -2,7 +2,7 @@
 
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SkillStatusEntry, SkillStatusReport } from "../types.ts";
+import type { AgentsListResult, SkillStatusEntry, SkillStatusReport } from "../types.ts";
 import { renderSkills, type SkillsProps } from "./skills.ts";
 
 const dialogRestores: Array<() => void> = [];
@@ -51,11 +51,22 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
     managedSkillsDir: "/tmp/skills",
     skills: [createSkill()],
   };
+  const agentsList: AgentsListResult = {
+    defaultId: "main",
+    mainKey: "main",
+    scope: "project",
+    agents: [
+      { id: "main", name: "Main" },
+      { id: "research", identity: { name: "Research", avatar: "R" } },
+    ],
+  };
 
   return {
     connected: true,
     loading: false,
     report,
+    agentsList,
+    selectedAgentId: "main",
     error: null,
     filter: "",
     statusFilter: "all",
@@ -80,6 +91,7 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
     clawhubDetailError: null,
     clawhubInstallSlug: null,
     clawhubInstallMessage: null,
+    onAgentChange: () => undefined,
     onFilterChange: () => undefined,
     onStatusFilterChange: () => undefined,
     onRefresh: () => undefined,
@@ -104,6 +116,37 @@ describe("renderSkills", () => {
     while (dialogRestores.length > 0) {
       dialogRestores.pop()?.();
     }
+  });
+
+  it("renders the agent selector and routes agent changes", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+    const onAgentChange = vi.fn();
+
+    render(
+      renderSkills(
+        createProps({
+          selectedAgentId: "research",
+          onAgentChange,
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const selector = container.querySelector<HTMLSelectElement>('select[name="skills-agent"]');
+    expect(selector).toBeInstanceOf(HTMLSelectElement);
+    expect(selector?.value).toBe("research");
+    expect(Array.from(selector!.options).map((option) => option.textContent?.trim())).toEqual([
+      "Main (default)",
+      "Research",
+    ]);
+
+    selector!.value = "main";
+    selector!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(onAgentChange).toHaveBeenCalledWith("main");
   });
 
   it("does not transfer toggle state when a skill leaves the disabled tab", async () => {

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -20,6 +20,7 @@ import { groupSkills } from "./skills-grouping.ts";
 import {
   computeSkillMissing,
   computeSkillReasons,
+  isSkillAvailable,
   renderSkillStatusChips,
 } from "./skills-shared.ts";
 
@@ -109,9 +110,9 @@ function skillMatchesStatus(skill: SkillStatusEntry, status: SkillsStatusFilter)
     case "all":
       return true;
     case "ready":
-      return !skill.disabled && skill.eligible;
+      return !skill.disabled && isSkillAvailable(skill);
     case "needs-setup":
-      return !skill.disabled && !skill.eligible;
+      return !skill.disabled && !isSkillAvailable(skill);
     case "disabled":
       return skill.disabled;
   }
@@ -122,7 +123,7 @@ function skillStatusClass(skill: SkillStatusEntry): string {
   if (skill.disabled) {
     return "muted";
   }
-  return skill.eligible ? "ok" : "warn";
+  return isSkillAvailable(skill) ? "ok" : "warn";
 }
 
 function verdictForSkill(skill: SkillStatusEntry, verdicts: SkillsProps["clawhubVerdicts"]) {
@@ -194,7 +195,7 @@ export function renderSkills(props: SkillsProps) {
   for (const s of skills) {
     if (s.disabled) {
       statusCounts.disabled++;
-    } else if (s.eligible) {
+    } else if (isSkillAvailable(s)) {
       statusCounts.ready++;
     } else {
       statusCounts["needs-setup"]++;

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -266,7 +266,7 @@ export function renderSkills(props: SkillsProps) {
                 >
                   ${agents.map(
                     (agent) => html`
-                      <option value=${agent.id}>
+                      <option value=${agent.id} ?selected=${agent.id === selectedAgentId}>
                         ${agentOptionLabel(agent, props.agentsList?.defaultId)}
                       </option>
                     `,

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -15,7 +15,7 @@ import { clampText } from "../format.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
 import { resolveSafeExternalUrl } from "../open-external-url.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
-import type { SkillStatusEntry, SkillStatusReport } from "../types.ts";
+import type { AgentsListResult, SkillStatusEntry, SkillStatusReport } from "../types.ts";
 import { groupSkills } from "./skills-grouping.ts";
 import {
   computeSkillMissing,
@@ -52,6 +52,8 @@ export type SkillsProps = {
   connected: boolean;
   loading: boolean;
   report: SkillStatusReport | null;
+  agentsList: AgentsListResult | null;
+  selectedAgentId: string | null;
   error: string | null;
   filter: string;
   statusFilter: SkillsStatusFilter;
@@ -77,6 +79,7 @@ export type SkillsProps = {
   clawhubInstallSlug: string | null;
   clawhubInstallMessage: { kind: "success" | "error"; text: string } | null;
   onFilterChange: (next: string) => void;
+  onAgentChange: (agentId: string) => void;
   onStatusFilterChange: (next: SkillsStatusFilter) => void;
   onRefresh: () => void;
   onToggle: (skillKey: string, enabled: boolean) => void;
@@ -169,8 +172,18 @@ function verdictChipClass(verdict: ClawHubSkillSecurityVerdict | null | undefine
   return status === "pending" || status === "not-run" ? "chip" : "chip-warn";
 }
 
+type SkillsAgentOption = AgentsListResult["agents"][number];
+
+function agentOptionLabel(agent: SkillsAgentOption, defaultId: string | undefined): string {
+  const baseName = agent.identity?.name?.trim() || agent.name?.trim() || agent.id;
+  return agent.id === defaultId ? `${baseName} (default)` : baseName;
+}
+
 export function renderSkills(props: SkillsProps) {
   const skills = props.report?.skills ?? [];
+  const agents = props.agentsList?.agents ?? [];
+  const selectedAgentId =
+    props.selectedAgentId ?? props.agentsList?.defaultId ?? agents[0]?.id ?? "";
 
   const statusCounts: Record<SkillsStatusFilter, number> = {
     all: skills.length,
@@ -240,6 +253,28 @@ export function renderSkills(props: SkillsProps) {
         class="filters"
         style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 12px;"
       >
+        ${agents.length > 0
+          ? html`
+              <label class="field" style="min-width: 180px;">
+                <span>Agent</span>
+                <select
+                  name="skills-agent"
+                  .value=${selectedAgentId}
+                  ?disabled=${props.loading || !props.connected || agents.length < 2}
+                  @change=${(e: Event) =>
+                    props.onAgentChange((e.target as HTMLSelectElement).value)}
+                >
+                  ${agents.map(
+                    (agent) => html`
+                      <option value=${agent.id}>
+                        ${agentOptionLabel(agent, props.agentsList?.defaultId)}
+                      </option>
+                    `,
+                  )}
+                </select>
+              </label>
+            `
+          : nothing}
         <label class="field" style="flex: 1; min-width: 180px;">
           <input
             .value=${props.filter}


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Adds an agent selector to the top-level Skills page so multi-agent setups can inspect non-default agent workspace skills.
- Threads the selected `agentId` through skill status, Skill Card, ClawHub verdict, and install requests that are workspace-scoped.
- Prevents stale skill reports, Skill Card content, verdicts, messages, and unsaved API-key drafts from leaking across agent switches.

Why does this matter now?

- `skills.status` already supports `agentId`, and the Agents page can inspect selected-agent skills, but the top-level Skills page only requested the default agent workspace.

What is the intended outcome?

- Users can switch agents on the Skills page and see/manage the selected agent workspace's skills without opening the Agents page first.

What is intentionally out of scope?

- No redesign of `skills.entries` config semantics.
- No changes to the existing Agents page skills panel.
- No live ClawHub registry behavior change beyond routing install/update workspace selection when `agentId` is provided.

What does success look like?

- Selecting a non-default agent reloads the Skills page with that agent's workspace skills.
- Stale in-flight responses from a previous agent do not overwrite the current selected agent view.
- Skill installs target the selected agent workspace instead of always using the default workspace.

What should reviewers focus on?

- Selected-agent state reset in `ui/src/ui/controllers/skills.ts`.
- Top-level Skills page selector wiring in `ui/src/ui/views/skills.ts` and `ui/src/ui/app-render.ts`.
- Gateway routing for `skills.install` and ClawHub `skills.update` in `src/gateway/server-methods/skills.ts`.

## Linked context

Which issue does this close?

Closes #78553

Which issues, PRs, or discussions are related?

Related #84599

Was this requested by a maintainer or owner?

Requested through the OpenClaw issue queue for the multi-agent Skills page gap.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: top-level Skills page could only load default-agent workspace skills because the UI called `skills.status` without an agent selector.
- Real environment tested: local OpenClaw checkout using the real gateway `skills.status` handler with temporary `main` and `research` agent workspaces.
- Exact steps or command run after this patch: ran a `node --import tsx` script that created two temporary agent workspaces, wrote one workspace-only skill in each, called `skills.status` with `{}` and `{ agentId: "research" }`, and printed the selected-agent result below.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "defaultHasDefaultOnly": true,
  "defaultHasResearchOnly": false,
  "researchHasDefaultOnly": false,
  "researchHasResearchOnly": true,
  "selectedAgentShowsResearchOnly": true
}
```

- Observed result after fix: the explicit `research` agent request sees the research workspace-only skill and does not include the default workspace-only skill.
- What was not tested: live ClawHub network install against the public registry, and manual browser screenshot proof.
- Proof limitations or environment constraints: the behavior proof exercises the real gateway handler; browser UI behavior is covered by focused view/controller tests rather than a captured browser recording.
- Before evidence (optional but encouraged): before this patch, the top-level Skills controller requested `skills.status` with `{}` and had no selected-agent UI state.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs ui/src/ui/controllers/skills.test.ts ui/src/ui/views/skills.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts ui/src/ui/views/agents.test.ts src/gateway/server-methods/skills.clawhub.test.ts src/gateway/server-methods/skills-upload.test.ts src/gateway/server-methods/skills.update.normalizes-api-key.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --reporter=verbose ui/src/ui/views/skills.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build`
- `node --import tsx scripts/protocol-gen.ts`
- `node --import tsx scripts/protocol-gen-swift.ts`
- `git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
- `git diff --check`

What regression coverage was added or updated?

- Controller tests for selected-agent `skills.status`, `skills.securityVerdicts`, `skills.skillCard`, legacy install, and ClawHub install payloads.
- Controller test for ignoring stale skill reports after switching agents, including clearing unsaved skill edit drafts.
- View test for rendering the agent selector and routing selector changes.
- App settings test for loading agents before rendering the Skills tab selector.
- Gateway test for routing explicit-agent ClawHub installs to the selected agent workspace.

What failed before this fix, if known?

- The top-level Skills controller had no selected-agent state and always called `skills.status` with `{}`.

If no test was added, why not?

- Not applicable; focused regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes

Did config, environment, or migration behavior change? (`Yes/No`)

No migration or config file behavior change. The gateway protocol now accepts optional `agentId` on workspace-scoped skill install and ClawHub update requests.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. Skill install execution can now target an explicitly selected configured agent workspace.

What is the highest-risk area?

- Routing a selected-agent install/update to the wrong workspace, or carrying stale UI state between agents.

How is that risk mitigated?

- Explicit `agentId` is validated against configured agents before resolving the workspace.
- Agent switches clear stale reports, messages, verdicts, Skill Card caches, and unsaved API-key drafts.
- Focused UI controller and gateway tests cover selected-agent request payloads and workspace routing.

## Current review state

What is the next action?

- CI rerun and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI after the follow-up commit that fixes the `check-test-types` and browser UI test failures.

Which bot or reviewer comments were addressed?

- Local autoreview found that unsaved skill edit drafts could bleed across agent switches; this was addressed by clearing `skillEdits` when the selected Skills agent changes.
- CI `check-test-types` failed on typed test mocks; the mocks now use explicit signatures instead of spreading `unknown[]`.
- CI `checks-node-core-runtime-media-ui` failed because the browser shard kept the first `<option>` selected; options now set `?selected` from the selected agent id.
