### PR TITLE
fix(approvals): reselect write-capable gateway client for operator.write RPCs

### DIFF
--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -1,6 +1,11 @@
 // Creates channel-native approval runtimes and delivery flows.
 import type { ChannelApprovalNativeAdapter } from "../channels/plugins/approval-native.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { callGatewayLeastPrivilege } from "../gateway/call.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../../packages/gateway-protocol/src/client-info.js";
 import {
   resolveChannelNativeApprovalDeliveryPlan,
   type ChannelApprovalNativePlannedTarget,
@@ -192,9 +197,6 @@ export function createChannelNativeApprovalRuntime<
   const nowMs = adapter.nowMs ?? Date.now;
   const resolveApprovalKind =
     adapter.resolveApprovalKind ?? ((request: TRequest) => defaultResolveApprovalKind(request));
-  let runtimeRequest:
-    | ((method: string, params: Record<string, unknown>) => Promise<unknown>)
-    | null = null;
   const handledEventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(
     adapter.eventKinds ?? ["exec"],
   );
@@ -204,10 +206,13 @@ export function createChannelNativeApprovalRuntime<
     channelLabel: adapter.channelLabel,
     accountId: adapter.accountId,
     requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> => {
-      if (!runtimeRequest) {
-        throw new Error(`${adapter.label}: gateway client not connected`);
-      }
-      return (await runtimeRequest(method, params)) as T;
+      return await callGatewayLeastPrivilege<T>({
+        config: adapter.cfg,
+        method,
+        params,
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      });
     },
   });
 
@@ -333,8 +338,6 @@ export function createChannelNativeApprovalRuntime<
       }
     },
   });
