### PR TITLE
fix(logging): respect redactSensitive config in tool payload redaction

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -986,7 +986,7 @@ describe("redactSensitiveText", () => {
     );
   });
 
-  it("forces redaction for tool details even when log redaction is disabled", () => {
+  it("respects redactSensitive off for tool details (no longer forces redaction)", () => {
     writeConfig(`{
       logging: {
         redactSensitive: "off",
@@ -994,7 +994,7 @@ describe("redactSensitiveText", () => {
     }`);
 
     expect(redactToolDetail("OPENAI_API_KEY=sk-1234567890abcdef")).toBe(
-      "OPENAI_API_KEY=sk-123…cdef",
+      "OPENAI_API_KEY=sk-1234567890abcdef",
     );
   });
 
@@ -1061,6 +1061,28 @@ describe("redactSensitiveText", () => {
 
   it("redacts standalone bearer tokens after the default prefilter", () => {
     expect(redactSensitiveText("Bearer abcdef1234567890ghij")).toBe("Bearer abcdef…ghij");
+  });
+
+  it("respects redactSensitive off for tool payload text", () => {
+    writeConfig(`{
+      logging: {
+        redactSensitive: "off",
+      },
+    }`);
+
+    expect(redactToolDetail("Authorization: Bearer sk-test123")).toBe(
+      "Authorization: Bearer sk-test123",
+    );
+  });
+
+  it("redacts tool payload text by default when redactSensitive is not configured", () => {
+    writeConfig(`{
+      logging: {},
+    }`);
+
+    expect(redactToolDetail("Authorization: Bearer sk-test123")).not.toBe(
+      "Authorization: Bearer sk-test123",
+    );
   });
 });
 

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1003,12 +1003,16 @@ function resolveToolPayloadRedaction(
     userPatterns && userPatterns.length > 0
       ? [...userPatterns, ...DEFAULT_REDACT_PATTERNS]
       : undefined;
-  return { mode: "tools", patterns };
+  const mode =
+    loggingConfig?.redactSensitive === "off"
+      ? "off"
+      : DEFAULT_REDACT_MODE;
+  return { mode, patterns };
 }
 
-// Forces tools-mode regardless of `logging.redactSensitive` (which governs log
-// output, not UI surfaces), and merges user `logging.redactPatterns` with the
-// built-in defaults so both apply.
+// Applies tool-payload redaction to UI/tool payload strings (tool args in
+// event streams, tool results displayed to users, transcript entries).
+// Respects `logging.redactSensitive` when set to "off".
 export function redactToolPayloadText(text: string): string {
   return redactToolPayloadTextWithConfig(text, readLoggingConfig());
 }


### PR DESCRIPTION
## Problem

`resolveToolPayloadRedaction()` in `src/logging/redact.ts` hardcodes `mode: "tools"`, ignoring the `logging.redactSensitive` config setting. This means users who set `redactSensitive: "off"` in their OpenClaw config still have tool arguments and results redacted in event streams and display surfaces.

## Root Cause

When debugging API integration issues (e.g. testing Bearer token patterns), the aggressive redaction of `Authorization: Bearer sk-xxx` strings in tool arguments makes it impossible to see what the agent is actually passing to `exec` or `write` tools.

## Fix

`resolveToolPayloadRedaction()` now reads `loggingConfig.redactSensitive` and uses the configured mode instead of hardcoding `"tools"`. Default behavior (mode: "tools") is preserved when the config is not set to "off".

### Changes

- **`src/logging/redact.ts`**: `resolveToolPayloadRedaction()` respects `logging.redactSensitive` config
- **`src/logging/redact.test.ts`**: Updated test for config-respecting behavior, added new tests

### Impact

- **Default**: No change — tool payloads are redacted as before
- **`redactSensitive: "off"`**: Tool payloads in event streams, tool details, and display surfaces are no longer redacted
- Transcript redaction (in `transcript-redact.ts`) already respects the config independently — unchanged

### Note on execution path

The actual tool execution path (in `attempt.ts` and `embedded-agent-subscribe.ts`) passes raw, unmodified tool arguments to executors. `sanitizeToolArgs` is only called in the event emission path (`emitAgentEvent` / `onAgentEvent`). This fix ensures the event emission path also respects the user‘s redaction preference.