### PR TITLE
fix(acpx): fail closed on Windows wrapper spawns

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -198,6 +198,9 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
     expect(wrapper).toContain('"@agentclientprotocol/claude-agent-acp@0.39.0"');
     expect(wrapper).toContain('"--", "claude-agent-acp"');
+    expect(wrapper).toContain('process.platform === "win32"');
+    expect(wrapper).toContain("direct npx.cmd/npx.ps1 wrapper spawn is disabled");
+    expect(wrapper).not.toContain('"npx.cmd"');
     expect(wrapper).not.toContain("@agentclientprotocol/claude-agent-acp@^0.31.0");
     expect(wrapper).not.toContain("@agentclientprotocol/claude-agent-acp@0.31.0");
   });

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -415,19 +415,37 @@ if (installedBinPath) {
 } else if (npmCliPath) {
   defaultCommand = process.execPath;
   defaultArgs = [npmCliPath, "exec", "--yes", "--package", "${params.packageSpec}", "--", "${params.binName}"];
+} else if (process.platform === "win32") {
+  defaultCommand = undefined;
+  defaultArgs = [];
 } else {
-  defaultCommand = process.platform === "win32" ? "npx.cmd" : "npx";
+  defaultCommand = "npx";
   defaultArgs = ["--yes", "--package", "${params.packageSpec}", "--", "${params.binName}"];
 }
-const command =
-  configuredArgs[0] === "${RUN_CONFIGURED_COMMAND_SENTINEL}" ? configuredArgs[1] : defaultCommand;
+const usesConfiguredCommand = configuredArgs[0] === "${RUN_CONFIGURED_COMMAND_SENTINEL}";
+const command = usesConfiguredCommand ? configuredArgs[1] : defaultCommand;
 const args =
-  configuredArgs[0] === "${RUN_CONFIGURED_COMMAND_SENTINEL}"
+  usesConfiguredCommand
     ? configuredArgs.slice(2)
     : [...defaultArgs, ...configuredArgs];
 
 if (!command) {
-  console.error("[openclaw] missing configured ${params.displayName} ACP command");
+  if (usesConfiguredCommand) {
+    console.error("[openclaw] missing configured ${params.displayName} ACP command");
+  } else if (process.platform === "win32") {
+    console.error(
+      "[openclaw] cannot launch ${params.displayName} ACP adapter on Windows: npm CLI was not found and direct npx.cmd/npx.ps1 wrapper spawn is disabled. Reinstall @openclaw/acpx dependencies or install Node.js with npm, then retry.",
+    );
+  } else {
+    console.error("[openclaw] missing ${params.displayName} ACP command");
+  }
+  process.exit(1);
+}
+
+if (process.platform === "win32" && /\\.(?:cmd|bat|ps1)$/i.test(path.basename(command))) {
+  console.error(
+    "[openclaw] cannot launch ${params.displayName} ACP adapter on Windows through a direct .cmd/.bat/.ps1 wrapper. Configure an .exe or Node entrypoint, or use an explicit cmd.exe wrapper if shell execution is intentionally allowed.",
+  );
   process.exit(1);
 }
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -274,6 +274,57 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(testing.normalizeClaudeAcpModelOverride("custom-model")).toBe("custom-model");
   });
 
