### PR TITLE
fix(skills): trust verified ClawHub source provenance

### DIFF
--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -273,6 +273,19 @@ export type ClawHubPackageSearchResult = {
   package: ClawHubPackageListItem;
 };
 
+export type ClawHubSkillSourceProvenance = {
+  source?: string | null;
+  sourceUrl?: string | null;
+  url?: string | null;
+  sourceRepo?: string | null;
+  repo?: string | null;
+  sourceCommit?: string | null;
+  commit?: string | null;
+  sourcePath?: string | null;
+  path?: string | null;
+  reason?: string | null;
+};
+
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
@@ -280,6 +293,8 @@ export type ClawHubSkillSearchResult = {
   summary?: string;
   version?: string;
   updatedAt?: number;
+  sourceUrl?: string | null;
+  provenance?: ClawHubSkillSourceProvenance | null;
 };
 
 export type ClawHubSkillDetail = {
@@ -290,11 +305,15 @@ export type ClawHubSkillDetail = {
     tags?: Record<string, string>;
     createdAt: number;
     updatedAt: number;
+    sourceUrl?: string | null;
+    provenance?: ClawHubSkillSourceProvenance | null;
   } | null;
   latestVersion?: {
     version: string;
     createdAt: number;
     changelog?: string;
+    sourceUrl?: string | null;
+    provenance?: ClawHubSkillSourceProvenance | null;
   } | null;
   metadata?: {
     os?: string[] | null;
@@ -312,21 +331,28 @@ export type ClawHubSkillInstallResolutionResponse =
       ok: true;
       slug: string;
       installKind: "archive";
+      sourceUrl?: string | null;
+      provenance?: ClawHubSkillSourceProvenance | null;
       archive: {
         version: string;
         downloadUrl: string;
+        sourceUrl?: string | null;
+        provenance?: ClawHubSkillSourceProvenance | null;
       };
     }
   | {
       ok: true;
       slug: string;
       installKind: "github";
+      sourceUrl?: string | null;
+      provenance?: ClawHubSkillSourceProvenance | null;
       github: {
         repo: string;
         path: string;
         commit: string;
         contentHash: string;
         sourceUrl: string;
+        provenance?: ClawHubSkillSourceProvenance | null;
       };
     }
   | {
@@ -349,7 +375,8 @@ export type ClawHubSkillVerificationResponse = {
   version: unknown;
   card: unknown;
   artifact: unknown;
-  provenance: unknown;
+  sourceUrl?: string | null;
+  provenance: ClawHubSkillSourceProvenance | null;
   security: unknown;
   signature: unknown;
 };
@@ -396,11 +423,15 @@ export type ClawHubSkillListResponse = {
       version: string;
       createdAt: number;
       changelog?: string;
+      sourceUrl?: string | null;
+      provenance?: ClawHubSkillSourceProvenance | null;
     } | null;
     metadata?: {
       os?: string[] | null;
       systems?: string[] | null;
     } | null;
+    sourceUrl?: string | null;
+    provenance?: ClawHubSkillSourceProvenance | null;
     createdAt: number;
     updatedAt: number;
   }>;

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -273,19 +273,6 @@ export type ClawHubPackageSearchResult = {
   package: ClawHubPackageListItem;
 };
 
-export type ClawHubSkillSourceProvenance = {
-  source?: string | null;
-  sourceUrl?: string | null;
-  url?: string | null;
-  sourceRepo?: string | null;
-  repo?: string | null;
-  sourceCommit?: string | null;
-  commit?: string | null;
-  sourcePath?: string | null;
-  path?: string | null;
-  reason?: string | null;
-};
-
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
@@ -293,8 +280,6 @@ export type ClawHubSkillSearchResult = {
   summary?: string;
   version?: string;
   updatedAt?: number;
-  sourceUrl?: string | null;
-  provenance?: ClawHubSkillSourceProvenance | null;
 };
 
 export type ClawHubSkillDetail = {
@@ -305,15 +290,11 @@ export type ClawHubSkillDetail = {
     tags?: Record<string, string>;
     createdAt: number;
     updatedAt: number;
-    sourceUrl?: string | null;
-    provenance?: ClawHubSkillSourceProvenance | null;
   } | null;
   latestVersion?: {
     version: string;
     createdAt: number;
     changelog?: string;
-    sourceUrl?: string | null;
-    provenance?: ClawHubSkillSourceProvenance | null;
   } | null;
   metadata?: {
     os?: string[] | null;
@@ -331,28 +312,21 @@ export type ClawHubSkillInstallResolutionResponse =
       ok: true;
       slug: string;
       installKind: "archive";
-      sourceUrl?: string | null;
-      provenance?: ClawHubSkillSourceProvenance | null;
       archive: {
         version: string;
         downloadUrl: string;
-        sourceUrl?: string | null;
-        provenance?: ClawHubSkillSourceProvenance | null;
       };
     }
   | {
       ok: true;
       slug: string;
       installKind: "github";
-      sourceUrl?: string | null;
-      provenance?: ClawHubSkillSourceProvenance | null;
       github: {
         repo: string;
         path: string;
         commit: string;
         contentHash: string;
         sourceUrl: string;
-        provenance?: ClawHubSkillSourceProvenance | null;
       };
     }
   | {
@@ -375,8 +349,7 @@ export type ClawHubSkillVerificationResponse = {
   version: unknown;
   card: unknown;
   artifact: unknown;
-  sourceUrl?: string | null;
-  provenance: ClawHubSkillSourceProvenance | null;
+  provenance: unknown;
   security: unknown;
   signature: unknown;
 };
@@ -423,15 +396,11 @@ export type ClawHubSkillListResponse = {
       version: string;
       createdAt: number;
       changelog?: string;
-      sourceUrl?: string | null;
-      provenance?: ClawHubSkillSourceProvenance | null;
     } | null;
     metadata?: {
       os?: string[] | null;
       systems?: string[] | null;
     } | null;
-    sourceUrl?: string | null;
-    provenance?: ClawHubSkillSourceProvenance | null;
     createdAt: number;
     updatedAt: number;
   }>;

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -382,6 +382,181 @@ describe("skills-clawhub", () => {
     }
   });
 
+  it("persists the source URL from ClawHub archive install resolution", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    const sourceUrl = "https://github.com/openclaw/skills/tree/abc123/agentreceipt";
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "agentreceipt",
+      installKind: "archive",
+      archive: {
+        version: "1.0.0",
+        downloadUrl: "https://clawhub.ai/api/v1/download?slug=agentreceipt&version=1.0.0",
+        sourceUrl,
+      },
+    });
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt?.sourceUrl).toBe(sourceUrl);
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBe(sourceUrl);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists the source URL from version verification provenance", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    const sourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    fetchClawHubSkillDetailMock.mockResolvedValueOnce({
+      skill: {
+        slug: "agentreceipt",
+        displayName: "AgentReceipt",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: {
+        version: "1.0.0",
+        createdAt: 3,
+      },
+    });
+    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: {
+        source: "github",
+        url: sourceUrl,
+        repo: "openclaw/skills",
+        commit: "def456",
+        path: "agentreceipt",
+      },
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+        version: "1.0.0",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt).toMatchObject({
+        sourceUrl,
+        verification: {
+          sourceUrl,
+          provenance: {
+            source: "github",
+            url: sourceUrl,
+            repo: "openclaw/skills",
+            commit: "def456",
+            path: "agentreceipt",
+          },
+        },
+      });
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBe(sourceUrl);
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not use latest-version detail source for older explicit version installs", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    fetchClawHubSkillDetailMock.mockResolvedValueOnce({
+      skill: {
+        slug: "agentreceipt",
+        displayName: "AgentReceipt",
+        createdAt: 1,
+        updatedAt: 2,
+        sourceUrl: "https://github.com/openclaw/skills/tree/latest/agentreceipt",
+      },
+      latestVersion: {
+        version: "2.0.0",
+        createdAt: 3,
+        sourceUrl: "https://github.com/openclaw/skills/tree/latest/agentreceipt",
+      },
+    });
+    fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+        version: "1.0.0",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt?.sourceUrl).toBeUndefined();
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBeUndefined();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps installing when the ClawHub verification snapshot is unavailable", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-lock-");
     fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -382,53 +382,7 @@ describe("skills-clawhub", () => {
     }
   });
 
