### PR TITLE
fix(plugins): auto-allowlist any explicitly selected plugin, not just ClickClack (fixes #93568)

### DIFF
--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -180,21 +180,19 @@ describe("enableExplicitlySelectedPluginInConfig", () => {
     expect(result.config.channels?.clickclack?.enabled).toBe(true);
   });
 
-  it("keeps unrelated explicit plugin enables blocked by a restrictive allowlist", () => {
-    const cfg = {
-      plugins: {
-        allow: ["memory-core"],
-      },
-    } as OpenClawConfig;
+  it("appends any explicitly selected plugin to a restrictive allowlist before enabling it", () => {
+    const result = enableExplicitlySelectedPluginInConfig(
+      {
+        plugins: {
+          allow: ["memory-core"],
+        },
+      } as OpenClawConfig,
+      "google",
+    );
 
-    const result = enableExplicitlySelectedPluginInConfig(cfg, "google");
-
-    expect(result).toEqual({
-      config: cfg,
-      enabled: false,
-      pluginId: "google",
-      reason: "blocked by allowlist",
-    });
+    expect(result.enabled).toBe(true);
+    expect(result.config.plugins?.allow).toEqual(["memory-core", "google"]);
+    expect(result.config.plugins?.entries?.google?.enabled).toBe(true);
   });
 
   it("keeps ClickClack blocked by the denylist without changing the allowlist", () => {

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -49,8 +49,10 @@ export function enablePluginInConfig(
 /**
  * Enables a plugin selected through an explicit user action.
  *
- * ClickClack is bundled without a separate install trust record, so selecting
- * it is the trust gesture that materializes its id in a restrictive allowlist.
+ * When a user explicitly selects a plugin (e.g. through channel setup or
+ * plugin install), that selection is the trust gesture. If a restrictive
+ * `plugins.allow` list blocks the plugin, the selection itself should
+ * materialize the plugin id in the allowlist before enabling.
  */
 export function enableExplicitlySelectedPluginInConfig(
   cfg: OpenClawConfig,
@@ -58,7 +60,7 @@ export function enableExplicitlySelectedPluginInConfig(
   options: PluginEnableOptions = {},
 ): PluginEnableResult {
   const result = enablePluginInConfig(cfg, pluginId, options);
-  if (result.reason !== "blocked by allowlist" || result.pluginId !== "clickclack") {
+  if (result.reason !== "blocked by allowlist") {
     return result;
   }
   return enablePluginInConfig(


### PR DESCRIPTION
## Summary

`enableExplicitlySelectedPluginInConfig` in `src/plugins/enable.ts` only auto-appended **ClickClack** to a restrictive `plugins.allow` list. Any other explicitly selected plugin (e.g. Weixin via channel setup) was blocked by the allowlist even though the user's selection is an explicit trust gesture.

This PR removes the ClickClack-only guard so that **any** explicitly selected plugin gets auto-appended to `plugins.allow` before enabling.

Fixes #93568

## Changes

- `src/plugins/enable.ts:63` — removed `|| result.pluginId !== "clickclack"` condition
- `src/plugins/enable.ts:52-55` — updated JSDoc to describe the general behavior, not ClickClack-specific
- `src/plugins/enable.test.ts:183-195` — updated test to verify any plugin gets auto-appended (not just ClickClack)

## Real behavior proof

- **Behavior addressed:** `enableExplicitlySelectedPluginInConfig` auto-appends any explicitly selected plugin to a restrictive `plugins.allow` list
- **Environment tested:** macOS, Node.js v25.8.2, openclaw main branch at f860ddca
- **Steps run after the patch:** Ran `node scripts/run-vitest.mjs run src/plugins/enable.test.ts` — 12 tests passed
- **Evidence after fix:**

```
$ grep -n 'blocked by allowlist' src/plugins/enable.ts
40:    return { config: cfg, enabled: false, pluginId: resolvedId, reason: "blocked by allowlist" };
63:  if (result.reason !== "blocked by allowlist") {

$ grep -n 'clickclack' src/plugins/enable.ts
(no matches — ClickClack-specific guard removed)

$ grep -n 'appends any' src/plugins/enable.test.ts
183:  it("appends any explicitly selected plugin to a restrictive allowlist before enabling it", () => {

$ node scripts/run-vitest.mjs run src/plugins/enable.test.ts
 ✓  unit-fast  src/plugins/enable.test.ts (12 tests) 8ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

- **Observed result after fix:** The ClickClack-only guard is removed. Any plugin selected through explicit user action (channel setup, plugin install) now gets auto-appended to `plugins.allow` if a restrictive allowlist blocks it.
- **What was not tested:** Live channel setup flow end-to-end (requires interactive terminal and Weixin plugin installation)
