### PR TITLE
build(docs): finish PowerShell-safe docs formatting

### DIFF
--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -1,46 +1,189 @@
 #!/usr/bin/env node
 
 // Formats docs Markdown/MDX and repairs Mintlify accordion indentation.
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { repairMintlifyAccordionIndentation } from "./lib/mintlify-accordion.mjs";
+import { buildCmdExeCommandLine } from "./windows-cmd-helpers.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const CHECK = process.argv.includes("--check");
-const OXFMT_BIN = path.join(ROOT, "node_modules", "oxfmt", "bin", "oxfmt");
-const OXFMT_CONFIG = path.join(ROOT, ".oxfmtrc.jsonc");
+const DOCS_FORMAT_MAX_BUFFER_BYTES = 1024 * 1024 * 16;
+export const DOCS_FORMAT_MAX_COMMAND_LINE_BYTES = 24 * 1024;
+const FAILURE_OUTPUT_TAIL_BYTES = 16 * 1024;
 
-function docsFiles() {
-  const output = execFileSync("git", ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"], {
-    cwd: ROOT,
-    encoding: "utf8",
-  });
-  return output
-    .split("\n")
-    .filter(Boolean)
-    .filter((relativePath) => fs.existsSync(path.join(ROOT, relativePath)));
+function outputText(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf8");
+  }
+  return "";
 }
 
