### PR TITLE
fix(cli): summarize cleanup dry-run by label

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -122,7 +122,7 @@ openclaw sessions cleanup --json
 - Cleanup also prunes unreferenced primary transcripts, compaction checkpoints, and trajectory sidecars older than `session.maintenance.pruneAfter`; files still referenced by `sessions.json` are preserved.
 
 - `--dry-run`: preview how many entries would be pruned/capped without writing.
-  - In text mode, dry-run prints a per-session action table (`Action`, `Key`, `Age`, `Model`, `Flags`) so you can see what would be kept vs removed.
+  - In text mode, dry-run prints a per-session action table (`Action`, `Key`, `Age`, `Model`, `Flags`) plus a summary grouped by session label so you can see what would be kept vs removed.
 - `--enforce`: apply maintenance even when `session.maintenance.mode` is `warn`.
 - `--fix-missing`: remove entries whose transcript files are missing or header-only/empty, even if they would not normally age/count out yet.
 - `--fix-dm-scope`: when `session.dmScope` is `main`, retire stale peer-keyed direct-DM rows left behind by earlier `per-peer`, `per-channel-peer`, or `per-account-channel-peer` routing. Use `--dry-run` first; applying the cleanup removes those rows from `sessions.json` and preserves their transcripts as deleted archives.

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -503,6 +503,80 @@ describe("sessionsCleanupCommand", () => {
     expect(stalePruneLines.length).toBeGreaterThan(0);
   });
 
