### PR TITLE
fix(agents): treat codex exec_command as exec-like

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -371,6 +371,33 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("suppresses non-mutating Codex exec_command warnings when verbose mode is off", () => {
+    expectNoPayloads({
+      lastToolError: {
+        toolName: "exec_command",
+        error: "grep exited 1 because the verification label was absent",
+        mutatingAction: false,
+      },
+      verboseLevel: "off",
+    });
+  });
+
+  it("keeps mutating Codex exec_command failures visible", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec_command",
+        error: "command failed",
+        mutatingAction: true,
+      },
+      verboseLevel: "off",
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Exec Command",
+      absentDetail: "command failed",
+    });
+  });
+
   it("marks middleware tool-error warnings after assistant output as non-terminal", () => {
     // Middleware failures after useful assistant output warn the user without
     // replacing the successful answer as the terminal payload.

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -337,6 +337,39 @@ describe("handleToolExecutionStart read path checks", () => {
 });
 
 describe("handleToolExecutionEnd cron mutation tracking", () => {
+  it("classifies Codex exec_command read-only failures as non-mutating", async () => {
+    const { ctx } = createTestContext();
+    const toolCallId = "tool-codex-exec-command-readonly";
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec_command",
+        toolCallId,
+        args: { cmd: "rg -n missing-label src/agents" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec_command",
+        toolCallId,
+        isError: true,
+        result: {
+          content: [{ type: "text", text: "rg exited with status 1" }],
+        },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toMatchObject({
+      toolName: "exec_command",
+      error: "rg exited with status 1",
+      mutatingAction: false,
+    });
+  });
+
   it("increments successfulCronAdds when cron add succeeds", async () => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -77,6 +77,7 @@ import {
 } from "./embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./embedded-agent-utils.js";
 import { parseExecApprovalResultText } from "./exec-approval-result.js";
+import { isExecLikeToolName } from "./exec-tool-names.js";
 import type { AgentEvent } from "./runtime/index.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
@@ -263,7 +264,7 @@ function buildToolItemTitle(toolName: string, meta?: string): string {
 }
 
 function isExecToolName(toolName: string): boolean {
-  return toolName === "exec" || toolName === "bash";
+  return isExecLikeToolName(toolName);
 }
 
 function isPatchToolName(toolName: string): boolean {
@@ -494,8 +495,7 @@ function buildPatchSummaryText(summary: ApplyPatchSummary): string {
 }
 
 function extendExecMeta(toolName: string, args: unknown, meta?: string): string | undefined {
-  const normalized = normalizeOptionalLowercaseString(toolName);
-  if (normalized !== "exec" && normalized !== "bash") {
+  if (!isExecLikeToolName(toolName)) {
     return meta;
   }
   if (!args || typeof args !== "object") {

--- a/src/agents/exec-tool-names.ts
+++ b/src/agents/exec-tool-names.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical names for shell-execution tools across native and Codex app-server runtimes.
+ */
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+
+const EXEC_TOOL_NAME_ALIASES: Record<string, string> = {
+  bash: "exec",
+  exec_command: "exec",
+};
+
+/** Normalizes shell-execution tool aliases to the OpenClaw exec policy id. */
+export function normalizeExecLikeToolName(toolName: string): string {
+  const normalized = normalizeOptionalLowercaseString(toolName) ?? "";
+  return EXEC_TOOL_NAME_ALIASES[normalized] ?? normalized;
+}
+
+/** Detects tools that share shell-execution retry, mutation, and warning semantics. */
+export function isExecLikeToolName(toolName: string): boolean {
+  return normalizeExecLikeToolName(toolName) === "exec";
+}

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -3,8 +3,8 @@
  *
  * Stores failure metadata used by transcripts, retry behavior, and mutation recovery logic.
  */
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { FileTarget } from "./tool-mutation.js";
+export { isExecLikeToolName } from "./exec-tool-names.js";
 
 export type ToolErrorSummary = {
   toolName: string;
@@ -17,10 +17,3 @@ export type ToolErrorSummary = {
   actionFingerprint?: string;
   fileTarget?: FileTarget;
 };
-
-const EXEC_LIKE_TOOL_NAMES = new Set(["exec", "bash"]);
-
-/** Detects shell-execution tools that share retry and mutation semantics. */
-export function isExecLikeToolName(toolName: string): boolean {
-  return EXEC_LIKE_TOOL_NAMES.has(normalizeOptionalLowercaseString(toolName) ?? "");
-}

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -52,6 +52,20 @@ describe("tool mutation helpers", () => {
     expect(buildToolActionFingerprint(toolName, { command }, command)).toBeUndefined();
   });
 
+  it("treats Codex exec_command cmd input like exec for mutation classification", () => {
+    expect(isLikelyMutatingToolName("exec_command")).toBe(true);
+    expect(isMutatingToolCall("exec_command", { cmd: "rg -n tool-mutation src/agents" })).toBe(
+      false,
+    );
+    expect(
+      buildToolMutationState("exec_command", { cmd: "rg -n tool-mutation src/agents" })
+        .mutatingAction,
+    ).toBe(false);
+    expect(buildToolActionFingerprint("exec_command", { cmd: "npm start" }, "npm start")).toBe(
+      "tool=exec_command|meta=npm start",
+    );
+  });
+
   it.each([
     ["exec", "sed -i 's/a/b/' file.txt"],
     ["exec", "sed --in-place 's/a/b/' file.txt"],

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
+import { normalizeExecLikeToolName } from "./exec-tool-names.js";
 import { asRecord } from "./tool-display-record.js";
 
 const MUTATING_TOOL_NAMES = new Set([
@@ -346,7 +347,7 @@ function appendFingerprintAlias(
 }
 
 export function isLikelyMutatingToolName(toolName: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(toolName);
+  const normalized = normalizeExecLikeToolName(toolName);
   if (!normalized) {
     return false;
   }
@@ -359,7 +360,7 @@ export function isLikelyMutatingToolName(toolName: string): boolean {
 }
 
 export function isMutatingToolCall(toolName: string, args: unknown): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(toolName);
+  const normalized = normalizeExecLikeToolName(toolName);
   const record = asRecord(args);
   const action = normalizeActionName(record?.action);
 
@@ -406,7 +407,7 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
 
 /** Return true only for tool calls whose structured contract proves replay safety. */
 export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(toolName);
+  const normalized = normalizeExecLikeToolName(toolName);
   const record = asRecord(args);
   const action = normalizeActionName(record?.action);
   if (REPLAY_SAFE_TOOL_NAMES.has(normalized)) {


### PR DESCRIPTION
## Summary

Fixes #93482.

Codex app-server exposes shell execution as `exec_command`, but OpenClaw's exec-like warning and mutation paths only treated `exec`/`bash` as shell execution tools. This meant a read-only Codex `exec_command` with a normal non-zero exit could fall through to the generic tool-error warning path instead of using the same compact behavior as native exec tools.

This PR adds a small shared exec-like tool-name helper and uses it in:

- tool-error warning policy and failure-signal classification
- tool lifecycle handling for command item/result paths
- mutation classification so Codex `cmd` input gets the same read-only shell detection as `exec`/`bash`

Mutating `exec_command` failures still surface a warning; only non-mutating exec-like failures keep the existing compact/suppressed behavior.

## Codex contract checked

I inspected sibling `../codex` source before changing this Codex-facing path:

- `codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs` returns `ToolName::plain("exec_command")` from `ExecCommandHandler::tool_name()`.
- `codex-rs/code-mode-protocol/src/description.rs` documents nested shell calls as `await tools.exec_command(...)`.
- `codex-rs/core/tests/suite/request_permissions.rs` builds real model events with `ev_function_call(call_id, "exec_command", ...)` and `cmd` arguments.

## Verification

- `node node_modules/oxfmt/bin/oxfmt --write --threads=1 --config .oxfmtrc.jsonc src/agents/exec-tool-names.ts src/agents/tool-error-summary.ts src/agents/tool-mutation.ts src/agents/tool-mutation.test.ts src/agents/embedded-agent-subscribe.handlers.tools.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts`
- `node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-runner/failure-signal.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `git diff --check`

## Real behavior proof

Behavior addressed: Codex app-server `exec_command` is now classified as exec-like for the OpenClaw tool handler, mutation classifier, failure signal helper, and payload warning policy; a read-only `cmd` command that exits non-zero no longer gets a generic user-visible tool failed warning, while mutating `exec_command` failures still warn.

Real environment tested: Local OpenClaw worktree based on upstream `main` commit `4292f0fe7f`, with a sibling OpenAI Codex checkout inspected for the real `exec_command` tool contract. Dependencies were hydrated by the repo committer workflow and tests ran through OpenClaw's `scripts/run-vitest.mjs` and `scripts/run-tsgo.mjs` wrappers.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-runner/failure-signal.test.ts`; `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`; `git diff --check`.

Evidence after fix: Vitest passed 2 shards, covering 4 files and 178 tests. The added handler test feeds a production `tool_execution_start`/`tool_execution_end` pair with `toolName: "exec_command"` and `cmd: "rg ..."`, proving OpenClaw records `lastToolError.mutatingAction: false` for the Codex event shape. The added payload tests prove the non-mutating `exec_command` warning is suppressed and the mutating `exec_command` warning remains visible.

Observed result after fix: `exec_command` now follows the same exec-like policy as `exec`/`bash`; benign read-only non-zero exits are not surfaced as generic failed warnings, and side-effecting failures remain visible.

What was not tested: I did not run a full live Codex app-server model turn; this PR uses source-contract inspection from `../codex` plus OpenClaw production helper tests for the event-to-warning path.
