### PR TITLE
fix(cron): normalize run-log jobId on write to match read-side validation

### DIFF
--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -626,4 +626,35 @@ describe("cron run log", () => {
       }
     });
   });
+
+  it("normalizes the jobId on write so the write/read roundtrip is symmetric", async () => {
+    await withRunLogDir("openclaw-cron-log-roundtrip-", async (dir) => {
+      const storePath = storePathForDir(dir);
+      await appendCronRunLog({
+        storePath,
+        entry: { ts: 1000, jobId: "  spaced-job  ", action: "finished", status: "ok" },
+      });
+      // Reads trim before querying, so the written row must be found under both the
+      // trimmed and the original whitespace-padded jobId, and stored normalized.
+      expect(readCronRunLogEntriesSync({ storePath, jobId: "spaced-job" })).toHaveLength(1);
+      expect(readCronRunLogEntriesSync({ storePath, jobId: "  spaced-job  " })).toHaveLength(1);
+      expect(readCronRunLogEntriesSync({ storePath, jobId: "spaced-job" })[0]?.jobId).toBe(
+        "spaced-job",
+      );
+    });
+  });
+
+  it("rejects unsafe job ids on write the same way reads do", async () => {
+    await withRunLogDir("openclaw-cron-log-write-reject-", async (dir) => {
+      const storePath = storePathForDir(dir);
+      for (const jobId of ["nested/job", "..\\job", "   "]) {
+        await expect(
+          appendCronRunLog({
+            storePath,
+            entry: { ts: 1000, jobId, action: "finished", status: "ok" },
+          }),
+        ).rejects.toThrow(/invalid cron run log job id/i);
+      }
+    });
+  });
 });

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -138,20 +138,30 @@ export async function appendCronRunLog(params: {
   entry: CronRunLogEntry;
   opts?: AppendCronRunLogOptions;
 }) {
+  // Normalize the jobId on write the same way reads do (assertSafeCronRunLogJobId
+  // trims + validates). Otherwise a jobId with surrounding whitespace is stored
+  // verbatim while reads trim before querying — the row is written but never read
+  // back — and a jobId containing "/" or "\\" is rejected on read yet silently
+  // accepted on write. Normalizing here keeps the write/read roundtrip symmetric.
+  const normalizedJobId = assertSafeCronRunLogJobId(params.entry.jobId);
+  const entry =
+    normalizedJobId === params.entry.jobId
+      ? params.entry
+      : { ...params.entry, jobId: normalizedJobId };
   const storeKey = cronStoreKey(params.storePath);
-  const writeKey = cronRunLogWriteKey(params.storePath, params.entry.jobId);
+  const writeKey = cronRunLogWriteKey(params.storePath, entry.jobId);
   const prev = writesByTarget.get(writeKey) ?? Promise.resolve();
   // Keep writes for the same store/job ordered so prune-by-count cannot race a later insert.
   const next = prev
     .catch(() => undefined)
     .then(async () => {
       runOpenClawStateWriteTransaction(({ db }) => {
-        insertCronRunLogEntry(db, storeKey, params.entry);
+        insertCronRunLogEntry(db, storeKey, entry);
         if (params.opts?.keepLines !== false) {
           pruneCronRunLogRows(
             db,
             storeKey,
-            params.entry.jobId,
+            entry.jobId,
             params.opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,
           );
         }


### PR DESCRIPTION
## Summary

`appendCronRunLog` stored `entry.jobId` verbatim, while reads (`readCronRunLogEntriesSync` / `readCronRunLogEntriesPage`) trim + validate via `assertSafeCronRunLogJobId`. The result was an asymmetric write/read roundtrip:

- a jobId with surrounding whitespace (`"  job  "`) is **written but never read back** — reads trim to `"job"` before querying, while the stored row keeps the padded key
- a jobId containing `/` or `\` is **rejected on read yet silently accepted on write**

## What changed

`src/cron/run-log.ts`: `appendCronRunLog` now normalizes `entry.jobId` with the same `assertSafeCronRunLogJobId` the read path uses — before computing the write key, inserting the row, and pruning. Rows are stored and queried under one consistent normalized key. Single-file change; well-formed jobIds (the common case) are unaffected.

## Real behavior proof

**Behavior addressed**: cron run-log jobId is normalized identically on write and read, so a whitespace-padded jobId is found on readback, and an unsafe jobId is rejected on write the same way it already is on read.

**Real environment tested**: Worktree of `origin/main` at the PR head, Node v22.22.0, with an isolated `OPENCLAW_STATE_DIR` temp dir. Drove the real exported `appendCronRunLog` + `readCronRunLogEntriesSync` via `node --import tsx` against a real SQLite state DB — no mocks/stubs.

**Exact steps or command run after this patch**:
```
OPENCLAW_STATE_DIR=<tmpdir> node --import tsx ./proof.mts   # real appendCronRunLog + readCronRunLogEntriesSync
node scripts/run-vitest.mjs src/cron/run-log.test.ts
```

**Evidence after fix**: Real console output driving the production functions against a real SQLite store:
```
[1] wrote run-log entry with jobId="  spaced-job  " (whitespace-padded)
[2] read jobId="spaced-job"   → 1 row(s), stored jobId="spaced-job"
[3] read jobId="  spaced-job  " → 1 row(s)
[4] write jobId="nested/job" rejected with: "invalid cron run log job id"

RESULT: PASS - jobId write/read roundtrip is symmetric (normalized on write, found on read across real SQLite; unsafe jobId rejected on write like reads).
```

**Observed result after fix**: The padded jobId is stored normalized (`"spaced-job"`) and found under both the trimmed and padded query forms; the unsafe jobId is rejected on write. Before the fix the padded row is written but reads return 0 rows (see negative control).

**What was not tested**: No live cron scheduler run; the change is in the run-log store's deterministic write path, exercised directly via the real exported functions + real SQLite.

## Tests and validation

- `src/cron/run-log.test.ts` (+2 regression tests): write-side jobId normalization roundtrip (padded jobId found on read, stored normalized) + write-side rejection of unsafe jobIds (`/`, `\`, blank). **18/18 pass.**
- **Negative control**: reverting the write-side normalization makes both new tests fail — the padded row is written but not read back, and unsafe jobIds are silently accepted on write.
- `node scripts/run-tsgo.mjs` clean on the changed file.
