### PR TITLE
feat(slack): inject image annotation in thread history for temporal context (fixes #48321)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/image-annotation.test.ts
+++ b/extensions/slack/src/monitor/message-handler/image-annotation.test.ts
@@ -1,0 +1,138 @@
+// Verification for image annotation utility.
+import { describe, expect, it } from "vitest";
+import {
+  buildImageAnnotation,
+  hasImageFiles,
+  isImageFile,
+} from "./image-annotation.js";
+
+describe("isImageFile", () => {
+  it("returns true for image MIME type", () => {
+    expect(isImageFile({ mimetype: "image/png", name: "photo.png" })).toBe(true);
+    expect(isImageFile({ mimetype: "image/jpeg" })).toBe(true);
+    expect(isImageFile({ mimetype: "IMAGE/GIF" })).toBe(true);
+  });
+
+  it("returns true for image file extension", () => {
+    expect(isImageFile({ name: "screenshot.png" })).toBe(true);
+    expect(isImageFile({ name: "photo.jpg" })).toBe(true);
+    expect(isImageFile({ name: "animation.gif" })).toBe(true);
+    expect(isImageFile({ name: "modern.webp" })).toBe(true);
+    expect(isImageFile({ name: "vector.svg" })).toBe(true);
+    expect(isImageFile({ name: "pic.HEIC" })).toBe(true);
+  });
+
+  it("returns false for non-image files", () => {
+    expect(isImageFile({ mimetype: "application/pdf", name: "doc.pdf" })).toBe(false);
+    expect(isImageFile({ mimetype: "text/plain", name: "readme.txt" })).toBe(false);
+    expect(isImageFile({ name: "data.csv" })).toBe(false);
+  });
+
+  it("returns false when no mimetype or name", () => {
+    expect(isImageFile({})).toBe(false);
+  });
+});
+
+describe("hasImageFiles", () => {
+  it("returns true when files contain an image", () => {
+    expect(hasImageFiles([{ mimetype: "image/png" }])).toBe(true);
+  });
+
+  it("returns false when files are all non-images", () => {
+    expect(hasImageFiles([{ mimetype: "application/pdf" }])).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(hasImageFiles(undefined)).toBe(false);
+  });
+
+  it("returns false for empty array", () => {
+    expect(hasImageFiles([])).toBe(false);
+  });
+});
+
+describe("buildImageAnnotation", () => {
+  it("formats annotation with all fields", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 8,
+      messageIndex: 1,
+      timestamp: "1710590400",
+      author: "alice (user)",
+      timezone: "UTC",
+    });
+    expect(result).toContain("Image — sent");
+    expect(result).toContain("message 1 of 8 in thread");
+    expect(result).toContain("from alice (user)");
+    expect(result).not.toContain("unknown time");
+  });
+
+  it("handles missing timestamp gracefully", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 3,
+      messageIndex: 2,
+    });
+    expect(result).toContain("unknown time");
+    expect(result).toContain("message 2 of 3 in thread");
+    expect(result).not.toContain("undefined");
+  });
+
+  it("omits author clause when author is absent", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 3,
+      messageIndex: 2,
+      timestamp: "1710590400",
+    });
+    expect(result).not.toContain("from");
+  });
+
+  it("omits author clause when author is empty string", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 3,
+      messageIndex: 2,
+      timestamp: "1710590400",
+      author: "  ",
+    });
+    expect(result).not.toContain("from");
+  });
+
+  it('shows "standalone message" for single-message threads', () => {
+    const result = buildImageAnnotation({
+      totalMessages: 1,
+      messageIndex: 1,
+      timestamp: "1710590400",
+      author: "bob",
+    });
+    expect(result).toContain("standalone message");
+    expect(result).not.toContain("of 1 in thread");
+  });
+
+  it("handles Slack-style decimal timestamp", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 5,
+      messageIndex: 3,
+      timestamp: "1710590400.123456",
+      timezone: "UTC",
+    });
+    expect(result).not.toContain("unknown time");
+    expect(result).toContain("message 3 of 5 in thread");
+  });
+
+  it("handles empty timestamp string", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 2,
+      messageIndex: 1,
+      timestamp: "",
+    });
+    expect(result).toContain("unknown time");
+  });
+
+  it("uses UTC as default timezone", () => {
+    const result = buildImageAnnotation({
+      totalMessages: 2,
+      messageIndex: 1,
+      timestamp: "1710590400",
+    });
+    expect(result).toContain("Image — sent");
+    expect(result).not.toContain("unknown time");
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/image-annotation.ts
+++ b/extensions/slack/src/monitor/message-handler/image-annotation.ts
@@ -1,0 +1,99 @@
+// Slack plugin module implements image annotation for thread history.
+// Injects temporal metadata before image references so the model can reason
+// about image freshness relative to the conversation flow.
+import type { SlackFile } from "../../types.js";
+
+/** Image MIME type prefixes that indicate a visual image file. */
+const IMAGE_MIME_PREFIX = "image/";
+
+/** Common image file extensions. */
+const IMAGE_EXTENSION_RE = /\.(png|jpe?g|gif|webp|bmp|tiff?|heic|heif|svg)$/i;
+
+/** Check whether a Slack file looks like an image based on its MIME type or name. */
+export function isImageFile(file: SlackFile): boolean {
+  if (file.mimetype?.toLowerCase().startsWith(IMAGE_MIME_PREFIX)) {
+    return true;
+  }
+  const name = file.name?.toLowerCase() ?? "";
+  return IMAGE_EXTENSION_RE.test(name);
+}
+
+/** Check whether a list of Slack files contains at least one image. */
+export function hasImageFiles(files: SlackFile[] | undefined): boolean {
+  return files?.some(isImageFile) ?? false;
+}
+
+/**
+ * Format a Slack-style decimal-seconds timestamp (e.g. "1710590400.123456")
+ * into a human-readable date string like "Mon 2026-03-16 10:50 EDT".
+ *
+ * Falls back to "unknown time" when the timestamp is missing or invalid.
+ */
+function formatTimestamp(ts: string | undefined, timezone: string): string {
+  if (!ts) {
+    return "unknown time";
+  }
+  const seconds = Number.parseFloat(ts);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "unknown time";
+  }
+  const ms = seconds < 1e12 ? seconds * 1000 : seconds;
+  const date = new Date(ms);
+  if (Number.isNaN(date.getTime())) {
+    return "unknown time";
+  }
+  try {
+    return date.toLocaleString("en-US", {
+      timeZone: timezone,
+      weekday: "short",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  } catch {
+    // Invalid timezone — fall back to UTC.
+    return date.toLocaleString("en-US", {
+      timeZone: "UTC",
+      weekday: "short",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  }
+}
+
+/**
+ * Build a metadata annotation line for an image in thread history.
+ *
+ * Format: `[Image — sent <date>, message N of M in thread, from <author>]`
+ * Single-message threads use "standalone message" instead of "N of M in thread".
+ *
+ * This gives the model temporal context so it can reason about image freshness
+ * rather than treating all images as equally current.
+ */
+export function buildImageAnnotation(params: {
+  totalMessages: number;
+  messageIndex: number;
+  timestamp?: string;
+  author?: string;
+  timezone?: string;
+}): string {
+  const timezone = params.timezone ?? "UTC";
+  const date = formatTimestamp(params.timestamp, timezone);
+
+  const position =
+    params.totalMessages <= 1
+      ? "standalone message"
+      : `message ${params.messageIndex} of ${params.totalMessages} in thread`;
+
+  const author = params.author?.trim();
+  const authorClause = author ? `, from ${author}` : "";
+
+  return `[Image — sent ${date}, ${position}${authorClause}]`;
+}

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -22,6 +22,7 @@ import {
   resolveSlackThreadHistoryFilterPolicy,
   shouldIncludeBotThreadStarterContext,
 } from "./prepare-thread-context-root.js";
+import { buildImageAnnotation, hasImageFiles } from "./image-annotation.js";
 import { resolveSlackTimestampMs } from "./timestamp.js";
 
 type SlackMediaModule = typeof import("../media.js");
@@ -297,7 +298,8 @@ export async function resolveSlackThreadContextData(params: {
       }
 
       const historyParts: string[] = [];
-      for (const historyMsg of filteredThreadHistory) {
+      const totalMessages = filteredThreadHistory.length;
+      for (const [msgIndex, historyMsg] of filteredThreadHistory.entries()) {
         const msgUser = historyMsg.userId ? userMap.get(historyMsg.userId) : null;
         const isOtherBot = Boolean(historyMsg.botId) && historyMsg.botId !== params.ctx.botId;
         const isCurrentBot = isCurrentBotAuthor({
@@ -309,7 +311,26 @@ export async function resolveSlackThreadContextData(params: {
         const msgSenderName = isCurrentBot
           ? "Bot (this assistant)"
           : (msgUser?.name ?? (historyMsg.botId ? `Bot (${historyMsg.botId})` : "Unknown"));
-        const msgWithId = `${historyMsg.text}\n[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
+
+        let imageAnnotation = "";
+        if (hasImageFiles(historyMsg.files)) {
+          const rawTimezone = params.envelopeOptions?.timezone;
+          const annotationTimezone =
+            !rawTimezone || rawTimezone === "local" || rawTimezone === "host"
+              ? (Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC")
+              : rawTimezone === "utc" || rawTimezone === "gmt"
+                ? "UTC"
+                : rawTimezone;
+          imageAnnotation = `${buildImageAnnotation({
+            totalMessages,
+            messageIndex: msgIndex + 1,
+            timestamp: historyMsg.ts,
+            author: `${msgSenderName} (${role})`,
+            timezone: annotationTimezone,
+          })}\n`;
+        }
+
+        const msgWithId = `${historyMsg.text}\n${imageAnnotation}[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;
         historyParts.push(
           formatInboundEnvelope({
             channel: "Slack",


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** When an agent replies in a threaded conversation (Slack, Discord, etc.), thread history images have no temporal metadata. The model treats all images as equally current, causing it to reference stale screenshots even after the user states the situation has changed.
- **Environment tested:** macOS 26.4.1, Node.js, openclaw/openclaw upstream/main at 66079161
- **Steps run after the patch:**
  1. Created `extensions/slack/src/monitor/message-handler/image-annotation.ts` with `isImageFile`, `hasImageFiles`, and `buildImageAnnotation` utilities
  2. Integrated annotation injection into `prepare-thread-context.ts` thread history assembly loop
  3. Ran related Slack extension tests
  4. Ran build
- **Evidence after fix:**

```
$ grep -n "buildImageAnnotation\|hasImageFiles\|imageAnnotation" extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
25:import { buildImageAnnotation, hasImageFiles } from "./image-annotation.js";
315:        let imageAnnotation = "";
316:        if (hasImageFiles(historyMsg.files)) {
324:          imageAnnotation = `${buildImageAnnotation({
333:        const msgWithId = `${historyMsg.text}\n${imageAnnotation}[slack message id: ${historyMsg.ts ?? "unknown"} channel: ${params.message.channel}]`;

$ grep -n "export function" extensions/slack/src/monitor/message-handler/image-annotation.ts
13:export function isImageFile(file: SlackFile): boolean {
22:export function hasImageFiles(files: SlackFile[] | undefined): boolean {
80:export function buildImageAnnotation(params: {
```

- **Observed result after fix:** All 111 tests pass (16 new + 10 existing prepare-thread-context + 85 existing prepare). Build succeeds. The annotation `[Image — sent <date>, message N of M in thread, from <sender>]` is injected before the `[slack message id: ...]` line in thread history messages that contain image attachments. Messages without images are unaffected.
- **What was not tested:** Live Slack workspace with actual thread conversations containing images. The annotation formatting and image detection logic are verified through focused tests covering edge cases (missing timestamps, empty files, single-message threads, various image MIME types).
