### PR TITLE
fix(acp): recover stale persistent sessions by structured resume-required code [AI-assisted]

### DIFF
--- a/packages/acp-core/src/runtime/errors.ts
+++ b/packages/acp-core/src/runtime/errors.ts
@@ -17,12 +17,23 @@ const ACP_ERROR_CODE_SET = new Set<AcpRuntimeErrorCode>(ACP_ERROR_CODES);
 /** Error type used at ACP runtime boundaries so callers can preserve structured failure codes. */
 export class AcpRuntimeError extends Error {
   readonly code: AcpRuntimeErrorCode;
+  /**
+   * Backend-specific structured failure code (e.g. acpx "SESSION_RESUME_REQUIRED"),
+   * preserved so recovery decisions key on the failure kind rather than parsing
+   * the human-readable message.
+   */
+  readonly detailCode?: string;
   override readonly cause?: unknown;
 
-  constructor(code: AcpRuntimeErrorCode, message: string, options?: { cause?: unknown }) {
+  constructor(
+    code: AcpRuntimeErrorCode,
+    message: string,
+    options?: { cause?: unknown; detailCode?: string },
+  ) {
     super(message);
     this.name = "AcpRuntimeError";
     this.code = code;
+    this.detailCode = options?.detailCode;
     this.cause = options?.cause;
   }
 }

--- a/src/acp/control-plane/manager.runtime-resume-state.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.ts
@@ -17,12 +17,28 @@ export function isRecoverableManagerAcpxExitError(message: string): boolean {
   return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
 }
 
-function isRecoverableMissingManagerPersistentSessionError(message: string): boolean {
-  const normalized = message.trim();
-  return (
-    /persistent acp session .* could not be resumed/i.test(normalized) &&
-    /(resource not found|no matching session)/i.test(normalized)
-  );
+/** acpx detail code for a persistent session that can no longer be resumed and must be re-created. */
+const SESSION_RESUME_REQUIRED_DETAIL_CODE = "SESSION_RESUME_REQUIRED";
+
+/**
+ * Detects a "persistent session can no longer be resumed" failure by acpx's
+ * structured detail code, on the error itself or anywhere in its cause chain.
+ * Keying on the structured code rather than the human reason text is what makes
+ * recovery independent of the backend's wording — Claude reports "Resource not
+ * found", Kiro reports "Internal error" (RequestError -32603), but both wrap a
+ * SessionResumeRequiredError; matching the reason text missed Kiro and left the
+ * thread permanently stuck (#87830).
+ */
+function isRecoverableMissingManagerPersistentSessionError(error: AcpRuntimeError): boolean {
+  let current: unknown = error;
+  // Depth-capped to defend against self-referential cause cycles.
+  for (let depth = 0; current && depth < 8; depth += 1) {
+    if ((current as { detailCode?: unknown }).detailCode === SESSION_RESUME_REQUIRED_DETAIL_CODE) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 /** Prepares a one-time fresh-handle retry for recoverable pre-output runtime failures. */
@@ -51,7 +67,7 @@ export async function prepareFreshManagerRuntimeHandleRetry(params: {
     !params.runtime ||
     !params.meta ||
     params.meta.mode !== "persistent" ||
-    !isRecoverableMissingManagerPersistentSessionError(params.error.message)
+    !isRecoverableMissingManagerPersistentSessionError(params.error)
   ) {
     return false;
   }

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -1,4 +1,5 @@
 /** Tests ACP turn terminal results and detached-task progress outcomes. */
+import type { AcpRuntimeEvent } from "@openclaw/acp-core/runtime/types";
 import { describe, expect, it, vi } from "vitest";
 import {
   requireTaskByRunId,
@@ -955,7 +956,11 @@ describe("AcpSessionManager turn results", () => {
     }
   });
 
-  it("retries once with a fresh persistent session after an early missing-session turn failure", async () => {
+  // Drives a thread-bound persistent ACP session whose first turn fails because
+  // the backend can no longer resume the stale session id, then a clean second
+  // turn. Returns observers so each case can assert whether the manager
+  // discarded the stale identity and retried fresh (#87830).
+  function setupStaleResumeScenario(firstTurn: () => AsyncIterable<AcpRuntimeEvent>) {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
       id: "acpx",
@@ -963,9 +968,7 @@ describe("AcpSessionManager turn results", () => {
     });
     const sessionKey = "agent:claude:acp:binding:discord:default:retry-no-session";
     let currentMeta: SessionAcpMeta = {
-      ...readySessionMeta({
-        agent: "claude",
-      }),
+      ...readySessionMeta({ agent: "claude" }),
       runtimeSessionName: sessionKey,
       identity: {
         state: "resolved",
@@ -976,11 +979,7 @@ describe("AcpSessionManager turn results", () => {
     };
     hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
       const key = (paramsUnknown as { sessionKey?: string }).sessionKey ?? sessionKey;
-      return {
-        sessionKey: key,
-        storeSessionKey: key,
-        acp: currentMeta,
-      };
+      return { sessionKey: key, storeSessionKey: key, acp: currentMeta };
     });
     hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
       const params = paramsUnknown as {
@@ -993,11 +992,7 @@ describe("AcpSessionManager turn results", () => {
       if (next) {
         currentMeta = next;
       }
-      return {
-        sessionId: "session-1",
-        updatedAt: Date.now(),
-        acp: currentMeta,
-      };
+      return { sessionId: "session-1", updatedAt: Date.now(), acp: currentMeta };
     });
     runtimeState.ensureSession.mockImplementation(async (inputUnknown: unknown) => {
       const input = inputUnknown as {
@@ -1018,44 +1013,90 @@ describe("AcpSessionManager turn results", () => {
       details: { status: "alive" },
     });
     runtimeState.runTurn
-      .mockImplementationOnce(async function* () {
-        yield {
-          type: "error" as const,
-          code: "NO_SESSION",
-          message:
-            "Persistent ACP session acpx-sid-stale could not be resumed: Resource not found: acpx-sid-stale",
-        };
-      })
+      .mockImplementationOnce(firstTurn)
       .mockImplementationOnce(async function* () {
         yield { type: "done" as const };
       });
-
     const manager = new AcpSessionManager();
-    await expect(
+    const runTurn = () =>
       manager.runTurn({
         cfg: baseCfg,
         sessionKey,
         text: "do work",
         mode: "prompt",
         requestId: "run-no-session",
-      }),
-    ).resolves.toBeUndefined();
+      });
+    return { runtimeState, sessionKey, runTurn, getMeta: () => currentMeta };
+  }
 
-    expect(runtimeState.prepareFreshSession).toHaveBeenCalledWith({
-      sessionKey,
+  function expectFreshRetry(scenario: ReturnType<typeof setupStaleResumeScenario>) {
+    expect(scenario.runtimeState.prepareFreshSession).toHaveBeenCalledWith({
+      sessionKey: scenario.sessionKey,
     });
-    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
-    expectRecordFields(mockCallArg(runtimeState.ensureSession), {
-      sessionKey,
+    expect(scenario.runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(scenario.runtimeState.ensureSession), {
+      sessionKey: scenario.sessionKey,
       resumeSessionId: "acpx-sid-stale",
     });
-    const retryInput = mockCallArg(runtimeState.ensureSession, 1);
-    expect(retryInput.resumeSessionId).toBeUndefined();
-    expect(currentMeta.identity?.acpxSessionId).toBe("acpx-sid-fresh");
-    expect(currentMeta.identity?.state).toBe("resolved");
+    expect(mockCallArg(scenario.runtimeState.ensureSession, 1).resumeSessionId).toBeUndefined();
+    expect(scenario.getMeta().identity?.acpxSessionId).toBe("acpx-sid-fresh");
+    expect(scenario.getMeta().identity?.state).toBe("resolved");
     const states = extractStatesFromUpserts();
     expect(states).toContain("running");
     expect(states).toContain("idle");
     expect(states).not.toContain("error");
+  }
+
+  // The structured SESSION_RESUME_REQUIRED detail code drives recovery
+  // regardless of the backend's human-readable reason. Claude reports
+  // "Resource not found"; Kiro reports "Internal error" (RequestError -32603) —
+  // both must discard the stale persistent id and retry fresh (#87830).
+  it.each([
+    ["Resource not found", "Resource not found: acpx-sid-stale"],
+    ["Internal error (Kiro RequestError -32603)", "Internal error"],
+  ])(
+    "retries with a fresh persistent session on a resume-required error: %s",
+    async (_label, reason) => {
+      const scenario = setupStaleResumeScenario(async function* () {
+        yield {
+          type: "error" as const,
+          code: "NO_SESSION",
+          detailCode: "SESSION_RESUME_REQUIRED",
+          message: `Persistent ACP session acpx-sid-stale could not be resumed: ${reason}`,
+        };
+      });
+      await expect(scenario.runTurn()).resolves.toBeUndefined();
+      expectFreshRetry(scenario);
+    },
+  );
+
+  it("recovers when the resume-required error is wrapped as a thrown cause", async () => {
+    const scenario = setupStaleResumeScenario(
+      // eslint-disable-next-line require-yield -- an async generator that only throws is a valid empty stream.
+      async function* () {
+        const error = new Error(
+          "Persistent ACP session acpx-sid-stale could not be resumed: Internal error",
+        ) as Error & { detailCode?: string };
+        error.detailCode = "SESSION_RESUME_REQUIRED";
+        throw error;
+      },
+    );
+    await expect(scenario.runTurn()).resolves.toBeUndefined();
+    expectFreshRetry(scenario);
+  });
+
+  it("does not retry a generic Internal error that is not a resume-required failure", async () => {
+    const scenario = setupStaleResumeScenario(async function* () {
+      // No SESSION_RESUME_REQUIRED detail code: a generic backend failure must
+      // surface, not silently discard the persistent session and retry.
+      yield {
+        type: "error" as const,
+        code: "ACP_TURN_FAILED",
+        message: "Internal error",
+      };
+    });
+    await expect(scenario.runTurn()).rejects.toThrow();
+    expect(scenario.runtimeState.prepareFreshSession).not.toHaveBeenCalled();
+    expect(scenario.runtimeState.ensureSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -42,6 +42,7 @@ async function consumeAcpTurnEvents(params: {
       streamError = new AcpRuntimeError(
         normalizeAcpErrorCode(event.code),
         normalizeText(event.message) || "ACP turn failed before completion.",
+        event.detailCode ? { detailCode: event.detailCode } : undefined,
       );
     } else if (event.type === "text_delta" || event.type === "tool_call") {
       sawOutput = true;
@@ -64,6 +65,7 @@ function errorFromTurnResult(result: Extract<AcpRuntimeTurnResult, { status: "fa
   return new AcpRuntimeError(
     normalizeAcpErrorCode(result.error.code),
     normalizeText(result.error.message) || "ACP turn failed before completion.",
+    result.error.detailCode ? { detailCode: result.error.detailCode } : undefined,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #87830 — thread-bound persistent ACP sessions stop replying on the second turn for Kiro.

When a backend can no longer resume a stale persistent session, acpx raises a `SessionResumeRequiredError` whose **reason text varies by backend**: Claude reports `"Resource not found"`, Kiro reports `"Internal error"` (`RequestError -32603`). OpenClaw's recovery gate (`manager.runtime-resume-state.ts`) matched the *human reason text* and required `"resource not found"`, so Kiro's "Internal error" never triggered the fresh-session retry — the turn failed with `ACP_TURN_FAILED` and the thread produced no reply, while Claude (whose reason happened to match the regex) recovered.

**Root cause is deeper than the reason text:** acpx tags every such failure with the structured contract `detailCode: "SESSION_RESUME_REQUIRED"` (`retryable: true`), independent of wording. But the two `AcpRuntimeError` construction seams (`consumeAcpTurnEvents`, `errorFromTurnResult`) were **discarding `detailCode`**, leaving the gate no choice but to parse the message.

The fix:
1. Preserve `detailCode` on `AcpRuntimeError` (additive optional field) so structured failure data isn't thrown away at construction.
2. Thread `detailCode` through both seams.
3. Match `SESSION_RESUME_REQUIRED` structurally across the error and its cause chain, instead of the reason regex.

This recovers **every** backend's resume-required failure (not just the two observed reasons) and is *more precise* than the old regex — a generic "Internal error" without the structured code is surfaced rather than silently retried.

### Relationship to #93315

#93315 (@xialonglee) targets the same bug by extending the message regex to also match `SessionResumeRequiredError` / `session resume required`. That approach cannot match the real failure: acpx builds the message as `` `Persistent ACP session ${id} could not be resumed: ${reason}` `` (acpx dist `live-checkpoint`, `makeSessionResumeRequiredError`), so the `AcpRuntimeError.message` reaching the gate is `"Persistent ACP session … could not be resumed: Internal error"` — the `SessionResumeRequiredError` string is the error's `.name`, never in the message (the seams use `normalizeText(event.message)` / `normalizeText(result.error.message)`, the raw message, not the `formatAcpErrorChain` rendering). #93315's retry test passes only because it manually concatenates `" <- SessionResumeRequiredError: …"` into the test event message — a string the real pipeline does not emit. Keying on the structured `detailCode` avoids depending on message wording entirely.

AI-assisted (Claude Code), directed and reviewed by the PR author.

## Real behavior proof

Behavior addressed: a thread-bound persistent ACP turn whose backend reports a resume-required failure with reason "Internal error" (Kiro / `RequestError -32603`) now discards the stale persistent identity and retries with a fresh session, instead of failing the turn (#87830).

Real environment tested: macOS (Darwin), Node 22, the real `AcpSessionManager` turn runner exercised end-to-end through `manager.runTurn` with the actual recovery path (`prepareFreshManagerRuntimeHandleRetry` → `ensureSession`). The failure reproduces fully at the manager boundary: the recovery code is pure error-classification and makes no backend/Bot-API call, so a mocked runtime emitting the exact acpx error shape (`detailCode: "SESSION_RESUME_REQUIRED"`, message `"…could not be resumed: Internal error"`) drives the real production path.

Exact steps or command run after this patch:
1. `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts`
2. Revert the three source files to `origin/main` and re-run to confirm the new cases fail without the fix.

Evidence after fix: copied live command output.

With the fix — all cases pass (the two resume-required reasons, the thrown-cause shape, and the negative precision case):

```
Tests  18 passed (18)
```

Reverting the source (matcher + seams + AcpRuntimeError) to `origin/main`, the Kiro "Internal error" and thrown-cause cases fail while the happy-path and precision cases still pass — proving the new behavior:

```
×  retries with a fresh persistent session on a resume-required error: Internal error (Kiro RequestError -32603)
×  recovers when the resume-required error is wrapped as a thrown cause
Tests  2 failed | 16 passed (18)
Caused by: AcpRuntimeError: Persistent ACP session acpx-sid-stale could not be resumed: Internal error
```

Dependency contract verified directly in `node_modules/acpx` dist: `SessionResumeRequiredError extends AcpxOperationalError` with `detailCode: "SESSION_RESUME_REQUIRED"`, `retryable: true`; the message is `` `Persistent ACP session ${id} could not be resumed: ${reason}` ``.

Observed result after fix: the manager calls `prepareFreshSession`, re-runs `ensureSession` with `resumeSessionId` undefined, the session identity is replaced with the fresh backend id, and the turn completes; session state transitions running→idle with no error.

What was not tested: the full gateway/chat surface (channel → gateway → manager) end-to-end. The resume failure and recovery themselves were validated **live** against a real `kiro-cli` backend through the real acpx runtime and the real manager seams (`consumeAcpTurnStream` → `prepareFreshManagerRuntimeHandleRetry`) — see "Live Kiro backend proof" below — not mocked.

## Live Kiro backend proof

Reproduced the failure **and** recovery against a real, logged-in `kiro-cli` 2.8.1 (free AWS Builder ID) — no mock backend.

**Backend (raw ACP over stdio).** A session is created in one `kiro-cli acp` process; that process is killed (gateway restart); a fresh `kiro-cli acp` asked to `session/load` it rejects with the exact #87830 shape:

```
session/load REJECTED: { "name":"RequestError", "code": -32603,
  "message": "Internal error",
  "data": "Failed to start session: Session not found: <session-id>" }
```

Kiro advertises `agentCapabilities.loadSession: true`, so acpx does attempt the reconnect — and the rejection is `-32603 "Internal error"`, not Claude's "Resource not found".

**End-to-end (real acpx runtime + real manager seams).** Turn 1 creates a persistent Kiro session with a real agent message (non-fallback-safe); a fresh acpx runtime sharing the same on-disk session store runs turn 2 → acpx reconnect → live Kiro `-32603` → real `consumeAcpTurnStream` → real `prepareFreshManagerRuntimeHandleRetry`:

```json
{ "kiroVersion": "kiro-cli 2.8.1",
  "turn2RuntimeError": [{ "type":"error", "code":"ACP_TURN_FAILED",
    "detailCode":"SESSION_RESUME_REQUIRED", "retryable":true,
    "message":"Persistent ACP session <id> could not be resumed: Internal error" }],
  "turn2ThrownError": { "instanceofAcpRuntimeError":true, "code":"ACP_TURN_FAILED",
    "detailCode":"SESSION_RESUME_REQUIRED" },
  "recovery": { "retry":true, "identityDowngradedTo":"pending", "runtimeHandleClearedAfter":true },
  "negativeControl": { "message":"…could not be resumed: Internal error", "detailCode":null, "retry":false } }
```

Negative control: the same human message with `detailCode` stripped → `retry: false`. Recovery fires on acpx's structured `SESSION_RESUME_REQUIRED`, never the reason text — which is exactly why the old text-match missed Kiro. (Live harness available on request.)

## Verification

- `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts` — 18 passed (4 new cases).
- ACP control-plane + acp-core runtime suites pass (`manager.test`, `manager.failover`, `manager.backend-failover`, `manager.initialize-session`, `manager.startup-identity-reconcile`, `acp-core/runtime/errors`, `error-text`).
- New regression cases fail against `origin/main`'s source and pass with the fix (verified by reverting the three source files).
- Live recovery validated against real `kiro-cli` 2.8.1 (raw ACP `-32603` repro + real acpx runtime through the real manager seams; run locally, not in CI).
- `tsgo:core` + `tsgo:core:test` green; oxlint/oxfmt clean; `pnpm build` green.

Release-note context: persistent ACP threads (notably Kiro) no longer get permanently stuck after a stale-session resume failure; recovery now keys on acpx's structured resume-required code rather than the backend's reason wording. Reported by @chouzz in #87830.
