### PR TITLE
fix(cron): preserve model overrides for text payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Release and test reliability: extend slow Gateway/full-suite watchdogs, split local full-suite shards when throttled, stabilize plugin auth marker fixtures, avoid brittle provider-ref error text, and keep QA Lab bootstrap selection assertions aligned with flow-only scenarios. (#92652)
 - macOS Peekaboo bridge: update the embedded Peekaboo package to 3.5.2 and route bundled-skill CLI commands through the OpenClaw app bridge so they inherit its Screen Recording and Accessibility grants.
 - Agent routing: route subagent RPC callbacks addressed to an agent-shaped `--to` target to the correct session key instead of falling back to the main session, so WeChat (and other channel) session-key callbacks reach the intended subagent session. (#90231) Thanks @zhangguiping-xydt.
+- Cron: preserve model, fallback, thinking, timeout, light-context, unsafe-content, and tool allow-list overrides on implicit text payloads by promoting them to agent turns, while explicit system events still prune those fields. Fixes #28905; carries forward #64060 and #73946. Thanks @liaoandi.
 - QQBot delivery: keep markdown table chunks self-contained across message boundaries by preserving table state across block deliveries, flushing unfinished table-row fragments as plain text, and detecting short pipe-terminated rows by column count so split rows are not sent as malformed markdown. (#92428) Thanks @sliverp.
 
 ## 2026.6.6

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -475,6 +475,38 @@ describe("normalizeCronJobCreate", () => {
     expect(validateCronAddParams(normalized)).toBe(true);
   });
 
+  it("promotes implicit text payloads with agentTurn hints to agentTurn create jobs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "implicit-agent-turn",
+      schedule: { kind: "every", everyMs: 60_000 },
+      payload: {
+        text: " summarize the build ",
+        model: " openai/gpt-5 ",
+        fallbacks: [" anthropic/claude-haiku-3-5 "],
+        thinking: " high ",
+        timeoutSeconds: 45,
+        lightContext: true,
+        toolsAllow: [" read "],
+        allowUnsafeExternalContent: true,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.sessionTarget).toBe("isolated");
+    expect((normalized.delivery as Record<string, unknown>).mode).toBe("announce");
+    expect(normalized.payload).toEqual({
+      kind: "agentTurn",
+      message: "summarize the build",
+      model: "openai/gpt-5",
+      fallbacks: ["anthropic/claude-haiku-3-5"],
+      thinking: "high",
+      timeoutSeconds: 45,
+      lightContext: true,
+      toolsAllow: ["read"],
+      allowUnsafeExternalContent: true,
+    });
+    expect(validateCronAddParams(normalized)).toBe(true);
+  });
+
   it("prunes agentTurn-only payload fields from systemEvent create jobs", () => {
     const normalized = normalizeCronJobCreate({
       name: "system-event-prune",
@@ -840,6 +872,22 @@ describe("normalizeCronJobPatch", () => {
     const payload = normalized.payload as Record<string, unknown>;
     expect(payload.kind).toBe("agentTurn");
     expect(payload.toolsAllow).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
+  it("promotes implicit text payloads with agentTurn hints to agentTurn patches", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        text: " continue the report ",
+        toolsAllow: [" read "],
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(normalized.payload).toEqual({
+      kind: "agentTurn",
+      message: "continue the report",
+      toolsAllow: ["read"],
+    });
     expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
   });
 

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -79,6 +79,18 @@ function normalizeCommandArgv(value: unknown): string[] | undefined {
   return [...value];
 }
 
+function hasAgentTurnOnlyPayloadHint(payload: UnknownRecord): boolean {
+  return (
+    "model" in payload ||
+    "fallbacks" in payload ||
+    "thinking" in payload ||
+    "timeoutSeconds" in payload ||
+    "toolsAllow" in payload ||
+    typeof payload.lightContext === "boolean" ||
+    typeof payload.allowUnsafeExternalContent === "boolean"
+  );
+}
+
 function coerceSchedule(schedule: UnknownRecord) {
   const next: UnknownRecord = { ...schedule };
   const rawKind = normalizeLowercaseStringOrEmpty(schedule.kind);
@@ -264,6 +276,10 @@ function coercePayload(payload: UnknownRecord) {
     typeof next.allowUnsafeExternalContent !== "boolean"
   ) {
     delete next.allowUnsafeExternalContent;
+  }
+  if (!("kind" in next) && typeof next.text === "string" && hasAgentTurnOnlyPayloadHint(next)) {
+    next.kind = "agentTurn";
+    next.message = next.text;
   }
   if (next.kind === "systemEvent") {
     delete next.message;


### PR DESCRIPTION
Fixes the cron text-payload model override lane from #64060/#73946 on the current main checkout.

This promotes implicit `text` payloads that also carry agent-turn-only fields such as `model`, `fallbacks`, `thinking`, `toolsAllow`, `timeoutSeconds`, `lightContext`, or `allowUnsafeExternalContent` to `agentTurn`, moving `text` to `message`. Explicit `systemEvent` payloads keep the existing pruning behavior.

Credit: this carries forward @liaoandi's source work in https://github.com/openclaw/openclaw/pull/64060 and the prior Clownfish replacement context from https://github.com/openclaw/openclaw/pull/73946.

Out of scope: #66543 model-ID whitespace repair, which needs a separate alias-preserving resolution-time fix.

Validation:
- `pnpm -s vitest run --config vitest.config.ts src/cron/normalize.test.ts`
- `pnpm check:changed`

Clownfish 🐠 replacement reef notes:
- Cluster: ghcrawl-156849-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/64060, https://github.com/openclaw/openclaw/pull/73946
- Credit: Preserve credit for @liaoandi and source PR https://github.com/openclaw/openclaw/pull/64060 for identifying and implementing the text-payload model override fix.; Mention replacement PR https://github.com/openclaw/openclaw/pull/73946 as prior Clownfish repair context, without claiming it is present in the current checkout.; Do not credit or fold in #66543; model-ID whitespace repair needs a separate alias-preserving cluster.
- Validation: pnpm -s vitest run --config vitest.config.ts src/cron/normalize.test.ts; pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against fdbd2bcf9dad.
