### PR TITLE
fix(tools): surface malformed availability diagnostics as warnings

### DIFF
--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -1,5 +1,21 @@
 // Verifies tool planner filtering, ordering, and unsupported-tool reporting.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const warnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+    isEnabled: vi.fn(() => false),
+  }),
+}));
+
 import { ToolPlanContractError } from "./diagnostics.js";
 import { formatToolExecutorRef } from "./execution.js";
 import { buildToolPlan } from "./planner.js";
@@ -111,6 +127,34 @@ describe("buildToolPlan", () => {
         message: "Empty availability allOf group",
       },
     ]);
+  });
+
+  it("logs a warning when a descriptor has malformed availability", () => {
+    warnMock.mockClear();
+
+    buildToolPlan({
+      descriptors: [descriptor("malformed", { availability: { anyOf: [] } })],
+    });
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      'Tool descriptor "malformed" has malformed availability: Empty availability anyOf group',
+    );
+  });
+
+  it("does not log warnings for ordinary runtime unavailability", () => {
+    warnMock.mockClear();
+
+    buildToolPlan({
+      descriptors: [
+        descriptor("missing-env", {
+          availability: { kind: "env", name: "MISSING_ENV" },
+        }),
+      ],
+      availability: { env: {} },
+    });
+
+    expect(warnMock).not.toHaveBeenCalled();
   });
 
   it("keeps protocol conversion separate from executor refs and model normalization", () => {

--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -1,4 +1,5 @@
 // Plans usable tools from descriptors, availability, and request constraints.
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { evaluateToolAvailability } from "./availability.js";
 import { ToolPlanContractError } from "./diagnostics.js";
 import type {
@@ -8,6 +9,8 @@ import type {
   ToolPlan,
   ToolPlanEntry,
 } from "./types.js";
+
+const log = createSubsystemLogger("tools/planner");
 
 /**
  * Deterministic planner for descriptor-backed tools.
@@ -48,6 +51,14 @@ export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
     const diagnostics = [
       ...evaluateToolAvailability({ descriptor, context: options.availability }),
     ];
+    const malformedDiagnostics = diagnostics.filter(
+      (entry) => entry.reason === "unsupported-signal",
+    );
+    for (const diagnostic of malformedDiagnostics) {
+      log.warn(
+        `Tool descriptor "${descriptor.name}" has malformed availability: ${diagnostic.message}`,
+      );
+    }
     if (diagnostics.length > 0) {
       hidden.push({ descriptor, diagnostics });
       continue;


### PR DESCRIPTION
## Summary
- Surface malformed availability diagnostics as warnings in `buildToolPlan`.
- Log a warning when a descriptor's availability evaluates to `unsupported-signal` (e.g. empty `allOf`/`anyOf` groups) so authors notice config errors instead of silently hiding tools.
- Add tests covering the warning behavior and ensuring ordinary runtime unavailability does not warn.

## Test plan
- [x] `node scripts/run-vitest.mjs run src/tools/planner.test.ts` passes
- [x] `pnpm exec oxlint src/tools/planner.ts src/tools/planner.test.ts` passes
- [x] `pnpm build` completes successfully

## Verification
Behavior addressed: malformed availability descriptors (empty `allOf`/`anyOf`) were hidden without any visible diagnostic; now `buildToolPlan` logs a warning.
Real environment tested: Linux x86_64, Node 22.19+, pnpm workspace.
Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs run src/tools/planner.test.ts`
  2. `pnpm exec oxlint src/tools/planner.ts src/tools/planner.test.ts`
  3. `pnpm build`
Evidence after fix:
  - Vitest: `Test Files  1 passed (1) / Tests  8 passed (8)`
  - oxlint: exited 0 with no output
  - build: completed with exit code 0
Observed result after fix: the new `logs a warning when a descriptor has malformed availability` test passes; the `does not log warnings for ordinary runtime unavailability` test confirms env-missing tools remain silent.
What was not tested: live gateway/tool runtime integration; this change is planner-local.