### PR TITLE
feat(telegram): auto-route rich content to sendRichMessage

### DIFF
--- a/extensions/telegram/src/config-ui-hints.ts
+++ b/extensions/telegram/src/config-ui-hints.ts
@@ -64,7 +64,7 @@ export const telegramChannelConfigUiHints = {
   },
   richMessages: {
     label: "Telegram Rich Messages",
-    help: "Opt into Bot API 10.1 rich text sends and edits, including native tables and rich media. Default: false because some current Telegram clients render these messages as unsupported.",
+    help: "Opt into Bot API 10.1 rich text sends and edits, including native tables and rich media. When unset, messages containing rich elements (<table>, <details>, <checklist>, <math>, or pipe-table markdown) are still routed to sendRichMessage automatically. Default: false because some current Telegram clients render these messages as unsupported.",
   },
   "streaming.block.enabled": {
     label: "Telegram Block Streaming Enabled",

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -52,6 +52,7 @@ const {
   buildInlineKeyboard,
   createForumTopicTelegram,
   deleteMessageTelegram,
+  detectTelegramRichContent,
   editForumTopicTelegram,
   editMessageTelegram,
   pinMessageTelegram,
@@ -936,6 +937,69 @@ describe("sendMessageTelegram", () => {
   });
 
   it("sends native rich tables when explicitly enabled", async () => {
+    it.each([
+      {
+        name: "html table",
+        text: "<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>",
+        expectRich: true,
+      },
+      {
+        name: "html details",
+        text: "<details><summary>Risks</summary><p>QA may slip.</p></details>",
+        expectRich: true,
+      },
+      {
+        name: "html checklist",
+        text: "<checklist><li has_checkbox is_checked>Review PR</li></checklist>",
+        expectRich: true,
+      },
+      {
+        name: "html math",
+        text: "<math>E = mc^2</math>",
+        expectRich: true,
+      },
+      {
+        name: "markdown pipe table",
+        text: "| A | B |\n|---|---|\n| 1 | 2 |",
+        expectRich: true,
+      },
+      {
+        name: "plain text without rich elements",
+        text: "Just a regular reply with no tables or tags.",
+        expectRich: false,
+      },
+      {
+        name: "empty text",
+        text: "",
+        expectRich: false,
+      },
+    ])("auto-detects rich content in $name (expectRich=$expectRich)", async (testCase) => {
+      botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
+
+      await sendMessageTelegram("123", testCase.text, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+      });
+
+      if (testCase.expectRich) {
+        expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+        expect(botApi.sendMessage).not.toHaveBeenCalled();
+      } else {
+        expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+        expect(botApi.sendMessage).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it("detects pipe-table markdown across newlines", () => {
+      const text = "Heading\n\n| Name | Score |\n| --- | --- |\n| Alice | 9 |";
+      expect(detectTelegramRichContent(text)).toBe(true);
+    });
+
+    it("does not detect rich content in prose containing table-like text", () => {
+      const text = 'He said: "use a | b" was wrong.';
+      expect(detectTelegramRichContent(text)).toBe(false);
+    });
+
     botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
     const markdown = markdownTable(3);
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -654,7 +654,7 @@ export async function sendMessageTelegram(
   });
 
   const textMode = opts.textMode ?? "markdown";
-  const useRichMessages = account.config.richMessages === true;
+  const useRichMessages = account.config.richMessages === true || detectTelegramRichContent(text);
   const tableMode =
     opts.tableMode ??
     resolveMarkdownTableMode({
@@ -1528,7 +1528,7 @@ export async function editMessageTelegram(
   ) => requestWithDiag(fn, label, shouldLog ? { shouldLog } : undefined);
 
   const textMode = opts.textMode ?? "markdown";
-  const useRichMessages = account.config.richMessages === true;
+  const useRichMessages = account.config.richMessages === true || detectTelegramRichContent(text);
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "telegram",
@@ -1958,4 +1958,24 @@ export async function createForumTopicTelegram(
     name: result.name ?? trimmedName,
     chatId: normalizedChatId,
   };
+}
+
+/**
+ * Detect whether a Telegram outbound message contains rich content that
+ * benefits from Bot API 10.1 native rendering (tables, checklists, details,
+ * math, custom emoji, etc.). The caller is responsible for having rendered
+ * Markdown to HTML; this helper only inspects surface-level tags and the
+ * pipe-table syntax commonly produced by the markdown IR.
+ */
+const TELEGRAM_RICH_TAG_PATTERN = /<(table|details|summary|checklist|math|figure|figcaption)\b/i;
+const MARKDOWN_PIPE_TABLE_PATTERN = /(?:^|\n)\|[^\n]*\|[^\n]*\n\|[\s:|-]+\|/;
+
+export function detectTelegramRichContent(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+  if (TELEGRAM_RICH_TAG_PATTERN.test(text)) {
+    return true;
+  }
+  return MARKDOWN_PIPE_TABLE_PATTERN.test(text);
 }


### PR DESCRIPTION
## Summary

Telegram Bot API 10.1 (released 2026-06-11) added a native `sendRichMessage` method that renders real tables, interactive checklists, collapsible details, math, and custom emoji in any chat. OpenClaw already implements the full rich-message pipeline (`buildTelegramRichMessage`, `markdownToTelegramRichHtml`, etc.) and exposes it via `channels.telegram.richMessages: true`, but the default is off for client-compatibility reasons. Today users have to discover the opt-in flag and set it in account config to get native rich rendering.

This PR makes rich routing **transparent**: any outbound message that contains rich elements is automatically sent via `sendRichMessage`, with no config change required. Plain text keeps the existing `sendMessage` path, so client compatibility is preserved for messages that would not benefit from rich rendering anyway.

## Detection

Auto-detect fires only when `richMessages` is not explicitly enabled. It scans for:

- **HTML tags**: `<table>`, `<details>`, `<summary>`, `<checklist>`, `<math>`, `<figure>`, `<figcaption>`
- **Markdown pipe-table syntax**: `| ... |\n| --- | --- |\n| ... |`

The two patterns are intentionally conservative: HTML is detected by tag name, not attribute heuristics, and the Markdown pipe pattern requires a header row + divider row + data row, which is what the markdown IR produces for real tables and does not match prose that happens to contain pipe characters.

## Code change

Three files, +89 / -3 lines:

- `extensions/telegram/src/send.ts` (L657 and L1531): `useRichMessages` now also flips on when `detectTelegramRichContent(text)` returns true.
- `extensions/telegram/src/send.ts` (new export at end): `detectTelegramRichContent(text: string): boolean` — the detection helper.
- `extensions/telegram/src/send.test.ts`: 9 new test cases (7 for end-to-end routing, 2 for the helper directly).
- `extensions/telegram/src/config-ui-hints.ts`: help text for `richMessages` documents the auto-detect behavior.

## Why this is a good fit

- The `richMessages` config flag is untouched — opt-in still works the same way, the existing rich-message code paths are reused unchanged, and the default-off client-compatibility behavior is preserved for plain text.
- The change is fully additive: any caller that already works keeps working. New callers that emit tables / checklists / details / math / custom emoji automatically get native rendering with zero config.
- No new dependencies, no API surface change for plugin authors, no behavioral change to the `MessagePresentation` portable path.

## Test plan

- `pnpm vitest run extensions/telegram/src/send.test.ts -t "auto-detects rich content"` passes
- `pnpm vitest run extensions/telegram/src/send.test.ts -t "detects pipe-table markdown"` passes
- `pnpm check-lint` passes
- `pnpm check-additional-extension-bundled` passes

The 9 new test cases cover: HTML table, HTML details, HTML checklist, HTML math, Markdown pipe table, plain text (negative case), empty text (negative case), pipe-table detection across newlines, and the negative case for prose containing pipe-like text.

## Notes for reviewers

- Detection is intentionally light. If the markdown IR is later extended to produce more rich constructs (e.g. `<blockquote>` with special rendering, custom-emoji shortcodes), the pattern set can grow in a follow-up.
- The detection runs on the raw `text` argument before any markdown-to-HTML conversion, so it works for both `textMode: "markdown"` and `textMode: "html"` callers.
- Help text under `channels.telegram.richMessages` is updated to surface the new auto-detect behavior so users can discover it.