+  it("logs and wraps ACP adapter spawn EINVAL failures with Windows guidance", async () => {
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const logger = { error: vi.fn() };
+    const { runtime, delegate } = makeRuntime(baseStore, {
+      openclawLogger: logger,
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "claude"
+            ? "npx -y @agentclientprotocol/claude-agent-acp@0.39.0 --token sk-testsecret1234567890"
+            : agentName,
+        list: () => ["claude", "openclaw"],
+      },
+    });
+    const cause = Object.assign(new Error("spawn EINVAL"), { code: "EINVAL" });
+    vi.spyOn(delegate, "ensureSession").mockRejectedValue(
+      new Error("Failed to spawn agent command: npx -y @agentclientprotocol/claude-agent-acp", {
+        cause,
+      }),
+    );
+
+    const outcome = await runtime
+      .ensureSession({
+        sessionKey: "agent:claude:acp:test",
+        agent: "claude",
+        mode: "persistent",
+      })
+      .then(
+        () => ({ status: "resolved" as const }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      );
+
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status !== "rejected") {
+      return;
+    }
+    expect(outcome.error).toBeInstanceOf(AcpRuntimeError);
+    expect(outcome.error).toMatchObject({
+      code: "ACP_SESSION_INIT_FAILED",
+      message: expect.stringContaining("ACP adapter spawn failed"),
+    });
+    expect((outcome.error as Error).message).toContain("direct .cmd/.bat/.ps1 wrappers");
+    expect(logger.error).toHaveBeenCalledOnce();
+    const logLine = String(logger.error.mock.calls[0]?.[0] ?? "");
+    expect(logLine).toContain("embedded acpx runtime agent spawn failed");
+    expect(logLine).toContain("@agentclientprotocol/claude-agent-acp");
+    expect(logLine).not.toContain("sk-testsecret1234567890");
+  });
+
   it("leaves Codex ACP startup defaults alone when no model or thinking is provided", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -26,7 +26,12 @@ import {
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { AcpRuntimeError, type AcpRuntime, type AcpRuntimeErrorCode } from "../runtime-api.js";
+import {
+  AcpRuntimeError,
+  type AcpRuntime,
+  type AcpRuntimeErrorCode,
+  type PluginLogger,
+} from "../runtime-api.js";
 import { splitCommandParts } from "./command-line.js";
 import {
   createAcpxProcessLeaseId,
@@ -49,6 +54,7 @@ type OpenClawAcpxRuntimeOptions = AcpRuntimeOptions & {
   openclawWrapperRoot?: string;
   openclawGatewayInstanceId?: string;
   openclawProcessLeaseStore?: AcpxProcessLeaseStore;
+  openclawLogger?: Pick<PluginLogger, "error">;
 };
 type AcpxRuntimeTestOptions = Record<string, unknown> & {
   openclawProcessCleanup?: AcpxProcessCleanupDeps;
@@ -107,6 +113,50 @@ function codexWrapperStderrLogFileName(leaseId: string): string {
 
 function compactDiagnosticText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+function collectErrorChainText(error: unknown): string[] {
+  const seen = new Set<unknown>();
+  const values: string[] = [];
+  let current = error;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    if (typeof current === "object") {
+      const { code, message, cause } = current as {
+        code?: unknown;
+        message?: unknown;
+        cause?: unknown;
+      };
+      for (const value of [code, message]) {
+        if (typeof value === "string" && value.trim()) {
+          values.push(value.trim());
+        }
+      }
+      current = cause;
+      continue;
+    }
+    if (typeof current === "string" && current.trim()) {
+      values.push(current.trim());
+    }
+    break;
+  }
+  return values;
+}
+
+function formatAcpSpawnFailureMessage(error: unknown): string | undefined {
+  const chain = collectErrorChainText(error);
+  const joined = chain.join(" ");
+  if (
+    !/\bspawn\b/i.test(joined) ||
+    !/\b(?:EINVAL|ENOENT|EACCES|EPERM|Failed to spawn agent command)\b/i.test(joined)
+  ) {
+    return undefined;
+  }
+  const detail = compactDiagnosticText(redactSensitiveText(chain.join(": "))).slice(0, 1_000);
+  return (
+    `ACP adapter spawn failed${detail ? `: ${detail}` : ""}. ` +
+    "On Windows, ACPX adapter commands must resolve to a Node or .exe entrypoint; direct .cmd/.bat/.ps1 wrappers are not spawned without an explicit safe shell wrapper."
+  );
 }
 
 function isGenericInternalAcpErrorMessage(message: string): boolean {
@@ -676,6 +726,7 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly wrapperRoot: string | undefined;
   private readonly gatewayInstanceId: string | undefined;
   private readonly processLeaseStore: AcpxProcessLeaseStore | undefined;
+  private readonly logger: Pick<PluginLogger, "error"> | undefined;
   private readonly launchLeaseScope = new AsyncLocalStorage<AcpxLaunchLeaseContext | undefined>();
   private readonly cwd: string;
 
@@ -685,6 +736,7 @@ export class AcpxRuntime implements AcpRuntime {
     this.wrapperRoot = options.openclawWrapperRoot;
     this.gatewayInstanceId = options.openclawGatewayInstanceId;
     this.processLeaseStore = options.openclawProcessLeaseStore;
+    this.logger = options.openclawLogger;
     this.cwd = options.cwd;
     this.sessionStore = createResetAwareSessionStore(options.sessionStore, {
       gatewayInstanceId: this.gatewayInstanceId,
@@ -841,7 +893,13 @@ export class AcpxRuntime implements AcpRuntime {
     return await this.launchLeaseScope.run(launch, params.run);
   }
 
-  private async withCodexWrapperDiagnostics<T>(params: {
+  private logAcpSpawnFailure(params: { command: string | undefined; message: string }): void {
+    this.logger?.error(
+      `embedded acpx runtime agent spawn failed: command=${redactSensitiveText(params.command ?? "(unknown)")}; error=${redactSensitiveText(params.message)}`,
+    );
+  }
+
+  private async withSessionInitDiagnostics<T>(params: {
     command: string | undefined;
     fallbackCode: AcpRuntimeErrorCode;
     run: () => Promise<T>;
@@ -849,6 +907,16 @@ export class AcpxRuntime implements AcpRuntime {
     try {
       return await params.run();
     } catch (error) {
+      const spawnFailureMessage = formatAcpSpawnFailureMessage(error);
+      if (spawnFailureMessage) {
+        this.logAcpSpawnFailure({
+          command: params.command,
+          message: spawnFailureMessage,
+        });
+        throw new AcpRuntimeError(params.fallbackCode, spawnFailureMessage, {
+          cause: error,
+        });
+      }
       if (!isCodexAcpCommand(params.command) || !isGenericInternalAcpError(error)) {
         throw error;
       }
@@ -986,7 +1054,7 @@ export class AcpxRuntime implements AcpRuntime {
         command: stableLaunchCommand,
         enabled: shouldStartWithLease,
         run: () =>
-          this.withCodexWrapperDiagnostics({
+          this.withSessionInitDiagnostics({
             command: stableLaunchCommand,
             fallbackCode: "ACP_SESSION_INIT_FAILED",
             run: () => delegate.ensureSession(withAcpxSessionOptions(ensureInput)),
@@ -1006,7 +1074,7 @@ export class AcpxRuntime implements AcpRuntime {
       enabled: shouldStartWithLease,
       run: () =>
         this.codexAcpModelOverrideScope.run(codexModelOverride, () =>
-          this.withCodexWrapperDiagnostics({
+          this.withSessionInitDiagnostics({
             command: stableLaunchCommand,
             fallbackCode: "ACP_SESSION_INIT_FAILED",
             run: () => delegate.ensureSession(withAcpxSessionOptions(normalizedInput)),

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -103,6 +103,7 @@ function createLazyDefaultRuntime(params: AcpxRuntimeFactoryParams): AcpxRuntime
         openclawGatewayInstanceId: params.gatewayInstanceId,
         openclawProcessLeaseStore: params.processLeaseStore,
         openclawWrapperRoot: params.wrapperRoot,
+        openclawLogger: params.logger,
         sessionStore: module.createFileSessionStore({
           stateDir: params.pluginConfig.stateDir,
         }),

--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -57,6 +57,21 @@ describe("resolveWindowsSpawnProgram", () => {
     ).toThrow(/without shell execution/);
   });
 
+  it("fails closed by default for unresolved Windows PowerShell wrappers", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const shimPath = path.join(dir, "npx.ps1");
+    await writeFile(shimPath, "Write-Output wrapper\n", "utf8");
+
+    expect(() =>
+      resolveWindowsSpawnProgram({
+        command: shimPath,
+        platform: "win32",
+        env: { PATH: dir, PATHEXT: ".PS1;.CMD;.EXE;.BAT" },
+        execPath: "C:\\node\\node.exe",
+      }),
+    ).toThrow(/without shell execution/);
+  });
+
   it("only returns shell fallback when explicitly opted in", async () => {
     const dir = await createTempDir("openclaw-windows-spawn-test-");
     const shimPath = path.join(dir, "wrapper.cmd");

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -338,6 +338,14 @@ export function resolveWindowsSpawnProgramCandidate(
     };
   }
 
+  if (ext === ".ps1") {
+    return {
+      command: resolvedCommand,
+      leadingArgv: [],
+      resolution: "unresolved-wrapper",
+    };
+  }
+
   return {
     command: resolvedCommand,
     leadingArgv: [],

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -607,111 +607,79 @@ function createStartupConfig(params: {
   memorySlot?: string;
   contextEngine?: string;
 }) {
-  const slotsConfig = {
-    ...(params.memorySlot ? { memory: params.memorySlot } : {}),
-    ...(params.contextEngine ? { contextEngine: params.contextEngine } : {}),
-  };
+  const slotsConfig: Record<string, string> = {};
+  if (params.memorySlot) {
+    slotsConfig.memory = params.memorySlot;
+  }
+  if (params.contextEngine) {
+    slotsConfig.contextEngine = params.contextEngine;
+  }
   const hasSlots = Object.keys(slotsConfig).length > 0;
-  return {
-    ...(params.noConfiguredChannels
-      ? {
-          channels: {},
-        }
-      : params.channelIds?.length
-        ? {
-            channels: Object.fromEntries(
-              params.channelIds.map((channelId) => [channelId, { enabled: true }]),
-            ),
-          }
-        : {}),
-    ...(params.enabledPluginIds?.length
-      ? {
-          plugins: {
-            ...(params.allowPluginIds?.length ? { allow: params.allowPluginIds } : {}),
-            ...(hasSlots ? { slots: slotsConfig } : {}),
-            entries: Object.fromEntries(
-              params.enabledPluginIds.map((pluginId) => [pluginId, { enabled: true }]),
-            ),
+  const config = {} as Record<string, unknown>;
+
+  if (params.noConfiguredChannels) {
+    config.channels = {};
+  } else if (params.channelIds?.length) {
+    config.channels = Object.fromEntries(
+      params.channelIds.map((channelId) => [channelId, { enabled: true }]),
+    );
+  }
+
+  if (params.enabledPluginIds?.length || params.allowPluginIds?.length || hasSlots) {
+    const plugins = {} as Record<string, unknown>;
+    if (params.allowPluginIds?.length) {
+      plugins.allow = params.allowPluginIds;
+    }
+    if (hasSlots) {
+      plugins.slots = slotsConfig;
+    }
+    if (params.enabledPluginIds?.length) {
+      plugins.entries = Object.fromEntries(
+        params.enabledPluginIds.map((pluginId) => [pluginId, { enabled: true }]),
+      );
+    }
+    config.plugins = plugins;
+  }
+
+  if (params.providerIds?.length) {
+    config.models = {
+      providers: Object.fromEntries(
+        params.providerIds.map((providerId) => [
+          providerId,
+          {
+            baseUrl: "https://example.com",
+            models: [],
           },
-        }
-      : params.allowPluginIds?.length
-        ? {
-            plugins: {
-              allow: params.allowPluginIds,
-            },
-          }
-        : hasSlots
-          ? {
-              plugins: {
-                slots: slotsConfig,
-              },
-            }
-          : {}),
-    ...(params.providerIds?.length
-      ? {
-          models: {
-            providers: Object.fromEntries(
-              params.providerIds.map((providerId) => [
-                providerId,
-                {
-                  baseUrl: "https://example.com",
-                  models: [],
-                },
-              ]),
-            ),
-          },
-        }
-      : {}),
-    ...(params.modelId
-      ? {
-          agents: {
-            defaults: {
-              model: { primary: params.modelId },
-              ...(params.agentRuntimeId
-                ? {
-                    agentRuntime: {
-                      id: params.agentRuntimeId,
-                      fallback: "none",
-                    },
-                  }
-                : {}),
-              models: {
-                [params.modelId]: {},
-              },
-            },
-            ...(params.agentRuntimeIds?.length
-              ? {
-                  list: params.agentRuntimeIds.map((runtime, index) => ({
-                    id: `agent-${index + 1}`,
-                    agentRuntime: { id: runtime },
-                  })),
-                }
-              : {}),
-          },
-        }
-      : params.agentRuntimeId || params.agentRuntimeIds?.length
-        ? {
-            agents: {
-              defaults: params.agentRuntimeId
-                ? {
-                    agentRuntime: {
-                      id: params.agentRuntimeId,
-                      fallback: "none",
-                    },
-                  }
-                : {},
-              ...(params.agentRuntimeIds?.length
-                ? {
-                    list: params.agentRuntimeIds.map((runtime, index) => ({
-                      id: `agent-${index + 1}`,
-                      agentRuntime: { id: runtime },
-                    })),
-                  }
-                : {}),
-            },
-          }
-        : {}),
-  } as OpenClawConfig;
+        ]),
+      ),
+    };
+  }
+
+  if (params.modelId || params.agentRuntimeId || params.agentRuntimeIds?.length) {
+    const defaults = {} as Record<string, unknown>;
+    if (params.modelId) {
+      defaults.model = { primary: params.modelId };
+      defaults.models = {
+        [params.modelId]: {},
+      };
+    }
+    if (params.agentRuntimeId) {
+      defaults.agentRuntime = {
+        id: params.agentRuntimeId,
+        fallback: "none",
+      };
+    }
+    const agents = { defaults } as Record<string, unknown>;
+    if (params.agentRuntimeIds?.length) {
+      agents.list = params.agentRuntimeIds.map((runtime, index) => ({
+        id: `agent-${index + 1}`,
+        agentRuntime: { id: runtime },
+      }));
+    }
+    config.agents = agents;
+  }
+
+  return config as OpenClawConfig;
 }
 
 describe("resolveGatewayStartupPluginIds", () => {
@@ -1415,22 +1383,23 @@ describe("resolveGatewayStartupPluginIds", () => {
   });
 
   it("includes auto-enabled external web search providers at startup", () => {
+    const webSearchTools = {} as NonNullable<OpenClawConfig["tools"]>;
+    webSearchTools.web = {
+      search: {
+        enabled: true,
+        provider: "brave",
+      },
+    };
     const rawConfig = {
       channels: {},
-      tools: {
-        web: {
-          search: {
-            enabled: true,
-            provider: "brave",
-          },
-        },
-      },
+      tools: webSearchTools,
       plugins: {
         allow: ["browser"],
       },
     } as OpenClawConfig;
     const effectiveConfig = {
-      ...rawConfig,
+      channels: rawConfig.channels,
+      tools: rawConfig.tools,
       plugins: {
         allow: ["browser", "brave"],
         entries: {


### PR DESCRIPTION
Closes #93465.

Summary:
- avoid direct Windows .cmd/.bat/.ps1 adapter wrapper spawns from ACPX generated launchers
- report ACP session-init spawn failures with redacted gateway logging and actionable Windows guidance
- keep the touched extension check green by making bounded Codex thread config merging total
- refresh generated Codex prompt snapshots and current guard baselines for the rebased main

## Real behavior proof
Behavior or issue addressed: ACPX launch preparation rejects unresolved Windows PowerShell wrappers and generated Claude ACP launchers no longer contain the direct `npx.cmd` fallback that produced raw `spawn EINVAL` failures.

Real environment tested: Local OpenClaw checkout on macOS, running the real plugin SDK Windows spawn resolver and ACPX generated-wrapper path with `platform: "win32"` inputs.

Exact steps or command run after this patch: `node --import tsx` created a temporary `npx.ps1`, called `resolveWindowsSpawnProgram` with Windows platform/PATHEXT inputs, then generated the Claude ACP wrapper with `prepareAcpxCodexAuthConfig`.

Evidence after fix: Console output from the live command:

```json
{
  "ps1WrapperRejected": true,
  "generatedWrapperHasWin32Guard": true,
  "generatedWrapperMentionsDisabledDirectNpx": true,
  "generatedWrapperDirectNpxCmdLiteral": false
}
```

Observed result after fix: The PowerShell wrapper path failed closed, and the generated launcher includes the Windows guard without a direct `npx.cmd` literal fallback.

What was not tested: Live Windows gateway launch was not tested on this macOS host.
