### PR TITLE
fix: preserve cron delivery awareness for target sessions

### DIFF
--- a/packages/sdk/src/package.e2e.test.ts
+++ b/packages/sdk/src/package.e2e.test.ts
@@ -5,8 +5,8 @@ import fs from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { createPnpmRunnerSpawnSpec } from "../../../scripts/pnpm-runner.mjs";
 import { afterEach, describe, expect, it } from "vitest";
+import { createPnpmRunnerSpawnSpec } from "../../../scripts/pnpm-runner.mjs";
 import { createNodeEvalArgs } from "../../../src/test-utils/node-process.js";
 
 type CommandResult = {
@@ -123,8 +123,9 @@ function runPnpmCommand(
     pnpmArgs: args,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  const cwd = typeof spec.options.cwd === "string" ? spec.options.cwd : options.cwd;
   return runCommand(spec.command, spec.args, {
-    cwd: spec.options.cwd ?? options.cwd,
+    cwd,
     env: spec.options.env,
     shell: spec.options.shell,
     timeoutMs: options.timeoutMs,

--- a/scripts/check-release-metadata-only.mjs
+++ b/scripts/check-release-metadata-only.mjs
@@ -29,23 +29,28 @@ function readRefOptionValue(argv, index, optionName) {
 }
 
 export function parseArgs(argv) {
+  const separatorIndex = argv.indexOf("--");
+  const flagArgv = separatorIndex === -1 ? argv : argv.slice(0, separatorIndex);
+  const explicitPaths =
+    separatorIndex === -1 ? [] : argv.slice(separatorIndex + 1).map(normalizePath);
   const args = { staged: false, base: "origin/main", head: "HEAD", paths: [] };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--") {
-      continue;
-    } else if (arg === "--staged") {
+  for (let index = 0; index < flagArgv.length; index += 1) {
+    const arg = flagArgv[index];
+    if (arg === "--staged") {
       args.staged = true;
     } else if (arg === "--base") {
-      args.base = readRefOptionValue(argv, index, arg);
+      args.base = readRefOptionValue(flagArgv, index, arg);
       index += 1;
     } else if (arg === "--head") {
-      args.head = readRefOptionValue(argv, index, arg);
+      args.head = readRefOptionValue(flagArgv, index, arg);
       index += 1;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
     } else {
       args.paths.push(normalizePath(arg));
     }
   }
+  args.paths.push(...explicitPaths);
   return args;
 }
 
@@ -164,5 +169,10 @@ export function main(argv = process.argv.slice(2)) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
-  main();
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }

--- a/src/agents/embedded-agent-runner/run/attempt-bootstrap-routing.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bootstrap-routing.ts
@@ -33,23 +33,6 @@ type AttemptWorkspaceBootstrapRoutingInput = Omit<
   bootstrapFiles?: readonly WorkspaceBootstrapFile[];
 };
 
-/**
- * Maps a resolved bootstrap mode to concrete prompt destinations. Today only
- * full bootstrap enters system context; limited/none intentionally avoid
- * runtime-context injection until that path has a separate contract.
- */
-export function resolveBootstrapContextTargets(params: {
-  bootstrapMode: BootstrapMode;
-}): Pick<
-  AttemptBootstrapRouting,
-  "includeBootstrapInSystemContext" | "includeBootstrapInRuntimeContext"
-> {
-  return {
-    includeBootstrapInSystemContext: params.bootstrapMode === "full",
-    includeBootstrapInRuntimeContext: false,
-  };
-}
-
 function resolveAttemptBootstrapRouting(
   params: AttemptBootstrapRoutingInput,
 ): AttemptBootstrapRouting {
@@ -66,20 +49,9 @@ function resolveAttemptBootstrapRouting(
 
   return {
     bootstrapMode,
-    ...resolveBootstrapContextTargets({ bootstrapMode }),
+    includeBootstrapInSystemContext: bootstrapMode === "full",
+    includeBootstrapInRuntimeContext: false,
   };
-}
-
-export function hasBootstrapFileContent(files?: readonly WorkspaceBootstrapFile[]): boolean {
-  return (
-    files?.some(
-      (file) =>
-        file.name === DEFAULT_BOOTSTRAP_FILENAME &&
-        !file.missing &&
-        typeof file.content === "string" &&
-        file.content.trim().length > 0,
-    ) ?? false
-  );
 }
 
 /**
@@ -94,7 +66,14 @@ export async function resolveAttemptWorkspaceBootstrapRouting(
   const workspaceBootstrapPending = await params.isWorkspaceBootstrapPending(
     params.resolvedWorkspace,
   );
-  const hasHookBootstrapContent = hasBootstrapFileContent(params.bootstrapFiles);
+  const hasHookBootstrapContent =
+    params.bootstrapFiles?.some(
+      (file) =>
+        file.name === DEFAULT_BOOTSTRAP_FILENAME &&
+        !file.missing &&
+        typeof file.content === "string" &&
+        file.content.trim().length > 0,
+    ) ?? false;
   return resolveAttemptBootstrapRouting({
     ...params,
     workspaceBootstrapPending: workspaceBootstrapPending || hasHookBootstrapContent,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts
@@ -1,10 +1,6 @@
 // Coverage for bootstrap routing across canonical and effective workspaces.
 import { describe, expect, it, vi } from "vitest";
-import {
-  hasBootstrapFileContent,
-  resolveBootstrapContextTargets,
-  resolveAttemptWorkspaceBootstrapRouting,
-} from "./attempt-bootstrap-routing.js";
+import { resolveAttemptWorkspaceBootstrapRouting } from "./attempt-bootstrap-routing.js";
 
 describe("runEmbeddedAttempt bootstrap routing", () => {
   it("resolves bootstrap pending from the canonical workspace instead of a copied sandbox", async () => {
@@ -100,34 +96,27 @@ describe("runEmbeddedAttempt bootstrap routing", () => {
     expect(routing.includeBootstrapInRuntimeContext).toBe(false);
   });
 
-  it("does not treat empty hook-provided BOOTSTRAP.md as pending bootstrap context", () => {
-    expect(
-      hasBootstrapFileContent([
+  it("does not treat empty hook-provided BOOTSTRAP.md as pending bootstrap context", async () => {
+    const routing = await resolveAttemptWorkspaceBootstrapRouting({
+      isWorkspaceBootstrapPending: vi.fn(async () => false),
+      bootstrapFiles: [
         {
           name: "BOOTSTRAP.md",
           path: "/tmp/openclaw-workspace/BOOTSTRAP.md",
           content: "   ",
           missing: false,
         },
-      ]),
-    ).toBe(false);
-  });
+      ],
+      trigger: "user",
+      isPrimaryRun: true,
+      isCanonicalWorkspace: true,
+      effectiveWorkspace: "/tmp/openclaw-workspace",
+      resolvedWorkspace: "/tmp/openclaw-workspace",
+      hasBootstrapFileAccess: true,
+    });
 
-  it("keeps BOOTSTRAP.md in Project Context for full bootstrap turns", () => {
-    expect(resolveBootstrapContextTargets({ bootstrapMode: "full" })).toEqual({
-      includeBootstrapInSystemContext: true,
-      includeBootstrapInRuntimeContext: false,
-    });
-  });
-
-  it("excludes BOOTSTRAP.md from every context outside full bootstrap turns", () => {
-    expect(resolveBootstrapContextTargets({ bootstrapMode: "limited" })).toEqual({
-      includeBootstrapInSystemContext: false,
-      includeBootstrapInRuntimeContext: false,
-    });
-    expect(resolveBootstrapContextTargets({ bootstrapMode: "none" })).toEqual({
-      includeBootstrapInSystemContext: false,
-      includeBootstrapInRuntimeContext: false,
-    });
+    expect(routing.bootstrapMode).toBe("none");
+    expect(routing.includeBootstrapInSystemContext).toBe(false);
+    expect(routing.includeBootstrapInRuntimeContext).toBe(false);
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -16,7 +16,6 @@ import {
   resolveEmbeddedAgentBaseStreamFn,
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
-import { resolveBootstrapContextTargets } from "./attempt-bootstrap-routing.js";
 import { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import {
   buildAfterTurnRuntimeContext,
@@ -329,23 +328,6 @@ describe("resolvePromptModeForSession", () => {
     expect(resolvePromptModeForSession(undefined)).toBe("full");
     expect(resolvePromptModeForSession("agent:main")).toBe("full");
     expect(resolvePromptModeForSession("agent:main:thread:abc")).toBe("full");
-  });
-});
-
-describe("resolveBootstrapContextTargets", () => {
-  it("keeps BOOTSTRAP.md in system Project Context only for full bootstrap turns", () => {
-    expect(resolveBootstrapContextTargets({ bootstrapMode: "full" })).toEqual({
-      includeBootstrapInSystemContext: true,
-      includeBootstrapInRuntimeContext: false,
-    });
-    expect(resolveBootstrapContextTargets({ bootstrapMode: "limited" })).toEqual({
-      includeBootstrapInSystemContext: false,
-      includeBootstrapInRuntimeContext: false,
-    });
-    expect(resolveBootstrapContextTargets({ bootstrapMode: "none" })).toEqual({
-      includeBootstrapInSystemContext: false,
-      includeBootstrapInRuntimeContext: false,
-    });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
@@ -1,65 +1,7 @@
 // Coverage for Tool Search control planning and allowlist accounting.
 import { describe, expect, it } from "vitest";
 import { setPluginToolMeta } from "../../../plugins/tools.js";
-import {
-  buildAutoAddedToolSearchControlNamesForAllowlistCheck,
-  buildCallableToolNamesForEmptyAllowlistCheck,
-  buildToolSearchRunPlan,
-} from "./attempt.tool-search-run-plan.js";
-
-describe("buildCallableToolNamesForEmptyAllowlistCheck", () => {
-  it("ignores auto-added Tool Search controls so bad allowlists still fail", () => {
-    // Auto-added controls are not real callable tools when the backing catalog
-    // is empty.
-    expect(
-      buildCallableToolNamesForEmptyAllowlistCheck({
-        effectiveToolNames: ["tool_search_code"],
-        autoAddedToolSearchControlNames: new Set(["tool_search_code"]),
-        toolSearchCatalogToolCount: 0,
-      }),
-    ).toEqual([]);
-  });
-
-  it("counts cataloged tools hidden behind auto-added Tool Search controls", () => {
-    expect(
-      buildCallableToolNamesForEmptyAllowlistCheck({
-        effectiveToolNames: ["tool_search_code"],
-        autoAddedToolSearchControlNames: new Set(["tool_search_code"]),
-        toolSearchCatalogToolCount: 1,
-      }),
-    ).toEqual(["tool-search:0"]);
-  });
-
-  it("keeps explicitly requested Tool Search controls callable", () => {
-    expect(
-      buildCallableToolNamesForEmptyAllowlistCheck({
-        effectiveToolNames: ["tool_search_code"],
-        autoAddedToolSearchControlNames: new Set(),
-        toolSearchCatalogToolCount: 0,
-      }),
-    ).toEqual(["tool_search_code"]);
-  });
-});
-
-describe("buildAutoAddedToolSearchControlNamesForAllowlistCheck", () => {
-  it("treats controls as auto-added unless any explicit allowlist requested them", () => {
-    expect(
-      buildAutoAddedToolSearchControlNamesForAllowlistCheck({
-        toolSearchControlsEnabled: true,
-        explicitAllowlistSources: [{ entries: ["missing_tool"] }],
-        controlNames: ["tool_search_code", "tool_search"],
-      }),
-    ).toEqual(new Set(["tool_search_code", "tool_search"]));
-
-    expect(
-      buildAutoAddedToolSearchControlNamesForAllowlistCheck({
-        toolSearchControlsEnabled: true,
-        explicitAllowlistSources: [{ entries: ["tool_search_code"] }],
-        controlNames: ["tool_search_code", "tool_search"],
-      }),
-    ).toEqual(new Set(["tool_search"]));
-  });
-});
+import { buildToolSearchRunPlan } from "./attempt.tool-search-run-plan.js";
 
 describe("buildToolSearchRunPlan", () => {
   it("keeps compact visible names separate from replay-safe names", () => {
@@ -159,6 +101,19 @@ describe("buildToolSearchRunPlan", () => {
     });
 
     expect(plan.emptyAllowlistCallableNames).toEqual([]);
+  });
+
+  it("keeps explicitly requested Tool Search controls callable", () => {
+    const plan = buildToolSearchRunPlan({
+      visibleTools: [{ name: "tool_search_code" }] as never,
+      uncompactedTools: [{ name: "tool_search_code" }] as never,
+      clientToolsCataloged: true,
+      catalogToolCount: 0,
+      controlsEnabled: true,
+      explicitAllowlistSources: [{ entries: ["tool_search_code"] }],
+    });
+
+    expect(plan.emptyAllowlistCallableNames).toEqual(["tool_search_code"]);
   });
 
   it("keeps uncataloged directory-mode client tools visible", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.ts
@@ -29,55 +29,8 @@ type ToolSearchRunPlan = {
   replayAllowedToolNames: Set<string>;
   liveAllowedToolNames: Set<string>;
   capabilityToolNames: Set<string>;
-  autoAddedControlNames?: Set<string>;
   emptyAllowlistCallableNames: string[];
 };
-
-/**
- * Builds the callable-name list used to decide whether an allowlist is empty.
- * Auto-added tool-search controls are excluded so they do not make an otherwise
- * empty user/tool allowlist look populated.
- */
-export function buildCallableToolNamesForEmptyAllowlistCheck(params: {
-  effectiveToolNames: string[];
-  autoAddedToolSearchControlNames?: Set<string>;
-  toolSearchCatalogToolCount: number;
-}): string[] {
-  return [
-    ...params.effectiveToolNames.filter(
-      (toolName) => !params.autoAddedToolSearchControlNames?.has(toolName),
-    ),
-    ...Array.from(
-      { length: params.toolSearchCatalogToolCount },
-      (_, index) => `tool-search:${index}`,
-    ),
-  ];
-}
-
-/**
- * Identifies tool-search control names that were added by policy rather than
- * explicitly allowed by the user. Explicit controls stay visible to empty
- * allowlist checks because the user selected them.
- */
-export function buildAutoAddedToolSearchControlNamesForAllowlistCheck(params: {
-  toolSearchControlsEnabled: boolean;
-  explicitAllowlistSources: Array<{ entries: string[] }>;
-  controlNames?: readonly string[];
-}): Set<string> | undefined {
-  if (!params.toolSearchControlsEnabled) {
-    return undefined;
-  }
-  const explicitlyAllowed = new Set(
-    params.explicitAllowlistSources.flatMap((source) =>
-      source.entries.map((entry) => normalizeToolName(entry)),
-    ),
-  );
-  return new Set(
-    (params.controlNames ?? TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES).filter(
-      (controlName) => !explicitlyAllowed.has(normalizeToolName(controlName)),
-    ),
-  );
-}
 
 function collectExplicitlyAllowedClientToolNames(params: {
   clientTools?: CollectAllowedToolNamesParams["clientTools"];
@@ -153,11 +106,17 @@ export function buildToolSearchRunPlan(params: {
       liveAllowedToolNames.add(visibleName);
     }
   }
-  const autoAddedControlNames = buildAutoAddedToolSearchControlNamesForAllowlistCheck({
-    toolSearchControlsEnabled: params.controlsEnabled,
-    explicitAllowlistSources: params.explicitAllowlistSources,
-    controlNames: params.controlNames,
-  });
+  const explicitControlAllowlistNames = new Set(
+    params.explicitAllowlistSources.flatMap((source) =>
+      source.entries.map((entry) => normalizeToolName(entry)),
+    ),
+  );
+  const autoAddedControlNames = new Set(
+    (params.controlsEnabled
+      ? (params.controlNames ?? TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES)
+      : []
+    ).filter((controlName) => !explicitControlAllowlistNames.has(normalizeToolName(controlName))),
+  );
   const explicitlyAllowedClientToolNames = collectExplicitlyAllowedClientToolNames({
     clientTools: params.clientTools,
     explicitAllowlistSources: params.explicitAllowlistSources,
@@ -175,13 +134,11 @@ export function buildToolSearchRunPlan(params: {
     replayAllowedToolNames,
     liveAllowedToolNames,
     capabilityToolNames,
-    autoAddedControlNames,
     emptyAllowlistCallableNames: [
-      ...buildCallableToolNamesForEmptyAllowlistCheck({
-        effectiveToolNames: [...emptyAllowlistVisibleToolNames],
-        autoAddedToolSearchControlNames: autoAddedControlNames,
-        toolSearchCatalogToolCount: params.catalogToolCount,
-      }),
+      ...[...emptyAllowlistVisibleToolNames].filter(
+        (toolName) => !autoAddedControlNames.has(toolName),
+      ),
+      ...Array.from({ length: params.catalogToolCount }, (_, index) => `tool-search:${index}`),
       ...explicitClientCallableNames,
     ],
   };

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -546,6 +546,67 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
+  it("queues message-tool awareness for explicit off-plan message-tool deliveries", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:openclaw-weixin:direct:user-123",
+      baseSessionKey: "agent:main:openclaw-weixin:direct:user-123",
+      to: "user-123",
+    });
+
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: {} as never,
+      job: {
+        id: "test-job",
+        name: "Test Job",
+        sessionTarget: "isolated",
+        deleteAfterRun: false,
+        payload: { kind: "agentTurn", message: "hello" },
+      } as never,
+      agentId: "main",
+      agentSessionKey: "agent:main",
+      runStartedAt: 1_000,
+      resolvedDelivery: makeResolvedDelivery({
+        channel: "telegram",
+        to: "123456",
+        accountId: "telegram-bot",
+        threadId: "42",
+      }),
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "openclaw-weixin",
+              to: "user-123",
+              text: "386502",
+            },
+            verifiedTarget: false,
+          },
+        ],
+        verifiedMessageToolDelivery: false,
+        satisfiesSourceDelivery: false,
+        unverifiedMessageToolDelivery: true,
+      },
+    });
+
+    expect(resolveOutboundSessionRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "openclaw-weixin",
+        target: "user-123",
+        accountId: undefined,
+        threadId: undefined,
+      }),
+    );
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      "A scheduled cron job delivered this message to this channel:\n386502",
+      {
+        sessionKey: "agent:main:openclaw-weixin:direct:user-123",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:openclaw-weixin::user-123:",
+      },
+    );
+  });
+
   it("keeps announce fallback when message-tool delivery is not verified for the target", async () => {
     const params = makeBaseParams({ synthesizedText: "Fallback cron summary." });
     params.sourceDeliveryOutcome = {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -580,6 +580,61 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
+  it("routes session-targeted message-tool awareness to the visible delivery target", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:telegram:direct:123456",
+      baseSessionKey: "agent:main:telegram:direct:123456",
+      to: "telegram:123456",
+    });
+
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: {} as never,
+      job: {
+        id: "test-job",
+        name: "Test Job",
+        sessionTarget: "session:agent:main:main",
+        deleteAfterRun: false,
+        payload: { kind: "agentTurn", message: "hello" },
+      } as never,
+      agentId: "main",
+      agentSessionKey: "agent:main:main",
+      runStartedAt: 1_000,
+      resolvedDelivery: makeResolvedDelivery(),
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "telegram",
+              to: "123456",
+              text: "Session-targeted off-plan update.",
+            },
+            verifiedTarget: false,
+          },
+        ],
+        verifiedMessageToolDelivery: false,
+        satisfiesSourceDelivery: false,
+        unverifiedMessageToolDelivery: true,
+      },
+    });
+
+    expect(resolveOutboundSessionRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentSessionKey: "agent:main:main",
+        channel: "telegram",
+        target: "123456",
+      }),
+    );
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      "A scheduled cron job delivered this message to this channel:\nSession-targeted off-plan update.",
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
+      },
+    );
+  });
+
   it("queues message-tool awareness for verified media-only deliveries", async () => {
     mockResolvedOutboundRoute();
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1727,18 +1727,16 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       to: "telegram:123456",
     });
     const deliveryError = new Error("second payload failed");
