### PR TITLE
fix(context-engine): demote host-incompatible engine to legacy instead of hard-failing every turn

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -960,7 +960,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
-  it("rejects CLI runs for context engines that require pre-prompt assembly", async () => {
+  it("demotes CLI runs to legacy for context engines that require pre-prompt assembly", async () => {
     const { dir, sessionFile } = createSessionFile();
     const engineId = `cli-unsupported-engine-${Date.now().toString(36)}`;
     registerContextEngine(engineId, (): ContextEngine => {
@@ -982,24 +982,24 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     });
 
     try {
-      await expect(
-        prepareCliRunContext({
-          sessionId: "session-test",
-          sessionFile,
-          workspaceDir: dir,
-          prompt: "latest ask",
-          provider: "test-cli",
-          model: "test-model",
-          timeoutMs: 1_000,
-          runId: "run-test-context-engine-host-compat",
-          config: {
-            ...createCliBackendConfig(),
-            plugins: { slots: { contextEngine: engineId } },
-          },
-        }),
-      ).rejects.toThrow(
-        `Context engine "${engineId}" cannot run operation "agent-run" on CLI backend "test-cli".`,
-      );
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-context-engine-host-compat",
+        config: {
+          ...createCliBackendConfig(),
+          plugins: { slots: { contextEngine: engineId } },
+        },
+      });
+
+      // CLI backend lacks assemble-before-prompt, so the engine demotes to
+      // legacy (undefined) instead of hard-failing the run.
+      expect(context.contextEngine).toBeUndefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -5,8 +5,8 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { getRuntimeConfig } from "../../config/config.js";
 import {
-  assertContextEngineHostSupport,
   buildGenericCliContextEngineHostSupport,
+  resolveHostCompatibleContextEngine,
 } from "../../context-engine/host-compat.js";
 import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import { resolveContextEngine } from "../../context-engine/registry.js";
@@ -819,18 +819,21 @@ export async function prepareCliRunContext(
       agentDir: contextEngineAgentDir,
       workspaceDir,
     });
-    const contextEngine =
-      resolvedContextEngine.info.id !== "legacy" ? resolvedContextEngine : undefined;
-    if (contextEngine) {
-      assertContextEngineHostSupport({
-        contextEngine,
-        operation: "agent-run",
-        host: buildGenericCliContextEngineHostSupport({
-          backendId: backendResolved.id,
-          capabilities: backendResolved.contextEngineHostCapabilities,
-        }),
-      });
+    const hostEngine =
+      resolvedContextEngine.info.id === "legacy"
+        ? undefined
+        : resolveHostCompatibleContextEngine({
+            contextEngine: resolvedContextEngine,
+            operation: "agent-run",
+            host: buildGenericCliContextEngineHostSupport({
+              backendId: backendResolved.id,
+              capabilities: backendResolved.contextEngineHostCapabilities,
+            }),
+          });
+    if (hostEngine && !hostEngine.ok) {
+      cliBackendLog.warn(hostEngine.warning);
     }
+    const contextEngine = hostEngine?.contextEngine;
     const hadSessionFile = await hasCliSessionTranscript({
       sessionId: params.sessionId,
       sessionFile: params.sessionFile,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -24,10 +24,6 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
-import {
-  assertContextEngineHostSupport,
-  OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-} from "../../../context-engine/host-compat.js";
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import type { AssembleResult } from "../../../context-engine/types.js";
 import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
@@ -1156,14 +1152,10 @@ export async function runEmbeddedAttempt(
         `raw model run enabled: modelRun=${params.modelRun === true} promptMode=${params.promptMode ?? "unset"}`,
       );
     }
+    // Host compatibility is enforced once per run at the harness bind seam
+    // (runAgentHarnessLifecycleAttempt), which demotes an unsupported engine to
+    // legacy before the openclaw harness runs. No second assert needed here.
     const activeContextEngine = isRawModelRun ? undefined : params.contextEngine;
-    if (activeContextEngine && activeContextEngine.info.id !== "legacy") {
-      assertContextEngineHostSupport({
-        contextEngine: activeContextEngine,
-        operation: "agent-run",
-        host: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
-      });
-    }
     const resolveActiveContextEnginePluginId = () =>
       resolveContextEngineOwnerPluginId(activeContextEngine);
     const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);

--- a/src/agents/harness/lifecycle.test.ts
+++ b/src/agents/harness/lifecycle.test.ts
@@ -146,10 +146,11 @@ describe("AgentHarness lifecycle runner", () => {
     expect(runAttempt).toHaveBeenCalledWith(params);
   });
 
-  it("rejects harnesses that do not advertise required context-engine capabilities", async () => {
+  it("demotes to legacy when a harness lacks required context-engine capabilities", async () => {
     const params = createAttemptParams();
     params.contextEngine = createContextEngineRequiringAssembly();
-    const runAttempt = vi.fn(async () => createAttemptResult());
+    const result = createAttemptResult();
+    const runAttempt = vi.fn(async () => result);
     const harness: AgentHarness = {
       id: "custom",
       label: "Custom",
@@ -157,10 +158,11 @@ describe("AgentHarness lifecycle runner", () => {
       runAttempt,
     };
 
-    await expect(runAgentHarnessLifecycleAttempt(harness, params)).rejects.toThrow(
-      'Context engine "lossless-claw" cannot run operation "agent-run" on agent harness "custom".',
-    );
-    expect(runAttempt).not.toHaveBeenCalled();
+    const attemptResult = await runAgentHarnessLifecycleAttempt(harness, params);
+
+    expect(attemptResult).toEqual({ ...result, agentHarnessId: "custom" });
+    expect(runAttempt).toHaveBeenCalledTimes(1);
+    expect(runAttempt.mock.calls[0]?.[0].contextEngine).toBeUndefined();
   });
 
   it("allows harnesses that advertise required context-engine capabilities", async () => {

--- a/src/agents/harness/lifecycle.ts
+++ b/src/agents/harness/lifecycle.ts
@@ -5,8 +5,8 @@
  * diagnostic events, trace propagation, and result classification.
  */
 import {
-  assertContextEngineHostSupport,
   type ContextEngineHostSupport,
+  resolveHostCompatibleContextEngine,
 } from "../../context-engine/host-compat.js";
 import { diagnosticErrorCategory } from "../../infra/diagnostic-error-metadata.js";
 import {
@@ -21,12 +21,15 @@ import {
   runWithDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { applyAgentHarnessResultClassification } from "./result-classification.js";
 import type {
   AgentHarness,
   AgentHarnessAttemptParams,
   AgentHarnessAttemptResult,
 } from "./types.js";
+
+const log = createSubsystemLogger("agents/harness");
 
 type AgentHarnessLifecyclePhase = DiagnosticHarnessRunErrorEvent["phase"];
 type AgentRunCompletedOutcome = "completed" | "aborted" | "blocked" | "error";
@@ -46,18 +49,27 @@ function buildAgentHarnessContextEngineHostSupport(
   };
 }
 
-function assertAgentHarnessContextEngineSupport(
+// Bind a host-compatible engine for this attempt, demoting to legacy when the
+// harness cannot run the configured context engine. A mixed fleet shares one
+// global slot, so an incompatible harness degrades per-run instead of failing
+// every turn at assembly.
+function resolveAgentHarnessContextEngineParams(
   harness: AgentHarness,
   params: AgentHarnessAttemptParams,
-): void {
+): AgentHarnessAttemptParams {
   if (!params.contextEngine || params.contextEngine.info.id === "legacy") {
-    return;
+    return params;
   }
-  assertContextEngineHostSupport({
+  const resolution = resolveHostCompatibleContextEngine({
     contextEngine: params.contextEngine,
     operation: "agent-run",
     host: buildAgentHarnessContextEngineHostSupport(harness),
   });
+  if (resolution.ok) {
+    return params;
+  }
+  log.warn(resolution.warning);
+  return { ...params, contextEngine: undefined };
 }
 
 function agentHarnessDiagnosticBase(
@@ -230,7 +242,7 @@ export async function runAgentHarnessLifecycleAttempt(
   emitAgentHarnessRunStarted(harness, params, activeHarnessTrace);
   try {
     phase = "prepare";
-    assertAgentHarnessContextEngineSupport(harness, params);
+    const runParams = resolveAgentHarnessContextEngineParams(harness, params);
     if (shouldEmitAgentRunDiagnostics(harness) && activeHarnessTrace) {
       // Non-OpenClaw harnesses get a child run trace so provider/harness spans
       // stay linked without reusing the parent harness trace id.
@@ -245,11 +257,11 @@ export async function runAgentHarnessLifecycleAttempt(
     }
     const runAndClassify = async () => {
       phase = "send";
-      const rawResult = await harness.runAttempt(params);
+      const rawResult = await harness.runAttempt(runParams);
       phase = "resolve";
       // Classification happens inside the diagnostic phase so failures identify
       // whether they came from send or result resolution.
-      return applyAgentHarnessResultClassification(harness, rawResult, params);
+      return applyAgentHarnessResultClassification(harness, rawResult, runParams);
     };
     result = agentRunTrace
       ? await runWithDiagnosticTraceContext(agentRunTrace, runAndClassify)

--- a/src/context-engine/host-compat.test.ts
+++ b/src/context-engine/host-compat.test.ts
@@ -6,6 +6,7 @@ import {
   CODEX_APP_SERVER_CONTEXT_ENGINE_HOST,
   evaluateContextEngineHostSupport,
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+  resolveHostCompatibleContextEngine,
 } from "./host-compat.js";
 import type { ContextEngine, ContextEngineHostCapability } from "./types.js";
 
@@ -89,5 +90,34 @@ describe("context engine host compatibility", () => {
       operation: "agent-run",
       host: CODEX_APP_SERVER_CONTEXT_ENGINE_HOST,
     });
+  });
+
+  it("resolves a supported engine without demotion", () => {
+    const engine = createEngine(["assemble-before-prompt"]);
+    const resolution = resolveHostCompatibleContextEngine({
+      contextEngine: engine,
+      operation: "agent-run",
+      host: OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
+    });
+
+    expect(resolution.ok).toBe(true);
+    expect(resolution.contextEngine).toBe(engine);
+  });
+
+  it("demotes to legacy with a warning when the host is unsupported", () => {
+    const resolution = resolveHostCompatibleContextEngine({
+      contextEngine: createEngine(["assemble-before-prompt"]),
+      operation: "agent-run",
+      host: buildGenericCliContextEngineHostSupport({ backendId: "claude-cli" }),
+    });
+
+    expect(resolution.ok).toBe(false);
+    expect(resolution.contextEngine).toBeUndefined();
+    if (!resolution.ok) {
+      expect(resolution.warning).toContain(
+        'Context engine "lossless-claw" cannot run operation "agent-run" on CLI backend "claude-cli".',
+      );
+      expect(resolution.warning).toContain("switch contextEngine to legacy");
+    }
   });
 });

--- a/src/context-engine/host-compat.ts
+++ b/src/context-engine/host-compat.ts
@@ -97,6 +97,26 @@ export function evaluateContextEngineHostSupport(params: {
   };
 }
 
+function formatContextEngineHostUnsupportedMessage(params: {
+  engineId: string;
+  operation: ContextEngineOperation;
+  host: ContextEngineHostSupport;
+  evaluation: Extract<ContextEngineHostSupportEvaluation, { ok: false }>;
+}): string {
+  const required = params.evaluation.requirements.requiredCapabilities.join(", ");
+  const actual =
+    params.host.capabilities.length > 0 ? params.host.capabilities.join(", ") : "(none)";
+  const guidance = params.evaluation.requirements.unsupportedMessage
+    ? ` ${params.evaluation.requirements.unsupportedMessage}`
+    : "";
+  return (
+    `Context engine "${params.engineId}" cannot run operation "${params.operation}" on ${params.host.label}. ` +
+    `Missing host capabilities: ${params.evaluation.missingCapabilities.join(", ")}. ` +
+    `Required capabilities: ${required}. ` +
+    `Host capabilities: ${actual}.${guidance}`
+  );
+}
+
 /** Assert that a context engine can safely run under the supplied host. */
 export function assertContextEngineHostSupport(params: {
   contextEngine: ContextEngine;
@@ -111,18 +131,48 @@ export function assertContextEngineHostSupport(params: {
   if (evaluation.ok) {
     return;
   }
-
-  const engineId = params.contextEngine.info.id;
-  const required = evaluation.requirements.requiredCapabilities.join(", ");
-  const actual =
-    params.host.capabilities.length > 0 ? params.host.capabilities.join(", ") : "(none)";
-  const guidance = evaluation.requirements.unsupportedMessage
-    ? ` ${evaluation.requirements.unsupportedMessage}`
-    : "";
   throw new Error(
-    `Context engine "${engineId}" cannot run operation "${params.operation}" on ${params.host.label}. ` +
-      `Missing host capabilities: ${evaluation.missingCapabilities.join(", ")}. ` +
-      `Required capabilities: ${required}. ` +
-      `Host capabilities: ${actual}.${guidance}`,
+    formatContextEngineHostUnsupportedMessage({
+      engineId: params.contextEngine.info.id,
+      operation: params.operation,
+      host: params.host,
+      evaluation,
+    }),
   );
+}
+
+export type HostCompatibleContextEngineResolution =
+  | { ok: true; contextEngine: ContextEngine }
+  | { ok: false; contextEngine: undefined; warning: string };
+
+/**
+ * Resolve the engine to bind for a host, demoting to legacy when the host
+ * cannot satisfy the engine's requirements. A mixed fleet keeps one global
+ * contextEngine slot: doctor leaves it set when only some runtimes are
+ * incompatible, so each runtime degrades per-session here instead of
+ * hard-failing every turn.
+ */
+export function resolveHostCompatibleContextEngine(params: {
+  contextEngine: ContextEngine;
+  operation: ContextEngineOperation;
+  host: ContextEngineHostSupport;
+}): HostCompatibleContextEngineResolution {
+  const evaluation = evaluateContextEngineHostSupport({
+    contextEngineInfo: params.contextEngine.info,
+    operation: params.operation,
+    host: params.host,
+  });
+  if (evaluation.ok) {
+    return { ok: true, contextEngine: params.contextEngine };
+  }
+  return {
+    ok: false,
+    contextEngine: undefined,
+    warning: formatContextEngineHostUnsupportedMessage({
+      engineId: params.contextEngine.info.id,
+      operation: params.operation,
+      host: params.host,
+      evaluation,
+    }),
+  };
 }


### PR DESCRIPTION
### Summary

- **Problem**: Issue #93337 reports that when `plugins.slots.contextEngine` is set to an engine whose `hostRequirements` are not satisfied by a given agent's runtime/harness, the runtime binds the engine anyway and **every turn for that agent fails at context assembly** — bare `error`, `message: null`, no assistant output — before the model is called. On a mixed fleet (some agents on a compatible runtime, one on an incompatible CLI harness), flipping the global slot silently takes down only the incompatible agent. The incompatibility is already detected, but only surfaces as a warning; it is never enforced as a per-session fallback to `legacy`.
- **Root Cause**: Host compatibility was enforced with `assertContextEngineHostSupport`, which **throws** when the host lacks the engine's required capabilities, at the runtime bind seams: the CLI prepare path (`src/agents/cli-runner/prepare.ts`), the harness lifecycle (`src/agents/harness/lifecycle.ts`), and the embedded attempt (`src/agents/embedded-agent-runner/run/attempt.ts`). The doctor side already treats per-session degradation as the intended behavior for mixed fleets: `maybeRepairContextEngineHostCompatibility` rewrites the global slot to `legacy` **only when the engine is incompatible with every configured host**, and explicitly declines to rewrite the global slot when some runtimes are compatible and others are not — leaving the runtime to degrade per-session. But the runtime hard-failed instead of degrading, so the only escape was to drop the engine for the whole fleet.
- **Fix**: Demote an unsupported engine to `legacy` per run, with a warning, instead of throwing.
  - `resolveHostCompatibleContextEngine` (in `src/context-engine/host-compat.ts`) evaluates host support and returns either the engine or `legacy` (undefined) plus the operator-facing warning (including the engine's own `unsupportedMessage` guidance). It reuses the same message the assert built, extracted into a shared formatter.
  - The CLI prepare bind (`prepare.ts`) and the harness lifecycle bind seam (`lifecycle.ts`) consume it: an incompatible engine is demoted to `legacy` for that run and the warning is logged, so the turn completes on legacy assembly while compatible agents keep using the engine.
  - The harness lifecycle is the single per-host seam for all harness runs (the `openclaw` embedded harness and plugin harnesses), so it demotes before the embedded runner executes.
- **What changed**:
  - `src/context-engine/host-compat.ts` — extract `formatContextEngineHostUnsupportedMessage`; add `resolveHostCompatibleContextEngine` returning a discriminated `{ ok: true; contextEngine } | { ok: false; contextEngine: undefined; warning }`. `assertContextEngineHostSupport` is kept (still the plugin-SDK-exported helper) and now reuses the shared formatter.
  - `src/agents/cli-runner/prepare.ts` — the CLI bind demotes an unsupported engine to `legacy` and warns instead of asserting.
  - `src/agents/harness/lifecycle.ts` — the harness bind seam demotes `params.contextEngine` to `legacy` and warns instead of asserting; the demoted params flow into `runAttempt`.
  - `src/agents/embedded-agent-runner/run/attempt.ts` — remove the now-redundant host-compat assert; the `openclaw` harness host equals the lifecycle host, so the lifecycle seam already demotes before the embedded runner runs.
  - Tests updated/added in `host-compat.test.ts`, `lifecycle.test.ts`, and `prepare.test.ts` to assert demotion-to-legacy instead of a throw.
- **What did NOT change (scope boundary)**:
  - The host-compat evaluation logic (`evaluateContextEngineHostSupport`, the embedded/codex/CLI capability sets) and engine resolution (`resolveContextEngine`) are unchanged.
  - The doctor warning (`collectContextEngineHostCompatibilityWarnings`) and the `doctor --fix` global rewrite (`maybeRepairContextEngineHostCompatibility`) are unchanged.
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged: `assertContextEngineHostSupport` remains the only host-compat symbol exported from the plugin SDK barrel; `resolveHostCompatibleContextEngine` is core-internal.
  - Gateway protocol unchanged.

### Reproduction

1. Fleet with at least one runtime that satisfies the engine (native Codex or OpenClaw embedded) and at least one CLI-harness agent (e.g. `claude-cli`) that does not advertise the required capabilities.
2. Set `plugins.slots.contextEngine` to an engine that requires pre-prompt assembly (and compact / runtime-llm-complete), e.g. a lossless-style context engine.
3. Force-respawn the CLI-harness agent and drive any turn; the configured runtimes for the other agents stay healthy.
4. **Before this PR**: the CLI prepare bind asserts and throws; the turn fails at context assembly with a bare `error`, `message: null`, and no assistant output. Doctor will not auto-fix the global slot because the other agents need the engine, so the incompatible agent is silently dead every turn.
5. **After this PR**: the CLI bind demotes that agent's engine to `legacy` for the run (logging the engine's unsupported-host guidance), the turn completes on legacy assembly, and the compatible agents keep using the engine.

### Real behavior proof

**Behavior addressed (#93337)**: an agent whose runtime/harness cannot satisfy the configured context engine's `hostRequirements` now degrades to `legacy` per run instead of hard-failing every turn at context assembly; compatible agents on the same global slot are unaffected.

**Real environment tested (Linux, Node 22 — Vitest against the production CLI prepare bind, harness lifecycle bind seam, and host-compat resolver)**: `prepareCliRunContext` resolving an engine the CLI backend cannot host; `runAgentHarnessLifecycleAttempt` with a harness that lacks the required capability; and `resolveHostCompatibleContextEngine` directly.

**Exact steps or command run after this patch**: `pnpm test src/context-engine/host-compat.test.ts src/agents/harness/lifecycle.test.ts src/agents/cli-runner/prepare.test.ts`; `pnpm tsgo:core`; `pnpm tsgo:core:test`; `node scripts/run-oxlint.mjs` and `pnpm format:check` on the changed files.

**Evidence after fix (Vitest output for the touched files)**:

```text
host-compat.test.ts                  Tests  7 passed (7)
lifecycle.test.ts + prepare.test.ts  Tests  56 passed (56)
```

**Observed result after fix**: `resolveHostCompatibleContextEngine` returns `{ ok: false, contextEngine: undefined }` with a warning naming the engine, the missing host capabilities, and the engine's `unsupportedMessage` when the host is unsupported, and returns the engine unchanged when supported. `prepareCliRunContext` resolves with `context.contextEngine === undefined` (legacy) for a CLI backend that lacks `assemble-before-prompt`, instead of rejecting. `runAgentHarnessLifecycleAttempt` runs the harness with `contextEngine` demoted to `undefined` (legacy) instead of throwing, and still rejects nothing.

**What was not tested**: the live gateway round trip with a third-party lossless-style context engine on a mixed fleet was not driven. The bind/demote behavior is covered deterministically against the production CLI prepare, harness lifecycle, and host-compat resolver functions.

**Repro confirmation**: the CLI-prepare and harness-lifecycle tests previously asserted a throw on an unsupported host; they now assert demotion-to-legacy and fail on the pre-fix (assert-and-throw) tree, so they cover the production change.

### Risk / Mitigation

- **Risk**: A supported engine could be wrongly demoted. **Mitigation**: demotion happens only when `evaluateContextEngineHostSupport` reports missing capabilities for the operation; a supported host returns the engine unchanged (covered by the supported-host tests for embedded, codex, and CLI hosts).
- **Risk**: Removing the embedded-attempt assert could drop the last host-compat guard for the embedded runner. **Mitigation**: the `openclaw` harness advertises exactly the embedded host capabilities, and `runEmbeddedAttempt` is only reached through `runAgentHarnessLifecycleAttempt`, which now demotes an unsupported engine to legacy before the embedded runner runs — so the removed assert is redundant, not load-bearing.
- **Risk**: Silent degradation hides a misconfiguration. **Mitigation**: each demotion logs the engine's unsupported-host warning (including its `unsupportedMessage`), and the existing `openclaw doctor` warning still flags the incompatibility.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents / runtime
- [x] Context engine

### Linked Issue/PR

Fixes #93337
