### PR TITLE
fix(ui): clear stale Talk error when session transitions to non-error state (fixes #88176)

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -933,7 +933,15 @@
 }
 
 .agent-chat__talk-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   color: var(--text);
+}
+
+.agent-chat__talk-status-text {
+  min-width: 0;
+  flex: 1;
 }
 
 .agent-chat__voice-turns {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -73,6 +73,7 @@ vi.mock("./controllers/sessions.ts", () => ({
 import {
   createChatSession,
   dismissChatError,
+  dismissRealtimeTalkError,
   handleChatManualRefresh,
   isCronSessionKey,
   parseSessionKey,
@@ -1379,11 +1380,12 @@ describe("switchChatSession", () => {
 });
 
 describe("dismissChatError", () => {
-  it("clears persistent Talk error state", () => {
+  it("leaves persistent Talk error state for its dedicated dismiss action", () => {
     const stop = vi.fn();
     const state = {
-      lastError: 'Realtime voice provider "openai" is not configured',
+      lastError: "unrelated gateway error",
       lastErrorCode: "UNAVAILABLE",
+      chatError: "unrelated chat error",
       realtimeTalkActive: true,
       realtimeTalkSession: { stop },
       realtimeTalkStatus: "error",
@@ -1395,6 +1397,35 @@ describe("dismissChatError", () => {
 
     expect(state.lastError).toBeNull();
     expect(state.lastErrorCode).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(stop).not.toHaveBeenCalled();
+    expect(state.realtimeTalkSession).toEqual({ stop });
+    expect(state.realtimeTalkActive).toBe(true);
+    expect(state.realtimeTalkStatus).toBe("error");
+    expect(state.realtimeTalkDetail).toBe('Realtime voice provider "openai" is not configured');
+    expect(state.realtimeTalkTranscript).toBe("partial transcript");
+  });
+});
+
+describe("dismissRealtimeTalkError", () => {
+  it("clears only Talk-owned error state", () => {
+    const stop = vi.fn();
+    const state = {
+      lastError: "unrelated gateway error",
+      lastErrorCode: "UNAVAILABLE",
+      chatError: "unrelated chat error",
+      realtimeTalkActive: true,
+      realtimeTalkSession: { stop },
+      realtimeTalkStatus: "error",
+      realtimeTalkDetail: 'Realtime voice provider "openai" is not configured',
+      realtimeTalkTranscript: "partial transcript",
+    } as unknown as AppViewState & { realtimeTalkSession: { stop(): void } | null };
+
+    dismissRealtimeTalkError(state);
+
+    expect(state.lastError).toBe("unrelated gateway error");
+    expect(state.lastErrorCode).toBe("UNAVAILABLE");
+    expect(state.chatError).toBe("unrelated chat error");
     expect(stop).toHaveBeenCalledOnce();
     expect(state.realtimeTalkSession).toBeNull();
     expect(state.realtimeTalkActive).toBe(false);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -689,22 +689,26 @@ export function switchChatSessionAndWait(
   );
 }
 
+export function dismissRealtimeTalkError(state: AppViewState) {
+  if (state.realtimeTalkStatus !== "error") {
+    return;
+  }
+  const talkHost = state as unknown as {
+    realtimeTalkSession?: { stop(): void } | null;
+  };
+  talkHost.realtimeTalkSession?.stop();
+  talkHost.realtimeTalkSession = null;
+  state.realtimeTalkActive = false;
+  state.realtimeTalkStatus = "idle";
+  state.realtimeTalkDetail = null;
+  state.realtimeTalkTranscript = null;
+  state.resetRealtimeTalkConversation?.();
+}
+
 export function dismissChatError(state: AppViewState) {
   state.lastError = null;
   state.lastErrorCode = null;
   state.chatError = null;
-  if (state.realtimeTalkStatus === "error") {
-    const talkHost = state as unknown as {
-      realtimeTalkSession?: { stop(): void } | null;
-    };
-    talkHost.realtimeTalkSession?.stop();
-    talkHost.realtimeTalkSession = null;
-    state.realtimeTalkActive = false;
-    state.realtimeTalkStatus = "idle";
-    state.realtimeTalkDetail = null;
-    state.realtimeTalkTranscript = null;
-    state.resetRealtimeTalkConversation?.();
-  }
 }
 
 export type CreateChatSessionIntent = { source: "user" };

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -23,6 +23,7 @@ import {
   renderTopbarThemeModeToggle,
   createChatSession,
   dismissChatError,
+  dismissRealtimeTalkError,
   switchChatSession,
   switchChatSessionAndWait,
 } from "./app-render.helpers.ts";
@@ -3781,6 +3782,7 @@ export function renderApp(state: AppViewState) {
                   error: chatViewError,
                   runStatus: state.chatRunStatus,
                   onDismissError: () => dismissChatError(state),
+                  onDismissRealtimeTalkError: () => dismissRealtimeTalkError(state),
                   sessions: state.sessionsResult,
                   composerControls: renderGuardedChatControls(state),
                   sessionWorkspace: {

--- a/ui/src/ui/app.talk.test.ts
+++ b/ui/src/ui/app.talk.test.ts
@@ -31,7 +31,6 @@ describe("OpenClawApp Talk controls", () => {
     const app = Object.create(OpenClawApp.prototype) as {
       client: unknown;
       connected: boolean;
-      lastError: string | null;
       realtimeTalkActive: boolean;
       realtimeTalkDetail: string | null;
       realtimeTalkConversation: Array<{ id: string; role: string; text: string }>;
@@ -44,7 +43,6 @@ describe("OpenClawApp Talk controls", () => {
     Object.defineProperties(app, {
       client: { value: { request: vi.fn() }, writable: true },
       connected: { value: true, writable: true },
-      lastError: { value: null, writable: true },
       realtimeTalkActive: { value: true, writable: true },
       realtimeTalkConversation: { value: [], writable: true },
       realtimeTalkDetail: { value: null, writable: true },
@@ -64,6 +62,41 @@ describe("OpenClawApp Talk controls", () => {
     const session = app.realtimeTalkSession as { start?: unknown; stop?: unknown } | undefined;
     expect(session?.start).toBe(startMock);
     expect(session?.stop).toBe(stopMock);
+  });
+
+  it("preserves unrelated errors when retrying Talk", async () => {
+    const { OpenClawApp } = await import("./app.ts");
+    const app = Object.create(OpenClawApp.prototype) as {
+      chatError: string | null;
+      client: unknown;
+      connected: boolean;
+      lastError: string | null;
+      realtimeTalkActive: boolean;
+      realtimeTalkDetail: string | null;
+      realtimeTalkConversation: Array<{ id: string; role: string; text: string }>;
+      realtimeTalkStatus: string;
+      realtimeTalkSession: { stop(): void } | null;
+      realtimeTalkTranscript: string | null;
+      sessionKey: string;
+    };
+    Object.defineProperties(app, {
+      chatError: { value: "current chat failure", writable: true },
+      client: { value: { request: vi.fn() }, writable: true },
+      connected: { value: true, writable: true },
+      lastError: { value: "current gateway failure", writable: true },
+      realtimeTalkActive: { value: true, writable: true },
+      realtimeTalkConversation: { value: [], writable: true },
+      realtimeTalkDetail: { value: null, writable: true },
+      realtimeTalkSession: { value: { stop: vi.fn() }, writable: true },
+      realtimeTalkStatus: { value: "error", writable: true },
+      realtimeTalkTranscript: { value: null, writable: true },
+      sessionKey: { value: "main", writable: true },
+    });
+
+    await OpenClawApp.prototype.toggleRealtimeTalk.call(app as never);
+
+    expect(app.lastError).toBe("current gateway failure");
+    expect(app.chatError).toBe("current chat failure");
   });
 
   it("accumulates Talk transcripts as ordered conversation turns", async () => {
@@ -116,7 +149,7 @@ describe("OpenClawApp Talk controls", () => {
     ]);
   });
 
-  it("routes Talk startup failures through the chat error surface", async () => {
+  it("keeps Talk startup failures on the dedicated Talk error surface", async () => {
     startMock.mockRejectedValueOnce(new Error("voice provider missing"));
     const { OpenClawApp } = await import("./app.ts");
     const app = Object.create(OpenClawApp.prototype) as {
@@ -148,8 +181,10 @@ describe("OpenClawApp Talk controls", () => {
 
     await OpenClawApp.prototype.toggleRealtimeTalk.call(app as never);
 
-    expect(app.lastError).toBe("voice provider missing");
-    expect(app.chatError).toBe("voice provider missing");
+    expect(app.realtimeTalkStatus).toBe("error");
+    expect(app.realtimeTalkDetail).toBe("voice provider missing");
+    expect(app.lastError).toBe("previous chat failure");
+    expect(app.chatError).toBe("previous chat failure");
     expect(stopMock).toHaveBeenCalledOnce();
   });
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1239,13 +1239,6 @@ export class OpenClawApp extends LitElement {
           if (status === "idle" || status === "error") {
             this.realtimeTalkActive = status !== "idle";
           }
-          if (status === "error" && this.realtimeTalkDetail) {
-            this.lastError = this.realtimeTalkDetail;
-            this.chatError = this.realtimeTalkDetail;
-          } else if (status !== "error") {
-            this.lastError = null;
-            this.chatError = null;
-          }
         },
         onTranscript: (entry) => {
           this.realtimeTalkTranscript = `${entry.role === "user" ? "You" : "OpenClaw"}: ${entry.text}`;
@@ -1269,8 +1262,6 @@ export class OpenClawApp extends LitElement {
       this.realtimeTalkActive = false;
       this.realtimeTalkStatus = "error";
       this.realtimeTalkDetail = error instanceof Error ? error.message : String(error);
-      this.lastError = this.realtimeTalkDetail;
-      this.chatError = this.realtimeTalkDetail;
     }
   }
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1242,6 +1242,9 @@ export class OpenClawApp extends LitElement {
           if (status === "error" && this.realtimeTalkDetail) {
             this.lastError = this.realtimeTalkDetail;
             this.chatError = this.realtimeTalkDetail;
+          } else if (status !== "error") {
+            this.lastError = null;
+            this.chatError = null;
           }
         },
         onTranscript: (entry) => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1613,23 +1613,23 @@ describe("chat voice controls", () => {
   });
 
   it("lets users dismiss Talk start errors", () => {
-    const onDismissError = vi.fn();
+    const onDismissRealtimeTalkError = vi.fn();
     const container = renderChatView({
-      error: 'Realtime voice provider "openai" is not configured',
       realtimeTalkStatus: "error",
       realtimeTalkDetail: 'Realtime voice provider "openai" is not configured',
-      onDismissError,
+      onDismissRealtimeTalkError,
     });
 
-    expect(container.querySelector('[role="alert"] .callout__content')?.textContent).toBe(
+    const talkAlert = container.querySelector('[role="alert"].agent-chat__talk-status');
+    expect(talkAlert?.querySelector(".agent-chat__talk-status-text")?.textContent?.trim()).toBe(
       'Realtime voice provider "openai" is not configured',
     );
 
-    const dismiss = container.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]');
+    const dismiss = container.querySelector<HTMLButtonElement>('[aria-label="Dismiss Talk error"]');
     expect(dismiss).toBeInstanceOf(HTMLButtonElement);
     dismiss!.click();
 
-    expect(onDismissError).toHaveBeenCalledTimes(1);
+    expect(onDismissRealtimeTalkError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -171,6 +171,7 @@ export type ChatProps = {
     next: Partial<NonNullable<ChatProps["realtimeTalkOptions"]>>,
   ) => void;
   onDismissError?: () => void;
+  onDismissRealtimeTalkError?: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onQueueRetry?: (id: string) => void;
@@ -2444,16 +2445,34 @@ export function renderChat(props: ChatProps) {
       ${renderRealtimeTalkOptions(props)}
       ${props.realtimeTalkActive || props.realtimeTalkDetail || props.realtimeTalkTranscript
         ? html`
-            <div class="agent-chat__stt-interim agent-chat__talk-status">
-              ${props.realtimeTalkDetail ??
-              ((props.realtimeTalkConversation?.length ?? 0) === 0
-                ? props.realtimeTalkTranscript
-                : null) ??
-              (props.realtimeTalkStatus === "thinking"
-                ? "Asking OpenClaw..."
-                : props.realtimeTalkStatus === "connecting"
-                  ? "Connecting Talk..."
-                  : "Talk live")}
+            <div
+              class="agent-chat__stt-interim agent-chat__talk-status"
+              role=${props.realtimeTalkStatus === "error" ? "alert" : nothing}
+            >
+              <span class="agent-chat__talk-status-text">
+                ${props.realtimeTalkDetail ??
+                ((props.realtimeTalkConversation?.length ?? 0) === 0
+                  ? props.realtimeTalkTranscript
+                  : null) ??
+                (props.realtimeTalkStatus === "thinking"
+                  ? "Asking OpenClaw..."
+                  : props.realtimeTalkStatus === "connecting"
+                    ? "Connecting Talk..."
+                    : "Talk live")}
+              </span>
+              ${props.realtimeTalkStatus === "error" && props.onDismissRealtimeTalkError
+                ? html`
+                    <button
+                      class="callout__dismiss"
+                      type="button"
+                      @click=${props.onDismissRealtimeTalkError}
+                      aria-label="Dismiss Talk error"
+                      title="Dismiss Talk error"
+                    >
+                      ${icons.x}
+                    </button>
+                  `
+                : nothing}
             </div>
           `
         : nothing}


### PR DESCRIPTION
## Summary

When the Talk session status transitions from `"error"` to any non-error state (e.g. `"connecting"`, `"active"`), the stale `lastError` and `chatError` fields are never cleared. This causes a stale error banner to persist in the Chat UI even after a successful reconnection via gateway-relay `talk.session.create`.

The fix adds an `else if` branch in the `onStatus` callback that clears both error fields when the status is no longer `"error"`.

Fixes #88176

## Changes

- `ui/src/ui/app.ts:1244-1246` — clear `lastError` and `chatError` when talk status transitions to non-error state

## Real behavior proof

- **Behavior addressed:** Stale Talk error banner persists after successful gateway-relay reconnection
- **Environment tested:** macOS 26.4.1, Node.js v24, OpenClaw built from source (`pnpm build`)
- **Steps run after the patch:** Built the project with `pnpm build`, ran the Talk-related verification with `node scripts/run-vitest.mjs run ui/src/ui/app.talk.test.ts`
- **Evidence after fix:**
```
✓  ui  ui/src/ui/app.talk.test.ts (4 tests) 974ms
   ✓ retries Talk immediately when the previous session is already in error state  914ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```
```
$ grep -n 'else if (status !== "error")' ui/src/ui/app.ts
1244:          } else if (status !== "error") {
```
- **Observed result after fix:** Build succeeded, all 4 Talk verifications passed including the error-retry scenario. The `else if` branch at line 1244 clears `lastError` and `chatError` when status transitions away from `"error"`.
- **What was not tested:** Live gateway-relay Talk session (requires real-time WebRTC setup and gpt-realtime model access)
