### PR TITLE
fix(feishu): suppress log noise for bot_p2p_chat_entered_v1 event [AI-assisted]

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -306,6 +306,9 @@ function registerEventHandlers(
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
     },
+    "im.chat.access_event.bot_p2p_chat_entered_v1": async () => {
+      // Ignore p2p chat entry notifications — no action needed
+    },
     "im.chat.member.bot.added_v1": async (data) => {
       try {
         const event = parseFeishuBotAddedEventPayload(data);

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -363,6 +363,32 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
+  it("does not emit unhandled-event warning for bot_p2p_chat_entered_v1", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "p2p-chat-entered",
+        path: "/hook-e2e-p2p-chat-entered",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const payload = {
+          schema: "2.0",
+          header: { event_type: "im.chat.access_event.bot_p2p_chat_entered_v1" },
+          event: {},
+        };
+        const response = await postSignedPayload(url, payload);
+
+        expect(response.status).toBe(200);
+        const body = await response.text();
+        expect(body).not.toContain("no im.chat.access_event.bot_p2p_chat_entered_v1 event handle");
+      },
+    );
+  });
+
   it("accepts signed encrypted url_verification challenges end-to-end", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
 


### PR DESCRIPTION
# fix(feishu): suppress log noise for bot_p2p_chat_entered_v1 event [AI-assisted]

## What and Why

Every time a user opens a 1-on-1 chat with the Feishu bot, Lark pushes an
`im.chat.access_event.bot_p2p_chat_entered_v1` event to the webhook endpoint. Because
`registerEventHandlers()` in `extensions/feishu/src/monitor.account.ts` had no handler registered
for this event type, the Lark SDK dispatcher logged:

```
[warn] no im.chat.access_event.bot_p2p_chat_entered_v1 event handle
```

on every p2p-chat entry — once per user open, per account — producing persistent warn-level log
noise with no actionable signal.

**Scope:** This PR suppresses the unhandled-event log noise only. Any gateway-restart behavior
referenced in the issue is a separate concern and is **not** claimed or addressed here.

## Change

A four-line no-op handler was added to the `eventDispatcher.register({...})` call in
`registerEventHandlers()`, immediately after the existing `im.message.message_read_v1` no-op (the
established in-file precedent for intentionally-ignored Lark lifecycle events):

```ts
// existing precedent:
"im.message.message_read_v1": async () => {
  // Ignore read receipts
},
// new handler:
"im.chat.access_event.bot_p2p_chat_entered_v1": async () => {
  // Ignore p2p chat entry notifications — no action needed
},
```

## Real behavior proof

**Behavior or issue addressed:** Opening a 1-on-1 Feishu chat with the bot emitted a
`no im.chat.access_event.bot_p2p_chat_entered_v1 event handle` warn-level log line on every entry,
because the event had no registered handler.

**Real environment tested:** Local clean checkout of `openclaw/openclaw` `main` (commit `042ebb4f`),
Node v24.7.0, pnpm 11.2.2, macOS (Darwin 25.4). The proof runs the Feishu webhook monitor as a
**real HTTP server** via the existing `withRunningWebhookMonitor` harness (a real
`@larksuiteoapi` `EventDispatcher`, not a mock of the dispatcher) and posts a signed
`bot_p2p_chat_entered_v1` payload to it.

**Exact steps or command run after this patch:**
```
node scripts/run-vitest.mjs run extensions/feishu/src/monitor.webhook-e2e.test.ts
```

**Before evidence (optional):** With no handler registered, the running monitor's HTTP response
carries the SDK's unhandled-event warning (copied live output):
```
[warn]: [ 'no im.chat.access_event.bot_p2p_chat_entered_v1 handle' ]
 × does not emit unhandled-event warning for bot_p2p_chat_entered_v1
AssertionError: expected '"no im.chat.access_event.bot_p2p_chat…' not to contain
'no im.chat.access_event.bot_p2p_chat_entered_v1 event handle'
 Tests  1 failed | 10 passed (11)
```

**Evidence after fix:** Re-running the same `node scripts/run-vitest.mjs` command against the
running monitor after adding the handler — copied live terminal output:
```
node scripts/run-vitest.mjs run extensions/feishu/src/monitor.webhook-e2e.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Observed result after fix:** The live webhook server now dispatches
`im.chat.access_event.bot_p2p_chat_entered_v1` to the no-op handler; the HTTP response body no
longer contains the `no ... event handle` warning. No other event handling changed (the other 10
webhook cases still pass).

**What was not tested:** A capture from a production Feishu tenant opening a real p2p chat was not
collected — that requires live Feishu app credentials, which were not available here. The behavior
is reproduced against a real running webhook server + real Lark `EventDispatcher` locally; the
"before" state (warning emitted) is deterministic for any p2p-chat-entry event.

## Checklist

- [x] Minimal diff — handler registration + test only
- [x] No CHANGELOG entry (per repo conventions; maintainers/ClawSweeper add changelog on landing)
- [x] American English throughout
- [x] No CODEOWNERS paths touched
- [x] AI-assisted; reviewed by a human before submission

> Maintainers: feel free to edit this PR (allow-maintainer-edits is on).

Fixes #42351
