### PR TITLE
fix(update): query npm metadata through npm

### DIFF
--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -218,11 +218,17 @@ function resolveBoundedThreadConfig(
   params: CodexBoundedTurnParams,
   workspace: { codexHome?: string },
 ): JsonObject {
-  const boundedConfig =
-    mergeCodexThreadConfigs(CODEX_BOUNDED_THREAD_CONFIG, params.threadConfig) ??
-    CODEX_BOUNDED_THREAD_CONFIG;
+  const boundedConfig = mergeCodexThreadConfigs(
+    CODEX_BOUNDED_THREAD_CONFIG,
+    params.threadConfig,
+  ) ?? {
+    ...CODEX_BOUNDED_THREAD_CONFIG,
+  };
   return workspace.codexHome
-    ? (mergeCodexThreadConfigs(boundedConfig, CODEX_PRIVATE_BOUNDED_THREAD_CONFIG) ?? boundedConfig)
+    ? (mergeCodexThreadConfigs(boundedConfig, CODEX_PRIVATE_BOUNDED_THREAD_CONFIG) ?? {
+        ...boundedConfig,
+        ...CODEX_PRIVATE_BOUNDED_THREAD_CONFIG,
+      })
     : boundedConfig;
 }
 

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -8,13 +8,13 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
 import type { ChannelAccessPolicy } from "./setup-group-access.js";
-import type { ChannelConfigAdapter, ChannelSetupAdapter } from "./types.adapters.js";
 import type {
   ChannelCapabilities,
   ChannelId,
   ChannelMeta,
   ChannelSetupInput,
 } from "./types.core.js";
