### PR TITLE
feat(llm): forward run context to model as opt-in request headers

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -611,6 +611,13 @@ export interface Model<TApi extends Api = Api> {
   headers?: Record<string, string>;
   /** Sends runtime credentials as Authorization: Bearer instead of provider-specific key headers. */
   authHeader?: boolean;
+  /**
+   * Opt-in run-context key-to-header mapping. Each value is a header name.
+   * When `options.runContext` is provided at request time, the corresponding
+   * run values are injected as HTTP headers (nothing sent unless configured).
+   * E.g. `{ runId: "x-task-id", messageChannel: "x-channel", runKind: "x-operation" }`.
+   */
+  requestContextHeaders?: Record<string, string>;
   /** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
   compat?: TApi extends "openai-completions"
     ? OpenAICompletionsCompat

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2842,6 +2842,11 @@ export async function runEmbeddedAttempt(
         resolvedApiKey: params.resolvedApiKey,
         authProfileId: resolveAttemptStreamAuthProfileId(params),
         authStorage: params.authStorage,
+        runContext: {
+          runId: params.runId,
+          messageChannel: params.messageChannel,
+          runKind: params.bootstrapContextRunKind ?? "default",
+        },
       });
       const providerTextTransforms = resolveProviderTextTransforms({
         provider: params.provider,

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -125,6 +125,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
   resolvedApiKey?: string;
   authProfileId?: string;
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
+  runContext?: { runId?: string; messageChannel?: string; runKind?: string };
 }): StreamFn {
   if (params.providerStreamFn) {
     return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
@@ -231,6 +232,7 @@ function wrapEmbeddedAgentStreamFn(
     providerId: string;
     sessionId?: string;
     promptCacheKey?: string;
+    runContext?: { runId?: string; messageChannel?: string; runKind?: string };
     transformContext?: (context: Parameters<StreamFn>[1]) => Parameters<StreamFn>[1];
   },
 ): StreamFn {
@@ -249,6 +251,9 @@ function wrapEmbeddedAgentStreamFn(
     }
     if (params.authProfileId && !merged?.authProfileId) {
       merged = { ...merged, authProfileId: params.authProfileId };
+    }
+    if (params.runContext) {
+      merged = { ...merged, runContext: merged?.runContext ?? params.runContext };
     }
     return signal ? { ...merged, signal } : merged;
   };

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -151,6 +151,7 @@ type BaseStreamOptions = {
   frequencyPenalty?: number;
   presencePenalty?: number;
   seed?: number;
+  runContext?: { runId?: string; messageChannel?: string; runKind?: string };
 };
 
 type ModelStreamCooperativeScheduler = {
@@ -1808,6 +1809,7 @@ function buildOpenAIClientHeaders(
   context: Context,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  runContext?: NonNullable<BaseStreamOptions>["runContext"],
 ): Record<string, string> {
   const providerHeaders = { ...model.headers };
   if (model.provider === "github-copilot") {
@@ -1818,6 +1820,14 @@ function buildOpenAIClientHeaders(
         hasImages: hasCopilotVisionInput(context.messages),
       }),
     );
+  }
+  if (model.requestContextHeaders && runContext) {
+    for (const [key, headerName] of Object.entries(model.requestContextHeaders)) {
+      const value = runContext[key as keyof typeof runContext];
+      if (typeof value === "string" && value) {
+        providerHeaders[headerName] = value;
+      }
+    }
   }
   const callerHeaders = { ...optionHeaders, ...turnHeaders };
   const headers = resolveProviderRequestPolicyConfig({
@@ -1898,12 +1908,13 @@ function createOpenAIResponsesClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  runContext?: NonNullable<BaseStreamOptions>["runContext"],
 ) {
   return new OpenAI({
     apiKey,
     baseURL: model.baseUrl,
     dangerouslyAllowBrowser: true,
-    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
+    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, runContext),
     fetch: buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   });
@@ -1946,6 +1957,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          responsesOptions?.runContext,
         );
         let params = buildOpenAIResponsesParams(
           model,
@@ -2395,6 +2407,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          responsesOptions?.runContext,
         );
         const deploymentName = resolveAzureDeploymentName(model);
         let params = buildAzureOpenAIResponsesParams(
@@ -2486,12 +2499,13 @@ function createAzureOpenAIClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  runContext?: NonNullable<BaseStreamOptions>["runContext"],
 ) {
   const baseURL = normalizeAzureBaseUrl(model.baseUrl);
   const clientOptions = {
     apiKey,
     dangerouslyAllowBrowser: true,
-    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
+    defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders, runContext),
     baseURL,
     fetch: buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -199,6 +199,12 @@ export type ModelDefinitionConfig = {
   agentRuntime?: AgentRuntimePolicyConfig;
   /** Static headers merged into requests for this model. */
   headers?: Record<string, string>;
+  /**
+   * Opt-in run-context key-to-header mapping for this model. Each key is a
+   * run-context field name (`runId`, `messageChannel`, `runKind`), and each
+   * value is the HTTP header name to use. Nothing sent unless configured.
+   */
+  requestContextHeaders?: Record<string, string>;
   /** Provider compatibility flags for payload shaping and feature gating. */
   compat?: ModelCompatConfig;
   /** Media input limits used by routing and preflight compression. */


### PR DESCRIPTION
## Summary

- Allow providers to opt-in to forwarding run-level context (`runId`, `messageChannel`, `runKind`) as custom HTTP request headers
- Solves cost attribution gap for teams running OpenClaw behind metering proxies (LiteLLM, Helicone, in-house gateways)
- Fully backward-compatible — nothing sent unless `requestContextHeaders` is configured

## Changes

- **`packages/llm-core/src/types.ts`**: Add `requestContextHeaders` to `Model` interface
- **`src/config/types.models.ts`**: Add `requestContextHeaders` to `ModelDefinitionConfig`
- **`src/agents/openai-transport-stream.ts`**: Add `runContext` to `BaseStreamOptions`; extend `buildOpenAIClientHeaders` to inject run-context headers
- **`src/agents/embedded-agent-runner/stream-resolution.ts`**: Pass `runContext` through stream wrapper
- **`src/agents/embedded-agent-runner/run/attempt.ts`**: Inject `runId`/`messageChannel`/`bootstrapContextRunKind` into stream options

## Example Config

```yaml
models:
  providers:
    openai:
      requestContextHeaders:
        runId: "x-task-id"
        messageChannel: "x-channel"
        runKind: "x-operation"
```

With this config a Telegram message turn meters as `{ x-task-id: <runId>, x-channel: telegram, x-operation: message }`, a heartbeat as `{ x-operation: heartbeat }`.

## Related

Closes #93436