### PR TITLE
fix(tools): warn when empty allOf/anyOf hides a tool from the plan

### DIFF
--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -1,5 +1,5 @@
 // Verifies tool planner filtering, ordering, and unsupported-tool reporting.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ToolPlanContractError } from "./diagnostics.js";
 import { formatToolExecutorRef } from "./execution.js";
 import { buildToolPlan } from "./planner.js";
@@ -111,6 +111,60 @@ describe("buildToolPlan", () => {
         message: "Empty availability allOf group",
       },
     ]);
+  });
+
+  it("warns when empty allOf group hides a tool", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      buildToolPlan({
+        descriptors: [
+          descriptor("broken-rule", { availability: { allOf: [] } }),
+        ],
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0]?.[0];
+      expect(message).toContain('"broken-rule"');
+      expect(message).toContain("Empty availability allOf group");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns when empty anyOf group hides a tool", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      buildToolPlan({
+        descriptors: [
+          descriptor("broken-any", { availability: { anyOf: [] } }),
+        ],
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0]?.[0];
+      expect(message).toContain('"broken-any"');
+      expect(message).toContain("Empty availability anyOf group");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not warn for non-unsupported-signal diagnostics like env-missing", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      buildToolPlan({
+        descriptors: [
+          descriptor("config-gated", {
+            availability: { kind: "env", name: "MISSING_VAR" },
+          }),
+        ],
+        availability: { env: {} },
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("keeps protocol conversion separate from executor refs and model normalization", () => {

--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -49,6 +49,13 @@ export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
       ...evaluateToolAvailability({ descriptor, context: options.availability }),
     ];
     if (diagnostics.length > 0) {
+      for (const diagnostic of diagnostics) {
+        if (diagnostic.reason === "unsupported-signal") {
+          console.warn(
+            `Tool "${descriptor.name}" hidden due to malformed availability: ${diagnostic.message}`,
+          );
+        }
+      }
       hidden.push({ descriptor, diagnostics });
       continue;
     }


### PR DESCRIPTION
## Summary

- When a plugin author defines an empty `allOf: []` or `anyOf: []` in a tool descriptor's availability expression, the tool was silently hidden with `reason: "unsupported-signal"` but no warning was emitted.
- This change adds a `console.warn` in `buildToolPlan` when unsupported-signal diagnostics hide a tool, so the authoring error is surfaced during gateway startup.

## Verification

- `node scripts/run-vitest.mjs run src/tools/planner.test.ts` → **9/9 passed** (6 existing + 3 new regression tests)
- `node scripts/run-vitest.mjs run src/tools/availability.test.ts` → **9/9 passed**
- `node scripts/run-vitest.mjs run src/tools/boundary.test.ts` → **2/2 passed** (module independence verified)

## Impact Assessment

- Scope: `src/tools/planner.ts` — `buildToolPlan` shared path; no scattered call sites
- Downstream: no external callers import `buildToolPlan` directly; `console.warn` is a side-effect-only addition
- Edge cases: empty allOf, empty anyOf, legitimate runtime unavailability (no false warnings)
- Hard-coded values: none — uses descriptor name and diagnostic message from existing data
- Existing fixes: PR #92368 was previously closed (insufficient proof); no other open PRs target this issue

## Real behavior proof

**Behavior addressed:** Empty allOf/anyOf availability groups silently hide tools with no warning to plugin authors. After the fix, `console.warn` emits a diagnostic message so authors catch the mistake at gateway startup.

**Environment tested:** Node 22.x on Linux, `node --import tsx` calling the actual production `buildToolPlan` function.

**Steps run after the patch:** Called `buildToolPlan` from source with empty allOf, empty anyOf, and a normal tool descriptor.

```bash
node --import tsx --no-warnings -e "
import { buildToolPlan } from './src/tools/planner.js';

const descriptor = (name, overrides = {}) => ({
  name, description: name + ' desc', inputSchema: { type: 'object' },
  owner: { kind: 'core' }, executor: { kind: 'core', executorId: name },
  ...overrides,
});

// Empty allOf
const plan1 = buildToolPlan({
  descriptors: [descriptor('broken-allof', { availability: { allOf: [] } })],
});
console.log('allOf hidden:', plan1.hidden.length, 'visible:', plan1.visible.length);

// Empty anyOf
const plan2 = buildToolPlan({
  descriptors: [descriptor('broken-anyof', { availability: { anyOf: [] } })],
});
console.log('anyOf hidden:', plan2.hidden.length, 'visible:', plan2.visible.length);

// Normal tool (no warning)
const plan3 = buildToolPlan({
  descriptors: [descriptor('normal-tool')],
});
console.log('normal hidden:', plan3.hidden.length, 'visible:', plan3.visible.length);
"
```

**Evidence after fix:**

```text
Tool "broken-allof" hidden due to malformed availability: Empty availability allOf group
allOf hidden: 1 visible: 0
Tool "broken-anyof" hidden due to malformed availability: Empty availability anyOf group
anyOf hidden: 1 visible: 0
normal hidden: 0 visible: 1
```

**Observed result:** Warnings are emitted for both empty allOf and empty anyOf groups. Tools are correctly hidden with diagnostics. Normal tools are unaffected (no warning, visible).

**Not tested:** Live gateway startup with a malformed plugin manifest was not exercised.

Closes #92361
