### PR TITLE
fix(memory): align session file counter denominator with indexer filter

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -9,6 +9,7 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -526,7 +527,7 @@ async function scanSessionFiles(agentId: string): Promise<SourceScan> {
   try {
     const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
     const totalFiles = entries.filter(
-      (entry) => entry.isFile() && entry.name.endsWith(".jsonl"),
+      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
     ).length;
     return { source: "sessions", totalFiles, issues };
   } catch (err) {


### PR DESCRIPTION
## fix(memory): align session file counter denominator with indexer filter

The `scanSessionFiles` function in `extensions/memory-core/src/cli.runtime.ts` counts session transcript files using `entry.name.endsWith(".jsonl")`, but the session indexer at `src/infra/session-cost-usage.ts:386` uses `isUsageCountedSessionTranscriptFileName()` which excludes non-session `.jsonl` files (trajectory artifacts, compaction checkpoints, archive backups).

This mismatch inflates the `totalFiles` count shown in the memory status CLI output, confusing operators who compare it against the actual indexed session count.

### What changed

- Import `isUsageCountedSessionTranscriptFileName` from the existing plugin SDK export at `memory-core-host-engine-qmd`
- Replace `.endsWith(".jsonl")` with `isUsageCountedSessionTranscriptFileName(entry.name)` in the `scanSessionFiles` filter

The function is already used by the indexer at `src/infra/session-cost-usage.ts:386` — this change aligns the counter with the same filter.

## Real behavior proof

- **Behavior addressed:** Session file counter in memory status CLI used a broader filter than the session indexer, causing inflated totalFiles counts.
- **Environment tested:** macOS, Node.js, openclaw local build from upstream/main
- **Steps run after the patch:**
  1. Verified the import resolves: `node -e` to call `isUsageCountedSessionTranscriptFileName` with test filenames
  2. Verified filter correctness: primary session transcripts return true, trajectory/checkpoint/archive files return false
  3. Ran `node scripts/run-vitest.mjs run extensions/memory-core/src/` — 63 test files, 934 tests passed
  4. Ran `pnpm build` — built successfully in 79.6s
- **Evidence after fix:**
```
node -e "const{isUsageCountedSessionTranscriptFileName}=require('./dist/plugin-sdk/memory-core-host-engine-qmd.js'); const tests=[['session-abc123.jsonl',true],['my-session.trajectory.jsonl',false],['session-abc.jsonl.reset.1718000000',false],['session-abc.jsonl.deleted.1718000000',false],['session-abc.jsonl.bak.1718000000',false],['sessions.json',false],['my-session.checkpoint.a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d.jsonl',false]]; let p=0; for(const[n,e]of tests){const g=isUsageCountedSessionTranscriptFileName(n); if(g!==e)console.log('FAIL:',n,'expected',e,'got',g); else p++;} console.log(p+'/'+tests.length+' passed');"
7/7 passed
```
```
grep -n "isUsageCountedSessionTranscriptFileName" extensions/memory-core/src/cli.runtime.ts
12:import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
530:      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
```
- **Observed result after fix:** Counter now uses the same filter as the indexer. Non-session `.jsonl` files (trajectory, checkpoints, archives) are excluded from the count.
- **What was not tested:** Live memory status CLI output comparison (requires running OpenClaw with actual session files). The function behavior is verified via direct invocation and existing test suite.
