### PR TITLE
fix(gateway): rotate already-stale generated transcript filename on /reset

### DIFF
--- a/src/gateway/drain-active-sessions-for-shutdown.test.ts
+++ b/src/gateway/drain-active-sessions-for-shutdown.test.ts
@@ -29,6 +29,7 @@ vi.mock("../plugins/hook-runner-global.js", () => ({
 }));
 
 vi.mock("./session-transcript-files.fs.js", () => ({
+  extractGeneratedTranscriptSessionId: vi.fn(() => undefined),
   resolveStableSessionEndTranscript: vi.fn(() => ({
     sessionFile: undefined,
     transcriptArchived: false,

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -372,6 +372,56 @@ test("sessions.reset rotates generated topic transcript files with the new sessi
   expect(path.basename(persistedEntry?.sessionFile ?? "")).toBe(`${nextSessionId}-topic-456.jsonl`);
 });
 
+test("sessions.reset rotates an already-stale generated transcript file to the new session id", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  // Post-upgrade state: the stored sessionFile still embeds an OLDER generated id
+  // that no longer matches the entry's logical sessionId, so rotation must key off
+  // the file's embedded id rather than the current sessionId (issue #77770).
+  const staleFileSessionId = "11111111-1111-4111-8111-111111111111";
+  const currentSessionId = "22222222-2222-4222-8222-222222222222";
+  const staleSessionFile = path.join(dir, `${staleFileSessionId}.jsonl`);
+  await fs.writeFile(staleSessionFile, `${JSON.stringify({ role: "user", content: "old" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry(currentSessionId, {
+        sessionFile: staleSessionFile,
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+    };
+  }>("sessions.reset", { key: "main" });
+
+  expect(reset.ok).toBe(true);
+  const nextSessionId = reset.payload?.entry.sessionId;
+  const nextSessionFile = reset.payload?.entry.sessionFile;
+  if (!nextSessionId || !nextSessionFile) {
+    throw new Error("expected reset session id and file");
+  }
+  expect(nextSessionId).not.toBe(currentSessionId);
+  // The new session must adopt the new session id, not keep the stale generated name.
+  expect(path.basename(nextSessionFile)).toBe(`${nextSessionId}.jsonl`);
+  expect(path.basename(nextSessionFile)).not.toBe(`${staleFileSessionId}.jsonl`);
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      sessionId?: string;
+      sessionFile?: string;
+    }
+  >;
+  const persistedEntry = store["agent:main:main"];
+  expect(persistedEntry?.sessionId).toBe(nextSessionId);
+  expect(path.basename(persistedEntry?.sessionFile ?? "")).toBe(`${nextSessionId}.jsonl`);
+});
+
 test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
   await expectMainResetModelFields({
     defaultPrimary: "openai/gpt-test-a",

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -61,6 +61,7 @@ import {
 import { findDirectChildSessionsForParent } from "./session-child-sessions.js";
 import {
   archiveSessionTranscriptsDetailed,
+  extractGeneratedTranscriptSessionId,
   resolveStableSessionEndTranscript,
   type ArchivedSessionTranscript,
 } from "./session-transcript-files.fs.js";
@@ -82,12 +83,16 @@ function resolveResetSessionFile(params: {
   agentId: string;
 }): string {
   const currentEntry = params.currentEntry;
-  // Preserve explicit session-file placement across reset while swapping the
-  // embedded session id, so linked runtimes keep writing beside old transcripts.
-  const rewrittenSessionFile = currentEntry?.sessionId
+  // Rotate generated transcript names by the file's *embedded* id, not the logical
+  // session id: a post-upgrade sessionFile can embed a stale id, so keying off
+  // currentEntry.sessionId would orphan the reset session on the old file. Explicit
+  // custom placements have no embedded id and stay preserved.
+  const rotationPreviousSessionId =
+    extractGeneratedTranscriptSessionId(currentEntry?.sessionFile) ?? currentEntry?.sessionId;
+  const rewrittenSessionFile = rotationPreviousSessionId
     ? rewriteSessionFileForNewSessionId({
-        sessionFile: currentEntry.sessionFile,
-        previousSessionId: currentEntry.sessionId,
+        sessionFile: currentEntry?.sessionFile,
+        previousSessionId: rotationPreviousSessionId,
         nextSessionId: params.nextSessionId,
       })
     : undefined;

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -106,7 +106,7 @@ function classifySessionTranscriptCandidate(
   return transcriptSessionId === sessionId ? "current" : "stale";
 }
 
-function extractGeneratedTranscriptSessionId(sessionFile?: string): string | undefined {
+export function extractGeneratedTranscriptSessionId(sessionFile?: string): string | undefined {
   const trimmed = sessionFile?.trim();
   if (!trimmed) {
     return undefined;


### PR DESCRIPTION
> **AI-assisted PR.** Implemented and verified with Claude (Claude Code). I have reviewed and understand the change and own the final diff.

## Summary

Gateway session `/reset` mints a new session id but, when the stored `sessionFile` basename still embeds a generated id that *differs* from the entry's logical `sessionId` (the post-upgrade "already-stale" state), keeps the new session writing to the old `<stale-id>.jsonl`. The old transcript is archived as `<stale-id>.jsonl.reset.<ts>`, yet the new active transcript reuses the stale filename even though its header carries the *new* session id.

`resolveResetSessionFile` rotated the filename via `rewriteSessionFileForNewSessionId({ previousSessionId: currentEntry.sessionId })`, which only matches when the basename equals the current logical id. This change keys rotation off the file's **actual embedded id** using the existing `extractGeneratedTranscriptSessionId` classifier, so already-stale generated names rotate too. Explicit custom transcript paths have no embedded id and are preserved unchanged.

- Surface: `src/gateway/session-reset-service.ts` (`resolveResetSessionFile`); exports `extractGeneratedTranscriptSessionId` from `src/gateway/session-transcript-files.fs.ts`.
- Runtime correctness only — no config / migration / security surface.

Refs #77770

## Real behavior proof

**Behavior addressed:** TUI/Gateway `/reset` reused a stale generated transcript filename (`<old-id>.jsonl`) for the new session when the stored `sessionFile` embedded an id different from the entry's logical `sessionId`, so the new session id in the transcript header no longer matched its filename.

**Real environment tested:** macOS (darwin 25.5.0), repo Node toolchain. Drove the production gateway reset entry point `performGatewaySessionReset` (the exact function `sessions.reset` / TUI `/reset` invoke) against a real on-disk session store under a throwaway `OPENCLAW_HOME`. No mocks, no test harness.

**Exact steps or command run after this patch:**
1. Seed a real `sessions.json` at `<state>/agents/main/sessions/` in the post-upgrade stale state: entry `agent:main:main` = `{ sessionId: 2222…, sessionFile: <dir>/1111….jsonl }`, with the real `1111….jsonl` transcript on disk.
2. Call the real `performGatewaySessionReset({ key: "main", reason: "reset", commandSource: "proof:77770" })`.
3. Read back `sessions.json` and list the sessions dir.

Run as `OPENCLAW_HOME=<tmp> node_modules/.bin/tsx driver.mts` from the repo root (driver reproduced below).

**Evidence after fix:**
```
== BEFORE /reset ==
  logical sessionId : 22222222-2222-4222-8222-222222222222
  active sessionFile: 11111111-1111-4111-8111-111111111111.jsonl   <-- embeds STALE id
== sessions.reset result ==  ok: true
  new sessionId     : 4381e912-5b6f-45bb-a36a-3ef373b3cd34
  new sessionFile   : 4381e912-5b6f-45bb-a36a-3ef373b3cd34.jsonl
== AFTER /reset (on disk) ==
  active sessionFile: 4381e912-5b6f-45bb-a36a-3ef373b3cd34.jsonl
  sessions dir      : [ '11111111-...jsonl.reset.2026-06-16T04-35-34.469Z',
                        '4381e912-...jsonl', 'sessions.json' ]
== VERDICT: ROTATED to new session id (FIXED) ==
```

Same driver on current `main` (before this patch):
```
== sessions.reset result ==  ok: true
  new sessionId     : 525b3ae9-0090-493a-8219-f353b9a38ba2
  new sessionFile   : 11111111-1111-4111-8111-111111111111.jsonl   <-- NOT rotated
== AFTER /reset (on disk) ==
  active sessionFile: 11111111-1111-4111-8111-111111111111.jsonl
== VERDICT: STILL STALE -- BUG ==
```

**Observed result after fix:** the new session's active transcript filename matches its new session id (`<new-id>.jsonl`) and the stale file is archived as `<old-id>.jsonl.reset.<ts>`. On `main` the active transcript stays `<old-id>.jsonl` while the header id advances — reproducing the report.

**What was not tested:** I drove the gateway reset runtime directly rather than typing `/reset` in the interactive TUI (the TUI is a thin client issuing exactly this `sessions.reset` call). Topic/fork stale variants are covered by unit tests only; no live channel was exercised.

## Tests and validation

- `pnpm test src/gateway/server.sessions.reset-models.test.ts` → **18 passed**, including a new stale-embedded-id rotation case. The new test is **red** on both gateway shards without the source fix and **green** with it (verified by reverting the fix).
- `pnpm tsgo:core` ✓ · `pnpm tsgo:test:src` ✓ · `pnpm exec oxfmt --check` ✓ · `oxlint` ✓ · core-boundary + session-accessor-boundary guards ✓.

## Risk / scope

Bounded runtime fix: one function plus one new export, reusing the existing `extractGeneratedTranscriptSessionId` classifier (no duplicated grammar). Custom transcript placements are unaffected (covered by the existing ownership-metadata test). No config, migration, or security surface touched.

<details><summary>Proof driver (driver.mts)</summary>

```ts
import fs from "node:fs";
import path from "node:path";
import { resolveDefaultSessionStorePath } from "<repo>/src/config/sessions/paths.js";
import { performGatewaySessionReset } from "<repo>/src/gateway/session-reset-service.js";

const storePath = resolveDefaultSessionStorePath();
const sessionsDir = path.dirname(storePath);
fs.mkdirSync(sessionsDir, { recursive: true });

const staleFileId = "11111111-1111-4111-8111-111111111111";
const currentId = "22222222-2222-4222-8222-222222222222";
const staleFile = path.join(sessionsDir, `${staleFileId}.jsonl`);
fs.writeFileSync(staleFile, `${JSON.stringify({ type: "session-header", sessionId: currentId })}\n`);
fs.writeFileSync(storePath, JSON.stringify({
  "agent:main:main": { sessionId: currentId, sessionFile: staleFile, updatedAt: Date.now() },
}, null, 2));

const result = await performGatewaySessionReset({ key: "main", reason: "reset", commandSource: "proof:77770" });
// ...read back sessions.json + list sessionsDir, compare basename to `${result.entry.sessionId}.jsonl`
```
</details>
