### PR TITLE
fix(plugins): pin workspace dir during session list to prevent O(rows) metadata scans (#90814)

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -74,6 +74,8 @@ import { listSessionEntries as listAccessorSessionEntries } from "../config/sess
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
+import { runWithPinnedWorkspaceDir } from "../plugins/workspace-dir-pin.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
@@ -2729,6 +2731,10 @@ export function listSessionsFromStore(params: {
 }): SessionsListResult {
   const { cfg, storePath, store, opts } = params;
   const now = Date.now();
+  // Pin the active plugin-registry workspace dir for the row-building batch
+  // so every row reads a stable value despite concurrent mutations (#90814).
+  const workspaceDir = getActivePluginRegistryWorkspaceDirFromState();
+  return runWithPinnedWorkspaceDir(workspaceDir, () => {
   const sessionListTranscriptUsageMaxBytes = 64 * 1024;
   const sessionListTranscriptFieldRows = 100;
   let rowContext: SessionListRowContext | undefined;
@@ -2798,6 +2804,7 @@ export function listSessionsFromStore(params: {
     defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
     sessions,
   };
+  }); // runWithPinnedWorkspaceDir
 }
 
 /**
@@ -2819,6 +2826,11 @@ export async function listSessionsFromStoreAsync(params: {
 }): Promise<SessionsListResult> {
   const { cfg, storePath, store, opts } = params;
   const now = Date.now();
+  // Pin workspace dir for the row loop. Yields between batches let concurrent
+  // agent-turns mutate the global workspaceDir; without the pin the plugin
+  // metadata snapshot memo misses every row → O(rows) scans (#90814).
+  const workspaceDir = getActivePluginRegistryWorkspaceDirFromState();
+  return runWithPinnedWorkspaceDir(workspaceDir, async () => {
   const sessionListTranscriptUsageMaxBytes = 64 * 1024;
   const sessionListTranscriptFieldRows = 100;
   let rowContext: SessionListRowContext | undefined;
@@ -2922,4 +2934,5 @@ export async function listSessionsFromStoreAsync(params: {
     defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
     sessions,
   };
+  }); // runWithPinnedWorkspaceDir
 }

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -1,5 +1,6 @@
 // Stores plugin runtime registry state for the current process lifecycle.
 import type { PluginRegistry } from "./registry-types.js";
+import { getPinnedWorkspaceDir } from "./workspace-dir-pin.js";
 
 export const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
@@ -37,6 +38,5 @@ export function getActivePluginChannelRegistryFromState(): RuntimeTrackedPluginR
 }
 
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
-  const state = getPluginRegistryState();
-  return state?.workspaceDir ?? undefined;
+  return getPinnedWorkspaceDir() ?? getPluginRegistryState()?.workspaceDir ?? undefined;
 }

--- a/src/plugins/runtime-workspace-state.ts
+++ b/src/plugins/runtime-workspace-state.ts
@@ -1,4 +1,6 @@
 // Shares plugin runtime workspace state across module reloads.
+import { getPinnedWorkspaceDir } from "./workspace-dir-pin.js";
+
 const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type GlobalRegistryWorkspaceState = typeof globalThis & {
@@ -10,6 +12,8 @@ type GlobalRegistryWorkspaceState = typeof globalThis & {
 /** Reads the active plugin registry workspace directory from global runtime state. */
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
   return (
-    (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined
+    getPinnedWorkspaceDir() ??
+    (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ??
+    undefined
   );
 }

--- a/src/plugins/workspace-dir-pin.test.ts
+++ b/src/plugins/workspace-dir-pin.test.ts
@@ -1,0 +1,105 @@
+// Verifies the active plugin-registry workspace dir pin is stable under
+// concurrent mutation, matching the sessions.list concurrency scenario
+// described in issue #90814.
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  getActivePluginRegistryWorkspaceDirFromState,
+} from "./runtime-workspace-state.js";
+import {
+  getPinnedWorkspaceDir,
+  runWithPinnedWorkspaceDir,
+} from "./workspace-dir-pin.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+
+function setActiveWorkspace(workspaceDir: string): void {
+  setActivePluginRegistry(
+    createEmptyPluginRegistry(),
+    workspaceDir,
+    "gateway-bindable",
+    workspaceDir,
+  );
+}
+
+describe("workspace dir pin", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("reads the live global workspace dir when no pin is active", () => {
+    setActiveWorkspace("/workspace/a");
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+    setActiveWorkspace("/workspace/b");
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("keeps the workspace dir stable inside a pinned scope despite concurrent mutation", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    const observed: Array<string | undefined> = [];
+    await runWithPinnedWorkspaceDir("/workspace/a", async () => {
+      observed.push(getActivePluginRegistryWorkspaceDirFromState());
+      // Simulate a concurrent agent-turn/cron mutating the global mid-batch,
+      // across an event-loop yield like sessions.list performs between batches.
+      setActiveWorkspace("/workspace/b");
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      observed.push(getActivePluginRegistryWorkspaceDirFromState());
+    });
+
+    // Both reads inside the pinned scope return the value captured at scope
+    // entry, immune to the mid-batch mutation.
+    expect(observed).toEqual(["/workspace/a", "/workspace/a"]);
+    // Once the scope exits, reads observe the live (mutated) global again.
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("reuses the outer pin for nested scopes", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await runWithPinnedWorkspaceDir("/workspace/a", async () => {
+      setActiveWorkspace("/workspace/b");
+      await runWithPinnedWorkspaceDir("/workspace/b", async () => {
+        // Nested scope must reuse the outer pin, not re-capture the
+        // mutated global.
+        expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+      });
+    });
+  });
+
+  it("propagates rejections and leaves no sticky pinned context", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await expect(
+      runWithPinnedWorkspaceDir("/workspace/a", async () => {
+        setActiveWorkspace("/workspace/b");
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // After the failed scope exits, reads observe the live global again —
+    // no leak.
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("returns undefined from getPinnedWorkspaceDir when no pin is active", () => {
+    setActiveWorkspace("/workspace/a");
+    expect(getPinnedWorkspaceDir()).toBeUndefined();
+  });
+
+  it("getPinnedWorkspaceDir returns the pinned value inside a scope", () => {
+    setActiveWorkspace("/workspace/a");
+    runWithPinnedWorkspaceDir("/workspace/a", () => {
+      expect(getPinnedWorkspaceDir()).toBe("/workspace/a");
+    });
+    expect(getPinnedWorkspaceDir()).toBeUndefined();
+  });
+
+  it("pinning undefined workspace dir is safe (cold-start / single-tenant)", () => {
+    // No setActiveWorkspace call — workspaceDir is undefined.
+    runWithPinnedWorkspaceDir(undefined, () => {
+      expect(getActivePluginRegistryWorkspaceDirFromState()).toBeUndefined();
+    });
+  });
+});

--- a/src/plugins/workspace-dir-pin.ts
+++ b/src/plugins/workspace-dir-pin.ts
@@ -1,0 +1,34 @@
+// Pins the active plugin-registry workspace dir for the duration of an async
+// scope so reads of the process-global workspace dir stay stable even when
+// concurrent agent-turns or crons mutate it via setActivePluginRegistry.
+//
+// Without a pin, a batch that yields the event loop between rows (e.g. gateway
+// sessions.list) reads a different workspaceDir each row, so the
+// plugin-metadata-snapshot memo key changes every row and never hits, turning
+// one list into O(rows) full metadata scans (~100 ms each).
+//
+// AsyncLocalStorage scopes the pin to the current async context only; other
+// concurrent contexts still observe the live global.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const pinnedWorkspaceDir = new AsyncLocalStorage<string | undefined>();
+
+/** Reads the workspace dir pinned to the current async context, if any. */
+export function getPinnedWorkspaceDir(): string | undefined {
+  return pinnedWorkspaceDir.getStore();
+}
+
+/**
+ * Runs `fn` with the active plugin-registry workspace dir pinned to the given
+ * value. Nested calls reuse the outer pin so a mid-batch registry mutation
+ * inside a pin scope does not change what the rest of the batch observes.
+ */
+export function runWithPinnedWorkspaceDir<T>(
+  workspaceDir: string | undefined,
+  fn: () => T,
+): T {
+  if (pinnedWorkspaceDir.getStore() !== undefined) {
+    return fn();
+  }
+  return pinnedWorkspaceDir.run(workspaceDir, fn);
+}


### PR DESCRIPTION
## Summary

Fixes #90814 — concurrent agent-turns can mutate the process-global `workspaceDir` during `listSessionsFromStoreAsync` batch yields, causing per-row plugin-metadata-snapshot memo misses. Every miss triggers a full metadata scan (~100 ms each), turning one `sessions.list` call into O(rows) expensive work.

## Root Cause

Both `getActivePluginRegistryWorkspaceDirFromState` implementations (`runtime-state.ts` and `runtime-workspace-state.ts`) read a process-global mutable value. Between batch yields in `listSessionsFromStoreAsync`, concurrent agents/crons call `setActivePluginRegistry`, changing the global `workspaceDir`. The downstream metadata snapshot memo key includes `workspaceDir`, so the key changes per row → cache always misses → O(rows) full scans.

PR #92362 extended the shared `SessionListRowContext` to single-entry lists but did not address the workspace-dir instability itself.

## Fix

- **New module `workspace-dir-pin.ts`**: Shared `AsyncLocalStorage` pin that both `getActivePluginRegistryWorkspaceDirFromState` implementations read before falling back to the global.
- **`runtime-state.ts` + `runtime-workspace-state.ts`**: Both getters now check `getPinnedWorkspaceDir()` first.
- **`session-utils.ts`**: `listSessionsFromStore` and `listSessionsFromStoreAsync` wrap their row loops with `runWithPinnedWorkspaceDir`.
- **`workspace-dir-pin.test.ts`**: 7 tests covering pin stability across yields, nested reuse, rejection cleanup, cold start, etc.

## Key design decisions

- Shared ALS module covers **both** `getActivePluginRegistryWorkspaceDirFromState` implementations (unlike PR #90819 which only covers one).
- Nested pins reuse the outer value (no re-capture of mutated global mid-batch).
- Sync `listSessionsFromStore` is also wrapped for defense-in-depth.

## Tests

```
workspace-dir-pin.test.ts          7 passed
session-utils.single-row-cache    16 passed
channel-plugin-ids.test.ts       144 passed
server-startup-plugins.test.ts    42 passed
plugin-lookup-table.test.ts       16 passed
```