### PR TITLE
fix(reply): clarify provider internal error copy

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -29,6 +29,7 @@ import {
 import { HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
 import {
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
+  PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
   PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
 } from "./provider-request-error-classifier.js";
 import type { FollowupRun } from "./queue.js";
@@ -6477,6 +6478,39 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE);
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
+  it("surfaces provider internal errors without session reset guidance before reply", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError(
+        "The AI service returned an internal error. Please try again in a moment.",
+        {
+          reason: "server_error",
+          provider: "fyapis",
+          model: "gpt-5.5",
+          status: 500,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "direct",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(PROVIDER_INTERNAL_ERROR_USER_MESSAGE);
+      expect(result.payload.text).not.toContain("/new");
       expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
     }
   });

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   classifyProviderRequestError,
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
+  PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
   PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
 } from "./provider-request-error-classifier.js";
 
@@ -58,5 +59,28 @@ describe("provider request error classifier", () => {
     expect(
       classifyProviderRequestError(new Error("INVALID_ARGUMENT: some other failure")),
     ).toBeUndefined();
+  });
+
+  it("surfaces provider internal errors without suggesting session reset", () => {
+    expect(
+      classifyProviderRequestError(
+        new Error("The AI service returned an internal error. Please try again in a moment."),
+      ),
+    ).toEqual({
+      code: "provider_internal_error",
+      userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
+      technicalMessage: "The AI service returned an internal error. Please try again in a moment.",
+    });
+  });
+
+  it("classifies generic server_error provider payloads as internal errors", () => {
+    const message =
+      "server_error: An error occurred while processing your request. Please include the request ID req_123.";
+
+    expect(classifyProviderRequestError(new Error(message))).toEqual({
+      code: "provider_internal_error",
+      userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
+      technicalMessage: message,
+    });
   });
 });

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -5,6 +5,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 /** Provider request error classes that get a specialized user-facing reply. */
 export type ProviderRequestErrorCode =
   | "provider_conversation_state_error"
+  | "provider_internal_error"
   | "provider_rate_limit_or_quota_error";
 
 /** Structured provider error classification for reply failure handling. */
@@ -20,6 +21,9 @@ export const PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE =
 
 export const PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE =
   "⚠️ The model provider returned HTTP 429 before replying. This can mean rate limiting, exhausted quota, or an account balance/billing issue. Check the selected provider/model, API key, and provider billing/quota dashboard, then try again.";