-    vi.mocked(deliverOutboundPayloads).mockImplementationOnce(
-      async (deliveryParams: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
-        deliveryParams.onPayloadDeliveryOutcome?.({
-          index: 1,
-          status: "failed",
-          error: deliveryError,
-          sentBeforeError: true,
-          stage: "platform_send",
-        });
-        return [{ channel: "telegram", messageId: "tg-first" }] as never;
-      },
-    );
+    vi.mocked(deliverOutboundPayloads).mockImplementationOnce(async (deliveryParams) => {
+      deliveryParams.onPayloadDeliveryOutcome?.({
+        index: 1,
+        status: "failed",
+        error: deliveryError,
+        sentBeforeError: true,
+        stage: "platform_send",
+      });
+      return [{ channel: "telegram", messageId: "tg-first" }] as never;
+    });
 
     const params = makeBaseParams({
       synthesizedText: undefined,

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1665,6 +1665,55 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
+  it("does not claim no delivery when direct cron delivery partially fails", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:telegram:direct:123456",
+      baseSessionKey: "agent:main:telegram:direct:123456",
+      to: "telegram:123456",
+    });
+    const deliveryError = new Error("second payload failed");
+    vi.mocked(deliverOutboundPayloads).mockImplementationOnce(
+      async (deliveryParams: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
+        deliveryParams.onPayloadDeliveryOutcome?.({
+          index: 1,
+          status: "failed",
+          error: deliveryError,
+          sentBeforeError: true,
+          stage: "platform_send",
+        });
+        return [{ channel: "telegram", messageId: "tg-first" }] as never;
+      },
+    );
+
+    const params = makeBaseParams({
+      synthesizedText: undefined,
+      runStartedAt: 1_000,
+    });
+    params.deliveryPayloads = [{ text: "First payload." }, { text: "Second payload." }];
+    params.outputText = "Second payload.";
+    params.summary = "Second payload.";
+    const state = await dispatchCronDelivery(params);
+
+    expectResultFields(state.result, {
+      status: "error",
+      error: String(deliveryError),
+      deliveryAttempted: true,
+    });
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      [
+        "A scheduled cron job attempted to deliver to this channel, but delivery failed.",
+        "Job: Test Job",
+        "Target: telegram:123456",
+        "Delivery error: second payload failed",
+        "One or more scheduled message payloads may already have been delivered.",
+      ].join("\n"),
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456::failure",
+      },
+    );
+  });
+
   it("surfaces structured direct delivery failures without retry when best-effort is disabled", async () => {
     vi.mocked(deliverOutboundPayloads).mockRejectedValue(new Error("boom"));
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -152,6 +152,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import {
   dispatchCronDelivery,
   getCompletedDirectCronDeliveriesCountForTests,
+  queueCronMessageToolDeliveryAwareness,
   resetCompletedDirectCronDeliveriesForTests,
 } from "./delivery-dispatch.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
@@ -311,6 +312,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     vi.mocked(retireSessionMcpRuntime).mockResolvedValue(true);
     vi.mocked(resolveOutboundSessionRoute).mockResolvedValue(null);
     vi.mocked(ensureOutboundSessionEntry).mockResolvedValue(undefined);
+    vi.mocked(enqueueSystemEvent).mockReset();
     vi.mocked(appendAssistantMessageToSessionTranscript).mockResolvedValue({
       ok: true,
       sessionFile: "session.jsonl",
@@ -400,6 +402,148 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
     expect(state.deliveryAttempted).toBe(true);
     expect(state.delivered).toBe(true);
+  });
+
+  it("queues message-tool awareness to the resolved thread for implicit thread evidence", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:telegram:direct:123456:thread:42",
+      baseSessionKey: "agent:main:telegram:direct:123456",
+      to: "telegram:123456",
+      threadId: "42",
+    });
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: {} as never,
+      job: {
+        id: "test-job",
+        name: "Test Job",
+        sessionTarget: "isolated",
+        deleteAfterRun: false,
+        payload: { kind: "agentTurn", message: "hello" },
+      } as never,
+      agentId: "main",
+      agentSessionKey: "agent:main",
+      runStartedAt: 1_000,
+      resolvedDelivery: makeResolvedDelivery({ threadId: "42" }),
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "telegram",
+              to: "123456",
+              threadImplicit: true,
+              text: "Threaded cron update.",
+            },
+            verifiedTarget: true,
+          },
+        ],
+        verifiedMessageToolDelivery: true,
+        satisfiesSourceDelivery: true,
+        unverifiedMessageToolDelivery: false,
+      },
+    });
+
+    expect(resolveOutboundSessionRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "42",
+      }),
+    );
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      "A scheduled cron job delivered this message to this channel:\nThreaded cron update.",
+      {
+        sessionKey: "agent:main:telegram:direct:123456:thread:42",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:42",
+      },
+    );
+  });
+
+  it("queues message-tool awareness when the target route resolves to the main session", async () => {
+    vi.mocked(resolveOutboundSessionRoute).mockResolvedValue(null);
+
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: {} as never,
+      job: {
+        id: "test-job",
+        name: "Test Job",
+        sessionTarget: "isolated",
+        deleteAfterRun: false,
+        payload: { kind: "agentTurn", message: "hello" },
+      } as never,
+      agentId: "main",
+      agentSessionKey: "agent:main",
+      runStartedAt: 1_000,
+      resolvedDelivery: makeResolvedDelivery(),
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "telegram",
+              to: "123456",
+              text: "Main-scoped cron update.",
+            },
+            verifiedTarget: true,
+          },
+        ],
+        verifiedMessageToolDelivery: true,
+        satisfiesSourceDelivery: true,
+        unverifiedMessageToolDelivery: false,
+      },
+    });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      "A scheduled cron job delivered this message to this channel:\nMain-scoped cron update.",
+      {
+        sessionKey: "agent:main",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
+      },
+    );
+  });
+
+  it("queues message-tool awareness for verified media-only deliveries", async () => {
+    mockResolvedOutboundRoute();
+
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: {} as never,
+      job: {
+        id: "test-job",
+        name: "Test Job",
+        sessionTarget: "isolated",
+        deleteAfterRun: false,
+        payload: { kind: "agentTurn", message: "hello" },
+      } as never,
+      agentId: "main",
+      agentSessionKey: "agent:main",
+      runStartedAt: 1_000,
+      resolvedDelivery: makeResolvedDelivery(),
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "telegram",
+              to: "123456",
+              mediaUrls: ["https://example.test/uploads/weather-map.png?token=secret"],
+            },
+            verifiedTarget: true,
+          },
+        ],
+        verifiedMessageToolDelivery: true,
+        satisfiesSourceDelivery: true,
+        unverifiedMessageToolDelivery: false,
+      },
+    });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      "A scheduled cron job delivered this message to this channel:\nweather-map.png",
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
+      },
+    );
   });
 
   it("keeps announce fallback when message-tool delivery is not verified for the target", async () => {
@@ -673,6 +817,13 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       sessionKey: "agent:main:main",
       contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
     });
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "A scheduled cron job delivered this message to this channel:\nRedacted cron update.",
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
+      },
+    );
   });
 
   it("preserves all successful text payloads for direct delivery", async () => {
@@ -708,6 +859,13 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       sessionKey: "agent:main:main",
       contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
     });
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "A scheduled cron job delivered this message to this channel:\nMorning briefing complete.",
+      {
+        sessionKey: "agent:main",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
+      },
+    );
   });
 
   it("does not mirror separately when the resolved delivery session is the awareness main session", async () => {
@@ -963,7 +1121,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
   });
 
