### PR TITLE
fix(plugins): auto-allowlist explicitly selected plugins in setup flows

### DIFF
--- a/src/plugins/enable.test.ts
+++ b/src/plugins/enable.test.ts
@@ -164,7 +164,7 @@ describe("enablePluginInConfig", () => {
 });
 
 describe("enableExplicitlySelectedPluginInConfig", () => {
-  it("appends ClickClack to a restrictive allowlist before enabling it", () => {
+  it("appends an explicitly selected plugin to a restrictive allowlist before enabling it", () => {
     const result = enableExplicitlySelectedPluginInConfig(
       {
         plugins: {
@@ -180,10 +180,27 @@ describe("enableExplicitlySelectedPluginInConfig", () => {
     expect(result.config.channels?.clickclack?.enabled).toBe(true);
   });
 
-  it("keeps unrelated explicit plugin enables blocked by a restrictive allowlist", () => {
+  it("appends an explicitly selected channel plugin to a restrictive allowlist before enabling it", () => {
+    const result = enableExplicitlySelectedPluginInConfig(
+      {
+        plugins: {
+          allow: ["memory-core"],
+        },
+      } as OpenClawConfig,
+      "telegram",
+    );
+
+    expect(result.enabled).toBe(true);
+    expect(result.config.plugins?.allow).toEqual(["memory-core", "telegram"]);
+    expect(result.config.plugins?.entries?.telegram?.enabled).toBe(true);
+    expect(result.config.channels?.telegram?.enabled).toBe(true);
+  });
+
+  it("keeps explicitly selected plugins blocked by the denylist without changing the allowlist", () => {
     const cfg = {
       plugins: {
         allow: ["memory-core"],
+        deny: ["google"],
       },
     } as OpenClawConfig;
 
@@ -193,24 +210,6 @@ describe("enableExplicitlySelectedPluginInConfig", () => {
       config: cfg,
       enabled: false,
       pluginId: "google",
-      reason: "blocked by allowlist",
-    });
-  });
-
-  it("keeps ClickClack blocked by the denylist without changing the allowlist", () => {
-    const cfg = {
-      plugins: {
-        allow: ["memory-core"],
-        deny: ["clickclack"],
-      },
-    } as OpenClawConfig;
-
-    const result = enableExplicitlySelectedPluginInConfig(cfg, "clickclack");
-
-    expect(result).toEqual({
-      config: cfg,
-      enabled: false,
-      pluginId: "clickclack",
       reason: "blocked by denylist",
     });
   });

--- a/src/plugins/enable.ts
+++ b/src/plugins/enable.ts
@@ -49,8 +49,10 @@ export function enablePluginInConfig(
 /**
  * Enables a plugin selected through an explicit user action.
  *
- * ClickClack is bundled without a separate install trust record, so selecting
- * it is the trust gesture that materializes its id in a restrictive allowlist.
+ * Selecting a plugin in a setup flow or CLI command is the trust gesture that
+ * materializes its id in a restrictive allowlist, so an allowlist block is
+ * treated as auto-approval rather than a hard failure. Denylist blocks are
+ * still honored.
  */
 export function enableExplicitlySelectedPluginInConfig(
   cfg: OpenClawConfig,
@@ -58,7 +60,7 @@ export function enableExplicitlySelectedPluginInConfig(
   options: PluginEnableOptions = {},
 ): PluginEnableResult {
   const result = enablePluginInConfig(cfg, pluginId, options);
-  if (result.reason !== "blocked by allowlist" || result.pluginId !== "clickclack") {
+  if (result.reason !== "blocked by allowlist") {
     return result;
   }
   return enablePluginInConfig(


### PR DESCRIPTION
## Summary
- Generalizes `enableExplicitlySelectedPluginInConfig` so any plugin selected through an explicit user action is auto-appended to a restrictive `plugins.allow` instead of failing with "blocked by allowlist".
- Removes the previous hard-coded `clickclack` special case, which left other channel plugins (e.g. `openclaw-weixin`) disabled after the interactive channel setup flow installed them.
- Updates unit tests in `src/plugins/enable.test.ts` to cover an explicitly selected channel plugin and to preserve the denylist guard.

## Test plan
- [x] `node scripts/run-vitest.mjs run src/plugins/enable.test.ts` passes (12/12).
- [x] `LANG=en_US.UTF-8 node scripts/run-vitest.mjs run src/flows/channel-setup.test.ts` passes (16/16).
- [x] `LANG=en_US.UTF-8 node scripts/run-vitest.mjs run src/commands/onboarding-plugin-install.test.ts` passes (27/27).
- [x] `pnpm format:check src/plugins/enable.ts src/plugins/enable.test.ts` passes.
- [x] Direct `oxlint` on changed files reports no issues.

## Verification
Behavior addressed: Channel setup flow now completes enablement for explicitly selected channel plugins even when `plugins.allow` is restrictive, instead of failing with "blocked by allowlist" after plugin install.
Real environment tested: Linux x64, Node v22.22.0, local source checkout at upstream main (ecd0d17243).
Exact steps or command run after this patch:
1. `node scripts/run-vitest.mjs run src/plugins/enable.test.ts`
2. `LANG=en_US.UTF-8 node scripts/run-vitest.mjs run src/flows/channel-setup.test.ts`
3. `LANG=en_US.UTF-8 node scripts/run-vitest.mjs run src/commands/onboarding-plugin-install.test.ts`
4. `pnpm format:check src/plugins/enable.ts src/plugins/enable.test.ts`
Evidence after fix: All targeted tests pass; the updated `enable.test.ts` asserts that selecting `telegram` with `plugins.allow: ["memory-core"]` results in `plugins.allow: ["memory-core", "telegram"]` and both `plugins.entries.telegram.enabled` and `channels.telegram.enabled` are `true`.
Observed result after fix: Explicit selection now materializes the plugin id in the allowlist and enables the entry, matching the existing ClickClack behavior.
What was not tested: Live interactive `openclaw channels add` TUI flow with a real Weixin plugin install (plugin not bundled in this checkout); full `pnpm build`; full `pnpm check` (local run hit unrelated pre-existing npm-shrinkwrap staleness and an OOM in the legacy-store guard).

Fixes #93568

## Real behavior proof

Behavior addressed: Explicitly selecting a channel plugin through the `openclaw plugins enable` CLI now appends it to a restrictive `plugins.allow` list and enables it, instead of failing with "blocked by allowlist". The denylist guard still blocks explicitly selected denied plugins.

Real environment tested: Local source checkout built from branch `fix/93568-weixin-setup-allowlist` at commit `e5b7ce9798b6f33ab391b03e838534270d943bc8` on Linux x64, Node v22.22.0.

Exact steps or command run after this patch:
1. Build the CLI: `pnpm build`
2. Create a fresh config with a restrictive allowlist:
   ```json
   {
     "plugins": {
       "allow": ["memory-core"]
     }
   }
   ```
3. Set `OPENCLAW_CONFIG_PATH` to that file.
4. Run `node openclaw.mjs plugins enable telegram`.
5. Inspect the resulting `openclaw.json`.
6. Repeat with `plugins.deny: ["telegram"]` to confirm the guard is preserved.

Evidence after fix:

```
$ OPENCLAW_CONFIG_PATH=/tmp/openclaw-proof-93603/openclaw.json node openclaw.mjs plugins enable telegram
Enabled plugin "telegram". Restart the gateway to apply.

$ cat /tmp/openclaw-proof-93603/openclaw.json
{
  "plugins": {
    "allow": ["memory-core", "telegram"],
    "entries": {
      "telegram": {
        "enabled": true
      }
    }
  },
  "meta": {
    "lastTouchedVersion": "2026.6.8",
    "lastTouchedAt": "2026-06-17T01:51:23.825Z"
  }
}
```

Observed result after fix: The `telegram` plugin id was automatically appended to the restrictive allowlist and the entry was enabled without manual editing. When `telegram` was placed on the denylist, the same command reported `Plugin "telegram" could not be enabled (blocked by denylist).` and left the allowlist unchanged.

What was not tested: Live interactive `openclaw channels add` TUI flow with a real Weixin plugin install (plugin not bundled in this checkout); the channel-setup flow was covered by existing targeted unit tests.
