### PR TITLE
fix(gateway): honor explicit systemd respawn markers

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -87,6 +87,19 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it("lets explicit OpenClaw systemd supervision override OPENCLAW_NO_RESPAWN", () => {
+    clearSupervisorHints();
+    setPlatform("linux");
+    process.env.OPENCLAW_NO_RESPAWN = "1";
+    process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result).toEqual({ mode: "supervised" });
+    expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("returns supervised when OpenClaw launchd markers are present on macOS (no kickstart)", () => {
     clearSupervisorHints();
     expectLaunchdSupervisedWithoutKickstart({ launchJobLabel: "ai.openclaw.gateway" });

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -21,9 +21,36 @@ type GatewayRespawnOptions = {
   env?: NodeJS.ProcessEnv;
 };
 
+function hasValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function isTruthy(value: string | undefined): boolean {
   const normalized = normalizeOptionalLowercaseString(value);
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function detectOpenClawSupervisorMarker(
+  env: NodeJS.ProcessEnv,
+): ReturnType<typeof detectRespawnSupervisor> {
+  if (process.platform === "darwin" && hasValue(env.OPENCLAW_LAUNCHD_LABEL)) {
+    return "launchd";
+  }
+  if (process.platform === "linux" && hasValue(env.OPENCLAW_SYSTEMD_UNIT)) {
+    return "systemd";
+  }
+  if (process.platform === "win32") {
+    if (hasValue(env.OPENCLAW_WINDOWS_TASK_NAME)) {
+      return "schtasks";
+    }
+    if (
+      env.OPENCLAW_SERVICE_MARKER?.trim() === "openclaw" &&
+      env.OPENCLAW_SERVICE_KIND?.trim() === "gateway"
+    ) {
+      return "schtasks";
+    }
+  }
+  return null;
 }
 
 function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
@@ -50,24 +77,16 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
 export function restartGatewayProcessWithFreshPid(
   _opts: GatewayRespawnOptions = {},
 ): GatewayRespawnResult {
+  const explicitSupervisor = detectOpenClawSupervisorMarker(process.env);
+  if (explicitSupervisor) {
+    return completeSupervisorRespawn(explicitSupervisor);
+  }
   if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
     return { mode: "disabled" };
   }
   const supervisor = detectRespawnSupervisor(process.env);
   if (supervisor) {
-    // On macOS launchd, exit cleanly and let KeepAlive relaunch the service.
-    // Avoid detached kickstart/start handoffs here so restart timing stays tied
-    // to launchd's native supervision rather than a second helper process.
-    if (supervisor === "schtasks") {
-      const restart = triggerOpenClawRestart();
-      if (!restart.ok) {
-        return {
-          mode: "failed",
-          detail: restart.detail ?? `${restart.method} restart failed`,
-        };
-      }
-    }
-    return { mode: "supervised" };
+    return completeSupervisorRespawn(supervisor);
   }
   if (process.platform === "win32") {
     // Detached respawn is unsafe on Windows without an identified Scheduled Task:
@@ -88,6 +107,23 @@ export function restartGatewayProcessWithFreshPid(
     mode: "disabled",
     detail: "unmanaged: use in-process restart to keep custom supervisor PID tracking stable",
   };
+}
+
+function completeSupervisorRespawn(
+  supervisor: NonNullable<ReturnType<typeof detectRespawnSupervisor>>,
+): GatewayRespawnResult {
+  // Native supervisors already track the gateway process; exit cleanly and let
+  // them relaunch instead of creating a helper process or keeping the old PID.
+  if (supervisor === "schtasks") {
+    const restart = triggerOpenClawRestart();
+    if (!restart.ok) {
+      return {
+        mode: "failed",
+        detail: restart.detail ?? `${restart.method} restart failed`,
+      };
+    }
+  }
+  return { mode: "supervised" };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Prefer explicit OpenClaw supervisor markers before `OPENCLAW_NO_RESPAWN` when choosing the gateway restart handoff mode.
- Keep `OPENCLAW_NO_RESPAWN` ahead of inherited supervisor hints, so dev/test and accidentally inherited launchd/systemd env still keep the old in-process behavior.
- Factor the shared supervised-respawn completion path so systemd/launchd/schtasks handling stays consistent.

## Problem
A Linux user service can carry both:

- `OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service` from the OpenClaw systemd unit, meaning the gateway should exit and let systemd relaunch it.
- `OPENCLAW_NO_RESPAWN=1` from local startup optimization, meaning unmanaged/dev restarts should remain in-process.

Before this change, `OPENCLAW_NO_RESPAWN` was checked first. That made a systemd-managed gateway perform an in-process restart instead of exiting for the supervisor. In a local restart/recovery incident, this produced the following sequence:

1. The gateway was systemd-managed and had an explicit OpenClaw systemd marker.
2. The gateway received `SIGTERM` while a restart intent was present.
3. The gateway logged `received SIGTERM; restarting`.
4. Shutdown completed cleanly.
5. The gateway logged `restart mode: in-process restart (OPENCLAW_NO_RESPAWN)`.
6. systemd later timed out the stop operation and killed the old process with `SIGKILL`.

This is adjacent to #84610: the exact SIGTERM sender can vary, but once systemd is the supervisor, an explicit OpenClaw systemd marker should not be masked by `OPENCLAW_NO_RESPAWN`.

## Fix
`restartGatewayProcessWithFreshPid()` now checks OpenClaw-owned explicit supervisor markers first:

- `OPENCLAW_LAUNCHD_LABEL`
- `OPENCLAW_SYSTEMD_UNIT`
- `OPENCLAW_WINDOWS_TASK_NAME`
- OpenClaw gateway service marker pair on Windows

If one is present, restart handoff returns `supervised`. Only after that does `OPENCLAW_NO_RESPAWN` disable fresh-PID respawn. Existing inherited-hint behavior is preserved: inherited launchd/systemd hints still lose to `OPENCLAW_NO_RESPAWN` unless OpenClaw itself injected the explicit supervisor marker.

## Validation
- `env -u OPENCLAW_SYSTEMD_UNIT -u OPENCLAW_NO_RESPAWN -u INVOCATION_ID -u SYSTEMD_EXEC_PID -u JOURNAL_STREAM node scripts/run-vitest.mjs src/infra/process-respawn.test.ts`
  - `24 passed`
- `pnpm exec oxfmt --check --threads=1 src/infra/process-respawn.ts src/infra/process-respawn.test.ts`
  - passed
- `git diff --check`
  - passed

Notes:
- `pnpm tsgo:core:test` was attempted locally after dependency install but the process was killed by the environment before emitting TypeScript diagnostics. The PR relies on the focused unit test plus CI for full type coverage.

## Risk
Low. The change is limited to restart handoff mode selection. It intentionally preserves the existing `OPENCLAW_NO_RESPAWN` behavior for unmanaged/dev environments and inherited supervisor hints, while allowing explicit OpenClaw supervisor markers to do what they already mean: hand restart back to the native supervisor.


## Current CI Notes
Initial CI on this PR also shows failures outside this diff:

- `checks-node-core-src-security`: `src/skills/runtime/session-snapshot.test.ts` assertions fail. This same current-main failure was already observed while triaging #93194 and is not touched by this PR.
- `check-additional-extension-package-boundary`: `extensions/codex/src/app-server/bounded-turn.ts` reports `TS2322` on lines 223-224. This PR only touches `src/infra/process-respawn*`.
- `checks-node-core-fast`: `test/scripts/plugin-sdk-surface-report.test.ts` reports `result.status=1`, also outside this PR's touched surface.

These are not being fixed here to keep the supervisor respawn change scoped.
