### PR TITLE
fix(daemon): keep systemd gateway running after child OOM

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -259,6 +259,7 @@ RestartSec=5
 TimeoutStopSec=30
 TimeoutStartSec=30
 SuccessExitStatus=0 143
+OOMPolicy=continue
 KillMode=control-group
 
 [Install]

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -86,6 +86,7 @@ RestartSec=5
 TimeoutStopSec=30
 TimeoutStartSec=30
 SuccessExitStatus=0 143
+OOMPolicy=continue
 KillMode=control-group
 
 [Install]
@@ -129,6 +130,11 @@ cat /proc/<child-pid>/oom_score_adj
 
 Expected value for covered children is `1000`. The Gateway process should keep
 its normal score, usually `0`.
+
+The recommended systemd unit also sets `OOMPolicy=continue`. This keeps the
+Gateway unit alive when a transient child process is selected by the OOM killer;
+the child command/session can fail and report its error without systemd marking
+the entire gateway service failed and restarting all channels.
 
 This does not replace normal memory tuning. If a VPS or container repeatedly
 kills children, increase the memory limit, reduce concurrency, or add stronger

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -23,6 +23,7 @@ describe("buildSystemdUnit", () => {
     expect(unit).toContain("TimeoutStopSec=30");
     expect(unit).toContain("TimeoutStartSec=30");
     expect(unit).toContain("SuccessExitStatus=0 143");
+    expect(unit).toContain("OOMPolicy=continue");
     expect(unit).toContain("StartLimitBurst=5");
     expect(unit).toContain("StartLimitIntervalSec=60");
     expect(unit).toContain("RestartPreventExitStatus=78");

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -81,6 +81,10 @@ export function buildSystemdUnit({
     "TimeoutStopSec=30",
     "TimeoutStartSec=30",
     "SuccessExitStatus=0 143",
+    // Transient child processes may be selected by the OOM killer before the
+    // gateway. Keep the service running when that happens; the child surface is
+    // already responsible for reporting the failed command/session.
+    "OOMPolicy=continue",
     // Keep service children in the same lifecycle so restarts do not leave
     // orphan ACP/runtime workers behind.
     "KillMode=control-group",


### PR DESCRIPTION
## Summary
- Add `OOMPolicy=continue` to generated Linux systemd gateway units.
- Align both public copyable Linux systemd unit examples with the generated unit: `docs/platforms/linux.md` and `docs/gateway/index.md`.
- Extend the existing systemd unit test so the new directive is covered by regression tests.

## Review feedback addressed
- Addressed ClawSweeper P2 feedback by adding `OOMPolicy=continue` to the copyable Linux systemd user-unit example in `docs/gateway/index.md`.
- The generated unit, Linux platform guide, and Gateway runbook now all place `OOMPolicy=continue` next to the existing lifecycle directives, so custom-install users no longer copy the old child-OOM restart behavior.
- CHANGELOG.md intentionally remains untouched because this is a narrow Linux service/docs consistency repair on top of the runtime fix.

## Problem
A systemd-managed gateway can run transient child processes in the same service cgroup, such as shell commands or focused local checks started through OpenClaw tools. OpenClaw already biases covered child processes toward being selected first by the OOM killer via `oom_score_adj=1000`, but with systemd's default OOM policy a child OOM kill can still mark the whole gateway unit failed and restart the gateway.

Observed chain on a Linux systemd user service:

```text
kernel: oom-kill: task_memcg=/user.slice/.../app.slice/openclaw-gateway.service, task=tsgo, pid=<child>, global_oom
kernel: Out of memory: Killed process <child> (tsgo) ... oom_score_adj:1000
systemd: openclaw-gateway.service: The kernel OOM killer killed some processes in this unit.
systemd: openclaw-gateway.service: Failed with result 'oom-kill'.
systemd: openclaw-gateway.service: Scheduled restart job, restart counter is at 1.
```

The killed process was the transient child, not the gateway PID. However, the gateway unit restarted anyway, interrupting active channel/session work.

## Fix
`OOMPolicy=continue` tells systemd to keep the unit running when one process in the unit is killed by the kernel OOM killer. That matches OpenClaw's existing child OOM-score strategy: the child command/session should fail and report its own error, while the gateway keeps channel connections and active session state alive.

This does **not** change:

- `KillMode=control-group` cleanup behavior on intentional gateway stops/restarts.
- the gateway's own OOM behavior if the main gateway PID is killed.
- `OPENCLAW_NO_RESPAWN` semantics from #93570.

## Validation
- Local targeted test: `node scripts/run-vitest.mjs src/daemon/systemd-unit.test.ts`
  - `4 passed`
- Local docs format: `pnpm exec oxfmt --check --threads=1 docs/gateway/index.md docs/platforms/linux.md`
  - passed
- Local whitespace check: `git diff --check`
  - passed
- Local generated-unit proof: rendered `buildSystemdUnit()` output and verified it with `systemd-analyze verify --user`
  - output included `OOMPolicy=continue`
  - `verify_exit=0`
- GitHub Actions CI: https://github.com/openclaw/openclaw/actions/runs/27616159562
  - passed core checks including `check-docs`, `check-lint`, `check-prod-types`, `check-test-types`, `check-guards`, and related changed-surface jobs
- GitHub Actions real behavior proof: https://github.com/openclaw/openclaw/actions/runs/27618484112
  - passed `Real behavior proof`
  - log confirms: `External PR includes after-fix real behavior proof.`

I intentionally did not rerun full local `tsgo` because that exact kind of heavy child process previously triggered the OOM chain described above. CI provides the broader type/lint/check signal, and the targeted local unit test covers the changed renderer.

## Risk
Low. The directive only affects systemd's reaction when an OOM kill happens inside the unit. It reduces unnecessary gateway restarts when transient children are killed, while preserving normal stop/restart cleanup semantics and main-process restart behavior.

## Real behavior proof

**Behavior or issue addressed:** A Linux systemd user-service gateway should keep the gateway unit alive when a transient child process, not the gateway PID, is selected by the kernel OOM killer. The child command/session should fail independently instead of causing systemd to mark `openclaw-gateway.service` failed and restart all channels.

**Real environment tested:** Linux systemd user-service environment. The unit was generated from this PR branch using `buildSystemdUnit()` and validated with `systemd-analyze verify --user` against the generated unit file. GitHub Actions also verified that the PR includes after-fix real behavior proof.

**Exact steps or command run after this patch:**
1. Render a gateway systemd unit from this PR branch:
   `pnpm exec tsx --eval "import { buildSystemdUnit } from './src/daemon/systemd-unit.ts'; console.log(buildSystemdUnit({ description: 'OpenClaw Gateway proof unit', programArguments: ['/bin/true'], environment: { OPENCLAW_GATEWAY_PORT: '18789' } }));" > /tmp/proof-openclaw-gateway-93585.service`
2. Inspect the lifecycle/OOM-related unit directives with `rg -n '^(Restart|RestartSec|OOMPolicy|KillMode|TimeoutStopSec|TimeoutStartSec|SuccessExitStatus)=' /tmp/proof-openclaw-gateway-93585.service`.
3. Verify the unit with `systemd-analyze verify --user /tmp/proof-openclaw-gateway-93585.service`.
4. Confirm the public CI proof gate passed: https://github.com/openclaw/openclaw/actions/runs/27618484112

**Evidence after fix:**
```text
$ rg -n '^(Restart|RestartSec|OOMPolicy|KillMode|TimeoutStopSec|TimeoutStartSec|SuccessExitStatus)=' /tmp/proof-openclaw-gateway-93585.service
10:Restart=always
11:RestartSec=5
13:TimeoutStopSec=30
14:TimeoutStartSec=30
15:SuccessExitStatus=0 143
16:OOMPolicy=continue
17:KillMode=control-group

$ systemd-analyze verify --user /tmp/proof-openclaw-gateway-93585.service
verify_exit=0

$ gh run view 27618484112 --repo openclaw/openclaw --log --job 81660471385
External PR includes after-fix real behavior proof.
```

**Observed result after fix:** The generated unit includes `OOMPolicy=continue` together with the existing restart and cleanup directives, and systemd accepts the unit file with exit code `0`. Both copyable public Linux systemd examples now include the same directive, so the generated-unit path and manual-install docs are aligned.

**What was not tested:** I did not intentionally trigger another live OOM event on the host. The pre-fix live incident already showed the bad chain (`task=tsgo` killed inside `openclaw-gateway.service`, followed by `Failed with result 'oom-kill'` and a gateway restart). Re-triggering OOM would risk interrupting active channels again.