+import type { ChannelConfigAdapter, ChannelSetupAdapter } from "./types.setup-config.js";
 
 export type ChannelSetupPlugin = {
   id: ChannelId;

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -41,10 +41,10 @@ import type {
   ChannelLogSink,
   ChannelSecurityContext,
   ChannelSecurityDmPolicy,
-  ChannelSetupInput,
   ChannelStatusIssue,
 } from "./types.core.js";
 export type { ChannelPairingAdapter } from "./pairing.types.js";
+export type { ChannelConfigAdapter, ChannelSetupAdapter } from "./types.setup-config.js";
 
 type ConfiguredBindingRule = AgentBinding;
 export type { ChannelApprovalKind } from "../../infra/approval-types.js";
@@ -77,87 +77,6 @@ export type ChannelCapabilitiesDiagnostics = {
 };
 
 type ChannelAdapterCallback<T extends (...args: never[]) => unknown> = T;
-
-export type ChannelSetupAdapter = {
-  resolveAccountId?: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string;
-    input?: ChannelSetupInput;
-  }) => string;
-  resolveBindingAccountId?: (params: {
-    cfg: OpenClawConfig;
-    agentId: string;
-    accountId?: string;
-  }) => string | undefined;
-  applyAccountName?: (params: {
-    cfg: OpenClawConfig;
-    accountId: string;
-    name?: string;
-  }) => OpenClawConfig;
-  applyAccountConfig: (params: {
-    cfg: OpenClawConfig;
-    accountId: string;
-    input: ChannelSetupInput;
-  }) => OpenClawConfig;
-  afterAccountConfigWritten?: (params: {
-    previousCfg: OpenClawConfig;
-    cfg: OpenClawConfig;
-    accountId: string;
-    input: ChannelSetupInput;
-    runtime: RuntimeEnv;
-  }) => Promise<void> | void;
-  validateInput?: (params: {
-    cfg: OpenClawConfig;
-    accountId: string;
-    input: ChannelSetupInput;
-  }) => string | null;
-  singleAccountKeysToMove?: readonly string[];
-  namedAccountPromotionKeys?: readonly string[];
-  resolveSingleAccountPromotionTarget?: (params: {
-    channel: Record<string, unknown>;
-  }) => string | undefined;
-};
-
-export type ChannelConfigAdapter<ResolvedAccount> = {
-  listAccountIds: (cfg: OpenClawConfig) => string[];
-  resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => ResolvedAccount;
-  inspectAccount?: (cfg: OpenClawConfig, accountId?: string | null) => unknown;
-  defaultAccountId?: (cfg: OpenClawConfig) => string;
-  setAccountEnabled?: (params: {
-    cfg: OpenClawConfig;
-    accountId: string;
-    enabled: boolean;
-  }) => OpenClawConfig;
-  deleteAccount?: (params: { cfg: OpenClawConfig; accountId: string }) => OpenClawConfig;
-  isEnabled?: ChannelAdapterCallback<(account: ResolvedAccount, cfg: OpenClawConfig) => boolean>;
-  disabledReason?: ChannelAdapterCallback<
-    (account: ResolvedAccount, cfg: OpenClawConfig) => string
-  >;
-  isConfigured?: ChannelAdapterCallback<
-    (account: ResolvedAccount, cfg: OpenClawConfig) => boolean | Promise<boolean>
-  >;
-  unconfiguredReason?: ChannelAdapterCallback<
-    (account: ResolvedAccount, cfg: OpenClawConfig) => string
-  >;
-  describeAccount?: ChannelAdapterCallback<
-    (account: ResolvedAccount, cfg: OpenClawConfig) => ChannelAccountSnapshot
-  >;
-  resolveAllowFrom?: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-  }) => Array<string | number> | undefined;
-  formatAllowFrom?: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-    allowFrom: Array<string | number>;
-  }) => string[];
-  hasConfiguredState?: (params: { cfg: OpenClawConfig; env?: NodeJS.ProcessEnv }) => boolean;
-  hasPersistedAuthState?: (params: { cfg: OpenClawConfig; env?: NodeJS.ProcessEnv }) => boolean;
-  resolveDefaultTo?: (params: {
-    cfg: OpenClawConfig;
-    accountId?: string | null;
-  }) => string | undefined;
-};
 
 export type ChannelSecretsAdapter = {
   secretTargetRegistryEntries?: readonly SecretTargetRegistryEntry[];

--- a/src/channels/plugins/types.setup-config.ts
+++ b/src/channels/plugins/types.setup-config.ts
@@ -1,0 +1,91 @@
+/**
+ * Channel plugin setup/config adapter type contracts.
+ *
+ * Kept as a leaf contract so setup wizard types do not pull the full adapter barrel.
+ */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { ChannelAccountSnapshot, ChannelSetupInput } from "./types.core.js";
+
+type ChannelAdapterCallback<T extends (...args: never[]) => unknown> = T;
+
+export type ChannelSetupAdapter = {
+  resolveAccountId?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string;
+    input?: ChannelSetupInput;
+  }) => string;
+  resolveBindingAccountId?: (params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    accountId?: string;
+  }) => string | undefined;
+  applyAccountName?: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    name?: string;
+  }) => OpenClawConfig;
+  applyAccountConfig: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    input: ChannelSetupInput;
+  }) => OpenClawConfig;
+  afterAccountConfigWritten?: (params: {
+    previousCfg: OpenClawConfig;
+    cfg: OpenClawConfig;
+    accountId: string;
+    input: ChannelSetupInput;
+    runtime: RuntimeEnv;
+  }) => Promise<void> | void;
+  validateInput?: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    input: ChannelSetupInput;
+  }) => string | null;
+  singleAccountKeysToMove?: readonly string[];
+  namedAccountPromotionKeys?: readonly string[];
+  resolveSingleAccountPromotionTarget?: (params: {
+    channel: Record<string, unknown>;
+  }) => string | undefined;
+};
+
+export type ChannelConfigAdapter<ResolvedAccount> = {
+  listAccountIds: (cfg: OpenClawConfig) => string[];
+  resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => ResolvedAccount;
+  inspectAccount?: (cfg: OpenClawConfig, accountId?: string | null) => unknown;
+  defaultAccountId?: (cfg: OpenClawConfig) => string;
+  setAccountEnabled?: (params: {
+    cfg: OpenClawConfig;
+    accountId: string;
+    enabled: boolean;
+  }) => OpenClawConfig;
+  deleteAccount?: (params: { cfg: OpenClawConfig; accountId: string }) => OpenClawConfig;
+  isEnabled?: ChannelAdapterCallback<(account: ResolvedAccount, cfg: OpenClawConfig) => boolean>;
+  disabledReason?: ChannelAdapterCallback<
+    (account: ResolvedAccount, cfg: OpenClawConfig) => string
+  >;
+  isConfigured?: ChannelAdapterCallback<
+    (account: ResolvedAccount, cfg: OpenClawConfig) => boolean | Promise<boolean>
+  >;
+  unconfiguredReason?: ChannelAdapterCallback<
+    (account: ResolvedAccount, cfg: OpenClawConfig) => string
+  >;
+  describeAccount?: ChannelAdapterCallback<
+    (account: ResolvedAccount, cfg: OpenClawConfig) => ChannelAccountSnapshot
+  >;
+  resolveAllowFrom?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+  }) => Array<string | number> | undefined;
+  formatAllowFrom?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+    allowFrom: Array<string | number>;
+  }) => string[];
+  hasConfiguredState?: (params: { cfg: OpenClawConfig; env?: NodeJS.ProcessEnv }) => boolean;
+  hasPersistedAuthState?: (params: { cfg: OpenClawConfig; env?: NodeJS.ProcessEnv }) => boolean;
+  resolveDefaultTo?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+  }) => string | undefined;
+};

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2215,6 +2215,15 @@ describe("update-cli", () => {
     await updateCommand({ yes: true });
 
     expectPackageInstallSpec("openclaw@latest");
+    const preflightParams = vi.mocked(fetchNpmPackageTargetStatus).mock.calls[0]?.[0];
+    expect(preflightParams).toEqual(
+      expect.objectContaining({
+        target: "latest",
+        spec: "openclaw@latest",
+        cwd: process.cwd(),
+      }),
+    );
+    expect(packageInstallCommandCall()?.[1].env).toBe(preflightParams?.env);
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
     expect(
       vi

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -98,6 +98,7 @@ export { readPackageName, readPackageVersion };
 export async function resolveTargetVersion(
   tag: string,
   timeoutMs?: number,
+  options: { spec?: string; cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Promise<string | null> {
   if (!canResolveRegistryVersionForPackageTarget(tag)) {
     return null;
@@ -106,7 +107,13 @@ export async function resolveTargetVersion(
   if (direct) {
     return direct;
   }
-  const res = await fetchNpmTagVersion({ tag, timeoutMs });
+  const res = await fetchNpmTagVersion({
+    tag,
+    timeoutMs,
+    spec: options.spec,
+    cwd: options.cwd,
+    env: options.env,
+  });
   return res.version ?? null;
 }
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1045,8 +1045,14 @@ async function resolvePackageRuntimePreflightError(params: {
   tag: string;
   timeoutMs?: number;
   nodeRunner?: string;
+  spec?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
 }): Promise<string | null> {
   if (!canResolveRegistryVersionForPackageTarget(params.tag)) {
+    return null;
+  }
+  if (params.spec && !canResolveRegistryVersionForPackageTarget(params.spec)) {
     return null;
   }
   const target = params.tag.trim();
@@ -1055,7 +1061,10 @@ async function resolvePackageRuntimePreflightError(params: {
   }
   const status = await fetchNpmPackageTargetStatus({
     target,
+    spec: params.spec,
     timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
   });
   if (status.error) {
     return null;
@@ -1503,13 +1512,14 @@ async function runPackageInstallUpdate(params: {
   invocationCwd?: string;
   honorPackageRoot?: boolean;
   nodeRunner?: string;
+  installEnv?: NodeJS.ProcessEnv;
 }): Promise<UpdateRunResult> {
   const manager = await resolveGlobalManager({
     root: params.root,
     installKind: params.installKind,
     timeoutMs: params.timeoutMs,
   });
-  const installEnv = await createGlobalInstallEnv();
+  const installEnv = params.installEnv ?? (await createGlobalInstallEnv());
   const runCommand = createGlobalCommandRunner();
   const installTarget = await resolveGlobalInstallTarget({
     manager,
@@ -3286,6 +3296,8 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   let downgradeRisk = false;
   let fallbackToLatest = false;
   let packageInstallSpec: string | null = null;
+  let packageInstallEnv: NodeJS.ProcessEnv | undefined;
+  let packageInstallCwd: string | undefined;
   let packageAlreadyCurrent = false;
   let managedServiceRootRedirect: ManagedServiceRootRedirect | null = null;
   // Resolved independently of the root redirect so it covers the common case
@@ -3340,11 +3352,27 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   }
 
   if (updateInstallKind !== "git") {
+    packageInstallEnv = await createGlobalInstallEnv();
+    packageInstallCwd = tryResolveInvocationCwd();
     currentVersion = switchToPackage ? null : await readPackageVersion(root);
     if (explicitTag) {
-      targetVersion = await resolveTargetVersion(tag, timeoutMs);
+      const explicitSpec = resolveGlobalInstallSpec({
+        packageName: DEFAULT_PACKAGE_NAME,
+        tag,
+        env: packageInstallEnv,
+      });
+      targetVersion = await resolveTargetVersion(tag, timeoutMs, {
+        spec: explicitSpec,
+        cwd: packageInstallCwd,
+        env: packageInstallEnv,
+      });
     } else {
-      targetVersion = await resolveNpmChannelTag({ channel, timeoutMs }).then((resolved) => {
+      targetVersion = await resolveNpmChannelTag({
+        channel,
+        timeoutMs,
+        cwd: packageInstallCwd,
+        env: packageInstallEnv,
+      }).then((resolved) => {
         tag = resolved.tag;
         fallbackToLatest = channel === "beta" && resolved.tag === "latest";
         return resolved.version;
@@ -3367,7 +3395,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     packageInstallSpec = resolveGlobalInstallSpec({
       packageName: DEFAULT_PACKAGE_NAME,
       tag,
-      env: process.env,
+      env: packageInstallEnv,
     });
   }
 
@@ -3485,8 +3513,11 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   if (updateInstallKind === "package") {
     const runtimePreflightError = await resolvePackageRuntimePreflightError({
       tag,
+      spec: packageInstallSpec ?? undefined,
       timeoutMs,
       nodeRunner: managedServiceNodeRunner,
+      cwd: packageInstallCwd,
+      env: packageInstallEnv,
     });
     if (runtimePreflightError) {
       defaultRuntime.error(runtimePreflightError);
@@ -3591,6 +3622,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
             honorPackageRoot:
               managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
             nodeRunner: managedServiceNodeRunner,
+            installEnv: packageInstallEnv,
           })
         : await runGitUpdate({
             root,

--- a/src/infra/approval-handler-runtime-types.ts
+++ b/src/infra/approval-handler-runtime-types.ts
@@ -1,7 +1,7 @@
 // Defines channel-native approval handler runtime types.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ChannelApprovalNativePlannedTarget } from "./approval-native-delivery.js";
-import type { PreparedChannelNativeApprovalTarget } from "./approval-native-runtime.js";
+import type { PreparedChannelNativeApprovalTarget } from "./approval-native-runtime-types.js";
 import type { ChannelApprovalKind } from "./approval-types.js";
 import type {
   ExpiredApprovalView,

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -1,7 +1,9 @@
 // Covers update status, dependency status, and registry fetch helpers.
 import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
@@ -43,38 +45,144 @@ describe("compareSemverStrings", () => {
 });
 
 describe("resolveNpmChannelTag", () => {
+  type NpmMetadataCommandRunner = NonNullable<
+    Parameters<typeof fetchNpmPackageTargetStatus>[0]["runCommand"]
+  >;
+
   let versionByTag: Record<string, string | null>;
+  let runCommand: NpmMetadataCommandRunner;
+  let runCommandMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     versionByTag = {};
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url =
-          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-        const tag = decodeURIComponent(url.split("/").pop() ?? "");
-        const version = versionByTag[tag] ?? null;
-        return {
-          ok: version != null,
-          status: version != null ? 200 : 404,
-          json: async () => ({
-            version,
-            engines: version != null ? { node: ">=22.19.0" } : undefined,
-          }),
-        } as Response;
+    runCommandMock = vi.fn(async (argv: string[]) => {
+      const spec = String(argv[2] ?? "");
+      const tag = spec.slice(spec.lastIndexOf("@") + 1);
+      const version = versionByTag[tag] ?? null;
+      return {
+        stdout:
+          version == null
+            ? ""
+            : JSON.stringify({
+                version,
+                "engines.node": ">=22.19.0",
+              }),
+        stderr: version == null ? "npm ERR! 404 Not Found" : "",
+        code: version == null ? 1 : 0,
+      };
+    });
+    runCommand = runCommandMock as unknown as NpmMetadataCommandRunner;
+  });
+
+  it("delegates package target metadata to npm view with global config scope", async () => {
+    versionByTag.latest = "1.0.4";
+    const env = { ...process.env, NPM_CONFIG_USERCONFIG: "/tmp/openclaw-user-npmrc" };
+
+    await expect(
+      fetchNpmPackageTargetStatus({
+        target: "latest",
+        spec: "openclaw@latest",
+        timeoutMs: 1000,
+        cwd: "/tmp/openclaw-project",
+        env,
+        runCommand,
+      }),
+    ).resolves.toEqual({
+      target: "latest",
+      version: "1.0.4",
+      nodeEngine: ">=22.19.0",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      ["npm", "view", "openclaw@latest", "version", "engines.node", "--json", "--global"],
+      expect.objectContaining({
+        timeoutMs: 1000,
+        cwd: "/tmp/openclaw-project",
+        env,
       }),
     );
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
+  it("uses npm global scope, user config auth, and ignores project npmrc for real metadata", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-view-" }, async (base) => {
+      const requests: Array<{ url: string; authorization?: string }> = [];
+      const server = http.createServer((req, res) => {
+        requests.push({
+          url: req.url ?? "",
+          authorization: req.headers.authorization,
+        });
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            name: "openclaw",
+            "dist-tags": { latest: "2026.6.6" },
+            versions: {
+              "2026.6.6": {
+                name: "openclaw",
+                version: "2026.6.6",
+                engines: { node: ">=22.19.0" },
+                dist: {
+                  tarball: "http://example.invalid/openclaw-2026.6.6.tgz",
+                  shasum: "0".repeat(40),
+                },
+              },
+            },
+          }),
+        );
+      });
+
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address() as AddressInfo;
+        const registry = `http://127.0.0.1:${address.port}/user/`;
+        const project = path.join(base, "project");
+        const home = path.join(base, "home");
+        const userConfig = path.join(home, ".npmrc");
+        await fs.mkdir(project, { recursive: true });
+        await fs.mkdir(home, { recursive: true });
+        await fs.writeFile(path.join(project, ".npmrc"), "registry=http://127.0.0.1:9/project/\n");
+        await fs.writeFile(
+          userConfig,
+          [`registry=${registry}`, `//127.0.0.1:${address.port}/user/:_authToken=test-token`].join(
+            "\n",
+          ),
+        );
+
+        await expect(
+          fetchNpmPackageTargetStatus({
+            target: "latest",
+            timeoutMs: 10_000,
+            cwd: project,
+            env: {
+              ...process.env,
+              HOME: home,
+              NPM_CONFIG_USERCONFIG: userConfig,
+            },
+          }),
+        ).resolves.toEqual({
+          target: "latest",
+          version: "2026.6.6",
+          nodeEngine: ">=22.19.0",
+        });
+
+        expect(requests.some((request) => request.url.startsWith("/user/openclaw"))).toBe(true);
+        expect(requests.some((request) => request.url.startsWith("/project/"))).toBe(false);
+        expect(requests.some((request) => request.authorization === "Bearer test-token")).toBe(
+          true,
+        );
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((err) => (err ? reject(err) : resolve()));
+        });
+      }
+    });
   });
 
   it("falls back to latest when beta is older", async () => {
     versionByTag.beta = "1.0.0-beta.1";
     versionByTag.latest = "1.0.1-1";
 
-    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
     expect(resolved).toEqual({ tag: "latest", version: "1.0.1-1" });
   });
@@ -83,7 +191,7 @@ describe("resolveNpmChannelTag", () => {
     versionByTag.beta = "1.0.2-beta.1";
     versionByTag.latest = "1.0.1-1";
 
-    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
     expect(resolved).toEqual({ tag: "beta", version: "1.0.2-beta.1" });
   });
@@ -92,7 +200,7 @@ describe("resolveNpmChannelTag", () => {
     versionByTag.beta = "1.0.1-beta.2";
     versionByTag.latest = "1.0.1";
 
-    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
     expect(resolved).toEqual({ tag: "latest", version: "1.0.1" });
   });
@@ -100,7 +208,9 @@ describe("resolveNpmChannelTag", () => {
   it("keeps non-beta channels unchanged", async () => {
     versionByTag.latest = "1.0.3";
 
-    await expect(resolveNpmChannelTag({ channel: "stable", timeoutMs: 1000 })).resolves.toEqual({
+    await expect(
+      resolveNpmChannelTag({ channel: "stable", timeoutMs: 1000, runCommand }),
+    ).resolves.toEqual({
       tag: "latest",
       version: "1.0.3",
     });
@@ -110,36 +220,42 @@ describe("resolveNpmChannelTag", () => {
     versionByTag.latest = "1.0.4";
 
     await expect(
-      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
+      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000, runCommand }),
     ).resolves.toEqual({
       target: "latest",
       version: "1.0.4",
       nodeEngine: ">=22.19.0",
     });
-    await expect(fetchNpmTagVersion({ tag: "latest", timeoutMs: 1000 })).resolves.toEqual({
+    await expect(
+      fetchNpmTagVersion({ tag: "latest", timeoutMs: 1000, runCommand }),
+    ).resolves.toEqual({
       tag: "latest",
       version: "1.0.4",
     });
-    await expect(fetchNpmLatestVersion({ timeoutMs: 1000 })).resolves.toEqual({
+    await expect(fetchNpmLatestVersion({ timeoutMs: 1000, runCommand })).resolves.toEqual({
       latestVersion: "1.0.4",
       error: undefined,
     });
     versionByTag.beta = "1.0.5-beta.1";
     await expect(
-      fetchNpmRegistryVersionForChannel({ channel: "beta", timeoutMs: 1000 }),
+      fetchNpmRegistryVersionForChannel({ channel: "beta", timeoutMs: 1000, runCommand }),
     ).resolves.toEqual({
       latestVersion: "1.0.5-beta.1",
       tag: "beta",
     });
-    await expect(fetchNpmTagVersion({ tag: "beta", timeoutMs: 1000 })).resolves.toEqual({
-      tag: "beta",
-      version: "1.0.5-beta.1",
-      error: undefined,
-    });
-    await expect(fetchNpmTagVersion({ tag: "missing", timeoutMs: 1000 })).resolves.toEqual({
+    await expect(fetchNpmTagVersion({ tag: "beta", timeoutMs: 1000, runCommand })).resolves.toEqual(
+      {
+        tag: "beta",
+        version: "1.0.5-beta.1",
+        error: undefined,
+      },
+    );
+    await expect(
+      fetchNpmTagVersion({ tag: "missing", timeoutMs: 1000, runCommand }),
+    ).resolves.toEqual({
       tag: "missing",
       version: null,
-      error: "HTTP 404",
+      error: "npm view failed: npm ERR! 404 Not Found",
     });
   });
 });

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -56,7 +56,7 @@ describe("resolveNpmChannelTag", () => {
   beforeEach(() => {
     versionByTag = {};
     runCommandMock = vi.fn(async (argv: string[]) => {
-      const spec = String(argv[2] ?? "");
+      const spec = argv[2] ?? "";
       const tag = spec.slice(spec.lastIndexOf("@") + 1);
       const version = versionByTag[tag] ?? null;
       return {
@@ -131,7 +131,9 @@ describe("resolveNpmChannelTag", () => {
         );
       });
 
-      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
       try {
         const address = server.address() as AddressInfo;
         const registry = `http://127.0.0.1:${address.port}/user/`;

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
@@ -58,6 +57,53 @@ export type UpdateCheckResult = {
   deps?: DepsStatus;
   registry?: RegistryStatus;
 };
+
+type NpmMetadataCommandRunner = (
+  argv: string[],
+  options: {
+    timeoutMs: number;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    maxOutputBytes?: number;
+  },
+) => Promise<{
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}>;
+
+function toOptionalTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseNpmPackageTargetMetadata(raw: string): {
+  version: string | null;
+  nodeEngine: string | null;
+} {
+  const parsed = JSON.parse(raw.trim()) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { version: null, nodeEngine: null };
+  }
+  const rec = parsed as Record<string, unknown>;
+  const engines = rec.engines && typeof rec.engines === "object" ? rec.engines : null;
+  const nodeEngine =
+    toOptionalTrimmedString(rec["engines.node"]) ??
+    (engines ? toOptionalTrimmedString((engines as Record<string, unknown>).node) : null);
+  return {
+    version: toOptionalTrimmedString(rec.version),
+    nodeEngine,
+  };
+}
+
+function formatNpmViewError(res: { stdout: string; stderr: string }): string {
+  const raw = (res.stderr.trim() || res.stdout.trim()).split("\n").slice(-3).join("\n");
+  return raw ? `npm view failed: ${raw}` : "npm view failed";
+}
+
+function packageTargetSpec(params: { target: string; spec?: string }): string {
+  const spec = params.spec?.trim();
+  return spec || `openclaw@${params.target.trim() || "latest"}`;
+}
 
 export function formatGitInstallLabel(update: UpdateCheckResult): string | null {
   if (update.installKind !== "git") {
@@ -300,8 +346,17 @@ export async function checkDepsStatus(params: {
 
 export async function fetchNpmLatestVersion(params?: {
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<RegistryStatus> {
-  const res = await fetchNpmTagVersion({ tag: "latest", timeoutMs: params?.timeoutMs });
+  const res = await fetchNpmTagVersion({
+    tag: "latest",
+    timeoutMs: params?.timeoutMs,
+    cwd: params?.cwd,
+    env: params?.env,
+    runCommand: params?.runCommand,
+  });
   return {
     latestVersion: res.version,
     error: res.error,
@@ -311,10 +366,16 @@ export async function fetchNpmLatestVersion(params?: {
 export async function fetchNpmRegistryVersionForChannel(params: {
   channel: UpdateChannel;
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<RegistryStatus> {
   const res = await resolveNpmChannelTag({
     channel: params.channel,
     timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
   });
   return {
     latestVersion: res.version,
@@ -325,24 +386,41 @@ export async function fetchNpmRegistryVersionForChannel(params: {
 export async function fetchNpmPackageTargetStatus(params: {
   target: string;
   timeoutMs?: number;
+  spec?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<NpmPackageTargetStatus> {
   const timeoutMs = params.timeoutMs ?? 3500;
   const target = params.target;
+  const runCommand = params.runCommand ?? runCommandWithTimeout;
   try {
-    const res = await fetchWithTimeout(
-      `https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`,
-      {},
-      Math.max(250, timeoutMs),
+    const res = await runCommand(
+      [
+        "npm",
+        "view",
+        packageTargetSpec({ target, spec: params.spec }),
+        "version",
+        "engines.node",
+        "--json",
+        "--global",
+      ],
+      {
+        timeoutMs: Math.max(250, timeoutMs),
+        cwd: params.cwd,
+        env: params.env,
+        maxOutputBytes: 1024 * 1024,
+      },
     );
-    if (!res.ok) {
-      return { target, version: null, nodeEngine: null, error: `HTTP ${res.status}` };
+    if (res.code !== 0) {
+      return {
+        target,
+        version: null,
+        nodeEngine: null,
+        error: formatNpmViewError(res),
+      };
     }
-    const json = (await res.json()) as {
-      version?: unknown;
-      engines?: { node?: unknown };
-    };
-    const version = typeof json?.version === "string" ? json.version : null;
-    const nodeEngine = typeof json?.engines?.node === "string" ? json.engines.node : null;
+    const { version, nodeEngine } = parseNpmPackageTargetMetadata(res.stdout);
     return { target, version, nodeEngine };
   } catch (err) {
     return { target, version: null, nodeEngine: null, error: String(err) };
@@ -352,10 +430,18 @@ export async function fetchNpmPackageTargetStatus(params: {
 export async function fetchNpmTagVersion(params: {
   tag: string;
   timeoutMs?: number;
+  spec?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<NpmTagStatus> {
   const res = await fetchNpmPackageTargetStatus({
     target: params.tag,
     timeoutMs: params.timeoutMs,
+    spec: params.spec,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
   });
   return {
     tag: params.tag,
@@ -367,14 +453,29 @@ export async function fetchNpmTagVersion(params: {
 export async function resolveNpmChannelTag(params: {
   channel: UpdateChannel;
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<{ tag: string; version: string | null }> {
   const channelTag = channelToNpmTag(params.channel);
-  const channelStatus = await fetchNpmTagVersion({ tag: channelTag, timeoutMs: params.timeoutMs });
+  const channelStatus = await fetchNpmTagVersion({
+    tag: channelTag,
+    timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
+  });
   if (params.channel !== "beta") {
     return { tag: channelTag, version: channelStatus.version };
   }
 
-  const latestStatus = await fetchNpmTagVersion({ tag: "latest", timeoutMs: params.timeoutMs });
+  const latestStatus = await fetchNpmTagVersion({
+    tag: "latest",
+    timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
+  });
   if (!latestStatus.version) {
     return { tag: channelTag, version: channelStatus.version };
   }


### PR DESCRIPTION
Closes #79140.

Summary:
- Replace the update metadata raw registry fetch with `npm view --global` so npm resolves registry config and scoped auth.
- Thread the global install spec, env, and cwd through update target resolution and runtime preflight.
- Add regression coverage for user npm config auth while a project `.npmrc` points at a different registry.
- Default the bounded Codex thread config and split setup adapter types onto leaf contracts so current CI architecture gates remain deterministic.

## Real behavior proof
Behavior addressed: update checks no longer hardcode `registry.npmjs.org` or bypass npm scoped auth when resolving OpenClaw package metadata.
Real environment tested: local source checkout on macOS with npm and a temporary HTTP registry stub.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/infra/update-check.test.ts`
Evidence after fix: the test `uses npm global scope, user config auth, and ignores project npmrc for real metadata` passed; the stub registry recorded `/user/openclaw` and `Authorization: Bearer test-token`, with no `/project/` registry request.
Observed result after fix: `17 passed (17)`.
What was not tested: a live private third-party npm registry; the local stub exercises npm actual `npm view --global` request/auth behavior without external credentials.