### PR TITLE
fix(cron): clear delivery routing fields from cron edit

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -465,7 +465,7 @@ openclaw cron edit <jobId> --clear-agent
 
 `openclaw cron run <jobId>` returns after enqueueing the manual run. Use `--wait` for shutdown hooks, maintenance scripts, or other automation that must block until the queued run finishes. Wait mode polls the exact returned `runId`; it exits `0` for status `ok` and non-zero for `error`, `skipped`, or a wait timeout.
 
-`openclaw cron create` is an alias for `openclaw cron add`, and new jobs can use a positional schedule (`"0 9 * * 1"`, `"every 1h"`, `"20m"`, or an ISO timestamp) followed by a positional agent prompt. Use `--webhook <url>` on `cron add|create` or `cron edit` to POST the finished run payload to an HTTP endpoint. Webhook delivery cannot be combined with chat delivery flags such as `--announce`, `--channel`, `--to`, `--thread-id`, or `--account`.
+`openclaw cron create` is an alias for `openclaw cron add`, and new jobs can use a positional schedule (`"0 9 * * 1"`, `"every 1h"`, `"20m"`, or an ISO timestamp) followed by a positional agent prompt. Use `--webhook <url>` on `cron add|create` or `cron edit` to POST the finished run payload to an HTTP endpoint. Webhook delivery cannot be combined with chat delivery flags such as `--announce`, `--channel`, `--to`, `--thread-id`, or `--account`. On `cron edit`, `--clear-channel`, `--clear-to`, `--clear-thread-id`, and `--clear-account` unset those routing fields individually (each rejected alongside its matching set flag), which is distinct from `--no-deliver` disabling runner fallback delivery.
 
 <Note>
 Model override note:

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -93,6 +93,8 @@ Isolated cron chat delivery is shared between the agent and the runner:
 
 Use `cron add|create --webhook <url>` or `cron edit <job-id> --webhook <url>` to set webhook delivery. Do not combine `--webhook` with chat delivery flags such as `--announce`, `--no-deliver`, `--channel`, `--to`, `--thread-id`, or `--account`.
 
+`cron edit <job-id>` can unset individual delivery routing fields with `--clear-channel`, `--clear-to`, `--clear-thread-id`, and `--clear-account` (each is rejected when combined with its matching set flag). Unlike `--no-deliver`, which only disables runner fallback delivery, these remove the stored field so the job resolves that part of its route from defaults again.
+
 `--announce` is runner fallback delivery for the final reply. `--no-deliver` disables that fallback but does not remove the agent's `message` tool when a chat route is available.
 
 Reminders created from an active chat preserve the live chat delivery target for fallback announce delivery. Internal session keys may be lowercase; do not use them as a source of truth for case-sensitive provider IDs such as Matrix room IDs.

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -1,6 +1,7 @@
 // Cron edit register tests cover cron edit command registration and option wiring.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
 
 const callGatewayFromCli = vi.fn();
 
