### PR TITLE
fix(plugins): include entry-only external channel plugins in gateway startup plan

### DIFF
--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -2334,6 +2334,59 @@ describe("resolveGatewayStartupPluginIds", () => {
     expect(plan.configuredDeferredChannelPluginIds).toStrictEqual([]);
   });
 
+  it("includes external channel plugin enabled via plugins.entries without channels config", () => {
+    // Simulates the WeChat plugin flow: plugin installed, enabled via
+    // plugins.entries.<id>.enabled=true, but no channels.<id>.enabled=true.
+    const registry = createManifestRegistryFixtureWithWorkspaceDemoChannel();
+    const index = createInstalledPluginIndexFixture(registry);
+
+    // No channels config at all → configuredChannelIds is empty.
+    listPotentialConfiguredChannelIds.mockReturnValue([]);
+
+    const plan = resolveGatewayStartupPluginPlanFromRegistry({
+      config: {
+        plugins: {
+          entries: {
+            "workspace-demo-channel-plugin": { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      env: createPluginPlanningTestEnv(),
+      index,
+      manifestRegistry: registry,
+    });
+
+    // The plugin should still be in the startup plan because
+    // isExternalChannelPlugin lets it past shouldConsiderForGatewayStartup,
+    // and the activation-state check sees explicitlyEnabled=true.
+    expect(plan.pluginIds).toContain("workspace-demo-channel-plugin");
+    expect(plan.channelPluginIds).toContain("demo-channel");
+  });
+
+  it("does not start external channel plugin with plugins.entries.enabled=false", () => {
+    // isExternalChannelPlugin lets the plugin through, but the
+    // activation-state check sees enabled=false → rejected.
+    const registry = createManifestRegistryFixtureWithWorkspaceDemoChannel();
+    const index = createInstalledPluginIndexFixture(registry);
+
+    listPotentialConfiguredChannelIds.mockReturnValue([]);
+
+    const plan = resolveGatewayStartupPluginPlanFromRegistry({
+      config: {
+        plugins: {
+          entries: {
+            "workspace-demo-channel-plugin": { enabled: false },
+          },
+        },
+      } as OpenClawConfig,
+      env: createPluginPlanningTestEnv(),
+      index,
+      manifestRegistry: registry,
+    });
+
+    expect(plan.pluginIds).not.toContain("workspace-demo-channel-plugin");
+  });
+
   it("carries deferred configured channel ids through the startup plan", () => {
     const registry = createManifestRegistryFixtureWithWorkspaceDemoChannel();
     const index = createInstalledPluginIndexFixture(registry);

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -206,6 +206,30 @@ function hasConfiguredStartupChannel(params: {
   );
 }
 
+/**
+ * Returns true for non-bundled plugins whose manifest declares at least one
+ * channel.  Externally-installed channel plugins (e.g. WeChat, Discord) may
+ * be enabled solely via `plugins.entries.<id>.enabled=true` without an
+ * explicit `channels.<id>.enabled=true` entry.  The startup planner must
+ * let them through to the activation-state check below, which enforces the
+ * `explicitlyEnabled` guard for non-bundled plugins.
+ */
+function isExternalChannelPlugin(params: {
+  plugin: InstalledPluginIndexRecord;
+  manifest: PluginManifestRecord | undefined;
+  manifestLookup: ManifestRegistryLookup;
+}): boolean {
+  if (params.plugin.origin === "bundled") {
+    return false;
+  }
+  if (!params.manifest) {
+    return false;
+  }
+  return (
+    listManifestChannelIds(params.manifestLookup, params.plugin.pluginId).length > 0
+  );
+}
+
 type ManifestRegistryLookup = ReadonlyMap<string, PluginManifestRecord>;
 
 function createManifestRegistryLookup(
@@ -2092,7 +2116,8 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
         startupDreamingPluginIds,
         memorySlotStartupPluginId,
         contextEngineSlotStartupPluginId,
-      })
+      }) &&
+      !isExternalChannelPlugin({ plugin, manifest, manifestLookup })
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary

- External channel plugins installed via `openclaw plugins install` and
  enabled solely via `plugins.entries.<id>.enabled=true` (without a
  `channels.<id>.enabled=true` config entry) were never loaded by the
  gateway.  The gateway only loaded the 8 bundled stock plugins.
- Root cause: `resolveGatewayStartupPluginPlanFromRegistry` filters
  candidates through `shouldConsiderForGatewayStartup`, which requires
  `manifest.activation.onStartup === true` or a memory/context-engine
  slot match.  Non-bundled channel plugins whose manifests declare no
  `activation.onStartup` (e.g. the published WeChat plugin
  `@tencent-weixin/openclaw-weixin`) never reached the activation-state
  check, so `plugins.entries.<id>.enabled=true` was never evaluated.
- Fix: add `isExternalChannelPlugin()` guard so non-bundled plugins
  that declare at least one channel in their manifest bypass the
  `shouldConsiderForGatewayStartup` filter.  The activation-state check
  below still enforces `explicitlyEnabled` for non-bundled plugins,
  preserving the trust boundary — only plugins with an explicit
  `plugins.entries.<id>.enabled=true` are loaded.
- Total diff: Source +26, Tests +53.  Total +79 across 2 files.

Fixes #93219

## Linked context

- Issue #93219: Gateway never loads externally-installed npm plugins
  (installed-plugin load stage skipped).  ClawSweeper review confirms
  reproducibility at source level and identifies the startup-planning
  gap in `resolveGatewayStartupPluginPlanFromRegistry`.
- ClawSweeper reviewed issue #93219 on June 15, 2026 and confirmed:
  > "Current main still routes gateway runtime loading through a
  > startup plugin-id plan, and that plan does not include an
  > externally installed channel plugin merely because
  > `plugins.entries.<id>.enabled=true`"
- Earlier fix for WeChat (#70ebf48) addressed `channels.<id>.enabled=true`
  but did not cover the plugin-entry-only setup path documented by the
  published `@tencent-weixin/openclaw-weixin@2.4.3` package README.
- This PR follows the same reuse principle as `src/infra/windows-encoding.ts`
  (PR #30652): reuse existing activation-state machinery instead of
  adding a separate loading path.

## Real behavior proof

**Behavior or issue addressed**: The gateway startup planner now includes
non-bundled channel plugins enabled via `plugins.entries.<id>.enabled=true`,
even when no `channels.<id>.enabled=true` config exists.  Before this fix,
such plugins were never evaluated for startup — the load stage was
skipped entirely.

**Real setup tested**: Linux 4.19.112-2.el8.x86_64, Node.js v24.13.1,
OpenClaw PR branch @ 6452605, tsx for runtime probing, vitest for tests.

**Exact steps or command run after fix**:

```bash
# Real runtime probe: call the startup planner directly with
# an external channel plugin + plugins.entries.<id>.enabled=true
# (no channels config).  The function now returns the plugin.

./node_modules/.bin/tsx -e "
import { resolveGatewayStartupPluginPlanFromRegistry }
  from './src/plugins/gateway-startup-plugin-ids.ts';

const registry = {
  plugins: [{
    id: 'test-channel-plugin',
    manifestPath: '/tmp/test-plugin/manifest.json',
    source: 'npm', rootDir: '/tmp/test-plugin',
    origin: 'workspace',
    channels: ['test-channel'],
    providers: [], cliBackends: [],
    activation: { onStartup: false },
  }],
  diagnostics: null,
};

const index = {
  version: 1, hostContractVersion: '2026.6.6',
  compatRegistryVersion: 'test', migrationVersion: 1,
  policyHash: 'test', generatedAtMs: Date.now(),
  installRecords: {},
  plugins: registry.plugins.map((r) => ({
    pluginId: r.id, manifestPath: r.manifestPath,
    manifestHash: 'test-' + r.id, source: r.source,
    rootDir: r.rootDir, origin: r.origin, enabled: true,
    startup: { sidecar: false, memory: false,
      deferConfiguredChannelFullLoadUntilAfterListen: false,
      agentHarnesses: [], configPaths: [] },
    contributions: { channels: r.channels },
    preferences: null, remote: null,
  })),
  diagnostics: null,
};

const plan = resolveGatewayStartupPluginPlanFromRegistry({
  config: { plugins: {
    entries: { 'test-channel-plugin': { enabled: true } },
    deny: [] } },
  env: {},
  index,
  manifestRegistry: registry,
});

console.log('pluginIds:', JSON.stringify(plan.pluginIds));
console.log('contains test-channel-plugin:',
  plan.pluginIds.includes('test-channel-plugin'));
"
```

**After-fix evidence**:

```
pluginIds: ["test-channel-plugin"]
contains test-channel-plugin: true
```

The external channel plugin is included in the startup plan.  The
`isExternalChannelPlugin()` guard lets non-bundled channel plugins
bypass `shouldConsiderForGatewayStartup`, and the activation-state
check below correctly recognizes `plugins.entries.<id>.enabled=true`
as `explicitlyEnabled=true`.

**Observed result after the fix**: The startup planner returns the
external channel plugin ID in `pluginIds`.  On a live gateway, this
means `loadGatewayPlugins` will include the plugin and the gateway
will log e.g. `http server listening (9 plugins: ..., weixin, ...)`
instead of only the 8 bundled plugins.

**What was not tested**: A live macOS + Homebrew node@22 gateway with
the real `@tencent-weixin/openclaw-weixin` plugin installed.  The fix
is exercised through the exact same code path (the planner function
shared by all installed plugins).  The `installed_plugin_index`
lookup and `plugins.entries` parsing are shared between the test
fixture and the real gateway — the fix operates at the planner level,
not on any platform-specific code.

**Proof limitations or environment constraints**: The real WeChat
plugin requires a macOS environment with WeChat desktop and a valid
Tencent WeChat developer account.  The runtime probe replicates the
identical planner call chain that the gateway uses for all installed
plugins, including WeChat.  The planner operates on in-memory
`InstalledPluginIndex` and `PluginManifestRegistry` snapshots — it
has no platform-specific logic.

## Tests and validation

```bash
# Channel plugin IDs + startup plan tests (146 passed, including 2 new):
node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts

# Gateway server startup + plugin loading (140 passed):
node scripts/run-vitest.mjs \
  src/gateway/server-startup-plugins.test.ts \
  src/gateway/server-plugins.test.ts
```

New test cases:
1. `includes external channel plugin enabled via plugins.entries
   without channels config` — verifies the fix
2. `does not start external channel plugin with
   plugins.entries.enabled=false` — verifies the trust boundary

All 302 tests pass (146 + 140 + 16), zero regressions.

## Risk checklist

Did user-visible behavior change? (`Yes`)
- External channel plugins installed via `openclaw plugins install`
  and enabled via `plugins.entries.<id>.enabled=true` now load at
  gateway startup instead of being silently skipped.

Did config, environment, or migration behavior change? (`No`)
- No new config keys, no migration.  The fix only changes which
  plugins pass the startup-consider filter.

Did security, auth, secrets, network, or tool execution behavior change? (`No`)
- The `explicitlyEnabled` guard for non-bundled plugins is unchanged.
  `plugins.entries.<id>.enabled=true` must still be explicitly set.
  Auto-discovered or untrusted plugins are not loaded.

What is the highest-risk area?
- An external channel plugin that was previously installed but
  silently not loading could now start.  This is the desired bug fix,
  not a regression — the plugin was installed and explicitly enabled
  by the user who expected it to load.

How is that risk mitigated?
- The activation-state check (`resolveEffectivePluginActivationState`)
  still requires `explicitlyEnabled === true` for non-bundled plugins.
  `plugins.entries.<id>.enabled=true` must be set by a deliberate
  user action (`openclaw plugins install` writes this automatically).
  Auto-discovered or untrusted plugins are never loaded.

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- CI (Real behavior proof check, lint, tests) must pass on the PR.
- A live WeChat-plugin integration test on macOS would be ideal
  additional validation but is blocked on platform/credential
  availability.

Which bot or reviewer comments were addressed?
- ClawSweeper issue review (#93219) identified the startup-planning
  gap.  This PR implements the recommended fix: "Make the gateway
  startup planner include explicitly enabled installed channel
  plugins from the persisted index/manifest contract."
- The fix keeps "existing allow/deny and explicit-trust rules
  intact" as clawsweeper specified.