+  it("renders a dry-run summary grouped by session label", async () => {
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.runSessionsCleanup.mockResolvedValue({
+      mode: "warn",
+      previewResults: [
+        {
+          summary: {
+            agentId: "main",
+            storePath: "/resolved/sessions.json",
+            mode: "warn",
+            dryRun: true,
+            beforeCount: 4,
+            afterCount: 2,
+            missing: 0,
+            dmScopeRetired: 0,
+            pruned: 1,
+            capped: 1,
+            unreferencedArtifacts: {
+              scannedFiles: 0,
+              removedFiles: 0,
+              freedBytes: 0,
+              olderThanMs: 604800000,
+            },
+            diskBudget: null,
+            wouldMutate: true,
+          },
+          beforeStore: {
+            cronKept: {
+              sessionId: "cron-kept",
+              updatedAt: 4,
+              model: "test:opus",
+              label: "Cron: daily-commit",
+            },
+            cronPruned: {
+              sessionId: "cron-pruned",
+              updatedAt: 3,
+              model: "test:opus",
+              label: "Cron: daily-commit",
+            },
+            directKept: {
+              sessionId: "direct-kept",
+              updatedAt: 2,
+              model: "test:opus",
+            },
+            directCapped: {
+              sessionId: "direct-capped",
+              updatedAt: 1,
+              model: "test:opus",
+            },
+          },
+          missingKeys: new Set<string>(),
+          staleKeys: new Set(["cronPruned"]),
+          cappedKeys: new Set(["directCapped"]),
+          budgetEvictedKeys: new Set<string>(),
+          dmScopeRetiredKeys: new Set<string>(),
+        },
+      ],
+      appliedSummaries: [],
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    expectLogsToInclude(logs, "Summary by Label:");
+    expectLogsToInclude(logs, "Cron: daily-commit  1 kept, 1 pruned");
+    expectLogsToInclude(logs, "Unlabeled           1 kept, 1 pruned");
+    expectLogsToInclude(logs, "Total: 2 kept, 2 pruned");
+  });
+
   it("returns grouped JSON for --all-agents dry-runs", async () => {
     mocks.resolveSessionStoreTargets.mockReturnValue([
       { agentId: "main", storePath: "/resolved/main-sessions.json" },

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -514,11 +514,11 @@ describe("sessionsCleanupCommand", () => {
             storePath: "/resolved/sessions.json",
             mode: "warn",
             dryRun: true,
-            beforeCount: 6,
+            beforeCount: 7,
             afterCount: 3,
             missing: 0,
             dmScopeRetired: 0,
-            pruned: 2,
+            pruned: 3,
             capped: 1,
             unreferencedArtifacts: {
               scannedFiles: 0,
@@ -564,9 +564,15 @@ describe("sessionsCleanupCommand", () => {
               model: "test:opus",
               label: "\u001b[31mAlert\nInjected",
             },
+            malformedLabelPruned: {
+              sessionId: "malformed-label-pruned",
+              updatedAt: 1,
+              model: "test:opus",
+              label: {} as unknown as string,
+            },
           },
           missingKeys: new Set<string>(),
-          staleKeys: new Set(["cronPruned", "unsafePruned"]),
+          staleKeys: new Set(["cronPruned", "unsafePruned", "malformedLabelPruned"]),
           cappedKeys: new Set(["directCapped"]),
           budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
@@ -586,13 +592,13 @@ describe("sessionsCleanupCommand", () => {
     expectLogsToInclude(logs, "Summary by Label:");
     const summaryLogs = logs.slice(logs.indexOf("Summary by Label:") + 1);
     expectLogsToInclude(logs, "Cron: daily-commit  1 kept, 1 pruned");
-    expect(summaryLogs.find((line) => line.includes("(unlabeled)"))).toContain("1 kept, 1 pruned");
+    expect(summaryLogs.find((line) => line.includes("(unlabeled)"))).toContain("1 kept, 2 pruned");
     expect(summaryLogs.find((line) => line.includes("Unlabeled"))).toContain("1 kept, 0 pruned");
     expect(summaryLogs.find((line) => line.includes("Alert\\nInjected"))).toContain(
       "0 kept, 1 pruned",
     );
     expect(logs.join("\n")).not.toContain("\u001b[31m");
-    expectLogsToInclude(logs, "Total: 3 kept, 3 pruned");
+    expectLogsToInclude(logs, "Total: 3 kept, 4 pruned");
   });
 
   it("returns grouped JSON for --all-agents dry-runs", async () => {

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -514,11 +514,11 @@ describe("sessionsCleanupCommand", () => {
             storePath: "/resolved/sessions.json",
             mode: "warn",
             dryRun: true,
-            beforeCount: 4,
-            afterCount: 2,
+            beforeCount: 6,
+            afterCount: 3,
             missing: 0,
             dmScopeRetired: 0,
-            pruned: 1,
+            pruned: 2,
             capped: 1,
             unreferencedArtifacts: {
               scannedFiles: 0,
@@ -552,9 +552,21 @@ describe("sessionsCleanupCommand", () => {
               updatedAt: 1,
               model: "test:opus",
             },
+            literalUnlabeled: {
+              sessionId: "literal-unlabeled",
+              updatedAt: 1,
+              model: "test:opus",
+              label: "Unlabeled",
+            },
+            unsafePruned: {
+              sessionId: "unsafe-pruned",
+              updatedAt: 1,
+              model: "test:opus",
+              label: "\u001b[31mAlert\nInjected",
+            },
           },
           missingKeys: new Set<string>(),
-          staleKeys: new Set(["cronPruned"]),
+          staleKeys: new Set(["cronPruned", "unsafePruned"]),
           cappedKeys: new Set(["directCapped"]),
           budgetEvictedKeys: new Set<string>(),
           dmScopeRetiredKeys: new Set<string>(),
@@ -572,9 +584,15 @@ describe("sessionsCleanupCommand", () => {
     );
 
     expectLogsToInclude(logs, "Summary by Label:");
+    const summaryLogs = logs.slice(logs.indexOf("Summary by Label:") + 1);
     expectLogsToInclude(logs, "Cron: daily-commit  1 kept, 1 pruned");
-    expectLogsToInclude(logs, "Unlabeled           1 kept, 1 pruned");
-    expectLogsToInclude(logs, "Total: 2 kept, 2 pruned");
+    expect(summaryLogs.find((line) => line.includes("(unlabeled)"))).toContain("1 kept, 1 pruned");
+    expect(summaryLogs.find((line) => line.includes("Unlabeled"))).toContain("1 kept, 0 pruned");
+    expect(summaryLogs.find((line) => line.includes("Alert\\nInjected"))).toContain(
+      "0 kept, 1 pruned",
+    );
+    expect(logs.join("\n")).not.toContain("\u001b[31m");
+    expectLogsToInclude(logs, "Total: 3 kept, 3 pruned");
   });
 
   it("returns grouped JSON for --all-agents dry-runs", async () => {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -37,6 +37,12 @@ type SessionCleanupActionRow = ReturnType<typeof toSessionDisplayRows>[number] &
   action: ReturnType<typeof resolveSessionCleanupAction>;
 };
 
+type SessionCleanupLabelSummary = {
+  label: string;
+  kept: number;
+  pruned: number;
+};
+
 function formatCleanupActionCell(
   action: ReturnType<typeof resolveSessionCleanupAction>,
   rich: boolean,
@@ -85,6 +91,45 @@ function buildActionRows(params: {
       }),
     }),
   );
+}
+
+function buildLabelSummaries(actionRows: SessionCleanupActionRow[]): SessionCleanupLabelSummary[] {
+  const summaryByLabel = new Map<string, SessionCleanupLabelSummary>();
+  for (const actionRow of actionRows) {
+    const label = actionRow.label?.trim() || "Unlabeled";
+    let summary = summaryByLabel.get(label);
+    if (!summary) {
+      summary = { label, kept: 0, pruned: 0 };
+      summaryByLabel.set(label, summary);
+    }
+    if (actionRow.action === "keep") {
+      summary.kept += 1;
+    } else {
+      summary.pruned += 1;
+    }
+  }
+  return [...summaryByLabel.values()].toSorted((a, b) => a.label.localeCompare(b.label));
+}
+
+function renderLabelSummaries(params: {
+  actionRows: SessionCleanupActionRow[];
+  runtime: RuntimeEnv;
+}) {
+  const summaries = buildLabelSummaries(params.actionRows);
+  if (summaries.length === 0) {
+    return;
+  }
+  const labelPad = Math.max(...summaries.map((summary) => summary.label.length));
+  const totalKept = summaries.reduce((total, summary) => total + summary.kept, 0);
+  const totalPruned = summaries.reduce((total, summary) => total + summary.pruned, 0);
+  params.runtime.log("");
+  params.runtime.log("Summary by Label:");
+  for (const summary of summaries) {
+    params.runtime.log(
+      `${summary.label.padEnd(labelPad)}  ${summary.kept} kept, ${summary.pruned} pruned`,
+    );
+  }
+  params.runtime.log(`Total: ${totalKept} kept, ${totalPruned} pruned`);
 }
 
 function renderStoreDryRunPlan(params: {
@@ -141,6 +186,7 @@ function renderStoreDryRunPlan(params: {
     ].join(" ");
     params.runtime.log(line.trimEnd());
   }
+  renderLabelSummaries({ actionRows: params.actionRows, runtime: params.runtime });
 }
 
 function renderAppliedSummaries(params: {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -99,7 +99,8 @@ function buildActionRows(params: {
 function buildLabelSummaries(actionRows: SessionCleanupActionRow[]): SessionCleanupLabelSummary[] {
   const summaryByLabel = new Map<string, SessionCleanupLabelSummary>();
   for (const actionRow of actionRows) {
-    const label = sanitizeTerminalText(actionRow.label?.trim() || "") || "(unlabeled)";
+    const rawLabel = typeof actionRow.label === "string" ? actionRow.label.trim() : "";
+    const label = sanitizeTerminalText(rawLabel) || "(unlabeled)";
     let summary = summaryByLabel.get(label);
     if (!summary) {
       summary = { label, kept: 0, pruned: 0 };

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -4,6 +4,7 @@
  * It can delegate cleanup to a live gateway or run local store maintenance,
  * with dry-run tables that explain every planned pruning action.
  */
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
@@ -35,6 +36,7 @@ const ACTION_PAD = 16;
 
 type SessionCleanupActionRow = ReturnType<typeof toSessionDisplayRows>[number] & {
   action: ReturnType<typeof resolveSessionCleanupAction>;
+  label?: string;
 };
 
 type SessionCleanupLabelSummary = {
@@ -81,6 +83,7 @@ function buildActionRows(params: {
   // action labels as the cleanup engine without mutating the preview store.
   return toSessionDisplayRows(params.beforeStore).map((row) =>
     Object.assign({}, row, {
+      label: params.beforeStore[row.key]?.label,
       action: resolveSessionCleanupAction({
         key: row.key,
         missingKeys: params.missingKeys,
@@ -96,7 +99,7 @@ function buildActionRows(params: {
 function buildLabelSummaries(actionRows: SessionCleanupActionRow[]): SessionCleanupLabelSummary[] {
   const summaryByLabel = new Map<string, SessionCleanupLabelSummary>();
   for (const actionRow of actionRows) {
-    const label = actionRow.label?.trim() || "Unlabeled";
+    const label = sanitizeTerminalText(actionRow.label?.trim() || "") || "(unlabeled)";
     let summary = summaryByLabel.get(label);
     if (!summary) {
       summary = { label, kept: 0, pruned: 0 };

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -33,6 +33,7 @@ export type SessionDisplayRow = {
   modelOverride?: string;
   contextTokens?: number;
   runtimePolicySessionKey?: string;
+  label?: string;
 };
 
 export const SESSION_KEY_PAD = 26;
@@ -65,6 +66,7 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
     contextTokens: entry?.contextTokens,
+    label: entry?.label,
   };
 }
 

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -33,7 +33,6 @@ export type SessionDisplayRow = {
   modelOverride?: string;
   contextTokens?: number;
   runtimePolicySessionKey?: string;
-  label?: string;
 };
 
 export const SESSION_KEY_PAD = 26;
@@ -66,7 +65,6 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
     contextTokens: entry?.contextTokens,
-    label: entry?.label,
   };
 }
 


### PR DESCRIPTION
## Summary

- add a text-mode `sessions cleanup --dry-run` summary grouped by session label
- count each label's kept vs pruned preview rows, with an `Unlabeled` bucket for entries without `SessionEntry.label`
- keep cleanup policy, JSON output, and apply behavior unchanged
- document the new dry-run text output in the sessions CLI docs

Fixes #76826.

## Proof

Red check before implementation:

```bash
pnpm test -- src/commands/sessions-cleanup.test.ts -t "renders a dry-run summary grouped by session label"
```

Failed as expected because `Summary by Label:` was absent from dry-run output.

Focused verification after implementation:

```bash
pnpm test -- src/commands/sessions-cleanup.test.ts -t "renders a dry-run summary grouped by session label"
pnpm test -- src/commands/sessions-cleanup.test.ts
pnpm exec oxfmt --check --threads=1 src/commands/sessions-cleanup.ts src/commands/sessions-cleanup.test.ts src/commands/sessions-table.ts docs/cli/sessions.md
git diff --check
```

All commands passed locally.

## Surface map

- Direct CLI dry-run path: `renderStoreDryRunPlan` now renders the existing action table and then a label summary from the same preview rows.
- Cleanup engine: unchanged; action classification still comes from `resolveSessionCleanupAction` and preview key sets.
- JSON/API output: unchanged; the label summary is text-only and does not alter `serializeSessionCleanupResult`.
- Apply path: unchanged; `renderAppliedSummaries` and gateway delegation are untouched.
- Multi-agent dry-runs: covered through the existing per-store render loop because each preview store renders its own label summary.
- Docs: `docs/cli/sessions.md` now describes the text-mode action table plus label summary.

## Risk notes

This does not add config, touch restricted CODEOWNERS paths, change retention rules, or modify session store data. Non-`keep` preview actions are counted as pruned in the summary because the dry-run asks what would be kept vs removed.
