### PR TITLE
fix #86957: [Bug]: Telegram Ingress Routing Bug

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -903,6 +903,79 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("drains worker-spooled updates without waiting for the next drain interval", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const handleUpdate = vi.fn(async () => {
+      abort.abort();
+    });
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    let onMessage: WorkerMessageListener | undefined;
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const ackSpooledUpdate = vi.fn();
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn((listener: WorkerMessageListener) => {
+        onMessage = listener;
+        return () => undefined;
+      }),
+      ackSpooledUpdate,
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 60_000,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(onMessage).toBeDefined());
+      onMessage?.({
+        type: "update",
+        requestId: "write-1",
+        update: { update_id: 42, message: { text: "hello" } },
+        queued: 1,
+      });
+
+      await vi.waitFor(() =>
+        expect(ackSpooledUpdate).toHaveBeenCalledWith("write-1", { ok: true, updateId: 42 }),
+      );
+      onMessage?.({ type: "spooled", updateId: 42, queued: 1 });
+      await vi.waitFor(() =>
+        expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
+      );
+      await vi.waitFor(async () => expect(await pendingUpdateIds(tempDir, "all")).toEqual([]));
+      stopWorker?.();
+      await runPromise;
+    } finally {
+      abort.abort();
+      stopWorker?.();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("drains existing isolated ingress spool entries below the persisted offset", async () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -989,6 +989,7 @@ export class TelegramPollingSession {
       forceCycleResolve = resolve;
     });
     const stalledBacklogKeys = new Set<string>();
+    let requestImmediateDrain: () => void = () => undefined;
     const unsubscribe = worker.onMessage((message) => {
       const ackSpooledUpdate = (
         requestId: string,
@@ -1042,6 +1043,7 @@ export class TelegramPollingSession {
         }).then(
           (updateId) => {
             ackSpooledUpdate(message.requestId, { ok: true, updateId });
+            requestImmediateDrain();
           },
           (err: unknown) => {
             ackSpooledUpdate(message.requestId, {
@@ -1054,6 +1056,7 @@ export class TelegramPollingSession {
       }
       if (message.type === "spooled") {
         liveness.noteGetUpdatesActivity();
+        requestImmediateDrain();
       }
     });
     const stopOnAbort = () => {
@@ -1133,6 +1136,9 @@ export class TelegramPollingSession {
       } finally {
         drainActive = false;
       }
+    };
+    requestImmediateDrain = () => {
+      void drainOnce();
     };
     await drainOnce();
     const drainTimer = setInterval(() => {


### PR DESCRIPTION
## Summary
- Wake the Telegram isolated polling drain immediately after a worker-spooled update is written to `channel_ingress_events`.
- Keep the existing durable queue, claim, completion, and interval-drain behavior unchanged.
- Add a regression test covering worker-spooled inbound delivery without waiting for the next drain interval.

## Issue
Fixes #86957.

## Root Cause
- **Root cause:** The root source of this state lifecycle bug is that the isolated Telegram ingress worker asks the main polling session to write inbound updates into `channel_ingress_events`, but the main session only drained that spool at cycle start and on the periodic drain timer. Because the worker-write lifecycle did not wake the queue drain, a subsequent worker-spooled inbound update could remain `pending` with `attempts = 0`, `claim_owner = null`, and no delivery queue entry until a later timer-driven drain.
- **Why this is root-cause fix:** The missing invariant was that a successful worker write must wake the production drain path that claims, dispatches, and completes the queued update. This patch requests a drain immediately after the main session persists a worker update, and again when the worker reports the update as spooled; the existing `drainActive`, abort, restart, claim, and completion guards still own ordering and concurrency.
- **Fix classification:** Minimal root-cause fix in the Telegram isolated ingress dispatcher wakeup path.
- **Maintainer-ready confidence:** High. The diff is limited to `extensions/telegram/src/polling-session.ts` and a focused regression in `extensions/telegram/src/polling-session.test.ts`; it does not change queue schema, channel policy, outbound Telegram behavior, access control, provider routing, or token handling.

## Why it matters / User impact
- **Why it matters / User impact:** Issue #86957 reports Telegram inbound routing wedging after a successful first Telegram turn: outbound Telegram still works, polling still starts, and the next inbound row reaches `channel_ingress_events`, but it stays pending/unclaimed with no delivery queue entry. This leaves users with an apparently live Telegram integration that stops responding to later DMs.
- **What did NOT change:** This PR only changes the isolated Telegram polling session's wakeup after worker-spooled updates. It does not change Telegram outbound delivery, non-isolated polling, channel authorization, DM allow/deny policy, queue schema, retry accounting, or completion semantics.
- **Architecture / source-of-truth check:** The source of truth for durable inbound delivery remains the existing `channel_ingress_events` queue plus the existing Telegram drain path in `polling-session.ts`. The patch does not introduce a second dispatcher, bypass queue claiming, or mutate public configuration/schema defaults.
- **Related open PR scan:** The daily-fix public-contract scan for this issue found no related open PRs competing on this contract surface.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts --run` — tests passed (requires pnpm install)
- `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-spool.test.ts --run` — tests passed
- `git diff --check` — passed

## Patch quality notes
- **Patch quality notes:** The implementation adds a wakeup call only after a successful worker queue write and after the existing worker activity notification. The existing `drainOnce()` implementation still handles stale backlog recovery, claim ordering, `drainActive` re-entry prevention, abort checks, restart checks, dispatch, completion, release, and failure handling.
- **Canonical scope:** The fix stays at the production session that receives worker messages and owns the drain loop. It intentionally does not add a fallback dispatcher in the queue adapter or alter durable receive journal behavior, because those layers already list/claim pending records when invoked.
- **Compatibility/default behavior:** No public config, schema, protocol payload, queue record format, default interval, or migration behavior changes.

## Merge risk
- **Risk labels considered:** `message-delivery`, `availability`, `session-state`.
- **Risk explanation:** This PR affects Telegram message delivery timing and the Telegram polling session's drain wakeup path. The main risk would be duplicate or concurrent drain attempts, but the existing `drainActive` guard keeps drain execution single-flight and the existing queue claim/complete path remains the only dispatch path.
- **Why acceptable:** The change narrows latency/stall behavior without bypassing durable queue semantics. If a worker writes an update while a drain is already active, the immediate request is ignored by the existing re-entry guard and the active drain continues using the same pending queue source of truth.
- **Not changed:** No database schema changes, no Telegram outbound changes, no policy/default/config changes, no provider/auth changes, and no token handling changes.
