### PR TITLE
feat(codex): support app-server network proxy profiles

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -103,7 +103,44 @@ Supported `appServer` fields:
 | `approvalsReviewer`                           | `"user"` or an allowed guardian reviewer               | Use `"auto_review"` to let Codex review native approval prompts when allowed.                                                                                                                                                                                                                                                                                    |
 | `defaultWorkspaceDir`                         | current process directory                              | Workspace used by `/codex bind` when `--cwd` is omitted.                                                                                                                                                                                                                                                                                                         |
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, and `null` clears the override. Legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                  |
+| `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects that profile on thread start or resume instead of sending `sandbox`.                                                                                                                                     |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with Codex app-server 0.132.0 or newer so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                          |
+
+`appServer.networkProxy` is explicit because it changes the Codex sandbox
+contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` in
+the Codex thread config so the generated permission profile can start Codex
+managed networking. The default generated profile is `openclaw-network`; use
+`profileName` to choose another local name.
+
+```js
+export default {
+  plugins: {
+    entries: {
+      codex: {
+        config: {
+          appServer: {
+            sandbox: "workspace-write",
+            networkProxy: {
+              enabled: true,
+              domains: {
+                "api.openai.com": "allow",
+                "blocked.example.com": "deny",
+              },
+              allowUpstreamProxy: true,
+              proxyUrl: "http://127.0.0.1:3128",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+If the normal app-server runtime would be `danger-full-access`, enabling
+`networkProxy` uses workspace-style filesystem access for the generated
+permission profile. Codex managed network enforcement is sandboxed networking,
+so a full-access profile would not protect outbound traffic.
 
 The plugin blocks older or unversioned app-server handshakes. Codex app-server
 must report stable version `0.125.0` or newer.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -109,8 +109,9 @@ Supported `appServer` fields:
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
 contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` and
 `default_permissions` in the Codex thread config so the generated permission