-
-  runtimeRequest = (method, params) => runtime.request(method, params);
 
   return {
     ...runtime,


### PR DESCRIPTION
## Summary

Fixes #93563 — the operator-approvals runtime connection was being used as
the transport for operator.write RPCs (`send`), causing approval route
notices to silently fail.

## Changes

**File:** `src/infra/approval-native-runtime.ts` (+12, −9)

### Removed (3 items)

```diff
- ① runtimeRequest variable declaration
- let runtimeRequest: (...) | null = null;
- 
- ② runtimeRequest deferred binding (root cause of the bug)
- runtimeRequest = (method, params) => runtime.request(method, params);
- 
- ③ requestGateway dependency on the approvals-only client
- requestGateway: async <T>(method, params) => {
-   if (!runtimeRequest) { throw new Error(...); }
-   return (await runtimeRequest(method, params)) as T;
- },
```

### Added (3 items)

```diff
+ ① Import the standard gateway call helper
+ import { callGatewayLeastPrivilege } from "../gateway/call.js";
+ 
+ ② Import client mode and name constants
+ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES }
+   from "../../packages/gateway-protocol/src/client-info.js";
+ 
+ ③ New requestGateway implementation
+ requestGateway: async <T>(method, params) => {
+   return await callGatewayLeastPrivilege<T>({
+     config: adapter.cfg,
+     method,
+     params,
+     clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+     mode: GATEWAY_CLIENT_MODES.BACKEND,
+   });
+ },
```

## Before vs After

### Before (broken on `main`)

**Environment:** openclaw 2026.5.26, multi-channel operator (Telegram + Slack),
native approvals enabled.

**Steps:** Trigger an exec approval in Slack → approval is routed to a
Telegram DM → approver approves it.

**`requestGateway("send")` call trace:**

```
1. maybeFinalizeApprovalRouteNotice() fires
2. resolveApprovalRouteNotice() returns { requestGateway, target: slack,
   text: "Approval routed to Telegram DM" }
3. notice.requestGateway("send", { channel: "slack", to: "general", ... })
   → requestGateway is bound to the approvals-runtime client
   → that client's scopes: ["operator.approvals"]
4. Gateway authorizeGatewayMethod(client, "send"):
   → connect.scopes.includes("operator.write") → false
   → returns: { code: -32600, message: "missing scope: operator.write" }
5. catch {} silently swallows the error
```

**Outcome:**

| Metric | Status |
|--------|--------|
| Approval delivery (Telegram DM) | ✅ Success |
| Origin-channel notice (Slack) | ❌ Never sent |
| Visible error in logs | None (swallowed by catch {}) |
| User perception | Agent receives but never replies |
| Recovery | Full gateway restart required |

### After (fixed on this branch)

**Environment:** Same as above.

**Steps:** Same as above.

**`requestGateway("send")` call trace:**

```
1. maybeFinalizeApprovalRouteNotice() fires
2. resolveApprovalRouteNotice() returns { requestGateway, target: slack,
   text: "Approval routed to Telegram DM" }
3. requestGateway calls callGatewayLeastPrivilege({ method: "send", config, ... })
   → resolveLeastPrivilegeOperatorScopesForMethod("send")
   → core-descriptors.ts:202 → scopes: ["operator.write"]
   → creates independent GatewayClient({ scopes: ["operator.write"],
     mode: BACKEND })
   → connects → sends request → returns success → client.stop()
4. Gateway authorizeGatewayMethod(client, "send"):
   → connect.scopes.includes("operator.write") → true ✅
   → allowed
```

**Outcome:**

| Metric | Status |
|--------|--------|
| Approval delivery (Telegram DM) | ✅ Success |
| Origin-channel notice (Slack) | ✅ Sent |
| Approvals client scope | `["operator.approvals"]` (unchanged) |
| Notice client scope | `["operator.write"]` (per-request, released after use) |

### Comparison matrix

| Scenario | Before | After |
|----------|--------|-------|
| Normal approval route notice | ❌ Silent failure | ✅ Sent correctly |
| Approvals connection healthy | ✅ Events work | ✅ Events work (unchanged) |
| Approvals client reconnects | ❌ send still uses approvals client, fails | ✅ Independent client, unaffected |
| Gateway unreachable | ❌ Fail + catch | ❌ Fail + catch (same) |
| Concurrent approval notices | ❌ All fail | ✅ Each gets its own scoped client |
| Missing credentials | ❌ Fail + catch | ❌ Fail + catch (same) |

## Impact analysis

### Runtime behavior changes

| Component | Before | After | Change |
|-----------|--------|-------|--------|
| `requestGateway("send")` | Routes through approvals client → rejected | Routes through scoped client → accepted | 🔧 Fixed |
| Approvals client connection | `operator.approvals` persistent | Same | None |
| `runtime.request()` method | Proxies to approvals client | Same (still available) | None |
| `exec.approval.requested/resolved` | Works | Same | None |

### Removed code impact

| Removed code | Original purpose | Impact of removal |
|-------------|-----------------|-------------------|
| `runtimeRequest` variable | Stores `runtime.request` reference | None, deferred binding no longer needed |
| `runtimeRequest = ...` | **Bug root cause**: binds `send` to approvals client | Removing it prevents the bug |
| `if (!runtimeRequest)` guard | Defensive null check | None, this path was never reachable in practice |

### Security impact

| Security property | Before | After | Change |
|-------------------|--------|-------|--------|
| Approvals connection scope | `operator.approvals` | `operator.approvals` | Unchanged |
| Send notice scope | `operator.approvals` (wrong — too narrow) | `operator.write` (correct) | 🔧 Fixed |
| URL resolution | From config | From config | Unchanged |
| Credential resolution | Config auth | Config auth | Unchanged |
| Least privilege | Approvals connection stays minimal | Approvals connection stays minimal | Unchanged |

### Unaffected components

| Component | Reason |
|-----------|--------|
| Approval event flow (`exec.approval.*`) | Approvals client logic untouched |
| Message send path (`message.ts`) | Uses own `callGatewayLeastPrivilege` |
| `approval-gateway-resolver.ts` | Uses independent `withOperatorApprovalsGatewayClient` |
| Existing tests | Delivery hooks use mocks, unaffected |
| `GATEWAY_CLIENT_MODES` / `GATEWAY_CLIENT_NAMES` | Standard constants, already used by 9+ call sites |

## Verification

### Static checks

- ✅ `callGatewayLeastPrivilege` → `src/gateway/call.ts:1255`, also used by
  `message.ts`, `message-action-runner.ts`, and the `callGateway` fallback
- ✅ `"send"` scope mapping → `src/gateway/methods/core-descriptors.ts:202`:
  `{ name: "send", scope: "operator.write" }`
- ✅ `GATEWAY_CLIENT_MODES`, `GATEWAY_CLIENT_NAMES` →
  `packages/gateway-protocol/src/client-info.ts:36,41`
- ✅ No remaining `runtimeRequest` references in the codebase

### Tests

- `approval-native-runtime.test.ts` — 3 tests pass (delivery hooks unchanged)
- `approval-native-route-coordinator.test.ts` — all tests pass (mocked `requestGateway`)

### Auth path verification

`callGatewayLeastPrivilege` resolves auth identically to other backend callers:
1. `resolveGatewayCallContext(opts)` — reads from `adapter.cfg` (no disk load)
2. No `url` override — avoids CLI URL override credential requirement
3. `resolveGatewayCredentials(context)` — resolves token/password from config
4. `shouldOmitDeviceIdentityForGatewayCall` — matches existing approvals client behavior (BACKEND + GATEWAY_CLIENT)

---

Closes #93563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
