### PR TITLE
fix(agents): strip injected inbound metadata before persisting user messages

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -281,6 +281,12 @@ export interface UserMessage {
   role: "user";
   content: string | (TextContent | ImageContent)[];
   timestamp: number; // Unix timestamp in milliseconds
+  /**
+   * Optional display label for the sender, typically derived from inbound
+   * channel metadata. Persisted separately so the raw message text can be
+   * stripped of transient metadata without losing sender attribution.
+   */
+  senderLabel?: string;
 }
 
 /** Assistant turn, including provider identity and final stop state. */

--- a/src/agents/harness/context-engine-lifecycle.test.ts
+++ b/src/agents/harness/context-engine-lifecycle.test.ts
@@ -29,6 +29,22 @@ function runtimeContextMessage(content: string, timestamp: number): AgentMessage
   } as AgentMessage;
 }
 
+function stringUserMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp,
+  } as AgentMessage;
+}
+
+function metadataPrefixedUserMessage(text: string, timestamp: number): AgentMessage {
+  return {
+    role: "user",
+    content: `Conversation info (untrusted metadata):\n\`\`\`json\n{"chat_id":"channel:123"}\n\`\`\`\n\nSender (untrusted metadata):\n\`\`\`json\n{"name":"Syu"}\n\`\`\`\n\n${text}`,
+    timestamp,
+  } as AgentMessage;
+}
+
 function createContextEngine(overrides: Partial<ContextEngine> = {}): ContextEngine {
   return {
     info: { id: "test", name: "Test context engine" },
@@ -111,6 +127,42 @@ describe("harness context engine lifecycle", () => {
       beforePromptUser,
       beforePromptAssistant,
       turnUser,
+      turnAssistant,
+    ]);
+    expect(afterTurnParams?.prePromptMessageCount).toBe(2);
+  });
+
+  it("strips injected inbound metadata before context engine afterTurn hooks", async () => {
+    const beforePromptUser = metadataPrefixedUserMessage("old ask", 1);
+    const beforePromptAssistant = textMessage("assistant", "old answer", 3);
+    const turnUser = metadataPrefixedUserMessage("new ask", 4);
+    const turnAssistant = textMessage("assistant", "new answer", 6);
+    const afterTurn = vi.fn(async () => {});
+
+    await finalizeHarnessContextEngineTurn({
+      contextEngine: createContextEngine({ afterTurn }),
+      promptError: false,
+      aborted: false,
+      yieldAborted: false,
+      sessionIdUsed: sessionParams.sessionIdUsed,
+      sessionKey: sessionParams.sessionKey,
+      sessionFile: sessionParams.sessionFile,
+      messagesSnapshot: [beforePromptUser, beforePromptAssistant, turnUser, turnAssistant],
+      prePromptMessageCount: 2,
+      tokenBudget: 2048,
+      runtimeContext: {},
+      runMaintenance: async () => undefined,
+      warn: () => {},
+    });
+
+    const afterTurnCalls = (afterTurn as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const afterTurnParams = afterTurnCalls[0]?.[0] as
+      | { messages?: AgentMessage[]; prePromptMessageCount?: number }
+      | undefined;
+    expect(afterTurnParams?.messages).toEqual([
+      stringUserMessage("old ask", 1),
+      beforePromptAssistant,
+      stringUserMessage("new ask", 4),
       turnAssistant,
     ]);
     expect(afterTurnParams?.prePromptMessageCount).toBe(2);

--- a/src/agents/harness/context-engine-lifecycle.ts
+++ b/src/agents/harness/context-engine-lifecycle.ts
@@ -1,6 +1,7 @@
 /**
  * Manages context-engine lifecycle hooks for native agent harnesses.
  */
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import type { MemoryCitationsMode } from "../../config/types.memory.js";
 import type {
   AssembleResult,
@@ -242,10 +243,37 @@ function buildContextEngineConversationSnapshot(params: {
   const turnMessages = stripRuntimeContextCustomMessages(
     params.messagesSnapshot.slice(params.prePromptMessageCount),
   );
+  const strippedPrePromptMessages = prePromptMessages.map(stripInboundMetadataFromMessage);
+  const strippedTurnMessages = turnMessages.map(stripInboundMetadataFromMessage);
   return {
-    messages: [...prePromptMessages, ...turnMessages],
-    prePromptMessageCount: prePromptMessages.length,
+    messages: [...strippedPrePromptMessages, ...strippedTurnMessages],
+    prePromptMessageCount: strippedPrePromptMessages.length,
   };
+}
+
+function stripInboundMetadataFromMessage(message: AgentMessage): AgentMessage {
+  if (message.role !== "user") {
+    return message;
+  }
+  if (typeof message.content === "string") {
+    const stripped = stripInboundMetadata(message.content);
+    return stripped === message.content ? message : { ...message, content: stripped };
+  }
+  if (!Array.isArray(message.content)) {
+    return message;
+  }
+  let changed = false;
+  const strippedContent = message.content.map((part) => {
+    if (part && typeof part === "object" && part.type === "text" && typeof part.text === "string") {
+      const stripped = stripInboundMetadata(part.text);
+      if (stripped !== part.text) {
+        changed = true;
+        return { ...part, text: stripped };
+      }
+    }
+    return part;
+  });
+  return changed ? { ...message, content: strippedContent } : message;
 }
 
 /**

--- a/src/agents/session-tool-result-guard-wrapper.test.ts
+++ b/src/agents/session-tool-result-guard-wrapper.test.ts
@@ -1,0 +1,141 @@
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { describe, expect, it } from "vitest";
+import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
+
+function buildInboundMetadataPrefixedText(body: string): string {
+  return [
+    "Conversation info (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      chat_id: "channel:123",
+      message_id: "msg-1",
+      sender_id: "sender-1",
+      sender: "Syu",
+      timestamp: "Tue 2026-06-16 13:56:07 GMT+9",
+      is_group_chat: true,
+    }),
+    "```",
+    "",
+    "Sender (untrusted metadata):",
+    "```json",
+    JSON.stringify({
+      label: "Syu (sender-1)",
+      id: "sender-1",
+      name: "Syu",
+      username: "syu8384",
+    }),
+    "```",
+    "",
+    body,
+  ].join("\n");
+}
+
+function getPersistedMessages(sm: SessionManager): AgentMessage[] {
+  return sm
+    .getEntries()
+    .filter((e) => e.type === "message")
+    .map((e) => (e as { message: AgentMessage }).message);
+}
+
+describe("guardSessionManager inbound metadata stripping", () => {
+  it("strips inbound metadata and preserves senderLabel when persisting user messages", () => {
+    const sm = SessionManager.inMemory();
+    guardSessionManager(sm);
+
+    const body = "what were the 5 email categories?";
+    const content = buildInboundMetadataPrefixedText(body);
+    sm.appendMessage({
+      role: "user",
+      content,
+      timestamp: Date.now(),
+    });
+
+    const persisted = getPersistedMessages(sm);
+    expect(persisted).toHaveLength(1);
+    const user = persisted[0] as { role: string; content: string; senderLabel?: string };
+    expect(user.role).toBe("user");
+    expect(user.content).toBe(body);
+    expect(user.content).not.toContain("untrusted metadata");
+    expect(user.senderLabel).toBe("Syu (sender-1)");
+  });
+
+  it("strips inbound metadata from user messages with array content", () => {
+    const sm = SessionManager.inMemory();
+    guardSessionManager(sm);
+
+    const body = "what were the 5 email categories?";
+    const text = buildInboundMetadataPrefixedText(body);
+    sm.appendMessage({
+      role: "user",
+      content: [
+        { type: "text", text },
+        { type: "text", text: "extra" },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const persisted = getPersistedMessages(sm);
+    expect(persisted).toHaveLength(1);
+    const user = persisted[0] as {
+      role: string;
+      content: Array<{ type: string; text: string }>;
+      senderLabel?: string;
+    };
+    expect(user.role).toBe("user");
+    expect(user.content[0].text).toBe(body);
+    expect(user.content[1].text).toBe("extra");
+    expect(user.content.map((c) => c.text).join("")).not.toContain("untrusted metadata");
+    expect(user.senderLabel).toBe("Syu (sender-1)");
+  });
+
+  it("does not strip inbound metadata from assistant messages", () => {
+    const sm = SessionManager.inMemory();
+    guardSessionManager(sm);
+
+    const content = buildInboundMetadataPrefixedText("I am the assistant");
+    sm.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: content }],
+      stopReason: "error",
+      timestamp: Date.now(),
+    });
+
+    const persisted = getPersistedMessages(sm);
+    expect(persisted).toHaveLength(1);
+    const assistant = persisted[0] as { role: string; content: Array<{ text: string }> };
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content[0].text).toContain("untrusted metadata");
+  });
+
+  it("preserves an explicit senderLabel when stripping inbound metadata", () => {
+    const sm = SessionManager.inMemory();
+    guardSessionManager(sm);
+
+    const body = "hello";
+    const content = buildInboundMetadataPrefixedText(body);
+    sm.appendMessage({
+      role: "user",
+      content,
+      timestamp: Date.now(),
+      senderLabel: "Custom Label",
+    });
+
+    const persisted = getPersistedMessages(sm);
+    const user = persisted[0] as { content: string; senderLabel?: string };
+    expect(user.content).toBe(body);
+    expect(user.senderLabel).toBe("Custom Label");
+  });
+
+  it("keeps the in-memory message identity when no metadata is present", () => {
+    const sm = SessionManager.inMemory();
+    guardSessionManager(sm);
+
+    const message = { role: "user", content: "plain", timestamp: Date.now() } as const;
+    sm.appendMessage(message);
+
+    const persisted = getPersistedMessages(sm);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toBe(message);
+  });
+});

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -3,6 +3,10 @@
  *
  * Installs message-write hooks, input provenance handling, and pending tool-result flush behavior once per manager.
  */
+import {
+  extractInboundSenderLabel,
+  stripInboundMetadata,
+} from "../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
@@ -85,6 +89,11 @@ export function guardSessionManager(
       message = redacted;
       changed = true;
     }
+    const stripped = stripInboundMetadataFromUserMessage(message);
+    if (stripped !== message) {
+      message = stripped;
+      changed = true;
+    }
     return changed ? { message } : undefined;
   };
 
@@ -151,4 +160,76 @@ export function guardSessionManager(
   (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
   (sessionManager as GuardedSessionManager).clearPendingToolResults = guard.clearPendingToolResults;
   return sessionManager as GuardedSessionManager;
+}
+
+type UserAgentMessage = Extract<AgentMessage, { role: "user" }>;
+
+function stripInboundMetadataFromUserMessage(message: AgentMessage): AgentMessage {
+  if (message.role !== "user") {
+    return message;
+  }
+  const userMessage = message as UserAgentMessage;
+  const senderLabel =
+    (message as { senderLabel?: string }).senderLabel ||
+    extractInboundSenderLabelFromMessage(userMessage);
+  const stripped = stripInboundMetadataFromMessageContent(userMessage);
+  if (!stripped && !senderLabel) {
+    return message;
+  }
+  const next: AgentMessage = { ...message };
+  if (stripped) {
+    (next as UserAgentMessage).content = stripped;
+  }
+  if (senderLabel) {
+    (next as { senderLabel?: string }).senderLabel = senderLabel;
+  }
+  return next;
+}
+
+function extractInboundSenderLabelFromMessage(message: UserAgentMessage): string | undefined {
+  const content = message.content;
+  if (typeof content === "string") {
+    return extractInboundSenderLabel(content) ?? undefined;
+  }
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        part.type === "text" &&
+        typeof part.text === "string"
+      ) {
+        const label = extractInboundSenderLabel(part.text);
+        if (label) {
+          return label;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function stripInboundMetadataFromMessageContent(
+  message: UserAgentMessage,
+): UserAgentMessage["content"] | undefined {
+  const content = message.content;
+  if (typeof content === "string") {
+    const stripped = stripInboundMetadata(content);
+    return stripped === content ? undefined : stripped;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  let changed = false;
+  const next = content.map((part) => {
+    if (part && typeof part === "object" && part.type === "text" && typeof part.text === "string") {
+      const stripped = stripInboundMetadata(part.text);
+      if (stripped !== part.text) {
+        changed = true;
+        return { ...part, text: stripped };
+      }
+    }
+    return part;
+  });
+  return changed ? next : undefined;
 }


### PR DESCRIPTION
## Summary

- Fixes same-session context loss caused by unstable user-message hashes.
- Root cause: OpenClaw injects `Conversation info` / `Sender` metadata blocks (containing `message_id`, timestamps, etc.) directly into persisted user message content. Downstream context systems that hash message content saw every turn as new.
- Solution: strip injected inbound metadata before writing user messages to the session; persist `senderLabel` explicitly on `UserMessage` so group-chat attribution survives.
- Defense-in-depth: also strip metadata from context-engine conversation snapshots.

## Linked context

Closes #39722
Closes #72704
Closes #90531
Related #77355
Related #77642
Related #87566
Related #87212

## Real behavior proof

- Behavior addressed: LCM failed to bootstrap active Discord sessions and the messages table stayed at 1 row despite 80+ session records.
- Real environment tested: local OpenClaw gateway + Discord agent + LCM plugin.
- Exact steps or command run after this patch:
  1. `pnpm openclaw gateway restart`
  2. Sent the message \"hi\" to the Discord agent in the active conversation.
  3. Ran `/lcm` in the Discord control channel.
  4. Queried the LCM state DB: `sqlite3 ~/.openclaw/lcm.db \"SELECT conversation_id, last_processed_offset FROM conversation_bootstrap_state WHERE conversation_id = <REDACTED>;\"`
- Evidence after fix: Terminal output from `/lcm` and the sqlite3 query showed `lcm health: healthy`, `messages: 4`, and a `last_processed_offset` matching the session file size. Inspecting the latest user message JSONL record showed the content contained the user text with no `Conversation info` or `Sender` metadata blocks.
- Observed result after fix: The follow-up message was ingested into the same LCM conversation and the conversation bootstrapped on the first turn after the fix, instead of remaining stuck at offset 0.
- What was not tested: Other agents or channels beyond the tested Discord session; historical rotated session files are not re-ingested.
- Before evidence: The active conversation had 1 message and `last_processed_offset: 0`; session file user records contained metadata blocks.

## Tests and validation

- Added `src/agents/session-tool-result-guard-wrapper.test.ts`
- Updated `src/agents/harness/context-engine-lifecycle.test.ts`
- `pnpm test src/agents/session-tool-result-guard-wrapper.test.ts src/agents/harness/context-engine-lifecycle.test.ts`
- `pnpm build`
- Restarted gateway and verified live ingestion.