### PR TITLE
fix(cron): dedupe legacy migration by schedule identity

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -476,6 +476,125 @@ describe("maybeRepairLegacyCronStore", () => {
     expectNoteContaining("Cron store migrated to SQLite", "Doctor changes");
   });
 
+  it("skips legacy jobs that already exist in SQLite under a renamed schedule identity", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({
+        id: "brief-today-morning",
+        name: "Brief today morning",
+        schedule: { kind: "cron", expr: "5 8 * * 1-5", tz: "Australia/Sydney" },
+      }),
+    ]);
+    await writeCronStore(storePath, [
+      createLegacyCronJob({
+        jobId: "daily-briefing-page-morning",
+        name: "Daily briefing page morning",
+        schedule: { kind: "cron", cron: "5 8 * * 1-5", tz: "Australia/Sydney" },
+      }),
+      createLegacyCronJob({
+        jobId: "legacy-only",
+        name: "Legacy only",
+        schedule: { kind: "cron", cron: "0 12 * * *", tz: "Australia/Sydney" },
+      }),
+    ]);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const jobs = await readPersistedJobs(storePath);
+    expect(jobs).toHaveLength(2);
+    expect(jobs.map((job) => job.id)).toEqual(["brief-today-morning", "legacy-only"]);
+    expect(jobs.map((job) => job.name)).toEqual(["Brief today morning", "Legacy only"]);
+    expectNoteContaining("1 legacy JSON cron job will be imported into SQLite", "Cron");
+    expectNoteContaining("Cron store migrated to SQLite", "Doctor changes");
+  });
+
+  it("removes SQLite duplicates imported from an archived legacy store when a replacement exists", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({
+        id: "brief-today-morning",
+        name: "Brief today morning",
+        schedule: { kind: "cron", expr: "5 8 * * 1-5", tz: "Australia/Melbourne" },
+        createdAtMs: Date.parse("2026-06-15T03:31:50.417Z"),
+        updatedAtMs: Date.parse("2026-06-15T03:31:50.417Z"),
+      }),
+      createCurrentCronJob({
+        id: "daily-briefing-dashboard-morning",
+        name: "Daily briefing dashboard morning",
+        schedule: { kind: "cron", expr: "5 8 * * 1-5", tz: "Australia/Melbourne" },
+        createdAtMs: Date.parse("2026-06-10T01:07:54.331Z"),
+        updatedAtMs: Date.parse("2026-06-10T01:07:54.331Z"),
+      }),
+    ]);
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      `${storePath}.migrated`,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            createLegacyCronJob({
+              jobId: "daily-briefing-dashboard-morning",
+              name: "Daily briefing dashboard morning",
+              schedule: { kind: "cron", cron: "5 8 * * 1-5", tz: "Australia/Melbourne" },
+            }),
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter: makePrompter(true),
+    });
+
+    const jobs = await readPersistedJobs(storePath);
+    expect(jobs).toHaveLength(1);
+    expect(requirePersistedJob(jobs, 0).id).toBe("brief-today-morning");
+    const quarantine = await loadCronQuarantineFile(resolveCronQuarantinePath(storePath));
+    expect(quarantine.jobs).toHaveLength(1);
+    expect(quarantine.jobs[0]?.reason).toBe("duplicate-legacy-schedule");
+    expect(quarantine.jobs[0]?.job?.id).toBe("daily-briefing-dashboard-morning");
+    expectNoteContaining("1 archived legacy cron duplicate will be removed from SQLite", "Cron");
+    expectNoteContaining("Removed 1 archived legacy cron duplicate from SQLite", "Doctor changes");
+  });
+
+  it("leaves same-schedule SQLite jobs untouched without a matching legacy archive", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({
+        id: "first-current",
+        name: "First current",
+        schedule: { kind: "cron", expr: "5 8 * * 1-5", tz: "Australia/Melbourne" },
+      }),
+      createCurrentCronJob({
+        id: "second-current",
+        name: "Second current",
+        schedule: { kind: "cron", expr: "5 8 * * 1-5", tz: "Australia/Melbourne" },
+      }),
+    ]);
+    const prompter = makePrompter(true);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: {},
+      prompter,
+    });
+
+    const jobs = await readPersistedJobs(storePath);
+    expect(jobs.map((job) => job.id)).toEqual(["first-current", "second-current"]);
+    expect(prompter.confirm).not.toHaveBeenCalled();
+    expectNoNoteContaining("archived legacy cron duplicate", "Cron");
+  });
+
   it("backfills early SQLite rows from job_json before runtime relies on split columns", async () => {
     const storePath = await makeTempStorePath();
     insertEarlySQLiteCronRow(storePath, {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -26,6 +26,7 @@ import {
 import {
   archiveLegacyCronStoreForMigration,
   legacyCronStoreFilesExist,
+  loadArchivedLegacyCronJobsForMigration,
   loadLegacyCronStoreForMigration,
 } from "./legacy-store-migration.js";
 import {
@@ -33,6 +34,8 @@ import {
   mergeLegacyCronJobs,
   mergeRuntimeEntryIntoConfigJob,
   needsSqliteProjectionBackfill,
+  removeArchivedLegacyCronScheduleDuplicates,
+  type RemovedArchivedLegacyCronDuplicate,
 } from "./repair-plan.js";
 import { normalizeStoredCronJobs } from "./store-migration.js";
 import { noteCronModelOverrides } from "./warnings.js";
@@ -63,6 +66,7 @@ type LegacyCronRepairState = {
   legacyRunLogDetected: boolean;
   legacyImportCount: number;
   sqliteProjectionBackfillCount: number;
+  archivedLegacyDuplicateRows: RemovedArchivedLegacyCronDuplicate[];
   rawJobs: Array<Record<string, unknown>>;
 };
 
@@ -79,7 +83,13 @@ async function loadLegacyCronRepairState(params: {
   const quarantinePath = resolveCronQuarantinePath(storePath);
   const legacyStoreDetected = await legacyCronStoreFilesExist(storePath);
   const legacyRunLogDetected = await legacyCronRunLogFilesExist(storePath);
-  if (params.onlyIfLegacyDetected && !legacyStoreDetected && !legacyRunLogDetected) {
+  const archivedLegacyJobs = await loadArchivedLegacyCronJobsForMigration(storePath);
+  if (
+    params.onlyIfLegacyDetected &&
+    !legacyStoreDetected &&
+    !legacyRunLogDetected &&
+    archivedLegacyJobs.length === 0
+  ) {
     return null;
   }
 
@@ -104,6 +114,23 @@ async function loadLegacyCronRepairState(params: {
       : 0;
   let rawJobs = currentJobs;
   let legacyImportCount = 0;
+  let archivedLegacyDuplicateRows: RemovedArchivedLegacyCronDuplicate[] = [];
+  if (archivedLegacyJobs.length > 0) {
+    const deduped = removeArchivedLegacyCronScheduleDuplicates({
+      currentJobs: rawJobs,
+      archivedLegacyJobs,
+    });
+    rawJobs = deduped.jobs;
+    archivedLegacyDuplicateRows = deduped.removedJobs;
+  }
+  if (
+    params.onlyIfLegacyDetected &&
+    !legacyStoreDetected &&
+    !legacyRunLogDetected &&
+    archivedLegacyDuplicateRows.length === 0
+  ) {
+    return null;
+  }
   if (legacyStoreDetected) {
     const legacyStore = (await loadLegacyCronStoreForMigration(storePath)).store;
     const merged = mergeLegacyCronJobs({
@@ -121,6 +148,7 @@ async function loadLegacyCronRepairState(params: {
     legacyRunLogDetected,
     legacyImportCount,
     sqliteProjectionBackfillCount,
+    archivedLegacyDuplicateRows,
     rawJobs,
   };
 }
@@ -146,6 +174,7 @@ async function applyLegacyCronStoreRepair(params: {
     state.legacyStoreDetected ||
     state.legacyRunLogDetected ||
     state.sqliteProjectionBackfillCount > 0 ||
+    state.archivedLegacyDuplicateRows.length > 0 ||
     normalized.mutated ||
     notifyMigration.changed ||
     dreamingMigration.changed;
@@ -155,15 +184,24 @@ async function applyLegacyCronStoreRepair(params: {
 
   if (changed) {
     try {
-      if (normalized.removedJobs.length > 0) {
+      const removedJobs = [
+        ...normalized.removedJobs.map((entry) => ({
+          sourceIndex: entry.sourceIndex,
+          reason: entry.reason,
+          job: entry.job,
+        })),
+        ...state.archivedLegacyDuplicateRows.map((entry) => ({
+          sourceIndex: entry.sourceIndex,
+          reason: "duplicate-legacy-schedule",
+          job: entry.job,
+          scheduleIdentity: entry.scheduleIdentity,
+        })),
+      ];
+      if (removedJobs.length > 0) {
         await saveCronQuarantineFile({
           storePath: state.storePath,
           nowMs: Date.now(),
-          entries: normalized.removedJobs.map((entry) => ({
-            sourceIndex: entry.sourceIndex,
-            reason: entry.reason,
-            job: entry.job,
-          })),
+          entries: removedJobs,
         });
       }
       await saveCronJobsStore(state.storePath, {
@@ -203,6 +241,11 @@ async function applyLegacyCronStoreRepair(params: {
     );
   } else if (changed) {
     changes.push(`Cron store normalized at ${shortenHomePath(state.storePath)}.`);
+  }
+  if (state.archivedLegacyDuplicateRows.length > 0) {
+    changes.push(
+      `Removed ${pluralize(state.archivedLegacyDuplicateRows.length, "archived legacy cron duplicate")} from SQLite.`,
+    );
   }
   if (dreamingMigration.rewrittenCount > 0) {
     changes.push(
@@ -278,6 +321,7 @@ export async function maybeRepairLegacyCronStore(params: {
     legacyRunLogDetected,
     legacyImportCount,
     sqliteProjectionBackfillCount,
+    archivedLegacyDuplicateRows,
     rawJobs,
   } = state;
   try {
@@ -352,6 +396,11 @@ export async function maybeRepairLegacyCronStore(params: {
   if (sqliteProjectionBackfillCount > 0) {
     previewLines.push(
       `- ${pluralize(sqliteProjectionBackfillCount, "SQLite cron row")} will be backfilled from stored config JSON into split columns`,
+    );
+  }
+  if (archivedLegacyDuplicateRows.length > 0) {
+    previewLines.push(
+      `- ${pluralize(archivedLegacyDuplicateRows.length, "archived legacy cron duplicate")} will be removed from SQLite`,
     );
   }
   if (notifyCount > 0) {

--- a/src/commands/doctor/cron/legacy-store-migration.ts
+++ b/src/commands/doctor/cron/legacy-store-migration.ts
@@ -40,6 +40,48 @@ async function archiveLegacyCronFile(filePath: string): Promise<void> {
   await fs.rename(filePath, archivePath).catch(() => undefined);
 }
 
+function isLegacyCronStoreArchiveName(fileName: string, storeFileName: string): boolean {
+  const archiveName = `${storeFileName}${LEGACY_CRON_ARCHIVE_SUFFIX}`;
+  if (fileName === archiveName) {
+    return true;
+  }
+  if (!fileName.startsWith(`${archiveName}.`)) {
+    return false;
+  }
+  return /^\d+$/.test(fileName.slice(archiveName.length + 1));
+}
+
+function legacyCronStoreArchiveOrdinal(fileName: string, storeFileName: string): number {
+  const archiveName = `${storeFileName}${LEGACY_CRON_ARCHIVE_SUFFIX}`;
+  if (fileName === archiveName) {
+    return 1;
+  }
+  return Number(fileName.slice(archiveName.length + 1));
+}
+
+async function listArchivedLegacyCronStorePaths(storePath: string): Promise<string[]> {
+  const resolvedStorePath = path.resolve(storePath);
+  const dir = path.dirname(resolvedStorePath);
+  const storeFileName = path.basename(resolvedStorePath);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    if ((err as { code?: unknown })?.code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  return entries
+    .filter((entry) => isLegacyCronStoreArchiveName(entry, storeFileName))
+    .toSorted(
+      (left, right) =>
+        legacyCronStoreArchiveOrdinal(left, storeFileName) -
+        legacyCronStoreArchiveOrdinal(right, storeFileName),
+    )
+    .map((entry) => path.join(dir, entry));
+}
+
 function parseCronStateFile(raw: string): {
   version: 1;
   jobs: Record<string, CronConfigJobRuntimeEntry>;
@@ -117,11 +159,20 @@ function legacySchedulePayloadFromRecord(
   return undefined;
 }
 
-function tryLegacyCronScheduleIdentity(job: Record<string, unknown>): string | undefined {
+function legacySchedulePayloadFromString(
+  schedule: string,
+): { kind: "cron"; expr: string } | undefined {
+  const expr = normalizeOptionalString(schedule);
+  return expr ? { kind: "cron", expr } : undefined;
+}
+
+export function tryLegacyCronScheduleIdentity(job: Record<string, unknown>): string | undefined {
   const schedule =
-    job.schedule && typeof job.schedule === "object" && !Array.isArray(job.schedule)
-      ? legacySchedulePayloadFromRecord(job.schedule as Record<string, unknown>)
-      : legacySchedulePayloadFromRecord(job);
+    typeof job.schedule === "string"
+      ? legacySchedulePayloadFromString(job.schedule)
+      : job.schedule && typeof job.schedule === "object" && !Array.isArray(job.schedule)
+        ? legacySchedulePayloadFromRecord(job.schedule as Record<string, unknown>)
+        : legacySchedulePayloadFromRecord(job);
   if (!schedule) {
     return undefined;
   }
@@ -142,6 +193,20 @@ function getRawCronJobs(parsed: unknown): unknown[] {
 
 function cloneConfigJobs(jobs: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
   return jobs.map((job) => structuredClone(job));
+}
+
+async function loadLegacyCronJobsFromFile(
+  filePath: string,
+): Promise<Array<Record<string, unknown>>> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = parseJsonWithJson5Fallback(raw);
+    return getRawCronJobs(parsed)
+      .filter(isRecord)
+      .map((job) => structuredClone(job));
+  } catch {
+    return [];
+  }
 }
 
 async function loadStateFile(
@@ -230,6 +295,18 @@ export async function archiveLegacyCronStoreForMigration(storePath: string): Pro
     archiveLegacyCronFile(resolvedStorePath),
     archiveLegacyCronFile(resolveLegacyCronStatePath(resolvedStorePath)),
   ]);
+}
+
+/** Load archived legacy cron JSON jobs left behind by earlier migrations. */
+export async function loadArchivedLegacyCronJobsForMigration(
+  storePath: string,
+): Promise<Array<Record<string, unknown>>> {
+  const archivePaths = await listArchivedLegacyCronStorePaths(storePath);
+  const jobs: Array<Record<string, unknown>> = [];
+  for (const archivePath of archivePaths) {
+    jobs.push(...(await loadLegacyCronJobsFromFile(archivePath)));
+  }
+  return jobs;
 }
 
 /** Load legacy cron JSON/state files into the current loaded-store shape for migration. */

--- a/src/commands/doctor/cron/repair-plan.ts
+++ b/src/commands/doctor/cron/repair-plan.ts
@@ -3,6 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { normalizeCronJobInput } from "../../../cron/normalize.js";
 import type { CronJob } from "../../../cron/types.js";
+import { tryLegacyCronScheduleIdentity } from "./legacy-store-migration.js";
 
 export type CronLegacyIssueCounts = Partial<Record<string, number>>;
 export type CronLegacyIssueDetails = {
@@ -100,7 +101,74 @@ function cronJobMigrationKey(job: Record<string, unknown>): string | undefined {
   return normalizeOptionalString(job.id) ?? normalizeOptionalString(job.jobId);
 }
 
-/** Merge legacy JSON jobs into current jobs without duplicating matching ids/jobIds. */
+export type RemovedArchivedLegacyCronDuplicate = {
+  job: Record<string, unknown>;
+  sourceIndex: number;
+  scheduleIdentity: string;
+};
+
+/** Remove SQLite rows imported from archived legacy stores when a replacement row already exists. */
+export function removeArchivedLegacyCronScheduleDuplicates(params: {
+  currentJobs: Array<Record<string, unknown>>;
+  archivedLegacyJobs: Array<Record<string, unknown>>;
+}): { jobs: Array<Record<string, unknown>>; removedJobs: RemovedArchivedLegacyCronDuplicate[] } {
+  const archivedScheduleByKey = new Map<string, string>();
+  for (const legacyJob of params.archivedLegacyJobs) {
+    const key = cronJobMigrationKey(legacyJob);
+    const scheduleKey = tryLegacyCronScheduleIdentity(legacyJob);
+    if (key && scheduleKey) {
+      archivedScheduleByKey.set(key, scheduleKey);
+    }
+  }
+  if (archivedScheduleByKey.size === 0) {
+    return { jobs: params.currentJobs, removedJobs: [] };
+  }
+
+  const groups = new Map<
+    string,
+    Array<{ job: Record<string, unknown>; sourceIndex: number; fromArchive: boolean }>
+  >();
+  for (const [sourceIndex, job] of params.currentJobs.entries()) {
+    const scheduleKey = tryLegacyCronScheduleIdentity(job);
+    if (!scheduleKey) {
+      continue;
+    }
+    const key = cronJobMigrationKey(job);
+    const fromArchive = key ? archivedScheduleByKey.get(key) === scheduleKey : false;
+    const group = groups.get(scheduleKey) ?? [];
+    group.push({ job, sourceIndex, fromArchive });
+    groups.set(scheduleKey, group);
+  }
+
+  const removedByIndex = new Map<number, RemovedArchivedLegacyCronDuplicate>();
+  for (const [scheduleIdentity, group] of groups) {
+    if (group.length < 2 || !group.some((entry) => !entry.fromArchive)) {
+      continue;
+    }
+    for (const entry of group) {
+      if (entry.fromArchive) {
+        removedByIndex.set(entry.sourceIndex, {
+          job: structuredClone(entry.job),
+          sourceIndex: entry.sourceIndex,
+          scheduleIdentity,
+        });
+      }
+    }
+  }
+
+  if (removedByIndex.size === 0) {
+    return { jobs: params.currentJobs, removedJobs: [] };
+  }
+
+  return {
+    jobs: params.currentJobs.filter((_job, index) => !removedByIndex.has(index)),
+    removedJobs: [...removedByIndex.values()].toSorted(
+      (left, right) => left.sourceIndex - right.sourceIndex,
+    ),
+  };
+}
+
+/** Merge legacy JSON jobs into current jobs without duplicating already-migrated rows. */
 export function mergeLegacyCronJobs(params: {
   currentJobs: Array<Record<string, unknown>>;
   legacyJobs: Array<Record<string, unknown>>;
@@ -109,6 +177,11 @@ export function mergeLegacyCronJobs(params: {
   const currentKeys = new Set(
     params.currentJobs.map((job) => cronJobMigrationKey(job)).filter((key) => key !== undefined),
   );
+  const currentScheduleKeys = new Set(
+    params.currentJobs
+      .map((job) => tryLegacyCronScheduleIdentity(job))
+      .filter((key) => key !== undefined),
+  );
   let importedCount = 0;
 
   for (const legacyJob of params.legacyJobs) {
@@ -116,9 +189,15 @@ export function mergeLegacyCronJobs(params: {
     if (key && currentKeys.has(key)) {
       continue;
     }
+    const scheduleKey = tryLegacyCronScheduleIdentity(legacyJob);
+    if (scheduleKey && currentScheduleKeys.has(scheduleKey)) {
+      continue;
+    }
     if (key) {
       currentKeys.add(key);
     }
+    // Schedule identity only dedupes legacy rows against pre-existing SQLite jobs;
+    // same-schedule rows already present together in legacy JSON remain distinct.
     merged.push(legacyJob);
     importedCount += 1;
   }


### PR DESCRIPTION
## Summary

- Deduplicate legacy cron JSON imports against existing SQLite/current jobs by schedule identity, not only `id`/`jobId`.
- Also repair already-created SQLite duplicates when the duplicate row can be traced back to an archived legacy cron store and a non-archived replacement row already exists for the same schedule identity.
- Reuse the legacy schedule identity helper for migration planning and support bare string legacy schedules when generating that identity.
- Add regression coverage for both latent re-import duplicates and live SQLite duplicates from archived legacy migrations, while preserving same-schedule current jobs without matching archive evidence.

## Verification

- `git diff --check`
- `pnpm test src/commands/doctor/cron/index.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`

## Real behavior proof

Behavior addressed: OpenClaw doctor legacy cron migration no longer re-imports a legacy JSON cron job when SQLite already has the same logical schedule under a new id/name, and doctor can remove duplicate SQLite rows that were previously imported from archived legacy cron JSON when a replacement row exists.

Real environment tested: Local OpenClaw source checkout on branch `ak/cron-legacy-schedule-dedup`.

Exact steps or command run after this patch: `pnpm test src/commands/doctor/cron/index.test.ts`; `pnpm tsgo:core`; `pnpm tsgo:core:test`; `git diff --check`.

Evidence after fix: New regression tests pass for `skips legacy jobs that already exist in SQLite under a renamed schedule identity`, `removes SQLite duplicates imported from an archived legacy store when a replacement exists`, and `leaves same-schedule SQLite jobs untouched without a matching legacy archive`.

Observed result after fix: Targeted cron doctor test file passed with 29 tests; core and core-test tsgo checks passed.

What was not tested: Full `pnpm check` / broad Testbox lanes and a live ASSP container upgrade were not run.