-function runOxfmt(files) {
-  const result = spawnSync(
-    process.execPath,
-    [OXFMT_BIN, "--write", "--threads=1", "--config", OXFMT_CONFIG, ...files],
-    {
-      cwd: ROOT,
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 16,
-    },
-  );
+function outputTail(value) {
+  const text = outputText(value).trim();
+  if (!text) {
+    return "";
+  }
+  const bytes = Buffer.from(text, "utf8");
+  if (bytes.byteLength <= FAILURE_OUTPUT_TAIL_BYTES) {
+    return text;
+  }
+  return bytes.subarray(bytes.byteLength - FAILURE_OUTPUT_TAIL_BYTES).toString("utf8");
+}
 
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim();
-    throw new Error(`oxfmt failed${stderr ? `:\n${stderr}` : ""}`);
+function commandFailureMessage(label, result, invocation) {
+  const details = [];
+  if (invocation) {
+    details.push(`command: ${invocation.command}`);
+    if (invocation.args.length > 0) {
+      const previewArgs = invocation.args.slice(0, 12).join(" ");
+      const suffix = invocation.args.length > 12 ? ` ... (${invocation.args.length} args)` : "";
+      details.push(`args: ${previewArgs}${suffix}`);
+    }
+  }
+  if (result.error?.message) {
+    details.push(result.error.message);
+  }
+  if (result.status !== null && result.status !== undefined && result.status !== 0) {
+    details.push(`exit status: ${result.status}`);
+  }
+  if (result.signal) {
+    details.push(`signal: ${result.signal}`);
+  }
+  const stderrTail = outputTail(result.stderr);
+  if (stderrTail) {
+    details.push(`stderr tail:\n${stderrTail}`);
+  }
+  const stdoutTail = outputTail(result.stdout);
+  if (stdoutTail) {
+    details.push(`stdout tail:\n${stdoutTail}`);
+  }
+  return `${label} failed${details.length > 0 ? `:\n${details.join("\n")}` : ""}`;
+}
+
+export function docsFiles(root = ROOT, deps = {}) {
+  const spawnSyncImpl = deps.spawnSync ?? spawnSync;
+  const result = spawnSyncImpl("git", ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: DOCS_FORMAT_MAX_BUFFER_BYTES,
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      commandFailureMessage("git ls-files", result, {
+        command: "git",
+        args: ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"],
+      }),
+    );
+  }
+  return outputText(result.stdout)
+    .split("\n")
+    .filter(Boolean)
+    .filter((relativePath) => (deps.existsSync ?? fs.existsSync)(path.join(root, relativePath)));
+}
+
+function commandLineBytes(args) {
+  return args.reduce((total, arg) => total + Buffer.byteLength(arg, "utf8") + 3, 0);
+}
+
+export function chunkFilesForCommand(
+  files,
+  prefixArgs,
+  maxBytes = DOCS_FORMAT_MAX_COMMAND_LINE_BYTES,
+) {
+  const chunks = [];
+  let chunk = [];
+  let chunkBytes = commandLineBytes(prefixArgs);
+
+  for (const file of files) {
+    const fileBytes = Buffer.byteLength(file, "utf8") + 3;
+    if (chunk.length > 0 && chunkBytes + fileBytes > maxBytes) {
+      chunks.push(chunk);
+      chunk = [];
+      chunkBytes = commandLineBytes(prefixArgs);
+    }
+    chunk.push(file);
+    chunkBytes += fileBytes;
+  }
+
+  if (chunk.length > 0) {
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+export function resolveOxfmtInvocation(args, params = {}) {
+  const repoRoot = params.repoRoot ?? ROOT;
+  const platform = params.platform ?? process.platform;
+  const existsSync = params.existsSync ?? fs.existsSync;
+  const shimName = platform === "win32" ? "oxfmt.cmd" : "oxfmt";
+  const shimPath = path.join(repoRoot, "node_modules", ".bin", shimName);
+
+  if (existsSync(shimPath)) {
+    if (platform === "win32") {
+      const comSpec = params.comSpec ?? process.env.ComSpec ?? "cmd.exe";
+      return {
+        command: comSpec,
+        args: ["/d", "/s", "/c", buildCmdExeCommandLine(shimPath, args)],
+        shell: false,
+        windowsVerbatimArguments: true,
+      };
+    }
+    return {
+      command: shimPath,
+      args,
+      shell: false,
+    };
+  }
+
+  return {
+    command: params.nodeExecPath ?? process.execPath,
+    args: [path.join(repoRoot, "node_modules", "oxfmt", "bin", "oxfmt"), ...args],
+    shell: false,
+  };
+}
+
+export function runOxfmt(files, params = {}, deps = {}) {
+  if (files.length === 0) {
+    return;
+  }
+  const repoRoot = params.repoRoot ?? ROOT;
+  const spawnSyncImpl = deps.spawnSync ?? spawnSync;
+  const prefixArgs = ["--write", "--threads=1", "--config", path.join(repoRoot, ".oxfmtrc.jsonc")];
+  for (const chunk of chunkFilesForCommand(
+    files,
+    prefixArgs,
+    params.maxCommandLineBytes ?? DOCS_FORMAT_MAX_COMMAND_LINE_BYTES,
+  )) {
+    const invocation = resolveOxfmtInvocation([...prefixArgs, ...chunk], {
+      comSpec: params.comSpec,
+      existsSync: deps.existsSync,
+      nodeExecPath: params.nodeExecPath,
+      platform: params.platform,
+      repoRoot,
+    });
+    const result = spawnSyncImpl(invocation.command, invocation.args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: DOCS_FORMAT_MAX_BUFFER_BYTES,
+      shell: invocation.shell,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    });
+
+    if (result.error || result.status !== 0) {
+      throw new Error(commandFailureMessage("oxfmt", result, invocation));
+    }
   }
 }
 
-function repairFiles(root, files) {
+export function repairFiles(root, files) {
   const changed = [];
   for (const relativePath of files) {
     const absolutePath = path.join(root, relativePath);
@@ -55,10 +198,10 @@ function repairFiles(root, files) {
   return changed;
 }
 
-function copyDocsToTemp(files) {
+function copyDocsToTemp(root, files) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docs-format-"));
   for (const relativePath of files) {
-    const source = path.join(ROOT, relativePath);
+    const source = path.join(root, relativePath);
     const target = path.join(tempRoot, relativePath);
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.copyFileSync(source, target);
@@ -66,39 +209,60 @@ function copyDocsToTemp(files) {
   return tempRoot;
 }
 
-const changed = [];
-const files = docsFiles();
+export function formatDocs(params = {}, deps = {}) {
+  const root = params.root ?? ROOT;
+  const check = params.check ?? false;
+  const changed = [];
+  const files = docsFiles(root, deps);
 
-if (CHECK) {
-  const tempRoot = copyDocsToTemp(files);
-  try {
-    runOxfmt(files.map((relativePath) => path.join(tempRoot, relativePath)));
-    repairFiles(tempRoot, files);
-    for (const relativePath of files) {
-      const raw = fs.readFileSync(path.join(ROOT, relativePath), "utf8");
-      const formatted = fs.readFileSync(path.join(tempRoot, relativePath), "utf8");
-      if (formatted !== raw) {
-        changed.push(relativePath);
+  if (check) {
+    const tempRoot = copyDocsToTemp(root, files);
+    try {
+      runOxfmt(
+        files.map((relativePath) => path.join(tempRoot, relativePath)),
+        { ...params, repoRoot: root },
+        deps,
+      );
+      repairFiles(tempRoot, files);
+      for (const relativePath of files) {
+        const raw = fs.readFileSync(path.join(root, relativePath), "utf8");
+        const formatted = fs.readFileSync(path.join(tempRoot, relativePath), "utf8");
+        if (formatted !== raw) {
+          changed.push(relativePath);
+        }
       }
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
     }
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+  } else {
+    runOxfmt(files, { ...params, repoRoot: root }, deps);
+    changed.push(...repairFiles(root, files));
   }
-} else {
-  runOxfmt(files);
-  changed.push(...repairFiles(ROOT, files));
+
+  return {
+    changed,
+    fileCount: files.length,
+  };
 }
 
-if (CHECK && changed.length > 0) {
-  console.error(`Format issues found in ${changed.length} docs file(s):`);
-  for (const relativePath of changed) {
-    console.error(`- ${relativePath}`);
+function main() {
+  const { changed, fileCount } = formatDocs({ check: CHECK, root: ROOT });
+
+  if (CHECK && changed.length > 0) {
+    console.error(`Format issues found in ${changed.length} docs file(s):`);
+    for (const relativePath of changed) {
+      console.error(`- ${relativePath}`);
+    }
+    process.exit(1);
   }
-  process.exit(1);
+
+  if (changed.length > 0) {
+    console.log(`Formatted ${changed.length} docs file(s).`);
+  } else {
+    console.log(`Docs formatting clean (${fileCount} files).`);
+  }
 }
 
-if (changed.length > 0) {
-  console.log(`Formatted ${changed.length} docs file(s).`);
-} else {
-  console.log(`Docs formatting clean (${files.length} files).`);
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
 }

--- a/test/scripts/format-docs.test.ts
+++ b/test/scripts/format-docs.test.ts
@@ -1,0 +1,154 @@
+// Format Docs tests cover the docs formatter helper process spawning.
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  chunkFilesForCommand,
+  docsFiles,
+  formatDocs,
+  resolveOxfmtInvocation,
+  runOxfmt,
+} from "../../scripts/format-docs.mjs";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+function writeDocsFixture(root: string): void {
+  fs.mkdirSync(path.join(root, "docs"), { recursive: true });
+  fs.writeFileSync(path.join(root, "README.md"), "# OpenClaw\n", "utf8");
+  fs.writeFileSync(path.join(root, "docs", "guide.mdx"), "# Guide\n", "utf8");
+}
+
+describe("format-docs", () => {
+  it("wraps the Windows oxfmt.cmd shim through cmd.exe", () => {
+    const invocation = resolveOxfmtInvocation(["--write", "docs\\guide.mdx"], {
+      comSpec: "C:\\Windows\\System32\\cmd.exe",
+      existsSync: (candidate: string) => candidate.endsWith("oxfmt.cmd"),
+      platform: "win32",
+      repoRoot: "C:\\repo",
+    });
+
+    expect(invocation.command).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(invocation.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+    expect(invocation.args[3]).toContain("oxfmt.cmd");
+    expect(invocation.args[3]).toContain("--write");
+    expect(invocation.args[3]).toContain("docs\\guide.mdx");
+    expect(invocation.shell).toBe(false);
+    expect(invocation.windowsVerbatimArguments).toBe(true);
+  });
+
+  it("batches oxfmt invocations when docs exceed the command line budget", () => {
+    const root = createTempDir("openclaw-format-docs-batch-");
+    const calls: Array<{ args: string[]; command: string }> = [];
+
+    runOxfmt(
+      ["docs/one.md", "docs/two.md", "docs/three.md"],
+      {
+        maxCommandLineBytes: 1,
+        repoRoot: root,
+      },
+      {
+        existsSync: () => false,
+        spawnSync: (command: string, args: string[]) => {
+          calls.push({ args, command });
+          return { status: 0, stderr: "", stdout: "" };
+        },
+      },
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(calls.every((call) => call.command === process.execPath)).toBe(true);
+    expect(calls.map((call) => call.args.at(-1))).toEqual([
+      "docs/one.md",
+      "docs/two.md",
+      "docs/three.md",
+    ]);
+  });
+
+  it("reports git and oxfmt spawn diagnostics", () => {
+    const root = createTempDir("openclaw-format-docs-failures-");
+
+    expect(() =>
+      docsFiles(root, {
+        spawnSync: () => ({
+          status: 128,
+          stderr: "fatal: not a git repository",
+          stdout: "",
+        }),
+      }),
+    ).toThrow(/git ls-files failed:[\s\S]*exit status: 128[\s\S]*fatal: not a git repository/u);
+
+    expect(() =>
+      runOxfmt(
+        ["README.md"],
+        { repoRoot: root },
+        {
+          existsSync: () => false,
+          spawnSync: () => ({
+            status: 1,
+            stderr: "formatter stderr",
+            stdout: "formatter stdout",
+          }),
+        },
+      ),
+    ).toThrow(
+      /oxfmt failed:[\s\S]*command:[\s\S]*exit status: 1[\s\S]*formatter stderr[\s\S]*formatter stdout/u,
+    );
+  });
+
+  it("uses repository paths in write mode and temporary paths in check mode", () => {
+    const root = createTempDir("openclaw-format-docs-mode-");
+    writeDocsFixture(root);
+    const oxfmtFileArgs: string[][] = [];
+
+    const spawnSync = (command: string, args: string[]) => {
+      if (command === "git") {
+        return {
+          status: 0,
+          stderr: "",
+          stdout: "README.md\ndocs/guide.mdx\n",
+        };
+      }
+      oxfmtFileArgs.push(args.slice(-2));
+      return { status: 0, stderr: "", stdout: "" };
+    };
+
+    expect(
+      formatDocs(
+        {
+          check: false,
+          repoRoot: root,
+          root,
+        },
+        {
+          existsSync: fs.existsSync,
+          spawnSync,
+        },
+      ),
+    ).toEqual({ changed: [], fileCount: 2 });
+
+    expect(
+      formatDocs(
+        {
+          check: true,
+          repoRoot: root,
+          root,
+        },
+        {
+          existsSync: fs.existsSync,
+          spawnSync,
+        },
+      ),
+    ).toEqual({ changed: [], fileCount: 2 });
+
+    expect(oxfmtFileArgs[0]).toEqual(["README.md", "docs/guide.mdx"]);
+    expect(oxfmtFileArgs[1]?.every((filePath) => path.isAbsolute(filePath))).toBe(true);
+    expect(oxfmtFileArgs[1]?.every((filePath) => filePath.startsWith(root))).toBe(false);
+  });
+
+  it("keeps single oversized docs in their own command chunk", () => {
+    expect(chunkFilesForCommand(["docs/very-long-name.md"], ["--write"], 1)).toEqual([
+      ["docs/very-long-name.md"],
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #44293.

This replacement carries forward the useful work from #44824, #48887, and #49913 with attribution to @tianxingleo, @soyames, and @yil337. The previous PR branches are closed/unmerged or uneditable, so Clownfish should land the narrow remaining fix separately while preserving source PR credit.

Planned changes:
- keep `format:docs` and `format:docs:check` routed through the shared docs formatter helper;
- invoke the npm-installed `oxfmt` shim safely on Windows, including `.cmd` handling;
- preserve command-line batching/chunking for large doc sets;
- print explicit spawn diagnostics for `git` and `oxfmt` failures;
- add focused tests for mode selection, batching, spawn-error handling, and Windows shell/shim behavior.

Validation:
- `pnpm -s vitest run test/scripts/format-docs.test.ts`
- `pnpm format:docs:check`
- `pnpm check:changed`

Clownfish 🐠 replacement reef notes:
- Cluster: ghcrawl-156809-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/44824, https://github.com/openclaw/openclaw/pull/48887, https://github.com/openclaw/openclaw/pull/49913
- Credit: Credit @tianxingleo for the original cross-platform `scripts/format-docs.mjs` direction in https://github.com/openclaw/openclaw/pull/44824.; Credit @soyames for the more complete Windows-clean formatter/check test direction in https://github.com/openclaw/openclaw/pull/48887.; Credit @yil337 for the PowerShell-friendly docs format check approach and command-line chunking direction in https://github.com/openclaw/openclaw/pull/49913.; Mention the maintainer repair context on #48887 and preserve contributor attribution in the replacement PR body.
- Validation: pnpm -s vitest run test/scripts/format-docs.test.ts; pnpm format:docs:check; pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against 5522f060ec0f.
