### PR TITLE
fix(tool-error): suppress "⚠ failed" warning for Codex app-server exec_command

### DIFF
--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -18,7 +18,7 @@ export type ToolErrorSummary = {
   fileTarget?: FileTarget;
 };
 
-const EXEC_LIKE_TOOL_NAMES = new Set(["exec", "bash"]);
+const EXEC_LIKE_TOOL_NAMES = new Set(["exec", "bash", "exec_command"]);
 
 /** Detects shell-execution tools that share retry and mutation semantics. */
 export function isExecLikeToolName(toolName: string): boolean {


### PR DESCRIPTION
## Summary

- Adds `"exec_command"` to `EXEC_LIKE_TOOL_NAMES` so that benign non-zero exits (e.g. `grep` no-match as a verification step) from the Codex app-server shell tool do not trigger a spurious `⚠️ … failed` warning.
- Matches the existing behavior of native `exec`/`bash` tools.
- The codebase already recognizes `exec_command` as the Codex equivalent of `exec` via `NATIVE_HOOK_TOOL_NAME_ALIASES` in `native-hook-relay.ts` — this fix closes the gap in the warning policy path.

Fixes #93482

## Real behavior proof

**Behavior addressed**: Tool-error warning (`⚠️ 🛠️ \`<command> (agent)\` failed`) should not fire for benign non-zero exits from the Codex app-server `exec_command` tool, matching the behavior of native `exec`/`bash`.

**Real setup tested**: OpenClaw local checkout on macOS, focused unit tests.

**Exact steps or command run after fix**:

```bash
node_modules/.bin/tsgo -p src/agents/tsconfig.json --noEmit
```

**After-fix evidence**:

```
$ node_modules/.bin/tsgo -p src/agents/tsconfig.json --noEmit
(no output — type check passes)
```

Since `isExecLikeToolName` is a pure function (input → boolean, no side effects), the change is verifiable by inspection: `EXEC_LIKE_TOOL_NAMES` now contains `"exec_command"`, so `isExecLikeToolName("exec_command")` returns `true`, and `resolveToolErrorWarningPolicy` will suppress the warning for benign exits.

**Observed result after the fix**: Type check passes. The fix is a single Set membership addition — no behavioral side effects.

**What was not tested**: Live Codex app-server runtime (requires an OpenAI Codex backend deployment).

**Proof limitations or environment constraints**: The fix is trivially correct by construction — a Set lookup with no branching or conditionals — so runtime testing beyond type check is not meaningful.

## Tests and validation

- TypeScript type check passes: `tsgo -p src/agents/tsconfig.json --noEmit`
- No new test added because the existing tests in `src/agents/harness/native-hook-relay.test.ts` already cover `exec_command` normalization semantics; adding a pure-function Set membership test would provide no additional confidence beyond the type check and code review

## Risk checklist

Did user-visible behavior change? (`Yes`)

Yes. The spurious `⚠️ … failed` warning will no longer appear for benign non-zero exits from `exec_command` on the Codex app-server backend.

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- The `isExecLikeToolName` function is also used by `failure-signal.ts` to determine retry semantics. Adding `exec_command` here means Codex shell failures may now be eligible for retry, which is the correct behavior (matching `exec`/`bash`).

How is that risk mitigated?
- The change is a single string addition to a `Set`. If `exec_command` should NOT be eligible for retry in `failure-signal.ts`, that can be handled by a separate check there — but the issue report specifically asks for exec-like treatment, and the existing alias in `NATIVE_HOOK_TOOL_NAME_ALIASES` confirms the intent.

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- CI and maintainer review. Live Codex app-server repro is environment-limited.

Which bot or reviewer comments were addressed?
- ClawSweeper review recommended normalizing `exec_command` through the same exec-like semantics as `exec`/`bash` — this fix adds `exec_command` to `EXEC_LIKE_TOOL_NAMES`, satisfying the recommendation.
