### PR TITLE
fix(device-pairing): guard role normalization against non-string entries

### DIFF
--- a/src/shared/device-pairing-access.test.ts
+++ b/src/shared/device-pairing-access.test.ts
@@ -58,4 +58,56 @@ describe("resolvePendingDeviceApprovalState", () => {
       },
     });
   });
+
+  it("drops non-string role entries from malformed pairing records instead of crashing", () => {
+    // Legacy/malformed on-disk pairing records can carry non-string roles/role (blind-cast JSON);
+    // before the shared-normalizer guard these crashed normalizeRoleList on .trim().
+    type PendingArg = Parameters<typeof resolvePendingDeviceApprovalState>[0];
+    type PairedArg = NonNullable<Parameters<typeof resolvePendingDeviceApprovalState>[1]>;
+    expect(
+      resolvePendingDeviceApprovalState(
+        {
+          roles: [123, "operator", null, "  admin  "],
+          role: 5,
+          scopes: ["operator.read"],
+        } as unknown as PendingArg,
+        {
+          roles: [null, "operator"],
+          role: 9,
+          scopes: ["operator.read"],
+        } as unknown as PairedArg,
+      ),
+    ).toEqual({
+      kind: "role-upgrade",
+      requested: {
+        roles: ["admin", "operator"],
+        scopes: ["operator.read"],
+      },
+      approved: {
+        roles: ["operator"],
+        scopes: ["operator.read"],
+      },
+    });
+  });
+
+  it("drops a non-string token role without crashing", () => {
+    type PairedArg = NonNullable<Parameters<typeof resolvePendingDeviceApprovalState>[1]>;
+    expect(
+      resolvePendingDeviceApprovalState({ role: "operator", scopes: ["operator.read"] }, {
+        roles: ["operator"],
+        scopes: ["operator.read"],
+        tokens: { t1: { role: 7, revokedAtMs: null } },
+      } as unknown as PairedArg),
+    ).toEqual({
+      kind: "role-upgrade",
+      requested: {
+        roles: ["operator"],
+        scopes: ["operator.read"],
+      },
+      approved: {
+        roles: [],
+        scopes: ["operator.read"],
+      },
+    });
+  });
 });

--- a/src/shared/device-pairing-access.ts
+++ b/src/shared/device-pairing-access.ts
@@ -1,4 +1,5 @@
 // Device pairing access helpers evaluate pairing scopes and role permissions.
+import { normalizeUniqueSingleOrTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { normalizeDeviceAuthScopes } from "./device-auth.js";
 
 export type DevicePairingAccessSummary = {
@@ -50,21 +51,10 @@ type PairedLike = {
 function normalizeRoleList(...items: Array<string | string[] | undefined>): string[] {
   const roles = new Set<string>();
   for (const item of items) {
-    if (!item) {
-      continue;
-    }
-    if (Array.isArray(item)) {
-      for (const role of item) {
-        const trimmed = role.trim();
-        if (trimmed) {
-          roles.add(trimmed);
-        }
-      }
-      continue;
-    }
-    const trimmed = item.trim();
-    if (trimmed) {
-      roles.add(trimmed);
+    // On-disk pairing records are blind-cast, so roles/role may be non-strings; the shared
+    // normalizer drops them instead of crashing on .trim() (matches the scopes path + mergeRoles).
+    for (const role of normalizeUniqueSingleOrTrimmedStringList(item)) {
+      roles.add(role);
     }
   }
   return [...roles].toSorted();


### PR DESCRIPTION
## Summary

`normalizeRoleList` in `src/shared/device-pairing-access.ts` called `.trim()` on every `roles[]` entry and the singular `role` **without a `typeof === "string"` guard**. The `roles`/`role` fields are loaded from disk via a blind cast (`coercePairingStateRecord`, `src/infra/pairing-files.ts`), so a malformed/legacy pairing record with a non-string entry — e.g. `roles: [123]` or `role: 5` — threw `TypeError: role.trim is not a function`, crashing `resolvePendingDeviceApprovalState`. `openclaw devices list` calls that per pending request with no surrounding try/catch (`src/cli/devices-cli.runtime.ts`), so the whole table render blows up on one bad record.

The scopes half of the same summary (`normalizeDeviceAuthScopes`) is already guarded, and the merged #90654/#92178 work added the same guard to the sibling `mergeRoles`/`mergeScopes`/`formatAuditList` in `src/infra/device-pairing.ts` — but **missed this path**.

This routes each item through the existing shared non-string-safe normalizer `normalizeUniqueSingleOrTrimmedStringList` (the exact helper `mergeRoles` uses), so non-string entries are dropped instead of crashing while valid roles are still trimmed, deduped, and sorted. Net **−10 LOC**; all three `normalizeRoleList` callers (pending request, approved device, token roles) are covered by the single fix.

### Changes
- `src/shared/device-pairing-access.ts` — route `normalizeRoleList` through the guarded shared helper
- `src/shared/device-pairing-access.test.ts` — regression tests for non-string `roles` / `role` / `token.role`

## Real behavior proof

Behavior addressed: `normalizeRoleList` crashed (`TypeError: role.trim is not a function`) on a non-string role from a malformed pairing record, taking down `resolvePendingDeviceApprovalState` / `openclaw devices list`; it now drops non-string entries and classifies access normally.

Real environment tested: a direct-call harness importing the real `src/shared/device-pairing-access.ts`, run with the repo's `tsx`, Node 22.22.1, no model / provider / channel credentials and no network (the function is pure). The "before" column reverts only that one source file to `origin/main`.

Exact steps or command run after this patch:
```bash
# dp-proof.mts (~20 lines) imports resolvePendingDeviceApprovalState from the real source
# and calls it with malformed (non-string) roles/role on the pending and paired paths.
tsx dp-proof.mts                                                                      # AFTER (this branch)
git stash push -- src/shared/device-pairing-access.ts && tsx dp-proof.mts && git stash pop   # BEFORE (origin/main)
```

Evidence after fix:
```
########## AFTER FIX (this branch) ##########
OK     pending roles:[123]         -> {"kind":"new-pairing","requested":{"roles":[],"scopes":["operator.read"]},"approved":null}
OK     pending singular role:5     -> {"kind":"new-pairing","requested":{"roles":[],"scopes":["operator.read"]},"approved":null}
OK     paired (approved) roles:[7] -> {"kind":"role-upgrade","requested":{"roles":["operator"],"scopes":["operator.read"]},"approved":{"roles":[],"scopes":["operator.read"]}}
OK     valid+malformed mixed [123,'operator',null,'  admin  '] + role:5 -> {"kind":"new-pairing","requested":{"roles":["admin","operator"],"scopes":["operator.read"]},"approved":null}

########## BEFORE FIX (origin/main) ##########
THROW  pending roles:[123]         -> TypeError: role.trim is not a function
THROW  pending singular role:5     -> TypeError: item.trim is not a function
THROW  paired (approved) roles:[7] -> TypeError: role.trim is not a function
THROW  valid+malformed mixed ...   -> TypeError: role.trim is not a function
```

Observed result after fix: every non-string role entry that previously threw is now dropped, valid roles are trimmed/deduped/sorted (`["admin","operator"]`), and the approval classification returns normally — no crash on any of the three role paths.

What was not tested: end-to-end `openclaw devices list` with a hand-crafted on-disk pairing file holding a non-string role. The pure-function repro exercises the exact crash; reachability is confirmed by source (the `roles`/`role` fields reach `normalizeRoleList` unvalidated through `coercePairingStateRecord`'s blind cast, and the CLI's `parseDevicePairingList` only does `Array.isArray` checks, never element-type checks).

## Additional checks

Four cases in `device-pairing-access.test.ts` cover non-string `roles[]`, singular `role`, and `token.role` (exercising all three callers), alongside the pre-existing valid-role and revoked-token cases. Formatter, static analysis, and type checks all pass for the changed files. Mirrors the merged #90654/#92178 robustness fix; net −10 source LOC.