+
+export const PROVIDER_INTERNAL_ERROR_USER_MESSAGE =
+  "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.";
 
 /** Classifies provider request failures that are actionable for users. */
 export function classifyProviderRequestError(
@@ -40,6 +44,13 @@ export function classifyProviderRequestError(
     return {
       code: "provider_conversation_state_error",
       userMessage: PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
+      technicalMessage,
+    };
+  }
+  if (isProviderInternalErrorMessage(technicalMessage)) {
+    return {
+      code: "provider_internal_error",
+      userMessage: PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
       technicalMessage,
     };
   }
@@ -66,6 +77,16 @@ function isGenericProviderRuntimeErrorMessage(message: string): boolean {
   return (
     lower.includes("an error occurred while processing your request") ||
     lower.includes("something went wrong while processing your request")
+  );
+}
+
+function isProviderInternalErrorMessage(message: string): boolean {
+  const lower = normalizeLowercaseStringOrEmpty(message);
+  return (
+    lower.includes("the ai service returned an internal error") ||
+    lower.includes("provider returned an internal error") ||
+    (isGenericProviderRuntimeErrorMessage(message) &&
+      (lower.includes("server_error") || lower.includes("internal error")))
   );
 }
 


### PR DESCRIPTION
## Summary
- Classify provider internal errors that occur before any reply as provider-internal failures.
- Surface a specific user-facing message that recommends retrying or switching models.
- Avoid the generic `/new` session-reset guidance for provider-side temporary errors.

## Problem
A real Telegram turn failed before reply when the selected provider returned a generic upstream `server_error`:

```text
[openai-transport] [responses] error provider=fyapis api=openai-responses model=gpt-5.5 code=server_error type=server_error message=An error occurred while processing your request...
[model-fallback/decision] decision=candidate_failed requested=fyapis/gpt-5.5 candidate=fyapis/gpt-5.5 reason=timeout next=none
[telegram] outbound message: ⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.
```

The session state was not corrupt; `/new` was misleading. The actual recovery is to retry later or switch to another model/provider when no runtime fallback candidate is configured.

This is distinct from #45050. That issue covered raw provider payloads leaking to channel users; current main already sanitizes the raw payload. The remaining problem is that the sanitized internal-error copy falls through to the generic external-run failure text.

## Fix
`classifyProviderRequestError()` now maps these provider internal-error shapes to a dedicated user-facing message:

```text
⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.
```

The classifier covers:

- `The AI service returned an internal error...`
- `provider returned an internal error...`
- generic provider runtime messages that also include `server_error` or `internal error`

## Validation
- `node scripts/run-vitest.mjs src/auto-reply/reply/provider-request-error-classifier.test.ts src/auto-reply/reply/agent-runner-execution.test.ts --testNamePattern 'provider internal errors|generic server_error|HTTP 429 failures before reply'`
  - `4 passed`
- `pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/provider-request-error-classifier.ts src/auto-reply/reply/provider-request-error-classifier.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
  - passed
- `git diff --check`
  - passed

## Real behavior proof

**Behavior or issue addressed:** A provider-side temporary internal error before any assistant reply should not be reported as a session-reset problem. The visible reply should tell the user to retry later or switch models instead of suggesting `/new`.

**Real environment tested:** Local OpenClaw checkout on Linux, using the same provider-internal sanitized error text observed in the Telegram incident.

**Exact steps or command run after this patch:**
`pnpm exec tsx --eval "import { classifyProviderRequestError } from './src/auto-reply/reply/provider-request-error-classifier.ts'; const result = classifyProviderRequestError(new Error('The AI service returned an internal error. Please try again in a moment.')); console.log(JSON.stringify(result, null, 2)); console.log('containsNewHint=' + String(result?.userMessage.includes('/new')));"`

**Evidence after fix:**
```text
{
  "code": "provider_internal_error",
  "userMessage": "⚠️ The model provider returned a temporary internal error before replying. Try again in a moment, or switch to another model if it keeps happening.",
  "technicalMessage": "The AI service returned an internal error. Please try again in a moment."
}
containsNewHint=false
```

**Observed result after fix:** The same sanitized provider internal-error text now maps to the provider-internal copy and does not include `/new` guidance.

**What was not tested:** I did not force another live provider `server_error` from the production Telegram channel. The after-fix proof uses the exact sanitized error string captured from the live incident, without sending another external model request.

## Risk
Low. The change only affects pre-reply provider request failures that already reached the provider-error classifier. Existing conversation-state and HTTP 429 handling remain unchanged.

### Verification refresh — 2026-06-19

Refreshed the PR branch onto current `origin/main` after the ClawSweeper review noted the unrelated `check-test-types` failure. New head: `8265fc71f30a556a2f17ca1401b1c8b8a6f3198d`.

Local verification after the rebase:

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs run src/auto-reply/reply/provider-request-error-classifier.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
  - `provider-request-error-classifier.test.ts`: 12 passed
  - `agent-runner-execution.test.ts`: 205 passed
- `pnpm check:test-types`

Observed result after fix: the provider internal-error classifier tests and agent-runner external reply regression remain green after rebasing, and the local test typecheck that previously blocked the PR now passes on the refreshed branch.

GitHub Actions note: the refreshed fork PR run currently needs maintainer workflow approval before the required upstream CI lanes can execute.
