### PR TITLE
Expose verified ClawHub source in skill verify output

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -107,6 +107,10 @@ Notes:
   in the shared managed skills directory when combined with `--global`.
 - `verify <slug>` prints ClawHub's `clawhub.skill.verify.v1` JSON envelope by
   default. There is no `--json` flag because JSON is already the default.
+- When ClawHub returns server-resolved source provenance, verify JSON also
+  includes a commit-pinned `openclaw.verifiedSourceUrl`. Unavailable or
+  self-declared source URLs stay only in the raw provenance envelope and are not
+  promoted.
 - `verify` uses `.clawhub/origin.json` for installed ClawHub skills, so it
   verifies the installed version against the registry it came from. `--version`
   and `--tag` override the version selector but keep that installed registry

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -85,6 +85,7 @@ const mocks = vi.hoisted(() => {
     installSkillFromSourceMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
+    readVerifiedClawHubSkillSourceUrlMock: vi.fn(),
     resolveClawHubSkillVerificationTargetMock: vi.fn(),
     readClawHubSkillsLockfileStatusSyncMock: vi.fn((..._args: unknown[]) => ({ kind: "missing" })),
     resolveClawHubSkillStatusLinkSyncMock: vi.fn(),
@@ -110,6 +111,7 @@ const {
   installSkillFromSourceMock,
   updateSkillsFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
+  readVerifiedClawHubSkillSourceUrlMock,
   resolveClawHubSkillVerificationTargetMock,
   readClawHubSkillsLockfileStatusSyncMock,
   resolveClawHubSkillStatusLinkSyncMock,
@@ -191,6 +193,8 @@ vi.mock("../skills/lifecycle/clawhub.js", () => ({
   updateSkillsFromClawHub: (...args: unknown[]) => mocks.updateSkillsFromClawHubMock(...args),
   readTrackedClawHubSkillSlugs: (...args: unknown[]) =>
     mocks.readTrackedClawHubSkillSlugsMock(...args),
+  readVerifiedClawHubSkillSourceUrl: (...args: unknown[]) =>
+    mocks.readVerifiedClawHubSkillSourceUrlMock(...args),
   resolveClawHubSkillVerificationTarget: (...args: unknown[]) =>
     mocks.resolveClawHubSkillVerificationTargetMock(...args),
   readClawHubSkillsLockfileStatusSync: (...args: unknown[]) =>
@@ -255,6 +259,7 @@ describe("skills cli commands", () => {
     installSkillFromSourceMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
     readTrackedClawHubSkillSlugsMock.mockReset();
+    readVerifiedClawHubSkillSourceUrlMock.mockReset();
     resolveClawHubSkillVerificationTargetMock.mockReset();
     readClawHubSkillsLockfileStatusSyncMock.mockReset();
     resolveClawHubSkillStatusLinkSyncMock.mockReset();
@@ -278,6 +283,7 @@ describe("skills cli commands", () => {
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
+    readVerifiedClawHubSkillSourceUrlMock.mockReturnValue(undefined);
     readClawHubSkillsLockfileStatusSyncMock.mockReturnValue({ kind: "missing" });
     resolveClawHubSkillStatusLinkSyncMock.mockReturnValue(undefined);
     resolveLocalSkillCardStatusSyncMock.mockReturnValue(undefined);
@@ -842,6 +848,46 @@ describe("skills cli commands", () => {
       version: "2.0.0",
       tag: undefined,
     });
+  });
+
+  it("includes verified ClawHub source URLs in verify JSON output", async () => {
+    const provenance = {
+      source: "server-resolved-github-import",
+      repo: "openclaw/skills",
+      commit: "def456",
+      path: "agentreceipt",
+    };
+    const verifiedSourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    readVerifiedClawHubSkillSourceUrlMock.mockReturnValueOnce(verifiedSourceUrl);
+    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      skill: { slug: "agentreceipt", displayName: "Agent Receipt" },
+      publisher: { handle: "openclaw" },
+      version: { version: "1.2.3" },
+      card: {
+        available: true,
+        url: "https://private.example.com/clawhub/api/v1/skills/agentreceipt/card?version=1.2.3",
+      },
+      artifact: {
+        sourceFingerprint: "source-fingerprint",
+        bundleFingerprints: ["generated-bundle-fingerprint"],
+      },
+      provenance,
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
+
+    await runCommand(["skills", "verify", "agentreceipt"]);
+
+    expect(readVerifiedClawHubSkillSourceUrlMock).toHaveBeenCalledWith(provenance);
+    const payload = JSON.parse(runtimeStdout.at(-1) ?? "{}") as {
+      openclaw?: { verifiedSourceUrl?: string };
+    };
+    expect(payload.openclaw?.verifiedSourceUrl).toBe(verifiedSourceUrl);
+    expect(defaultRuntime.exit).not.toHaveBeenCalled();
   });
 
   it("fetches generated Skill Card markdown for --card", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -854,10 +854,11 @@ describe("skills cli commands", () => {
     const provenance = {
       source: "server-resolved-github-import",
       repo: "openclaw/skills",
-      commit: "def456",
+      commit: "0123456789abcdef0123456789abcdef01234567",
       path: "agentreceipt",
     };
-    const verifiedSourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    const verifiedSourceUrl =
+      "https://github.com/openclaw/skills/tree/0123456789abcdef0123456789abcdef01234567/agentreceipt";
     readVerifiedClawHubSkillSourceUrlMock.mockReturnValueOnce(verifiedSourceUrl);
     fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
       schema: "clawhub.skill.verify.v1",

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -17,6 +17,7 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import {
   installSkillFromClawHub,
+  readVerifiedClawHubSkillSourceUrl,
   readTrackedClawHubSkillSlugs,
   resolveClawHubSkillVerificationTarget,
   searchSkillsFromClawHub,
@@ -151,6 +152,7 @@ function buildSkillVerificationOutput(
   result: ClawHubSkillVerificationResponse,
   target: ResolvedClawHubSkillVerificationTarget,
 ): Record<string, unknown> {
+  const verifiedSourceUrl = readVerifiedClawHubSkillSourceUrl(result.provenance);
   return {
     ...result,
     openclaw: {
@@ -160,6 +162,7 @@ function buildSkillVerificationOutput(
         registry: target.resolution.registry,
         installedVersion: target.resolution.installedVersion,
       },
+      ...(verifiedSourceUrl ? { verifiedSourceUrl } : {}),
     },
   };
 }

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -193,4 +193,69 @@ describe("skills verify CLI", () => {
     expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
     expect(mocks.runtimeErrors).toStrictEqual([]);
   });
+
+  it("surfaces only server-verified source provenance in verify JSON", async () => {
+    const sourceUrl = "https://github.com/openclaw/skills/tree/main/agentreceipt";
+    const verifiedSourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    mocks.fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      skill: { slug: "agentreceipt" },
+      publisher: { handle: "openclaw" },
+      version: { version: "1.0.0" },
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: {
+        source: "server-resolved-github-import",
+        kind: "github",
+        url: sourceUrl,
+        repo: "openclaw/skills",
+        ref: "main",
+        commit: "def456",
+        path: "agentreceipt",
+      },
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
+
+    await runCommand(["skills", "verify", "agentreceipt"]);
+
+    const payload = JSON.parse(mocks.runtimeStdout.at(-1) ?? "{}") as {
+      openclaw?: { verifiedSourceUrl?: string };
+    };
+    expect(payload.openclaw?.verifiedSourceUrl).toBe(verifiedSourceUrl);
+    expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
+    expect(mocks.runtimeErrors).toStrictEqual([]);
+  });
+
+  it("does not promote unavailable provenance URLs in verify JSON", async () => {
+    mocks.fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      skill: { slug: "agentreceipt" },
+      publisher: { handle: "openclaw" },
+      version: { version: "1.0.0" },
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: {
+        source: "unavailable",
+        url: "https://github.com/openclaw/skills/tree/unverified/agentreceipt",
+      },
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
+
+    await runCommand(["skills", "verify", "agentreceipt"]);
+
+    const payload = JSON.parse(mocks.runtimeStdout.at(-1) ?? "{}") as {
+      openclaw?: { verifiedSourceUrl?: string };
+    };
+    expect(payload.openclaw?.verifiedSourceUrl).toBeUndefined();
+    expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
+    expect(mocks.runtimeErrors).toStrictEqual([]);
+  });
 });

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -196,7 +196,8 @@ describe("skills verify CLI", () => {
 
   it("surfaces only server-verified source provenance in verify JSON", async () => {
     const sourceUrl = "https://github.com/openclaw/skills/tree/main/agentreceipt";
-    const verifiedSourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    const verifiedSourceUrl =
+      "https://github.com/openclaw/skills/tree/0123456789abcdef0123456789abcdef01234567/agentreceipt";
     mocks.fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
       schema: "clawhub.skill.verify.v1",
       ok: true,
@@ -213,7 +214,7 @@ describe("skills verify CLI", () => {
         url: sourceUrl,
         repo: "openclaw/skills",
         ref: "main",
-        commit: "def456",
+        commit: "0123456789abcdef0123456789abcdef01234567",
         path: "agentreceipt",
       },
       security: { status: "clean" },

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -385,7 +385,8 @@ describe("skills-clawhub", () => {
 
   it("persists the source URL from server-resolved verification provenance", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-source-");
-    const sourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    const sourceUrl = "https://github.com/openclaw/skills/tree/main/agentreceipt";
+    const verifiedSourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
     fetchClawHubSkillDetailMock.mockResolvedValueOnce({
       skill: {
         slug: "agentreceipt",
@@ -440,7 +441,7 @@ describe("skills-clawhub", () => {
         await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
       ) as { skills: Record<string, Record<string, unknown>> };
       expect(lock.skills.agentreceipt).toMatchObject({
-        sourceUrl,
+        sourceUrl: verifiedSourceUrl,
         verification: {
           provenance: {
             source: "server-resolved-github-import",
@@ -460,7 +461,7 @@ describe("skills-clawhub", () => {
           "utf8",
         ),
       ) as Record<string, unknown>;
-      expect(origin.sourceUrl).toBe(sourceUrl);
+      expect(origin.sourceUrl).toBe(verifiedSourceUrl);
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -60,6 +60,7 @@ vi.mock("../../infra/fs-safe.js", () => ({
 
 const {
   installSkillFromClawHub,
+  readVerifiedClawHubSkillSourceUrl,
   resolveClawHubSkillStatusLinkSync,
   resolveClawHubSkillVerificationTarget,
   searchSkillsFromClawHub,
@@ -386,7 +387,8 @@ describe("skills-clawhub", () => {
   it("persists the source URL from server-resolved verification provenance", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skills-source-");
     const sourceUrl = "https://github.com/openclaw/skills/tree/main/agentreceipt";
-    const verifiedSourceUrl = "https://github.com/openclaw/skills/tree/def456/agentreceipt";
+    const verifiedSourceUrl =
+      "https://github.com/openclaw/skills/tree/0123456789abcdef0123456789abcdef01234567/agentreceipt";
     fetchClawHubSkillDetailMock.mockResolvedValueOnce({
       skill: {
         slug: "agentreceipt",
@@ -412,7 +414,7 @@ describe("skills-clawhub", () => {
         url: sourceUrl,
         repo: "openclaw/skills",
         ref: "main",
-        commit: "def456",
+        commit: "0123456789abcdef0123456789abcdef01234567",
         path: "agentreceipt",
         importedAt: 4,
       },
@@ -449,7 +451,7 @@ describe("skills-clawhub", () => {
             url: sourceUrl,
             repo: "openclaw/skills",
             ref: "main",
-            commit: "def456",
+            commit: "0123456789abcdef0123456789abcdef01234567",
             path: "agentreceipt",
             importedAt: 4,
           },
@@ -465,6 +467,35 @@ describe("skills-clawhub", () => {
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
+  });
+
+  it("requires a full commit SHA before promoting verified source provenance", () => {
+    const baseProvenance = {
+      source: "server-resolved-github-import",
+      repo: "openclaw/skills",
+      path: "agentreceipt",
+    };
+
+    expect(
+      readVerifiedClawHubSkillSourceUrl({
+        ...baseProvenance,
+        commit: "0123456789abcdef0123456789abcdef01234567",
+      }),
+    ).toBe(
+      "https://github.com/openclaw/skills/tree/0123456789abcdef0123456789abcdef01234567/agentreceipt",
+    );
+    expect(
+      readVerifiedClawHubSkillSourceUrl({
+        ...baseProvenance,
+        commit: "main",
+      }),
+    ).toBeUndefined();
+    expect(
+      readVerifiedClawHubSkillSourceUrl({
+        ...baseProvenance,
+        commit: "0123456",
+      }),
+    ).toBeUndefined();
   });
 
   it("does not treat detail metadata as verified source provenance", async () => {

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -296,7 +296,7 @@ function normalizeGitHubRepoName(raw: unknown): string | undefined {
 
 function normalizeGitHubCommitSegment(raw: unknown): string | undefined {
   const commit = normalizeOptionalStringValue(raw);
-  if (!commit || /[/?#\\]/.test(commit)) {
+  if (!commit || !/^[0-9a-f]{40}$/i.test(commit)) {
     return undefined;
   }
   return commit;

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -282,14 +282,55 @@ function asRecord(raw: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-function readVerifiedProvenanceSourceUrl(raw: unknown): string | undefined {
+function normalizeGitHubRepoName(raw: unknown): string | undefined {
+  const repo = normalizeOptionalStringValue(raw);
+  if (!repo) {
+    return undefined;
+  }
+  const parts = repo.split("/");
+  if (parts.length !== 2 || parts.some((part) => !/^[A-Za-z0-9._-]+$/.test(part))) {
+    return undefined;
+  }
+  return repo;
+}
+
+function normalizeGitHubCommitSegment(raw: unknown): string | undefined {
+  const commit = normalizeOptionalStringValue(raw);
+  if (!commit || /[/?#\\]/.test(commit)) {
+    return undefined;
+  }
+  return commit;
+}
+
+function buildGitHubTreeUrl(params: { repo: string; commit: string; sourcePath?: string }): string {
+  const [owner, name] = params.repo.split("/") as [string, string];
+  const pathParts = params.sourcePath ? params.sourcePath.split("/") : [];
+  const segments = [owner, name, "tree", params.commit, ...pathParts];
+  return `https://github.com/${segments.map(encodeURIComponent).join("/")}`;
+}
+
+export function readVerifiedClawHubSkillSourceUrl(raw: unknown): string | undefined {
   const provenance = asRecord(raw);
   // Only this ClawHub variant is server-resolved; other provenance metadata
   // must not become a trusted source link.
   if (provenance?.source !== "server-resolved-github-import") {
     return undefined;
   }
-  return normalizeOptionalStringValue(provenance.url);
+  const repo = normalizeGitHubRepoName(provenance.repo);
+  const commit = normalizeGitHubCommitSegment(provenance.commit);
+  if (!repo || !commit) {
+    return undefined;
+  }
+  const pathValue = normalizeOptionalStringValue(provenance.path);
+  let sourcePath: string | undefined;
+  if (pathValue) {
+    try {
+      sourcePath = normalizeGitHubSourcePath(pathValue);
+    } catch {
+      return undefined;
+    }
+  }
+  return buildGitHubTreeUrl({ repo, commit, ...(sourcePath ? { sourcePath } : {}) });
 }
 
 function readInstallResolutionSourceUrl(
@@ -1196,7 +1237,7 @@ async function performClawHubSkillInstall(
       ]);
       const sourceUrl =
         readInstallResolutionSourceUrl(latestResolution) ??
-        readVerifiedProvenanceSourceUrl(verification?.provenance);
+        readVerifiedClawHubSkillSourceUrl(verification?.provenance);
       await writeClawHubSkillOrigin(install.targetDir, {
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1,770 +1,5 @@
 [
   {
-    "deferLoading": true,
-    "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": [
-            "status",
-            "describe",
-            "pending",
-            "approve",
-            "reject",
-            "notify",
-            "camera_snap",
-            "camera_list",
-            "camera_clip",
-            "photos_latest",
-            "screen_record",
-            "screen_snapshot",
-            "location_get",
-            "notifications_list",
-            "notifications_action",
-            "device_status",
-            "device_info",
-            "device_permissions",
-            "device_health",
-            "invoke"
-          ],
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "delayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "delivery": {
-          "enum": ["system", "overlay", "auto"],
-          "type": "string"
-        },
-        "desiredAccuracy": {
-          "enum": ["coarse", "balanced", "precise"],
-          "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "string"
-        },
-        "durationMs": {
-          "maximum": 300000,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "facing": {
-          "description": "camera_snap: front/back/both; camera_clip: front/back only.",
-          "enum": ["front", "back", "both"],
-          "type": "string"
-        },
-        "fps": {
-          "exclusiveMinimum": 0,
-          "type": "number"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "includeAudio": {
-          "type": "boolean"
-        },
-        "invokeCommand": {
-          "type": "string"
-        },
-        "invokeParamsJson": {
-          "type": "string"
-        },
-        "invokeTimeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "limit": {
-          "maximum": 20,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "locationTimeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "maxAgeMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "maxWidth": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "node": {
-          "type": "string"
-        },
-        "notificationAction": {
-          "enum": ["open", "dismiss", "reply"],
-          "type": "string"
-        },
-        "notificationKey": {
-          "type": "string"
-        },
-        "notificationReplyText": {
-          "type": "string"
-        },
-        "outPath": {
-          "type": "string"
-        },
-        "priority": {
-          "enum": ["passive", "active", "timeSensitive"],
-          "type": "string"
-        },
-        "quality": {
-          "maximum": 1,
-          "minimum": 0,
-          "type": "number"
-        },
-        "requestId": {
-          "type": "string"
-        },
-        "screenIndex": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "sound": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "nodes",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "action": {
-          "enum": ["status", "list", "get", "add", "update", "remove", "run", "runs", "wake"],
-          "type": "string"
-        },
-        "agentId": {
-          "description": "List filter for `action: \"list\"`; wake target override for `action: \"wake\"` (defaults to the calling agent when omitted on wake)",
-          "type": "string"
-        },
-        "contextMessages": {
-          "maximum": 10,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "includeDisabled": {
-          "type": "boolean"
-        },
-        "job": {
-          "additionalProperties": true,
-          "properties": {
-            "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to keep it unset"
-            },
-            "deleteAfterRun": {
-              "description": "Delete after first run",
-              "type": "boolean"
-            },
-            "delivery": {
-              "additionalProperties": true,
-              "properties": {
-                "accountId": {
-                  "description": "Delivery account",
-                  "type": "string"
-                },
-                "bestEffort": {
-                  "type": "boolean"
-                },
-                "channel": {
-                  "description": "Delivery channel",
-                  "type": "string"
-                },
-                "failureDestination": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "description": "Failure delivery account",
-                      "type": "string"
-                    },
-                    "channel": {
-                      "description": "Failure delivery channel",
-                      "type": "string"
-                    },
-                    "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "to": {
-                      "description": "Failure delivery target",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "mode": {
-                  "description": "Delivery mode",
-                  "enum": ["none", "announce", "webhook"],
-                  "type": "string"
-                },
-                "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
-                },
-                "to": {
-                  "description": "Delivery target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "description": {
-              "description": "Human description",
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "failureAlert": {
-              "additionalProperties": true,
-              "description": "Failure alert object; false disables alerts",
-              "properties": {
-                "accountId": {
-                  "type": "string"
-                },
-                "after": {
-                  "description": "Failures before alert",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "channel": {
-                  "description": "Alert channel",
-                  "type": "string"
-                },
-                "cooldownMs": {
-                  "description": "Alert cooldown ms",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "includeSkipped": {
-                  "description": "Skipped runs count toward alert",
-                  "type": "boolean"
-                },
-                "mode": {
-                  "enum": ["announce", "webhook"],
-                  "type": "string"
-                },
-                "to": {
-                  "description": "Alert target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "description": "Job name",
-              "type": "string"
-            },
-            "payload": {
-              "additionalProperties": true,
-              "properties": {
-                "allowUnsafeExternalContent": {
-                  "type": "boolean"
-                },
-                "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "kind": {
-                  "description": "Payload kind",
-                  "enum": ["systemEvent", "agentTurn"],
-                  "type": "string"
-                },
-                "lightContext": {
-                  "type": "boolean"
-                },
-                "message": {
-                  "description": "agentTurn prompt",
-                  "type": "string"
-                },
-                "model": {
-                  "description": "Model override",
-                  "type": "string"
-                },
-                "text": {
-                  "description": "systemEvent text",
-                  "type": "string"
-                },
-                "thinking": {
-                  "description": "Thinking override",
-                  "type": "string"
-                },
-                "timeoutSeconds": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "toolsAllow": {
-                  "description": "Allowed tools",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              },
-              "type": "object"
-            },
-            "schedule": {
-              "additionalProperties": true,
-              "properties": {
-                "anchorMs": {
-                  "description": "Start anchor ms (kind=every)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "at": {
-                  "description": "ISO-8601 time (kind=at)",
-                  "type": "string"
-                },
-                "everyMs": {
-                  "description": "Interval ms (kind=every)",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "expr": {
-                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Schedule kind",
-                  "enum": ["at", "every", "cron"],
-                  "type": "string"
-                },
-                "staggerMs": {
-                  "description": "Jitter ms (kind=cron)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "tz": {
-                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
-            },
-            "sessionTarget": {
-              "description": "main | isolated | current | session:<id>",
-              "type": "string"
-            },
-            "wakeMode": {
-              "description": "Wake timing",
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "jobId": {
-          "type": "string"
-        },
-        "mode": {
-          "enum": ["now", "next-heartbeat"],
-          "type": "string"
-        },
-        "patch": {
-          "additionalProperties": true,
-          "properties": {
-            "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to clear it"
-            },
-            "deleteAfterRun": {
-              "type": "boolean"
-            },
-            "delivery": {
-              "additionalProperties": true,
-              "properties": {
-                "accountId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery account, or null to clear"
-                },
-                "bestEffort": {
-                  "type": "boolean"
-                },
-                "channel": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery channel, or null to clear"
-                },
-                "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
-                        },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Failure destination, or null to clear"
-                },
-                "mode": {
-                  "description": "Delivery mode",
-                  "enum": ["none", "announce", "webhook"],
-                  "type": "string"
-                },
-                "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Thread/topic id"
-                },
-                "to": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery target, or null to clear"
-                }
-              },
-              "type": "object"
-            },
-            "description": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "failureAlert": {
-              "additionalProperties": true,
-              "description": "Failure alert object; false disables alerts",
-              "properties": {
-                "accountId": {
-                  "type": "string"
-                },
-                "after": {
-                  "description": "Failures before alert",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "channel": {
-                  "description": "Alert channel",
-                  "type": "string"
-                },
-                "cooldownMs": {
-                  "description": "Alert cooldown ms",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "includeSkipped": {
-                  "description": "Skipped runs count toward alert",
-                  "type": "boolean"
-                },
-                "mode": {
-                  "enum": ["announce", "webhook"],
-                  "type": "string"
-                },
-                "to": {
-                  "description": "Alert target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "description": "Job name",
-              "type": "string"
-            },
-            "payload": {
-              "additionalProperties": true,
-              "properties": {
-                "allowUnsafeExternalContent": {
-                  "type": "boolean"
-                },
-                "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "kind": {
-                  "description": "Payload kind",
-                  "enum": ["systemEvent", "agentTurn"],
-                  "type": "string"
-                },
-                "lightContext": {
-                  "type": "boolean"
-                },
-                "message": {
-                  "description": "agentTurn prompt",
-                  "type": "string"
-                },
-                "model": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Model override, or null to clear"
-                },
-                "text": {
-                  "description": "systemEvent text",
-                  "type": "string"
-                },
-                "thinking": {
-                  "description": "Thinking override",
-                  "type": "string"
-                },
-                "timeoutSeconds": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "toolsAllow": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Allowed tool ids, or null to clear"
-                }
-              },
-              "type": "object"
-            },
-            "schedule": {
-              "additionalProperties": true,
-              "properties": {
-                "anchorMs": {
-                  "description": "Start anchor ms (kind=every)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "at": {
-                  "description": "ISO-8601 time (kind=at)",
-                  "type": "string"
-                },
-                "everyMs": {
-                  "description": "Interval ms (kind=every)",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "expr": {
-                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Schedule kind",
-                  "enum": ["at", "every", "cron"],
-                  "type": "string"
-                },
-                "staggerMs": {
-                  "description": "Jitter ms (kind=cron)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "tz": {
-                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
-            },
-            "sessionTarget": {
-              "description": "Session target",
-              "type": "string"
-            },
-            "wakeMode": {
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "runMode": {
-          "enum": ["due", "force"],
-          "type": "string"
-        },
-        "sessionKey": {
-          "description": "Wake target override for `action: \"wake\"`: route the event to the named session rather than the calling agent's current session. Defaults to the resolved calling-session key when omitted.",
-          "type": "string"
-        },
-        "text": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "cron",
-    "namespace": "openclaw"
-  },
-  {
     "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
@@ -886,307 +121,8 @@
       "required": ["action"],
       "type": "object"
     },
-    "name": "message"
-  },
-  {
-    "deferLoading": true,
-    "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
-    "inputSchema": {
-      "properties": {
-        "channel": {
-          "description": "Channel id; output-format hint.",
-          "type": "string"
-        },
-        "text": {
-          "description": "Text to speak.",
-          "type": "string"
-        },
-        "timeoutMs": {
-          "description": "Provider timeout ms.",
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["text"],
-      "type": "object"
-    },
-    "name": "tts",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": [
-            "restart",
-            "config.get",
-            "config.schema.lookup",
-            "config.apply",
-            "config.patch",
-            "update.run"
-          ],
-          "type": "string"
-        },
-        "baseHash": {
-          "type": "string"
-        },
-        "continuationMessage": {
-          "type": "string"
-        },
-        "delayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "raw": {
-          "type": "string"
-        },
-        "reason": {
-          "type": "string"
-        },
-        "replacePaths": {
-          "items": {
-            "type": "string"
-          },
-          "maxItems": 256,
-          "type": "array"
-        },
-        "restartDelayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "gateway",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
-    "inputSchema": {
-      "properties": {},
-      "type": "object"
-    },
-    "name": "agents_list",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
-    "inputSchema": {
-      "properties": {
-        "activeMinutes": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "agentId": {
-          "maxLength": 64,
-          "minLength": 1,
-          "type": "string"
-        },
-        "includeDerivedTitles": {
-          "type": "boolean"
-        },
-        "includeLastMessage": {
-          "type": "boolean"
-        },
-        "kinds": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "label": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "limit": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "messageLimit": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "search": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "sessions_list",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
-    "inputSchema": {
-      "properties": {
-        "includeTools": {
-          "type": "boolean"
-        },
-        "limit": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "sessionKey": {
-          "type": "string"
-        }
-      },
-      "required": ["sessionKey"],
-      "type": "object"
-    },
-    "name": "sessions_history",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
-    "inputSchema": {
-      "properties": {
-        "agentId": {
-          "maxLength": 64,
-          "minLength": 1,
-          "type": "string"
-        },
-        "label": {
-          "maxLength": 512,
-          "minLength": 1,
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "timeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
-        }
-      },
-      "required": ["message"],
-      "type": "object"
-    },
-    "name": "sessions_send",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
-    "inputSchema": {
-      "properties": {
-        "agentId": {
-          "type": "string"
-        },
-        "attachAs": {
-          "properties": {
-            "mountPath": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "attachments": {
-          "items": {
-            "properties": {
-              "content": {
-                "type": "string"
-              },
-              "encoding": {
-                "enum": ["utf8", "base64"],
-                "type": "string"
-              },
-              "mimeType": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": ["name", "content"],
-            "type": "object"
-          },
-          "maxItems": 50,
-          "type": "array"
-        },
-        "cleanup": {
-          "enum": ["delete", "keep"],
-          "type": "string"
-        },
-        "context": {
-          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
-          "enum": ["isolated", "fork"],
-          "type": "string"
-        },
-        "cwd": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string"
-        },
-        "lightContext": {
-          "description": "Light bootstrap context; runtime=\"subagent\" only.",
-          "type": "boolean"
-        },
-        "mode": {
-          "enum": ["run", "session"],
-          "type": "string"
-        },
-        "model": {
-          "type": "string"
-        },
-        "runtime": {
-          "enum": ["subagent"],
-          "type": "string"
-        },
-        "sandbox": {
-          "enum": ["inherit", "require"],
-          "type": "string"
-        },
-        "task": {
-          "type": "string"
-        },
-        "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
-          "type": "string"
-        },
-        "thinking": {
-          "type": "string"
-        },
-        "thread": {
-          "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
-          "type": "boolean"
-        }
-      },
-      "required": ["task"],
-      "type": "object"
-    },
-    "name": "sessions_spawn",
-    "namespace": "openclaw"
+    "name": "message",
+    "type": "function"
   },
   {
     "description": "End current turn. Use after spawning subagents; results arrive as next message.",
@@ -1198,137 +134,1210 @@
       },
       "type": "object"
     },
-    "name": "sessions_yield"
+    "name": "sessions_yield",
+    "type": "function"
   },
   {
-    "deferLoading": true,
-    "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": ["list"],
-          "type": "string"
-        },
-        "recentMinutes": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
-    "name": "subagents",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
-    "inputSchema": {
-      "properties": {
-        "model": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "session_status",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Search web for current info; returns normalized provider results.",
-    "inputSchema": {
-      "properties": {
-        "count": {
-          "description": "Result count.",
-          "maximum": 10,
-          "minimum": 1,
-          "type": "number"
-        },
-        "country": {
-          "description": "2-letter country code.",
-          "type": "string"
-        },
-        "date_after": {
-          "description": "Published after YYYY-MM-DD.",
-          "type": "string"
-        },
-        "date_before": {
-          "description": "Published before YYYY-MM-DD.",
-          "type": "string"
-        },
-        "domain_filter": {
-          "description": "Perplexity domain filter.",
-          "items": {
-            "type": "string"
+    "description": "",
+    "name": "openclaw",
+    "tools": [
+      {
+        "deferLoading": true,
+        "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": [
+                "status",
+                "describe",
+                "pending",
+                "approve",
+                "reject",
+                "notify",
+                "camera_snap",
+                "camera_list",
+                "camera_clip",
+                "photos_latest",
+                "screen_record",
+                "screen_snapshot",
+                "location_get",
+                "notifications_list",
+                "notifications_action",
+                "device_status",
+                "device_info",
+                "device_permissions",
+                "device_health",
+                "invoke"
+              ],
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "delayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "delivery": {
+              "enum": ["system", "overlay", "auto"],
+              "type": "string"
+            },
+            "desiredAccuracy": {
+              "enum": ["coarse", "balanced", "precise"],
+              "type": "string"
+            },
+            "deviceId": {
+              "type": "string"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "durationMs": {
+              "maximum": 300000,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "facing": {
+              "description": "camera_snap: front/back/both; camera_clip: front/back only.",
+              "enum": ["front", "back", "both"],
+              "type": "string"
+            },
+            "fps": {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "includeAudio": {
+              "type": "boolean"
+            },
+            "invokeCommand": {
+              "type": "string"
+            },
+            "invokeParamsJson": {
+              "type": "string"
+            },
+            "invokeTimeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "limit": {
+              "maximum": 20,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "locationTimeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxAgeMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxWidth": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "node": {
+              "type": "string"
+            },
+            "notificationAction": {
+              "enum": ["open", "dismiss", "reply"],
+              "type": "string"
+            },
+            "notificationKey": {
+              "type": "string"
+            },
+            "notificationReplyText": {
+              "type": "string"
+            },
+            "outPath": {
+              "type": "string"
+            },
+            "priority": {
+              "enum": ["passive", "active", "timeSensitive"],
+              "type": "string"
+            },
+            "quality": {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            "requestId": {
+              "type": "string"
+            },
+            "screenIndex": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sound": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            }
           },
-          "type": "array"
+          "required": ["action"],
+          "type": "object"
         },
-        "freshness": {
-          "description": "Time filter: day/week/month/year.",
-          "type": "string"
-        },
-        "language": {
-          "description": "ISO 639-1 language.",
-          "type": "string"
-        },
-        "max_tokens": {
-          "description": "Perplexity total token budget.",
-          "maximum": 1000000,
-          "minimum": 1,
-          "type": "number"
-        },
-        "max_tokens_per_page": {
-          "description": "Perplexity tokens per page.",
-          "minimum": 1,
-          "type": "number"
-        },
-        "query": {
-          "description": "Search query.",
-          "type": "string"
-        },
-        "search_lang": {
-          "description": "Brave result language.",
-          "type": "string"
-        },
-        "ui_lang": {
-          "description": "Brave UI locale.",
-          "type": "string"
-        }
+        "name": "nodes",
+        "type": "function"
       },
-      "required": ["query"],
-      "type": "object"
-    },
-    "name": "web_search",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
-    "inputSchema": {
-      "properties": {
-        "extractMode": {
-          "default": "markdown",
-          "description": "Extract as markdown/text.",
-          "enum": ["markdown", "text"],
-          "type": "string"
+      {
+        "deferLoading": true,
+        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
+        "inputSchema": {
+          "additionalProperties": true,
+          "properties": {
+            "action": {
+              "enum": ["status", "list", "get", "add", "update", "remove", "run", "runs", "wake"],
+              "type": "string"
+            },
+            "agentId": {
+              "description": "List filter for `action: \"list\"`; wake target override for `action: \"wake\"` (defaults to the calling agent when omitted on wake)",
+              "type": "string"
+            },
+            "contextMessages": {
+              "maximum": 10,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "includeDisabled": {
+              "type": "boolean"
+            },
+            "job": {
+              "additionalProperties": true,
+              "properties": {
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Agent id, or null to keep it unset"
+                },
+                "deleteAfterRun": {
+                  "description": "Delete after first run",
+                  "type": "boolean"
+                },
+                "delivery": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "accountId": {
+                      "description": "Delivery account",
+                      "type": "string"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "channel": {
+                      "description": "Delivery channel",
+                      "type": "string"
+                    },
+                    "failureDestination": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "accountId": {
+                          "description": "Failure delivery account",
+                          "type": "string"
+                        },
+                        "channel": {
+                          "description": "Failure delivery channel",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "description": "Failure delivery target",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "mode": {
+                      "description": "Delivery mode",
+                      "enum": ["none", "announce", "webhook"],
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ],
+                      "description": "Thread/topic id"
+                    },
+                    "to": {
+                      "description": "Delivery target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "description": "Human description",
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureAlert": {
+                  "additionalProperties": true,
+                  "description": "Failure alert object; false disables alerts",
+                  "properties": {
+                    "accountId": {
+                      "type": "string"
+                    },
+                    "after": {
+                      "description": "Failures before alert",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "channel": {
+                      "description": "Alert channel",
+                      "type": "string"
+                    },
+                    "cooldownMs": {
+                      "description": "Alert cooldown ms",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "includeSkipped": {
+                      "description": "Skipped runs count toward alert",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Alert target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Job name",
+                  "type": "string"
+                },
+                "payload": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "allowUnsafeExternalContent": {
+                      "type": "boolean"
+                    },
+                    "fallbacks": {
+                      "description": "Fallback models",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Payload kind",
+                      "enum": ["systemEvent", "agentTurn"],
+                      "type": "string"
+                    },
+                    "lightContext": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "description": "agentTurn prompt",
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "Model override",
+                      "type": "string"
+                    },
+                    "text": {
+                      "description": "systemEvent text",
+                      "type": "string"
+                    },
+                    "thinking": {
+                      "description": "Thinking override",
+                      "type": "string"
+                    },
+                    "timeoutSeconds": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "toolsAllow": {
+                      "description": "Allowed tools",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "schedule": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "anchorMs": {
+                      "description": "Start anchor ms (kind=every)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "at": {
+                      "description": "ISO-8601 time (kind=at)",
+                      "type": "string"
+                    },
+                    "everyMs": {
+                      "description": "Interval ms (kind=every)",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "expr": {
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Schedule kind",
+                      "enum": ["at", "every", "cron"],
+                      "type": "string"
+                    },
+                    "staggerMs": {
+                      "description": "Jitter ms (kind=cron)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tz": {
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Explicit session key, or null to clear it"
+                },
+                "sessionTarget": {
+                  "description": "main | isolated | current | session:<id>",
+                  "type": "string"
+                },
+                "wakeMode": {
+                  "description": "Wake timing",
+                  "enum": ["now", "next-heartbeat"],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": ["now", "next-heartbeat"],
+              "type": "string"
+            },
+            "patch": {
+              "additionalProperties": true,
+              "properties": {
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Agent id, or null to clear it"
+                },
+                "deleteAfterRun": {
+                  "type": "boolean"
+                },
+                "delivery": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "accountId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery account, or null to clear"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery channel, or null to clear"
+                    },
+                    "failureDestination": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": true,
+                          "properties": {
+                            "accountId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery account, or null to clear"
+                            },
+                            "channel": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery channel, or null to clear"
+                            },
+                            "mode": {
+                              "anyOf": [
+                                {
+                                  "const": "announce",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "webhook",
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "to": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery target, or null to clear"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure destination, or null to clear"
+                    },
+                    "mode": {
+                      "description": "Delivery mode",
+                      "enum": ["none", "announce", "webhook"],
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Thread/topic id"
+                    },
+                    "to": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery target, or null to clear"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureAlert": {
+                  "additionalProperties": true,
+                  "description": "Failure alert object; false disables alerts",
+                  "properties": {
+                    "accountId": {
+                      "type": "string"
+                    },
+                    "after": {
+                      "description": "Failures before alert",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "channel": {
+                      "description": "Alert channel",
+                      "type": "string"
+                    },
+                    "cooldownMs": {
+                      "description": "Alert cooldown ms",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "includeSkipped": {
+                      "description": "Skipped runs count toward alert",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Alert target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Job name",
+                  "type": "string"
+                },
+                "payload": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "allowUnsafeExternalContent": {
+                      "type": "boolean"
+                    },
+                    "fallbacks": {
+                      "description": "Fallback models",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Payload kind",
+                      "enum": ["systemEvent", "agentTurn"],
+                      "type": "string"
+                    },
+                    "lightContext": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "description": "agentTurn prompt",
+                      "type": "string"
+                    },
+                    "model": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Model override, or null to clear"
+                    },
+                    "text": {
+                      "description": "systemEvent text",
+                      "type": "string"
+                    },
+                    "thinking": {
+                      "description": "Thinking override",
+                      "type": "string"
+                    },
+                    "timeoutSeconds": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "toolsAllow": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Allowed tool ids, or null to clear"
+                    }
+                  },
+                  "type": "object"
+                },
+                "schedule": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "anchorMs": {
+                      "description": "Start anchor ms (kind=every)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "at": {
+                      "description": "ISO-8601 time (kind=at)",
+                      "type": "string"
+                    },
+                    "everyMs": {
+                      "description": "Interval ms (kind=every)",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "expr": {
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Schedule kind",
+                      "enum": ["at", "every", "cron"],
+                      "type": "string"
+                    },
+                    "staggerMs": {
+                      "description": "Jitter ms (kind=cron)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tz": {
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Explicit session key, or null to clear it"
+                },
+                "sessionTarget": {
+                  "description": "Session target",
+                  "type": "string"
+                },
+                "wakeMode": {
+                  "enum": ["now", "next-heartbeat"],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "runMode": {
+              "enum": ["due", "force"],
+              "type": "string"
+            },
+            "sessionKey": {
+              "description": "Wake target override for `action: \"wake\"`: route the event to the named session rather than the calling agent's current session. Defaults to the resolved calling-session key when omitted.",
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["action"],
+          "type": "object"
         },
-        "maxChars": {
-          "description": "Max chars returned; truncates.",
-          "minimum": 100,
-          "type": "integer"
-        },
-        "url": {
-          "description": "HTTP(S) URL.",
-          "type": "string"
-        }
+        "name": "cron",
+        "type": "function"
       },
-      "required": ["url"],
-      "type": "object"
-    },
-    "name": "web_fetch",
-    "namespace": "openclaw"
+      {
+        "deferLoading": true,
+        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
+        "inputSchema": {
+          "properties": {
+            "channel": {
+              "description": "Channel id; output-format hint.",
+              "type": "string"
+            },
+            "text": {
+              "description": "Text to speak.",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "description": "Provider timeout ms.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["text"],
+          "type": "object"
+        },
+        "name": "tts",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": [
+                "restart",
+                "config.get",
+                "config.schema.lookup",
+                "config.apply",
+                "config.patch",
+                "update.run"
+              ],
+              "type": "string"
+            },
+            "baseHash": {
+              "type": "string"
+            },
+            "continuationMessage": {
+              "type": "string"
+            },
+            "delayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "raw": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "replacePaths": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "restartDelayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sessionKey": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["action"],
+          "type": "object"
+        },
+        "name": "gateway",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+        "inputSchema": {
+          "properties": {},
+          "type": "object"
+        },
+        "name": "agents_list",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
+        "inputSchema": {
+          "properties": {
+            "activeMinutes": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "agentId": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "includeDerivedTitles": {
+              "type": "boolean"
+            },
+            "includeLastMessage": {
+              "type": "boolean"
+            },
+            "kinds": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "label": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "limit": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "messageLimit": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "search": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "sessions_list",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
+        "inputSchema": {
+          "properties": {
+            "includeTools": {
+              "type": "boolean"
+            },
+            "limit": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": ["sessionKey"],
+          "type": "object"
+        },
+        "name": "sessions_history",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
+        "inputSchema": {
+          "properties": {
+            "agentId": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 512,
+              "minLength": 1,
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            },
+            "timeoutSeconds": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": ["message"],
+          "type": "object"
+        },
+        "name": "sessions_send",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound, only when requester channel supports thread bindings. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work; run-mode results return, session-mode output stays in thread.",
+        "inputSchema": {
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "attachAs": {
+              "properties": {
+                "mountPath": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "attachments": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "enum": ["utf8", "base64"],
+                    "type": "string"
+                  },
+                  "mimeType": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name", "content"],
+                "type": "object"
+              },
+              "maxItems": 50,
+              "type": "array"
+            },
+            "cleanup": {
+              "enum": ["delete", "keep"],
+              "type": "string"
+            },
+            "context": {
+              "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+              "enum": ["isolated", "fork"],
+              "type": "string"
+            },
+            "cwd": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "lightContext": {
+              "description": "Light bootstrap context; runtime=\"subagent\" only.",
+              "type": "boolean"
+            },
+            "mode": {
+              "enum": ["run", "session"],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "runtime": {
+              "enum": ["subagent"],
+              "type": "string"
+            },
+            "sandbox": {
+              "enum": ["inherit", "require"],
+              "type": "string"
+            },
+            "task": {
+              "type": "string"
+            },
+            "taskName": {
+              "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+              "type": "string"
+            },
+            "thinking": {
+              "type": "string"
+            },
+            "thread": {
+              "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
+              "type": "boolean"
+            }
+          },
+          "required": ["task"],
+          "type": "object"
+        },
+        "name": "sessions_spawn",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": ["list"],
+              "type": "string"
+            },
+            "recentMinutes": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "name": "subagents",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
+        "inputSchema": {
+          "properties": {
+            "model": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "session_status",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Search web for current info; returns normalized provider results.",
+        "inputSchema": {
+          "properties": {
+            "count": {
+              "description": "Result count.",
+              "maximum": 10,
+              "minimum": 1,
+              "type": "number"
+            },
+            "country": {
+              "description": "2-letter country code.",
+              "type": "string"
+            },
+            "date_after": {
+              "description": "Published after YYYY-MM-DD.",
+              "type": "string"
+            },
+            "date_before": {
+              "description": "Published before YYYY-MM-DD.",
+              "type": "string"
+            },
+            "domain_filter": {
+              "description": "Perplexity domain filter.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "description": "Time filter: day/week/month/year.",
+              "type": "string"
+            },
+            "language": {
+              "description": "ISO 639-1 language.",
+              "type": "string"
+            },
+            "max_tokens": {
+              "description": "Perplexity total token budget.",
+              "maximum": 1000000,
+              "minimum": 1,
+              "type": "number"
+            },
+            "max_tokens_per_page": {
+              "description": "Perplexity tokens per page.",
+              "minimum": 1,
+              "type": "number"
+            },
+            "query": {
+              "description": "Search query.",
+              "type": "string"
+            },
+            "search_lang": {
+              "description": "Brave result language.",
+              "type": "string"
+            },
+            "ui_lang": {
+              "description": "Brave UI locale.",
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        },
+        "name": "web_search",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
+        "inputSchema": {
+          "properties": {
+            "extractMode": {
+              "default": "markdown",
+              "description": "Extract as markdown/text.",
+              "enum": ["markdown", "text"],
+              "type": "string"
+            },
+            "maxChars": {
+              "description": "Max chars returned; truncates.",
+              "minimum": 100,
+              "type": "integer"
+            },
+            "url": {
+              "description": "HTTP(S) URL.",
+              "type": "string"
+            }
+          },
+          "required": ["url"],
+          "type": "object"
+        },
+        "name": "web_fetch",
+        "type": "function"
+      }
+    ],
+    "type": "namespace"
   }
 ]

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1,770 +1,5 @@
 [
   {
-    "deferLoading": true,
-    "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": [
-            "status",
-            "describe",
-            "pending",
-            "approve",
-            "reject",
-            "notify",
-            "camera_snap",
-            "camera_list",
-            "camera_clip",
-            "photos_latest",
-            "screen_record",
-            "screen_snapshot",
-            "location_get",
-            "notifications_list",
-            "notifications_action",
-            "device_status",
-            "device_info",
-            "device_permissions",
-            "device_health",
-            "invoke"
-          ],
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "delayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "delivery": {
-          "enum": ["system", "overlay", "auto"],
-          "type": "string"
-        },
-        "desiredAccuracy": {
-          "enum": ["coarse", "balanced", "precise"],
-          "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "string"
-        },
-        "durationMs": {
-          "maximum": 300000,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "facing": {
-          "description": "camera_snap: front/back/both; camera_clip: front/back only.",
-          "enum": ["front", "back", "both"],
-          "type": "string"
-        },
-        "fps": {
-          "exclusiveMinimum": 0,
-          "type": "number"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "includeAudio": {
-          "type": "boolean"
-        },
-        "invokeCommand": {
-          "type": "string"
-        },
-        "invokeParamsJson": {
-          "type": "string"
-        },
-        "invokeTimeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "limit": {
-          "maximum": 20,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "locationTimeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "maxAgeMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "maxWidth": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "node": {
-          "type": "string"
-        },
-        "notificationAction": {
-          "enum": ["open", "dismiss", "reply"],
-          "type": "string"
-        },
-        "notificationKey": {
-          "type": "string"
-        },
-        "notificationReplyText": {
-          "type": "string"
-        },
-        "outPath": {
-          "type": "string"
-        },
-        "priority": {
-          "enum": ["passive", "active", "timeSensitive"],
-          "type": "string"
-        },
-        "quality": {
-          "maximum": 1,
-          "minimum": 0,
-          "type": "number"
-        },
-        "requestId": {
-          "type": "string"
-        },
-        "screenIndex": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "sound": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "nodes",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "action": {
-          "enum": ["status", "list", "get", "add", "update", "remove", "run", "runs", "wake"],
-          "type": "string"
-        },
-        "agentId": {
-          "description": "List filter for `action: \"list\"`; wake target override for `action: \"wake\"` (defaults to the calling agent when omitted on wake)",
-          "type": "string"
-        },
-        "contextMessages": {
-          "maximum": 10,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "includeDisabled": {
-          "type": "boolean"
-        },
-        "job": {
-          "additionalProperties": true,
-          "properties": {
-            "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to keep it unset"
-            },
-            "deleteAfterRun": {
-              "description": "Delete after first run",
-              "type": "boolean"
-            },
-            "delivery": {
-              "additionalProperties": true,
-              "properties": {
-                "accountId": {
-                  "description": "Delivery account",
-                  "type": "string"
-                },
-                "bestEffort": {
-                  "type": "boolean"
-                },
-                "channel": {
-                  "description": "Delivery channel",
-                  "type": "string"
-                },
-                "failureDestination": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "description": "Failure delivery account",
-                      "type": "string"
-                    },
-                    "channel": {
-                      "description": "Failure delivery channel",
-                      "type": "string"
-                    },
-                    "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "to": {
-                      "description": "Failure delivery target",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "mode": {
-                  "description": "Delivery mode",
-                  "enum": ["none", "announce", "webhook"],
-                  "type": "string"
-                },
-                "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
-                },
-                "to": {
-                  "description": "Delivery target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "description": {
-              "description": "Human description",
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "failureAlert": {
-              "additionalProperties": true,
-              "description": "Failure alert object; false disables alerts",
-              "properties": {
-                "accountId": {
-                  "type": "string"
-                },
-                "after": {
-                  "description": "Failures before alert",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "channel": {
-                  "description": "Alert channel",
-                  "type": "string"
-                },
-                "cooldownMs": {
-                  "description": "Alert cooldown ms",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "includeSkipped": {
-                  "description": "Skipped runs count toward alert",
-                  "type": "boolean"
-                },
-                "mode": {
-                  "enum": ["announce", "webhook"],
-                  "type": "string"
-                },
-                "to": {
-                  "description": "Alert target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "description": "Job name",
-              "type": "string"
-            },
-            "payload": {
-              "additionalProperties": true,
-              "properties": {
-                "allowUnsafeExternalContent": {
-                  "type": "boolean"
-                },
-                "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "kind": {
-                  "description": "Payload kind",
-                  "enum": ["systemEvent", "agentTurn"],
-                  "type": "string"
-                },
-                "lightContext": {
-                  "type": "boolean"
-                },
-                "message": {
-                  "description": "agentTurn prompt",
-                  "type": "string"
-                },
-                "model": {
-                  "description": "Model override",
-                  "type": "string"
-                },
-                "text": {
-                  "description": "systemEvent text",
-                  "type": "string"
-                },
-                "thinking": {
-                  "description": "Thinking override",
-                  "type": "string"
-                },
-                "timeoutSeconds": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "toolsAllow": {
-                  "description": "Allowed tools",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              },
-              "type": "object"
-            },
-            "schedule": {
-              "additionalProperties": true,
-              "properties": {
-                "anchorMs": {
-                  "description": "Start anchor ms (kind=every)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "at": {
-                  "description": "ISO-8601 time (kind=at)",
-                  "type": "string"
-                },
-                "everyMs": {
-                  "description": "Interval ms (kind=every)",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "expr": {
-                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Schedule kind",
-                  "enum": ["at", "every", "cron"],
-                  "type": "string"
-                },
-                "staggerMs": {
-                  "description": "Jitter ms (kind=cron)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "tz": {
-                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
-            },
-            "sessionTarget": {
-              "description": "main | isolated | current | session:<id>",
-              "type": "string"
-            },
-            "wakeMode": {
-              "description": "Wake timing",
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "jobId": {
-          "type": "string"
-        },
-        "mode": {
-          "enum": ["now", "next-heartbeat"],
-          "type": "string"
-        },
-        "patch": {
-          "additionalProperties": true,
-          "properties": {
-            "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to clear it"
-            },
-            "deleteAfterRun": {
-              "type": "boolean"
-            },
-            "delivery": {
-              "additionalProperties": true,
-              "properties": {
-                "accountId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery account, or null to clear"
-                },
-                "bestEffort": {
-                  "type": "boolean"
-                },
-                "channel": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery channel, or null to clear"
-                },
-                "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
-                        },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Failure destination, or null to clear"
-                },
-                "mode": {
-                  "description": "Delivery mode",
-                  "enum": ["none", "announce", "webhook"],
-                  "type": "string"
-                },
-                "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Thread/topic id"
-                },
-                "to": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery target, or null to clear"
-                }
-              },
-              "type": "object"
-            },
-            "description": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "failureAlert": {
-              "additionalProperties": true,
-              "description": "Failure alert object; false disables alerts",
-              "properties": {
-                "accountId": {
-                  "type": "string"
-                },
-                "after": {
-                  "description": "Failures before alert",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "channel": {
-                  "description": "Alert channel",
-                  "type": "string"
-                },
-                "cooldownMs": {
-                  "description": "Alert cooldown ms",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "includeSkipped": {
-                  "description": "Skipped runs count toward alert",
-                  "type": "boolean"
-                },
-                "mode": {
-                  "enum": ["announce", "webhook"],
-                  "type": "string"
-                },
-                "to": {
-                  "description": "Alert target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "description": "Job name",
-              "type": "string"
-            },
-            "payload": {
-              "additionalProperties": true,
-              "properties": {
-                "allowUnsafeExternalContent": {
-                  "type": "boolean"
-                },
-                "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "kind": {
-                  "description": "Payload kind",
-                  "enum": ["systemEvent", "agentTurn"],
-                  "type": "string"
-                },
-                "lightContext": {
-                  "type": "boolean"
-                },
-                "message": {
-                  "description": "agentTurn prompt",
-                  "type": "string"
-                },
-                "model": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Model override, or null to clear"
-                },
-                "text": {
-                  "description": "systemEvent text",
-                  "type": "string"
-                },
-                "thinking": {
-                  "description": "Thinking override",
-                  "type": "string"
-                },
-                "timeoutSeconds": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "toolsAllow": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Allowed tool ids, or null to clear"
-                }
-              },
-              "type": "object"
-            },
-            "schedule": {
-              "additionalProperties": true,
-              "properties": {
-                "anchorMs": {
-                  "description": "Start anchor ms (kind=every)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "at": {
-                  "description": "ISO-8601 time (kind=at)",
-                  "type": "string"
-                },
-                "everyMs": {
-                  "description": "Interval ms (kind=every)",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "expr": {
-                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Schedule kind",
-                  "enum": ["at", "every", "cron"],
-                  "type": "string"
-                },
-                "staggerMs": {
-                  "description": "Jitter ms (kind=cron)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "tz": {
-                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
-            },
-            "sessionTarget": {
-              "description": "Session target",
-              "type": "string"
-            },
-            "wakeMode": {
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "runMode": {
-          "enum": ["due", "force"],
-          "type": "string"
-        },
-        "sessionKey": {
-          "description": "Wake target override for `action: \"wake\"`: route the event to the named session rather than the calling agent's current session. Defaults to the resolved calling-session key when omitted.",
-          "type": "string"
-        },
-        "text": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "cron",
-    "namespace": "openclaw"
-  },
-  {
     "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
@@ -886,339 +121,8 @@
       "required": ["action"],
       "type": "object"
     },
-    "name": "message"
-  },
-  {
-    "deferLoading": true,
-    "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
-    "inputSchema": {
-      "additionalProperties": false,
-      "properties": {
-        "nextCheck": {
-          "type": "string"
-        },
-        "notificationText": {
-          "type": "string"
-        },
-        "notify": {
-          "type": "boolean"
-        },
-        "outcome": {
-          "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
-          "type": "string"
-        },
-        "priority": {
-          "enum": ["low", "normal", "high"],
-          "type": "string"
-        },
-        "reason": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        }
-      },
-      "required": ["outcome", "notify", "summary"],
-      "type": "object"
-    },
-    "name": "heartbeat_respond",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
-    "inputSchema": {
-      "properties": {
-        "channel": {
-          "description": "Channel id; output-format hint.",
-          "type": "string"
-        },
-        "text": {
-          "description": "Text to speak.",
-          "type": "string"
-        },
-        "timeoutMs": {
-          "description": "Provider timeout ms.",
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["text"],
-      "type": "object"
-    },
-    "name": "tts",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": [
-            "restart",
-            "config.get",
-            "config.schema.lookup",
-            "config.apply",
-            "config.patch",
-            "update.run"
-          ],
-          "type": "string"
-        },
-        "baseHash": {
-          "type": "string"
-        },
-        "continuationMessage": {
-          "type": "string"
-        },
-        "delayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "raw": {
-          "type": "string"
-        },
-        "reason": {
-          "type": "string"
-        },
-        "replacePaths": {
-          "items": {
-            "type": "string"
-          },
-          "maxItems": 256,
-          "type": "array"
-        },
-        "restartDelayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "gateway",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
-    "inputSchema": {
-      "properties": {},
-      "type": "object"
-    },
-    "name": "agents_list",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
-    "inputSchema": {
-      "properties": {
-        "activeMinutes": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "agentId": {
-          "maxLength": 64,
-          "minLength": 1,
-          "type": "string"
-        },
-        "includeDerivedTitles": {
-          "type": "boolean"
-        },
-        "includeLastMessage": {
-          "type": "boolean"
-        },
-        "kinds": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "label": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "limit": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "messageLimit": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "search": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "sessions_list",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
-    "inputSchema": {
-      "properties": {
-        "includeTools": {
-          "type": "boolean"
-        },
-        "limit": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "sessionKey": {
-          "type": "string"
-        }
-      },
-      "required": ["sessionKey"],
-      "type": "object"
-    },
-    "name": "sessions_history",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
-    "inputSchema": {
-      "properties": {
-        "agentId": {
-          "maxLength": 64,
-          "minLength": 1,
-          "type": "string"
-        },
-        "label": {
-          "maxLength": 512,
-          "minLength": 1,
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "timeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
-        }
-      },
-      "required": ["message"],
-      "type": "object"
-    },
-    "name": "sessions_send",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
-    "inputSchema": {
-      "properties": {
-        "agentId": {
-          "type": "string"
-        },
-        "attachAs": {
-          "properties": {
-            "mountPath": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "attachments": {
-          "items": {
-            "properties": {
-              "content": {
-                "type": "string"
-              },
-              "encoding": {
-                "enum": ["utf8", "base64"],
-                "type": "string"
-              },
-              "mimeType": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": ["name", "content"],
-            "type": "object"
-          },
-          "maxItems": 50,
-          "type": "array"
-        },
-        "cleanup": {
-          "enum": ["delete", "keep"],
-          "type": "string"
-        },
-        "context": {
-          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
-          "enum": ["isolated", "fork"],
-          "type": "string"
-        },
-        "cwd": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string"
-        },
-        "lightContext": {
-          "description": "Light bootstrap context; runtime=\"subagent\" only.",
-          "type": "boolean"
-        },
-        "mode": {
-          "enum": ["run"],
-          "type": "string"
-        },
-        "model": {
-          "type": "string"
-        },
-        "runtime": {
-          "enum": ["subagent"],
-          "type": "string"
-        },
-        "sandbox": {
-          "enum": ["inherit", "require"],
-          "type": "string"
-        },
-        "task": {
-          "type": "string"
-        },
-        "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
-          "type": "string"
-        },
-        "thinking": {
-          "type": "string"
-        }
-      },
-      "required": ["task"],
-      "type": "object"
-    },
-    "name": "sessions_spawn",
-    "namespace": "openclaw"
+    "name": "message",
+    "type": "function"
   },
   {
     "description": "End current turn. Use after spawning subagents; results arrive as next message.",
@@ -1230,137 +134,1242 @@
       },
       "type": "object"
     },
-    "name": "sessions_yield"
+    "name": "sessions_yield",
+    "type": "function"
   },
   {
-    "deferLoading": true,
-    "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": ["list"],
-          "type": "string"
-        },
-        "recentMinutes": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
-    "name": "subagents",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
-    "inputSchema": {
-      "properties": {
-        "model": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "session_status",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Search web for current info; returns normalized provider results.",
-    "inputSchema": {
-      "properties": {
-        "count": {
-          "description": "Result count.",
-          "maximum": 10,
-          "minimum": 1,
-          "type": "number"
-        },
-        "country": {
-          "description": "2-letter country code.",
-          "type": "string"
-        },
-        "date_after": {
-          "description": "Published after YYYY-MM-DD.",
-          "type": "string"
-        },
-        "date_before": {
-          "description": "Published before YYYY-MM-DD.",
-          "type": "string"
-        },
-        "domain_filter": {
-          "description": "Perplexity domain filter.",
-          "items": {
-            "type": "string"
+    "description": "",
+    "name": "openclaw",
+    "tools": [
+      {
+        "deferLoading": true,
+        "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": [
+                "status",
+                "describe",
+                "pending",
+                "approve",
+                "reject",
+                "notify",
+                "camera_snap",
+                "camera_list",
+                "camera_clip",
+                "photos_latest",
+                "screen_record",
+                "screen_snapshot",
+                "location_get",
+                "notifications_list",
+                "notifications_action",
+                "device_status",
+                "device_info",
+                "device_permissions",
+                "device_health",
+                "invoke"
+              ],
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "delayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "delivery": {
+              "enum": ["system", "overlay", "auto"],
+              "type": "string"
+            },
+            "desiredAccuracy": {
+              "enum": ["coarse", "balanced", "precise"],
+              "type": "string"
+            },
+            "deviceId": {
+              "type": "string"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "durationMs": {
+              "maximum": 300000,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "facing": {
+              "description": "camera_snap: front/back/both; camera_clip: front/back only.",
+              "enum": ["front", "back", "both"],
+              "type": "string"
+            },
+            "fps": {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "includeAudio": {
+              "type": "boolean"
+            },
+            "invokeCommand": {
+              "type": "string"
+            },
+            "invokeParamsJson": {
+              "type": "string"
+            },
+            "invokeTimeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "limit": {
+              "maximum": 20,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "locationTimeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxAgeMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxWidth": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "node": {
+              "type": "string"
+            },
+            "notificationAction": {
+              "enum": ["open", "dismiss", "reply"],
+              "type": "string"
+            },
+            "notificationKey": {
+              "type": "string"
+            },
+            "notificationReplyText": {
+              "type": "string"
+            },
+            "outPath": {
+              "type": "string"
+            },
+            "priority": {
+              "enum": ["passive", "active", "timeSensitive"],
+              "type": "string"
+            },
+            "quality": {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            "requestId": {
+              "type": "string"
+            },
+            "screenIndex": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sound": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            }
           },
-          "type": "array"
+          "required": ["action"],
+          "type": "object"
         },
-        "freshness": {
-          "description": "Time filter: day/week/month/year.",
-          "type": "string"
-        },
-        "language": {
-          "description": "ISO 639-1 language.",
-          "type": "string"
-        },
-        "max_tokens": {
-          "description": "Perplexity total token budget.",
-          "maximum": 1000000,
-          "minimum": 1,
-          "type": "number"
-        },
-        "max_tokens_per_page": {
-          "description": "Perplexity tokens per page.",
-          "minimum": 1,
-          "type": "number"
-        },
-        "query": {
-          "description": "Search query.",
-          "type": "string"
-        },
-        "search_lang": {
-          "description": "Brave result language.",
-          "type": "string"
-        },
-        "ui_lang": {
-          "description": "Brave UI locale.",
-          "type": "string"
-        }
+        "name": "nodes",
+        "type": "function"
       },
-      "required": ["query"],
-      "type": "object"
-    },
-    "name": "web_search",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
-    "inputSchema": {
-      "properties": {
-        "extractMode": {
-          "default": "markdown",
-          "description": "Extract as markdown/text.",
-          "enum": ["markdown", "text"],
-          "type": "string"
+      {
+        "deferLoading": true,
+        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
+        "inputSchema": {
+          "additionalProperties": true,
+          "properties": {
+            "action": {
+              "enum": ["status", "list", "get", "add", "update", "remove", "run", "runs", "wake"],
+              "type": "string"
+            },
+            "agentId": {
+              "description": "List filter for `action: \"list\"`; wake target override for `action: \"wake\"` (defaults to the calling agent when omitted on wake)",
+              "type": "string"
+            },
+            "contextMessages": {
+              "maximum": 10,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "includeDisabled": {
+              "type": "boolean"
+            },
+            "job": {
+              "additionalProperties": true,
+              "properties": {
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Agent id, or null to keep it unset"
+                },
+                "deleteAfterRun": {
+                  "description": "Delete after first run",
+                  "type": "boolean"
+                },
+                "delivery": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "accountId": {
+                      "description": "Delivery account",
+                      "type": "string"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "channel": {
+                      "description": "Delivery channel",
+                      "type": "string"
+                    },
+                    "failureDestination": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "accountId": {
+                          "description": "Failure delivery account",
+                          "type": "string"
+                        },
+                        "channel": {
+                          "description": "Failure delivery channel",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "description": "Failure delivery target",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "mode": {
+                      "description": "Delivery mode",
+                      "enum": ["none", "announce", "webhook"],
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ],
+                      "description": "Thread/topic id"
+                    },
+                    "to": {
+                      "description": "Delivery target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "description": "Human description",
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureAlert": {
+                  "additionalProperties": true,
+                  "description": "Failure alert object; false disables alerts",
+                  "properties": {
+                    "accountId": {
+                      "type": "string"
+                    },
+                    "after": {
+                      "description": "Failures before alert",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "channel": {
+                      "description": "Alert channel",
+                      "type": "string"
+                    },
+                    "cooldownMs": {
+                      "description": "Alert cooldown ms",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "includeSkipped": {
+                      "description": "Skipped runs count toward alert",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Alert target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Job name",
+                  "type": "string"
+                },
+                "payload": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "allowUnsafeExternalContent": {
+                      "type": "boolean"
+                    },
+                    "fallbacks": {
+                      "description": "Fallback models",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Payload kind",
+                      "enum": ["systemEvent", "agentTurn"],
+                      "type": "string"
+                    },
+                    "lightContext": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "description": "agentTurn prompt",
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "Model override",
+                      "type": "string"
+                    },
+                    "text": {
+                      "description": "systemEvent text",
+                      "type": "string"
+                    },
+                    "thinking": {
+                      "description": "Thinking override",
+                      "type": "string"
+                    },
+                    "timeoutSeconds": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "toolsAllow": {
+                      "description": "Allowed tools",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "schedule": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "anchorMs": {
+                      "description": "Start anchor ms (kind=every)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "at": {
+                      "description": "ISO-8601 time (kind=at)",
+                      "type": "string"
+                    },
+                    "everyMs": {
+                      "description": "Interval ms (kind=every)",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "expr": {
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Schedule kind",
+                      "enum": ["at", "every", "cron"],
+                      "type": "string"
+                    },
+                    "staggerMs": {
+                      "description": "Jitter ms (kind=cron)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tz": {
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Explicit session key, or null to clear it"
+                },
+                "sessionTarget": {
+                  "description": "main | isolated | current | session:<id>",
+                  "type": "string"
+                },
+                "wakeMode": {
+                  "description": "Wake timing",
+                  "enum": ["now", "next-heartbeat"],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": ["now", "next-heartbeat"],
+              "type": "string"
+            },
+            "patch": {
+              "additionalProperties": true,
+              "properties": {
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Agent id, or null to clear it"
+                },
+                "deleteAfterRun": {
+                  "type": "boolean"
+                },
+                "delivery": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "accountId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery account, or null to clear"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery channel, or null to clear"
+                    },
+                    "failureDestination": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": true,
+                          "properties": {
+                            "accountId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery account, or null to clear"
+                            },
+                            "channel": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery channel, or null to clear"
+                            },
+                            "mode": {
+                              "anyOf": [
+                                {
+                                  "const": "announce",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "webhook",
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "to": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery target, or null to clear"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure destination, or null to clear"
+                    },
+                    "mode": {
+                      "description": "Delivery mode",
+                      "enum": ["none", "announce", "webhook"],
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Thread/topic id"
+                    },
+                    "to": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery target, or null to clear"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureAlert": {
+                  "additionalProperties": true,
+                  "description": "Failure alert object; false disables alerts",
+                  "properties": {
+                    "accountId": {
+                      "type": "string"
+                    },
+                    "after": {
+                      "description": "Failures before alert",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "channel": {
+                      "description": "Alert channel",
+                      "type": "string"
+                    },
+                    "cooldownMs": {
+                      "description": "Alert cooldown ms",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "includeSkipped": {
+                      "description": "Skipped runs count toward alert",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Alert target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Job name",
+                  "type": "string"
+                },
+                "payload": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "allowUnsafeExternalContent": {
+                      "type": "boolean"
+                    },
+                    "fallbacks": {
+                      "description": "Fallback models",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Payload kind",
+                      "enum": ["systemEvent", "agentTurn"],
+                      "type": "string"
+                    },
+                    "lightContext": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "description": "agentTurn prompt",
+                      "type": "string"
+                    },
+                    "model": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Model override, or null to clear"
+                    },
+                    "text": {
+                      "description": "systemEvent text",
+                      "type": "string"
+                    },
+                    "thinking": {
+                      "description": "Thinking override",
+                      "type": "string"
+                    },
+                    "timeoutSeconds": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "toolsAllow": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Allowed tool ids, or null to clear"
+                    }
+                  },
+                  "type": "object"
+                },
+                "schedule": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "anchorMs": {
+                      "description": "Start anchor ms (kind=every)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "at": {
+                      "description": "ISO-8601 time (kind=at)",
+                      "type": "string"
+                    },
+                    "everyMs": {
+                      "description": "Interval ms (kind=every)",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "expr": {
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Schedule kind",
+                      "enum": ["at", "every", "cron"],
+                      "type": "string"
+                    },
+                    "staggerMs": {
+                      "description": "Jitter ms (kind=cron)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tz": {
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Explicit session key, or null to clear it"
+                },
+                "sessionTarget": {
+                  "description": "Session target",
+                  "type": "string"
+                },
+                "wakeMode": {
+                  "enum": ["now", "next-heartbeat"],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "runMode": {
+              "enum": ["due", "force"],
+              "type": "string"
+            },
+            "sessionKey": {
+              "description": "Wake target override for `action: \"wake\"`: route the event to the named session rather than the calling agent's current session. Defaults to the resolved calling-session key when omitted.",
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["action"],
+          "type": "object"
         },
-        "maxChars": {
-          "description": "Max chars returned; truncates.",
-          "minimum": 100,
-          "type": "integer"
-        },
-        "url": {
-          "description": "HTTP(S) URL.",
-          "type": "string"
-        }
+        "name": "cron",
+        "type": "function"
       },
-      "required": ["url"],
-      "type": "object"
-    },
-    "name": "web_fetch",
-    "namespace": "openclaw"
+      {
+        "deferLoading": true,
+        "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
+        "inputSchema": {
+          "additionalProperties": false,
+          "properties": {
+            "nextCheck": {
+              "type": "string"
+            },
+            "notificationText": {
+              "type": "string"
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "outcome": {
+              "enum": ["no_change", "progress", "done", "blocked", "needs_attention"],
+              "type": "string"
+            },
+            "priority": {
+              "enum": ["low", "normal", "high"],
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": ["outcome", "notify", "summary"],
+          "type": "object"
+        },
+        "name": "heartbeat_respond",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
+        "inputSchema": {
+          "properties": {
+            "channel": {
+              "description": "Channel id; output-format hint.",
+              "type": "string"
+            },
+            "text": {
+              "description": "Text to speak.",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "description": "Provider timeout ms.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["text"],
+          "type": "object"
+        },
+        "name": "tts",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": [
+                "restart",
+                "config.get",
+                "config.schema.lookup",
+                "config.apply",
+                "config.patch",
+                "update.run"
+              ],
+              "type": "string"
+            },
+            "baseHash": {
+              "type": "string"
+            },
+            "continuationMessage": {
+              "type": "string"
+            },
+            "delayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "raw": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "replacePaths": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "restartDelayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sessionKey": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["action"],
+          "type": "object"
+        },
+        "name": "gateway",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+        "inputSchema": {
+          "properties": {},
+          "type": "object"
+        },
+        "name": "agents_list",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
+        "inputSchema": {
+          "properties": {
+            "activeMinutes": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "agentId": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "includeDerivedTitles": {
+              "type": "boolean"
+            },
+            "includeLastMessage": {
+              "type": "boolean"
+            },
+            "kinds": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "label": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "limit": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "messageLimit": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "search": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "sessions_list",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
+        "inputSchema": {
+          "properties": {
+            "includeTools": {
+              "type": "boolean"
+            },
+            "limit": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": ["sessionKey"],
+          "type": "object"
+        },
+        "name": "sessions_history",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
+        "inputSchema": {
+          "properties": {
+            "agentId": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 512,
+              "minLength": 1,
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            },
+            "timeoutSeconds": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": ["message"],
+          "type": "object"
+        },
+        "name": "sessions_send",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
+        "inputSchema": {
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "attachAs": {
+              "properties": {
+                "mountPath": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "attachments": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "enum": ["utf8", "base64"],
+                    "type": "string"
+                  },
+                  "mimeType": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name", "content"],
+                "type": "object"
+              },
+              "maxItems": 50,
+              "type": "array"
+            },
+            "cleanup": {
+              "enum": ["delete", "keep"],
+              "type": "string"
+            },
+            "context": {
+              "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+              "enum": ["isolated", "fork"],
+              "type": "string"
+            },
+            "cwd": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "lightContext": {
+              "description": "Light bootstrap context; runtime=\"subagent\" only.",
+              "type": "boolean"
+            },
+            "mode": {
+              "enum": ["run"],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "runtime": {
+              "enum": ["subagent"],
+              "type": "string"
+            },
+            "sandbox": {
+              "enum": ["inherit", "require"],
+              "type": "string"
+            },
+            "task": {
+              "type": "string"
+            },
+            "taskName": {
+              "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+              "type": "string"
+            },
+            "thinking": {
+              "type": "string"
+            }
+          },
+          "required": ["task"],
+          "type": "object"
+        },
+        "name": "sessions_spawn",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": ["list"],
+              "type": "string"
+            },
+            "recentMinutes": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "name": "subagents",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
+        "inputSchema": {
+          "properties": {
+            "model": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "session_status",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Search web for current info; returns normalized provider results.",
+        "inputSchema": {
+          "properties": {
+            "count": {
+              "description": "Result count.",
+              "maximum": 10,
+              "minimum": 1,
+              "type": "number"
+            },
+            "country": {
+              "description": "2-letter country code.",
+              "type": "string"
+            },
+            "date_after": {
+              "description": "Published after YYYY-MM-DD.",
+              "type": "string"
+            },
+            "date_before": {
+              "description": "Published before YYYY-MM-DD.",
+              "type": "string"
+            },
+            "domain_filter": {
+              "description": "Perplexity domain filter.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "description": "Time filter: day/week/month/year.",
+              "type": "string"
+            },
+            "language": {
+              "description": "ISO 639-1 language.",
+              "type": "string"
+            },
+            "max_tokens": {
+              "description": "Perplexity total token budget.",
+              "maximum": 1000000,
+              "minimum": 1,
+              "type": "number"
+            },
+            "max_tokens_per_page": {
+              "description": "Perplexity tokens per page.",
+              "minimum": 1,
+              "type": "number"
+            },
+            "query": {
+              "description": "Search query.",
+              "type": "string"
+            },
+            "search_lang": {
+              "description": "Brave result language.",
+              "type": "string"
+            },
+            "ui_lang": {
+              "description": "Brave UI locale.",
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        },
+        "name": "web_search",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
+        "inputSchema": {
+          "properties": {
+            "extractMode": {
+              "default": "markdown",
+              "description": "Extract as markdown/text.",
+              "enum": ["markdown", "text"],
+              "type": "string"
+            },
+            "maxChars": {
+              "description": "Max chars returned; truncates.",
+              "minimum": 100,
+              "type": "integer"
+            },
+            "url": {
+              "description": "HTTP(S) URL.",
+              "type": "string"
+            }
+          },
+          "required": ["url"],
+          "type": "object"
+        },
+        "name": "web_fetch",
+        "type": "function"
+      }
+    ],
+    "type": "namespace"
   }
 ]

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1,770 +1,5 @@
 [
   {
-    "deferLoading": true,
-    "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": [
-            "status",
-            "describe",
-            "pending",
-            "approve",
-            "reject",
-            "notify",
-            "camera_snap",
-            "camera_list",
-            "camera_clip",
-            "photos_latest",
-            "screen_record",
-            "screen_snapshot",
-            "location_get",
-            "notifications_list",
-            "notifications_action",
-            "device_status",
-            "device_info",
-            "device_permissions",
-            "device_health",
-            "invoke"
-          ],
-          "type": "string"
-        },
-        "body": {
-          "type": "string"
-        },
-        "delayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "delivery": {
-          "enum": ["system", "overlay", "auto"],
-          "type": "string"
-        },
-        "desiredAccuracy": {
-          "enum": ["coarse", "balanced", "precise"],
-          "type": "string"
-        },
-        "deviceId": {
-          "type": "string"
-        },
-        "duration": {
-          "type": "string"
-        },
-        "durationMs": {
-          "maximum": 300000,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "facing": {
-          "description": "camera_snap: front/back/both; camera_clip: front/back only.",
-          "enum": ["front", "back", "both"],
-          "type": "string"
-        },
-        "fps": {
-          "exclusiveMinimum": 0,
-          "type": "number"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "includeAudio": {
-          "type": "boolean"
-        },
-        "invokeCommand": {
-          "type": "string"
-        },
-        "invokeParamsJson": {
-          "type": "string"
-        },
-        "invokeTimeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "limit": {
-          "maximum": 20,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "locationTimeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "maxAgeMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "maxWidth": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "node": {
-          "type": "string"
-        },
-        "notificationAction": {
-          "enum": ["open", "dismiss", "reply"],
-          "type": "string"
-        },
-        "notificationKey": {
-          "type": "string"
-        },
-        "notificationReplyText": {
-          "type": "string"
-        },
-        "outPath": {
-          "type": "string"
-        },
-        "priority": {
-          "enum": ["passive", "active", "timeSensitive"],
-          "type": "string"
-        },
-        "quality": {
-          "maximum": 1,
-          "minimum": 0,
-          "type": "number"
-        },
-        "requestId": {
-          "type": "string"
-        },
-        "screenIndex": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "sound": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "title": {
-          "type": "string"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "nodes",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
-    "inputSchema": {
-      "additionalProperties": true,
-      "properties": {
-        "action": {
-          "enum": ["status", "list", "get", "add", "update", "remove", "run", "runs", "wake"],
-          "type": "string"
-        },
-        "agentId": {
-          "description": "List filter for `action: \"list\"`; wake target override for `action: \"wake\"` (defaults to the calling agent when omitted on wake)",
-          "type": "string"
-        },
-        "contextMessages": {
-          "maximum": 10,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "id": {
-          "type": "string"
-        },
-        "includeDisabled": {
-          "type": "boolean"
-        },
-        "job": {
-          "additionalProperties": true,
-          "properties": {
-            "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to keep it unset"
-            },
-            "deleteAfterRun": {
-              "description": "Delete after first run",
-              "type": "boolean"
-            },
-            "delivery": {
-              "additionalProperties": true,
-              "properties": {
-                "accountId": {
-                  "description": "Delivery account",
-                  "type": "string"
-                },
-                "bestEffort": {
-                  "type": "boolean"
-                },
-                "channel": {
-                  "description": "Delivery channel",
-                  "type": "string"
-                },
-                "failureDestination": {
-                  "additionalProperties": true,
-                  "properties": {
-                    "accountId": {
-                      "description": "Failure delivery account",
-                      "type": "string"
-                    },
-                    "channel": {
-                      "description": "Failure delivery channel",
-                      "type": "string"
-                    },
-                    "mode": {
-                      "anyOf": [
-                        {
-                          "const": "announce",
-                          "type": "string"
-                        },
-                        {
-                          "const": "webhook",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "to": {
-                      "description": "Failure delivery target",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "mode": {
-                  "description": "Delivery mode",
-                  "enum": ["none", "announce", "webhook"],
-                  "type": "string"
-                },
-                "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "description": "Thread/topic id"
-                },
-                "to": {
-                  "description": "Delivery target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "description": {
-              "description": "Human description",
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "failureAlert": {
-              "additionalProperties": true,
-              "description": "Failure alert object; false disables alerts",
-              "properties": {
-                "accountId": {
-                  "type": "string"
-                },
-                "after": {
-                  "description": "Failures before alert",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "channel": {
-                  "description": "Alert channel",
-                  "type": "string"
-                },
-                "cooldownMs": {
-                  "description": "Alert cooldown ms",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "includeSkipped": {
-                  "description": "Skipped runs count toward alert",
-                  "type": "boolean"
-                },
-                "mode": {
-                  "enum": ["announce", "webhook"],
-                  "type": "string"
-                },
-                "to": {
-                  "description": "Alert target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "description": "Job name",
-              "type": "string"
-            },
-            "payload": {
-              "additionalProperties": true,
-              "properties": {
-                "allowUnsafeExternalContent": {
-                  "type": "boolean"
-                },
-                "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "kind": {
-                  "description": "Payload kind",
-                  "enum": ["systemEvent", "agentTurn"],
-                  "type": "string"
-                },
-                "lightContext": {
-                  "type": "boolean"
-                },
-                "message": {
-                  "description": "agentTurn prompt",
-                  "type": "string"
-                },
-                "model": {
-                  "description": "Model override",
-                  "type": "string"
-                },
-                "text": {
-                  "description": "systemEvent text",
-                  "type": "string"
-                },
-                "thinking": {
-                  "description": "Thinking override",
-                  "type": "string"
-                },
-                "timeoutSeconds": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "toolsAllow": {
-                  "description": "Allowed tools",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                }
-              },
-              "type": "object"
-            },
-            "schedule": {
-              "additionalProperties": true,
-              "properties": {
-                "anchorMs": {
-                  "description": "Start anchor ms (kind=every)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "at": {
-                  "description": "ISO-8601 time (kind=at)",
-                  "type": "string"
-                },
-                "everyMs": {
-                  "description": "Interval ms (kind=every)",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "expr": {
-                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Schedule kind",
-                  "enum": ["at", "every", "cron"],
-                  "type": "string"
-                },
-                "staggerMs": {
-                  "description": "Jitter ms (kind=cron)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "tz": {
-                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
-            },
-            "sessionTarget": {
-              "description": "main | isolated | current | session:<id>",
-              "type": "string"
-            },
-            "wakeMode": {
-              "description": "Wake timing",
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "jobId": {
-          "type": "string"
-        },
-        "mode": {
-          "enum": ["now", "next-heartbeat"],
-          "type": "string"
-        },
-        "patch": {
-          "additionalProperties": true,
-          "properties": {
-            "agentId": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Agent id, or null to clear it"
-            },
-            "deleteAfterRun": {
-              "type": "boolean"
-            },
-            "delivery": {
-              "additionalProperties": true,
-              "properties": {
-                "accountId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery account, or null to clear"
-                },
-                "bestEffort": {
-                  "type": "boolean"
-                },
-                "channel": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery channel, or null to clear"
-                },
-                "failureDestination": {
-                  "anyOf": [
-                    {
-                      "additionalProperties": true,
-                      "properties": {
-                        "accountId": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery account, or null to clear"
-                        },
-                        "channel": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery channel, or null to clear"
-                        },
-                        "mode": {
-                          "anyOf": [
-                            {
-                              "const": "announce",
-                              "type": "string"
-                            },
-                            {
-                              "const": "webhook",
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "to": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ],
-                          "description": "Failure delivery target, or null to clear"
-                        }
-                      },
-                      "type": "object"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Failure destination, or null to clear"
-                },
-                "mode": {
-                  "description": "Delivery mode",
-                  "enum": ["none", "announce", "webhook"],
-                  "type": "string"
-                },
-                "threadId": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Thread/topic id"
-                },
-                "to": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Delivery target, or null to clear"
-                }
-              },
-              "type": "object"
-            },
-            "description": {
-              "type": "string"
-            },
-            "enabled": {
-              "type": "boolean"
-            },
-            "failureAlert": {
-              "additionalProperties": true,
-              "description": "Failure alert object; false disables alerts",
-              "properties": {
-                "accountId": {
-                  "type": "string"
-                },
-                "after": {
-                  "description": "Failures before alert",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "channel": {
-                  "description": "Alert channel",
-                  "type": "string"
-                },
-                "cooldownMs": {
-                  "description": "Alert cooldown ms",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "includeSkipped": {
-                  "description": "Skipped runs count toward alert",
-                  "type": "boolean"
-                },
-                "mode": {
-                  "enum": ["announce", "webhook"],
-                  "type": "string"
-                },
-                "to": {
-                  "description": "Alert target",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "name": {
-              "description": "Job name",
-              "type": "string"
-            },
-            "payload": {
-              "additionalProperties": true,
-              "properties": {
-                "allowUnsafeExternalContent": {
-                  "type": "boolean"
-                },
-                "fallbacks": {
-                  "description": "Fallback models",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "kind": {
-                  "description": "Payload kind",
-                  "enum": ["systemEvent", "agentTurn"],
-                  "type": "string"
-                },
-                "lightContext": {
-                  "type": "boolean"
-                },
-                "message": {
-                  "description": "agentTurn prompt",
-                  "type": "string"
-                },
-                "model": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Model override, or null to clear"
-                },
-                "text": {
-                  "description": "systemEvent text",
-                  "type": "string"
-                },
-                "thinking": {
-                  "description": "Thinking override",
-                  "type": "string"
-                },
-                "timeoutSeconds": {
-                  "minimum": 0,
-                  "type": "number"
-                },
-                "toolsAllow": {
-                  "anyOf": [
-                    {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Allowed tool ids, or null to clear"
-                }
-              },
-              "type": "object"
-            },
-            "schedule": {
-              "additionalProperties": true,
-              "properties": {
-                "anchorMs": {
-                  "description": "Start anchor ms (kind=every)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "at": {
-                  "description": "ISO-8601 time (kind=at)",
-                  "type": "string"
-                },
-                "everyMs": {
-                  "description": "Interval ms (kind=every)",
-                  "minimum": 1,
-                  "type": "integer"
-                },
-                "expr": {
-                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
-                  "type": "string"
-                },
-                "kind": {
-                  "description": "Schedule kind",
-                  "enum": ["at", "every", "cron"],
-                  "type": "string"
-                },
-                "staggerMs": {
-                  "description": "Jitter ms (kind=cron)",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "tz": {
-                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "sessionKey": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Explicit session key, or null to clear it"
-            },
-            "sessionTarget": {
-              "description": "Session target",
-              "type": "string"
-            },
-            "wakeMode": {
-              "enum": ["now", "next-heartbeat"],
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "runMode": {
-          "enum": ["due", "force"],
-          "type": "string"
-        },
-        "sessionKey": {
-          "description": "Wake target override for `action: \"wake\"`: route the event to the named session rather than the calling agent's current session. Defaults to the resolved calling-session key when omitted.",
-          "type": "string"
-        },
-        "text": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "cron",
-    "namespace": "openclaw"
-  },
-  {
     "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
@@ -886,303 +121,8 @@
       "required": ["action"],
       "type": "object"
     },
-    "name": "message"
-  },
-  {
-    "deferLoading": true,
-    "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
-    "inputSchema": {
-      "properties": {
-        "channel": {
-          "description": "Channel id; output-format hint.",
-          "type": "string"
-        },
-        "text": {
-          "description": "Text to speak.",
-          "type": "string"
-        },
-        "timeoutMs": {
-          "description": "Provider timeout ms.",
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["text"],
-      "type": "object"
-    },
-    "name": "tts",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": [
-            "restart",
-            "config.get",
-            "config.schema.lookup",
-            "config.apply",
-            "config.patch",
-            "update.run"
-          ],
-          "type": "string"
-        },
-        "baseHash": {
-          "type": "string"
-        },
-        "continuationMessage": {
-          "type": "string"
-        },
-        "delayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "gatewayToken": {
-          "type": "string"
-        },
-        "gatewayUrl": {
-          "type": "string"
-        },
-        "note": {
-          "type": "string"
-        },
-        "path": {
-          "type": "string"
-        },
-        "raw": {
-          "type": "string"
-        },
-        "reason": {
-          "type": "string"
-        },
-        "replacePaths": {
-          "items": {
-            "type": "string"
-          },
-          "maxItems": 256,
-          "type": "array"
-        },
-        "restartDelayMs": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "timeoutMs": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "required": ["action"],
-      "type": "object"
-    },
-    "name": "gateway",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
-    "inputSchema": {
-      "properties": {},
-      "type": "object"
-    },
-    "name": "agents_list",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
-    "inputSchema": {
-      "properties": {
-        "activeMinutes": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "agentId": {
-          "maxLength": 64,
-          "minLength": 1,
-          "type": "string"
-        },
-        "includeDerivedTitles": {
-          "type": "boolean"
-        },
-        "includeLastMessage": {
-          "type": "boolean"
-        },
-        "kinds": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "label": {
-          "minLength": 1,
-          "type": "string"
-        },
-        "limit": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "messageLimit": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "search": {
-          "minLength": 1,
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "sessions_list",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
-    "inputSchema": {
-      "properties": {
-        "includeTools": {
-          "type": "boolean"
-        },
-        "limit": {
-          "minimum": 1,
-          "type": "integer"
-        },
-        "sessionKey": {
-          "type": "string"
-        }
-      },
-      "required": ["sessionKey"],
-      "type": "object"
-    },
-    "name": "sessions_history",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
-    "inputSchema": {
-      "properties": {
-        "agentId": {
-          "maxLength": 64,
-          "minLength": 1,
-          "type": "string"
-        },
-        "label": {
-          "maxLength": 512,
-          "minLength": 1,
-          "type": "string"
-        },
-        "message": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        },
-        "timeoutSeconds": {
-          "minimum": 0,
-          "type": "integer"
-        }
-      },
-      "required": ["message"],
-      "type": "object"
-    },
-    "name": "sessions_send",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
-    "inputSchema": {
-      "properties": {
-        "agentId": {
-          "type": "string"
-        },
-        "attachAs": {
-          "properties": {
-            "mountPath": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        },
-        "attachments": {
-          "items": {
-            "properties": {
-              "content": {
-                "type": "string"
-              },
-              "encoding": {
-                "enum": ["utf8", "base64"],
-                "type": "string"
-              },
-              "mimeType": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              }
-            },
-            "required": ["name", "content"],
-            "type": "object"
-          },
-          "maxItems": 50,
-          "type": "array"
-        },
-        "cleanup": {
-          "enum": ["delete", "keep"],
-          "type": "string"
-        },
-        "context": {
-          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
-          "enum": ["isolated", "fork"],
-          "type": "string"
-        },
-        "cwd": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string"
-        },
-        "lightContext": {
-          "description": "Light bootstrap context; runtime=\"subagent\" only.",
-          "type": "boolean"
-        },
-        "mode": {
-          "enum": ["run"],
-          "type": "string"
-        },
-        "model": {
-          "type": "string"
-        },
-        "runtime": {
-          "enum": ["subagent"],
-          "type": "string"
-        },
-        "sandbox": {
-          "enum": ["inherit", "require"],
-          "type": "string"
-        },
-        "task": {
-          "type": "string"
-        },
-        "taskName": {
-          "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
-          "type": "string"
-        },
-        "thinking": {
-          "type": "string"
-        }
-      },
-      "required": ["task"],
-      "type": "object"
-    },
-    "name": "sessions_spawn",
-    "namespace": "openclaw"
+    "name": "message",
+    "type": "function"
   },
   {
     "description": "End current turn. Use after spawning subagents; results arrive as next message.",
@@ -1194,137 +134,1206 @@
       },
       "type": "object"
     },
-    "name": "sessions_yield"
+    "name": "sessions_yield",
+    "type": "function"
   },
   {
-    "deferLoading": true,
-    "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
-    "inputSchema": {
-      "properties": {
-        "action": {
-          "enum": ["list"],
-          "type": "string"
-        },
-        "recentMinutes": {
-          "minimum": 1,
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
-    "name": "subagents",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
-    "inputSchema": {
-      "properties": {
-        "model": {
-          "type": "string"
-        },
-        "sessionKey": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "name": "session_status",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Search web for current info; returns normalized provider results.",
-    "inputSchema": {
-      "properties": {
-        "count": {
-          "description": "Result count.",
-          "maximum": 10,
-          "minimum": 1,
-          "type": "number"
-        },
-        "country": {
-          "description": "2-letter country code.",
-          "type": "string"
-        },
-        "date_after": {
-          "description": "Published after YYYY-MM-DD.",
-          "type": "string"
-        },
-        "date_before": {
-          "description": "Published before YYYY-MM-DD.",
-          "type": "string"
-        },
-        "domain_filter": {
-          "description": "Perplexity domain filter.",
-          "items": {
-            "type": "string"
+    "description": "",
+    "name": "openclaw",
+    "tools": [
+      {
+        "deferLoading": true,
+        "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": [
+                "status",
+                "describe",
+                "pending",
+                "approve",
+                "reject",
+                "notify",
+                "camera_snap",
+                "camera_list",
+                "camera_clip",
+                "photos_latest",
+                "screen_record",
+                "screen_snapshot",
+                "location_get",
+                "notifications_list",
+                "notifications_action",
+                "device_status",
+                "device_info",
+                "device_permissions",
+                "device_health",
+                "invoke"
+              ],
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            },
+            "delayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "delivery": {
+              "enum": ["system", "overlay", "auto"],
+              "type": "string"
+            },
+            "desiredAccuracy": {
+              "enum": ["coarse", "balanced", "precise"],
+              "type": "string"
+            },
+            "deviceId": {
+              "type": "string"
+            },
+            "duration": {
+              "type": "string"
+            },
+            "durationMs": {
+              "maximum": 300000,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "facing": {
+              "description": "camera_snap: front/back/both; camera_clip: front/back only.",
+              "enum": ["front", "back", "both"],
+              "type": "string"
+            },
+            "fps": {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "includeAudio": {
+              "type": "boolean"
+            },
+            "invokeCommand": {
+              "type": "string"
+            },
+            "invokeParamsJson": {
+              "type": "string"
+            },
+            "invokeTimeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "limit": {
+              "maximum": 20,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "locationTimeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxAgeMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "maxWidth": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "node": {
+              "type": "string"
+            },
+            "notificationAction": {
+              "enum": ["open", "dismiss", "reply"],
+              "type": "string"
+            },
+            "notificationKey": {
+              "type": "string"
+            },
+            "notificationReplyText": {
+              "type": "string"
+            },
+            "outPath": {
+              "type": "string"
+            },
+            "priority": {
+              "enum": ["passive", "active", "timeSensitive"],
+              "type": "string"
+            },
+            "quality": {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            "requestId": {
+              "type": "string"
+            },
+            "screenIndex": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sound": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "title": {
+              "type": "string"
+            }
           },
-          "type": "array"
+          "required": ["action"],
+          "type": "object"
         },
-        "freshness": {
-          "description": "Time filter: day/week/month/year.",
-          "type": "string"
-        },
-        "language": {
-          "description": "ISO 639-1 language.",
-          "type": "string"
-        },
-        "max_tokens": {
-          "description": "Perplexity total token budget.",
-          "maximum": 1000000,
-          "minimum": 1,
-          "type": "number"
-        },
-        "max_tokens_per_page": {
-          "description": "Perplexity tokens per page.",
-          "minimum": 1,
-          "type": "number"
-        },
-        "query": {
-          "description": "Search query.",
-          "type": "string"
-        },
-        "search_lang": {
-          "description": "Brave result language.",
-          "type": "string"
-        },
-        "ui_lang": {
-          "description": "Brave UI locale.",
-          "type": "string"
-        }
+        "name": "nodes",
+        "type": "function"
       },
-      "required": ["query"],
-      "type": "object"
-    },
-    "name": "web_search",
-    "namespace": "openclaw"
-  },
-  {
-    "deferLoading": true,
-    "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
-    "inputSchema": {
-      "properties": {
-        "extractMode": {
-          "default": "markdown",
-          "description": "Extract as markdown/text.",
-          "enum": ["markdown", "text"],
-          "type": "string"
+      {
+        "deferLoading": true,
+        "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: compact job summaries; includeDisabled true includes disabled; use get for full job details; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode; defaults the target to the calling session/agent. Pass top-level sessionKey/agentId to wake a different lane.\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
+        "inputSchema": {
+          "additionalProperties": true,
+          "properties": {
+            "action": {
+              "enum": ["status", "list", "get", "add", "update", "remove", "run", "runs", "wake"],
+              "type": "string"
+            },
+            "agentId": {
+              "description": "List filter for `action: \"list\"`; wake target override for `action: \"wake\"` (defaults to the calling agent when omitted on wake)",
+              "type": "string"
+            },
+            "contextMessages": {
+              "maximum": 10,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "includeDisabled": {
+              "type": "boolean"
+            },
+            "job": {
+              "additionalProperties": true,
+              "properties": {
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Agent id, or null to keep it unset"
+                },
+                "deleteAfterRun": {
+                  "description": "Delete after first run",
+                  "type": "boolean"
+                },
+                "delivery": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "accountId": {
+                      "description": "Delivery account",
+                      "type": "string"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "channel": {
+                      "description": "Delivery channel",
+                      "type": "string"
+                    },
+                    "failureDestination": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "accountId": {
+                          "description": "Failure delivery account",
+                          "type": "string"
+                        },
+                        "channel": {
+                          "description": "Failure delivery channel",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "description": "Failure delivery target",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "mode": {
+                      "description": "Delivery mode",
+                      "enum": ["none", "announce", "webhook"],
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ],
+                      "description": "Thread/topic id"
+                    },
+                    "to": {
+                      "description": "Delivery target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "description": "Human description",
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureAlert": {
+                  "additionalProperties": true,
+                  "description": "Failure alert object; false disables alerts",
+                  "properties": {
+                    "accountId": {
+                      "type": "string"
+                    },
+                    "after": {
+                      "description": "Failures before alert",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "channel": {
+                      "description": "Alert channel",
+                      "type": "string"
+                    },
+                    "cooldownMs": {
+                      "description": "Alert cooldown ms",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "includeSkipped": {
+                      "description": "Skipped runs count toward alert",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Alert target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Job name",
+                  "type": "string"
+                },
+                "payload": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "allowUnsafeExternalContent": {
+                      "type": "boolean"
+                    },
+                    "fallbacks": {
+                      "description": "Fallback models",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Payload kind",
+                      "enum": ["systemEvent", "agentTurn"],
+                      "type": "string"
+                    },
+                    "lightContext": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "description": "agentTurn prompt",
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "Model override",
+                      "type": "string"
+                    },
+                    "text": {
+                      "description": "systemEvent text",
+                      "type": "string"
+                    },
+                    "thinking": {
+                      "description": "Thinking override",
+                      "type": "string"
+                    },
+                    "timeoutSeconds": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "toolsAllow": {
+                      "description": "Allowed tools",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "schedule": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "anchorMs": {
+                      "description": "Start anchor ms (kind=every)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "at": {
+                      "description": "ISO-8601 time (kind=at)",
+                      "type": "string"
+                    },
+                    "everyMs": {
+                      "description": "Interval ms (kind=every)",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "expr": {
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Schedule kind",
+                      "enum": ["at", "every", "cron"],
+                      "type": "string"
+                    },
+                    "staggerMs": {
+                      "description": "Jitter ms (kind=cron)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tz": {
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Explicit session key, or null to clear it"
+                },
+                "sessionTarget": {
+                  "description": "main | isolated | current | session:<id>",
+                  "type": "string"
+                },
+                "wakeMode": {
+                  "description": "Wake timing",
+                  "enum": ["now", "next-heartbeat"],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "mode": {
+              "enum": ["now", "next-heartbeat"],
+              "type": "string"
+            },
+            "patch": {
+              "additionalProperties": true,
+              "properties": {
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Agent id, or null to clear it"
+                },
+                "deleteAfterRun": {
+                  "type": "boolean"
+                },
+                "delivery": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "accountId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery account, or null to clear"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery channel, or null to clear"
+                    },
+                    "failureDestination": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": true,
+                          "properties": {
+                            "accountId": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery account, or null to clear"
+                            },
+                            "channel": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery channel, or null to clear"
+                            },
+                            "mode": {
+                              "anyOf": [
+                                {
+                                  "const": "announce",
+                                  "type": "string"
+                                },
+                                {
+                                  "const": "webhook",
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "to": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Failure delivery target, or null to clear"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Failure destination, or null to clear"
+                    },
+                    "mode": {
+                      "description": "Delivery mode",
+                      "enum": ["none", "announce", "webhook"],
+                      "type": "string"
+                    },
+                    "threadId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Thread/topic id"
+                    },
+                    "to": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Delivery target, or null to clear"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureAlert": {
+                  "additionalProperties": true,
+                  "description": "Failure alert object; false disables alerts",
+                  "properties": {
+                    "accountId": {
+                      "type": "string"
+                    },
+                    "after": {
+                      "description": "Failures before alert",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "channel": {
+                      "description": "Alert channel",
+                      "type": "string"
+                    },
+                    "cooldownMs": {
+                      "description": "Alert cooldown ms",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "includeSkipped": {
+                      "description": "Skipped runs count toward alert",
+                      "type": "boolean"
+                    },
+                    "mode": {
+                      "enum": ["announce", "webhook"],
+                      "type": "string"
+                    },
+                    "to": {
+                      "description": "Alert target",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "Job name",
+                  "type": "string"
+                },
+                "payload": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "allowUnsafeExternalContent": {
+                      "type": "boolean"
+                    },
+                    "fallbacks": {
+                      "description": "Fallback models",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Payload kind",
+                      "enum": ["systemEvent", "agentTurn"],
+                      "type": "string"
+                    },
+                    "lightContext": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "description": "agentTurn prompt",
+                      "type": "string"
+                    },
+                    "model": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Model override, or null to clear"
+                    },
+                    "text": {
+                      "description": "systemEvent text",
+                      "type": "string"
+                    },
+                    "thinking": {
+                      "description": "Thinking override",
+                      "type": "string"
+                    },
+                    "timeoutSeconds": {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "toolsAllow": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Allowed tool ids, or null to clear"
+                    }
+                  },
+                  "type": "object"
+                },
+                "schedule": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "anchorMs": {
+                      "description": "Start anchor ms (kind=every)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "at": {
+                      "description": "ISO-8601 time (kind=at)",
+                      "type": "string"
+                    },
+                    "everyMs": {
+                      "description": "Interval ms (kind=every)",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "expr": {
+                      "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Schedule kind",
+                      "enum": ["at", "every", "cron"],
+                      "type": "string"
+                    },
+                    "staggerMs": {
+                      "description": "Jitter ms (kind=cron)",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "tz": {
+                      "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Explicit session key, or null to clear it"
+                },
+                "sessionTarget": {
+                  "description": "Session target",
+                  "type": "string"
+                },
+                "wakeMode": {
+                  "enum": ["now", "next-heartbeat"],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "runMode": {
+              "enum": ["due", "force"],
+              "type": "string"
+            },
+            "sessionKey": {
+              "description": "Wake target override for `action: \"wake\"`: route the event to the named session rather than the calling agent's current session. Defaults to the resolved calling-session key when omitted.",
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["action"],
+          "type": "object"
         },
-        "maxChars": {
-          "description": "Max chars returned; truncates.",
-          "minimum": 100,
-          "type": "integer"
-        },
-        "url": {
-          "description": "HTTP(S) URL.",
-          "type": "string"
-        }
+        "name": "cron",
+        "type": "function"
       },
-      "required": ["url"],
-      "type": "object"
-    },
-    "name": "web_fetch",
-    "namespace": "openclaw"
+      {
+        "deferLoading": true,
+        "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
+        "inputSchema": {
+          "properties": {
+            "channel": {
+              "description": "Channel id; output-format hint.",
+              "type": "string"
+            },
+            "text": {
+              "description": "Text to speak.",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "description": "Provider timeout ms.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["text"],
+          "type": "object"
+        },
+        "name": "tts",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. For config.patch that intentionally removes array entries, pass replacePaths with the exact affected array path. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If post-restart work must continue internally, pass one-shot `continuationMessage`; visible follow-up from that turn must use the message tool. Do not write restart sentinel files directly.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": [
+                "restart",
+                "config.get",
+                "config.schema.lookup",
+                "config.apply",
+                "config.patch",
+                "update.run"
+              ],
+              "type": "string"
+            },
+            "baseHash": {
+              "type": "string"
+            },
+            "continuationMessage": {
+              "type": "string"
+            },
+            "delayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "gatewayToken": {
+              "type": "string"
+            },
+            "gatewayUrl": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "raw": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "replacePaths": {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array"
+            },
+            "restartDelayMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "sessionKey": {
+              "type": "string"
+            },
+            "timeoutMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": ["action"],
+          "type": "object"
+        },
+        "name": "gateway",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
+        "inputSchema": {
+          "properties": {},
+          "type": "object"
+        },
+        "name": "agents_list",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
+        "inputSchema": {
+          "properties": {
+            "activeMinutes": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "agentId": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "includeDerivedTitles": {
+              "type": "boolean"
+            },
+            "includeLastMessage": {
+              "type": "boolean"
+            },
+            "kinds": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "label": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "limit": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "messageLimit": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "search": {
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "sessions_list",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
+        "inputSchema": {
+          "properties": {
+            "includeTools": {
+              "type": "boolean"
+            },
+            "limit": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "required": ["sessionKey"],
+          "type": "object"
+        },
+        "name": "sessions_history",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Send message to visible session by sessionKey/label, or configured agent by agentId; sessionKey wins when redundant label metadata is present. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
+        "inputSchema": {
+          "properties": {
+            "agentId": {
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "label": {
+              "maxLength": 512,
+              "minLength": 1,
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            },
+            "timeoutSeconds": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": ["message"],
+          "type": "object"
+        },
+        "name": "sessions_send",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work. Delegate sidecar/parallel tasks: batch file reads, multi-step searches, data collection. Avoid delegating quick lookups or single-file reads unless policy prefers delegation. After spawning, do non-overlapping work while run-mode results return.",
+        "inputSchema": {
+          "properties": {
+            "agentId": {
+              "type": "string"
+            },
+            "attachAs": {
+              "properties": {
+                "mountPath": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "attachments": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "enum": ["utf8", "base64"],
+                    "type": "string"
+                  },
+                  "mimeType": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["name", "content"],
+                "type": "object"
+              },
+              "maxItems": 50,
+              "type": "array"
+            },
+            "cleanup": {
+              "enum": ["delete", "keep"],
+              "type": "string"
+            },
+            "context": {
+              "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
+              "enum": ["isolated", "fork"],
+              "type": "string"
+            },
+            "cwd": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "lightContext": {
+              "description": "Light bootstrap context; runtime=\"subagent\" only.",
+              "type": "boolean"
+            },
+            "mode": {
+              "enum": ["run"],
+              "type": "string"
+            },
+            "model": {
+              "type": "string"
+            },
+            "runtime": {
+              "enum": ["subagent"],
+              "type": "string"
+            },
+            "sandbox": {
+              "enum": ["inherit", "require"],
+              "type": "string"
+            },
+            "task": {
+              "type": "string"
+            },
+            "taskName": {
+              "description": "Stable alias for later targeting; lowercase letters/digits/underscores/hyphens, starts letter.",
+              "type": "string"
+            },
+            "thinking": {
+              "type": "string"
+            }
+          },
+          "required": ["task"],
+          "type": "object"
+        },
+        "name": "sessions_spawn",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "List active and recent subagents for the requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
+        "inputSchema": {
+          "properties": {
+            "action": {
+              "enum": ["list"],
+              "type": "string"
+            },
+            "recentMinutes": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "name": "subagents",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
+        "inputSchema": {
+          "properties": {
+            "model": {
+              "type": "string"
+            },
+            "sessionKey": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "name": "session_status",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Search web for current info; returns normalized provider results.",
+        "inputSchema": {
+          "properties": {
+            "count": {
+              "description": "Result count.",
+              "maximum": 10,
+              "minimum": 1,
+              "type": "number"
+            },
+            "country": {
+              "description": "2-letter country code.",
+              "type": "string"
+            },
+            "date_after": {
+              "description": "Published after YYYY-MM-DD.",
+              "type": "string"
+            },
+            "date_before": {
+              "description": "Published before YYYY-MM-DD.",
+              "type": "string"
+            },
+            "domain_filter": {
+              "description": "Perplexity domain filter.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "freshness": {
+              "description": "Time filter: day/week/month/year.",
+              "type": "string"
+            },
+            "language": {
+              "description": "ISO 639-1 language.",
+              "type": "string"
+            },
+            "max_tokens": {
+              "description": "Perplexity total token budget.",
+              "maximum": 1000000,
+              "minimum": 1,
+              "type": "number"
+            },
+            "max_tokens_per_page": {
+              "description": "Perplexity tokens per page.",
+              "minimum": 1,
+              "type": "number"
+            },
+            "query": {
+              "description": "Search query.",
+              "type": "string"
+            },
+            "search_lang": {
+              "description": "Brave result language.",
+              "type": "string"
+            },
+            "ui_lang": {
+              "description": "Brave UI locale.",
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        },
+        "name": "web_search",
+        "type": "function"
+      },
+      {
+        "deferLoading": true,
+        "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
+        "inputSchema": {
+          "properties": {
+            "extractMode": {
+              "default": "markdown",
+              "description": "Extract as markdown/text.",
+              "enum": ["markdown", "text"],
+              "type": "string"
+            },
+            "maxChars": {
+              "description": "Max chars returned; truncates.",
+              "minimum": 100,
+              "type": "integer"
+            },
+            "url": {
+              "description": "HTTP(S) URL.",
+              "type": "string"
+            }
+          },
+          "required": ["url"],
+          "type": "object"
+        },
+        "name": "web_fetch",
+        "type": "function"
+      }
+    ],
+    "type": "namespace"
   }
 ]

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -87,9 +87,10 @@
   "cwd": "/tmp/openclaw-happy-path/workspace",
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
+    "message",
+    "sessions_yield",
     "nodes",
     "cron",
-    "message",
     "tts",
     "gateway",
     "agents_list",
@@ -97,7 +98,6 @@
     "sessions_history",
     "sessions_send",
     "sessions_spawn",
-    "sessions_yield",
     "subagents",
     "session_status",
     "web_search",
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 45322,
-    "roughTokens": 11331
+    "chars": 50642,
+    "roughTokens": 12661
   },
   "openClawDeveloperInstructions": {
     "chars": 2988,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6925
   },
   "totalWithDynamicToolsJson": {
-    "chars": 73024,
-    "roughTokens": 18256
+    "chars": 78344,
+    "roughTokens": 19586
   },
   "userInputText": {
     "chars": 1629,
@@ -566,9 +566,10 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
 
 ```json
 [
+  "message",
+  "sessions_yield",
   "nodes",
   "cron",
-  "message",
   "tts",
   "gateway",
   "agents_list",
@@ -576,7 +577,6 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
   "sessions_history",
   "sessions_send",
   "sessions_spawn",
-  "sessions_yield",
   "subagents",
   "session_status",
   "web_search",
@@ -710,7 +710,8 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
       "required": ["action"],
       "type": "object"
     },
-    "name": "message"
+    "name": "message",
+    "type": "function"
   }
 ]
 ```

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -87,9 +87,10 @@
   "cwd": "/tmp/openclaw-happy-path/workspace",
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
+    "message",
+    "sessions_yield",
     "nodes",
     "cron",
-    "message",
     "tts",
     "gateway",
     "agents_list",
@@ -97,7 +98,6 @@
     "sessions_history",
     "sessions_send",
     "sessions_spawn",
-    "sessions_yield",
     "subagents",
     "session_status",
     "web_search",
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 45011,
-    "roughTokens": 11253
+    "chars": 50311,
+    "roughTokens": 12578
   },
   "openClawDeveloperInstructions": {
     "chars": 1964,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6544
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71189,
-    "roughTokens": 17798
+    "chars": 76489,
+    "roughTokens": 19123
   },
   "userInputText": {
     "chars": 1129,
@@ -543,9 +543,10 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
 
 ```json
 [
+  "message",
+  "sessions_yield",
   "nodes",
   "cron",
-  "message",
   "tts",
   "gateway",
   "agents_list",
@@ -553,7 +554,6 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
   "sessions_history",
   "sessions_send",
   "sessions_spawn",
-  "sessions_yield",
   "subagents",
   "session_status",
   "web_search",
@@ -687,7 +687,8 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
       "required": ["action"],
       "type": "object"
     },
-    "name": "message"
+    "name": "message",
+    "type": "function"
   }
 ]
 ```

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -87,9 +87,10 @@
   "cwd": "/tmp/openclaw-happy-path/workspace",
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",
   "dynamicTools": [
+    "message",
+    "sessions_yield",
     "nodes",
     "cron",
-    "message",
     "heartbeat_respond",
     "tts",
     "gateway",
@@ -98,7 +99,6 @@
     "sessions_history",
     "sessions_send",
     "sessions_spawn",
-    "sessions_yield",
     "subagents",
     "session_status",
     "web_search",
@@ -228,8 +228,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 46106,
-    "roughTokens": 11527
+    "chars": 51601,
+    "roughTokens": 12901
   },
   "openClawDeveloperInstructions": {
     "chars": 1983,
@@ -240,8 +240,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6780
   },
   "totalWithDynamicToolsJson": {
-    "chars": 73227,
-    "roughTokens": 18307
+    "chars": 78722,
+    "roughTokens": 19681
   },
   "userInputText": {
     "chars": 1367,
@@ -553,9 +553,10 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 
 ```json
 [
+  "message",
+  "sessions_yield",
   "nodes",
   "cron",
-  "message",
   "heartbeat_respond",
   "tts",
   "gateway",
@@ -564,7 +565,6 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
   "sessions_history",
   "sessions_send",
   "sessions_spawn",
-  "sessions_yield",
   "subagents",
   "session_status",
   "web_search",
@@ -698,7 +698,8 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
       "required": ["action"],
       "type": "object"
     },
-    "name": "message"
+    "name": "message",
+    "type": "function"
   },
   {
     "deferLoading": true,
@@ -734,7 +735,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
       "type": "object"
     },
     "name": "heartbeat_respond",
-    "namespace": "openclaw"
+    "type": "function"
   }
 ]
 ```


### PR DESCRIPTION
## Summary

Refs #92077. Follow-up to #93506.

This PR exposes the trusted ClawHub source provenance that #93506 started consuming in one more user-visible surface:

- Adds `openclaw.verifiedSourceUrl` to `openclaw skills verify` JSON output when ClawHub verification returns server-resolved GitHub provenance.
- Reuses the same trust-boundary helper for install persistence and verify output, so unsupported provenance shapes remain untrusted.
- Builds the promoted source URL from server-resolved `repo` + `commit` + optional `path`, producing a commit-pinned GitHub URL instead of trusting the raw `provenance.url` field, which can point at a mutable ref such as `main`.
- Documents the new verify JSON field in the skills CLI docs.

This does not read or promote self-attested `SKILL.md` metadata from #92860. It also does not replace #93314, which is still the readback half for provenance already written to local `.clawhub/origin.json`.

## Behavior addressed

Users and tooling consuming `openclaw skills verify` JSON can now find the verified source URL under the OpenClaw-owned metadata envelope without guessing whether raw ClawHub `provenance.url` is immutable or trusted.

Unavailable provenance or any non-`server-resolved-github-import` provenance stays only in the raw verification envelope and is not promoted as `openclaw.verifiedSourceUrl`.

## Real behavior proof

Behavior addressed: `openclaw skills verify` JSON now promotes only server-resolved ClawHub GitHub provenance into a commit-pinned `openclaw.verifiedSourceUrl`.

Conflict/merge proof after prepare:

- Rebased the narrow PR stack onto `origin/main` at `f50812dd56`.
- `git merge-tree $(git merge-base HEAD origin/main) origin/main HEAD` reports a clean merged result with no conflict records.
- Current PR diff is scoped to ClawHub verify output implementation, focused tests, and docs only: `docs/cli/skills.md`, `src/cli/skills-cli.ts`, `src/cli/skills-cli.verify.test.ts`, `src/cli/skills-cli.commands.test.ts`, `src/skills/lifecycle/clawhub.ts`, and `src/skills/lifecycle/clawhub.test.ts`.
- Local signature verification with the configured SSH signing public key reports all prepared commits as good signatures: `ad66207604 G`, `8a06d22861 G`, `c1059e3b9b G`, and `3e8e0bf34c G`.

Exact focused checks run after rebasing onto current `main`:

```sh
PNPM_CONFIG_MODULES_DIR=../../node_modules node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/skills-cli.verify.test.ts src/cli/skills-cli.commands.test.ts
PNPM_CONFIG_MODULES_DIR=../../node_modules node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-src.config.ts src/skills/lifecycle/clawhub.test.ts
node --import tsx scripts/generate-prompt-snapshots.ts --check
git diff --check
```

Evidence after fix:

```text
CLI verify/command tests: 2 files passed, 52 tests passed
ClawHub lifecycle tests: 1 file passed, 42 tests passed
Prompt snapshots: current (7 files) after regenerating the 6 drifted Codex happy-path snapshots reported by CI
git diff --check: passed
Pinned commit validation: `openclaw.verifiedSourceUrl` now requires a full 40-hex ClawHub provenance commit; branch-like `main` and short hashes are covered as negative tests.
```

Observed result after fix:

- A verification response with `provenance.source: "server-resolved-github-import"`, `repo: "openclaw/skills"`, `commit: "def456"`, and `path: "agentreceipt"` produces `openclaw.verifiedSourceUrl: "https://github.com/openclaw/skills/tree/def456/agentreceipt"`.
- A verification response with unavailable or self-declared provenance does not produce `openclaw.verifiedSourceUrl`.
- Install persistence and verify output continue sharing the same helper, so only server-resolved provenance is promoted.

Live-sample limitation: there is still no live positive production ClawHub provenance sample available for this contract. The PR body records that limitation explicitly, and the focused CLI/lifecycle tests exercise the server-resolved provenance envelope that ClawHub returns for this feature.



