### PR TITLE
fix(agents): return string assistant content in getLastAssistantText

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -122,6 +122,30 @@ function normalizeBranchSummaryResult(
   return { error: result.error.message };
 }
 
+function hasPersistedAssistantContent(content: unknown): boolean {
+  return (typeof content === "string" || Array.isArray(content)) && content.length > 0;
+}
+
+function extractPersistedAssistantText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  let text = "";
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const candidate = block as { type?: unknown; text?: unknown };
+    if (candidate.type === "text" && typeof candidate.text === "string") {
+      text += candidate.text;
+    }
+  }
+  return text;
+}
+
 // ============================================================================
 // Skill Block Parsing
 // ============================================================================
@@ -3213,10 +3237,8 @@ export class AgentSession {
         if (m.role !== "assistant") {
           return false;
         }
-        const msg = m;
-        // Skip aborted messages with no content. `.length === 0` is correct for
-        // both an empty content array and a persisted/legacy string content "".
-        if (msg.stopReason === "aborted" && msg.content.length === 0) {
+        const content = (m as { content?: unknown }).content;
+        if (m.stopReason === "aborted" && !hasPersistedAssistantContent(content)) {
           return false;
         }
         return true;
@@ -3226,23 +3248,8 @@ export class AgentSession {
       return undefined;
     }
 
-    let text = "";
-    // Persisted/legacy transcripts may carry a string `content` (the same case
-    // hasAssistantToolCallArguments guards against). Treat it as the text itself,
-    // matching extractTextContent(); otherwise iterating the string would yield
-    // characters, never a `type === "text"` block, and silently drop the text.
-    const lastAssistantContent = (lastAssistant as AssistantMessage).content;
-    if (typeof lastAssistantContent === "string") {
-      text = lastAssistantContent;
-    } else {
-      for (const content of lastAssistantContent) {
-        if (content.type === "text") {
-          text += content.text;
-        }
-      }
-    }
-
-    return text.trim() || undefined;
+    const content = (lastAssistant as { content?: unknown }).content;
+    return extractPersistedAssistantText(content).trim() || undefined;
   }
 
   // =========================================================================

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -3214,7 +3214,8 @@ export class AgentSession {
           return false;
         }
         const msg = m;
-        // Skip aborted messages with no content
+        // Skip aborted messages with no content. `.length === 0` is correct for
+        // both an empty content array and a persisted/legacy string content "".
         if (msg.stopReason === "aborted" && msg.content.length === 0) {
           return false;
         }
@@ -3226,9 +3227,18 @@ export class AgentSession {
     }
 
     let text = "";
-    for (const content of (lastAssistant as AssistantMessage).content) {
-      if (content.type === "text") {
-        text += content.text;
+    // Persisted/legacy transcripts may carry a string `content` (the same case
+    // hasAssistantToolCallArguments guards against). Treat it as the text itself,
+    // matching extractTextContent(); otherwise iterating the string would yield
+    // characters, never a `type === "text"` block, and silently drop the text.
+    const lastAssistantContent = (lastAssistant as AssistantMessage).content;
+    if (typeof lastAssistantContent === "string") {
+      text = lastAssistantContent;
+    } else {
+      for (const content of lastAssistantContent) {
+        if (content.type === "text") {
+          text += content.text;
+        }
       }
     }
 

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -110,6 +110,84 @@ async function createSessionAndStreamModel(model: Model): Promise<SimpleStreamOp
   return streamMocks.streamSimple.mock.lastCall?.[2] ?? {};
 }
 
+function appendPersistedAssistantMessage(params: {
+  sessionManager: SessionManager;
+  content: unknown;
+  stopReason?: "stop" | "aborted";
+}) {
+  params.sessionManager.appendMessage({
+    role: "assistant",
+    content: params.content,
+    api: "messages",
+    provider: "anthropic",
+    model: "sonnet-4.6",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: params.stopReason ?? "stop",
+    timestamp: Date.now(),
+  } as Parameters<SessionManager["appendMessage"]>[0]);
+}
+
+async function createSessionFromManager(sessionManager: SessionManager) {
+  const { session } = await createAgentSession({
+    model: testModel,
+    resourceLoader: createEmptyResourceLoader(),
+    sessionManager,
+    settingsManager: SettingsManager.inMemory(),
+    modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+  });
+  return session;
+}
+
+async function createSessionWithPersistedAssistantContent(content: unknown) {
+  const sessionManager = SessionManager.inMemory();
+  appendPersistedAssistantMessage({ sessionManager, content });
+  return await createSessionFromManager(sessionManager);
+}
+
+describe("AgentSession getLastAssistantText", () => {
+  it.each([
+    {
+      name: "legacy string content",
+      content: " legacy assistant text ",
+      expected: "legacy assistant text",
+    },
+    {
+      name: "normal text blocks",
+      content: [
+        { type: "thinking", thinking: "hidden" },
+        { type: "text", text: "visible " },
+        { type: "text", text: "answer" },
+      ],
+      expected: "visible answer",
+    },
+    { name: "null content", content: null, expected: undefined },
+    { name: "object content", content: { type: "text", text: "malformed" }, expected: undefined },
+  ])("reads $name without throwing", async ({ content, expected }) => {
+    const session = await createSessionWithPersistedAssistantContent(content);
+    expect(session.getLastAssistantText()).toBe(expected);
+  });
+
+  it("skips aborted malformed content and returns the preceding assistant text", async () => {
+    const sessionManager = SessionManager.inMemory();
+    appendPersistedAssistantMessage({ sessionManager, content: "previous answer" });
+    appendPersistedAssistantMessage({
+      sessionManager,
+      content: null,
+      stopReason: "aborted",
+    });
+    const session = await createSessionFromManager(sessionManager);
+
+    expect(session.getLastAssistantText()).toBe("previous answer");
+  });
+});
+
 describe("createAgentSession attribution headers", () => {
   it("tolerates Bedrock models that do not expose baseUrl", async () => {
     const options = await createSessionAndStreamModel(


### PR DESCRIPTION
## Summary

`getLastAssistantText()` assumed persisted assistant content was always an array. Legacy string content was iterated character-by-character and silently returned as `undefined`; malformed persisted values could also throw. This repair safely narrows persisted content while preserving the normal content-block path.

## Changes

- Return legacy persisted string content as assistant text.
- Ignore malformed persisted assistant content safely.
- Skip aborted malformed content and fall back to the preceding assistant reply.
- Add direct SDK regression coverage for strings, content blocks, null/object content, and aborted fallback.

## Real behavior proof

Behavior addressed: persisted string assistant replies are returned instead of silently dropped, and malformed persisted content no longer breaks the lookup.

Real environment tested: local OpenClaw source checkout on Node, using the real `createAgentSession` and `SessionManager` session path.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts src/agents/embedded-agent-runner/replay-history.test.ts`

Evidence after fix: 2 Vitest shards passed; 47 tests passed.

Observed result after fix: legacy string content and normal text blocks return their text; null/object content returns undefined; an aborted malformed message falls back to the prior assistant text.

What was not tested: no live multi-turn provider run; the repaired path is deterministic persisted-session text extraction.

## Verification

- `node scripts/run-oxlint.mjs src/agents/sessions/agent-session.ts src/agents/sessions/sdk.test.ts`
- `node scripts/run-vitest.mjs src/agents/sessions/sdk.test.ts src/agents/embedded-agent-runner/replay-history.test.ts`
- `git diff --check`
- Fresh Codex autoreview against `origin/main`: no accepted/actionable findings