-  it("persists the source URL from ClawHub archive install resolution", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
-    const sourceUrl = "https://github.com/openclaw/skills/tree/abc123/agentreceipt";
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
-      slug: "agentreceipt",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl: "https://clawhub.ai/api/v1/download?slug=agentreceipt&version=1.0.0",
-        sourceUrl,
-      },
-    });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
-
-    try {
-      const result = await installSkillFromClawHub({
-        workspaceDir,
-        slug: "agentreceipt",
-      });
-
-      expectInstalledSkill(result, {
-        slug: "agentreceipt",
-        version: "1.0.0",
-        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
-      });
-      const lock = JSON.parse(
-        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
-      ) as { skills: Record<string, Record<string, unknown>> };
-      expect(lock.skills.agentreceipt?.sourceUrl).toBe(sourceUrl);
-      const origin = JSON.parse(
-        await fs.readFile(
-          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
-          "utf8",
-        ),
-      ) as Record<string, unknown>;
-      expect(origin.sourceUrl).toBe(sourceUrl);
-    } finally {
-      await fs.rm(workspaceDir, { recursive: true, force: true });
-    }
-  });
-
-  it("persists the source URL from version verification provenance", async () => {
+  it("persists the source URL from server-resolved verification provenance", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-source-");
     const sourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
     fetchClawHubSkillDetailMock.mockResolvedValueOnce({
@@ -451,11 +405,14 @@ describe("skills-clawhub", () => {
       card: { available: true },
       artifact: { sourceFingerprint: "source-fp" },
       provenance: {
-        source: "github",
+        source: "server-resolved-github-import",
+        kind: "github",
         url: sourceUrl,
         repo: "openclaw/skills",
+        ref: "main",
         commit: "def456",
         path: "agentreceipt",
+        importedAt: 4,
       },
       security: { status: "clean" },
       signature: { status: "unsigned" },
@@ -484,13 +441,15 @@ describe("skills-clawhub", () => {
       expect(lock.skills.agentreceipt).toMatchObject({
         sourceUrl,
         verification: {
-          sourceUrl,
           provenance: {
-            source: "github",
+            source: "server-resolved-github-import",
+            kind: "github",
             url: sourceUrl,
             repo: "openclaw/skills",
+            ref: "main",
             commit: "def456",
             path: "agentreceipt",
+            importedAt: 4,
           },
         },
       });
@@ -506,7 +465,7 @@ describe("skills-clawhub", () => {
     }
   });
 
-  it("does not use latest-version detail source for older explicit version installs", async () => {
+  it("does not treat detail metadata as verified source provenance", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-source-");
     fetchClawHubSkillDetailMock.mockResolvedValueOnce({
       skill: {
@@ -517,12 +476,62 @@ describe("skills-clawhub", () => {
         sourceUrl: "https://github.com/openclaw/skills/tree/latest/agentreceipt",
       },
       latestVersion: {
-        version: "2.0.0",
+        version: "1.0.0",
         createdAt: 3,
         sourceUrl: "https://github.com/openclaw/skills/tree/latest/agentreceipt",
       },
     });
     fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    try {
+      const result = await installSkillFromClawHub({
+        workspaceDir,
+        slug: "agentreceipt",
+        version: "1.0.0",
+      });
+
+      expectInstalledSkill(result, {
+        slug: "agentreceipt",
+        version: "1.0.0",
+        targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
+      });
+      const lock = JSON.parse(
+        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+      ) as { skills: Record<string, Record<string, unknown>> };
+      expect(lock.skills.agentreceipt?.sourceUrl).toBeUndefined();
+      const origin = JSON.parse(
+        await fs.readFile(
+          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+          "utf8",
+        ),
+      ) as Record<string, unknown>;
+      expect(origin.sourceUrl).toBeUndefined();
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not trust URLs from unavailable verification provenance", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-source-");
+    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: {
+        source: "unavailable",
+        url: "https://github.com/openclaw/skills/tree/unverified/agentreceipt",
+      },
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
       await fs.mkdir(params.targetDir, { recursive: true });
       await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -19,6 +19,7 @@ import {
   type ClawHubSkillDetail,
   type ClawHubSkillInstallResolutionResponse,
   type ClawHubSkillSearchResult,
+  type ClawHubSkillSourceProvenance,
   type ClawHubSkillVerificationResponse,
 } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -55,9 +56,10 @@ type ClawHubSkillVerificationLock = {
   ok: boolean;
   decision: ClawHubSkillVerificationResponse["decision"];
   reasons: string[];
+  sourceUrl?: string;
   card?: unknown;
   artifact?: unknown;
-  provenance?: unknown;
+  provenance?: ClawHubSkillSourceProvenance | null;
   security?: unknown;
   signature?: unknown;
 };
@@ -273,12 +275,55 @@ function normalizeOptionalStringValue(raw: unknown): string | undefined {
   return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
 }
 
-function readSkillDetailSourceUrl(detail: ClawHubSkillDetail | undefined): string | undefined {
-  const skill = detail?.skill;
-  if (!skill || typeof skill !== "object") {
+function asRecord(raw: unknown): Record<string, unknown> | undefined {
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : undefined;
+}
+
+function readSourceUrlFromSourceMetadata(raw: unknown): string | undefined {
+  const record = asRecord(raw);
+  if (!record) {
     return undefined;
   }
-  return normalizeOptionalStringValue((skill as { sourceUrl?: unknown }).sourceUrl);
+  return (
+    normalizeOptionalStringValue(record.sourceUrl) ??
+    normalizeOptionalStringValue(record.url) ??
+    readSourceUrlFromSourceMetadata(record.provenance)
+  );
+}
+
+function readSkillDetailSourceUrl(
+  detail: ClawHubSkillDetail | undefined,
+  installedVersion: string,
+): string | undefined {
+  if (detail?.latestVersion?.version !== installedVersion) {
+    return undefined;
+  }
+  return (
+    readSourceUrlFromSourceMetadata(detail.latestVersion) ??
+    readSourceUrlFromSourceMetadata(detail.skill)
+  );
+}
+
+function readInstallResolutionSourceUrl(
+  resolution: Extract<ClawHubSkillInstallResolutionResponse, { ok: true }> | undefined,
+): string | undefined {
+  if (!resolution) {
+    return undefined;
+  }
+  return (
+    readSourceUrlFromSourceMetadata(resolution) ??
+    (resolution.installKind === "github"
+      ? readSourceUrlFromSourceMetadata(resolution.github)
+      : readSourceUrlFromSourceMetadata(resolution.archive))
+  );
+}
+
+function readVerificationSourceUrl(
+  verification: ClawHubSkillVerificationLock | undefined,
+): string | undefined {
+  return readSourceUrlFromSourceMetadata(verification);
 }
 
 function buildDownloadedArtifactLock(
@@ -309,11 +354,13 @@ function buildInstallTelemetrySkills(
 function snapshotClawHubSkillVerification(
   verification: ClawHubSkillVerificationResponse,
 ): ClawHubSkillVerificationLock {
+  const sourceUrl = readSourceUrlFromSourceMetadata(verification);
   return {
     schema: verification.schema,
     ok: verification.ok,
     decision: verification.decision,
     reasons: [...verification.reasons],
+    ...(sourceUrl ? { sourceUrl } : {}),
     ...(verification.card !== undefined ? { card: verification.card } : {}),
     ...(verification.artifact !== undefined ? { artifact: verification.artifact } : {}),
     ...(verification.provenance !== undefined ? { provenance: verification.provenance } : {}),
@@ -1106,10 +1153,6 @@ async function performClawHubSkillInstall(
 
       const installedAt = Date.now();
       const artifact = buildDownloadedArtifactLock(archive);
-      const sourceUrl =
-        latestResolution?.installKind === "github"
-          ? normalizeOptionalStringValue(latestResolution.github.sourceUrl)
-          : readSkillDetailSourceUrl(detail);
       const verificationVersion =
         latestResolution?.installKind === "github" && !params.version ? undefined : version;
       const [skillFile, verification] = await Promise.all([
@@ -1120,6 +1163,10 @@ async function performClawHubSkillInstall(
           baseUrl: params.baseUrl,
         }),
       ]);
+      const sourceUrl =
+        readInstallResolutionSourceUrl(latestResolution) ??
+        readVerificationSourceUrl(verification) ??
+        readSkillDetailSourceUrl(detail, version);
       await writeClawHubSkillOrigin(install.targetDir, {
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -19,7 +19,6 @@ import {
   type ClawHubSkillDetail,
   type ClawHubSkillInstallResolutionResponse,
   type ClawHubSkillSearchResult,
-  type ClawHubSkillSourceProvenance,
   type ClawHubSkillVerificationResponse,
 } from "../../infra/clawhub.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -56,10 +55,9 @@ type ClawHubSkillVerificationLock = {
   ok: boolean;
   decision: ClawHubSkillVerificationResponse["decision"];
   reasons: string[];
-  sourceUrl?: string;
   card?: unknown;
   artifact?: unknown;
-  provenance?: ClawHubSkillSourceProvenance | null;
+  provenance?: unknown;
   security?: unknown;
   signature?: unknown;
 };
@@ -281,49 +279,23 @@ function asRecord(raw: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-function readSourceUrlFromSourceMetadata(raw: unknown): string | undefined {
-  const record = asRecord(raw);
-  if (!record) {
+function readVerifiedProvenanceSourceUrl(raw: unknown): string | undefined {
+  const provenance = asRecord(raw);
+  // Only this ClawHub variant is server-resolved; other provenance metadata
+  // must not become a trusted source link.
+  if (provenance?.source !== "server-resolved-github-import") {
     return undefined;
   }
-  return (
-    normalizeOptionalStringValue(record.sourceUrl) ??
-    normalizeOptionalStringValue(record.url) ??
-    readSourceUrlFromSourceMetadata(record.provenance)
-  );
-}
-
-function readSkillDetailSourceUrl(
-  detail: ClawHubSkillDetail | undefined,
-  installedVersion: string,
-): string | undefined {
-  if (detail?.latestVersion?.version !== installedVersion) {
-    return undefined;
-  }
-  return (
-    readSourceUrlFromSourceMetadata(detail.latestVersion) ??
-    readSourceUrlFromSourceMetadata(detail.skill)
-  );
+  return normalizeOptionalStringValue(provenance.url);
 }
 
 function readInstallResolutionSourceUrl(
   resolution: Extract<ClawHubSkillInstallResolutionResponse, { ok: true }> | undefined,
 ): string | undefined {
-  if (!resolution) {
+  if (resolution?.installKind !== "github") {
     return undefined;
   }
-  return (
-    readSourceUrlFromSourceMetadata(resolution) ??
-    (resolution.installKind === "github"
-      ? readSourceUrlFromSourceMetadata(resolution.github)
-      : readSourceUrlFromSourceMetadata(resolution.archive))
-  );
-}
-
-function readVerificationSourceUrl(
-  verification: ClawHubSkillVerificationLock | undefined,
-): string | undefined {
-  return readSourceUrlFromSourceMetadata(verification);
+  return normalizeOptionalStringValue(resolution.github.sourceUrl);
 }
 
 function buildDownloadedArtifactLock(
@@ -354,13 +326,11 @@ function buildInstallTelemetrySkills(
 function snapshotClawHubSkillVerification(
   verification: ClawHubSkillVerificationResponse,
 ): ClawHubSkillVerificationLock {
-  const sourceUrl = readSourceUrlFromSourceMetadata(verification);
   return {
     schema: verification.schema,
     ok: verification.ok,
     decision: verification.decision,
     reasons: [...verification.reasons],
-    ...(sourceUrl ? { sourceUrl } : {}),
     ...(verification.card !== undefined ? { card: verification.card } : {}),
     ...(verification.artifact !== undefined ? { artifact: verification.artifact } : {}),
     ...(verification.provenance !== undefined ? { provenance: verification.provenance } : {}),
@@ -1165,8 +1135,7 @@ async function performClawHubSkillInstall(
       ]);
       const sourceUrl =
         readInstallResolutionSourceUrl(latestResolution) ??
-        readVerificationSourceUrl(verification) ??
-        readSkillDetailSourceUrl(detail, version);
+        readVerifiedProvenanceSourceUrl(verification?.provenance);
       await writeClawHubSkillOrigin(install.targetDir, {
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),


### PR DESCRIPTION
## Summary

Direct-land the valid core of #93477 with the required trust-boundary repair.

- consume ClawHub source provenance only when it is server-verified or a pinned GitHub resolver URL
- preserve provenance in local install records without trusting generic recursive URL/detail/unavailable responses
- retain network provenance as unknown when verification cannot establish it
- add focused contract coverage

This direct-land PR is necessary because #93477 has `maintainerCanModify=false` and its original branch trusts provenance shapes that ClawHub does not emit. Original implementation and design credit: @momothemage.

Refs #92077. Supersedes #93477.

## Verification

- focused ClawHub lifecycle/infra/CLI proof: 93 tests passed
- `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on changed files passed
- `git diff --check` passed
- fresh autoreview clean, confidence 0.90
- Azure Crabbox `cbx_40d442543e33`, run `run_d87f342ce56a`: changed core/coreTests lanes passed

Known gap: no live positive ClawHub provenance sample; current ClawHub server source and tests were inspected.
