### PR TITLE
fix(daemon): strip leading backslash from schtasks name before managed-task comparison

### DIFF
--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -199,7 +199,10 @@ function isOpenClawGatewaySystemdService(name: string, contents: string): boolea
 }
 
 function isOpenClawGatewayTaskName(name: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(name);
+  // Windows schtasks may report names with a leading backslash
+  // (e.g. "\OpenClaw Gateway"); strip it before comparison.
+  const stripped = name.replace(/^\\/u, "");
+  const normalized = normalizeLowercaseStringOrEmpty(stripped);
   if (!normalized) {
     return false;
   }


### PR DESCRIPTION
## Summary
Windows scheduled tasks created via `schtasks /create` may produce names with leading backslashes. Strip it before comparing with managed task list.

## Changes
- `src/daemon/inspect.ts`: Normalize task name before comparison

## Files
1 file changed, 4 insertions(+), 1 deletion(-)

## Verification
- Minimal, targeted fix
- No behavioral change for non-Windows paths
