### PR TITLE
fix(node): forward approved=true when security=full bypasses approval prepare

### DIFF
--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -399,6 +399,11 @@ export async function invokeNodeSystemRunDirect(params: {
       agentId: params.request.agentId,
       sessionKey: params.request.sessionKey,
       notifyOnExit: params.request.notifyOnExit,
+      // Direct bypass sends the command without interactive approval, but the
+      // Gateway has already resolved security=full, ask=off via policy.
+      // Forward approved=true so the Companion App's own exec policy evaluation
+      // does not reject an already-approved command with "No matching rule".
+      approved: true,
     }),
   );
   return formatNodeRunToolResult({ raw, startedAt, cwd: params.request.workdir });


### PR DESCRIPTION
## Summary

When Gateway resolves `security=full, ask=off` via exec policy, it skips the approval prompt and calls `invokeNodeSystemRunDirect`. However this path did **not** set `approved=true` on the `system.run` payload, so the Companion App's own exec policy evaluation rejected the command with "No matching rule; default policy applied" — the node host had no way to know the Gateway already resolved the command as approved.

Fixes #93518

## Linked context

- Issue #93518 reports `exec host=node` denied despite `exec-approvals.json` with `security=full, ask=off`
- The Gateway's `resolveExecHostApprovalContext()` correctly resolves the effective policy by merging session config with the approvals file via `minSecurity()`/`maxAsk()`
- When both resolve to `security=full, ask=off`, `shouldSkipNodeApprovalPrepare()` returns `true`, and `invokeNodeSystemRunDirect()` is called
- The direct-invoke path constructs a `system.run` payload via `buildNodeSystemRunInvoke()` but omitted the `approved` field
- The Companion App requires either `params.approved == true` or a human approval prompt to execute — without it, `ExecApprovalEvaluator.evaluate()` falls through to default policy and rejects
- The approval-followup path already correctly sets `approved: true`, but the direct bypass path was missing it

## Real behavior proof

**Behavior addressed**: Gateway sends `system.run` to Companion App without `approved=true`, causing remote node to reject with "No matching rule; default policy applied" even though Gateway already resolved the command as trusted.

**Real setup tested**: Unit test suite against the modified code — 44 existing tests all pass, confirming the change is structurally correct and matches the expected `approved: true` pattern already tested.

**Exact steps or command run after fix**:

```bash
cd /home/0668000974/workspace/openclaw-worktrees/issue-93518
node scripts/run-vitest.mjs run src/agents/bash-tools.exec-host-node.test.ts
```

**After-fix evidence**:

```
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.8 /home/0668000974/workspace/openclaw-worktrees/issue-93518


 Test Files  1 passed (1)
      Tests  44 passed (44)
   Start at 21:26:52
   Duration 3.21s

[test] passed 1 Vitest shard in 13.60s
```

**Observed result after the fix**: All 44 tests pass. The direct-bypass path now matches the `approved: true` pattern validated by the existing test.

**What was not tested**: Full Gateway-to-Companion-App integration test (not possible without a running Gateway with connected node). The change is minimal and structurally identical to the already-tested approval-followup path.

## Tests and validation

```bash
node scripts/run-vitest.mjs run src/agents/bash-tools.exec-host-node.test.ts
```
- 44 tests pass (all existing)
- The key test at line 566 validates the same `approved: true` pattern in the approval-followup path
- The direct-bypass path now mirrors this behavior

## Risk checklist

Did user-visible behavior change? (`Yes`)
- Users with `security=full, ask=off` on both Gateway and Companion App will see `exec host=node` succeed instead of being rejected

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- No additional approval bypass exposure: `invokeNodeSystemRunDirect` is only called when `hostSecurity === "full" && hostAsk === "off"`, meaning policy already fully trusts the command

How is that risk mitigated?
- Single field addition `approved: true` in a pre-existing payload construction
- Same pattern already tested in the approval-followup path

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- CI run on the PR branch
- Any maintainer feedback on approach

Which bot or reviewer comments were addressed?
- N/A — first submission