@@ -227,5 +228,115 @@ describe("cron edit command", () => {
 
     expect(help).toContain("--clear-model");
     expect(help).toContain("--clear-tools");
+  });
+
+  it("clears the delivery channel with --clear-channel (CLI parity with cron.update channel:null)", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-channel"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearChannel: true }),
+      {
+        id: "job-1",
+        patch: { delivery: { channel: null } },
+      },
+    );
+  });
+
+  it("clears the delivery destination with --clear-to", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-to"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearTo: true }),
+      {
+        id: "job-1",
+        patch: { delivery: { to: null } },
+      },
+    );
+  });
+
+  it("clears the delivery thread id with --clear-thread-id", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-thread-id"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearThreadId: true }),
+      {
+        id: "job-1",
+        patch: { delivery: { threadId: null } },
+      },
+    );
+  });
+
+  it("clears the delivery account override with --clear-account", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-account"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearAccount: true }),
+      {
+        id: "job-1",
+        patch: { delivery: { accountId: null } },
+      },
+    );
+  });
+
+  it.each([
+    { set: "--channel", value: "telegram", clear: "--clear-channel" },
+    { set: "--to", value: "12345", clear: "--clear-to" },
+    { set: "--thread-id", value: "42", clear: "--clear-thread-id" },
+    { set: "--account", value: "writer", clear: "--clear-account" },
+  ])("rejects $set combined with $clear", async ({ set, value, clear }) => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", set, value, clear], { from: "user" });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`Use ${set} or ${clear}, not both`),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("rejects --webhook combined with a delivery clear flag", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const program = createCronProgram();
+
+    await program.parseAsync(
+      ["edit", "job-1", "--webhook", "https://example.invalid/hook", "--clear-channel"],
+      { from: "user" },
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("--webhook cannot be combined with chat delivery options."),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("documents the delivery clear flags alongside the sibling --clear-model", () => {
+    const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");
+    const help = editCommand?.helpInformation() ?? "";
+
+    expect(help).toContain("--clear-channel");
+    expect(help).toContain("--clear-to");
+    expect(help).toContain("--clear-thread-id");
+    expect(help).toContain("--clear-account");
   });
 });

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -87,10 +87,7 @@ export function registerCronEditCommand(cron: Command) {
       .option("--session-key <key>", "Set session key for job routing")
       .option("--clear-session-key", "Unset session key", false)
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)")
-      .option(
-        "--at <when>",
-        "Set one-shot time (ISO, offset-less uses --tz) or duration like 20m",
-      )
+      .option("--at <when>", "Set one-shot time (ISO, offset-less uses --tz) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
       .option(
@@ -138,6 +135,10 @@ export function registerCronEditCommand(cron: Command) {
       )
       .option("--thread-id <id>", "Telegram forum topic thread id")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
+      .option("--clear-channel", "Unset the delivery channel", false)
+      .option("--clear-to", "Unset the delivery destination", false)
+      .option("--clear-thread-id", "Unset the Telegram forum topic thread id", false)
+      .option("--clear-account", "Unset the per-job delivery account override", false)
       .option(
         "--best-effort-deliver",
         "Do not fail job if delivery fails (also implies --announce when used alone)",
@@ -322,11 +323,28 @@ export function registerCronEditCommand(cron: Command) {
           const threadId = parseCronThreadIdOption(opts.threadId);
           const hasDeliveryThreadId = typeof threadId === "number";
           const hasDeliveryTarget =
-            typeof opts.channel === "string" || typeof opts.to === "string" || hasDeliveryThreadId;
-          const hasDeliveryAccount = typeof opts.account === "string";
+            typeof opts.channel === "string" ||
+            typeof opts.to === "string" ||
+            hasDeliveryThreadId ||
+            Boolean(opts.clearChannel) ||
+            Boolean(opts.clearTo) ||
+            Boolean(opts.clearThreadId);
+          const hasDeliveryAccount = typeof opts.account === "string" || Boolean(opts.clearAccount);
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
           if (hasWebhookDelivery && (hasDeliveryTarget || hasDeliveryAccount)) {
             throw new Error("--webhook cannot be combined with chat delivery options.");
+          }
+          if (typeof opts.channel === "string" && opts.clearChannel) {
+            throw new Error("Use --channel or --clear-channel, not both");
+          }
+          if (typeof opts.to === "string" && opts.clearTo) {
+            throw new Error("Use --to or --clear-to, not both");
+          }
+          if (hasDeliveryThreadId && opts.clearThreadId) {
+            throw new Error("Use --thread-id or --clear-thread-id, not both");
+          }
+          if (typeof opts.account === "string" && opts.clearAccount) {
+            throw new Error("Use --account or --clear-account, not both");
           }
           const hasCommandSpecificPayloadField =
             Boolean(commandShell) ||
@@ -444,21 +462,29 @@ export function registerCronEditCommand(cron: Command) {
               // Back-compat: best-effort true and payload edits historically implied announce mode.
               delivery.mode = "announce";
             }
-            if (typeof opts.channel === "string") {
+            if (opts.clearChannel) {
+              delivery.channel = null;
+            } else if (typeof opts.channel === "string") {
               const channel = opts.channel.trim();
               delivery.channel = channel ? channel : undefined;
             }
             if (hasWebhookDelivery) {
               const webhook = normalizeOptionalString(opts.webhook) ?? "";
               delivery.to = webhook ? webhook : undefined;
+            } else if (opts.clearTo) {
+              delivery.to = null;
             } else if (typeof opts.to === "string") {
               const to = opts.to.trim();
               delivery.to = to ? to : undefined;
             }
-            if (hasDeliveryThreadId) {
+            if (opts.clearThreadId) {
+              delivery.threadId = null;
+            } else if (hasDeliveryThreadId) {
               delivery.threadId = threadId;
             }
-            if (typeof opts.account === "string") {
+            if (opts.clearAccount) {
+              delivery.accountId = null;
+            } else if (typeof opts.account === "string") {
               const account = opts.account.trim();
               delivery.accountId = account ? account : undefined;
             }

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -68,6 +68,16 @@ describe("applyJobPatch delivery merge", () => {
     expect(job.delivery).toEqual({ mode: "announce" });
   });
 
+  it("preserves implicit delivery when clearing an absent override", () => {
+    const job = makeJob({ delivery: undefined });
+
+    applyJobPatch(job, {
+      delivery: { channel: null },
+    });
+
+    expect(job.delivery).toBeUndefined();
+  });
+
   it("clears nullable failure destination fields", () => {
     const job = makeJob({
       delivery: {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1012,7 +1012,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
 function mergeCronDelivery(
   existing: CronDelivery | undefined,
   patch: CronDeliveryPatch,
-): CronDelivery {
+): CronDelivery | undefined {
   const hasCompletionDestinationPatch = "completionDestination" in patch;
   const next: CronDelivery = {
     mode: existing?.mode ?? "none",
@@ -1114,6 +1114,22 @@ function mergeCronDelivery(
         Object.hasOwn(nextFd, "mode");
       next.failureDestination = hasFailureDestination ? nextFd : undefined;
     }
+  }
+
+  if (
+    existing === undefined &&
+    !("mode" in patch) &&
+    next.mode === "none" &&
+    next.channel === undefined &&
+    next.to === undefined &&
+    next.threadId === undefined &&
+    next.accountId === undefined &&
+    next.bestEffort === undefined &&
+    next.completionDestination === undefined &&
+    next.failureDestination === undefined
+  ) {
+    // Clearing an absent override must preserve implicit detached-job delivery.
+    return undefined;
   }
 
   return next;

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -185,9 +185,16 @@ function assertValidCronUpdatePatch(params: {
     defaultAgentId: params.defaultAgentId,
   });
   if ("delivery" in params.patch) {
+    const delivery =
+      params.patch.delivery?.channel === null &&
+      nextJob.delivery &&
+      (nextJob.delivery.mode ?? "announce") === "announce" &&
+      nextJob.delivery.channel === undefined
+        ? { ...nextJob.delivery, channel: "last" as const }
+        : nextJob.delivery;
     assertValidCronAnnounceDelivery({
       cfg: params.cfg,
-      delivery: nextJob.delivery,
+      delivery,
     });
   }
 }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -189,7 +189,8 @@ function assertValidCronUpdatePatch(params: {
       params.patch.delivery?.channel === null &&
       nextJob.delivery &&
       (nextJob.delivery.mode ?? "announce") === "announce" &&
-      nextJob.delivery.channel === undefined
+      nextJob.delivery.channel === undefined &&
+      resolveTargetPrefixedChannel(nextJob.delivery.to) === undefined
         ? { ...nextJob.delivery, channel: "last" as const }
         : nextJob.delivery;
     assertValidCronAnnounceDelivery({

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -599,6 +599,20 @@ describe("cron method validation", () => {
     expectResponseError(respond, { messageIncludes: "belongs to telegram, not slack" });
   });
 
+  it("accepts clearing an explicit channel back to runtime last", async () => {
+    setRuntimeConfig(telegramSlackConfig());
+
+    const { context, respond } = await invokeCronUpdateDelivery(
+      { channel: null },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      }),
+    );
+
+    expect(context.cron.update).toHaveBeenCalled();
+    expectCronSuccess(respond);
+  });
+
   it("accepts completion webhook delivery patches and nullable clears", async () => {
     const currentJob = createCronJob({
       delivery: { mode: "announce" },

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -613,6 +613,20 @@ describe("cron method validation", () => {
     expectCronSuccess(respond);
   });
 
+  it("validates a provider-prefixed target when clearing its explicit channel", async () => {
+    setRuntimeConfig(slackConfig());
+
+    const { context, respond } = await invokeCronUpdateDelivery(
+      { channel: null },
+      createCronJob({
+        delivery: { mode: "announce", channel: "telegram", to: "telegram:123" },
+      }),
+    );
+
+    expect(context.cron.update).not.toHaveBeenCalled();
+    expectResponseError(respond, { messageIncludes: "delivery.channel must be one of: slack" });
+  });
+
   it("accepts completion webhook delivery patches and nullable clears", async () => {
     const currentJob = createCronJob({
       delivery: { mode: "announce" },


### PR DESCRIPTION
## Summary

`openclaw cron edit` can **set** delivery routing fields (`--channel`, `--to`, `--thread-id`, `--account`) but had **no way to unset them**. Passing an empty value such as `--to ""` builds `delivery.to = undefined`, which is dropped from the JSON-RPC patch, so `mergeCronDelivery` never sees the key and the field is silently kept — a no-op.

The gateway RPC already supports clearing each field via an explicit `null`: `CronDeliveryPatchSchema` allows `null` for `channel` / `to` / `threadId` / `accountId`, and `mergeCronDelivery` clears via `normalizeOptionalString(null) -> undefined`. The CLI just never sent it.

This adds `--clear-channel`, `--clear-to`, `--clear-thread-id`, and `--clear-account` to `cron edit`, each emitting an explicit `null` — the same shape as the existing `--clear-model` and `--clear-tools` flags. Each is mutually exclusive with its matching set flag and with `--webhook` (chat delivery is rejected in webhook mode).

### Changes
- `src/cli/cron-cli/register.cron-edit.ts` — the four flags, conflict guards, and the null-emitting delivery patch build
- `src/cli/cron-cli/register.cron-edit.test.ts` — happy-path null patches, table-driven set/clear conflicts, `--webhook` + clear rejection, help listing
- `docs/cli/cron.md`, `docs/automation/cron-jobs.md` — document the new flags

## Real behavior proof

Behavior addressed: `openclaw cron edit` could not unset delivery `channel` / `to` / `thread-id` / `account`; an empty value is JSON-dropped and silently kept. The new `--clear-*` flags clear each field via an explicit `null`.

Real environment tested: local dev gateway built from this branch (`gateway run --dev --auth none --port 4599`), Node 22.22.1, isolated `OPENCLAW_STATE_DIR` / `OPENCLAW_HOME`, no auth and no model / provider / channel credentials — pure cron RPC.

Exact steps or command run after this patch:
```bash
openclaw cron add "every 1h" "proof noop" --name clrproof --session isolated \
  --announce --to "tg:12345" --account "writer-acct" --thread-id 42   # -> job id ac039601...
openclaw cron edit ac039601... --to "" --account ""        # pre-existing empty-string no-op
openclaw cron edit ac039601... --clear-account
openclaw cron edit ac039601... --clear-to --clear-thread-id
openclaw cron edit ac039601... --clear-channel
openclaw cron edit ac039601... --account x --clear-account # conflict guard
# delivery inspected with `openclaw cron get ac039601...` after each step
```

Evidence after fix (the `delivery` object from `cron get` after each step):
```
INITIAL                              {mode:announce, channel:last, to:tg:12345, threadId:42, accountId:writer-acct}
edit --to "" --account ""            {mode:announce, channel:last, to:tg:12345, threadId:42, accountId:writer-acct}   (unchanged - the pre-existing no-op)
edit --clear-account                 {mode:announce, channel:last, to:tg:12345, threadId:42}
edit --clear-to --clear-thread-id    {mode:announce, channel:last}
edit --clear-channel                 {mode:announce}
edit --account x --clear-account     Error: Use --account or --clear-account, not both
```

Observed result after fix: each `--clear-*` flag removes exactly its target field and leaves the others intact; empty-string args remain a no-op so existing behavior is unchanged; the set/clear conflict guard rejects the combination before any RPC call.

What was not tested: live message delivery to a real chat channel — clearing is a stored-config patch verified through `cron get`; no telegram/discord credentials were configured and no agent/model run was performed, which is out of scope for a config-patch change.

## Additional checks

The 19 cases in `register.cron-edit.test.ts` cover each `--clear-*` flag's `null` patch, the four set/clear conflicts, the `--webhook` + clear rejection, and the help listing. Formatter, static analysis, and type checks all pass for the changed files.
