### PR TITLE
fix(skills): quote skill-creator template description

### DIFF
--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -22,7 +22,7 @@ ALLOWED_RESOURCES = {"scripts", "references", "assets"}
 
 SKILL_TEMPLATE = """---
 name: {skill_name}
-description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+description: '[TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]'
 ---
 
 # {skill_title}

--- a/skills/skill-creator/scripts/test_init_skill.py
+++ b/skills/skill-creator/scripts/test_init_skill.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Regression tests for skill initialization.
+"""
+
+import shutil
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest import TestCase, main
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import init_skill
+
+
+class TestInitSkill(TestCase):
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp(prefix="test_init_skill_"))
+
+    def tearDown(self):
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir)
+
+    def test_generated_description_placeholder_is_yaml_string(self):
+        with redirect_stdout(StringIO()):
+            skill_dir = init_skill.init_skill("yaml-description-skill", self.temp_dir, [], False)
+
+        self.assertIsNotNone(skill_dir)
+        content = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        frontmatter = content.split("---", 2)[1]
+
+        self.assertIn("description: '[TODO:", frontmatter)
+
+        try:
+            import yaml
+        except ImportError:
+            self.skipTest("PyYAML is not installed")
+
+        parsed = yaml.safe_load(frontmatter)
+
+        self.assertIsInstance(parsed["description"], str)
+        self.assertTrue(parsed["description"].startswith("[TODO: Complete"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Quote the generated `description` placeholder in `skills/skill-creator/scripts/init_skill.py` so YAML parsers keep it as a string instead of a flow sequence.
- Add focused regression coverage for the generated SKILL.md frontmatter.
- Leave workspace default-path behavior from #54386 out of scope.

## Credit
This carries forward the narrow YAML-template fix from @parubets in https://github.com/openclaw/openclaw/pull/43253. Clownfish could not safely update that closed, conflicted, uneditable branch, so this replacement PR preserves attribution while applying the smallest current-main patch.

## Validation
- `pnpm check:changed`

Clownfish 🐠 replacement reef notes:
- Cluster: ghcrawl-157065-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/43253
- Credit: Credit @parubets for the source idea and implementation direction from https://github.com/openclaw/openclaw/pull/43253.; Mention that Clownfish replaced the closed, conflicted, uneditable source branch while preserving attribution.; Do not credit #54386 for this narrow PR; its workspace default-path behavior is separate follow-up work.
- Validation: pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against 02fecbcfbfcf.