-  it("skips main-session awareness for session-bound cron jobs", async () => {
+  it("queues target-session awareness for session-bound cron jobs without main awareness", async () => {
     const params = makeBaseParams({
       synthesizedText: "Session-bound cron update.",
       sessionTarget: "session:agent:main:main:thread:9999",
@@ -974,7 +1132,15 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.delivered).toBe(true);
     expect(state.deliveryAttempted).toBe(true);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
-    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      "A scheduled cron job delivered this message to this channel:\nSession-bound cron update.",
+      {
+        sessionKey: "agent:main",
+        contextKey: expect.stringMatching(
+          /^cron-direct-delivery:v1:cron:test-job:\d+:telegram::123456:$/,
+        ),
+      },
+    );
   });
 
   it("skips main-session awareness for best-effort deliveries", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -502,6 +502,84 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     );
   });
 
+  it("keeps same-recipient message-tool awareness separate across channels", async () => {
+    vi.mocked(resolveOutboundSessionRoute)
+      .mockResolvedValueOnce({
+        sessionKey: "agent:main:telegram:direct:123456",
+        baseSessionKey: "agent:main:telegram:direct:123456",
+        peer: { kind: "direct", id: "123456" },
+        chatType: "direct",
+        from: "telegram:123456",
+        to: "123456",
+      })
+      .mockResolvedValueOnce({
+        sessionKey: "agent:main:openclaw-weixin:direct:123456",
+        baseSessionKey: "agent:main:openclaw-weixin:direct:123456",
+        peer: { kind: "direct", id: "123456" },
+        chatType: "direct",
+        from: "openclaw-weixin:123456",
+        to: "123456",
+      });
+
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: {} as never,
+      job: {
+        id: "test-job",
+        name: "Test Job",
+        sessionTarget: "isolated",
+        deleteAfterRun: false,
+        payload: { kind: "agentTurn", message: "hello" },
+      } as never,
+      agentId: "main",
+      agentSessionKey: "agent:main",
+      runStartedAt: 1_000,
+      resolvedDelivery: makeResolvedDelivery(),
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "telegram",
+              to: "123456",
+              text: "Shared cron update.",
+            },
+            verifiedTarget: false,
+          },
+          {
+            via: "message_tool",
+            target: {
+              tool: "message",
+              provider: "openclaw-weixin",
+              to: "123456",
+              text: "Shared cron update.",
+            },
+            verifiedTarget: false,
+          },
+        ],
+        verifiedMessageToolDelivery: false,
+        satisfiesSourceDelivery: false,
+        unverifiedMessageToolDelivery: true,
+      },
+    });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(2);
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "A scheduled cron job delivered this message to this channel:\nShared cron update.",
+      {
+        sessionKey: "agent:main:telegram:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
+      },
+    );
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "A scheduled cron job delivered this message to this channel:\nShared cron update.",
+      {
+        sessionKey: "agent:main:openclaw-weixin:direct:123456",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:openclaw-weixin::123456:",
+      },
+    );
+  });
+
   it("queues message-tool awareness for verified media-only deliveries", async () => {
     mockResolvedOutboundRoute();
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1487,6 +1487,45 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
   });
 
