### PR TITLE
docs: fix docs metadata spellcheck

### DIFF
--- a/docs/specs/claw-supervisor.md
+++ b/docs/specs/claw-supervisor.md
@@ -1,7 +1,7 @@
 ---
 title: Claw Supervisor
-description: Fleet supervision plan for Codex app-server sessions controlled by OpenClaw.
-readWhen:
+summary: "Fleet supervision plan for Codex app-server sessions controlled by OpenClaw."
+read_when:
   - Designing Codex fleet supervision
   - Building OpenClaw tools that read, steer, or spawn Codex sessions
   - Choosing between local, Cloudflare, and VPS deployment for supervised Codex

--- a/scripts/codespell-ignore.txt
+++ b/scripts/codespell-ignore.txt
@@ -12,3 +12,5 @@ Ballance
 optIn
 Brining
 wit
+allowIn
+planText


### PR DESCRIPTION
## Summary

- Update `docs/specs/claw-supervisor.md` frontmatter from the old `description` / `readWhen` keys to the canonical `summary` / `read_when` keys parsed by `pnpm docs:list`.
- Add `allowIn` and `planText` to the docs spellcheck ignore list because they are documented camelCase API/config identifiers, not typos.

## Real behavior proof

- Behavior or issue addressed: `pnpm docs:list` could not surface the Claw Supervisor doc summary/read-when metadata because that page used stale frontmatter keys, and docs spellcheck needed ignores for real camelCase docs tokens.
- Real environment tested: Local OpenClaw checkout on macOS, on branch `codex/docs-metadata-spellcheck` at `111fb71783cf5c5572becd8df148122cb2efa814`.
- Exact steps or command run after this patch: `pnpm docs:list` and `pnpm docs:spellcheck`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local checkout after this patch:

  ```text
  $ pnpm docs:list
  $ node scripts/docs-list.js
  Listing all markdown files in docs folder:
  ...
  specs/claw-supervisor.md - Fleet supervision plan for Codex app-server sessions controlled by OpenClaw.
    Read when: Designing Codex fleet supervision; Building OpenClaw tools that read, steer, or spawn Codex sessions; Choosing between local, Cloudflare, and VPS deployment for supervised Codex
  ...
  Reminder: keep docs up to date as behavior changes. When your task matches any "Read when" hint above (React hooks, cache directives, database work, tests, etc.), read that doc before coding, and suggest new coverage when it is missing.

  $ pnpm docs:spellcheck
  $ bash scripts/docs-spellcheck.sh
  ```

- Observed result after fix: `specs/claw-supervisor.md` appears in the docs listing with the intended summary and read-when hints, and the docs spellcheck command exits with no diagnostics for `allowIn` or `planText`.
- What was not tested: Runtime behavior, packaging, or the full product suite; this is a docs metadata and spellcheck configuration patch only.
- Proof limitations or environment constraints: `pnpm docs:spellcheck` is quiet on success, so the terminal capture shows the invoked script with no diagnostics after it.

## Tests and validation

- `pnpm docs:list`
- `pnpm docs:spellcheck`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`
- `pnpm docs:check-i18n-glossary`
- `pnpm format:docs:check`
- `pnpm lint:docs`
- `pnpm exec oxfmt --check --threads=1 docs/specs/claw-supervisor.md scripts/codespell-ignore.txt`
- `git diff --check -- docs/specs/claw-supervisor.md scripts/codespell-ignore.txt`

## Review

Claude autoreview reported the patch as correct and landable. It raised one P3 question about whether `allowIn` was needed in the ignore list; I verified that removing `allowIn` makes codespell fail on the bare `allowIn` tokens in `docs/channels/groups.md`, so the ignore entry is intentional.

## Risk checklist

Did user-visible behavior change? `Yes`, docs tooling now reads this page's summary/read-when metadata correctly.

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No`.

What is the highest-risk area? Low docs-tooling risk: keeping the codespell ignore list scoped to real docs identifiers.

How is that risk mitigated? Both ignored tokens were verified against documented identifiers in `docs/**`, and docs spellcheck passes after the patch.

## Current review state

Ready for review and merge once GitHub checks are green.