### PR TITLE
Add ClawHub content rights docs to sidebar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1385,7 +1385,8 @@
                 "pages": [
                   "clawhub/api",
                   "clawhub/http-api",
-                  "clawhub/acceptable-usage"
+                  "clawhub/acceptable-usage",
+                  "clawhub/content-rights"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary

- Adds `clawhub/content-rights` to the ClawHub docs sidebar under `API and trust`.

## Verification

```bash
pnpm docs:list
pnpm check:docs
```

Both commands passed. `pnpm check:docs` synced the ClawHub docs source and verified no broken internal links.

## Notes

- Companion ClawHub docs copy PR should land first or alongside this PR so the synced page is available when the docs sidebar is published.