+  it("queues target-session awareness when direct cron delivery fails", async () => {
+    mockResolvedOutboundRoute({
+      sessionKey: "agent:main:telegram:direct:123456:thread:42",
+      baseSessionKey: "agent:main:telegram:direct:123456",
+      to: "telegram:123456",
+      threadId: "42",
+    });
+    const deliveryError = new Error(
+      "Call to 'sendMessage' failed! (400: Bad Request: message thread not found)",
+    );
+    vi.mocked(deliverOutboundPayloads).mockRejectedValue(deliveryError);
+
+    const params = makeBaseParams({
+      synthesizedText: "This delivery will fail.",
+      runStartedAt: 1_000,
+    });
+    params.resolvedDelivery = makeResolvedDelivery({ threadId: "42" });
+    const state = await dispatchCronDelivery(params);
+
+    expectResultFields(state.result, {
+      status: "error",
+      error: String(deliveryError),
+      deliveryAttempted: true,
+    });
+    expect(enqueueSystemEvent).toHaveBeenCalledExactlyOnceWith(
+      [
+        "A scheduled cron job attempted to deliver to this channel, but delivery failed.",
+        "Job: Test Job",
+        "Target: telegram:123456 thread 42",
+        "Delivery error: Call to 'sendMessage' failed! (400: Bad Request: message thread not found)",
+        "No scheduled message was delivered.",
+      ].join("\n"),
+      {
+        sessionKey: "agent:main:telegram:direct:123456:thread:42",
+        contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:42:failure",
+      },
+    );
+  });
+
   it("surfaces structured direct delivery failures without retry when best-effort is disabled", async () => {
     vi.mocked(deliverOutboundPayloads).mockRejectedValue(new Error("boom"));
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -637,19 +637,16 @@ function canonicalizeDirectCronRouteSessionKey(params: {
   return `${canonicalBase}:thread:${thread.threadId}`;
 }
 
-export async function resolveDirectCronDeliverySessionKey(params: {
+// Resolves the session for a concrete visible delivery target and ensures the
+// outbound session exists before cron awareness or transcript code references it.
+async function resolveCronDeliveryRouteSessionKey(params: {
   cfg: OpenClawConfig;
-  job: CronJob;
+  jobId: string;
   agentId: string;
   agentSessionKey: string;
   delivery: SuccessfulDeliveryTarget;
+  warningContext: string;
 }): Promise<string> {
-  if (isCustomCronSessionTarget(params.job.sessionTarget)) {
-    // Custom session targets are already caller-selected; do not remap them
-    // through outbound routing or the explicit session identity would drift.
-    return params.agentSessionKey;
-  }
-
   try {
     const { resolveOutboundSessionRoute, ensureOutboundSessionEntry } =
       await loadOutboundSessionRuntime();
@@ -696,10 +693,34 @@ export async function resolveDirectCronDeliverySessionKey(params: {
     return canonicalRouteSessionKey;
   } catch (err) {
     await logCronDeliveryWarn(
-      `[cron:${params.job.id}] failed to resolve destination session for direct delivery mirror: ${formatErrorMessage(err)}`,
+      `[cron:${params.jobId}] failed to resolve destination session for ${params.warningContext}: ${formatErrorMessage(err)}`,
     );
     return params.agentSessionKey;
   }
+}
+
+/** Resolves the transcript mirror session for direct cron delivery. */
+export async function resolveDirectCronDeliverySessionKey(params: {
+  cfg: OpenClawConfig;
+  job: CronJob;
+  agentId: string;
+  agentSessionKey: string;
+  delivery: SuccessfulDeliveryTarget;
+}): Promise<string> {
+  if (isCustomCronSessionTarget(params.job.sessionTarget)) {
+    // Custom session targets are already caller-selected; do not remap them
+    // through outbound routing or the explicit session identity would drift.
+    return params.agentSessionKey;
+  }
+
+  return await resolveCronDeliveryRouteSessionKey({
+    cfg: params.cfg,
+    jobId: params.job.id,
+    agentId: params.agentId,
+    agentSessionKey: params.agentSessionKey,
+    delivery: params.delivery,
+    warningContext: "direct delivery mirror",
+  });
 }
 
 function resolveCronMessageToolAwarenessTarget(params: {
@@ -780,12 +801,13 @@ export async function queueCronMessageToolDeliveryAwareness(params: {
       continue;
     }
     seen.add(dedupeKey);
-    const targetSessionKey = await resolveDirectCronDeliverySessionKey({
+    const targetSessionKey = await resolveCronDeliveryRouteSessionKey({
       cfg: params.cfg,
-      job: params.job,
+      jobId: params.job.id,
       agentId: params.agentId,
       agentSessionKey: params.agentSessionKey,
       delivery: target,
+      warningContext: "message-tool delivery awareness",
     });
     const deliveryIdempotencyKey = buildDirectCronDeliveryIdempotencyKey({
       jobId: params.job.id,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -703,9 +703,6 @@ function resolveCronMessageToolAwarenessTarget(params: {
   delivery: SourceDeliveryVisibleDelivery;
   resolvedDelivery: DeliveryTargetResolution;
 }): (SuccessfulDeliveryTarget & { text: string }) | undefined {
-  if (!params.delivery.verifiedTarget) {
-    return undefined;
-  }
   const { target } = params.delivery;
   const text =
     normalizeOptionalString(target.text) ??
@@ -718,21 +715,25 @@ function resolveCronMessageToolAwarenessTarget(params: {
   const channel =
     targetChannel && targetChannel !== "message"
       ? targetChannel
-      : params.resolvedDelivery.ok
+      : params.delivery.verifiedTarget && params.resolvedDelivery.ok
         ? params.resolvedDelivery.channel
         : undefined;
   const to =
     normalizeOptionalString(target.to) ??
-    (params.resolvedDelivery.ok ? params.resolvedDelivery.to : undefined);
+    (params.delivery.verifiedTarget && params.resolvedDelivery.ok
+      ? params.resolvedDelivery.to
+      : undefined);
   if (!channel || !to) {
     return undefined;
   }
   const accountId =
     target.accountId ??
-    (params.resolvedDelivery.ok ? params.resolvedDelivery.accountId : undefined);
+    (params.delivery.verifiedTarget && params.resolvedDelivery.ok
+      ? params.resolvedDelivery.accountId
+      : undefined);
   const threadId =
     target.threadId ??
-    (target.threadImplicit === true && params.resolvedDelivery.ok
+    (params.delivery.verifiedTarget && target.threadImplicit === true && params.resolvedDelivery.ok
       ? params.resolvedDelivery.threadId
       : undefined);
   return {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -462,6 +462,26 @@ export function formatTargetCronDeliveryAwarenessText(text: string): string {
   return `A scheduled cron job delivered this message to this channel:\n${text}`;
 }
 
+function formatTargetCronDeliveryFailureAwarenessText(params: {
+  job: CronJob;
+  channel: string;
+  to: string;
+  threadId?: string;
+  error: unknown;
+}): string {
+  const targetParts = [`${params.channel}:${params.to}`];
+  if (params.threadId) {
+    targetParts.push(`thread ${params.threadId}`);
+  }
+  return [
+    "A scheduled cron job attempted to deliver to this channel, but delivery failed.",
+    `Job: ${params.job.name || params.job.id}`,
+    `Target: ${targetParts.join(" ")}`,
+    `Delivery error: ${formatErrorMessage(params.error)}`,
+    "No scheduled message was delivered.",
+  ].join("\n");
+}
+
 async function queueCronAwarenessSystemEvent(params: {
   cfg: OpenClawConfig;
   jobId: string;
@@ -470,6 +490,7 @@ async function queueCronAwarenessSystemEvent(params: {
   queueMainSession: boolean;
   targetSessionKey?: string;
   text: string;
+  targetText?: string;
 }): Promise<void> {
   try {
     const { enqueueSystemEvent } = await loadDeliveryOutboundRuntime();
@@ -488,7 +509,7 @@ async function queueCronAwarenessSystemEvent(params: {
       targetSessionKey &&
       (!isSameSessionKey(targetSessionKey, mainSessionKey) || !params.queueMainSession);
     if (shouldQueueTargetSession) {
-      enqueueSystemEvent(formatTargetCronDeliveryAwarenessText(params.text), {
+      enqueueSystemEvent(params.targetText ?? formatTargetCronDeliveryAwarenessText(params.text), {
         sessionKey: targetSessionKey,
         contextKey: params.deliveryIdempotencyKey,
       });
@@ -1098,13 +1119,35 @@ export async function dispatchCronDelivery(
         }
         return send.status === "sent" || send.status === "partial_failed" ? send.results : [];
       };
-      const deliveryResults = options?.retryTransient
-        ? await retryTransientDirectCronDelivery({
-            jobId: params.job.id,
-            signal: params.abortSignal,
-            run: runDelivery,
-          })
-        : await runDelivery();
+      let deliveryResults: OutboundDeliveryResult[];
+      try {
+        deliveryResults = options?.retryTransient
+          ? await retryTransientDirectCronDelivery({
+              jobId: params.job.id,
+              signal: params.abortSignal,
+              run: runDelivery,
+            })
+          : await runDelivery();
+      } catch (err) {
+        const failureAwarenessText = formatTargetCronDeliveryFailureAwarenessText({
+          job: params.job,
+          channel: delivery.channel,
+          to: delivery.to,
+          threadId: stringifyRouteThreadId(delivery.threadId),
+          error: err,
+        });
+        await queueCronAwarenessSystemEvent({
+          cfg: params.cfgWithAgentDefaults,
+          jobId: params.job.id,
+          agentId: params.agentId,
+          deliveryIdempotencyKey: `${deliveryIdempotencyKey}:failure`,
+          queueMainSession: false,
+          targetSessionKey: deliverySessionKey,
+          text: failureAwarenessText,
+          targetText: failureAwarenessText,
+        });
+        throw err;
+      }
       // Only mark delivered when ALL payloads succeeded (no partial failure).
       delivered = deliveryResults.length > 0 && !hadPartialFailure;
       // Intentionally leave partial success uncached: replay may duplicate the

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -767,6 +767,7 @@ export async function queueCronMessageToolDeliveryAwareness(params: {
       continue;
     }
     const dedupeKey = [
+      target.channel,
       normalizeDeliveryTarget(target.channel, target.to),
       target.accountId ?? "",
       target.threadId ?? "",

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -468,6 +468,7 @@ function formatTargetCronDeliveryFailureAwarenessText(params: {
   to: string;
   threadId?: string;
   error: unknown;
+  partialDelivered?: boolean;
 }): string {
   const targetParts = [`${params.channel}:${params.to}`];
   if (params.threadId) {
@@ -478,7 +479,9 @@ function formatTargetCronDeliveryFailureAwarenessText(params: {
     `Job: ${params.job.name || params.job.id}`,
     `Target: ${targetParts.join(" ")}`,
     `Delivery error: ${formatErrorMessage(params.error)}`,
-    "No scheduled message was delivered.",
+    params.partialDelivered
+      ? "One or more scheduled message payloads may already have been delivered."
+      : "No scheduled message was delivered.",
   ].join("\n");
 }
 
@@ -1072,6 +1075,7 @@ export async function dispatchCronDelivery(
       // Track bestEffort partial failures so we can log them and avoid
       // marking the job as delivered when payloads were silently dropped.
       let hadPartialFailure = false;
+      let partialDeliverySucceededBeforeFailure = false;
       // `onPayload` fires after send hooks render the outbound payload, but before
       // platform send. The mirror only consumes this array after full delivery succeeds.
       const attemptedPayloadsForMirror: NormalizedOutboundPayload[] = [];
@@ -1110,13 +1114,14 @@ export async function dispatchCronDelivery(
           // See: https://github.com/openclaw/openclaw/issues/40545
           skipQueue: true,
         });
-        if (
-          send.status === "failed" ||
-          (!params.deliveryBestEffort && send.status === "partial_failed")
-        ) {
+        if (send.status === "failed") {
           throw send.error;
         }
         if (send.status === "partial_failed") {
+          partialDeliverySucceededBeforeFailure = send.results.length > 0;
+          if (!params.deliveryBestEffort) {
+            throw send.error;
+          }
           hadPartialFailure = true;
         }
         return send.status === "sent" || send.status === "partial_failed" ? send.results : [];
@@ -1137,6 +1142,7 @@ export async function dispatchCronDelivery(
           to: delivery.to,
           threadId: stringifyRouteThreadId(delivery.threadId),
           error: err,
+          partialDelivered: partialDeliverySucceededBeforeFailure,
         });
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -31,7 +31,10 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForMirror,
 } from "../../infra/outbound/payloads.js";
-import type { SourceDeliveryOutcome } from "../../infra/outbound/source-delivery-plan.js";
+import type {
+  SourceDeliveryOutcome,
+  SourceDeliveryVisibleDelivery,
+} from "../../infra/outbound/source-delivery-plan.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
@@ -455,33 +458,44 @@ function resolveCronAwarenessText(params: {
         normalizeOptionalString(params.synthesizedText));
 }
 
+export function formatTargetCronDeliveryAwarenessText(text: string): string {
+  return `A scheduled cron job delivered this message to this channel:\n${text}`;
+}
+
 async function queueCronAwarenessSystemEvent(params: {
   cfg: OpenClawConfig;
   jobId: string;
   agentId: string;
   deliveryIdempotencyKey: string;
-  outputText?: string;
-  synthesizedText?: string;
-  deliveryPayloads?: ReplyPayload[];
-  outboundPayloads?: NormalizedOutboundPayload[];
+  queueMainSession: boolean;
+  targetSessionKey?: string;
+  text: string;
 }): Promise<void> {
-  const text = resolveCronAwarenessText(params);
-  if (!text) {
-    return;
-  }
-
   try {
     const { enqueueSystemEvent } = await loadDeliveryOutboundRuntime();
-    enqueueSystemEvent(text, {
-      sessionKey: resolveCronAwarenessMainSessionKey({
-        cfg: params.cfg,
-        agentId: params.agentId,
-      }),
-      contextKey: params.deliveryIdempotencyKey,
+    const mainSessionKey = resolveCronAwarenessMainSessionKey({
+      cfg: params.cfg,
+      agentId: params.agentId,
     });
+    if (params.queueMainSession) {
+      enqueueSystemEvent(params.text, {
+        sessionKey: mainSessionKey,
+        contextKey: params.deliveryIdempotencyKey,
+      });
+    }
+    const targetSessionKey = params.targetSessionKey;
+    const shouldQueueTargetSession =
+      targetSessionKey &&
+      (!isSameSessionKey(targetSessionKey, mainSessionKey) || !params.queueMainSession);
+    if (shouldQueueTargetSession) {
+      enqueueSystemEvent(formatTargetCronDeliveryAwarenessText(params.text), {
+        sessionKey: targetSessionKey,
+        contextKey: params.deliveryIdempotencyKey,
+      });
+    }
   } catch (err) {
     await logCronDeliveryWarn(
-      `[cron:${params.jobId}] failed to queue isolated cron awareness for the main session: ${formatErrorMessage(err)}`,
+      `[cron:${params.jobId}] failed to queue isolated cron awareness: ${formatErrorMessage(err)}`,
     );
   }
 }
@@ -599,7 +613,7 @@ function canonicalizeDirectCronRouteSessionKey(params: {
   return `${canonicalBase}:thread:${thread.threadId}`;
 }
 
-async function resolveDirectCronDeliverySessionKey(params: {
+export async function resolveDirectCronDeliverySessionKey(params: {
   cfg: OpenClawConfig;
   job: CronJob;
   agentId: string;
@@ -661,6 +675,106 @@ async function resolveDirectCronDeliverySessionKey(params: {
       `[cron:${params.job.id}] failed to resolve destination session for direct delivery mirror: ${formatErrorMessage(err)}`,
     );
     return params.agentSessionKey;
+  }
+}
+
+function resolveCronMessageToolAwarenessTarget(params: {
+  delivery: SourceDeliveryVisibleDelivery;
+  resolvedDelivery: DeliveryTargetResolution;
+}): (SuccessfulDeliveryTarget & { text: string }) | undefined {
+  if (!params.delivery.verifiedTarget) {
+    return undefined;
+  }
+  const { target } = params.delivery;
+  const text =
+    normalizeOptionalString(target.text) ??
+    resolveMirroredTranscriptText({ mediaUrls: target.mediaUrls }) ??
+    undefined;
+  if (!text) {
+    return undefined;
+  }
+  const targetChannel = normalizeOptionalString(target.provider);
+  const channel =
+    targetChannel && targetChannel !== "message"
+      ? targetChannel
+      : params.resolvedDelivery.ok
+        ? params.resolvedDelivery.channel
+        : undefined;
+  const to =
+    normalizeOptionalString(target.to) ??
+    (params.resolvedDelivery.ok ? params.resolvedDelivery.to : undefined);
+  if (!channel || !to) {
+    return undefined;
+  }
+  const accountId =
+    target.accountId ??
+    (params.resolvedDelivery.ok ? params.resolvedDelivery.accountId : undefined);
+  const threadId =
+    target.threadId ??
+    (target.threadImplicit === true && params.resolvedDelivery.ok
+      ? params.resolvedDelivery.threadId
+      : undefined);
+  return {
+    ok: true,
+    channel: channel as SuccessfulDeliveryTarget["channel"],
+    to,
+    ...(accountId ? { accountId } : {}),
+    ...(threadId ? { threadId } : {}),
+    mode: "explicit",
+    text,
+  };
+}
+
+/** Queues target-session context awareness for cron deliveries made via message tool. */
+export async function queueCronMessageToolDeliveryAwareness(params: {
+  cfg: OpenClawConfig;
+  job: CronJob;
+  agentId: string;
+  agentSessionKey: string;
+  runStartedAt: number;
+  resolvedDelivery: DeliveryTargetResolution;
+  sourceDeliveryOutcome: SourceDeliveryOutcome;
+}): Promise<void> {
+  const seen = new Set<string>();
+  for (const delivery of params.sourceDeliveryOutcome.visibleDeliveries) {
+    const target = resolveCronMessageToolAwarenessTarget({
+      delivery,
+      resolvedDelivery: params.resolvedDelivery,
+    });
+    if (!target) {
+      continue;
+    }
+    const dedupeKey = [
+      normalizeDeliveryTarget(target.channel, target.to),
+      target.accountId ?? "",
+      target.threadId ?? "",
+      target.text,
+    ].join("\0");
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+    const targetSessionKey = await resolveDirectCronDeliverySessionKey({
+      cfg: params.cfg,
+      job: params.job,
+      agentId: params.agentId,
+      agentSessionKey: params.agentSessionKey,
+      delivery: target,
+    });
+    const deliveryIdempotencyKey = buildDirectCronDeliveryIdempotencyKey({
+      jobId: params.job.id,
+      runStartedAt: params.runStartedAt,
+      delivery: target,
+    });
+    await queueCronAwarenessSystemEvent({
+      cfg: params.cfg,
+      jobId: params.job.id,
+      agentId: params.agentId,
+      deliveryIdempotencyKey,
+      queueMainSession: false,
+      targetSessionKey,
+      text: target.text,
+    });
   }
 }
 
@@ -996,6 +1110,12 @@ export async function dispatchCronDelivery(
       // Intentionally leave partial success uncached: replay may duplicate the
       // successful subset, but caching it here would permanently drop the
       // failed payloads by converting the replay into delivered=true.
+      const deliveryAwarenessText = resolveCronAwarenessText({
+        outputText,
+        synthesizedText,
+        deliveryPayloads: payloadsForDelivery,
+        outboundPayloads: attemptedPayloadsForMirror,
+      });
       const shouldQueueAwarenessForDelivery = shouldQueueCronAwareness({
         job: params.job,
         delivery,
@@ -1004,14 +1124,7 @@ export async function dispatchCronDelivery(
       // For explicit isolated deliveries that resolve to the main session, the
       // awareness queue is the intentional main-session record on the next turn;
       // adding an immediate assistant mirror would make the cron text appear twice.
-      const awarenessText = shouldQueueAwarenessForDelivery
-        ? resolveCronAwarenessText({
-            outputText,
-            synthesizedText,
-            deliveryPayloads: payloadsForDelivery,
-            outboundPayloads: attemptedPayloadsForMirror,
-          })
-        : undefined;
+      const awarenessText = shouldQueueAwarenessForDelivery ? deliveryAwarenessText : undefined;
       const deliveryWillReachAwarenessMainSession =
         mirrorTargetsAwarenessMainSession &&
         shouldQueueAwarenessForDelivery &&
@@ -1058,16 +1171,21 @@ export async function dispatchCronDelivery(
           mirror: transcriptMirror,
         });
       }
-      if (delivered && shouldQueueAwarenessForDelivery) {
+      if (
+        delivered &&
+        !params.deliveryBestEffort &&
+        deliveryAwarenessText &&
+        (shouldQueueAwarenessForDelivery ||
+          !isSameSessionKey(deliverySessionKey, awarenessMainSessionKey))
+      ) {
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,
           jobId: params.job.id,
           agentId: params.agentId,
           deliveryIdempotencyKey,
-          outputText,
-          synthesizedText,
-          deliveryPayloads: payloadsForDelivery,
-          outboundPayloads: attemptedPayloadsForMirror,
+          queueMainSession: shouldQueueAwarenessForDelivery,
+          text: deliveryAwarenessText,
+          targetSessionKey: deliverySessionKey,
         });
       }
       if (delivered) {

--- a/src/cron/isolated-agent/run-delivery.runtime.ts
+++ b/src/cron/isolated-agent/run-delivery.runtime.ts
@@ -3,5 +3,6 @@ export { resolveDeliveryTarget } from "./delivery-target.js";
 export {
   cleanupDirectCronSession,
   dispatchCronDelivery,
+  queueCronMessageToolDeliveryAwareness,
   resolveCronDeliveryBestEffort,
 } from "./delivery-dispatch.js";

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -252,13 +252,17 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
   async function expectCronFallbackSkippedForMessageToolDelivery(options: {
     sentTargets: Array<Record<string, unknown>>;
     job?: Parameters<typeof makeAnnounceMessageToolJob>[0];
+    cfg?: Record<string, unknown>;
   }) {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
     runEmbeddedAgentMock.mockResolvedValue(makeMessageToolRunResult(options.sentTargets));
+    const params = makeParams();
+    const cfg = options.cfg ?? params.cfg;
 
     const result = await runCronIsolatedAgentTurn({
-      ...makeParams(),
+      ...params,
+      cfg,
       job: makeAnnounceMessageToolJob(options.job),
     });
 
@@ -285,6 +289,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       fallbackUsed: false,
       delivered: true,
     });
+    return { cfg, result };
   }
 
   beforeEach(() => {
@@ -1177,11 +1182,14 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
   });
 
   it("skips cron fallback delivery when the message tool already sent to the same target", async () => {
-    await expectCronFallbackSkippedForMessageToolDelivery({
+    const { cfg } = await expectCronFallbackSkippedForMessageToolDelivery({
+      cfg: { session: { dmScope: "agent" } },
       sentTargets: [{ tool: "message", provider: "messagechat", to: "123" }],
     });
     expect(queueCronMessageToolDeliveryAwarenessMock).toHaveBeenCalledTimes(1);
-    expect(queueCronMessageToolDeliveryAwarenessMock.mock.calls[0]?.[0]).toMatchObject({
+    const awarenessParams = queueCronMessageToolDeliveryAwarenessMock.mock.calls[0]?.[0];
+    expect(awarenessParams?.cfg).not.toBe(cfg);
+    expect(awarenessParams).toMatchObject({
       job: { id: "message-tool-policy" },
       resolvedDelivery: { ok: true, channel: "messagechat", to: "123" },
       sourceDeliveryOutcome: {

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1222,6 +1222,51 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("queues awareness for explicit message-tool sends even when they do not satisfy the delivery target", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    runEmbeddedAgentMock.mockResolvedValue(
+      makeMessageToolRunResult([
+        {
+          tool: "message",
+          provider: "openclaw-weixin",
+          to: "user-123",
+          text: "386502",
+        },
+      ]),
+    );
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob({
+        id: "message-tool-off-plan-awareness",
+        name: "Message Tool Off Plan Awareness",
+      }),
+    });
+
+    expect(queueCronMessageToolDeliveryAwarenessMock).toHaveBeenCalledTimes(1);
+    expect(queueCronMessageToolDeliveryAwarenessMock.mock.calls[0]?.[0]).toMatchObject({
+      job: { id: "message-tool-off-plan-awareness" },
+      sourceDeliveryOutcome: {
+        visibleDeliveries: [
+          {
+            via: "message_tool",
+            verifiedTarget: false,
+            target: {
+              tool: "message",
+              provider: "openclaw-weixin",
+              to: "user-123",
+              text: "386502",
+            },
+          },
+        ],
+        verifiedMessageToolDelivery: false,
+        satisfiesSourceDelivery: false,
+        unverifiedMessageToolDelivery: true,
+      },
+    });
+  });
+
   it("rewrites generic message provider to resolved channel in delivery trace", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -15,6 +15,7 @@ import {
   makeCronSession,
   mockRunCronFallbackPassthrough,
   preflightCronModelProviderMock,
+  queueCronMessageToolDeliveryAwarenessMock,
   resolveCronPayloadOutcomeMock,
   resolveCronSessionMock,
   resetRunCronIsolatedAgentTurnHarness,
@@ -1178,6 +1179,15 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
   it("skips cron fallback delivery when the message tool already sent to the same target", async () => {
     await expectCronFallbackSkippedForMessageToolDelivery({
       sentTargets: [{ tool: "message", provider: "messagechat", to: "123" }],
+    });
+    expect(queueCronMessageToolDeliveryAwarenessMock).toHaveBeenCalledTimes(1);
+    expect(queueCronMessageToolDeliveryAwarenessMock.mock.calls[0]?.[0]).toMatchObject({
+      job: { id: "message-tool-policy" },
+      resolvedDelivery: { ok: true, channel: "messagechat", to: "123" },
+      sourceDeliveryOutcome: {
+        verifiedMessageToolDelivery: true,
+        satisfiesSourceDelivery: true,
+      },
     });
   });
 

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -69,6 +69,7 @@ export const resolveCronPayloadOutcomeMock = createMock();
 export const resolveCronDeliveryPlanMock = createMock();
 export const resolveDeliveryTargetMock = createMock();
 export const dispatchCronDeliveryMock = createMock();
+export const queueCronMessageToolDeliveryAwarenessMock = createMock();
 export const cleanupDirectCronSessionMock = createMock();
 export const preflightCronModelProviderMock = createMock();
 export const isHeartbeatOnlyResponseMock = createMock();
@@ -312,6 +313,7 @@ vi.mock("./run-delivery.runtime.js", async () => {
     cleanupDirectCronSession: cleanupDirectCronSessionMock,
     resolveDeliveryTarget: resolveDeliveryTargetMock,
     dispatchCronDelivery: dispatchCronDeliveryMock,
+    queueCronMessageToolDeliveryAwareness: queueCronMessageToolDeliveryAwarenessMock,
   };
 });
 
@@ -631,6 +633,8 @@ function resetRunOutcomeMocks(): void {
       deliveryPayloads,
     }),
   );
+  queueCronMessageToolDeliveryAwarenessMock.mockReset();
+  queueCronMessageToolDeliveryAwarenessMock.mockResolvedValue(undefined);
   cleanupDirectCronSessionMock.mockReset();
   cleanupDirectCronSessionMock.mockResolvedValue(undefined);
   preflightCronModelProviderMock.mockReset();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1226,7 +1226,7 @@ async function finalizeCronRun(params: {
   if (sourceDeliveryOutcome.visibleDeliveries.length > 0) {
     const { queueCronMessageToolDeliveryAwareness } = await loadCronDeliveryRuntime();
     await queueCronMessageToolDeliveryAwareness({
-      cfg: prepared.input.cfg,
+      cfg: prepared.cfgWithAgentDefaults,
       job: prepared.input.job,
       agentId: prepared.agentId,
       agentSessionKey: prepared.agentSessionKey,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1223,7 +1223,7 @@ async function finalizeCronRun(params: {
     didSendViaMessageTool: finalRunResult.didSendViaMessagingTool,
     messageToolSentTargets: finalRunResult.messagingToolSentTargets,
   });
-  if (sourceDeliveryOutcome.verifiedMessageToolDelivery) {
+  if (sourceDeliveryOutcome.visibleDeliveries.length > 0) {
     const { queueCronMessageToolDeliveryAwareness } = await loadCronDeliveryRuntime();
     await queueCronMessageToolDeliveryAwareness({
       cfg: prepared.input.cfg,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1223,6 +1223,18 @@ async function finalizeCronRun(params: {
     didSendViaMessageTool: finalRunResult.didSendViaMessagingTool,
     messageToolSentTargets: finalRunResult.messagingToolSentTargets,
   });
+  if (sourceDeliveryOutcome.verifiedMessageToolDelivery) {
+    const { queueCronMessageToolDeliveryAwareness } = await loadCronDeliveryRuntime();
+    await queueCronMessageToolDeliveryAwareness({
+      cfg: prepared.input.cfg,
+      job: prepared.input.job,
+      agentId: prepared.agentId,
+      agentSessionKey: prepared.agentSessionKey,
+      runStartedAt: execution.runStartedAt,
+      resolvedDelivery: prepared.resolvedDelivery,
+      sourceDeliveryOutcome,
+    });
+  }
   if (hasFatalStructuredErrorPayload && prepared.deliveryRequested) {
     // Structured run error payloads belong in cron state and failure alerts,
     // not the normal completion announce path where provider JSON can leak.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
@@ -61,7 +62,7 @@ function createStalledBodyResponse(params: { headers: HeadersInit; firstChunk: U
 }
 
 describe("clawhub helpers", () => {
-  const originalHome = process.env.HOME;
+  const originalEnv = captureEnv(["HOME", "XDG_CONFIG_HOME"]);
 
   afterEach(() => {
     delete process.env.OPENCLAW_CLAWHUB_URL;
@@ -71,12 +72,7 @@ describe("clawhub helpers", () => {
     delete process.env.OPENCLAW_CLAWHUB_CONFIG_PATH;
     delete process.env.CLAWHUB_CONFIG_PATH;
     delete process.env.CLAWDHUB_CONFIG_PATH;
-    delete process.env.XDG_CONFIG_HOME;
-    if (originalHome == null) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
+    originalEnv.restore();
   });
 
   it("parses explicit ClawHub package specs", () => {
@@ -264,7 +260,7 @@ describe("clawhub helpers", () => {
         await withTempDir({ prefix: "openclaw-clawhub-xdg-" }, async (xdgRoot) => {
           const configPath = path.join(xdgRoot, "clawhub", "config.json");
           const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
-          process.env.XDG_CONFIG_HOME = xdgRoot;
+          setTestEnvValue("XDG_CONFIG_HOME", xdgRoot);
           try {
             await fs.mkdir(path.dirname(configPath), { recursive: true });
             await fs.writeFile(configPath, JSON.stringify({ token: "xdg-token-123" }), "utf8");

--- a/src/security/audit-plugins-trust.test.ts
+++ b/src/security/audit-plugins-trust.test.ts
@@ -7,7 +7,13 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "../plugins/installed-plugin-index.js";
-import { createPathResolutionEnv, withEnvAsync } from "../test-utils/env.js";
+import {
+  captureEnv,
+  createPathResolutionEnv,
+  deleteTestEnvValue,
+  setTestEnvValue,
+  withEnvAsync,
+} from "../test-utils/env.js";
 
 type CollectPluginsTrustFindings =
   typeof import("./audit-plugins-trust.js").collectPluginsTrustFindings;
@@ -489,8 +495,7 @@ describe("security audit extension tool reachability findings", () => {
     "OPENCLAW_STATE_DIR",
     "OPENCLAW_BUNDLED_PLUGINS_DIR",
   ] as const;
-  const previousPathResolutionEnv: Partial<Record<(typeof pathResolutionEnvKeys)[number], string>> =
-    {};
+  let pathResolutionEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
   const runSharedExtensionsAudit = async (config: OpenClawConfig) => {
     return await collectPluginsTrustFindingsForTest({
@@ -505,13 +510,13 @@ describe("security audit extension tool reachability findings", () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-security-extensions-"));
     isolatedHome = path.join(fixtureRoot, "home");
     const isolatedEnv = createPathResolutionEnv(isolatedHome, { OPENCLAW_HOME: isolatedHome });
+    pathResolutionEnvSnapshot = captureEnv([...pathResolutionEnvKeys]);
     for (const key of pathResolutionEnvKeys) {
-      previousPathResolutionEnv[key] = process.env[key];
       const value = isolatedEnv[key];
       if (value === undefined) {
-        delete process.env[key];
+        deleteTestEnvValue(key);
       } else {
-        process.env[key] = value;
+        setTestEnvValue(key, value);
       }
     }
     homedirSpy = vitestModule.vi
@@ -527,14 +532,7 @@ describe("security audit extension tool reachability findings", () => {
 
   afterAll(async () => {
     homedirSpy?.mockRestore();
-    for (const key of pathResolutionEnvKeys) {
-      const value = previousPathResolutionEnv[key];
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
+    pathResolutionEnvSnapshot?.restore();
     if (fixtureRoot) {
       await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => undefined);
     }

--- a/src/skills/loading/workspace-bundled-allowlist.test.ts
+++ b/src/skills/loading/workspace-bundled-allowlist.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { captureEnv } from "../../test-utils/env.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import { buildWorkspaceSkillsPrompt } from "./workspace.js";
 
@@ -12,10 +12,10 @@ describe("buildWorkspaceSkillsPrompt", () => {
     const env = captureEnv(["HOME", "USERPROFILE", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
     try {
-      process.env.HOME = workspaceDir;
-      process.env.USERPROFILE = workspaceDir;
-      delete process.env.OPENCLAW_HOME;
-      delete process.env.OPENCLAW_STATE_DIR;
+      setTestEnvValue("HOME", workspaceDir);
+      setTestEnvValue("USERPROFILE", workspaceDir);
+      deleteTestEnvValue("OPENCLAW_HOME");
+      deleteTestEnvValue("OPENCLAW_STATE_DIR");
       const bundledDir = path.join(workspaceDir, ".bundled");
       const bundledSkillDir = path.join(bundledDir, "peekaboo");
       const workspaceSkillDir = path.join(workspaceDir, "skills", "demo-skill");

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -4,30 +4,8 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { testing } from "../../scripts/bench-cli-startup.ts";
+import { withEnv } from "../../src/test-utils/env.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
-
-function withEnv<T>(env: Record<string, string | undefined>, callback: () => T): T {
-  const previous = new Map<string, string | undefined>();
-  for (const [key, value] of Object.entries(env)) {
-    previous.set(key, process.env[key]);
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-  try {
-    return callback();
-  } finally {
-    for (const [key, value] of previous) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
-}
 
 function isProcessAlive(pid: number): boolean {
   try {

--- a/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
+++ b/test/scripts/bundled-plugin-install-uninstall-probe.test.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../../src/test-utils/env.js";
 
 const tempDirs: string[] = [];
 const probePath = path.resolve("scripts/e2e/lib/bundled-plugin-install-uninstall/probe.mjs");
@@ -97,28 +98,11 @@ function runRuntimeSmoke(root: string, args: string[]) {
 }
 
 async function importRuntimeSmokeWithEnv(env: Record<string, string | undefined>) {
-  const previous = new Map<string, string | undefined>();
-  for (const [key, value] of Object.entries(env)) {
-    previous.set(key, process.env[key]);
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
-  try {
+  return await withEnvAsync(env, async () => {
     return await import(
       `${pathToFileURL(runtimeSmokePath).href}?case=${Date.now()}-${Math.random()}`
     );
-  } finally {
-    for (const [key, value] of previous.entries()) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
+  });
 }
 
 async function listenOnLoopback(server: HttpServer | NetServer): Promise<number> {

--- a/test/scripts/check-release-metadata-only.test.ts
+++ b/test/scripts/check-release-metadata-only.test.ts
@@ -25,4 +25,17 @@ describe("check-release-metadata-only", () => {
     expect(() => parseArgs(["--head"])).toThrow("Expected --head <ref>.");
     expect(() => parseArgs(["--base", ""])).toThrow("Expected --base <ref>.");
   });
+
+  it("rejects unknown options before treating args as paths", () => {
+    expect(() => parseArgs(["--stgaed"])).toThrow("Unknown option: --stgaed");
+  });
+
+  it("preserves option-shaped paths after the separator", () => {
+    expect(parseArgs(["--staged", "--", "--head"])).toEqual({
+      staged: true,
+      base: "origin/main",
+      head: "HEAD",
+      paths: ["--head"],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes isolated cron deliveries so the channel that receives a scheduled delivery also gets ephemeral context awareness for the next agent turn.
- Keeps the existing user-visible delivery content unchanged: transcript mirrors and channel sends still contain only the delivered message body, while cron metadata stays in system-event context.
- Covers direct/automatic cron delivery, verified message-tool delivery, and explicit off-plan message-tool sends that visibly delivered to a channel.
- Also records target-channel awareness for delivery failures when a scheduled delivery reaches a channel-level failure path, so the target session can understand what happened.
- Intentionally out of scope: persisting awareness in chat history, changing webchat display, or adding user-visible cron job metadata to delivered messages.
- Success means a user can reply in the delivery channel after a cron send and the agent knows what was just delivered, without leaking cron internals into the channel message.
- Reviewers should focus on target session resolution, threaded message-tool verification, idempotency/dedupe behavior, and preserving the existing double-announce guard.

## Linked context

Closes: N/A

Related:

- Addresses #74743 - cron responses can reach the destination channel while the destination session lacks injected response context; this PR fixes the target-channel next-turn context part without auto-closing the issue before maintainer confirmation.
- #88757 - broader proactive-message/session-context desynchronization issue; this PR covers the isolated cron delivery slice.
- #80786 - merged cron direct-announce transcript mirror work; this PR adds next-turn context without relying on transcript replay.

Was this requested by a maintainer or owner?

Yes. This was requested from a local maintainer workflow after observing that cron deliveries reached a channel but did not enter that channel's next-turn context.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: isolated cron delivery reached Weixin and Telegram, but the receiving channel's next agent turn did not reliably know a scheduled delivery had happened.
- Real environment tested: local OpenClaw gateway using the user's existing OpenClaw state/config, Weixin channel, Telegram DM channel, real scheduled cron delivery, Codex harness target session, and Pi-style/openai-completions target session.
- Exact steps or command run after this patch: built the local code, started the gateway on port 18789 with the existing state/config, triggered scheduled cron deliveries, then replied in the same Weixin and Telegram conversations asking what number/content had just been delivered.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): redacted runtime log excerpt from the local OpenClaw gateway shows awareness entering the target prompt before model execution:

```text
Codex harness, message-tool delivery:
cron artifact trace=60acc6ab-bf9c-4e81-9077-f42d8b344829 ts=2026-06-17T10:33:17.869Z
provider=deepseek model=deepseek-v4-flash modelApi=openai-completions
runId=60acc6ab-bf9c-4e81-9077-f42d8b344829 didSendViaMessagingTool=true
messagingToolSentTargets=[{"tool":"message","provider":"openclaw-weixin","to":"<weixin direct>","text":"593827"}]
messagingToolSentTexts=["593827"]

target prompt trace=24b33b5d-4e7a-4fde-9e81-15bc1d6f3306 ts=2026-06-17T10:33:35.133Z
provider=openai model=gpt-5.5 modelApi=openai-chatgpt-responses runId=cdcd6ac5-dc61-43b3-9970-00195d4d6ffc
System: [2026-06-17 18:33:17 GMT+8] A scheduled cron job delivered this message to this channel:
System: 593827
What number did you receive from the cron message tool delivery? If you didn't receive any number, just say you didn't receive one.
tool.call message {"action":"send","message":"593827"}

Pi-style/openai-completions harness, direct delivery:
target prompt trace=f0ced73b-a26d-40b8-9f57-8e5897e65cfe ts=2026-06-16T09:37:13.317Z
provider=deepseek model=deepseek-v4-flash modelApi=openai-completions runId=b682d521-8c15-4289-bd48-7701396fc2a0
System: [2026-06-16 17:26:17 GMT+8] A scheduled cron job delivered this message to this channel:
System: Guangzhou weather delivery body was present here in the target prompt.
```
- Observed result after fix: the receiving channel's next agent turn had awareness of the cron-delivered content; the Weixin- and Telegram-visible deliveries remained only the delivered payload and did not include cron job ids or scheduling metadata.
- What was not tested: live channels beyond Weixin and Telegram in the local environment.
- Proof limitations or environment constraints: awareness is intentionally an in-memory system-event queue and is consumed by the next agent turn, so it is not visible as a normal webchat/transcript row.
- Before evidence: prior behavior delivered the cron message to the channel but left no target-channel context for the next agent turn; for Codex message-tool delivery, the target reply previously said it did not receive a number. Live Telegram before/after screenshots are reserved below for maintainer upload.

### Harness proof logs

Codex harness, message-tool delivery path:

```text
cron artifact trace=60acc6ab-bf9c-4e81-9077-f42d8b344829 ts=2026-06-17T10:33:17.869Z
provider=deepseek model=deepseek-v4-flash modelApi=openai-completions
runId=60acc6ab-bf9c-4e81-9077-f42d8b344829 didSendViaMessagingTool=true
messagingToolSentTargets=[{"tool":"message","provider":"openclaw-weixin","to":"<weixin direct>","text":"593827"}]
messagingToolSentTexts=["593827"]

target prompt trace=24b33b5d-4e7a-4fde-9e81-15bc1d6f3306 ts=2026-06-17T10:33:35.133Z
provider=openai model=gpt-5.5 modelApi=openai-chatgpt-responses runId=cdcd6ac5-dc61-43b3-9970-00195d4d6ffc
System: [2026-06-17 18:33:17 GMT+8] A scheduled cron job delivered this message to this channel:
System: 593827
What number did you receive from the cron message tool delivery? If you didn't receive any number, just say you didn't receive one.

tool.call message {"action":"send","message":"593827"}
```

Pi-style/openai-completions harness, direct delivery path:

```text
target prompt trace=f0ced73b-a26d-40b8-9f57-8e5897e65cfe ts=2026-06-16T09:37:13.317Z
provider=deepseek model=deepseek-v4-flash modelApi=openai-completions runId=b682d521-8c15-4289-bd48-7701396fc2a0
System: [2026-06-16 17:26:17 GMT+8] A scheduled cron job delivered this message to this channel:
System: Guangzhou weather delivery body was present here in the target prompt.
```

Additional Codex direct-delivery check:

```text
target prompt trace=a4d04758-8bf9-4c6a-8736-353b76fc5ce7 ts=2026-06-17T08:00:04.947Z
provider=openai model=gpt-5.5 modelApi=openai-chatgpt-responses runId=0c0638a6-2edb-4055-97c0-c888d235e4cb
System: [2026-06-17 15:58:34 GMT+8] A scheduled cron job delivered this message to this channel:
System: random number 742531
What number did you receive from the cron message? If you didn't receive any number, just say you didn't receive one.

tool.call message {"action":"send","message":"I received cron random number 742531"}
```

### Telegram live before/after proof

Maintainer live-tested Telegram DM delivery against the published npm baseline and this PR using the same local state/config and the same Telegram DM target. These screenshots are intentionally left as upload slots so the maintainer can attach the private Telegram captures directly in GitHub.

Before fix, npm release `openclaw@2026.6.8` / Gateway `2026.6.8 (844f405)` delivered the Telegram cron message but the next Telegram turn did not know what had just been delivered.

<img width="645" height="1398" alt="before" src="https://github.com/user-attachments/assets/ff19ccbe-c2f7-4b24-b104-cf7a38cd99ff" />


After fix, PR build `05df61064ca4ea1f0efa7ace6022b70c5628f99b` delivered the Telegram cron/message-tool content and the next Telegram turn could answer with the exact delivered code.

<img width="645" height="1398" alt="after" src="https://github.com/user-attachments/assets/449ecf88-e262-41d1-88f3-b9bb5c91699c" />

Telegram regression check:

- Published npm baseline cron fallback delivery reached Telegram successfully: `NPM_CRON_PR93580_TELEGRAM_20260620_0550`, `deliveryStatus: delivered`, `fallbackUsed: true`.
- Published npm baseline message-tool delivery reached Telegram successfully: `NPM_MESSAGE_TOOL_PR93580_TELEGRAM_20260620_0553`, `messageToolSentTo: telegram:8941550703`, `fallbackUsed: false`, `delivered: true`.
- The failure was limited to next-turn target-session awareness, not Telegram transport delivery. Telegram normal delivery and message-tool routing continued to work before and after the fix.
- This PR changes the hidden target-session system-event awareness queue only; the Telegram-visible message payload remains the delivered text and does not include cron metadata.

Commands used for the published npm baseline:

```text
openclaw --version
OpenClaw 2026.6.8 (844f405)

openclaw cron run 4dc93909-ce1a-437f-ae38-b7fc66ec3d6e --wait --wait-timeout 5m --poll-interval 2s
# delivered: true, deliveryStatus: delivered, fallbackUsed: true

openclaw cron run 3983f8e2-682e-45f0-8e33-b54a6dcaaf35 --wait --wait-timeout 5m --poll-interval 2s
# delivered: true, messageToolSentTo: telegram:8941550703, fallbackUsed: false
```

## Tests and validation

Which commands did you run?

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` - passed, 77 tests.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts` - passed, 52 tests.
- `git diff --check` - passed.
- `pnpm build` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - final run clean: no accepted/actionable findings, `overall: patch is correct (0.82)`.
- `CLAWSWEEPER_CODEX_LOGIN_METHOD=chatgpt pnpm local-review -- --target-dir <openclaw checkout> --target-repo openclaw/openclaw --base origin/main` - final run clean on `da94c9cf902fff9df45b8ee3b8b3d7154079311e`: `result: nothing_found`, `check_conclusion: success`.

What regression coverage was added or updated?

- Direct cron delivery now asserts target-session awareness is queued separately from existing main-session awareness.
- Session-bound cron delivery now asserts target-session awareness without main-session leakage.
- Verified message-tool cron delivery now queues target awareness.
- Explicit off-plan message-tool delivery now queues target awareness when a visible channel send is observed, without inheriting account/thread from the scheduled delivery target.
- Threaded message-tool delivery with implicit thread evidence now asserts awareness resolves to the actual thread session.
- Message-tool delivery whose resolved target session is the main session now still queues target awareness instead of being dropped.
- Media-only verified message-tool delivery now queues awareness using the existing transcript mirror filename projection.
- Failure-path delivery dispatch now announces failed delivery context to the resolved target session when delivery reaches the target-aware failure branch.

What failed before this fix, if known?

- Live follow-up in the delivery channel lacked context that a cron delivery had just happened.
- Codex message-tool delivery could send a visible channel message, but the next target turn could still reply that it did not receive the number because the off-plan visible send was not queued as target awareness.
- The first local autoreview pass found that explicit off-plan message-tool sends could incorrectly inherit account/thread from the scheduled delivery target; this PR gates fallback account/thread use to verified target deliveries and adds regression coverage.
- Earlier ClawSweeper/local review passes found same-session and media-only message-tool awareness gaps; both are fixed, and the final local review was clean.

If no test was added, why not?

Tests were added/updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. The next agent turn in a cron delivery target can now see the delivered message or delivery failure as system-event context. The outbound channel message content itself is unchanged.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Session targeting for awareness events, especially threaded deliveries, duplicate main-session/target-session awareness, explicit off-plan message-tool sends, and non-text message-tool deliveries.

How is that risk mitigated?

The patch reuses existing outbound session route resolution, transcript mirror projection, and idempotency keys; queues target awareness only after successful non-best-effort delivery or explicit target-aware failure handling; avoids duplicate target queueing when direct fallback already queues main-session awareness; does not add cron metadata to user-visible channel payloads; and adds focused regression tests for direct, session-bound, message-tool, off-plan explicit message-tool, same-session, media-only, failure, and threaded implicit-thread cases.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI is pending. Live Weixin proof was completed locally by the maintainer across Codex and Pi-style/openai-completions harness paths.

Which bot or reviewer comments were addressed?

Local autoreview found one P1 issue around explicit off-plan message-tool target resolution; this PR fixes it by avoiding scheduled-target account/thread fallback for unverified off-plan sends and adds a regression test. The final local ClawSweeper review found nothing.

