### PR TITLE
feat(onboard): show upfront ETA timeline during setup wizard (fixes #74399)

### DIFF
--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1185,6 +1185,37 @@ describe("runSetupWizard", () => {
     expect(matchingQuickStartNotes.length).toBeGreaterThan(0);
   });
 
+  it("shows an upfront ETA timeline before setup choices", async () => {
+    const note: WizardPrompter["note"] = vi.fn(async () => {});
+    const prompter = buildWizardPrompter({ note });
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("plan for up to ~40 minutes"),
+      "Setup timeline",
+    );
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Typical timeline:"),
+      "Setup timeline",
+    );
+  });
+
   it("localizes the quickstart summary", async () => {
     const previousPort = process.env.OPENCLAW_GATEWAY_PORT;
     const previousLocale = process.env.OPENCLAW_LOCALE;

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -43,6 +43,15 @@ type ConfigLoggingModule = typeof import("../config/logging.js");
 type ModelPickerModule = typeof import("../commands/model-picker.js");
 type OnboardConfigModule = typeof import("../commands/onboard-config.js");
 
+const ONBOARDING_TIMELINE_NOTE = [
+  "Setup can take a while on a fresh machine — plan for up to ~40 minutes if OpenClaw needs to install dependencies, build UI assets, or configure channel runtimes.",
+  "Typical timeline:",
+  "1. Choose setup mode and accept the security note (1-2 min)",
+  "2. Configure gateway, auth, model, skills, and channels (5-15 min)",
+  "3. Install or verify local runtime dependencies (10-25 min)",
+  "4. Run health checks and launch the dashboard/TUI (2-5 min)",
+].join("\n");
+
 let authChoiceModulePromise: Promise<AuthChoiceModule> | undefined;
 let configLoggingModulePromise: Promise<ConfigLoggingModule> | undefined;
 let modelPickerModulePromise: Promise<ModelPickerModule> | undefined;
@@ -231,6 +240,7 @@ export async function runSetupWizard(
   const onboardHelpers = await import("../commands/onboard-helpers.js");
   onboardHelpers.printWizardHeader(runtime);
   await prompter.intro(t("wizard.setup.intro"));
+  await prompter.note(ONBOARDING_TIMELINE_NOTE, "Setup timeline");
   await requireRiskAcknowledgement({ opts, prompter });
 
   const snapshot = await readSetupConfigFileSnapshot();


### PR DESCRIPTION
## What does this PR do?

Adds an upfront ETA timeline note to the `openclaw onboard` setup wizard so new users know the setup can take up to ~40 minutes before they start.

## Related Issue

Fixes #74399

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `src/wizard/setup.ts`: Added `ONBOARDING_TIMELINE_NOTE` constant and calls `prompter.note()` after the intro to display the timeline
- `src/wizard/setup.test.ts`: Added verification that the timeline note is displayed during setup

## How to Test

1. Run `node scripts/run-vitest.mjs run src/wizard/setup.test.ts`
2. Run `pnpm build`
3. `grep -n "ONBOARDING_TIMELINE_NOTE" src/wizard/setup.ts`

## Real behavior proof

- **Behavior addressed:** `openclaw onboard` provides no indication of how long setup takes, leading to a poor onboarding experience for beginners
- **Environment tested:** macOS 26.4.1, Node.js, pnpm build
- **Steps run after the patch:**

```
$ pnpm build
[build-all] phase timings: total 85.5s
```

- **Evidence after fix:**

```
$ grep -n "ONBOARDING_TIMELINE_NOTE" src/wizard/setup.ts
46:const ONBOARDING_TIMELINE_NOTE = [
243:  await prompter.note(ONBOARDING_TIMELINE_NOTE, "Setup timeline");

$ grep -n "plan for up to" src/wizard/setup.ts
47:  "Setup can take a while on a fresh machine — plan for up to ~40 minutes if OpenClaw needs to install dependencies, build UI assets, or configure channel runtimes.",
```

- **Observed result after fix:** The setup wizard displays a timeline note after the intro, showing the 4 phases and their estimated durations
- **What was not tested:** Full end-to-end `openclaw onboard` run (requires live environment with channel runtimes)
