### PR TITLE
fix(acp): retry Kiro persistent session after Internal error resume failure (fixes #87830)

### DIFF
--- a/src/acp/control-plane/manager.runtime-resume-state.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.ts
@@ -21,7 +21,7 @@ function isRecoverableMissingManagerPersistentSessionError(message: string): boo
   const normalized = message.trim();
   return (
     /persistent acp session .* could not be resumed/i.test(normalized) &&
-    /(resource not found|no matching session)/i.test(normalized)
+    /(resource not found|no matching session|internal error)/i.test(normalized)
   );
 }
 

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -1058,4 +1058,107 @@ describe("AcpSessionManager turn results", () => {
     expect(states).toContain("idle");
     expect(states).not.toContain("error");
   });
+
+  it("retries once with a fresh persistent session after a Kiro Internal error turn failure", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    const sessionKey = "agent:claude:acp:binding:discord:default:retry-kiro-internal";
+    let currentMeta: SessionAcpMeta = {
+      ...readySessionMeta({
+        agent: "claude",
+      }),
+      runtimeSessionName: sessionKey,
+      identity: {
+        state: "resolved",
+        source: "status",
+        acpxSessionId: "acpx-sid-kiro",
+        lastUpdatedAt: Date.now(),
+      },
+    };
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const key = (paramsUnknown as { sessionKey?: string }).sessionKey ?? sessionKey;
+      return {
+        sessionKey: key,
+        storeSessionKey: key,
+        acp: currentMeta,
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      const next = params.mutate(currentMeta, { acp: currentMeta });
+      if (next) {
+        currentMeta = next;
+      }
+      return {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        acp: currentMeta,
+      };
+    });
+    runtimeState.ensureSession.mockImplementation(async (inputUnknown: unknown) => {
+      const input = inputUnknown as {
+        sessionKey: string;
+        mode: "persistent" | "oneshot";
+        resumeSessionId?: string;
+      };
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime`,
+        backendSessionId: input.resumeSessionId ? "acpx-sid-kiro" : "acpx-sid-fresh",
+      };
+    });
+    runtimeState.getStatus.mockResolvedValue({
+      summary: "status=alive",
+      backendSessionId: "acpx-sid-fresh",
+      details: { status: "alive" },
+    });
+    runtimeState.runTurn
+      .mockImplementationOnce(async function* () {
+        yield {
+          type: "error" as const,
+          code: "NO_SESSION",
+          message: "Persistent ACP session acpx-sid-kiro could not be resumed: Internal error",
+        };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { type: "done" as const };
+      });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey,
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-kiro-internal",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeState.prepareFreshSession).toHaveBeenCalledWith({
+      sessionKey,
+    });
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(runtimeState.ensureSession), {
+      sessionKey,
+      resumeSessionId: "acpx-sid-kiro",
+    });
+    const retryInput = mockCallArg(runtimeState.ensureSession, 1);
+    expect(retryInput.resumeSessionId).toBeUndefined();
+    expect(currentMeta.identity?.acpxSessionId).toBe("acpx-sid-fresh");
+    expect(currentMeta.identity?.state).toBe("resolved");
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states).toContain("idle");
+    expect(states).not.toContain("error");
+  });
 });


### PR DESCRIPTION
### Summary

- **Problem**: Thread-bound ACP sessions for Kiro fail with `SessionResumeRequiredError` / `Internal error` when the backend invalidates the persistent session. The existing retry helper only matches Claude-shaped error messages (`Resource not found`, `No matching session`), leaving Kiro threads unusable for normal replies.
- **Root Cause**: `isRecoverableMissingManagerPersistentSessionError` in `manager.runtime-resume-state.ts` requires the error message to match `/(resource not found|no matching session)/i`, but Kiro wraps the same condition as `Persistent ACP session <id> could not be resumed: Internal error`.
- **Fix**: Add `internal error` to the second regex alternation so the persistent-session wrapper (already guarded by the first regex) triggers a fresh-handle retry for Kiro-shaped errors as well. The narrow scope is intentional — unrelated generic `Internal error` messages cannot match because the first regex requires the `Persistent ACP session ... could not be resumed` wrapper.
- **What changed**:
  - `src/acp/control-plane/manager.runtime-resume-state.ts` — 1 line: added `|internal error` to the error-matching regex
- **What did NOT change (scope boundary)**:
  - No change to the general ACP error retry logic (only this specific persistent-session wrapper matcher)
  - No change to how Kiro or Claude sessions are initialized
  - No config surface, no new constants, no API changes

### Reproduction

1. Spawn a thread-bound ACP session for Kiro with `runtime: "acp"`, `thread: true`, `mode: "session"`.
2. Send a first message and allow the session to initialize.
3. Wait for the persistent session to become stale on the backend.
4. Send another message to the same thread.
5. **Before this PR**: `ACP_TURN_FAILED` — `Persistent ACP session <id> could not be resumed: Internal error` — the thread shows processing signals but never returns a normal reply.
6. **After this PR**: The stale identity is cleared, a fresh persistent session is created, and the turn succeeds.

### Real behavior proof

**Behavior or issue addressed (#87830)**: Kiro persistent ACP sessions fail to recover when the backend returns `Internal error` through `SessionResumeRequiredError`; the existing retry helper only recognizes Claude-style `Resource not found` / `No matching session` error messages, so Kiro threads become permanently unusable after backend invalidation.

**Real environment tested**: Linux, Node 22 — test harness with mocked ACP runtime against `prepareFreshManagerRuntimeHandleRetry`

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts`

**Evidence after fix**:
```text
 RUN  v4.1.8 /home/0668001395/openclawProject1


 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  21:03:06
   Duration  3.56s (transform 2.45s, setup 0ms, import 3.25s, tests 106ms, environment 0ms)

[test] passed 1 shard in 13.25s
```

**Observed result after fix**: The new test case "retries once with a fresh persistent session after a Kiro Internal error turn failure" verifies that when the ACP runtime yields `Persistent ACP session acpx-sid-kiro could not be resumed: Internal error`, the manager clears the stale identity, calls `prepareFreshSession`, creates a fresh handle with no `resumeSessionId`, and the turn completes successfully — matching the existing behavior for Claude's `Resource not found` error.

**What was not tested**: Live Kiro CLI round-trip was not driven (this is a headless Linux environment without Kiro installed); the fix was validated at the ACP-manager unit-test layer with a Kiro-shaped error message fixture.

**Repro confirmation**: The new test case (modeled after the existing `Resource not found` retry test at line 958) confirms that on `origin/main` a `Persistent ACP session ... could not be resumed: Internal error` message would NOT trigger the fresh-handle retry path; after the patch the same message is recognized as recoverable and triggers the same retry logic as Claude's `Resource not found`.

### Risk / Mitigation

- **Risk**: Adding `internal error` to the matcher could theoretically match unrelated persistent-session errors that should NOT be retried.
  **Mitigation**: The first regex (`persistent acp session .* could not be resumed`) already restricts matches to the specific persistent-session-resume wrapper. Generic `Internal error` messages from unrelated turn failures cannot match this wrapper and will continue to surface as normal errors.

- **Risk**: The retry could hide backend issues that should be surfaced to the user.
  **Mitigation**: The retry is single-attempt (`attempt > 0` guard), only fires before output (`sawTurnOutput` guard), and the recovery is identical to the existing Claude `Resource not found` path which is already production-proven.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] ACP / ACPX runtime
- [x] ACP manager tests

### Regression Test Plan

- `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #87830