### PR TITLE
fix(skills): clear orphaned idempotency pointer on corrupt-metadata re-begin

### DIFF
--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -481,6 +481,45 @@ describe("skill upload store", () => {
     expect(next.uploadId).not.toBe(committed.uploadId);
     await expectMissingPath(path.join(rootDir, committed.uploadId));
   });
+
+  it("clears the orphaned idempotency pointer when re-begin hits corrupt metadata before the active cap throws", async () => {
+    const rootDir = await makeTempDir();
+    const store = createSkillUploadStore({ rootDir });
+    const idempotencyKey = "orphan-pointer-key";
+
+    // begin with an idempotency key → writes the upload plus its idempotency pointer
+    const first = await store.begin({
+      kind: "skill-archive",
+      slug: "demo-skill",
+      sizeBytes: 8,
+      idempotencyKey,
+    });
+    const idempotencyDir = path.join(rootDir, "idempotency");
+    const pointerFiles = await fs.readdir(idempotencyDir);
+    expect(pointerFiles).toHaveLength(1);
+    const pointerFile = pointerFiles[0];
+
+    // corrupt the upload metadata so readRecordIfPresent() returns null on re-begin
+    // (this also drops the upload from the active-upload count)
+    await fs.rm(path.join(rootDir, first.uploadId, "metadata.json"), { force: true });
+
+    // saturate the active-upload cap with unrelated uploads
+    for (let i = 0; i < MAX_ACTIVE_SKILL_UPLOADS; i++) {
+      await store.begin({ kind: "skill-archive", slug: `filler-${i}`, sizeBytes: 8 });
+    }
+
+    // re-begin the same key: the pointer still matches, but its upload metadata is gone,
+    // so the corrupt-metadata branch runs and then the active-upload cap throws before the
+    // pointer would be rewritten. The pointer must have been cleared by that branch — not
+    // left stranded pointing at the now-deleted (ghost) uploadId.
+    await expectUploadError(
+      store.begin({ kind: "skill-archive", slug: "demo-skill", sizeBytes: 8, idempotencyKey }),
+      "too many active skill uploads",
+    );
+
+    const remaining = await fs.readdir(idempotencyDir).catch(() => [] as string[]);
+    expect(remaining).not.toContain(pointerFile);
+  });
 });
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/src/skills/lifecycle/upload-store.ts
+++ b/src/skills/lifecycle/upload-store.ts
@@ -421,7 +421,13 @@ export function createSkillUploadStore(options?: {
                 if (record) {
                   await removeRecordFiles(rootDir, record);
                 } else {
+                  // Mirror removeRecordFiles for the corrupt/missing-metadata branch.
+                  // The idempotency pointer still references this now-deleted upload,
+                  // so drop it too. Otherwise, if the active-upload cap throws below
+                  // before the pointer is rewritten, it strands an orphan idempotency
+                  // file pointing at a ghost uploadId.
                   await removeUploadDir(rootDir, existingUploadId);
+                  await fs.rm(resolveIdempotencyPath(rootDir, keyHash), { force: true });
                 }
                 return null;
               },


### PR DESCRIPTION
## Summary

`createSkillUploadStore().begin()` handles a re-begin that matches an existing idempotency pointer. When the matched upload's metadata is missing/corrupt (`readRecordIfPresent` returns `null`), the `else` branch called only `removeUploadDir(rootDir, existingUploadId)` — it removed the upload directory but **left the idempotency pointer file behind**, still referencing the now-deleted (ghost) `uploadId`. The sibling `record != null` branch already removes both, via `removeRecordFiles` (upload dir **and** the idempotency pointer).

The two branches were asymmetric. If the active-upload cap (`MAX_ACTIVE_SKILL_UPLOADS`) throws right after the `else` branch — before the pointer would be rewritten further down in `begin()` — the orphan idempotency file is stranded pointing at a ghost `uploadId`.

## What changed

`src/skills/lifecycle/upload-store.ts`: mirror `removeRecordFiles` in the corrupt-metadata `else` branch — after `removeUploadDir`, also `await fs.rm(resolveIdempotencyPath(rootDir, keyHash), { force: true })`. Single-file change; behavior is unchanged on the healthy path (where the upload dir still exists or the upload is still active).

## Real behavior proof

**Behavior addressed**: A re-begin whose matched upload has missing/corrupt metadata no longer strands the idempotency pointer when the active-upload cap throws before the pointer is rewritten.

**Real environment tested**: Worktree of `origin/main` at the PR head, Node v22.22.0. Drove the real exported `createSkillUploadStore` via `node --import tsx` against a real temp filesystem — actual production store, no mocks/stubs.

**Exact steps or command run after this patch**:
```
TSX_TSCONFIG_PATH=tsconfig.json node --import tsx ./proof.mts   # drives the real createSkillUploadStore
node scripts/run-vitest.mjs src/skills/lifecycle/upload-store.test.ts
```

**Evidence after fix**: Real console output from `node --import tsx` driving the production `createSkillUploadStore` with a real on-disk root:
```
[1] after begin: idempotency pointers on disk = ["dbc7b840...json"] (uploadId=20d86568...)
[2] removed metadata.json of upload 20d86568... (simulated crash/corruption)
[3] saturated the active-upload cap with 32 uploads
[4] re-begin same key rejected with: "too many active skill uploads"
[5] idempotency pointers on disk after = []

RESULT: PASS - the orphan idempotency pointer was cleared by the corrupt-metadata branch (no ghost pointer stranded).
```

**Observed result after fix**: After the re-begin hits the corrupt-metadata branch and the active-upload cap throws, the idempotency directory is empty — the orphan pointer was cleared, not left pointing at the deleted uploadId. Before the fix the same scenario leaves the pointer stranded (see negative control below).

**What was not tested**: No live Gateway `skills.upload` RPC round-trip; the change is in the store's deterministic filesystem cleanup, exercised directly via the real exported store + real temp filesystem.

## Tests and validation

- `src/skills/lifecycle/upload-store.test.ts` (+1 regression test): re-begin with corrupt metadata + a saturated active-upload cap leaves no orphan idempotency pointer. **12/12 pass.**
- **Negative control**: reverting the added `fs.rm` makes the new test fail (`expected [Array(1)] to not include '<keyHash>.json'` — the pointer is stranded), confirming the regression is real.
- `node scripts/run-tsgo.mjs` clean on the changed file.