-profile can start Codex managed networking. The default generated profile is
-`openclaw-network`; use `profileName` to choose another local name.
+profile can start Codex managed networking. By default, OpenClaw generates a
+collision-resistant `openclaw-network-<fingerprint>` profile name from the
+profile body; use `profileName` only when a stable local name is required.
 
 ```js
 export default {

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -103,14 +103,14 @@ Supported `appServer` fields:
 | `approvalsReviewer`                           | `"user"` or an allowed guardian reviewer               | Use `"auto_review"` to let Codex review native approval prompts when allowed.                                                                                                                                                                                                                                                                                    |
 | `defaultWorkspaceDir`                         | current process directory                              | Workspace used by `/codex bind` when `--cwd` is omitted.                                                                                                                                                                                                                                                                                                         |
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, and `null` clears the override. Legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                  |
-| `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects that profile on thread start or resume instead of sending `sandbox`.                                                                                                                                     |
+| `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects it with `default_permissions` instead of sending `sandbox`.                                                                                                                                              |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with Codex app-server 0.132.0 or newer so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                          |
 
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
-contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` in
-the Codex thread config so the generated permission profile can start Codex
-managed networking. The default generated profile is `openclaw-network`; use
-`profileName` to choose another local name.
+contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` and
+`default_permissions` in the Codex thread config so the generated permission
+profile can start Codex managed networking. The default generated profile is
+`openclaw-network`; use `profileName` to choose another local name.
 
 ```js
 export default {

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -561,7 +561,44 @@ Supported `appServer` fields:
 | `sandbox`                                     | `"danger-full-access"` or an allowed guardian sandbox  | Native Codex sandbox mode sent to thread start/resume. Guardian defaults prefer `"workspace-write"` when allowed, otherwise `"read-only"`. When an OpenClaw sandbox is active, `danger-full-access` turns use Codex `workspace-write` with network access derived from the OpenClaw sandbox egress setting.                                                      |
 | `approvalsReviewer`                           | `"user"` or an allowed guardian reviewer               | Use `"auto_review"` to let Codex review native approval prompts when allowed, otherwise `guardian_subagent` or `user`. `guardian_subagent` remains a legacy alias.                                                                                                                                                                                               |
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, `null` clears the override, and legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                  |
+| `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects that profile on thread start or resume instead of sending `sandbox`.                                                                                                                                     |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with Codex app-server 0.132.0 or newer so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                          |
+
+`appServer.networkProxy` is explicit because it changes the Codex sandbox
+contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` in
+the Codex thread config so the generated permission profile can start Codex
+managed networking. The default generated profile is `openclaw-network`; use
+`profileName` to choose another local name.
+
+```js
+export default {
+  plugins: {
+    entries: {
+      codex: {
+        config: {
+          appServer: {
+            sandbox: "workspace-write",
+            networkProxy: {
+              enabled: true,
+              domains: {
+                "api.openai.com": "allow",
+                "blocked.example.com": "deny",
+              },
+              allowUpstreamProxy: true,
+              proxyUrl: "http://127.0.0.1:3128",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+```
+
+If the normal app-server runtime would be `danger-full-access`, enabling
+`networkProxy` uses workspace-style filesystem access for the generated
+permission profile. Codex managed network enforcement is sandboxed networking,
+so a full-access profile would not protect outbound traffic.
 
 OpenClaw-owned dynamic tool calls are bounded independently from
 `appServer.requestTimeoutMs`: Codex `item/tool/call` requests use a 90 second

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -567,8 +567,9 @@ Supported `appServer` fields:
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
 contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` and
 `default_permissions` in the Codex thread config so the generated permission
-profile can start Codex managed networking. The default generated profile is
-`openclaw-network`; use `profileName` to choose another local name.
+profile can start Codex managed networking. By default, OpenClaw generates a
+collision-resistant `openclaw-network-<fingerprint>` profile name from the
+profile body; use `profileName` only when a stable local name is required.
 
 ```js
 export default {

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -561,14 +561,14 @@ Supported `appServer` fields:
 | `sandbox`                                     | `"danger-full-access"` or an allowed guardian sandbox  | Native Codex sandbox mode sent to thread start/resume. Guardian defaults prefer `"workspace-write"` when allowed, otherwise `"read-only"`. When an OpenClaw sandbox is active, `danger-full-access` turns use Codex `workspace-write` with network access derived from the OpenClaw sandbox egress setting.                                                      |
 | `approvalsReviewer`                           | `"user"` or an allowed guardian reviewer               | Use `"auto_review"` to let Codex review native approval prompts when allowed, otherwise `guardian_subagent` or `user`. `guardian_subagent` remains a legacy alias.                                                                                                                                                                                               |
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, `null` clears the override, and legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                  |
-| `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects that profile on thread start or resume instead of sending `sandbox`.                                                                                                                                     |
+| `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects it with `default_permissions` instead of sending `sandbox`.                                                                                                                                              |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with Codex app-server 0.132.0 or newer so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                          |
 
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
-contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` in
-the Codex thread config so the generated permission profile can start Codex
-managed networking. The default generated profile is `openclaw-network`; use
-`profileName` to choose another local name.
+contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` and
+`default_permissions` in the Codex thread config so the generated permission
+profile can start Codex managed networking. The default generated profile is
+`openclaw-network`; use `profileName` to choose another local name.
 
 ```js
 export default {

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -586,7 +586,7 @@ export default {
               },
               unixSockets: {
                 "/tmp/proxy.sock": "allow",
-                "/tmp/blocked.sock": "none",
+                "/tmp/blocked.sock": "deny",
               },
               allowUpstreamProxy: true,
               proxyUrl: "http://127.0.0.1:3128",
@@ -604,7 +604,7 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile. Codex managed network enforcement is sandboxed networking,
 so a full-access profile would not protect outbound traffic.
 Domain entries use `allow` or `deny`; Unix socket entries use Codex's
-`allow` or `none` values.
+`allow` or `deny` values.
 
 OpenClaw-owned dynamic tool calls are bounded independently from
 `appServer.requestTimeoutMs`: Codex `item/tool/call` requests use a 90 second

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -584,6 +584,10 @@ export default {
                 "api.openai.com": "allow",
                 "blocked.example.com": "deny",
               },
+              unixSockets: {
+                "/tmp/proxy.sock": "allow",
+                "/tmp/blocked.sock": "none",
+              },
               allowUpstreamProxy: true,
               proxyUrl: "http://127.0.0.1:3128",
             },
@@ -599,6 +603,8 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 `networkProxy` uses workspace-style filesystem access for the generated
 permission profile. Codex managed network enforcement is sandboxed networking,
 so a full-access profile would not protect outbound traffic.
+Domain entries use `allow` or `deny`; Unix socket entries use Codex's
+`allow` or `none` values.
 
 OpenClaw-owned dynamic tool calls are bounded independently from
 `appServer.requestTimeoutMs`: Codex `item/tool/call` requests use a 90 second

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -193,6 +193,47 @@
             "enum": ["user", "auto_review", "guardian_subagent"]
           },
           "serviceTier": { "type": ["string", "null"] },
+          "networkProxy": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false
+              },
+              "profileName": { "type": "string" },
+              "baseProfile": {
+                "type": "string",
+                "enum": ["read-only", "workspace"]
+              },
+              "mode": {
+                "type": "string",
+                "enum": ["limited", "full"]
+              },
+              "domains": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": ["allow", "deny"]
+                }
+              },
+              "unixSockets": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": ["allow", "deny"]
+                }
+              },
+              "proxyUrl": { "type": "string" },
+              "socksUrl": { "type": "string" },
+              "enableSocks5": { "type": "boolean" },
+              "enableSocks5Udp": { "type": "boolean" },
+              "allowUpstreamProxy": { "type": "boolean" },
+              "allowLocalBinding": { "type": "boolean" },
+              "dangerouslyAllowNonLoopbackProxy": { "type": "boolean" },
+              "dangerouslyAllowAllUnixSockets": { "type": "boolean" }
+            }
+          },
           "defaultWorkspaceDir": {
             "type": "string"
           },
@@ -383,6 +424,81 @@
     "appServer.serviceTier": {
       "label": "Service Tier",
       "help": "Optional Codex app-server service tier. Use priority, flex, or null. Legacy fast is accepted as priority.",
+      "advanced": true
+    },
+    "appServer.networkProxy": {
+      "label": "Network Proxy",
+      "help": "Enable Codex permissions-profile networking for app-server commands.",
+      "advanced": true
+    },
+    "appServer.networkProxy.enabled": {
+      "label": "Network Proxy Enabled",
+      "help": "When enabled, OpenClaw defines a Codex permissions profile and selects it on thread start or resume instead of sandbox fields.",
+      "advanced": true
+    },
+    "appServer.networkProxy.profileName": {
+      "label": "Network Proxy Profile",
+      "help": "Codex permissions profile name generated for app-server network access.",
+      "advanced": true
+    },
+    "appServer.networkProxy.baseProfile": {
+      "label": "Network Proxy Base",
+      "help": "Filesystem access used by the generated profile. Defaults to read-only for read-only sandboxes and workspace otherwise.",
+      "advanced": true
+    },
+    "appServer.networkProxy.domains": {
+      "label": "Network Domains",
+      "help": "Domain allow and deny rules for Codex sandboxed networking.",
+      "advanced": true
+    },
+    "appServer.networkProxy.unixSockets": {
+      "label": "Unix Sockets",
+      "help": "Unix socket allow and deny rules for Codex sandboxed networking.",
+      "advanced": true
+    },
+    "appServer.networkProxy.proxyUrl": {
+      "label": "HTTP Proxy URL",
+      "help": "HTTP listener URL used by Codex sandboxed networking.",
+      "advanced": true
+    },
+    "appServer.networkProxy.socksUrl": {
+      "label": "SOCKS Proxy URL",
+      "help": "SOCKS listener URL used by Codex sandboxed networking.",
+      "advanced": true
+    },
+    "appServer.networkProxy.enableSocks5": {
+      "label": "Enable SOCKS5",
+      "help": "Expose SOCKS5 support for the generated Codex permissions profile.",
+      "advanced": true
+    },
+    "appServer.networkProxy.enableSocks5Udp": {
+      "label": "Enable SOCKS5 UDP",
+      "help": "Allow UDP over the SOCKS5 listener when SOCKS5 is enabled.",
+      "advanced": true
+    },
+    "appServer.networkProxy.allowUpstreamProxy": {
+      "label": "Allow Upstream Proxy",
+      "help": "Allow Codex sandboxed networking to chain through inherited HTTP(S)_PROXY or ALL_PROXY settings.",
+      "advanced": true
+    },
+    "appServer.networkProxy.allowLocalBinding": {
+      "label": "Allow Local Binding",
+      "help": "Permit broader local and private-network access through Codex sandboxed networking.",
+      "advanced": true
+    },
+    "appServer.networkProxy.mode": {
+      "label": "Network Mode",
+      "help": "Codex sandboxed networking mode for subprocess traffic.",
+      "advanced": true
+    },
+    "appServer.networkProxy.dangerouslyAllowNonLoopbackProxy": {
+      "label": "Allow Non-Loopback Proxy",
+      "help": "Permit non-loopback bind addresses for Codex sandboxed networking listeners.",
+      "advanced": true
+    },
+    "appServer.networkProxy.dangerouslyAllowAllUnixSockets": {
+      "label": "Allow All Unix Sockets",
+      "help": "Bypass Codex's Unix socket allowlist for tightly controlled environments.",
       "advanced": true
     },
     "appServer.defaultWorkspaceDir": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -438,7 +438,7 @@
     },
     "appServer.networkProxy.profileName": {
       "label": "Network Proxy Profile",
-      "help": "Codex permissions profile name generated for app-server network access.",
+      "help": "Optional stable Codex permissions profile name. Leave unset to use a generated openclaw-network fingerprint name.",
       "advanced": true
     },
     "appServer.networkProxy.baseProfile": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -433,7 +433,7 @@
     },
     "appServer.networkProxy.enabled": {
       "label": "Network Proxy Enabled",
-      "help": "When enabled, OpenClaw defines a Codex permissions profile and selects it on thread start or resume instead of sandbox fields.",
+      "help": "When enabled, OpenClaw defines a Codex permissions profile and selects it with default_permissions instead of sandbox fields.",
       "advanced": true
     },
     "appServer.networkProxy.profileName": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -221,7 +221,7 @@
                 "type": "object",
                 "additionalProperties": {
                   "type": "string",
-                  "enum": ["allow", "deny"]
+                  "enum": ["allow", "none"]
                 }
               },
               "proxyUrl": { "type": "string" },
@@ -453,7 +453,7 @@
     },
     "appServer.networkProxy.unixSockets": {
       "label": "Unix Sockets",
-      "help": "Unix socket allow and deny rules for Codex sandboxed networking.",
+      "help": "Unix socket allow and none rules for Codex sandboxed networking.",
       "advanced": true
     },
     "appServer.networkProxy.proxyUrl": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -221,7 +221,7 @@
                 "type": "object",
                 "additionalProperties": {
                   "type": "string",
-                  "enum": ["allow", "none"]
+                  "enum": ["allow", "deny"]
                 }
               },
               "proxyUrl": { "type": "string" },
@@ -453,7 +453,7 @@
     },
     "appServer.networkProxy.unixSockets": {
       "label": "Unix Sockets",
-      "help": "Unix socket allow and none rules for Codex sandboxed networking.",
+      "help": "Unix socket allow and deny rules for Codex sandboxed networking.",
       "advanced": true
     },
     "appServer.networkProxy.proxyUrl": {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -125,6 +125,89 @@ describe("Codex app-server config", () => {
     });
   });
 
+  it("builds Codex permissions-profile config for app-server network proxy", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          sandbox: "workspace-write",
+          networkProxy: {
+            enabled: true,
+            profileName: "mock-proxy",
+            mode: "limited",
+            domains: {
+              " api.openai.com ": "allow",
+              "blocked.example.com": "deny",
+            },
+            unixSockets: {
+              " /tmp/mock-proxy.sock ": "allow",
+            },
+            proxyUrl: "http://127.0.0.1:3128",
+            socksUrl: "socks5h://127.0.0.1:8081",
+            enableSocks5: true,
+            enableSocks5Udp: false,
+            allowUpstreamProxy: true,
+            allowLocalBinding: false,
+          },
+        },
+      },
+    });
+
+    expect(runtime.networkProxy).toEqual({
+      profileName: "mock-proxy",
+      configPatch: {
+        "features.network_proxy.enabled": true,
+        permissions: {
+          "mock-proxy": {
+            filesystem: {
+              ":minimal": "read",
+              ":workspace_roots": {
+                ".": "write",
+              },
+            },
+            network: {
+              enabled: true,
+              mode: "limited",
+              domains: {
+                "api.openai.com": "allow",
+                "blocked.example.com": "deny",
+              },
+              unix_sockets: {
+                "/tmp/mock-proxy.sock": "allow",
+              },
+              proxy_url: "http://127.0.0.1:3128",
+              socks_url: "socks5h://127.0.0.1:8081",
+              enable_socks5: true,
+              enable_socks5_udp: false,
+              allow_upstream_proxy: true,
+              allow_local_binding: false,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("uses read-only filesystem rules for read-only network proxy profiles", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          sandbox: "read-only",
+          networkProxy: {
+            enabled: true,
+            domains: { "example.com": "allow" },
+          },
+        },
+      },
+    });
+    const permissions = runtime.networkProxy?.configPatch.permissions as Record<
+      string,
+      { filesystem: { ":workspace_roots": { ".": string } } }
+    >;
+
+    expect(runtime.networkProxy?.profileName).toBe("openclaw-network");
+    expect(permissions["openclaw-network"]?.filesystem[":workspace_roots"]["."]).toBe("read");
+  });
+
   it("clamps oversized app-server timer config", () => {
     const runtime = resolveRuntimeForTest({
       pluginConfig: {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -226,13 +226,15 @@ describe("Codex app-server config", () => {
         },
       },
     });
+    const profileName = runtime.networkProxy?.profileName;
     const permissions = runtime.networkProxy?.configPatch.permissions as Record<
       string,
       { filesystem: { ":workspace_roots": { ".": string } } }
     >;
 
-    expect(runtime.networkProxy?.profileName).toBe("openclaw-network");
-    expect(permissions["openclaw-network"]?.filesystem[":workspace_roots"]["."]).toBe("read");
+    expect(profileName).toMatch(/^openclaw-network-[a-f0-9]{16}$/u);
+    expect(runtime.networkProxy?.configPatch.default_permissions).toBe(profileName);
+    expect(permissions[profileName ?? ""]?.filesystem[":workspace_roots"]["."]).toBe("read");
   });
 
   it("clamps oversized app-server timer config", () => {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -156,6 +156,7 @@ describe("Codex app-server config", () => {
       profileName: "mock-proxy",
       configPatch: {
         "features.network_proxy.enabled": true,
+        default_permissions: "mock-proxy",
         permissions: {
           "mock-proxy": {
             filesystem: {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -156,7 +156,7 @@ describe("Codex app-server config", () => {
             },
             unixSockets: {
               " /tmp/mock-proxy.sock ": "allow",
-              "/tmp/blocked.sock": "none",
+              "/tmp/blocked.sock": "deny",
             },
             proxyUrl: "http://127.0.0.1:3128",
             socksUrl: "socks5h://127.0.0.1:8081",
@@ -183,7 +183,7 @@ describe("Codex app-server config", () => {
           "mock-proxy": {
             filesystem: {
               ":minimal": "read",
-              ":project_roots": {
+              ":workspace_roots": {
                 ".": "write",
               },
             },
@@ -196,7 +196,7 @@ describe("Codex app-server config", () => {
               },
               unix_sockets: {
                 "/tmp/mock-proxy.sock": "allow",
-                "/tmp/blocked.sock": "none",
+                "/tmp/blocked.sock": "deny",
               },
               proxy_url: "http://127.0.0.1:3128",
               socks_url: "socks5h://127.0.0.1:8081",
@@ -228,11 +228,11 @@ describe("Codex app-server config", () => {
     });
     const permissions = runtime.networkProxy?.configPatch.permissions as Record<
       string,
-      { filesystem: { ":project_roots": { ".": string } } }
+      { filesystem: { ":workspace_roots": { ".": string } } }
     >;
 
     expect(runtime.networkProxy?.profileName).toBe("openclaw-network");
-    expect(permissions["openclaw-network"]?.filesystem[":project_roots"]["."]).toBe("read");
+    expect(permissions["openclaw-network"]?.filesystem[":workspace_roots"]["."]).toBe("read");
   });
 
   it("clamps oversized app-server timer config", () => {

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -10,6 +10,7 @@ import {
   CODEX_PLUGINS_CONFIG_KEYS,
   canUseCodexModelBackedApprovalsReviewerForModel,
   codexAppServerStartOptionsKey,
+  fingerprintCodexAppServerNetworkProxyConfigPatch,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -83,6 +84,21 @@ describe("Codex app-server config", () => {
         sandbox: "danger-full-access",
       }),
     ).toBe(false);
+    expect(
+      shouldAutoApproveCodexAppServerApprovals({
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        networkProxy: {
+          profileName: "openclaw-network",
+          configFingerprint: "network-proxy-v1",
+          configPatch: {
+            "features.network_proxy.enabled": true,
+            default_permissions: "openclaw-network",
+            permissions: {},
+          },
+        },
+      }),
+    ).toBe(false);
   });
 
   it("parses typed plugin config before falling back to environment knobs", () => {
@@ -140,6 +156,7 @@ describe("Codex app-server config", () => {
             },
             unixSockets: {
               " /tmp/mock-proxy.sock ": "allow",
+              "/tmp/blocked.sock": "none",
             },
             proxyUrl: "http://127.0.0.1:3128",
             socksUrl: "socks5h://127.0.0.1:8081",
@@ -152,8 +169,13 @@ describe("Codex app-server config", () => {
       },
     });
 
-    expect(runtime.networkProxy).toEqual({
+    const networkProxy = runtime.networkProxy;
+    if (!networkProxy) {
+      throw new Error("Expected network proxy runtime config");
+    }
+    expect(networkProxy).toEqual({
       profileName: "mock-proxy",
+      configFingerprint: expect.any(String),
       configPatch: {
         "features.network_proxy.enabled": true,
         default_permissions: "mock-proxy",
@@ -161,7 +183,7 @@ describe("Codex app-server config", () => {
           "mock-proxy": {
             filesystem: {
               ":minimal": "read",
-              ":workspace_roots": {
+              ":project_roots": {
                 ".": "write",
               },
             },
@@ -174,6 +196,7 @@ describe("Codex app-server config", () => {
               },
               unix_sockets: {
                 "/tmp/mock-proxy.sock": "allow",
+                "/tmp/blocked.sock": "none",
               },
               proxy_url: "http://127.0.0.1:3128",
               socks_url: "socks5h://127.0.0.1:8081",
@@ -186,6 +209,9 @@ describe("Codex app-server config", () => {
         },
       },
     });
+    expect(networkProxy.configFingerprint).toBe(
+      fingerprintCodexAppServerNetworkProxyConfigPatch(networkProxy.configPatch),
+    );
   });
 
   it("uses read-only filesystem rules for read-only network proxy profiles", () => {
@@ -202,11 +228,11 @@ describe("Codex app-server config", () => {
     });
     const permissions = runtime.networkProxy?.configPatch.permissions as Record<
       string,
-      { filesystem: { ":workspace_roots": { ".": string } } }
+      { filesystem: { ":project_roots": { ".": string } } }
     >;
 
     expect(runtime.networkProxy?.profileName).toBe("openclaw-network");
-    expect(permissions["openclaw-network"]?.filesystem[":workspace_roots"]["."]).toBe("read");
+    expect(permissions["openclaw-network"]?.filesystem[":project_roots"]["."]).toBe("read");
   });
 
   it("clamps oversized app-server timer config", () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -16,7 +16,7 @@ import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { detectWindowsSpawnCommandInlineArgs } from "openclaw/plugin-sdk/windows-spawn";
 import { z } from "zod";
-import type { CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
+import type { CodexSandboxPolicy, CodexServiceTier, JsonObject, JsonValue } from "./protocol.js";
 
 const START_OPTIONS_KEY_SECRET_SYMBOL = Symbol.for("openclaw.codexAppServerStartOptionsKeySecret");
 const START_OPTIONS_KEY_SECRET = getStartOptionsKeySecret();
@@ -111,6 +111,32 @@ export type CodexAppServerExperimentalConfig = {
   sandboxExecServer?: boolean;
 };
 
+export type CodexAppServerNetworkProxyPermission = "allow" | "deny";
+export type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
+export type CodexAppServerNetworkProxyMode = "limited" | "full";
+
+export type CodexAppServerNetworkProxyConfig = {
+  enabled?: boolean;
+  profileName?: string;
+  baseProfile?: CodexAppServerNetworkProxyBaseProfile;
+  mode?: CodexAppServerNetworkProxyMode;
+  domains?: Record<string, CodexAppServerNetworkProxyPermission>;
+  unixSockets?: Record<string, CodexAppServerNetworkProxyPermission>;
+  proxyUrl?: string;
+  socksUrl?: string;
+  enableSocks5?: boolean;
+  enableSocks5Udp?: boolean;
+  allowUpstreamProxy?: boolean;
+  allowLocalBinding?: boolean;
+  dangerouslyAllowNonLoopbackProxy?: boolean;
+  dangerouslyAllowAllUnixSockets?: boolean;
+};
+
+export type ResolvedCodexAppServerNetworkProxyConfig = {
+  profileName: string;
+  configPatch: JsonObject;
+};
+
 export type ResolvedCodexPluginPolicy = {
   configKey: string;
   marketplaceName: typeof CODEX_PLUGINS_MARKETPLACE_NAME;
@@ -151,6 +177,7 @@ export type CodexAppServerRuntimeOptions = {
   sandbox: CodexAppServerSandboxMode;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
+  networkProxy?: ResolvedCodexAppServerNetworkProxyConfig;
 };
 
 export type CodexModelBackedReviewerContext = {
@@ -188,6 +215,7 @@ export type CodexPluginConfig = {
     sandbox?: CodexAppServerSandboxMode;
     approvalsReviewer?: CodexAppServerApprovalsReviewer;
     serviceTier?: CodexServiceTier | null;
+    networkProxy?: CodexAppServerNetworkProxyConfig;
     defaultWorkspaceDir?: string;
     experimental?: CodexAppServerExperimentalConfig;
   };
@@ -216,6 +244,7 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "sandbox",
   "approvalsReviewer",
   "serviceTier",
+  "networkProxy",
   "defaultWorkspaceDir",
   "experimental",
 ] as const;
@@ -249,6 +278,7 @@ export const CODEX_PLUGIN_ENTRY_CONFIG_KEYS = [
 const DEFAULT_CODEX_COMPUTER_USE_PLUGIN_NAME = "computer-use";
 const DEFAULT_CODEX_COMPUTER_USE_MCP_SERVER_NAME = "computer-use";
 const DEFAULT_CODEX_COMPUTER_USE_MARKETPLACE_DISCOVERY_TIMEOUT_MS = 60_000;
+const DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE = "openclaw-network";
 
 const codexAppServerTransportSchema = z.enum(["stdio", "websocket"]);
 const codexAppServerPolicyModeSchema = z.enum(["yolo", "guardian"]);
@@ -271,6 +301,25 @@ const codexAppServerServiceTierSchema = z
 const codexAppServerExperimentalSchema = z
   .object({
     sandboxExecServer: z.boolean().optional(),
+  })
+  .strict();
+const codexAppServerNetworkProxyPermissionSchema = z.enum(["allow", "deny"]);
+const codexAppServerNetworkProxySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    profileName: z.string().trim().min(1).optional(),
+    baseProfile: z.enum(["read-only", "workspace"]).optional(),
+    mode: z.enum(["limited", "full"]).optional(),
+    domains: z.record(z.string(), codexAppServerNetworkProxyPermissionSchema).optional(),
+    unixSockets: z.record(z.string(), codexAppServerNetworkProxyPermissionSchema).optional(),
+    proxyUrl: z.string().trim().min(1).optional(),
+    socksUrl: z.string().trim().min(1).optional(),
+    enableSocks5: z.boolean().optional(),
+    enableSocks5Udp: z.boolean().optional(),
+    allowUpstreamProxy: z.boolean().optional(),
+    allowLocalBinding: z.boolean().optional(),
+    dangerouslyAllowNonLoopbackProxy: z.boolean().optional(),
+    dangerouslyAllowAllUnixSockets: z.boolean().optional(),
   })
   .strict();
 
@@ -334,6 +383,7 @@ const codexPluginConfigSchema = z
         sandbox: codexAppServerSandboxSchema.optional(),
         approvalsReviewer: codexAppServerApprovalsReviewerSchema.optional(),
         serviceTier: codexAppServerServiceTierSchema,
+        networkProxy: codexAppServerNetworkProxySchema.optional(),
         defaultWorkspaceDir: z.string().optional(),
         experimental: codexAppServerExperimentalSchema.optional(),
       })
@@ -549,6 +599,11 @@ export function resolveCodexAppServerRuntimeOptions(
     ? normalizedPolicyMode
     : (explicitPolicyMode ?? normalizedPolicyMode ?? defaultPolicy?.mode ?? "yolo");
   const serviceTier = normalizeCodexServiceTier(config.serviceTier);
+  const resolvedSandbox =
+    forcedPolicy?.sandbox ??
+    configuredSandbox ??
+    defaultPolicy?.sandbox ??
+    (policyMode === "guardian" ? "workspace-write" : "danger-full-access");
   if (transport === "websocket" && !url) {
     throw new Error(
       "plugins.entries.codex.config.appServer.url is required when appServer.transport is websocket",
@@ -597,17 +652,14 @@ export function resolveCodexAppServerRuntimeOptions(
       : {}),
     approvalPolicy: forcedPolicy?.approvalPolicy ?? approvalPolicy,
     approvalPolicySource,
-    sandbox:
-      forcedPolicy?.sandbox ??
-      configuredSandbox ??
-      defaultPolicy?.sandbox ??
-      (policyMode === "guardian" ? "workspace-write" : "danger-full-access"),
+    sandbox: resolvedSandbox,
     approvalsReviewer:
       forcedPolicy?.approvalsReviewer ??
       explicitApprovalsReviewer ??
       defaultPolicy?.approvalsReviewer ??
       (policyMode === "guardian" ? "auto_review" : "user"),
     ...(serviceTier ? { serviceTier } : {}),
+    ...resolveCodexAppServerNetworkProxy(config.networkProxy, resolvedSandbox),
   };
 }
 
@@ -819,6 +871,69 @@ export function codexSandboxPolicyForTurn(
     excludeTmpdirEnvVar: false,
     excludeSlashTmp: false,
   };
+}
+
+function resolveCodexAppServerNetworkProxy(
+  config: CodexAppServerNetworkProxyConfig | undefined,
+  sandbox: CodexAppServerSandboxMode,
+): { networkProxy?: ResolvedCodexAppServerNetworkProxyConfig } {
+  if (config?.enabled !== true) {
+    return {};
+  }
+  const profileName =
+    readNonEmptyString(config.profileName) ?? DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE;
+  const fileSystemMode =
+    config.baseProfile === "read-only" || (!config.baseProfile && sandbox === "read-only")
+      ? "read"
+      : "write";
+  const networkConfig = removeUndefinedJsonFields({
+    enabled: true,
+    mode: config.mode,
+    domains: normalizeNetworkProxyPermissionMap(config.domains),
+    unix_sockets: normalizeNetworkProxyPermissionMap(config.unixSockets),
+    proxy_url: readNonEmptyString(config.proxyUrl),
+    socks_url: readNonEmptyString(config.socksUrl),
+    enable_socks5: config.enableSocks5,
+    enable_socks5_udp: config.enableSocks5Udp,
+    allow_upstream_proxy: config.allowUpstreamProxy,
+    allow_local_binding: config.allowLocalBinding,
+    dangerously_allow_non_loopback_proxy: config.dangerouslyAllowNonLoopbackProxy,
+    dangerously_allow_all_unix_sockets: config.dangerouslyAllowAllUnixSockets,
+  });
+  return {
+    networkProxy: {
+      profileName,
+      configPatch: {
+        "features.network_proxy.enabled": true,
+        permissions: {
+          [profileName]: {
+            filesystem: {
+              ":minimal": "read",
+              ":workspace_roots": {
+                ".": fileSystemMode,
+              },
+            },
+            network: networkConfig,
+          },
+        },
+      },
+    },
+  };
+}
+
+function normalizeNetworkProxyPermissionMap(
+  value: Record<string, CodexAppServerNetworkProxyPermission> | undefined,
+): Record<string, CodexAppServerNetworkProxyPermission> | undefined {
+  const entries = Object.entries(value ?? {})
+    .map(([key, permission]) => [key.trim(), permission] as const)
+    .filter(([key]) => key.length > 0);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function removeUndefinedJsonFields(value: Record<string, JsonValue | undefined>): JsonObject {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, JsonValue] => entry[1] !== undefined),
+  );
 }
 
 export function withMcpElicitationsApprovalPolicy(

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -905,6 +905,7 @@ function resolveCodexAppServerNetworkProxy(
       profileName,
       configPatch: {
         "features.network_proxy.enabled": true,
+        default_permissions: profileName,
         permissions: {
           [profileName]: {
             filesystem: {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -284,7 +284,7 @@ export const CODEX_PLUGIN_ENTRY_CONFIG_KEYS = [
 const DEFAULT_CODEX_COMPUTER_USE_PLUGIN_NAME = "computer-use";
 const DEFAULT_CODEX_COMPUTER_USE_MCP_SERVER_NAME = "computer-use";
 const DEFAULT_CODEX_COMPUTER_USE_MARKETPLACE_DISCOVERY_TIMEOUT_MS = 60_000;
-const DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE = "openclaw-network";
+const DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE_PREFIX = "openclaw-network";
 
 const codexAppServerTransportSchema = z.enum(["stdio", "websocket"]);
 const codexAppServerPolicyModeSchema = z.enum(["yolo", "guardian"]);
@@ -887,8 +887,6 @@ function resolveCodexAppServerNetworkProxy(
   if (config?.enabled !== true) {
     return {};
   }
-  const profileName =
-    readNonEmptyString(config.profileName) ?? DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE;
   const fileSystemMode =
     config.baseProfile === "read-only" || (!config.baseProfile && sandbox === "read-only")
       ? "read"
@@ -907,19 +905,21 @@ function resolveCodexAppServerNetworkProxy(
     dangerously_allow_non_loopback_proxy: config.dangerouslyAllowNonLoopbackProxy,
     dangerously_allow_all_unix_sockets: config.dangerouslyAllowAllUnixSockets,
   });
+  const profile = {
+    filesystem: {
+      ":minimal": "read",
+      ":workspace_roots": {
+        ".": fileSystemMode,
+      },
+    },
+    network: networkConfig,
+  };
+  const profileName = resolveNetworkProxyPermissionProfileName(config, profile);
   const configPatch: JsonObject = {
     "features.network_proxy.enabled": true,
     default_permissions: profileName,
     permissions: {
-      [profileName]: {
-        filesystem: {
-          ":minimal": "read",
-          ":workspace_roots": {
-            ".": fileSystemMode,
-          },
-        },
-        network: networkConfig,
-      },
+      [profileName]: profile,
     },
   };
   return {
@@ -929,6 +929,21 @@ function resolveCodexAppServerNetworkProxy(
       configPatch,
     },
   };
+}
+
+function resolveNetworkProxyPermissionProfileName(
+  config: CodexAppServerNetworkProxyConfig,
+  profile: JsonObject,
+): string {
+  const explicitProfileName = readNonEmptyString(config.profileName);
+  if (explicitProfileName) {
+    return explicitProfileName;
+  }
+  const suffix = createHash("sha256")
+    .update(stableStringifyJson({ version: 1, profile }))
+    .digest("hex")
+    .slice(0, 16);
+  return `${DEFAULT_CODEX_APP_SERVER_NETWORK_PROXY_PROFILE_PREFIX}-${suffix}`;
 }
 
 export function fingerprintCodexAppServerNetworkProxyConfigPatch(configPatch: JsonObject): string {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -112,7 +112,7 @@ export type CodexAppServerExperimentalConfig = {
 };
 
 export type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
-export type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "none";
+export type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "deny";
 export type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
 export type CodexAppServerNetworkProxyMode = "limited" | "full";
 
@@ -310,7 +310,7 @@ const codexAppServerExperimentalSchema = z
   })
   .strict();
 const codexAppServerNetworkProxyDomainPermissionSchema = z.enum(["allow", "deny"]);
-const codexAppServerNetworkProxyUnixSocketPermissionSchema = z.enum(["allow", "none"]);
+const codexAppServerNetworkProxyUnixSocketPermissionSchema = z.enum(["allow", "deny"]);
 const codexAppServerNetworkProxySchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -914,7 +914,7 @@ function resolveCodexAppServerNetworkProxy(
       [profileName]: {
         filesystem: {
           ":minimal": "read",
-          ":project_roots": {
+          ":workspace_roots": {
             ".": fileSystemMode,
           },
         },

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,5 +1,5 @@
 // Codex helper module supports config behavior.
-import { createHmac, randomBytes } from "node:crypto";
+import { createHash, createHmac, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { hostname as readHostName } from "node:os";
 import path from "node:path";
@@ -111,7 +111,8 @@ export type CodexAppServerExperimentalConfig = {
   sandboxExecServer?: boolean;
 };
 
-export type CodexAppServerNetworkProxyPermission = "allow" | "deny";
+export type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
+export type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "none";
 export type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
 export type CodexAppServerNetworkProxyMode = "limited" | "full";
 
@@ -120,8 +121,8 @@ export type CodexAppServerNetworkProxyConfig = {
   profileName?: string;
   baseProfile?: CodexAppServerNetworkProxyBaseProfile;
   mode?: CodexAppServerNetworkProxyMode;
-  domains?: Record<string, CodexAppServerNetworkProxyPermission>;
-  unixSockets?: Record<string, CodexAppServerNetworkProxyPermission>;
+  domains?: Record<string, CodexAppServerNetworkProxyDomainPermission>;
+  unixSockets?: Record<string, CodexAppServerNetworkProxyUnixSocketPermission>;
   proxyUrl?: string;
   socksUrl?: string;
   enableSocks5?: boolean;
@@ -134,6 +135,7 @@ export type CodexAppServerNetworkProxyConfig = {
 
 export type ResolvedCodexAppServerNetworkProxyConfig = {
   profileName: string;
+  configFingerprint: string;
   configPatch: JsonObject;
 };
 
@@ -222,9 +224,13 @@ export type CodexPluginConfig = {
 };
 
 export function shouldAutoApproveCodexAppServerApprovals(
-  appServer: Pick<CodexAppServerRuntimeOptions, "approvalPolicy" | "sandbox">,
+  appServer: Pick<CodexAppServerRuntimeOptions, "approvalPolicy" | "networkProxy" | "sandbox">,
 ): boolean {
-  return appServer.approvalPolicy === "never" && appServer.sandbox === "danger-full-access";
+  return (
+    appServer.networkProxy === undefined &&
+    appServer.approvalPolicy === "never" &&
+    appServer.sandbox === "danger-full-access"
+  );
 }
 
 export const CODEX_APP_SERVER_CONFIG_KEYS = [
@@ -303,15 +309,16 @@ const codexAppServerExperimentalSchema = z
     sandboxExecServer: z.boolean().optional(),
   })
   .strict();
-const codexAppServerNetworkProxyPermissionSchema = z.enum(["allow", "deny"]);
+const codexAppServerNetworkProxyDomainPermissionSchema = z.enum(["allow", "deny"]);
+const codexAppServerNetworkProxyUnixSocketPermissionSchema = z.enum(["allow", "none"]);
 const codexAppServerNetworkProxySchema = z
   .object({
     enabled: z.boolean().optional(),
     profileName: z.string().trim().min(1).optional(),
     baseProfile: z.enum(["read-only", "workspace"]).optional(),
     mode: z.enum(["limited", "full"]).optional(),
-    domains: z.record(z.string(), codexAppServerNetworkProxyPermissionSchema).optional(),
-    unixSockets: z.record(z.string(), codexAppServerNetworkProxyPermissionSchema).optional(),
+    domains: z.record(z.string(), codexAppServerNetworkProxyDomainPermissionSchema).optional(),
+    unixSockets: z.record(z.string(), codexAppServerNetworkProxyUnixSocketPermissionSchema).optional(),
     proxyUrl: z.string().trim().min(1).optional(),
     socksUrl: z.string().trim().min(1).optional(),
     enableSocks5: z.boolean().optional(),
@@ -900,31 +907,37 @@ function resolveCodexAppServerNetworkProxy(
     dangerously_allow_non_loopback_proxy: config.dangerouslyAllowNonLoopbackProxy,
     dangerously_allow_all_unix_sockets: config.dangerouslyAllowAllUnixSockets,
   });
+  const configPatch: JsonObject = {
+    "features.network_proxy.enabled": true,
+    default_permissions: profileName,
+    permissions: {
+      [profileName]: {
+        filesystem: {
+          ":minimal": "read",
+          ":project_roots": {
+            ".": fileSystemMode,
+          },
+        },
+        network: networkConfig,
+      },
+    },
+  };
   return {
     networkProxy: {
       profileName,
-      configPatch: {
-        "features.network_proxy.enabled": true,
-        default_permissions: profileName,
-        permissions: {
-          [profileName]: {
-            filesystem: {
-              ":minimal": "read",
-              ":workspace_roots": {
-                ".": fileSystemMode,
-              },
-            },
-            network: networkConfig,
-          },
-        },
-      },
+      configFingerprint: fingerprintCodexAppServerNetworkProxyConfigPatch(configPatch),
+      configPatch,
     },
   };
 }
 
-function normalizeNetworkProxyPermissionMap(
-  value: Record<string, CodexAppServerNetworkProxyPermission> | undefined,
-): Record<string, CodexAppServerNetworkProxyPermission> | undefined {
+export function fingerprintCodexAppServerNetworkProxyConfigPatch(configPatch: JsonObject): string {
+  return createHash("sha256").update(stableStringifyJson(configPatch)).digest("hex");
+}
+
+function normalizeNetworkProxyPermissionMap<TPermission extends string>(
+  value: Record<string, TPermission> | undefined,
+): Record<string, TPermission> | undefined {
   const entries = Object.entries(value ?? {})
     .map(([key, permission]) => [key.trim(), permission] as const)
     .filter(([key]) => key.length > 0);
@@ -935,6 +948,19 @@ function removeUndefinedJsonFields(value: Record<string, JsonValue | undefined>)
   return Object.fromEntries(
     Object.entries(value).filter((entry): entry is [string, JsonValue] => entry[1] !== undefined),
   );
+}
+
+function stableStringifyJson(value: JsonValue): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringifyJson(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableStringifyJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }
 
 export function withMcpElicitationsApprovalPolicy(

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -107,12 +107,6 @@ export type CodexTurnEnvironmentParams = JsonObject & {
   cwd: string;
 };
 
-export type CodexPermissionProfileSelection = JsonObject & {
-  type: "profile";
-  id: string;
-  modifications?: JsonValue[] | null;
-};
-
 export type CodexThreadStartParams = JsonObject & {
   input?: CodexUserInput[];
   cwd?: string;
@@ -122,7 +116,6 @@ export type CodexThreadStartParams = JsonObject & {
   approvalPolicy?: string | JsonObject;
   approvalsReviewer?: string | null;
   sandbox?: string;
-  permissions?: CodexPermissionProfileSelection;
   serviceTier?: CodexServiceTier | null;
   dynamicTools?: CodexThreadStartDynamicToolSpec[] | null;
   developerInstructions?: string;
@@ -140,7 +133,6 @@ export type CodexThreadResumeParams = JsonObject & {
   approvalPolicy?: string | JsonObject;
   approvalsReviewer?: string | null;
   sandbox?: string;
-  permissions?: CodexPermissionProfileSelection;
   serviceTier?: CodexServiceTier | null;
   config?: JsonObject;
   developerInstructions?: string;
@@ -192,7 +184,6 @@ export type CodexTurnStartParams = JsonObject & {
   approvalPolicy?: string | JsonObject;
   approvalsReviewer?: string | null;
   sandboxPolicy?: CodexSandboxPolicy;
-  permissions?: CodexPermissionProfileSelection;
   serviceTier?: CodexServiceTier | null;
   effort?: string | null;
   personality?: string | null;

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -107,6 +107,12 @@ export type CodexTurnEnvironmentParams = JsonObject & {
   cwd: string;
 };
 
+export type CodexPermissionProfileSelection = JsonObject & {
+  type: "profile";
+  id: string;
+  modifications?: JsonValue[] | null;
+};
+
 export type CodexThreadStartParams = JsonObject & {
   input?: CodexUserInput[];
   cwd?: string;
@@ -116,6 +122,7 @@ export type CodexThreadStartParams = JsonObject & {
   approvalPolicy?: string | JsonObject;
   approvalsReviewer?: string | null;
   sandbox?: string;
+  permissions?: CodexPermissionProfileSelection;
   serviceTier?: CodexServiceTier | null;
   dynamicTools?: CodexThreadStartDynamicToolSpec[] | null;
   developerInstructions?: string;
@@ -133,6 +140,7 @@ export type CodexThreadResumeParams = JsonObject & {
   approvalPolicy?: string | JsonObject;
   approvalsReviewer?: string | null;
   sandbox?: string;
+  permissions?: CodexPermissionProfileSelection;
   serviceTier?: CodexServiceTier | null;
   config?: JsonObject;
   developerInstructions?: string;
@@ -184,6 +192,7 @@ export type CodexTurnStartParams = JsonObject & {
   approvalPolicy?: string | JsonObject;
   approvalsReviewer?: string | null;
   sandboxPolicy?: CodexSandboxPolicy;
+  permissions?: CodexPermissionProfileSelection;
   serviceTier?: CodexServiceTier | null;
   effort?: string | null;
   personality?: string | null;

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -60,6 +60,8 @@ describe("codex app-server session binding", () => {
       cwd: tempDir,
       model: "gpt-5.4-codex",
       modelProvider: "openai",
+      networkProxyProfileName: "openclaw-network",
+      networkProxyConfigFingerprint: "network-proxy-v1",
       dynamicToolsFingerprint: "tools-v1",
       webSearchThreadConfigFingerprint: "web-search-v1",
       userMcpServersFingerprint: "user-mcp-v1",
@@ -74,6 +76,8 @@ describe("codex app-server session binding", () => {
     expect(binding?.cwd).toBe(tempDir);
     expect(binding?.model).toBe("gpt-5.4-codex");
     expect(binding?.modelProvider).toBe("openai");
+    expect(binding?.networkProxyProfileName).toBe("openclaw-network");
+    expect(binding?.networkProxyConfigFingerprint).toBe("network-proxy-v1");
     expect(binding?.dynamicToolsFingerprint).toBe("tools-v1");
     expect(binding?.webSearchThreadConfigFingerprint).toBe("web-search-v1");
     expect(binding?.userMcpServersFingerprint).toBe("user-mcp-v1");

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -66,6 +66,7 @@ export type CodexAppServerThreadBinding = {
   approvalPolicy?: CodexAppServerApprovalPolicy;
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
+  networkProxyProfileName?: string;
   dynamicToolsFingerprint?: string;
   dynamicToolsContainDeferred?: boolean;
   webSearchThreadConfigFingerprint?: string;
@@ -181,6 +182,10 @@ export async function readCodexAppServerBinding(
       approvalPolicy: readApprovalPolicy(parsed.approvalPolicy),
       sandbox: readSandboxMode(parsed.sandbox),
       serviceTier: readServiceTier(parsed.serviceTier),
+      networkProxyProfileName:
+        typeof parsed.networkProxyProfileName === "string"
+          ? parsed.networkProxyProfileName
+          : undefined,
       dynamicToolsFingerprint:
         typeof parsed.dynamicToolsFingerprint === "string"
           ? parsed.dynamicToolsFingerprint
@@ -256,6 +261,7 @@ export async function writeCodexAppServerBinding(
       approvalPolicy: binding.approvalPolicy,
       sandbox: binding.sandbox,
       serviceTier: binding.serviceTier,
+      networkProxyProfileName: binding.networkProxyProfileName,
       dynamicToolsFingerprint: binding.dynamicToolsFingerprint,
       dynamicToolsContainDeferred: binding.dynamicToolsContainDeferred,
       webSearchThreadConfigFingerprint: binding.webSearchThreadConfigFingerprint,

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -67,6 +67,7 @@ export type CodexAppServerThreadBinding = {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   networkProxyProfileName?: string;
+  networkProxyConfigFingerprint?: string;
   dynamicToolsFingerprint?: string;
   dynamicToolsContainDeferred?: boolean;
   webSearchThreadConfigFingerprint?: string;
@@ -186,6 +187,10 @@ export async function readCodexAppServerBinding(
         typeof parsed.networkProxyProfileName === "string"
           ? parsed.networkProxyProfileName
           : undefined,
+      networkProxyConfigFingerprint:
+        typeof parsed.networkProxyConfigFingerprint === "string"
+          ? parsed.networkProxyConfigFingerprint
+          : undefined,
       dynamicToolsFingerprint:
         typeof parsed.dynamicToolsFingerprint === "string"
           ? parsed.dynamicToolsFingerprint
@@ -262,6 +267,7 @@ export async function writeCodexAppServerBinding(
       sandbox: binding.sandbox,
       serviceTier: binding.serviceTier,
       networkProxyProfileName: binding.networkProxyProfileName,
+      networkProxyConfigFingerprint: binding.networkProxyConfigFingerprint,
       dynamicToolsFingerprint: binding.dynamicToolsFingerprint,
       dynamicToolsContainDeferred: binding.dynamicToolsContainDeferred,
       webSearchThreadConfigFingerprint: binding.webSearchThreadConfigFingerprint,

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1161,6 +1161,7 @@ describe("runCodexAppServerSideQuestion", () => {
           appServer: {
             networkProxy: {
               enabled: true,
+              profileName: "side-proxy",
               domains: { "api.openai.com": "allow" },
               unixSockets: { "/tmp/proxy.sock": "allow" },
               allowUpstreamProxy: true,
@@ -1176,9 +1177,9 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(forkParams).not.toHaveProperty("sandbox");
     expect(config).toMatchObject({
       "features.network_proxy.enabled": true,
-      default_permissions: "openclaw-network",
+      default_permissions: "side-proxy",
       permissions: {
-        "openclaw-network": {
+        "side-proxy": {
           filesystem: {
             ":minimal": "read",
             ":workspace_roots": { ".": "write" },

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1151,6 +1151,52 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(config?.["features.code_mode_only"]).toBe(true);
   });
 
+  it("applies network-proxy config to side-thread forks", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(sideParams(), {
+        pluginConfig: {
+          appServer: {
+            networkProxy: {
+              enabled: true,
+              domains: { "api.openai.com": "allow" },
+              unixSockets: { "/tmp/proxy.sock": "allow" },
+              allowUpstreamProxy: true,
+              proxyUrl: "http://127.0.0.1:3128",
+            },
+          },
+        },
+      }),
+    ).resolves.toEqual({ text: "Side answer." });
+
+    const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(forkParams).not.toHaveProperty("sandbox");
+    expect(config).toMatchObject({
+      "features.network_proxy.enabled": true,
+      default_permissions: "openclaw-network",
+      permissions: {
+        "openclaw-network": {
+          filesystem: {
+            ":minimal": "read",
+            ":project_roots": { ".": "write" },
+          },
+          network: {
+            enabled: true,
+            domains: { "api.openai.com": "allow" },
+            unix_sockets: { "/tmp/proxy.sock": "allow" },
+            allow_upstream_proxy: true,
+            proxy_url: "http://127.0.0.1:3128",
+          },
+        },
+      },
+    });
+    expect(config?.["features.code_mode"]).toBe(true);
+    expect(config?.["features.code_mode_only"]).toBe(false);
+  });
+
   it("keeps Codex code-mode-only while disabling Guardian for provider-qualified local models", async () => {
     const client = createFakeClient();
     getSharedCodexAppServerClientMock.mockResolvedValue(client);

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1181,7 +1181,7 @@ describe("runCodexAppServerSideQuestion", () => {
         "openclaw-network": {
           filesystem: {
             ":minimal": "read",
-            ":project_roots": { ".": "write" },
+            ":workspace_roots": { ".": "write" },
           },
           network: {
             enabled: true,

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -322,12 +322,16 @@ export async function runCodexAppServerSideQuestion(
           threadId: childThreadId,
           turnId,
           nativeHookRelay,
-          execPolicy,
-          execReviewerAgentId: sessionAgentId,
-          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
-          autoApprove: shouldAutoApproveCodexAppServerApprovals({ approvalPolicy, sandbox }),
-          signal: runAbortController.signal,
-        });
+	          execPolicy,
+	          execReviewerAgentId: sessionAgentId,
+	          internalExecAutoReview: modelScopedAppServer.approvalsReviewer === "user",
+	          autoApprove: shouldAutoApproveCodexAppServerApprovals({
+	            approvalPolicy,
+	            networkProxy: modelScopedAppServer.networkProxy,
+	            sandbox,
+	          }),
+	          signal: runAbortController.signal,
+	        });
       }
       if (request.method !== "item/tool/call") {
         return undefined;
@@ -415,8 +419,12 @@ export async function runCodexAppServerSideQuestion(
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
     });
-    const threadConfig =
-      mergeCodexThreadConfigs(nativeHookRelayConfig, runtimeThreadConfig) ?? runtimeThreadConfig;
+	    const threadConfig =
+	      mergeCodexThreadConfigs(
+	        nativeHookRelayConfig,
+	        runtimeThreadConfig,
+	        modelScopedAppServer.networkProxy?.configPatch,
+	      ) ?? runtimeThreadConfig;
     const forkResponse = assertCodexThreadForkResponse(
       await forkCodexSideThread(
         client,
@@ -428,7 +436,7 @@ export async function runCodexAppServerSideQuestion(
           cwd,
           approvalPolicy,
           approvalsReviewer: modelScopedAppServer.approvalsReviewer,
-          sandbox,
+	          ...(modelScopedAppServer.networkProxy ? {} : { sandbox }),
           ...(serviceTier ? { serviceTier } : {}),
           config: threadConfig,
           developerInstructions: SIDE_DEVELOPER_INSTRUCTIONS,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -12,6 +12,7 @@ import {
   readCodexAppServerBinding,
   writeCodexAppServerBinding as writeRawCodexAppServerBinding,
 } from "./session-binding.js";
+import { fingerprintCodexAppServerNetworkProxyConfigPatch } from "./config.js";
 import { startOrResumeThread } from "./thread-lifecycle.js";
 
 function createThreadLifecycleAppServerOptions(): Parameters<
@@ -30,6 +31,38 @@ function createThreadLifecycleAppServerOptions(): Parameters<
     approvalsReviewer: "user",
     sandbox: "workspace-write",
     codeModeOnly: false,
+  };
+}
+
+function createNetworkProxyThreadLifecycleAppServerOptions() {
+  const configPatch = {
+    "features.network_proxy.enabled": true,
+    default_permissions: "openclaw-network",
+    permissions: {
+      "openclaw-network": {
+        filesystem: {
+          ":minimal": "read",
+          ":workspace_roots": {
+            ".": "write",
+          },
+        },
+        network: {
+          enabled: true,
+          domains: {
+            "api.openai.com": "allow",
+          },
+          proxy_url: "http://127.0.0.1:3128",
+        },
+      },
+    },
+  };
+  return {
+    ...createThreadLifecycleAppServerOptions(),
+    networkProxy: {
+      profileName: "openclaw-network",
+      configFingerprint: fingerprintCodexAppServerNetworkProxyConfigPatch(configPatch),
+      configPatch,
+    },
   };
 }
 
@@ -1445,6 +1478,42 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-existing");
+  });
+
+  it("starts a new thread when the network proxy config is not active on the binding", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "[]",
+    });
+    const appServer = createNetworkProxyThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-network-proxy");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+    });
+
+    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
+    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
+    expect(requestCalls[0]?.[1]).not.toHaveProperty("sandbox");
+    expect(requestCalls[0]?.[1].config).toMatchObject(appServer.networkProxy.configPatch);
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.threadId).toBe("thread-network-proxy");
+    expect(binding?.networkProxyProfileName).toBe("openclaw-network");
+    expect(binding?.networkProxyConfigFingerprint).toBe(appServer.networkProxy.configFingerprint);
   });
 
   it("passes native hook relay config on thread start and resume", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -93,6 +93,7 @@ function createNetworkProxyAppServerOptions() {
       profileName: "mock-proxy",
       configPatch: {
         "features.network_proxy.enabled": true,
+        default_permissions: "mock-proxy",
         permissions: {
           "mock-proxy": {
             filesystem: {
@@ -453,7 +454,7 @@ describe("Codex app-server native code mode config", () => {
     });
   });
 
-  it("uses a Codex permissions profile for network-proxy thread/start requests", () => {
+  it("selects the Codex network-proxy permissions profile in thread/start config", () => {
     const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
       cwd: "/repo",
       dynamicTools: [],
@@ -461,10 +462,11 @@ describe("Codex app-server native code mode config", () => {
       developerInstructions: "test instructions",
     });
 
-    expect(request.permissions).toEqual({ type: "profile", id: "mock-proxy" });
+    expect(request).not.toHaveProperty("permissions");
     expect(request).not.toHaveProperty("sandbox");
     expect(request.config).toMatchObject({
       "features.network_proxy.enabled": true,
+      default_permissions: "mock-proxy",
       permissions: {
         "mock-proxy": {
           network: {
@@ -477,17 +479,18 @@ describe("Codex app-server native code mode config", () => {
     });
   });
 
-  it("uses a Codex permissions profile for network-proxy thread/resume requests", () => {
+  it("selects the Codex network-proxy permissions profile in thread/resume config", () => {
     const request = buildThreadResumeParams(createAttemptParams({ provider: "openai" }), {
       threadId: "thread-1",
       appServer: createNetworkProxyAppServerOptions() as never,
       developerInstructions: "test instructions",
     });
 
-    expect(request.permissions).toEqual({ type: "profile", id: "mock-proxy" });
+    expect(request).not.toHaveProperty("permissions");
     expect(request).not.toHaveProperty("sandbox");
     expect(request.config).toMatchObject({
       "features.network_proxy.enabled": true,
+      default_permissions: "mock-proxy",
       permissions: {
         "mock-proxy": {
           network: {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CODEX_GPT5_BEHAVIOR_CONTRACT } from "../../prompt-overlay.js";
+import { fingerprintCodexAppServerNetworkProxyConfigPatch } from "./config.js";
 import { createCodexTestModel } from "./test-support.js";
 import {
   buildDeveloperInstructions,
@@ -83,36 +84,38 @@ function createAppServerOptions() {
     approvalPolicy: "on-request",
     approvalsReviewer: "user",
     sandbox: "workspace-write",
-  } as const;
+  };
 }
 
 function createNetworkProxyAppServerOptions() {
+  const configPatch = {
+    "features.network_proxy.enabled": true,
+    default_permissions: "mock-proxy",
+    permissions: {
+      "mock-proxy": {
+        filesystem: {
+          ":minimal": "read",
+          ":workspace_roots": {
+            ".": "write",
+          },
+        },
+        network: {
+          enabled: true,
+          domains: {
+            "api.openai.com": "allow",
+          },
+          allow_upstream_proxy: true,
+          proxy_url: "http://127.0.0.1:3128",
+        },
+      },
+    },
+  } as const;
   return {
     ...createAppServerOptions(),
     networkProxy: {
       profileName: "mock-proxy",
-      configPatch: {
-        "features.network_proxy.enabled": true,
-        default_permissions: "mock-proxy",
-        permissions: {
-          "mock-proxy": {
-            filesystem: {
-              ":minimal": "read",
-              ":workspace_roots": {
-                ".": "write",
-              },
-            },
-            network: {
-              enabled: true,
-              domains: {
-                "api.openai.com": "allow",
-              },
-              allow_upstream_proxy: true,
-              proxy_url: "http://127.0.0.1:3128",
-            },
-          },
-        },
-      },
+      configFingerprint: fingerprintCodexAppServerNetworkProxyConfigPatch(configPatch),
+      configPatch,
     },
   } as const;
 }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -86,6 +86,36 @@ function createAppServerOptions() {
   } as const;
 }
 
+function createNetworkProxyAppServerOptions() {
+  return {
+    ...createAppServerOptions(),
+    networkProxy: {
+      profileName: "mock-proxy",
+      configPatch: {
+        "features.network_proxy.enabled": true,
+        permissions: {
+          "mock-proxy": {
+            filesystem: {
+              ":minimal": "read",
+              ":workspace_roots": {
+                ".": "write",
+              },
+            },
+            network: {
+              enabled: true,
+              domains: {
+                "api.openai.com": "allow",
+              },
+              allow_upstream_proxy: true,
+              proxy_url: "http://127.0.0.1:3128",
+            },
+          },
+        },
+      },
+    },
+  } as const;
+}
+
 function createThreadLifecycleParams(
   sessionFile: string,
   workspaceDir: string,
@@ -423,6 +453,53 @@ describe("Codex app-server native code mode config", () => {
     });
   });
 
+  it("uses a Codex permissions profile for network-proxy thread/start requests", () => {
+    const request = buildThreadStartParams(createAttemptParams({ provider: "openai" }), {
+      cwd: "/repo",
+      dynamicTools: [],
+      appServer: createNetworkProxyAppServerOptions() as never,
+      developerInstructions: "test instructions",
+    });
+
+    expect(request.permissions).toEqual({ type: "profile", id: "mock-proxy" });
+    expect(request).not.toHaveProperty("sandbox");
+    expect(request.config).toMatchObject({
+      "features.network_proxy.enabled": true,
+      permissions: {
+        "mock-proxy": {
+          network: {
+            enabled: true,
+            allow_upstream_proxy: true,
+            proxy_url: "http://127.0.0.1:3128",
+          },
+        },
+      },
+    });
+  });
+
+  it("uses a Codex permissions profile for network-proxy thread/resume requests", () => {
+    const request = buildThreadResumeParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-1",
+      appServer: createNetworkProxyAppServerOptions() as never,
+      developerInstructions: "test instructions",
+    });
+
+    expect(request.permissions).toEqual({ type: "profile", id: "mock-proxy" });
+    expect(request).not.toHaveProperty("sandbox");
+    expect(request.config).toMatchObject({
+      "features.network_proxy.enabled": true,
+      permissions: {
+        "mock-proxy": {
+          network: {
+            domains: {
+              "api.openai.com": "allow",
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("disables Codex tool-search features for nano models", () => {
     const request = buildThreadStartParams(
       createAttemptParams({ provider: "openai", modelId: "gpt-5.4-nano" }),
@@ -638,6 +715,35 @@ describe("Codex app-server turn input image sanitizing", () => {
       networkAccess: true,
       excludeTmpdirEnvVar: false,
       excludeSlashTmp: false,
+    });
+  });
+
+  it("uses Codex permissions for network-proxy turn/start requests", () => {
+    const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer: createNetworkProxyAppServerOptions() as never,
+    });
+
+    expect(request).not.toHaveProperty("permissions");
+    expect(request).not.toHaveProperty("sandboxPolicy");
+  });
+
+  it("keeps explicit sandbox policy overrides ahead of network-proxy turn permissions", () => {
+    const request = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-1",
+      cwd: "/repo",
+      appServer: createNetworkProxyAppServerOptions() as never,
+      sandboxPolicy: {
+        type: "externalSandbox",
+        networkAccess: "enabled",
+      },
+    });
+
+    expect(request).not.toHaveProperty("permissions");
+    expect(request.sandboxPolicy).toEqual({
+      type: "externalSandbox",
+      networkAccess: "enabled",
     });
   });
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -1401,16 +1401,11 @@ export function buildTurnStartParams(
 
 function codexThreadSandboxOrPermissions(
   appServer: Pick<CodexAppServerRuntimeOptions, "networkProxy" | "sandbox">,
-): Pick<CodexThreadStartParams, "permissions" | "sandbox"> {
-  const permissionProfile = appServer.networkProxy?.profileName;
-  if (permissionProfile) {
-    return { permissions: codexPermissionProfileSelection(permissionProfile) };
+): Pick<CodexThreadStartParams, "sandbox"> {
+  if (appServer.networkProxy) {
+    return {};
   }
   return { sandbox: appServer.sandbox };
-}
-
-function codexPermissionProfileSelection(profileName: string): CodexPermissionProfileSelection {
-  return { type: "profile", id: profileName };
 }
 
 function resolveCodexThreadEnvironmentSelection(options: {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -42,7 +42,6 @@ import {
   type CodexDynamicToolFunctionSpec,
   type CodexDynamicToolSpec,
   type CodexLegacyDynamicToolFunctionSpec,
-  type CodexPermissionProfileSelection,
   type CodexSandboxPolicy,
   type CodexThreadResumeParams,
   type CodexThreadStartParams,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -339,6 +339,7 @@ export async function startOrResumeThread(params: {
     }),
   );
   const webSearchThreadConfigFingerprint = fingerprintJsonObject(webSearchPlan.threadConfig);
+  const networkProxyConfigFingerprint = params.appServer.networkProxy?.configFingerprint;
   const contextEngineBinding = lifecycleTiming.measureSync("context-engine-binding", () =>
     buildContextEngineBinding(params.params, params.contextEngineProjection),
   );
@@ -459,10 +460,7 @@ export async function startOrResumeThread(params: {
     }
     binding = undefined;
   }
-  if (
-    binding?.threadId &&
-    transientNativeToolRestriction
-  ) {
+  if (binding?.threadId && transientNativeToolRestriction) {
     embeddedAgentLog.debug(
       "codex app-server native tool surface disabled for turn; starting transient thread",
       {
@@ -513,6 +511,17 @@ export async function startOrResumeThread(params: {
         threadId: binding.threadId,
       },
     );
+    await clearCodexAppServerBinding(params.params.sessionFile);
+    binding = undefined;
+  }
+  if (
+    binding?.threadId &&
+    (binding.networkProxyConfigFingerprint !== networkProxyConfigFingerprint ||
+      binding.networkProxyProfileName !== params.appServer.networkProxy?.profileName)
+  ) {
+    embeddedAgentLog.debug("codex app-server network proxy config changed; starting a new thread", {
+      threadId: binding.threadId,
+    });
     await clearCodexAppServerBinding(params.params.sessionFile);
     binding = undefined;
   }
@@ -661,6 +670,7 @@ export async function startOrResumeThread(params: {
               userMcpServersFingerprint,
               mcpServersFingerprint: nextMcpServersFingerprint,
               networkProxyProfileName: params.appServer.networkProxy?.profileName,
+              networkProxyConfigFingerprint,
               nativeHookRelayGeneration:
                 finalConfigPatch.nativeHookRelayGeneration ??
                 resumeBinding.nativeHookRelayGeneration,
@@ -711,6 +721,7 @@ export async function startOrResumeThread(params: {
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
           networkProxyProfileName: params.appServer.networkProxy?.profileName,
+          networkProxyConfigFingerprint,
           nativeHookRelayGeneration:
             finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
           pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
@@ -812,6 +823,7 @@ export async function startOrResumeThread(params: {
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
           networkProxyProfileName: params.appServer.networkProxy?.profileName,
+          networkProxyConfigFingerprint,
           nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
           pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
           pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
@@ -861,6 +873,7 @@ export async function startOrResumeThread(params: {
     userMcpServersFingerprint,
     mcpServersFingerprint: nextMcpServersFingerprint,
     networkProxyProfileName: params.appServer.networkProxy?.profileName,
+    networkProxyConfigFingerprint,
     nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -42,6 +42,7 @@ import {
   type CodexDynamicToolFunctionSpec,
   type CodexDynamicToolSpec,
   type CodexLegacyDynamicToolFunctionSpec,
+  type CodexPermissionProfileSelection,
   type CodexSandboxPolicy,
   type CodexThreadResumeParams,
   type CodexThreadStartParams,
@@ -659,6 +660,7 @@ export async function startOrResumeThread(params: {
               webSearchThreadConfigFingerprint,
               userMcpServersFingerprint,
               mcpServersFingerprint: nextMcpServersFingerprint,
+              networkProxyProfileName: params.appServer.networkProxy?.profileName,
               nativeHookRelayGeneration:
                 finalConfigPatch.nativeHookRelayGeneration ??
                 resumeBinding.nativeHookRelayGeneration,
@@ -708,6 +710,7 @@ export async function startOrResumeThread(params: {
           webSearchThreadConfigFingerprint,
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
+          networkProxyProfileName: params.appServer.networkProxy?.profileName,
           nativeHookRelayGeneration:
             finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
           pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
@@ -808,6 +811,7 @@ export async function startOrResumeThread(params: {
           webSearchThreadConfigFingerprint,
           userMcpServersFingerprint,
           mcpServersFingerprint: nextMcpServersFingerprint,
+          networkProxyProfileName: params.appServer.networkProxy?.profileName,
           nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
           pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
           pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
@@ -856,6 +860,7 @@ export async function startOrResumeThread(params: {
     dynamicToolsContainDeferred,
     userMcpServersFingerprint,
     mcpServersFingerprint: nextMcpServersFingerprint,
+    networkProxyProfileName: params.appServer.networkProxy?.profileName,
     nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
     pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
     pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
@@ -1065,7 +1070,7 @@ export function buildThreadStartParams(
     cwd: options.cwd,
     approvalPolicy: options.appServer.approvalPolicy,
     approvalsReviewer: options.appServer.approvalsReviewer,
-    sandbox: options.appServer.sandbox,
+    ...codexThreadSandboxOrPermissions(options.appServer),
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
     personality: CODEX_NATIVE_PERSONALITY_NONE,
     serviceName: "OpenClaw",
@@ -1074,6 +1079,7 @@ export function buildThreadStartParams(
       nativeProviderWebSearchSupport: options.nativeProviderWebSearchSupport,
       nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
       webSearchAllowed: options.webSearchAllowed,
+      appServer: options.appServer,
     }),
     ...resolveCodexThreadEnvironmentSelection(options),
     developerInstructions:
@@ -1144,7 +1150,7 @@ export function buildThreadResumeParams(
     ...(modelSelection.modelProvider ? { modelProvider: modelSelection.modelProvider } : {}),
     approvalPolicy: options.appServer.approvalPolicy,
     approvalsReviewer: options.appServer.approvalsReviewer,
-    sandbox: options.appServer.sandbox,
+    ...codexThreadSandboxOrPermissions(options.appServer),
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
     personality: CODEX_NATIVE_PERSONALITY_NONE,
     config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
@@ -1152,6 +1158,7 @@ export function buildThreadResumeParams(
       nativeProviderWebSearchSupport: options.nativeProviderWebSearchSupport,
       nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
       webSearchAllowed: options.webSearchAllowed,
+      appServer: options.appServer,
     }),
     developerInstructions:
       options.developerInstructions ??
@@ -1305,6 +1312,7 @@ function buildCodexRuntimeThreadConfigForRun(
     nativeProviderWebSearchSupport?: CodexNativeWebSearchSupport;
     nativeCodeModeOnlyEnabled?: boolean;
     webSearchAllowed?: boolean;
+    appServer?: Pick<CodexAppServerRuntimeOptions, "networkProxy">;
   } = {},
 ): JsonObject {
   const webSearchConfig = resolveCodexWebSearchPlan({
@@ -1321,6 +1329,7 @@ function buildCodexRuntimeThreadConfigForRun(
   const runtimeConfig =
     mergeCodexThreadConfigs(
       baseConfig,
+      options.appServer?.networkProxy?.configPatch,
       shouldDisableCodexToolSearchForModel(params.modelId)
         ? CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG
         : undefined,
@@ -1361,14 +1370,20 @@ export function buildTurnStartParams(
     agentDir: params.agentDir,
     config: params.config,
   });
+  const useThreadPermissionProfile = options.appServer.networkProxy && !options.sandboxPolicy;
   return {
     threadId: options.threadId,
     input: buildUserInput(params, options.promptText),
     cwd: options.cwd,
     approvalPolicy: options.appServer.approvalPolicy,
     approvalsReviewer: options.appServer.approvalsReviewer,
-    sandboxPolicy:
-      options.sandboxPolicy ?? codexSandboxPolicyForTurn(options.appServer.sandbox, options.cwd),
+    ...(useThreadPermissionProfile
+      ? {}
+      : {
+          sandboxPolicy:
+            options.sandboxPolicy ??
+            codexSandboxPolicyForTurn(options.appServer.sandbox, options.cwd),
+        }),
     model: modelSelection.model,
     personality: CODEX_NATIVE_PERSONALITY_NONE,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
@@ -1382,6 +1397,20 @@ export function buildTurnStartParams(
       heartbeatCollaborationInstructions: options.heartbeatCollaborationInstructions,
     }),
   };
+}
+
+function codexThreadSandboxOrPermissions(
+  appServer: Pick<CodexAppServerRuntimeOptions, "networkProxy" | "sandbox">,
+): Pick<CodexThreadStartParams, "permissions" | "sandbox"> {
+  const permissionProfile = appServer.networkProxy?.profileName;
+  if (permissionProfile) {
+    return { permissions: codexPermissionProfileSelection(permissionProfile) };
+  }
+  return { sandbox: appServer.sandbox };
+}
+
+function codexPermissionProfileSelection(profileName: string): CodexPermissionProfileSelection {
+  return { type: "profile", id: profileName };
 }
 
 function resolveCodexThreadEnvironmentSelection(options: {

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -180,6 +180,54 @@ describe("codex conversation binding", () => {
     );
   });
 
+  it("uses Codex permissions for network-proxy app-server bind threads", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        return {
+          thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+          model: "gpt-5.4-mini",
+        };
+      }),
+    });
+
+    await startCodexConversationThread({
+      pluginConfig: {
+        appServer: {
+          networkProxy: {
+            enabled: true,
+            domains: { "api.openai.com": "allow" },
+            allowUpstreamProxy: true,
+            proxyUrl: "http://127.0.0.1:3128",
+          },
+        },
+      },
+      sessionFile,
+      workspaceDir: tempDir,
+      model: "gpt-5.4-mini",
+      modelProvider: "openai",
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe("thread/start");
+    expect(requests[0]?.params.permissions).toEqual({ type: "profile", id: "openclaw-network" });
+    expect(requests[0]?.params).not.toHaveProperty("sandbox");
+    expect(requests[0]?.params.config).toMatchObject({
+      "features.network_proxy.enabled": true,
+      permissions: {
+        "openclaw-network": {
+          network: {
+            domains: { "api.openai.com": "allow" },
+            allow_upstream_proxy: true,
+            proxy_url: "http://127.0.0.1:3128",
+          },
+        },
+      },
+    });
+  });
+
   it("preserves Codex auth and omits the public OpenAI provider for native bind threads", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({
@@ -937,7 +985,7 @@ describe("codex conversation binding", () => {
     await fs.writeFile(
       `${sessionFile}.codex-app-server.json`,
       JSON.stringify({
-        schemaVersion: 1,
+        schemaVersion: 2,
         threadId: "thread-1",
         cwd: tempDir,
         approvalPolicy: "never",
@@ -1126,6 +1174,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 1,
         threadId: "thread-1",
         cwd: tempDir,
+        networkProxyProfileName: "openclaw-network",
       }),
     );
     let notificationHandler: ((notification: unknown) => void) | undefined;
@@ -1201,6 +1250,92 @@ describe("codex conversation binding", () => {
     expect(turnStartParams[0]?.sandboxPolicy).toEqual({
       type: "dangerFullAccess",
     });
+  });
+
+  it("uses Codex permissions for network-proxy bound app-server turns", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      `${sessionFile}.codex-app-server.json`,
+      JSON.stringify({
+        schemaVersion: 2,
+        threadId: "thread-1",
+        cwd: tempDir,
+        networkProxyProfileName: "openclaw-network",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    const turnStartParams: Record<string, unknown>[] = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        if (method === "turn/start") {
+          turnStartParams.push(requestParams);
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-1",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "hello",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      {
+        pluginConfig: {
+          appServer: {
+            networkProxy: {
+              enabled: true,
+              domains: { "api.openai.com": "allow" },
+              allowUpstreamProxy: true,
+              proxyUrl: "http://127.0.0.1:3128",
+            },
+          },
+        },
+        timeoutMs: 50,
+      },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(turnStartParams[0]).not.toHaveProperty("permissions");
+    expect(turnStartParams[0]).not.toHaveProperty("sandboxPolicy");
   });
 
   it("blocks Guardian-mode bound turns with stale no-approval policy on custom model providers", async () => {

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -74,34 +74,29 @@ import {
   handleCodexConversationInboundClaim,
   startCodexConversationThread,
 } from "./conversation-binding.js";
-import { fingerprintCodexAppServerNetworkProxyConfigPatch } from "./app-server/config.js";
+import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
 
 let tempDir: string;
 
-const NETWORK_PROXY_CONFIG_PATCH = {
-  "features.network_proxy.enabled": true,
-  default_permissions: "openclaw-network",
-  permissions: {
-    "openclaw-network": {
-      filesystem: {
-        ":minimal": "read",
-        ":workspace_roots": {
-          ".": "write",
-        },
-      },
-      network: {
-        enabled: true,
-        domains: { "api.openai.com": "allow" },
-        allow_upstream_proxy: true,
-        proxy_url: "http://127.0.0.1:3128",
-      },
+const NETWORK_PROXY_PLUGIN_CONFIG = {
+  appServer: {
+    networkProxy: {
+      enabled: true,
+      domains: { "api.openai.com": "allow" },
+      allowUpstreamProxy: true,
+      proxyUrl: "http://127.0.0.1:3128",
     },
   },
 };
-
-const NETWORK_PROXY_CONFIG_FINGERPRINT = fingerprintCodexAppServerNetworkProxyConfigPatch(
-  NETWORK_PROXY_CONFIG_PATCH,
-);
+const NETWORK_PROXY_RUNTIME = resolveCodexAppServerRuntimeOptions({
+  env: {},
+  requirementsToml: null,
+  pluginConfig: NETWORK_PROXY_PLUGIN_CONFIG,
+});
+const NETWORK_PROXY_PROFILE_NAME = NETWORK_PROXY_RUNTIME.networkProxy?.profileName ?? "missing";
+const NETWORK_PROXY_CONFIG_PATCH = NETWORK_PROXY_RUNTIME.networkProxy?.configPatch ?? {};
+const NETWORK_PROXY_CONFIG_FINGERPRINT =
+  NETWORK_PROXY_RUNTIME.networkProxy?.configFingerprint ?? "missing";
 
 function conversationThreadStartResult(threadId: string) {
   return {
@@ -252,16 +247,7 @@ describe("codex conversation binding", () => {
     });
 
     await startCodexConversationThread({
-      pluginConfig: {
-        appServer: {
-          networkProxy: {
-            enabled: true,
-            domains: { "api.openai.com": "allow" },
-            allowUpstreamProxy: true,
-            proxyUrl: "http://127.0.0.1:3128",
-          },
-        },
-      },
+      pluginConfig: NETWORK_PROXY_PLUGIN_CONFIG,
       sessionFile,
       workspaceDir: tempDir,
       model: "gpt-5.4-mini",
@@ -272,19 +258,7 @@ describe("codex conversation binding", () => {
     expect(requests[0]?.method).toBe("thread/start");
     expect(requests[0]?.params).not.toHaveProperty("permissions");
     expect(requests[0]?.params).not.toHaveProperty("sandbox");
-    expect(requests[0]?.params.config).toMatchObject({
-      "features.network_proxy.enabled": true,
-      default_permissions: "openclaw-network",
-      permissions: {
-        "openclaw-network": {
-          network: {
-            domains: { "api.openai.com": "allow" },
-            allow_upstream_proxy: true,
-            proxy_url: "http://127.0.0.1:3128",
-          },
-        },
-      },
-    });
+    expect(requests[0]?.params.config).toMatchObject(NETWORK_PROXY_CONFIG_PATCH);
   });
 
   it("starts a fresh proxy-backed thread when binding an explicit app-server thread id", async () => {
@@ -301,16 +275,7 @@ describe("codex conversation binding", () => {
     });
 
     await startCodexConversationThread({
-      pluginConfig: {
-        appServer: {
-          networkProxy: {
-            enabled: true,
-            domains: { "api.openai.com": "allow" },
-            allowUpstreamProxy: true,
-            proxyUrl: "http://127.0.0.1:3128",
-          },
-        },
-      },
+      pluginConfig: NETWORK_PROXY_PLUGIN_CONFIG,
       sessionFile,
       threadId: "thread-old",
       workspaceDir: tempDir,
@@ -326,7 +291,7 @@ describe("codex conversation binding", () => {
       await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
     ) as Record<string, unknown>;
     expect(bindingAfterStart.threadId).toBe("thread-new");
-    expect(bindingAfterStart.networkProxyProfileName).toBe("openclaw-network");
+    expect(bindingAfterStart.networkProxyProfileName).toBe(NETWORK_PROXY_PROFILE_NAME);
     expect(bindingAfterStart.networkProxyConfigFingerprint).toBe(
       NETWORK_PROXY_CONFIG_FINGERPRINT,
     );
@@ -1363,7 +1328,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 2,
         threadId: "thread-1",
         cwd: tempDir,
-        networkProxyProfileName: "openclaw-network",
+        networkProxyProfileName: NETWORK_PROXY_PROFILE_NAME,
         networkProxyConfigFingerprint: NETWORK_PROXY_CONFIG_FINGERPRINT,
       }),
     );
@@ -1450,7 +1415,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 2,
         threadId: "thread-old",
         cwd: tempDir,
-        networkProxyProfileName: "openclaw-network",
+        networkProxyProfileName: "openclaw-network-stale",
         networkProxyConfigFingerprint: "stale-proxy-config",
       }),
     );
@@ -1539,6 +1504,7 @@ describe("codex conversation binding", () => {
       await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
     ) as Record<string, unknown>;
     expect(bindingAfterRefresh.threadId).toBe("thread-new");
+    expect(bindingAfterRefresh.networkProxyProfileName).toBe(NETWORK_PROXY_PROFILE_NAME);
     expect(bindingAfterRefresh.networkProxyConfigFingerprint).toBe(
       NETWORK_PROXY_CONFIG_FINGERPRINT,
     );

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -180,7 +180,7 @@ describe("codex conversation binding", () => {
     );
   });
 
-  it("uses Codex permissions for network-proxy app-server bind threads", async () => {
+  it("selects Codex network-proxy permissions through app-server bind thread config", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
@@ -212,10 +212,11 @@ describe("codex conversation binding", () => {
 
     expect(requests).toHaveLength(1);
     expect(requests[0]?.method).toBe("thread/start");
-    expect(requests[0]?.params.permissions).toEqual({ type: "profile", id: "openclaw-network" });
+    expect(requests[0]?.params).not.toHaveProperty("permissions");
     expect(requests[0]?.params).not.toHaveProperty("sandbox");
     expect(requests[0]?.params.config).toMatchObject({
       "features.network_proxy.enabled": true,
+      default_permissions: "openclaw-network",
       permissions: {
         "openclaw-network": {
           network: {
@@ -1252,7 +1253,7 @@ describe("codex conversation binding", () => {
     });
   });
 
-  it("uses Codex permissions for network-proxy bound app-server turns", async () => {
+  it("keeps network-proxy bound app-server turns on their thread permissions profile", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await fs.writeFile(
       `${sessionFile}.codex-app-server.json`,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -85,7 +85,7 @@ const NETWORK_PROXY_CONFIG_PATCH = {
     "openclaw-network": {
       filesystem: {
         ":minimal": "read",
-        ":project_roots": {
+        ":workspace_roots": {
           ".": "write",
         },
       },

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -287,6 +287,51 @@ describe("codex conversation binding", () => {
     });
   });
 
+  it("starts a fresh proxy-backed thread when binding an explicit app-server thread id", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/resume") {
+          throw new Error("thread/resume should not receive network proxy config");
+        }
+        return conversationThreadStartResult("thread-new");
+      }),
+    });
+
+    await startCodexConversationThread({
+      pluginConfig: {
+        appServer: {
+          networkProxy: {
+            enabled: true,
+            domains: { "api.openai.com": "allow" },
+            allowUpstreamProxy: true,
+            proxyUrl: "http://127.0.0.1:3128",
+          },
+        },
+      },
+      sessionFile,
+      threadId: "thread-old",
+      workspaceDir: tempDir,
+      model: "gpt-5.4-mini",
+      modelProvider: "openai",
+    });
+
+    expect(requests.map((request) => request.method)).toEqual(["thread/start"]);
+    expect(requests[0]?.params).not.toHaveProperty("threadId");
+    expect(requests[0]?.params).not.toHaveProperty("sandbox");
+    expect(requests[0]?.params.config).toMatchObject(NETWORK_PROXY_CONFIG_PATCH);
+    const bindingAfterStart = JSON.parse(
+      await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
+    ) as Record<string, unknown>;
+    expect(bindingAfterStart.threadId).toBe("thread-new");
+    expect(bindingAfterStart.networkProxyProfileName).toBe("openclaw-network");
+    expect(bindingAfterStart.networkProxyConfigFingerprint).toBe(
+      NETWORK_PROXY_CONFIG_FINGERPRINT,
+    );
+  });
+
   it("preserves Codex auth and omits the public OpenAI provider for native bind threads", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -74,8 +74,66 @@ import {
   handleCodexConversationInboundClaim,
   startCodexConversationThread,
 } from "./conversation-binding.js";
+import { fingerprintCodexAppServerNetworkProxyConfigPatch } from "./app-server/config.js";
 
 let tempDir: string;
+
+const NETWORK_PROXY_CONFIG_PATCH = {
+  "features.network_proxy.enabled": true,
+  default_permissions: "openclaw-network",
+  permissions: {
+    "openclaw-network": {
+      filesystem: {
+        ":minimal": "read",
+        ":project_roots": {
+          ".": "write",
+        },
+      },
+      network: {
+        enabled: true,
+        domains: { "api.openai.com": "allow" },
+        allow_upstream_proxy: true,
+        proxy_url: "http://127.0.0.1:3128",
+      },
+    },
+  },
+};
+
+const NETWORK_PROXY_CONFIG_FINGERPRINT = fingerprintCodexAppServerNetworkProxyConfigPatch(
+  NETWORK_PROXY_CONFIG_PATCH,
+);
+
+function conversationThreadStartResult(threadId: string) {
+  return {
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    cwd: tempDir,
+    model: "gpt-5.4-mini",
+    modelProvider: "openai",
+    sandbox: { type: "workspaceWrite", networkAccess: false },
+    serviceTier: null,
+    activePermissionProfile: null,
+    thread: {
+      id: threadId,
+      sessionId: "session-1",
+      preview: "",
+      ephemeral: false,
+      modelProvider: "openai",
+      createdAt: 1,
+      updatedAt: 1,
+      status: { type: "idle" },
+      path: null,
+      cwd: tempDir,
+      cliVersion: "0.125.0",
+      source: "unknown",
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    },
+  };
+}
 
 function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0): unknown {
   const call = mock.mock.calls[callIndex];
@@ -1175,7 +1233,6 @@ describe("codex conversation binding", () => {
         schemaVersion: 1,
         threadId: "thread-1",
         cwd: tempDir,
-        networkProxyProfileName: "openclaw-network",
       }),
     );
     let notificationHandler: ((notification: unknown) => void) | undefined;
@@ -1262,6 +1319,7 @@ describe("codex conversation binding", () => {
         threadId: "thread-1",
         cwd: tempDir,
         networkProxyProfileName: "openclaw-network",
+        networkProxyConfigFingerprint: NETWORK_PROXY_CONFIG_FINGERPRINT,
       }),
     );
     let notificationHandler: ((notification: unknown) => void) | undefined;
@@ -1337,6 +1395,108 @@ describe("codex conversation binding", () => {
     expect(result).toEqual({ handled: true, reply: { text: "done" } });
     expect(turnStartParams[0]).not.toHaveProperty("permissions");
     expect(turnStartParams[0]).not.toHaveProperty("sandboxPolicy");
+  });
+
+  it("refreshes stale network-proxy bound app-server threads before the turn", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      `${sessionFile}.codex-app-server.json`,
+      JSON.stringify({
+        schemaVersion: 2,
+        threadId: "thread-old",
+        cwd: tempDir,
+        networkProxyProfileName: "openclaw-network",
+        networkProxyConfigFingerprint: "stale-proxy-config",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return conversationThreadStartResult("thread-new");
+        }
+        if (method === "turn/start") {
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-new",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "hello",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      {
+        pluginConfig: {
+          appServer: {
+            serviceTier: "priority",
+            networkProxy: {
+              enabled: true,
+              domains: { "api.openai.com": "allow" },
+              allowUpstreamProxy: true,
+              proxyUrl: "http://127.0.0.1:3128",
+            },
+          },
+        },
+        timeoutMs: 50,
+      },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests[0]?.params.config).toMatchObject(NETWORK_PROXY_CONFIG_PATCH);
+    expect(requests[0]?.params).not.toHaveProperty("sandbox");
+    expect(requests[0]?.params.serviceTier).toBe("priority");
+    expect(requests[1]?.params.threadId).toBe("thread-new");
+    expect(requests[1]?.params).not.toHaveProperty("sandboxPolicy");
+    const bindingAfterRefresh = JSON.parse(
+      await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8"),
+    ) as Record<string, unknown>;
+    expect(bindingAfterRefresh.threadId).toBe("thread-new");
+    expect(bindingAfterRefresh.networkProxyConfigFingerprint).toBe(
+      NETWORK_PROXY_CONFIG_FINGERPRINT,
+    );
   });
 
   it("blocks Guardian-mode bound turns with stale no-approval policy on custom model providers", async () => {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -30,9 +30,11 @@ import {
 } from "./app-server/config.js";
 import type {
   CodexServiceTier,
+  CodexPermissionProfileSelection,
   CodexThreadResumeResponse,
   CodexThreadStartResponse,
   CodexTurnStartResponse,
+  JsonObject,
   JsonValue,
 } from "./app-server/protocol.js";
 import {
@@ -415,20 +417,41 @@ function buildThreadRequestRuntimeOptions(
 ): {
   approvalPolicy: ConversationAppServerRuntime["runtime"]["approvalPolicy"];
   approvalsReviewer: ConversationAppServerRuntime["runtime"]["approvalsReviewer"];
-  sandbox: ConversationAppServerRuntime["runtime"]["sandbox"];
+  sandbox?: ConversationAppServerRuntime["runtime"]["sandbox"];
   serviceTier?: CodexServiceTier;
+  permissions?: CodexPermissionProfileSelection;
+  config?: JsonObject;
 } {
   const serviceTier = params.serviceTier ?? resolved.runtime.serviceTier;
+  const sandbox = resolved.execPolicy?.touched
+    ? resolved.runtime.sandbox
+    : (params.sandbox ?? resolved.runtime.sandbox);
   return {
     approvalPolicy: resolved.execPolicy?.touched
       ? resolved.runtime.approvalPolicy
       : (params.approvalPolicy ?? resolved.runtime.approvalPolicy),
     approvalsReviewer: resolved.runtime.approvalsReviewer,
-    sandbox: resolved.execPolicy?.touched
-      ? resolved.runtime.sandbox
-      : (params.sandbox ?? resolved.runtime.sandbox),
+    ...codexConversationSandboxOrPermissions(resolved.runtime, sandbox),
     ...(serviceTier ? { serviceTier } : {}),
   };
+}
+
+function codexConversationSandboxOrPermissions(
+  runtime: Pick<ConversationAppServerRuntime["runtime"], "networkProxy">,
+  sandbox: ConversationAppServerRuntime["runtime"]["sandbox"],
+): {
+  sandbox?: ConversationAppServerRuntime["runtime"]["sandbox"];
+  permissions?: CodexPermissionProfileSelection;
+  config?: JsonObject;
+} {
+  const networkProxy = runtime.networkProxy;
+  if (networkProxy) {
+    return {
+      permissions: { type: "profile", id: networkProxy.profileName },
+      config: networkProxy.configPatch,
+    };
+  }
+  return { sandbox };
 }
 
 async function writeThreadBindingFromResponse(
@@ -459,6 +482,7 @@ async function writeThreadBindingFromResponse(
         ? resolved.runtime.sandbox
         : (params.sandbox ?? resolved.runtime.sandbox),
       serviceTier: params.serviceTier ?? resolved.runtime.serviceTier,
+      networkProxyProfileName: resolved.runtime.networkProxy?.profileName,
     },
     {
       ...resolved.agentLookup,
@@ -568,6 +592,9 @@ async function runBoundTurn(params: {
   const sandbox = useModelScopedPolicy
     ? modelScopedRuntime.sandbox
     : (binding.sandbox ?? modelScopedRuntime.sandbox);
+  const permissionProfile = modelScopedRuntime.networkProxy?.profileName;
+  const useStickyNetworkProfile =
+    permissionProfile !== undefined && binding.networkProxyProfileName === permissionProfile;
   assertNativeConversationApprovalPolicySupported({
     execPolicy,
     approvalPolicy,
@@ -641,7 +668,9 @@ async function runBoundTurn(params: {
         cwd: workspaceDir,
         approvalPolicy,
         approvalsReviewer: modelScopedRuntime.approvalsReviewer,
-        sandboxPolicy: codexSandboxPolicyForTurn(sandbox, workspaceDir),
+        ...(useStickyNetworkProfile
+          ? {}
+          : { sandboxPolicy: codexSandboxPolicyForTurn(sandbox, workspaceDir) }),
         ...(modelSelection?.model ? { model: modelSelection.model } : {}),
         personality: CODEX_NATIVE_PERSONALITY_NONE,
         ...((binding.serviceTier ?? runtime.serviceTier)

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -30,7 +30,6 @@ import {
 } from "./app-server/config.js";
 import type {
   CodexServiceTier,
-  CodexPermissionProfileSelection,
   CodexThreadResumeResponse,
   CodexThreadStartResponse,
   CodexTurnStartResponse,
@@ -419,7 +418,6 @@ function buildThreadRequestRuntimeOptions(
   approvalsReviewer: ConversationAppServerRuntime["runtime"]["approvalsReviewer"];
   sandbox?: ConversationAppServerRuntime["runtime"]["sandbox"];
   serviceTier?: CodexServiceTier;
-  permissions?: CodexPermissionProfileSelection;
   config?: JsonObject;
 } {
   const serviceTier = params.serviceTier ?? resolved.runtime.serviceTier;
@@ -441,13 +439,11 @@ function codexConversationSandboxOrPermissions(
   sandbox: ConversationAppServerRuntime["runtime"]["sandbox"],
 ): {
   sandbox?: ConversationAppServerRuntime["runtime"]["sandbox"];
-  permissions?: CodexPermissionProfileSelection;
   config?: JsonObject;
 } {
   const networkProxy = runtime.networkProxy;
   if (networkProxy) {
     return {
-      permissions: { type: "profile", id: networkProxy.profileName },
       config: networkProxy.configPatch,
     };
   }

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -52,6 +52,7 @@ import {
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
 } from "./app-server/shared-client.js";
+import { assertCodexThreadStartResponse } from "./app-server/protocol-validators.js";
 import {
   CODEX_NATIVE_PERSONALITY_NONE,
   resolveCodexAppServerRequestModelSelection,
@@ -479,6 +480,7 @@ async function writeThreadBindingFromResponse(
         : (params.sandbox ?? resolved.runtime.sandbox),
       serviceTier: params.serviceTier ?? resolved.runtime.serviceTier,
       networkProxyProfileName: resolved.runtime.networkProxy?.profileName,
+      networkProxyConfigFingerprint: resolved.runtime.networkProxy?.configFingerprint,
     },
     {
       ...resolved.agentLookup,
@@ -546,10 +548,10 @@ async function runBoundTurn(params: {
 }): Promise<BoundTurnResult> {
   const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir, config: params.config });
   const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
-  const threadId = binding?.threadId;
-  if (!threadId) {
+  if (!binding?.threadId) {
     throw new Error("bound Codex conversation has no thread binding");
   }
+  let threadId = binding.threadId;
   const workspaceDir = binding.cwd || params.data.workspaceDir;
   const reviewerModelProvider = resolveModelBackedReviewerPolicyProvider({
     authProfileId: binding.authProfileId,
@@ -589,8 +591,15 @@ async function runBoundTurn(params: {
     ? modelScopedRuntime.sandbox
     : (binding.sandbox ?? modelScopedRuntime.sandbox);
   const permissionProfile = modelScopedRuntime.networkProxy?.profileName;
-  const useStickyNetworkProfile =
-    permissionProfile !== undefined && binding.networkProxyProfileName === permissionProfile;
+  const networkProxyConfigFingerprint = modelScopedRuntime.networkProxy?.configFingerprint;
+  const networkProxyBindingChanged =
+    binding.networkProxyProfileName !== permissionProfile ||
+    binding.networkProxyConfigFingerprint !== networkProxyConfigFingerprint;
+  const serviceTier = binding.serviceTier ?? runtime.serviceTier;
+  let useStickyNetworkProfile =
+    permissionProfile !== undefined &&
+    binding.networkProxyProfileName === permissionProfile &&
+    binding.networkProxyConfigFingerprint === networkProxyConfigFingerprint;
   assertNativeConversationApprovalPolicySupported({
     execPolicy,
     approvalPolicy,
@@ -612,12 +621,60 @@ async function runBoundTurn(params: {
     authProfileId: binding.authProfileId,
     ...agentLookup,
   });
-  const collector = createCodexConversationTurnCollector(threadId);
-  const notificationCleanup = client.addNotificationHandler((notification) =>
-    collector.handleNotification(notification),
-  );
-  const requestCleanup = client.addRequestHandler(
-    async (request): Promise<JsonValue | undefined> => {
+  let notificationCleanup: () => void = () => undefined;
+  let requestCleanup: () => void = () => undefined;
+  try {
+    if (networkProxyBindingChanged) {
+      const response = assertCodexThreadStartResponse(
+        await client.request(
+          "thread/start",
+          {
+            cwd: workspaceDir,
+            ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+            ...(modelSelection?.modelProvider ? { modelProvider: modelSelection.modelProvider } : {}),
+            personality: CODEX_NATIVE_PERSONALITY_NONE,
+            approvalPolicy,
+            approvalsReviewer: modelScopedRuntime.approvalsReviewer,
+            ...(modelScopedRuntime.networkProxy
+              ? { config: modelScopedRuntime.networkProxy.configPatch }
+              : { sandbox }),
+            ...(serviceTier ? { serviceTier } : {}),
+            developerInstructions:
+              "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.",
+            experimentalRawEvents: true,
+            persistExtendedHistory: true,
+          },
+          { timeoutMs: runtime.requestTimeoutMs },
+        ),
+      );
+      threadId = response.thread.id;
+      await writeCodexAppServerBinding(
+        params.data.sessionFile,
+        {
+          threadId,
+          cwd: response.thread.cwd ?? workspaceDir,
+          authProfileId: binding.authProfileId,
+          model: response.model ?? modelSelection?.model ?? binding.model,
+          modelProvider: normalizeCodexAppServerBindingModelProvider({
+            authProfileId: binding.authProfileId,
+            modelProvider: response.modelProvider ?? modelSelection?.modelProvider ?? binding.modelProvider,
+            ...agentLookup,
+          }),
+          approvalPolicy: typeof approvalPolicy === "string" ? approvalPolicy : undefined,
+          sandbox,
+          serviceTier,
+          networkProxyProfileName: modelScopedRuntime.networkProxy?.profileName,
+          networkProxyConfigFingerprint: modelScopedRuntime.networkProxy?.configFingerprint,
+        },
+        agentLookup,
+      );
+      useStickyNetworkProfile = modelScopedRuntime.networkProxy !== undefined;
+    }
+    const collector = createCodexConversationTurnCollector(threadId);
+    notificationCleanup = client.addNotificationHandler((notification) =>
+      collector.handleNotification(notification),
+    );
+    requestCleanup = client.addRequestHandler(async (request): Promise<JsonValue | undefined> => {
       if (request.method === "item/tool/call") {
         return {
           contentItems: [
@@ -650,9 +707,7 @@ async function runBoundTurn(params: {
         };
       }
       return undefined;
-    },
-  );
-  try {
+    });
     const response: CodexTurnStartResponse = await client.request(
       "turn/start",
       {
@@ -669,9 +724,7 @@ async function runBoundTurn(params: {
           : { sandboxPolicy: codexSandboxPolicyForTurn(sandbox, workspaceDir) }),
         ...(modelSelection?.model ? { model: modelSelection.model } : {}),
         personality: CODEX_NATIVE_PERSONALITY_NONE,
-        ...((binding.serviceTier ?? runtime.serviceTier)
-          ? { serviceTier: binding.serviceTier ?? runtime.serviceTier }
-          : {}),
+        ...(serviceTier ? { serviceTier } : {}),
       },
       { timeoutMs: runtime.requestTimeoutMs },
     );

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -158,6 +158,8 @@ async function resolveConversationAppServerRuntime(params: {
 }
 
 const CODEX_CONVERSATION_GLOBAL_STATE = Symbol.for("openclaw.codex.conversationBinding");
+const CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS =
+  "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.";
 
 function getGlobalState(): CodexConversationGlobalState {
   const globalState = globalThis as typeof globalThis & {
@@ -451,6 +453,26 @@ function codexConversationSandboxOrPermissions(
   return { sandbox };
 }
 
+async function requestNewConversationBindingThread(
+  params: CodexThreadBindingParams,
+  resolved: CodexThreadBindingRuntime,
+): Promise<CodexThreadStartResponse> {
+  return await resolved.client.request(
+    "thread/start",
+    {
+      cwd: params.workspaceDir,
+      ...(resolved.model ? { model: resolved.model } : {}),
+      ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
+      personality: CODEX_NATIVE_PERSONALITY_NONE,
+      ...buildThreadRequestRuntimeOptions(params, resolved),
+      developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
+      experimentalRawEvents: true,
+      persistExtendedHistory: true,
+    },
+    { timeoutMs: resolved.runtime.requestTimeoutMs },
+  );
+}
+
 async function writeThreadBindingFromResponse(
   params: CodexThreadBindingParams,
   resolved: CodexThreadBindingRuntime,
@@ -495,18 +517,23 @@ async function attachExistingThread(
 ): Promise<void> {
   const resolved = await resolveThreadBindingRuntime(params);
   try {
-    const response: CodexThreadResumeResponse = await resolved.client.request(
-      CODEX_CONTROL_METHODS.resumeThread,
-      {
-        threadId: params.threadId,
-        ...(resolved.model ? { model: resolved.model } : {}),
-        ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
-        personality: CODEX_NATIVE_PERSONALITY_NONE,
-        ...buildThreadRequestRuntimeOptions(params, resolved),
-        persistExtendedHistory: true,
-      },
-      { timeoutMs: resolved.runtime.requestTimeoutMs },
-    );
+    // Codex applies network-proxy permission profiles at thread/start. Resuming
+    // an arbitrary existing thread cannot prove that profile is active.
+    const response: CodexThreadResumeResponse | CodexThreadStartResponse =
+      resolved.runtime.networkProxy
+        ? await requestNewConversationBindingThread(params, resolved)
+        : await resolved.client.request(
+            CODEX_CONTROL_METHODS.resumeThread,
+            {
+              threadId: params.threadId,
+              ...(resolved.model ? { model: resolved.model } : {}),
+              ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
+              personality: CODEX_NATIVE_PERSONALITY_NONE,
+              ...buildThreadRequestRuntimeOptions(params, resolved),
+              persistExtendedHistory: true,
+            },
+            { timeoutMs: resolved.runtime.requestTimeoutMs },
+          );
     await writeThreadBindingFromResponse(params, resolved, response);
   } finally {
     releaseLeasedSharedCodexAppServerClient(resolved.client);
@@ -516,21 +543,7 @@ async function attachExistingThread(
 async function createThread(params: CodexThreadBindingParams): Promise<void> {
   const resolved = await resolveThreadBindingRuntime(params);
   try {
-    const response: CodexThreadStartResponse = await resolved.client.request(
-      "thread/start",
-      {
-        cwd: params.workspaceDir,
-        ...(resolved.model ? { model: resolved.model } : {}),
-        ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
-        personality: CODEX_NATIVE_PERSONALITY_NONE,
-        ...buildThreadRequestRuntimeOptions(params, resolved),
-        developerInstructions:
-          "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.",
-        experimentalRawEvents: true,
-        persistExtendedHistory: true,
-      },
-      { timeoutMs: resolved.runtime.requestTimeoutMs },
-    );
+    const response = await requestNewConversationBindingThread(params, resolved);
     await writeThreadBindingFromResponse(params, resolved, response);
   } finally {
     releaseLeasedSharedCodexAppServerClient(resolved.client);
@@ -639,8 +652,7 @@ async function runBoundTurn(params: {
               ? { config: modelScopedRuntime.networkProxy.configPatch }
               : { sandbox }),
             ...(serviceTier ? { serviceTier } : {}),
-            developerInstructions:
-              "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.",
+            developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
             experimentalRawEvents: true,
             persistExtendedHistory: true,
           },

--- a/extensions/cohere/index.test.ts
+++ b/extensions/cohere/index.test.ts
@@ -35,7 +35,11 @@ function captureCoherePayload(context: Context): Record<string, unknown> {
     return {} as ReturnType<StreamFn>;
   };
 
-  void createCohereCompletionsWrapper(baseStreamFn)(requireCohereModel(), context, {
+  const wrappedStreamFn = createCohereCompletionsWrapper(baseStreamFn);
+  if (!wrappedStreamFn) {
+    throw new Error("Cohere wrapper did not return a stream function");
+  }
+  void wrappedStreamFn(requireCohereModel(), context, {
     onPayload: (payload) => {
       captured = payload as Record<string, unknown>;
     },


### PR DESCRIPTION
## Summary

- Adds `appServer.networkProxy` for the bundled Codex plugin so OpenClaw can enable Codex's managed network proxy through an app-server permission profile.
- Builds the Codex config patch for `features.network_proxy.enabled` plus `permissions.<profile>.network.*`, including loopback proxy URLs, domain allowlists, SOCKS options, and local/private-network escape hatches.
- Sends Codex's current protocol shape, `permissions: { type: "profile", id }`, on thread start/resume and keeps bound turns sticky instead of reselecting an ephemeral generated profile.
- Updates plugin metadata, docs, binding persistence, and tests for the app-server thread lifecycle and conversation binding paths.

## Linked context

Which issue does this close?

- None.

Which issues, PRs, or discussions are related?

- None.

Was this requested by a maintainer or owner?

- Maintainer request from Vincent to support Codex's new network proxy in OpenClaw's app-server proxy setup.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex app-server runtime config can now opt into managed network proxy profiles and route OpenClaw app-server threads through the generated profile selection.
- Real environment tested: Crabbox with Blacksmith Testbox `tbx_01kv7mhsy79j2f048vxzhb78f3` from branch `codex-network-proxy-app-server`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/conversation-binding.test.ts && env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
- Evidence after fix: targeted sync was 12 files; focused Vitest passed `3 passed`, `187 passed`; `check:changed` selected `lanes=extensions, extensionTests, docs`; Blacksmith run summary ended `exit=0`.
- Observed result after fix: mock loopback proxy config is normalized into Codex network profile config; thread start/resume use the profile object; bound turns omit sandbox/profile overrides when the persisted proxy profile is still active; explicit sandbox overrides still win.
- What was not tested: a live upstream Codex network egress request through a real proxy server. The PR verifies OpenClaw's payload/config contract and lifecycle behavior with mock proxy config plus type/lint/check gates.
- Proof limitations or environment constraints: `pnpm docs:list` and `scripts/committer` were not run locally because this Codex worktree is linked/sparse and local pnpm wrapper paths attempt dependency reconciliation; validation was run through the repo's Crabbox/Testbox path instead.
- Before evidence: prior Testbox run `tbx_01kv7m6nevz7vct3tfazeyta0e` failed `check:changed` on `bounded-turn.ts` config typing after the rebase; this branch includes the typed merge fallback and the final Testbox gate is green.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/conversation-binding.test.ts`
- Crabbox/Testbox `tbx_01kv7mhsy79j2f048vxzhb78f3`: targeted Vitest plus `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`
- `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main` reported no accepted/actionable findings.

Regression coverage added or updated:

- Network proxy config schema and patch generation, including mock loopback proxy URL/domain rules.
- Codex app-server thread start/resume profile selection and sticky turn behavior.
- Conversation binding persistence and bound-turn sandbox/profile behavior.
- Bounded-turn config merge typing after the rebase.

Dependency/protocol proof:

- Checked sibling Codex source at `codex-rs/app-server-protocol/src/protocol/v2/permissions.rs:505` through `permissions.rs:519`: `PermissionProfileSelectionParams` is tagged and uses the `Profile { id, modifications }` shape.
- Checked `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:117` through `thread.rs:124` and `thread.rs:274` through `thread.rs:281`: thread start/resume expose `permissions: Option<PermissionProfileSelectionParams>` and cannot combine it with `sandbox`.
- Checked `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:75` through `turn.rs:84`: turn/start has optional `permissions`, but this PR avoids using it for generated thread-local profiles unless an explicit sandbox override is requested.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, for users who opt into the new Codex app-server network proxy config.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes, new optional plugin config keys under `appServer.networkProxy`.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, network sandbox/proxy behavior changes when explicitly enabled.

What is the highest-risk area?

Misrouting sandbox/profile selection across thread start, resume, and bound turns.

How is that risk mitigated?

The runtime only enables the profile when `appServer.networkProxy.enabled` is set, persists the active generated profile name in bindings, omits reselecting ephemeral profiles on bound turns, keeps explicit sandbox overrides higher priority, and covers those cases in unit tests plus Testbox type/lint gates.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

CI after PR creation. No known author-side blockers.

Which bot or reviewer comments were addressed?

Local autoreview initially caught the protocol shape and ephemeral profile reselection issues; both were fixed before this PR. Final autoreview is clean.

AI-assisted: yes; the implementation was reviewed against upstream Codex protocol source and validated with Crabbox/Testbox before opening.
