### PR TITLE
fix(exec): align node-host exec security/ask defaults with exec-approvals constants

### DIFF
--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -294,11 +294,11 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   }
 
   function resolveProductionExecSecurity(value?: string): "deny" | "allowlist" | "full" {
-    return value === "deny" || value === "allowlist" || value === "full" ? value : "allowlist";
+    return value === "deny" || value === "allowlist" || value === "full" ? value : "full";
   }
 
   function resolveProductionExecAsk(value?: string): "off" | "on-miss" | "always" {
-    return value === "off" || value === "on-miss" || value === "always" ? value : "on-miss";
+    return value === "off" || value === "on-miss" || value === "always" ? value : "off";
   }
 
   function createInvokeSpies(params?: { runCommand?: MockedRunCommand }): {

--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -155,6 +155,6 @@ describe("node host invoke", () => {
     const payload = JSON.parse(result.payloadJSON ?? "{}") as {
       execPolicy?: { security?: string; ask?: string };
     };
-    expect(payload.execPolicy).toEqual({ security: "allowlist", ask: "on-miss" });
+    expect(payload.execPolicy).toEqual({ security: "full", ask: "off" });
   });
 });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -197,7 +197,7 @@ type NodeInvokeRequestPayload = {
 export type { SkillBinsProvider } from "./invoke-types.js";
 
 function resolveExecSecurity(value?: string): ExecSecurity {
-  return value === "deny" || value === "allowlist" || value === "full" ? value : "allowlist";
+  return value === "deny" || value === "allowlist" || value === "full" ? value : "full";
 }
 
 function isCmdExeInvocation(argv: string[]): boolean {
@@ -210,7 +210,7 @@ function isCmdExeInvocation(argv: string[]): boolean {
 }
 
 function resolveExecAsk(value?: string): ExecAsk {
-  return value === "off" || value === "on-miss" || value === "always" ? value : "on-miss";
+  return value === "off" || value === "on-miss" || value === "always" ? value : "off";
 }
 
 /** Builds a sanitized execution environment with controlled PATH and approved overrides. */


### PR DESCRIPTION
## Summary
- resolveExecSecurity and resolveExecAsk in node-host/invoke.ts fell back to "allowlist" and "on-miss" when no explicit value was provided
- These defaults conflicted with the canonical exec-approvals security=full and ask=off defaults, causing node-host exec commands to be downgraded when exec-approvals.json was configured for full/off
- Changed the fallback from "allowlist"/"on-miss" to "full"/"off" to align with the canonical defaults
- Updated test mirror functions and invoke test assertions to match the new defaults

## Change Type
- [x] Bug fix / [ ] Feature / [ ] Refactor / [ ] Docs / [ ] Security / [ ] Chore

## Scope
- [x] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [ ] Integrations / [ ] API / [ ] UI/UX / [ ] CI

## Real behavior proof

**Behavior or issue addressed:** node-host exec security/ask defaults now align with the canonical exec-approvals defaults (full/off), preventing unintended policy downgrade when exec-approvals.json is configured.

**Environment tested:** Node 24.x on Linux, pnpm vitest.

**Exact steps or command run after the patch:** Called resolveExecSecurity and resolveExecAsk with undefined input and explicit valid values, comparing patched defaults against old defaults and exec-approvals canonical constants.

**Evidence after fix:**

```text
=== After patch (PR #93592) ===
resolveExecSecurity(undefined): full
resolveExecAsk(undefined): off
resolveExecSecurity('full'): full
resolveExecAsk('off'): off

=== Before patch (current main) ===
oldResolveExecSecurity(undefined): allowlist
oldResolveExecAsk(undefined): on-miss

=== Alignment check ===
Patched defaults match exec-approvals canonical: true
Old defaults match exec-approvals canonical: false

=== Unit tests ===
 ✓ src/node-host/exec-policy.test.ts (12 tests) 8ms
 ✓ src/node-host/invoke-system-run.test.ts (20 tests) 84ms
 ✓ src/node-host/invoke.sanitize-env.test.ts (9 tests) 16ms

 Test Files  3 passed (3)
      Tests  41 passed (41)
```

**Observed result after the fix:** The patched resolveExecSecurity(undefined) returns "full" and resolveExecAsk(undefined) returns "off", matching the canonical exec-approvals defaults. The old defaults ("allowlist"/"on-miss") did not match, confirming the misalignment that caused policy downgrade. All 41 node-host tests pass with the new defaults.

**Not tested:** Live Companion App exec on WSL2/Windows with a real exec-approvals.json configuration. Did not exercise the full node-host IPC path with a running macOS app or headless node runner.

## Root Cause
- Root cause: node-host/invoke.ts resolveExecSecurity and resolveExecAsk used hardcoded fallback values ("allowlist" / "on-miss") that contradicted the canonical defaults ("full" / "off") in exec-approvals. When exec-approvals.json configured security=full and ask=off, the merge via minSecurity/maxAsk lowered security to "allowlist" and raised ask to "on-miss", causing exec host=node commands to be rejected.
- Missing detection/guardrail: No cross-module test verified that node-host fallback defaults aligned with exec-approvals defaults.

## Regression Test Plan
- Target test file: src/node-host/invoke-system-run.test.ts and src/node-host/exec-policy.test.ts — existing tests cover the merged policy evaluation with the new defaults.
- Why this is the smallest reliable guardrail: The invoke-system-run tests already verify the full minSecurity/maxAsk merge chain. With the defaults aligned, these tests prove that configured full/off values survive the merge instead of being downgraded.

## User-visible / Behavior Changes
When a node host is configured with exec-approvals.json security=full and ask=off, commands will now correctly evaluate to full/off instead of being downgraded to allowlist/on-miss. This aligns runtime behavior with the documented defaults.

## Security Impact
- New permissions? No — this aligns fallback defaults with the already-documented canonical values
- Secrets handling changed? No
- New network calls? No

Closes #90572
