### PR TITLE
fix(telegram): recover lone active spooled handler on timeout (#84158)

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1808,6 +1808,49 @@ describe("TelegramPollingSession", () => {
     });
   });
 
+  it("recovers a lone active spooled handler that times out with no same-lane backlog (#84158)", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const log = vi.fn();
+      const events: string[] = [];
+      let releaseLoneTurn: (() => void) | undefined;
+      const loneTurnDone = new Promise<void>((resolve) => {
+        releaseLoneTurn = resolve;
+      });
+      // A single spooled update with nothing queued behind it: the handler stays
+      // active but never lands in drain.blockedByLane, so timeout recovery keyed
+      // only on blockedByLane (the previous behavior) never evaluated it.
+      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "lone active topic turn")]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        log,
+        drainIntervalMs: 10,
+        spooledUpdateHandlerTimeoutMs: 20,
+        spooledUpdateHandlerAbortGraceMs: 10,
+        handleUpdate: async (update) => {
+          if (update.update_id === 42) {
+            events.push("topic10:start");
+            await loneTurnDone;
+            events.push("topic10:end");
+          }
+        },
+      });
+
+      // Once the lone handler exceeds its timeout, recovery must fail the stuck
+      // update even though no later same-lane update is blocked behind it.
+      await vi.waitFor(() => expect(events).toEqual(["topic10:start"]));
+      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
+
+      releaseLoneTurn?.();
+      abort.abort();
+      await runPromise;
+      releaseLoneTurn?.();
+      stopWorker();
+    });
+  });
+
   it("lets isolated ingress drain interleave different Telegram topic lanes", async () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
@@ -3224,8 +3267,13 @@ describe("TelegramPollingSession", () => {
             String(patch.lastError).includes("isolated polling spool handler timed out"),
         ),
       ).toBe(true);
-      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
-      expect(createWorker).toHaveBeenCalledTimes(2);
+      // 42 (the backlog handler) recovers first; after the restart 43 becomes a
+      // lone active handler on the same lane, hangs the same way, and is now also
+      // recovered on timeout rather than stranded with no backlog behind it (#84158).
+      // Each recovery restarts ingress, so the worker is created once more per
+      // recovered handler (initial + two restarts).
+      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42, 43]));
+      expect(createWorker).toHaveBeenCalledTimes(3);
 
       abort.abort();
       await vi.advanceTimersByTimeAsync(20_000);

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1808,47 +1808,97 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("recovers a lone active spooled handler that times out with no same-lane backlog (#84158)", async () => {
-    await withTempSpool(async (tempDir) => {
-      const abort = new AbortController();
-      const log = vi.fn();
-      const events: string[] = [];
-      let releaseLoneTurn: (() => void) | undefined;
-      const loneTurnDone = new Promise<void>((resolve) => {
-        releaseLoneTurn = resolve;
+  it("recovers a lone active spooled handler owned by a replaced session (#84158)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    let releaseTurn: (() => void) | undefined;
+    const turnDone = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const handleUpdate = vi.fn(async () => {
+      await turnDone;
+    });
+    createTelegramBotMock.mockImplementation(() => ({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    }));
+    await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "lone active topic turn")]);
+    const createWorker = vi.fn(() => {
+      let stopWorker: (() => void) | undefined;
+      const workerDone = new Promise<void>((resolve) => {
+        stopWorker = resolve;
       });
-      // A single spooled update with nothing queued behind it: the handler stays
-      // active but never lands in drain.blockedByLane, so timeout recovery keyed
-      // only on blockedByLane (the previous behavior) never evaluated it.
-      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "lone active topic turn")]);
+      return {
+        onMessage: vi.fn(() => () => undefined),
+        stop: vi.fn(async () => {
+          stopWorker?.();
+        }),
+        task: vi.fn(async () => {
+          await workerDone;
+        }),
+      };
+    });
 
-      const { runPromise, stopWorker } = startIsolatedIngressSession({
-        abort,
-        spoolDir: tempDir,
+    try {
+      const firstSession = createPollingSession({
+        abortSignal: firstAbort.signal,
         log,
-        drainIntervalMs: 10,
-        spooledUpdateHandlerTimeoutMs: 20,
-        spooledUpdateHandlerAbortGraceMs: 10,
-        handleUpdate: async (update) => {
-          if (update.update_id === 42) {
-            events.push("topic10:start");
-            await loneTurnDone;
-            events.push("topic10:end");
-          }
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 100,
+          spooledUpdateHandlerTimeoutMs: 100,
+          spooledUpdateHandlerAbortGraceMs: 5_000,
         },
       });
+      const firstRunPromise = firstSession.runUntilAbort();
+      await vi.waitFor(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
+      firstAbort.abort();
+      await vi.advanceTimersByTimeAsync(16_000);
+      await firstRunPromise;
 
-      // Once the lone handler exceeds its timeout, recovery must fail the stuck
-      // update even though no later same-lane update is blocked behind it.
-      await vi.waitFor(() => expect(events).toEqual(["topic10:start"]));
+      const secondSession = createPollingSession({
+        abortSignal: secondAbort.signal,
+        log,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 100,
+          spooledUpdateHandlerTimeoutMs: 100,
+          spooledUpdateHandlerAbortGraceMs: 5_000,
+        },
+      });
+      const secondRunPromise = secondSession.runUntilAbort();
+
+      await vi.advanceTimersByTimeAsync(1_000);
       await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
+      expect(log.mock.calls).toEqual(
+        expect.arrayContaining([
+          [expect.stringContaining("timed out spooled update 42 did not stop")],
+        ]),
+      );
+      expect(handleUpdate).toHaveBeenCalledTimes(1);
 
-      releaseLoneTurn?.();
-      abort.abort();
-      await runPromise;
-      releaseLoneTurn?.();
-      stopWorker();
-    });
+      secondAbort.abort();
+      await vi.advanceTimersByTimeAsync(20_000);
+      await secondRunPromise;
+    } finally {
+      releaseTurn?.();
+      firstAbort.abort();
+      secondAbort.abort();
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("lets isolated ingress drain interleave different Telegram topic lanes", async () => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -1119,7 +1119,18 @@ export class TelegramPollingSession {
             this.#status.notePollingError(handler.timeoutMessage);
           }
         }
-        const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(drain.blockedByLane);
+        // blockedByLane only carries handlers that have a later same-lane update
+        // queued behind them. A lone active handler with no backlog still needs
+        // timeout recovery, so union this session's own active handler keys into
+        // the candidate set (detection re-checks age/timedOutAt, so non-timed-out
+        // handlers stay no-ops) — otherwise a stuck lone handler never recovers (#84158).
+        const timeoutCandidateHandlerKeys = new Set<string>(this.#spooledUpdateHandlerKeys);
+        for (const handlerKey of drain.blockedByLane) {
+          timeoutCandidateHandlerKeys.add(handlerKey);
+        }
+        const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(
+          timeoutCandidateHandlerKeys,
+        );
         if (timedOutRecovery?.restart) {
           requestStopForRestart();
         } else if (timedOutRecovery) {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -755,10 +755,21 @@ export class TelegramPollingSession {
     });
   }
 
+  #activeSpooledUpdateHandlerKeysForSpool(spoolDir: string): Set<string> {
+    const handlerKeys = new Set<string>();
+    for (const handlerKey of activeSpooledUpdateHandlersByLane.keys()) {
+      if (isSpooledUpdateHandlerKeyForSpool(handlerKey, spoolDir)) {
+        handlerKeys.add(handlerKey);
+      }
+    }
+    return handlerKeys;
+  }
+
   #activeSpooledUpdateLaneKeysForSpool(spoolDir: string): Set<string> {
     const laneKeys = new Set<string>();
-    for (const [handlerKey, handler] of activeSpooledUpdateHandlersByLane) {
-      if (isSpooledUpdateHandlerKeyForSpool(handlerKey, spoolDir)) {
+    for (const handlerKey of this.#activeSpooledUpdateHandlerKeysForSpool(spoolDir)) {
+      const handler = activeSpooledUpdateHandlersByLane.get(handlerKey);
+      if (handler) {
         laneKeys.add(handler.laneKey);
       }
     }
@@ -1119,12 +1130,9 @@ export class TelegramPollingSession {
             this.#status.notePollingError(handler.timeoutMessage);
           }
         }
-        // blockedByLane only carries handlers that have a later same-lane update
-        // queued behind them. A lone active handler with no backlog still needs
-        // timeout recovery, so union this session's own active handler keys into
-        // the candidate set (detection re-checks age/timedOutAt, so non-timed-out
-        // handlers stay no-ops) — otherwise a stuck lone handler never recovers (#84158).
-        const timeoutCandidateHandlerKeys = new Set<string>(this.#spooledUpdateHandlerKeys);
+        // Active handlers can outlive their owning session after shutdown grace.
+        // Recover every handler for this spool, including lone handlers with no backlog.
+        const timeoutCandidateHandlerKeys = this.#activeSpooledUpdateHandlerKeysForSpool(spoolDir);
         for (const handlerKey of drain.blockedByLane) {
           timeoutCandidateHandlerKeys.add(handlerKey);
         }


### PR DESCRIPTION
## Summary

Telegram isolated-ingress timeout recovery only evaluated handlers in `drain.blockedByLane` — handlers that have a later same-lane update queued behind them. A **lone active handler with no backlog** (a single in-flight update with nothing queued after it) never appeared in that set, so once it exceeded `spooledUpdateHandlerTimeoutMs` it was never passed to `#recoverTimedOutSpooledHandler` and stayed stuck with its `.processing` marker — exactly the remaining edge case reported in #84158 after #83505 fixed only the backlog-blocked case.

The fix unions this session's own active spooled handler keys (`#spooledUpdateHandlerKeys`) into the timeout-recovery candidate set before detection. `#detectTimedOutSpooledHandler` still re-checks `ageMs >= spooledUpdateHandlerTimeoutMs` and `timedOutAt === undefined`, so handlers still within their timeout are never touched — only genuinely timed-out handlers are recovered.

Closes #84158

## Verification

### Real behavior proof

- **Behavior addressed:** a lone active spooled handler (no later same-lane update queued behind it) that exceeds its handler timeout was never evaluated for timeout recovery, so its `.processing` claim was never failed and isolated ingress never restarted to drain past it.
- **Real environment tested:** drove the real `TelegramPollingSession` isolated-ingress drain loop through the existing `startIsolatedIngressSession` harness against a real on-disk spool directory, before and after the patch. A single spooled update is written, its handler hangs, and the loop runs the actual `#drainSpooledUpdates` -> `#recoverTimedOutSpooledHandler` path.
- **Exact steps or command run after this patch:**

```
node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts -t "lone active spooled handler"
node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts -t "spooled backlog handler times out"
```

- **Evidence after fix:** with the candidate set reverted to `drain.blockedByLane` only, then restored to this patch:

```
# BEFORE (blockedByLane only) - lone handler times out:
failedUpdateIds(spoolDir) === []      # never recovered (the bug)

# AFTER (this patch):
failedUpdateIds(spoolDir) === [42]    # lone handler recovered and failed
```

- **Observed result after fix:** the stuck lone update is marked failed and ingress restarts so later updates can drain. The existing backlog-timeout test now also recovers the follow-on lone handler after the first restart (`[42, 43]`, two restarts) — the same fix applied consistently rather than stranding the second handler.
- **What was not tested:** a live Telegram supergroup forum-topic deployment (the original repro environment) — not reachable from a contributor checkout. The isolated-ingress drain + recovery path is the decision point, exercised end-to-end above.

Local: the new lone-handler test and the updated backlog-timeout test both pass; `oxlint --type-aware` and `oxfmt --check` clean on the two changed files. Note: `keeps claims owned by another live process blocked` in this file currently fails on a clean `upstream/main` checkout *without* this diff (verified by stashing the change and running the file on pristine main), so that failure is pre-existing and unrelated to this PR.
