### PR TITLE
fix(plugins): activate dreaming engine sidecar under restrictive allowlist

### DIFF
--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -21,6 +21,7 @@ export type PluginActivationCause =
   | "blocked-by-denylist"
   | "disabled-in-config"
   | "workspace-disabled-by-default"
+  | "selected-dreaming-sidecar"
   | "not-in-allowlist"
   | "enabled-by-effective-config"
   | "bundled-channel-configured"
@@ -65,6 +66,7 @@ export const PLUGIN_ACTIVATION_REASON_BY_CAUSE: Record<PluginActivationCause, st
   "blocked-by-denylist": "blocked by denylist",
   "disabled-in-config": "disabled in config",
   "workspace-disabled-by-default": "workspace plugin (disabled by default)",
+  "selected-dreaming-sidecar": "selected dreaming sidecar",
   "not-in-allowlist": "not in allowlist",
   "enabled-by-effective-config": "enabled by effective config",
   "bundled-channel-configured": "channel configured",
@@ -134,6 +136,7 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   activationSource?: PluginActivationConfigSourceLike<TRootConfig>;
   autoEnabledReason?: string;
   allowBundledChannelExplicitBypassesAllowlist?: boolean;
+  isDreamingSidecar?: boolean;
   isBundledChannelEnabledByChannelConfig: (
     rootConfig: TRootConfig | undefined,
     pluginId: string,
@@ -210,6 +213,21 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
       explicitlyEnabled: true,
       source: "explicit",
       cause: "selected-context-engine-slot",
+    };
+  }
+  // The bundled dreaming engine runs as a sidecar of the selected memory slot
+  // plugin. Like the slot plugins above, it must activate even when a
+  // restrictive allowlist names the memory plugin but not the engine, otherwise
+  // dreaming sweeps silently stop. Higher-priority denials above (plugins
+  // disabled, denylist, disabled-in-config) still apply because they return
+  // earlier, so an operator can still explicitly disable the engine.
+  if (params.isDreamingSidecar === true) {
+    return {
+      enabled: true,
+      activated: true,
+      explicitlyEnabled: true,
+      source: "explicit",
+      cause: "selected-dreaming-sidecar",
     };
   }
   if (

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -569,6 +569,91 @@ describe("resolveEffectivePluginActivationState", () => {
       reason: "selected context engine slot",
     });
   });
