### PR TITLE
fix(gateway): reap stale MCP processes on session reset regardless of…

### DIFF
--- a/src/agents/agent-bundle-mcp-manager-api.ts
+++ b/src/agents/agent-bundle-mcp-manager-api.ts
@@ -79,6 +79,7 @@ export async function retireSessionMcpRuntime(params: {
   sessionId?: string | null;
   reason: string;
   preserveActiveLeases?: boolean;
+  retainAcrossReuse?: boolean;
   onError?: (error: unknown, sessionId: string, reason: string) => void;
 }): Promise<boolean> {
   const sessionId = normalizeOptionalString(params.sessionId);
@@ -86,13 +87,23 @@ export async function retireSessionMcpRuntime(params: {
     return false;
   }
   const manager = getSessionMcpRuntimeManager();
+  const retainAcrossReuse =
+    params.preserveActiveLeases === true && params.retainAcrossReuse === true;
   // Aggregate leases across static + all requester-scoped parts so preserveActiveLeases
   // does not miss a leased scoped runtime while peeking only the bare session key.
-  if (params.preserveActiveLeases === true && manager.totalActiveLeasesForSession(sessionId) > 0) {
-    manager.deferRetirement(sessionId);
-    return true;
+  if (params.preserveActiveLeases === true) {
+    manager.deferRetirement(sessionId, {
+      retainAcrossReuse,
+    });
+    if (manager.totalActiveLeasesForSession(sessionId) > 0) {
+      return true;
+    }
   }
   try {
+    if (retainAcrossReuse) {
+      await manager.completeDeferredRetirement(sessionId);
+      return true;
+    }
     await disposeSessionMcpRuntime(sessionId);
     return true;
   } catch (error) {

--- a/src/agents/agent-bundle-mcp-manager-install.ts
+++ b/src/agents/agent-bundle-mcp-manager-install.ts
@@ -65,6 +65,13 @@ export function createSessionMcpRuntimeManagerInstall(
   lifecycle: SessionMcpRuntimeManagerLifecycle,
 ): SessionMcpRuntimeManagerInstall {
   const { store } = lifecycle;
+  const cancelReusableRetirement = (sessionId: string) => {
+    if (store.requiredRetirementSessionIds.has(sessionId)) {
+      store.deferredRetirementSessionIds.add(sessionId);
+      return;
+    }
+    store.deferredRetirementSessionIds.delete(sessionId);
+  };
 
   /** Static/session runtime get-or-create (createInFlight dedup for bare keys only). */
   const getOrCreateRuntimeEntry = async (
@@ -97,7 +104,7 @@ export function createSessionMcpRuntimeManagerInstall(
         store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
         await existing.dispose();
       } else {
-        store.deferredRetirementSessionIds.delete(params.sessionId);
+        cancelReusableRetirement(params.sessionId);
         existing.markUsed();
         store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
         return existing;
@@ -139,7 +146,7 @@ export function createSessionMcpRuntimeManagerInstall(
         configFingerprint: nextFingerprint,
       }),
     ).then((runtime) => {
-      store.deferredRetirementSessionIds.delete(params.sessionId);
+      cancelReusableRetirement(params.sessionId);
       runtime.markUsed();
       store.runtimesBySessionId.set(params.runtimeKey, runtime);
       store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
@@ -199,7 +206,7 @@ export function createSessionMcpRuntimeManagerInstall(
         candidate: existing,
       })
     ) {
-      store.deferredRetirementSessionIds.delete(params.sessionId);
+      cancelReusableRetirement(params.sessionId);
       existing.markUsed();
       store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
       store.connectionMetaByRuntimeKey.set(params.runtimeKey, {
@@ -282,7 +289,7 @@ export function createSessionMcpRuntimeManagerInstall(
         candidate: existing,
       })
     ) {
-      store.deferredRetirementSessionIds.delete(params.sessionId);
+      cancelReusableRetirement(params.sessionId);
       existing.markUsed();
       store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
       return existing;

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -31,6 +31,8 @@ type SessionMcpRuntimeManagerStore = {
   sessionIdBySessionKey: Map<string, string>;
   idleTtlMsBySessionId: Map<string, number>;
   deferredRetirementSessionIds: Set<string>;
+  // Reset/delete retirement survives late creation or reuse by the stopping run.
+  requiredRetirementSessionIds: Set<string>;
   connectionMetaByRuntimeKey: Map<string, { connectionHash: string; resolvedAt: number }>;
   advertisedScopedCatalogBySessionId: Map<string, AdvertisedScopedCatalogEntry>;
   requesterWorkChains: Map<string, Promise<unknown>>;
@@ -74,6 +76,7 @@ export function createSessionMcpRuntimeManagerStore(
     sessionIdBySessionKey: new Map<string, string>(),
     idleTtlMsBySessionId: new Map<string, number>(),
     deferredRetirementSessionIds: new Set<string>(),
+    requiredRetirementSessionIds: new Set<string>(),
     // Manager-side only: connection hash + resolve time. Never stores raw url/headers.
     connectionMetaByRuntimeKey: new Map(),
     /**
@@ -112,7 +115,10 @@ export type SessionMcpRuntimeManagerLifecycle = {
   ensureIdleSweepTimer: () => void;
   clearIdleSweepTimer: () => void;
   disposeRuntimeKeyNow: (runtimeKey: string) => Promise<void>;
-  disposeManagedSession: (sessionId: string) => Promise<void>;
+  disposeManagedSession: (
+    sessionId: string,
+    opts?: { preserveRequiredRetirement?: boolean },
+  ) => Promise<void>;
   rememberAdvertisedScopedCatalog: (sessionId: string, catalog: McpToolCatalog) => void;
   getAdvertisedScopedCatalog: (sessionId: string) => McpToolCatalog | null;
 };
@@ -297,8 +303,14 @@ export function createSessionMcpRuntimeManagerLifecycle(
     }
   };
 
-  const disposeManagedSession = async (sessionId: string): Promise<void> => {
+  const disposeManagedSession = async (
+    sessionId: string,
+    opts?: { preserveRequiredRetirement?: boolean },
+  ): Promise<void> => {
     store.deferredRetirementSessionIds.delete(sessionId);
+    if (opts?.preserveRequiredRetirement !== true) {
+      store.requiredRetirementSessionIds.delete(sessionId);
+    }
     store.advertisedScopedCatalogBySessionId.delete(sessionId);
     const runtimeKeys = new Set(runtimeKeysForSessionId(sessionId));
     for (const runtimeKey of store.createInFlight.keys()) {

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -302,15 +302,15 @@ export function createSessionMcpRuntimeManager(
     async disposeSession(sessionId) {
       await lifecycle.disposeManagedSession(sessionId);
     },
-    deferRetirement(sessionId, opts) {
-      if (opts?.retainAcrossReuse === true) {
+    deferRetirement(sessionId, retirementOpts) {
+      if (retirementOpts?.retainAcrossReuse === true) {
         store.requiredRetirementSessionIds.add(sessionId);
       } else {
         store.requiredRetirementSessionIds.delete(sessionId);
       }
       if (
         lifecycle.runtimeKeysForSessionId(sessionId).length === 0 &&
-        opts?.retainAcrossReuse !== true
+        retirementOpts?.retainAcrossReuse !== true
       ) {
         return false;
       }

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -302,20 +302,31 @@ export function createSessionMcpRuntimeManager(
     async disposeSession(sessionId) {
       await lifecycle.disposeManagedSession(sessionId);
     },
-    deferRetirement(sessionId) {
-      if (lifecycle.runtimeKeysForSessionId(sessionId).length === 0) {
+    deferRetirement(sessionId, opts) {
+      if (opts?.retainAcrossReuse === true) {
+        store.requiredRetirementSessionIds.add(sessionId);
+      } else {
+        store.requiredRetirementSessionIds.delete(sessionId);
+      }
+      if (
+        lifecycle.runtimeKeysForSessionId(sessionId).length === 0 &&
+        opts?.retainAcrossReuse !== true
+      ) {
         return false;
       }
       store.deferredRetirementSessionIds.add(sessionId);
       return true;
     },
     async completeDeferredRetirement(sessionId, runtime) {
-      if (!store.deferredRetirementSessionIds.has(sessionId) || runtime.sessionId !== sessionId) {
+      if (
+        !store.deferredRetirementSessionIds.has(sessionId) ||
+        (runtime !== undefined && runtime.sessionId !== sessionId)
+      ) {
         return false;
       }
       if (
         lifecycle.totalActiveLeasesForSessionId(sessionId) > 0 ||
-        (runtime.activeLeases ?? 0) > 0
+        (runtime?.activeLeases ?? 0) > 0
       ) {
         return false;
       }
@@ -327,14 +338,18 @@ export function createSessionMcpRuntimeManager(
         return false;
       }
       const managedSet = new Set(managed);
-      if (isCombinedSessionMcpRuntime(runtime)) {
-        if (!runtime.managedParts.every((part) => managedSet.has(part))) {
+      if (runtime !== undefined) {
+        if (isCombinedSessionMcpRuntime(runtime)) {
+          if (!runtime.managedParts.every((part) => managedSet.has(part))) {
+            return false;
+          }
+        } else if (!managedSet.has(runtime)) {
           return false;
         }
-      } else if (!managedSet.has(runtime)) {
-        return false;
       }
-      await lifecycle.disposeManagedSession(sessionId);
+      await lifecycle.disposeManagedSession(sessionId, {
+        preserveRequiredRetirement: store.requiredRetirementSessionIds.has(sessionId),
+      });
       return true;
     },
     async disposeAll() {
@@ -350,6 +365,7 @@ export function createSessionMcpRuntimeManager(
       store.sessionIdBySessionKey.clear();
       store.idleTtlMsBySessionId.clear();
       store.deferredRetirementSessionIds.clear();
+      store.requiredRetirementSessionIds.clear();
       store.connectionMetaByRuntimeKey.clear();
       store.advertisedScopedCatalogBySessionId.clear();
       const lateRuntimes = await Promise.all(

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -7,7 +7,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta, setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
-import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,
@@ -32,6 +31,10 @@ async function releaseRuntimeLease(params: {
   releaseLease?: () => void;
 }): Promise<void> {
   params.releaseLease?.();
+  // Lease retirement is a lifecycle-only edge. Keep the manager graph out of
+  // read-only CLI startup paths that load tool materialization metadata.
+  const { completeDeferredSessionMcpRuntimeRetirement } =
+    await import("./agent-bundle-mcp-manager-api.js");
   await completeDeferredSessionMcpRuntimeRetirement(params.runtime).catch((error: unknown) => {
     logWarn(`bundle-mcp: deferred runtime cleanup failed: ${String(error)}`);
   });

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta, setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
+import { completeDeferredSessionMcpRuntimeRetirement } from "./agent-bundle-mcp-manager-api.js";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,
@@ -24,6 +25,16 @@ import type { AgentToolResult } from "./runtime/index.js";
 import type { AnyAgentTool } from "./tools/common.js";
 function isAppOnlyTool(tool: McpCatalogTool): boolean {
   return tool.uiVisibility !== undefined && !tool.uiVisibility.includes("model");
+}
+
+async function releaseRuntimeLease(params: {
+  runtime: SessionMcpRuntime;
+  releaseLease?: () => void;
+}): Promise<void> {
+  params.releaseLease?.();
+  await completeDeferredSessionMcpRuntimeRetirement(params.runtime).catch((error: unknown) => {
+    logWarn(`bundle-mcp: deferred runtime cleanup failed: ${String(error)}`);
+  });
 }
 
 function buildAppToolPolicyProjections(params: {
@@ -403,7 +414,7 @@ export async function materializeBundleMcpToolsForRun(params: {
   try {
     catalog = await params.runtime.getCatalog();
   } catch (error) {
-    releaseLease?.();
+    await releaseRuntimeLease({ runtime: params.runtime, releaseLease });
     throw error;
   }
   const reservedToolNames = params.reservedToolNames
@@ -522,7 +533,9 @@ export async function materializeBundleMcpToolsForRun(params: {
         return;
       }
       disposed = true;
-      releaseLease?.();
+      // Reset/delete can request retirement while this run owns the lease.
+      // Dispose as soon as the final run, view, or request lease has released.
+      await releaseRuntimeLease({ runtime: params.runtime, releaseLease });
       await params.disposeRuntime?.();
     },
   };

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2169,7 +2169,10 @@ process.on("SIGINT", shutdown);`,
 
     expect(manager.deferRetirement(params.sessionId, { retainAcrossReuse: true })).toBe(true);
     const firstRuntime = await manager.getOrCreate(params);
-    const release = expectDefined(firstRuntime.acquireLease)();
+    const release = expectDefined(
+      firstRuntime.acquireLease,
+      "firstRuntime.acquireLease test invariant",
+    )();
     await expect(manager.completeDeferredRetirement(params.sessionId, firstRuntime)).resolves.toBe(
       false,
     );

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2158,6 +2158,41 @@ process.on("SIGINT", shutdown);`,
     await manager.disposeAll();
   });
 
+  it("keeps required retirement armed across late runtime creation and reuse", async () => {
+    const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+    const params = {
+      sessionId: "session-required-retirement",
+      sessionKey: "agent:test:session-required-retirement",
+      workspaceDir: "/workspace",
+      cfg: { mcp: { servers: {}, sessionIdleTtlMs: 0 } },
+    };
+
+    expect(manager.deferRetirement(params.sessionId, { retainAcrossReuse: true })).toBe(true);
+    const firstRuntime = await manager.getOrCreate(params);
+    const release = expectDefined(firstRuntime.acquireLease)();
+    await expect(manager.completeDeferredRetirement(params.sessionId, firstRuntime)).resolves.toBe(
+      false,
+    );
+    release();
+    await expect(manager.completeDeferredRetirement(params.sessionId, firstRuntime)).resolves.toBe(
+      true,
+    );
+    expect(manager.listSessionIds()).not.toContain(params.sessionId);
+
+    const lateRuntime = await manager.getOrCreate(params);
+    await expect(manager.completeDeferredRetirement(params.sessionId, lateRuntime)).resolves.toBe(
+      true,
+    );
+    expect(manager.listSessionIds()).not.toContain(params.sessionId);
+
+    await manager.disposeSession(params.sessionId);
+    const reusableRuntime = await manager.getOrCreate(params);
+    await expect(
+      manager.completeDeferredRetirement(params.sessionId, reusableRuntime),
+    ).resolves.toBe(false);
+    await manager.disposeAll();
+  });
+
   it("retires global session runtimes by session key", async () => {
     await getOrCreateSessionMcpRuntime({
       sessionId: "session-retire-key",

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2036,6 +2036,28 @@ process.on("SIGINT", shutdown);`,
     expect(testing.getCachedSessionIds()).not.toContain("session-view-lease");
   });
 
+  it("completes deferred retirement when a materialized run releases its lease", async () => {
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-run-lease",
+      sessionKey: "agent:test:session-run-lease",
+      workspaceDir: "/workspace",
+      cfg: { mcp: { sessionIdleTtlMs: 0 } },
+    });
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+
+    await expect(
+      retireSessionMcpRuntime({
+        sessionId: "session-run-lease",
+        reason: "gateway-session-cleanup",
+        preserveActiveLeases: true,
+      }),
+    ).resolves.toBe(true);
+    expect(testing.getCachedSessionIds()).toContain("session-run-lease");
+
+    await materialized.dispose();
+    expect(testing.getCachedSessionIds()).not.toContain("session-run-lease");
+  });
+
   it("cancels deferred retirement when a later run reuses the runtime", async () => {
     const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
     const params = {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2058,6 +2058,61 @@ process.on("SIGINT", shutdown);`,
     expect(testing.getCachedSessionIds()).not.toContain("session-run-lease");
   });
 
+  it("keeps an active MCP child alive until deferred run retirement completes", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-deferred-run-"));
+    const serverPath = path.join(tempDir, "server.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const pidPath = path.join(tempDir, "server.pid");
+    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath });
+    let materialized: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
+
+    try {
+      const runtime = await getOrCreateSessionMcpRuntime({
+        sessionId: "session-run-child",
+        sessionKey: "agent:test:session-run-child",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            sessionIdleTtlMs: 0,
+            servers: {
+              child: { command: process.execPath, args: [serverPath] },
+            },
+          },
+        },
+      });
+      materialized = await materializeBundleMcpToolsForRun({ runtime });
+      await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+
+      await retireSessionMcpRuntime({
+        sessionId: "session-run-child",
+        reason: "gateway-session-cleanup",
+        preserveActiveLeases: true,
+      });
+      expect(() => process.kill(pid, 0)).not.toThrow();
+      expect(testing.getCachedSessionIds()).toContain("session-run-child");
+
+      await materialized.dispose();
+      materialized = undefined;
+      await waitForPredicate(
+        () => {
+          try {
+            process.kill(pid, 0);
+            return false;
+          } catch {
+            return true;
+          }
+        },
+        "deferred MCP child process exit",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      expect(testing.getCachedSessionIds()).not.toContain("session-run-child");
+    } finally {
+      await materialized?.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("cancels deferred retirement when a later run reuses the runtime", async () => {
     const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
     const params = {

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
@@ -57,6 +58,7 @@ async function writeListToolsMcpServer(params: {
     _meta?: Record<string, unknown>;
   }>;
   capabilities?: Record<string, unknown>;
+  databasePath?: string;
   pidPath?: string;
   notifyListChangedOnInitialized?: boolean;
   notifyListChangedAfterFirstList?: boolean;
@@ -77,6 +79,7 @@ const delayMs = ${params.delayMs ?? 0};
 const initializeDelayMs = ${params.initializeDelayMs ?? 0};
 const hang = ${params.hang === true};
 const capabilities = ${JSON.stringify(params.capabilities ?? { tools: {} })};
+const databasePath = ${JSON.stringify(params.databasePath)};
 const pidPath = ${JSON.stringify(params.pidPath)};
 const notifyListChangedOnInitialized = ${params.notifyListChangedOnInitialized === true};
 const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList === true};
@@ -100,6 +103,12 @@ let buffer = "";
 let listCount = 0;
 let pendingTimer;
 let keepAlive;
+let database;
+if (databasePath) {
+  const { DatabaseSync } = await import("node:sqlite");
+  database = new DatabaseSync(databasePath);
+  database.exec("PRAGMA busy_timeout = 0; CREATE TABLE IF NOT EXISTS lock_probe (value TEXT); BEGIN IMMEDIATE; INSERT INTO lock_probe VALUES ('held')");
+}
 if (pidPath) {
   await fs.writeFile(pidPath, String(process.pid), "utf8");
 }
@@ -232,6 +241,10 @@ function shutdown() {
   if (keepAlive) {
     clearInterval(keepAlive);
   }
+  try {
+    database?.exec("ROLLBACK");
+  } catch {}
+  database?.close();
   process.exit(0);
 }
 process.stdin.on("data", (chunk) => {
@@ -2058,13 +2071,15 @@ process.on("SIGINT", shutdown);`,
     expect(testing.getCachedSessionIds()).not.toContain("session-run-lease");
   });
 
-  it("keeps an active MCP child alive until deferred run retirement completes", async () => {
+  it("keeps an active MCP child and its database lock until deferred retirement completes", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-deferred-run-"));
     const serverPath = path.join(tempDir, "server.mjs");
     const logPath = path.join(tempDir, "server.log");
     const pidPath = path.join(tempDir, "server.pid");
-    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath });
+    const databasePath = path.join(tempDir, "locked.sqlite");
+    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath, databasePath });
     let materialized: Awaited<ReturnType<typeof materializeBundleMcpToolsForRun>> | undefined;
+    let lockProbe: DatabaseSync | undefined;
 
     try {
       const runtime = await getOrCreateSessionMcpRuntime({
@@ -2083,6 +2098,11 @@ process.on("SIGINT", shutdown);`,
       materialized = await materializeBundleMcpToolsForRun({ runtime });
       await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
       const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+      const { DatabaseSync } = await import("node:sqlite");
+      const database = new DatabaseSync(databasePath);
+      lockProbe = database;
+      database.exec("PRAGMA busy_timeout = 0");
+      expect(() => database.exec("BEGIN IMMEDIATE")).toThrow(/database is locked|SQLITE_BUSY/iu);
 
       await retireSessionMcpRuntime({
         sessionId: "session-run-child",
@@ -2107,7 +2127,10 @@ process.on("SIGINT", shutdown);`,
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
       expect(testing.getCachedSessionIds()).not.toContain("session-run-child");
+      expect(() => database.exec("BEGIN IMMEDIATE")).not.toThrow();
+      database.exec("ROLLBACK");
     } finally {
+      lockProbe?.close();
       await materialized?.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -164,8 +164,9 @@ export type SessionMcpRuntimeManager = {
     sessionKey?: string;
   }) => SessionMcpRuntime | undefined;
   disposeSession: (sessionId: string) => Promise<void>;
-  deferRetirement: (sessionId: string) => boolean;
-  completeDeferredRetirement: (sessionId: string, runtime: SessionMcpRuntime) => Promise<boolean>;
+  /** Required retirement stays armed when a stopping run creates or reuses a runtime. */
+  deferRetirement: (sessionId: string, opts?: { retainAcrossReuse?: boolean }) => boolean;
+  completeDeferredRetirement: (sessionId: string, runtime?: SessionMcpRuntime) => Promise<boolean>;
   disposeAll: () => Promise<void>;
   sweepIdleRuntimes: () => Promise<number>;
   listSessionIds: () => string[];

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -47,7 +47,7 @@ export type ActiveEmbeddedRunSnapshot = {
 
 export type EmbeddedRunWaiter = {
   resolve: (ended: boolean) => void;
-  timer: NodeJS.Timeout;
+  timer?: NodeJS.Timeout;
 };
 
 export type AbandonedEmbeddedRun = {

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -906,6 +906,25 @@ describe("embedded-agent runner run registry", () => {
     }
   });
 
+  it("waits for a reply-backed run without an embedded handle", async () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:reply-wait",
+      sessionId: "session-reply-wait",
+      resetTriggered: false,
+    });
+
+    const waitPromise = waitForEmbeddedAgentRunEnd("session-reply-wait", null);
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    operation.complete();
+    await expect(waitPromise).resolves.toBe(true);
+  });
+
   it("waits for a replacement run under the same session id", async () => {
     const firstHandle = createRunHandle();
     const replacementHandle = createRunHandle();

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -906,6 +906,27 @@ describe("embedded-agent runner run registry", () => {
     }
   });
 
+  it("waits for a replacement run under the same session id", async () => {
+    const firstHandle = createRunHandle();
+    const replacementHandle = createRunHandle();
+    setActiveEmbeddedRun("session-replaced", firstHandle);
+
+    const waitPromise = waitForEmbeddedAgentRunEnd("session-replaced", null);
+    clearActiveEmbeddedRun("session-replaced", firstHandle);
+    setActiveEmbeddedRun("session-replaced", replacementHandle);
+    await Promise.resolve();
+
+    let settled = false;
+    void waitPromise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    clearActiveEmbeddedRun("session-replaced", replacementHandle);
+    await expect(waitPromise).resolves.toBe(true);
+  });
+
   it("waits for active runs to drain", async () => {
     vi.useFakeTimers();
     try {

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -888,6 +888,24 @@ describe("embedded-agent runner run registry", () => {
     }
   });
 
+  it("waits without a timer when no run-end timeout is requested", async () => {
+    vi.useFakeTimers();
+    try {
+      const handle = createRunHandle();
+      setActiveEmbeddedRun("session-unbounded", handle);
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      const waitPromise = waitForEmbeddedAgentRunEnd("session-unbounded", null);
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      clearActiveEmbeddedRun("session-unbounded", handle);
+      await expect(waitPromise).resolves.toBe(true);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for active runs to drain", async () => {
     vi.useFakeTimers();
     try {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -714,13 +714,10 @@ export async function waitForActiveEmbeddedRuns(
   }
 }
 
-export function waitForEmbeddedAgentRunEnd(
+function waitForCurrentEmbeddedAgentRunEnd(
   sessionId: string,
-  timeoutMs: number | null = 15_000,
+  timeoutMs: number | null,
 ): Promise<boolean> {
-  if (!sessionId) {
-    return Promise.resolve(true);
-  }
   if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
     return waitForReplyRunEndBySessionId(sessionId, timeoutMs);
   }
@@ -757,6 +754,26 @@ export function waitForEmbeddedAgentRunEnd(
       resolve(true);
     }
   });
+}
+
+export async function waitForEmbeddedAgentRunEnd(
+  sessionId: string,
+  timeoutMs: number | null = 15_000,
+): Promise<boolean> {
+  if (!sessionId) {
+    return true;
+  }
+  const deadline = timeoutMs === null ? undefined : Date.now() + timeoutMs;
+  while (isEmbeddedAgentRunActive(sessionId)) {
+    const remainingMs = deadline === undefined ? null : deadline - Date.now();
+    if (remainingMs !== null && remainingMs <= 0) {
+      return false;
+    }
+    if (!(await waitForCurrentEmbeddedAgentRunEnd(sessionId, remainingMs))) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export type AbortAndDrainEmbeddedAgentRunResult = {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -716,7 +716,7 @@ export async function waitForActiveEmbeddedRuns(
 
 export function waitForEmbeddedAgentRunEnd(
   sessionId: string,
-  timeoutMs = 15_000,
+  timeoutMs: number | null = 15_000,
 ): Promise<boolean> {
   if (!sessionId) {
     return Promise.resolve(true);
@@ -724,12 +724,15 @@ export function waitForEmbeddedAgentRunEnd(
   if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
     return waitForReplyRunEndBySessionId(sessionId, timeoutMs);
   }
-  diag.debug(`waiting for run end: sessionId=${sessionId} timeoutMs=${timeoutMs}`);
+  const timeoutLabel = timeoutMs === null ? "none" : String(timeoutMs);
+  diag.debug(`waiting for run end: sessionId=${sessionId} timeoutMs=${timeoutLabel}`);
   return new Promise((resolve) => {
     const waiters = EMBEDDED_RUN_WAITERS.get(sessionId) ?? new Set();
     const waiter: EmbeddedRunWaiter = {
       resolve,
-      timer: setTimeout(
+    };
+    if (timeoutMs !== null) {
+      waiter.timer = setTimeout(
         () => {
           waiters.delete(waiter);
           if (waiters.size === 0) {
@@ -739,8 +742,8 @@ export function waitForEmbeddedAgentRunEnd(
           resolve(false);
         },
         resolveTimerTimeoutMs(timeoutMs, 100, 100),
-      ),
-    };
+      );
+    }
     waiters.add(waiter);
     EMBEDDED_RUN_WAITERS.set(sessionId, waiters);
     if (!ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
@@ -748,7 +751,9 @@ export function waitForEmbeddedAgentRunEnd(
       if (waiters.size === 0) {
         EMBEDDED_RUN_WAITERS.delete(sessionId);
       }
-      clearTimeout(waiter.timer);
+      if (waiter.timer) {
+        clearTimeout(waiter.timer);
+      }
       resolve(true);
     }
   });
@@ -800,7 +805,9 @@ function notifyEmbeddedRunEnded(sessionId: string) {
   EMBEDDED_RUN_WAITERS.delete(sessionId);
   diag.debug(`notifying waiters: sessionId=${sessionId} waiterCount=${waiters.size}`);
   for (const waiter of waiters) {
-    clearTimeout(waiter.timer);
+    if (waiter.timer) {
+      clearTimeout(waiter.timer);
+    }
     waiter.resolve(true);
   }
 }
@@ -919,7 +926,9 @@ const testing = {
   resetActiveEmbeddedRuns() {
     for (const waiters of EMBEDDED_RUN_WAITERS.values()) {
       for (const waiter of waiters) {
-        clearTimeout(waiter.timer);
+        if (waiter.timer) {
+          clearTimeout(waiter.timer);
+        }
         waiter.resolve(true);
       }
     }

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -157,7 +157,7 @@ const queueEmbeddedAgentMessageWithOutcomeMock = vi.fn<
   gatewayHealth: "live",
 }));
 const waitForEmbeddedAgentRunEndMock = vi.fn<typeof embeddedRuns.waitForEmbeddedAgentRunEnd>(
-  async (_sessionId: string, _timeoutMs?: number) => true,
+  async (_sessionId: string, _timeoutMs?: number | null) => true,
 );
 const embeddedRunMock = {
   isEmbeddedAgentRunActive: embeddedAgentRunActiveMock,

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -1057,6 +1057,27 @@ describe("reply run registry", () => {
     }
   });
 
+  it("waits for reply-run completion without a timer when requested", async () => {
+    vi.useFakeTimers();
+    try {
+      const operation = createReplyOperation({
+        sessionKey: "agent:main:unbounded",
+        sessionId: "session-unbounded",
+        resetTriggered: false,
+      });
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      const waitPromise = waitForReplyRunEndBySessionId("session-unbounded", null);
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      operation.complete();
+      await expect(waitPromise).resolves.toBe(true);
+    } finally {
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
   it("queues messages only through the active running backend", () => {
     const queueMessage = vi.fn(async () => {});
     const operation = createReplyOperation({

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -209,7 +209,7 @@ type ReplyRunRegistry = {
   abort(sessionKey: string): boolean;
   waitForIdle(
     sessionKey: string,
-    timeoutMs?: number,
+    timeoutMs?: number | null,
     opts?: { signal?: AbortSignal },
   ): Promise<boolean>;
   resolveSessionId(sessionKey: string): string | undefined;
@@ -1195,7 +1195,7 @@ export function clearReplyRunForResetBySessionId(sessionId: string): void {
 
 export function waitForReplyRunEndBySessionId(
   sessionId: string,
-  timeoutMs: number,
+  timeoutMs?: number | null,
 ): Promise<boolean> {
   const waitKey = resolveReplyRunWaitKey(sessionId);
   if (!waitKey) {

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -985,6 +985,11 @@ test("sessions.delete returns unavailable when active run does not stop", async 
 
   embeddedRunMock.activeIds.add("sess-active");
   embeddedRunMock.waitResults.set("sess-active", false);
+  const waitCallCountsAtRetirement: number[] = [];
+  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementationOnce(async () => {
+    waitCallCountsAtRetirement.push(embeddedRunMock.waitCalls.length);
+    return true;
+  });
 
   const { ws } = await openClient();
 
@@ -999,6 +1004,13 @@ test("sessions.delete returns unavailable when active run does not stop", async 
     ["discord:group:dev", "agent:main:discord:group:dev", "sess-active"],
     "sess-active",
   );
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledWith({
+    sessionId: "sess-active",
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    onError: expect.any(Function),
+  });
+  expect(waitCallCountsAtRetirement).toEqual([0]);
   expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
 
   const storedEntry = loadSessionEntry({

--- a/src/gateway/server.sessions.delete-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-lifecycle.test.ts
@@ -986,7 +986,7 @@ test("sessions.delete returns unavailable when active run does not stop", async 
   embeddedRunMock.activeIds.add("sess-active");
   embeddedRunMock.waitResults.set("sess-active", false);
   const waitCallCountsAtRetirement: number[] = [];
-  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementationOnce(async () => {
+  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementation(async () => {
     waitCallCountsAtRetirement.push(embeddedRunMock.waitCalls.length);
     return true;
   });
@@ -1008,9 +1008,11 @@ test("sessions.delete returns unavailable when active run does not stop", async 
     sessionId: "sess-active",
     reason: "gateway-session-cleanup",
     preserveActiveLeases: true,
+    retainAcrossReuse: true,
     onError: expect.any(Function),
   });
-  expect(waitCallCountsAtRetirement).toEqual([0]);
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(2);
+  expect(waitCallCountsAtRetirement).toEqual([0, 1]);
   expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
 
   const storedEntry = loadSessionEntry({

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -252,30 +252,6 @@ test("sessions.reset watches reply-backed MCP retirement after an active-run tim
   });
 });
 
-test("sessions.reset refreshes MCP retirement when the original run ends before timeout", async () => {
-  await seedActiveMainSession();
-  embeddedRunMock.waitResults.set("sess-main", false);
-  embeddedRunMock.resolveEndBeforeTimeoutIds.add("sess-main");
-
-  const reset = await resetMainSession();
-
-  expect(reset.ok).toBe(false);
-  expect(embeddedRunMock.endWaitCalls).toEqual(["sess-main", "sess-main"]);
-  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(3);
-
-  embeddedRunMock.endWaiters.get("sess-main")?.(true);
-  await vi.waitFor(() => {
-    expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(4);
-  });
-  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenLastCalledWith({
-    sessionId: "sess-main",
-    reason: "gateway-session-cleanup",
-    preserveActiveLeases: true,
-    retainAcrossReuse: false,
-    onError: expect.any(Function),
-  });
-});
-
 test("sessions.reset forwards the retired generation to registered agent harnesses", async () => {
   const registeredHarnesses = listRegisteredAgentHarnesses();
   const reset = vi.fn(async () => undefined);

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -166,6 +166,20 @@ test("sessions.reset aborts active runs and clears queues", async () => {
   expect(peekSystemEvents("main")).toStrictEqual([]);
   expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
   expect(peekSystemEvents("sess-main")).toStrictEqual([]);
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenNthCalledWith(1, {
+    sessionId: "sess-main",
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    retainAcrossReuse: true,
+    onError: expect.any(Function),
+  });
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenNthCalledWith(2, {
+    sessionId: "sess-main",
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    retainAcrossReuse: false,
+    onError: expect.any(Function),
+  });
   expect(bundleMcpRuntimeMocks.disposeSessionMcpRuntime).toHaveBeenCalledWith("sess-main");
   expect(waitCallCountAtSnapshotClear).toEqual([1]);
   expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).toHaveBeenCalledTimes(1);
@@ -194,12 +208,11 @@ test("sessions.reset aborts active runs and clears queues", async () => {
   });
 });
 
-test("sessions.reset defers MCP retirement before an active-run timeout", async () => {
+test("sessions.reset watches reply-backed MCP retirement after an active-run timeout", async () => {
   await seedActiveMainSession();
-  embeddedRunMock.activeIds.add("sess-main");
   embeddedRunMock.waitResults.set("sess-main", false);
   const waitCallCountsAtRetirement: number[] = [];
-  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementationOnce(async () => {
+  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementation(async () => {
     waitCallCountsAtRetirement.push(embeddedRunMock.waitCalls.length);
     return true;
   });
@@ -212,10 +225,55 @@ test("sessions.reset defers MCP retirement before an active-run timeout", async 
     sessionId: "sess-main",
     reason: "gateway-session-cleanup",
     preserveActiveLeases: true,
+    retainAcrossReuse: true,
     onError: expect.any(Function),
   });
-  expect(waitCallCountsAtRetirement).toEqual([0]);
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(2);
+  expect(waitCallCountsAtRetirement).toEqual([0, 1]);
   expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
+  expect(embeddedRunMock.endWaitCalls).toEqual(["sess-main"]);
+
+  const retry = await resetMainSession();
+  expect(retry.ok).toBe(false);
+  expect(embeddedRunMock.endWaitCalls).toEqual(["sess-main"]);
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(4);
+  expect(waitCallCountsAtRetirement).toEqual([0, 1, 1, 2]);
+
+  embeddedRunMock.endWaiters.get("sess-main")?.(true);
+  await vi.waitFor(() => {
+    expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(5);
+  });
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenLastCalledWith({
+    sessionId: "sess-main",
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    retainAcrossReuse: false,
+    onError: expect.any(Function),
+  });
+});
+
+test("sessions.reset refreshes MCP retirement when the original run ends before timeout", async () => {
+  await seedActiveMainSession();
+  embeddedRunMock.waitResults.set("sess-main", false);
+  embeddedRunMock.resolveEndBeforeTimeoutIds.add("sess-main");
+
+  const reset = await resetMainSession();
+
+  expect(reset.ok).toBe(false);
+  expect(embeddedRunMock.endWaitCalls).toEqual(["sess-main", "sess-main"]);
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(3);
+
+  embeddedRunMock.endWaiters.get("sess-main")?.(true);
+  await vi.waitFor(() => {
+    expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledTimes(4);
+  });
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenLastCalledWith({
+    sessionId: "sess-main",
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    retainAcrossReuse: false,
+    onError: expect.any(Function),
+  });
 });
 
 test("sessions.reset forwards the retired generation to registered agent harnesses", async () => {

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -194,6 +194,30 @@ test("sessions.reset aborts active runs and clears queues", async () => {
   });
 });
 
+test("sessions.reset defers MCP retirement before an active-run timeout", async () => {
+  await seedActiveMainSession();
+  embeddedRunMock.activeIds.add("sess-main");
+  embeddedRunMock.waitResults.set("sess-main", false);
+  const waitCallCountsAtRetirement: number[] = [];
+  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementationOnce(async () => {
+    waitCallCountsAtRetirement.push(embeddedRunMock.waitCalls.length);
+    return true;
+  });
+
+  const reset = await resetMainSession();
+
+  expect(reset.ok).toBe(false);
+  expect(reset.error?.code).toBe("UNAVAILABLE");
+  expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenCalledWith({
+    sessionId: "sess-main",
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    onError: expect.any(Function),
+  });
+  expect(waitCallCountsAtRetirement).toEqual([0]);
+  expect(browserSessionTabMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
+});
+
 test("sessions.reset forwards the retired generation to registered agent harnesses", async () => {
   const registeredHarnesses = listRegisteredAgentHarnesses();
   const reset = vi.fn(async () => undefined);

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -252,6 +252,78 @@ test("sessions.reset watches reply-backed MCP retirement after an active-run tim
   });
 });
 
+test("sessions.reset keeps watching a replacement registered after waiter settlement", async () => {
+  await seedActiveMainSession();
+  embeddedRunMock.waitResults.set("sess-main", false);
+
+  const reset = await resetMainSession();
+  expect(reset.ok).toBe(false);
+
+  embeddedRunMock.endWaiters.get("sess-main")?.(true);
+  embeddedRunMock.activeIds.add("sess-main");
+  const retry = await resetMainSession();
+  expect(retry.ok).toBe(false);
+  await vi.waitFor(() => {
+    expect(embeddedRunMock.endWaitCalls).toEqual(["sess-main", "sess-main"]);
+  });
+
+  embeddedRunMock.activeIds.delete("sess-main");
+  embeddedRunMock.endWaiters.get("sess-main")?.(true);
+  await vi.waitFor(() => {
+    expect(bundleMcpRuntimeMocks.retireSessionMcpRuntime).toHaveBeenLastCalledWith({
+      sessionId: "sess-main",
+      reason: "gateway-session-cleanup",
+      preserveActiveLeases: true,
+      retainAcrossReuse: false,
+      onError: expect.any(Function),
+    });
+  });
+});
+
+test("sessions.reset installs a new watcher while prior MCP retirement is still disposing", async () => {
+  await seedActiveMainSession();
+  embeddedRunMock.waitResults.set("sess-main", false);
+  let releaseFirstRetirement = () => {};
+  const firstRetirementReleased = new Promise<void>((resolve) => {
+    releaseFirstRetirement = resolve;
+  });
+  let markFirstRetirementStarted = () => {};
+  const firstRetirementStarted = new Promise<void>((resolve) => {
+    markFirstRetirementStarted = resolve;
+  });
+  let heldFirstRetirement = false;
+  bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementation(async (params) => {
+    if (params.retainAcrossReuse === false && !heldFirstRetirement) {
+      heldFirstRetirement = true;
+      markFirstRetirementStarted();
+      await firstRetirementReleased;
+    }
+    return true;
+  });
+
+  const reset = await resetMainSession();
+  expect(reset.ok).toBe(false);
+  embeddedRunMock.endWaiters.get("sess-main")?.(true);
+  await firstRetirementStarted;
+
+  embeddedRunMock.activeIds.add("sess-main");
+  const retry = await resetMainSession();
+  expect(retry.ok).toBe(false);
+  await vi.waitFor(() => {
+    expect(embeddedRunMock.endWaitCalls).toEqual(["sess-main", "sess-main"]);
+  });
+
+  embeddedRunMock.activeIds.delete("sess-main");
+  embeddedRunMock.endWaiters.get("sess-main")?.(true);
+  releaseFirstRetirement();
+  await vi.waitFor(() => {
+    const completedRetirements = bundleMcpRuntimeMocks.retireSessionMcpRuntime.mock.calls.filter(
+      ([params]) => params.retainAcrossReuse === false,
+    );
+    expect(completedRetirements).toHaveLength(2);
+  });
+});
+
 test("sessions.reset forwards the retired generation to registered agent harnesses", async () => {
   const registeredHarnesses = listRegisteredAgentHarnesses();
   const reset = vi.fn(async () => undefined);

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -415,13 +415,6 @@ async function ensureSessionRuntimeCleanup(params: {
   await retireMcpRuntime(true);
   const ended = await waitForEmbeddedAgentRunEnd(sessionId, 15_000);
   params.assertCurrent?.();
-  if (!ended) {
-    // The original run may have ended and been replaced during the first
-    // retirement await. Let its watcher settle, then bind cleanup to whichever
-    // run actually timed out.
-    await Promise.resolve();
-    ensureMcpRetirementWatcher();
-  }
   // A stopping run can create or reuse its runtime while we wait. Retire again
   // after a clean stop; otherwise keep the required marker armed for late work.
   await retireMcpRuntime(!ended);

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -83,6 +83,8 @@ import {
   resolveSessionStoreKey,
 } from "./session-utils.js";
 
+const mcpRunEndWatchers = new Map<string, Promise<boolean>>();
+
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
 
 export function archiveSessionTranscriptsForSessionDetailed(params: {
@@ -367,21 +369,62 @@ async function ensureSessionRuntimeCleanup(params: {
     await closeTrackedBrowserTabs();
     return undefined;
   }
+  const sessionId = params.sessionId;
   params.assertCurrent?.();
-  abortEmbeddedAgentRun(params.sessionId);
+  const retireMcpRuntime = async (retainAcrossReuse: boolean) => {
+    await retireSessionMcpRuntime({
+      sessionId,
+      reason: "gateway-session-cleanup",
+      preserveActiveLeases: true,
+      retainAcrossReuse,
+      onError: (error, sessionId) => {
+        logVerbose(
+          `sessions cleanup: failed to dispose bundle MCP runtime for ${sessionId}: ${String(error)}`,
+        );
+      },
+    });
+  };
+  const ensureMcpRetirementWatcher = () => {
+    if (mcpRunEndWatchers.has(sessionId)) {
+      return;
+    }
+    const runEnd = waitForEmbeddedAgentRunEnd(sessionId, null);
+    mcpRunEndWatchers.set(sessionId, runEnd);
+    void runEnd
+      .then(async (eventuallyEnded) => {
+        if (mcpRunEndWatchers.get(sessionId) === runEnd) {
+          mcpRunEndWatchers.delete(sessionId);
+        }
+        if (eventuallyEnded) {
+          await retireMcpRuntime(false);
+        }
+      })
+      .catch((error: unknown) => {
+        if (mcpRunEndWatchers.get(sessionId) === runEnd) {
+          mcpRunEndWatchers.delete(sessionId);
+        }
+        logVerbose(`sessions cleanup: failed to disarm deferred MCP retirement: ${String(error)}`);
+      });
+  };
+  // Register against the run being stopped before abort or any await allows a
+  // later embedded or reply-backed run to replace it in the active registry.
+  ensureMcpRetirementWatcher();
+  abortEmbeddedAgentRun(sessionId);
   // Mark cleanup before waiting so the timeout path cannot strand MCP children.
   // Active tool/app leases keep in-flight work alive until their final release.
-  await retireSessionMcpRuntime({
-    sessionId: params.sessionId,
-    reason: "gateway-session-cleanup",
-    preserveActiveLeases: true,
-    onError: (error, sessionId) => {
-      logVerbose(
-        `sessions cleanup: failed to dispose bundle MCP runtime for ${sessionId}: ${String(error)}`,
-      );
-    },
-  });
-  const ended = await waitForEmbeddedAgentRunEnd(params.sessionId, 15_000);
+  await retireMcpRuntime(true);
+  const ended = await waitForEmbeddedAgentRunEnd(sessionId, 15_000);
+  params.assertCurrent?.();
+  if (!ended) {
+    // The original run may have ended and been replaced during the first
+    // retirement await. Let its watcher settle, then bind cleanup to whichever
+    // run actually timed out.
+    await Promise.resolve();
+    ensureMcpRetirementWatcher();
+  }
+  // A stopping run can create or reuse its runtime while we wait. Retire again
+  // after a clean stop; otherwise keep the required marker armed for late work.
+  await retireMcpRuntime(!ended);
   params.assertCurrent?.();
   clearBootstrapSnapshot(params.target.canonicalKey);
   if (ended) {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -377,9 +377,9 @@ async function ensureSessionRuntimeCleanup(params: {
       reason: "gateway-session-cleanup",
       preserveActiveLeases: true,
       retainAcrossReuse,
-      onError: (error, sessionId) => {
+      onError: (error, retiredSessionId) => {
         logVerbose(
-          `sessions cleanup: failed to dispose bundle MCP runtime for ${sessionId}: ${String(error)}`,
+          `sessions cleanup: failed to dispose bundle MCP runtime for ${retiredSessionId}: ${String(error)}`,
         );
       },
     });

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -369,20 +369,22 @@ async function ensureSessionRuntimeCleanup(params: {
   }
   params.assertCurrent?.();
   abortEmbeddedAgentRun(params.sessionId);
+  // Mark cleanup before waiting so the timeout path cannot strand MCP children.
+  // Active tool/app leases keep in-flight work alive until their final release.
+  await retireSessionMcpRuntime({
+    sessionId: params.sessionId,
+    reason: "gateway-session-cleanup",
+    preserveActiveLeases: true,
+    onError: (error, sessionId) => {
+      logVerbose(
+        `sessions cleanup: failed to dispose bundle MCP runtime for ${sessionId}: ${String(error)}`,
+      );
+    },
+  });
   const ended = await waitForEmbeddedAgentRunEnd(params.sessionId, 15_000);
   params.assertCurrent?.();
   clearBootstrapSnapshot(params.target.canonicalKey);
   if (ended) {
-    params.assertCurrent?.();
-    await retireSessionMcpRuntime({
-      sessionId: params.sessionId,
-      reason: "gateway-session-cleanup",
-      onError: (error, sessionId) => {
-        logVerbose(
-          `sessions cleanup: failed to dispose bundle MCP runtime for ${sessionId}: ${String(error)}`,
-        );
-      },
-    });
     params.assertCurrent?.();
     await closeTrackedBrowserTabs();
     return undefined;

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -9,7 +9,6 @@ import {
   upsertAcpSessionMeta,
   writeAcpSessionMetaForMigration,
 } from "../acp/runtime/session-meta.js";
-import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
@@ -338,7 +337,10 @@ async function ensureSessionRuntimeCleanup(params: {
 }) {
   // Session lifecycle mutation owns this heavy runtime edge; read-only gateway
   // commands such as status must not load the embedded-agent barrel.
-  const embeddedAgent = await import("../agents/embedded-agent.js");
+  const [embeddedAgent, mcpTools] = await Promise.all([
+    import("../agents/embedded-agent.js"),
+    import("../agents/agent-bundle-mcp-tools.js"),
+  ]);
   params.assertCurrent?.();
   const closeTrackedBrowserTabs = async () => {
     params.assertCurrent?.();
@@ -375,7 +377,7 @@ async function ensureSessionRuntimeCleanup(params: {
   const sessionId = params.sessionId;
   params.assertCurrent?.();
   const retireMcpRuntime = async (retainAcrossReuse: boolean) => {
-    await retireSessionMcpRuntime({
+    await mcpTools.retireSessionMcpRuntime({
       sessionId,
       reason: "gateway-session-cleanup",
       preserveActiveLeases: true,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -17,7 +17,11 @@ import {
 } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { clearAllCliSessions } from "../agents/cli-session.js";
-import { abortEmbeddedAgentRun, waitForEmbeddedAgentRunEnd } from "../agents/embedded-agent.js";
+import {
+  abortEmbeddedAgentRun,
+  isEmbeddedAgentRunActive,
+  waitForEmbeddedAgentRunEnd,
+} from "../agents/embedded-agent.js";
 import { resetRegisteredAgentHarnessSessions } from "../agents/harness/registry.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import { resolveSessionPlacementResetBlock } from "../agents/session-placement-admission.js";
@@ -83,7 +87,7 @@ import {
   resolveSessionStoreKey,
 } from "./session-utils.js";
 
-const mcpRunEndWatchers = new Map<string, Promise<boolean>>();
+const mcpRunEndWatchers = new Map<string, Promise<void>>();
 
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
 
@@ -388,22 +392,29 @@ async function ensureSessionRuntimeCleanup(params: {
     if (mcpRunEndWatchers.has(sessionId)) {
       return;
     }
-    const runEnd = waitForEmbeddedAgentRunEnd(sessionId, null);
-    mcpRunEndWatchers.set(sessionId, runEnd);
-    void runEnd
-      .then(async (eventuallyEnded) => {
-        if (mcpRunEndWatchers.get(sessionId) === runEnd) {
+    const watcher = (async () => {
+      while (await waitForEmbeddedAgentRunEnd(sessionId, null)) {
+        // A replacement can register after the wait promise settles but before
+        // this continuation runs. Keep the required retirement armed for it.
+        if (isEmbeddedAgentRunActive(sessionId)) {
+          continue;
+        }
+        if (mcpRunEndWatchers.get(sessionId) === watcher) {
           mcpRunEndWatchers.delete(sessionId);
         }
-        if (eventuallyEnded) {
-          await retireMcpRuntime(false);
-        }
-      })
+        await retireMcpRuntime(false);
+        return;
+      }
+    })();
+    mcpRunEndWatchers.set(sessionId, watcher);
+    void watcher
       .catch((error: unknown) => {
-        if (mcpRunEndWatchers.get(sessionId) === runEnd) {
+        logVerbose(`sessions cleanup: failed to disarm deferred MCP retirement: ${String(error)}`);
+      })
+      .finally(() => {
+        if (mcpRunEndWatchers.get(sessionId) === watcher) {
           mcpRunEndWatchers.delete(sessionId);
         }
-        logVerbose(`sessions cleanup: failed to disarm deferred MCP retirement: ${String(error)}`);
       });
   };
   // Register against the run being stopped before abort or any await allows a

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -17,11 +17,6 @@ import {
 } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { clearAllCliSessions } from "../agents/cli-session.js";
-import {
-  abortEmbeddedAgentRun,
-  isEmbeddedAgentRunActive,
-  waitForEmbeddedAgentRunEnd,
-} from "../agents/embedded-agent.js";
 import { resetRegisteredAgentHarnessSessions } from "../agents/harness/registry.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import { resolveSessionPlacementResetBlock } from "../agents/session-placement-admission.js";
@@ -341,6 +336,10 @@ async function ensureSessionRuntimeCleanup(params: {
   sessionId?: string;
   assertCurrent?: () => void;
 }) {
+  // Session lifecycle mutation owns this heavy runtime edge; read-only gateway
+  // commands such as status must not load the embedded-agent barrel.
+  const embeddedAgent = await import("../agents/embedded-agent.js");
+  params.assertCurrent?.();
   const closeTrackedBrowserTabs = async () => {
     params.assertCurrent?.();
     const closeKeys = new Set<string>([
@@ -394,10 +393,10 @@ async function ensureSessionRuntimeCleanup(params: {
     }
     const watcherRef: { current?: Promise<void> } = {};
     const watcher = (async () => {
-      while (await waitForEmbeddedAgentRunEnd(sessionId, null)) {
+      while (await embeddedAgent.waitForEmbeddedAgentRunEnd(sessionId, null)) {
         // A replacement can register after the wait promise settles but before
         // this continuation runs. Keep the required retirement armed for it.
-        if (isEmbeddedAgentRunActive(sessionId)) {
+        if (embeddedAgent.isEmbeddedAgentRunActive(sessionId)) {
           continue;
         }
         if (mcpRunEndWatchers.get(sessionId) === watcherRef.current) {
@@ -422,11 +421,11 @@ async function ensureSessionRuntimeCleanup(params: {
   // Register against the run being stopped before abort or any await allows a
   // later embedded or reply-backed run to replace it in the active registry.
   ensureMcpRetirementWatcher();
-  abortEmbeddedAgentRun(sessionId);
+  embeddedAgent.abortEmbeddedAgentRun(sessionId);
   // Mark cleanup before waiting so the timeout path cannot strand MCP children.
   // Active tool/app leases keep in-flight work alive until their final release.
   await retireMcpRuntime(true);
-  const ended = await waitForEmbeddedAgentRunEnd(sessionId, 15_000);
+  const ended = await embeddedAgent.waitForEmbeddedAgentRunEnd(sessionId, 15_000);
   params.assertCurrent?.();
   // A stopping run can create or reuse its runtime while we wait. Retire again
   // after a clean stop; otherwise keep the required marker armed for late work.

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -392,6 +392,7 @@ async function ensureSessionRuntimeCleanup(params: {
     if (mcpRunEndWatchers.has(sessionId)) {
       return;
     }
+    const watcherRef: { current?: Promise<void> } = {};
     const watcher = (async () => {
       while (await waitForEmbeddedAgentRunEnd(sessionId, null)) {
         // A replacement can register after the wait promise settles but before
@@ -399,13 +400,14 @@ async function ensureSessionRuntimeCleanup(params: {
         if (isEmbeddedAgentRunActive(sessionId)) {
           continue;
         }
-        if (mcpRunEndWatchers.get(sessionId) === watcher) {
+        if (mcpRunEndWatchers.get(sessionId) === watcherRef.current) {
           mcpRunEndWatchers.delete(sessionId);
         }
         await retireMcpRuntime(false);
         return;
       }
     })();
+    watcherRef.current = watcher;
     mcpRunEndWatchers.set(sessionId, watcher);
     void watcher
       .catch((error: unknown) => {

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -27,9 +27,21 @@ function createEmbeddedRunMockExports() {
       embeddedRunMock.abortCalls.push(sessionId);
       return embeddedRunMock.activeIds.has(sessionId);
     },
-    waitForEmbeddedAgentRunEnd: async (sessionId: string) => {
+    waitForEmbeddedAgentRunEnd: async (sessionId: string, timeoutMs?: number | null) => {
+      if (timeoutMs === null) {
+        embeddedRunMock.endWaitCalls.push(sessionId);
+        return await new Promise<boolean>((resolve) => {
+          embeddedRunMock.endWaiters.set(sessionId, resolve);
+        });
+      }
       embeddedRunMock.waitCalls.push(sessionId);
-      return embeddedRunMock.waitResults.get(sessionId) ?? true;
+      const ended = embeddedRunMock.waitResults.get(sessionId) ?? true;
+      if (ended) {
+        embeddedRunMock.endWaiters.get(sessionId)?.(true);
+      } else if (embeddedRunMock.resolveEndBeforeTimeoutIds.delete(sessionId)) {
+        embeddedRunMock.endWaiters.get(sessionId)?.(true);
+      }
+      return ended;
     },
   };
 }

--- a/src/gateway/test-helpers.runtime-state.ts
+++ b/src/gateway/test-helpers.runtime-state.ts
@@ -57,6 +57,9 @@ type GatewayTestHoistedState = {
     abortCalls: string[];
     waitCalls: string[];
     waitResults: Map<string, boolean>;
+    endWaitCalls: string[];
+    endWaiters: Map<string, (ended: boolean) => void>;
+    resolveEndBeforeTimeoutIds: Set<string>;
     compactEmbeddedAgentSession: Mock<CompactEmbeddedAgentSessionFn>;
   };
   testTailscaleWhois: { value: TailscaleWhoisIdentity | null };
@@ -107,6 +110,9 @@ const gatewayTestHoisted = vi.hoisted(() => {
       abortCalls: [],
       waitCalls: [],
       waitResults: new Map<string, boolean>(),
+      endWaitCalls: [],
+      endWaiters: new Map<string, (ended: boolean) => void>(),
+      resolveEndBeforeTimeoutIds: new Set<string>(),
       compactEmbeddedAgentSession: vi.fn().mockResolvedValue({
         ok: true,
         compacted: true,

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -403,6 +403,12 @@ async function resetGatewayTestState(options: { uniqueConfigRoot: boolean }) {
   embeddedRunMock.abortCalls = [];
   embeddedRunMock.waitCalls = [];
   embeddedRunMock.waitResults.clear();
+  embeddedRunMock.endWaitCalls = [];
+  for (const resolve of embeddedRunMock.endWaiters.values()) {
+    resolve(false);
+  }
+  embeddedRunMock.endWaiters.clear();
+  embeddedRunMock.resolveEndBeforeTimeoutIds.clear();
   embeddedRunMock.compactEmbeddedAgentSession.mockReset();
   embeddedRunMock.compactEmbeddedAgentSession.mockResolvedValue({
     ok: true,
@@ -496,6 +502,12 @@ async function resetGatewayTestRuntimeOnly() {
   embeddedRunMock.abortCalls = [];
   embeddedRunMock.waitCalls = [];
   embeddedRunMock.waitResults.clear();
+  embeddedRunMock.endWaitCalls = [];
+  for (const resolve of embeddedRunMock.endWaiters.values()) {
+    resolve(false);
+  }
+  embeddedRunMock.endWaiters.clear();
+  embeddedRunMock.resolveEndBeforeTimeoutIds.clear();
   embeddedRunMock.compactEmbeddedAgentSession.mockReset();
   embeddedRunMock.compactEmbeddedAgentSession.mockResolvedValue({
     ok: true,

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -183,6 +183,9 @@ const browserSessionTabMocks = vi.hoisted(() => ({
 const bundleMcpRuntimeMocks = vi.hoisted(() => ({
   disposeSessionMcpRuntime: vi.fn(async (_sessionId: string) => {}),
   disposeAllSessionMcpRuntimes: vi.fn(async () => {}),
+  retireSessionMcpRuntime: vi.fn(
+    async (_params: { sessionId?: string | null; preserveActiveLeases?: boolean }) => true,
+  ),
 }));
 
 vi.mock("../../auto-reply/reply/queue.js", async () => {
@@ -302,10 +305,7 @@ vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
 vi.mock("../../agents/agent-bundle-mcp-tools.js", () => ({
   disposeSessionMcpRuntime: bundleMcpRuntimeMocks.disposeSessionMcpRuntime,
   disposeAllSessionMcpRuntimes: bundleMcpRuntimeMocks.disposeAllSessionMcpRuntimes,
-  retireSessionMcpRuntime: ({ sessionId }: { sessionId?: string | null }) =>
-    sessionId
-      ? bundleMcpRuntimeMocks.disposeSessionMcpRuntime(sessionId).then(() => true)
-      : Promise.resolve(false),
+  retireSessionMcpRuntime: bundleMcpRuntimeMocks.retireSessionMcpRuntime,
 }));
 
 export function setupGatewaySessionsTestHarness() {
@@ -361,6 +361,14 @@ export function setupGatewaySessionsTestHarness() {
     browserSessionTabMocks.closeTrackedBrowserTabsForSessions.mockResolvedValue(0);
     bundleMcpRuntimeMocks.disposeSessionMcpRuntime.mockClear();
     bundleMcpRuntimeMocks.disposeSessionMcpRuntime.mockResolvedValue(undefined);
+    bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockReset();
+    bundleMcpRuntimeMocks.retireSessionMcpRuntime.mockImplementation(async ({ sessionId }) => {
+      if (!sessionId) {
+        return false;
+      }
+      await bundleMcpRuntimeMocks.disposeSessionMcpRuntime(sessionId);
+      return true;
+    });
   });
 
   const requireHarness = () => {

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -42,6 +42,9 @@ export async function getSessionsHandlers() {
 type TestTranscriptMessage = Record<string, unknown> & {
   role: string;
 };
+type RetireSessionMcpRuntimeParams = Parameters<
+  (typeof import("../../agents/agent-bundle-mcp-tools.js"))["retireSessionMcpRuntime"]
+>[0];
 
 export async function seedSessionTranscript(params: {
   agentId?: string;
@@ -183,9 +186,7 @@ const browserSessionTabMocks = vi.hoisted(() => ({
 const bundleMcpRuntimeMocks = vi.hoisted(() => ({
   disposeSessionMcpRuntime: vi.fn(async (_sessionId: string) => {}),
   disposeAllSessionMcpRuntimes: vi.fn(async () => {}),
-  retireSessionMcpRuntime: vi.fn(
-    async (_params: { sessionId?: string | null; preserveActiveLeases?: boolean }) => true,
-  ),
+  retireSessionMcpRuntime: vi.fn(async (_params: RetireSessionMcpRuntimeParams) => true),
 }));
 
 vi.mock("../../auto-reply/reply/queue.js", async () => {


### PR DESCRIPTION
Closes #92569

## What Problem This Solves

Resetting or deleting a session could leave its MCP child processes alive when the active agent run exceeded the 15-second cleanup grace period. Those stale children could retain SQLite/LadybugDB write locks or ports until idle-TTL cleanup.

## Why This Is the Best Fix

Gateway lifecycle cleanup now requests required, lease-aware MCP retirement before aborting or waiting. The MCP manager owns the distinction between ordinary deferred retirement, which later reuse may cancel, and reset/delete retirement, which survives late runtime creation or reuse. Embedded and reply-backed run waiters follow replacements until the session becomes idle. Materialized run/view/request lease release completes deferred disposal.

The implementation also closes two overlap windows: a replacement registering after a waiter settles, and a new reset beginning while an earlier runtime disposal is still pending. Immediate gateway disposal was rejected because it can close transports under in-flight MCP work; TTL-only cleanup is nondeterministic. Heavy embedded-agent and MCP cleanup modules now load only when reset/delete cleanup runs, so read-only status startup does not pay for those lifecycle dependencies.

## User Impact

Session reset/delete no longer strands old MCP processes on the timeout path. Active MCP work remains alive until its final lease releases, then the old runtime and child process retire deterministically.

## Evidence

- Exact head: `6aed7bf40780c659740b17863a6fc9f57813c553`
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29569605106
- Focused command: `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts src/agents/subagent-announce.format.e2e.test.ts src/agents/embedded-agent-runner/runs.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/gateway/server.sessions.reset-cleanup.test.ts src/gateway/server.sessions.delete-lifecycle.test.ts`
- Result: 6 files, 299 tests passed across gateway, auto-reply, agent, and E2E shards.
- Formatting/lint: all 20 changed TypeScript files pass `oxfmt --check` and `oxlint --deny-warnings`; `git diff --check` passes.
- Real stdio proof: an MCP child remains alive while a lease is held, then exits after final release: https://github.com/zhanxingxin1998/openclaw/actions/runs/29503144525
- Real lock proof: the regression child holds an SQLite `BEGIN IMMEDIATE` write lock during deferred retirement; final lease release terminates the child and lets the parent acquire the lock.

Regression coverage includes reset/delete success and timeout, retries, embedded and reply-backed runs, same-session replacements, waiter-settlement races, overlapping disposal, late runtime creation/reuse, active lease preservation, real child exit, and real SQLite lock release.

## Risk and Compatibility

- No config, storage schema, protocol, dependency, UI, or plugin API changes.
- Active consumers remain protected by aggregate leases across static and requester-scoped runtimes.
- Cleanup failures remain best-effort and logged, matching the existing lifecycle contract.

Co-authored-by: 詹幸心0668001037 <zhan.xingxin@xydigit.com>
