### PR TITLE
fix(qwen): place DashScope image prompts in user content

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -884,6 +884,59 @@ describe("describeImageWithModel", () => {
     ]);
   });
 
+  it("places DashScope image prompts in user content before images", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        api: "openai-completions",
+        provider: "qwen",
+        id: "qwen-vl-max-latest",
+        input: ["text", "image"],
+        baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "qwen",
+      model: "qwen-vl-max-latest",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "dashscope ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "qwen",
+      model: "qwen-vl-max-latest",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "dashscope ok",
+      model: "qwen-vl-max-latest",
+    });
+    const firstCall = requireFirstMockCall(completeMock, "DashScope image completion");
+    const [, context] = firstCall;
+    expect(context.systemPrompt).toBeUndefined();
+    const userMessage = context.messages[0];
+    if (!userMessage) {
+      throw new Error("expected DashScope image completion user message");
+    }
+    expect(userMessage.content).toEqual([
+      { type: "text", text: "Describe the image." },
+      {
+        type: "image",
+        data: Buffer.from("png-bytes").toString("base64"),
+        mimeType: "image/png",
+      },
+    ]);
+  });
+
   it.each([
     {
       name: "direct OpenAI Responses baseUrl",

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -298,6 +298,7 @@ function shouldPlaceImagePromptInUserContent(model: Model): boolean {
   });
   return (
     capabilities.endpointClass === "openrouter" ||
+    capabilities.endpointClass === "modelstudio-native" ||
     (model.provider.toLowerCase() === "openrouter" && capabilities.endpointClass === "default")
   );
 }


### PR DESCRIPTION
Fixes #92688.

This updates the media-understanding image runtime so Qwen/DashScope Model Studio image requests put the prompt text in the user message with the image block. DashScope rejects the current system-prompt plus image-only user message shape with `Unexpected item type in content`.

The change should stay narrow: extend the prompt-in-user-content routing for `modelstudio-native` image media-understanding endpoints and add a focused regression asserting Qwen/DashScope image requests have no `systemPrompt` and include `{ type: "text" }` before the image content.

Credit: thanks @Yachiyo404 for the report and reproduction details in #92688.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-125-autonomous-terminal-gap
- Source PRs: none
- Credit: Credit @Yachiyo404 for the #92688 report and reproduction details.; Do not treat #63654 or #67759 as duplicates to close; both are already closed older model-resolution issues.; Existing-overlap PR refs #92704, #92770, and #92782 were excluded from actionable refs in this job and are not source PRs for this replacement artifact.
- Validation: pnpm -s vitest run src/media-understanding/image.test.ts src/agents/tools/image-tool.test.ts; pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against f114920a7bec.