+
+  it("activates the dreaming sidecar engine under a restrictive allowlist (#92536)", () => {
+    const rawConfig = {
+      plugins: {
+        allow: ["memory-lancedb-pro", "discord"],
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+      },
+    };
+
+    expect(
+      resolveEffectivePluginActivationState({
+        id: "memory-core",
+        origin: "bundled",
+        config: normalizePluginsConfig(rawConfig.plugins),
+        rootConfig: rawConfig,
+        activationSource: createPluginActivationSource({ config: rawConfig }),
+        isDreamingSidecar: true,
+      }),
+    ).toEqual({
+      enabled: true,
+      activated: true,
+      explicitlyEnabled: true,
+      source: "explicit",
+      reason: "selected dreaming sidecar",
+    });
+  });
+
+  it("still rejects a non-sidecar bundled plugin under the same allowlist (#92536)", () => {
+    const rawConfig = {
+      plugins: {
+        allow: ["memory-lancedb-pro", "discord"],
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+      },
+    };
+
+    expect(
+      resolveEffectivePluginActivationState({
+        id: "memory-core",
+        origin: "bundled",
+        config: normalizePluginsConfig(rawConfig.plugins),
+        rootConfig: rawConfig,
+        activationSource: createPluginActivationSource({ config: rawConfig }),
+        isDreamingSidecar: false,
+      }),
+    ).toEqual({
+      enabled: false,
+      activated: false,
+      explicitlyEnabled: false,
+      source: "disabled",
+      reason: "not in allowlist",
+    });
+  });
+
+  it("keeps the denylist authoritative over the dreaming sidecar exemption (#92536)", () => {
+    const rawConfig = {
+      plugins: {
+        allow: ["memory-lancedb-pro", "discord"],
+        deny: ["memory-core"],
+        slots: {
+          memory: "memory-lancedb-pro",
+        },
+      },
+    };
+
+    expect(
+      resolveEffectivePluginActivationState({
+        id: "memory-core",
+        origin: "bundled",
+        config: normalizePluginsConfig(rawConfig.plugins),
+        rootConfig: rawConfig,
+        activationSource: createPluginActivationSource({ config: rawConfig }),
+        isDreamingSidecar: true,
+      }),
+    ).toEqual({
+      enabled: false,
+      activated: false,
+      explicitlyEnabled: false,
+      source: "disabled",
+      reason: "blocked by denylist",
+    });
+  });
 });
 
 describe("resolveEnableState", () => {

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -164,6 +164,7 @@ export function resolvePluginActivationState(params: {
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
   autoEnabledReason?: string;
+  isDreamingSidecar?: boolean;
 }): PluginActivationState {
   return toPluginActivationState(
     resolvePluginActivationDecisionShared({
@@ -194,6 +195,7 @@ type EffectiveActivationParams = {
   rootConfig?: OpenClawConfig;
   enabledByDefault?: boolean;
   activationSource?: PluginActivationConfigSource;
+  isDreamingSidecar?: boolean;
 };
 
 export const resolveEffectiveEnableState =
@@ -209,6 +211,7 @@ export function resolveEffectivePluginActivationState(params: {
   enabledByDefault?: EffectiveActivationParams["enabledByDefault"];
   activationSource?: EffectiveActivationParams["activationSource"];
   autoEnabledReason?: string;
+  isDreamingSidecar?: EffectiveActivationParams["isDreamingSidecar"];
 }): PluginActivationState {
   return resolvePluginActivationState(params);
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -249,7 +249,7 @@ const CLI_METADATA_ENTRY_BASENAMES = [
   "cli-metadata.cjs",
 ] as const;
 
-function resolveDreamingSidecarEngineId(params: {
+export function resolveDreamingSidecarEngineId(params: {
   cfg: OpenClawConfig;
   memorySlot: string | null | undefined;
 }): string | null {
@@ -2006,6 +2006,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
         activationSource,
         autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
+        isDreamingSidecar: pluginId === dreamingEngineId,
       });
       const existingOrigin = seenIds.get(pluginId);
       if (existingOrigin) {
@@ -2046,6 +2047,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         rootConfig: cfg,
         enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
         activationSource,
+        isDreamingSidecar: pluginId === dreamingEngineId,
       });
       const entry = normalized.entries[pluginId];
       const record = createPluginRecord({
@@ -2973,6 +2975,7 @@ export async function loadOpenClawPluginCliRegistry(
       enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
       activationSource,
       autoEnabledReason: formatAutoEnabledActivationReason(autoEnabledReasons[pluginId]),
+      isDreamingSidecar: pluginId === dreamingEngineId,
     });
     const existingOrigin = seenIds.get(pluginId);
     if (existingOrigin) {
@@ -3013,6 +3016,7 @@ export async function loadOpenClawPluginCliRegistry(
       rootConfig: cfg,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(manifestRecord),
       activationSource,
+      isDreamingSidecar: pluginId === dreamingEngineId,
     });
     const entry = normalized.entries[pluginId];
     const record = createPluginRecord({


### PR DESCRIPTION
## Summary

Fixes #92536. When a third-party Dreaming-compatible memory plugin holds the memory slot and `plugins.allow` is a restrictive list that omits `memory-core` (the bundled dreaming engine), the dreaming engine was rejected as `not-in-allowlist` and never activated as a sidecar — so dreaming sweeps silently never ran (the Control UI showed Dreaming enabled but the scheduled sweep time rendered as `-`).

The loader already computes the dreaming sidecar engine id before the activation loop (`resolveDreamingSidecarEngineId`), but the activation decision didn't know the plugin was a required sidecar, so the generic allowlist filter rejected it.

## Changes

- `src/plugins/config-activation-shared.ts`: add an `isDreamingSidecar` input to `resolvePluginActivationDecisionShared`. When set, the plugin activates as the selected memory slot's dreaming sidecar (new `selected-dreaming-sidecar` cause), mirroring the existing memory/context-engine slot exemptions — instead of falling through to the allowlist filter. Higher-priority rejections (`plugins-disabled`, `blocked-by-denylist`, `disabled-in-config`) still apply, since they return before this block.
- `src/plugins/config-state.ts`: thread `isDreamingSidecar` through `resolveEffectivePluginActivationState` → `resolvePluginActivationState`.
- `src/plugins/loader.ts`: pass `isDreamingSidecar: pluginId === dreamingEngineId` at the four activation/enable-state resolution sites (both `resolveEffectivePluginActivationState` and `resolveEffectiveEnableState`, in both the loader and the CLI-registry pass — the enable-state path is what gates `resolvePluginRegistrationPlan`). Export `resolveDreamingSidecarEngineId` so the sidecar condition can be driven directly in tests/proof.

`isDreamingSidecar` is only true when `resolveDreamingSidecarEngineId` already resolved this plugin as the required sidecar (i.e. a non-default memory-slot plugin with `dreaming.enabled`), so the exemption is scoped to exactly the case in the bug report.

## Real behavior proof

**Behavior addressed**: under a restrictive `plugins.allow` that omits `memory-core`, the bundled dreaming engine now activates as the memory slot's sidecar instead of being rejected as `not-in-allowlist`.

**Real environment tested**: local worktree of `upstream/main`, Node v22, driving the real exported functions via `node --import tsx` (no mocks/stubs).

**Exact steps or command run after this patch**:
```
TSX_TSCONFIG_PATH=tsconfig.json node --import tsx ./proof-dreaming-sidecar.mts
node scripts/run-vitest.mjs src/plugins/config-state.test.ts
node scripts/run-vitest.mjs src/plugins/loader.test.ts
```

**Evidence after fix** (driving the real `resolveDreamingSidecarEngineId` + `resolveEffectivePluginActivationState`; `isDreamingSidecar` is derived from real config via the real function, not hard-coded):
```
[1] resolveDreamingSidecarEngineId({cfg, memorySlot}) = "memory-core"
PASS [1] sidecar condition resolves to memory-core
    isDreamingSidecar (derived) = (pluginId === dreamingEngineId) = true

[2] resolveEffectivePluginActivationState (sidecar) = {"enabled":true,"activated":true,...,"reason":"selected dreaming sidecar"}
PASS [2] memory-core sidecar is activated under restrictive allowlist
PASS [2] memory-core sidecar is NOT reported as not-in-allowlist

[3] resolveEffectivePluginActivationState (control / isDreamingSidecar=false) = {"enabled":false,"activated":false,...,"reason":"not in allowlist"}
PASS [3] control: memory-core is rejected as not-in-allowlist

PASS [*] the sidecar flag is the decisive switch (patched.enabled=true !== control.enabled=false)
RESULT: PASS
```

**Observed result after fix**: with a restrictive allowlist that omits `memory-core`, the dreaming sidecar resolves to `memory-core` and activates (`reason: "selected dreaming sidecar"`); the negative control (same input without the sidecar flag) still rejects with `not-in-allowlist`, confirming the exemption is the decisive switch and isn't trivially true.

**What was not tested**: this proof drives the activation/enable-state decision layer (where the bug lives), not a full `loadOpenClawPlugins` run landing `memory-core` into a live registry — that would require a real bundled-extension discovery environment. End-to-end registry landing is covered indirectly by the unit tests below rather than by the standalone proof script.

## Tests and validation

- `src/plugins/config-state.test.ts` (+3 regression tests): dreaming sidecar activates under a restrictive allowlist; a non-sidecar bundled plugin is still rejected by the same allowlist; denylist still overrides the sidecar exemption. **53/53 pass.**
- `src/plugins/loader.test.ts`: **160/160 pass** (no regression from the export + four `isDreamingSidecar` injection sites).
- `npx oxlint --import-plugin` clean on the four changed files.
- Negative control: forcing `isDreamingSidecar=false` reproduces the original `not-in-allowlist` rejection.
