### PR TITLE
fix(redact): respect redactSensitive off for tool payload redaction

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -986,7 +986,7 @@ describe("redactSensitiveText", () => {
     );
   });
 
-  it("forces redaction for tool details even when log redaction is disabled", () => {
+  it("respects redactSensitive off for tool details", () => {
     writeConfig(`{
       logging: {
         redactSensitive: "off",
@@ -994,7 +994,7 @@ describe("redactSensitiveText", () => {
     }`);
 
     expect(redactToolDetail("OPENAI_API_KEY=sk-1234567890abcdef")).toBe(
-      "OPENAI_API_KEY=sk-123…cdef",
+      "OPENAI_API_KEY=sk-1234567890abcdef",
     );
   });
 

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -999,16 +999,22 @@ function resolveToolPayloadRedaction(
   loggingConfig: LoggingConfig | undefined = readLoggingConfig(),
 ): RedactOptions {
   const userPatterns = loggingConfig?.redactPatterns;
+  const mode = normalizeMode(loggingConfig?.redactSensitive);
+  if (mode === "off") {
+    return { mode: "off", patterns: [] };
+  }
   const patterns =
     userPatterns && userPatterns.length > 0
       ? [...userPatterns, ...DEFAULT_REDACT_PATTERNS]
       : undefined;
-  return { mode: "tools", patterns };
+  return { mode, patterns };
 }
 
-// Forces tools-mode regardless of `logging.redactSensitive` (which governs log
-// output, not UI surfaces), and merges user `logging.redactPatterns` with the
-// built-in defaults so both apply.
+// Resolves tool payload redaction, respecting `logging.redactSensitive` when
+// set, and merges user `logging.redactPatterns` with the built-in defaults
+// so both apply. When `redactSensitive` is "off", all tool payload redaction
+// is disabled, matching the user's intent to disable sensitive-value masking
+// (including in tool event args such as `Authorization: Bearer` headers).
 export function redactToolPayloadText(text: string): string {
   return redactToolPayloadTextWithConfig(text, readLoggingConfig());
 }


### PR DESCRIPTION
## Summary

Previously `resolveToolPayloadRedaction()` hardcoded `mode: "tools"`, ignoring the `logging.redactSensitive` config setting entirely. This meant users who set `redactSensitive: "off"` could not disable sensitive-value masking in tool event args (e.g. `Authorization: Bearer sk-xxx` headers in `web_fetch` args).

## Root Cause

In `src/logging/redact.ts`, `resolveToolPayloadRedaction()` always returned `{ mode: "tools", patterns }` regardless of what `redactSensitive` was set to. The existing test explicitly confirmed this was by-design: `"forces redaction for tool details even when log redaction is disabled"`.

However, this behavior conflicts with user expectations. When a user sets `redactSensitive: "off"`, they intend to disable ALL sensitive value masking, including in tool payloads. The hardcoded `tools` mode causes issues with tools like `web_fetch` where `Authorization: Bearer` credentials in args get redacted before reaching event surfaces, even though actual tool execution uses the original args.

## Fix

`resolveToolPayloadRedaction()` now:
1. Reads `redactSensitive` from the logging config and normalizes it via `normalizeMode()`
2. Returns `{ mode: "off", patterns: [] }` when mode is `"off"`
3. Uses the resolved mode instead of hardcoded `"tools"` for all other cases

## Changes

- `src/logging/redact.ts`: Updated `resolveToolPayloadRedaction()` to respect config
- `src/logging/redact.test.ts`: Updated test to expect no redaction when `redactSensitive: "off"`

## Verification

- Default behavior unchanged: `redactSensitiveFieldValue` without explicit options still uses tool-mode redaction by default (since `normalizeMode(undefined)` returns `"tools"`)
- When `redactSensitive: "off"` is set, `sanitizeToolArgs`, `redactToolPayloadText`, and `redactToolDetail` all pass through text unredacted
- The fix correctly respects the user's intent to disable redaction