### PR TITLE
fix(update): avoid per-Node npm prefixes during self-update

### DIFF
--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -373,6 +373,100 @@ describe("update global helpers", () => {
     });
   });
 
+  it("keeps npm ownership but avoids per-Node npm commands for reinstall", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-node-version-prefix-" }, async (base) => {
+        const pathNpmRoot = path.join(base, "path-npm", "lib", "node_modules");
+        const layouts = [
+          {
+            name: "homebrew-cellar",
+            prefix: path.join(base, "opt", "homebrew", "Cellar", "node", "24.5.0"),
+          },
+          {
+            name: "nvm",
+            prefix: path.join(base, "home", ".nvm", "versions", "node", "v24.5.0"),
+          },
+          {
+            name: "asdf",
+            prefix: path.join(base, "home", ".asdf", "installs", "nodejs", "24.5.0"),
+          },
+          {
+            name: "volta",
+            prefix: path.join(base, "home", ".volta", "tools", "image", "node", "24.5.0"),
+          },
+          {
+            name: "fnm",
+            prefix: path.join(
+              base,
+              "home",
+              ".local",
+              "share",
+              "fnm",
+              "node-versions",
+              "v24.5.0",
+              "installation",
+            ),
+          },
+          {
+            name: "n",
+            prefix: path.join(base, "usr", "local", "n", "versions", "node", "24.5.0"),
+          },
+        ];
+
+        for (const layout of layouts) {
+          const nodeManagedRoot = path.join(layout.prefix, "lib", "node_modules");
+          const pkgRoot = path.join(nodeManagedRoot, "openclaw");
+          const nodeManagedNpm = path.join(layout.prefix, "bin", "npm");
+          await fs.mkdir(pkgRoot, { recursive: true });
+          await fs.mkdir(path.dirname(nodeManagedNpm), { recursive: true });
+          await fs.writeFile(nodeManagedNpm, "", "utf8");
+
+          const runCommand = createNpmRootRunner({
+            defaultNpmRoot: pathNpmRoot,
+            overrideCommand: nodeManagedNpm,
+            overrideNpmRoot: nodeManagedRoot,
+          });
+
+          await expect(
+            detectGlobalInstallManagerForRoot(runCommand, pkgRoot, 1000),
+            layout.name,
+          ).resolves.toBe("npm");
+          await expect(
+            resolveGlobalRoot("npm", runCommand, 1000, pkgRoot),
+            layout.name,
+          ).resolves.toBe(pathNpmRoot);
+          expect(resolveGlobalInstallCommand("npm", pkgRoot), layout.name).toEqual({
+            manager: "npm",
+            command: "npm",
+          });
+          expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot), layout.name).toEqual([
+            "npm",
+            "i",
+            "-g",
+            "openclaw@latest",
+            "--no-fund",
+            "--no-audit",
+            "--loglevel=error",
+            "--min-release-age=0",
+          ]);
+          expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot), layout.name).toEqual(
+            [
+              "npm",
+              "i",
+              "-g",
+              "openclaw@latest",
+              "--omit=optional",
+              "--no-fund",
+              "--no-audit",
+              "--loglevel=error",
+              "--min-release-age=0",
+            ],
+          );
+        }
+      });
+    });
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -526,7 +526,52 @@ export function resolveNpmGlobalPrefixLayoutFromPrefix(prefix: string): NpmGloba
   };
 }
 
-function resolvePreferredNpmCommand(pkgRoot?: string | null): string | null {
+function splitNormalizedPathParts(value: string): string[] {
+  return path
+    .resolve(value)
+    .split(path.sep)
+    .filter(Boolean)
+    .map((part) => normalizeLowercaseStringOrEmpty(part));
+}
+
+function isNodeVersionPathPart(value: string | undefined): boolean {
+  return value !== undefined && /^v?\d+(?:\.\d+){0,3}(?:[-+][0-9a-z.-]+)?$/u.test(value);
+}
+
+function hasPathSequence(parts: readonly string[], sequence: readonly string[]): boolean {
+  const lastStart = parts.length - sequence.length;
+  for (let index = 0; index <= lastStart; index += 1) {
+    if (sequence.every((part, offset) => parts[index + offset] === part)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isEphemeralNodeManagedNpmPrefix(prefix: string): boolean {
+  const parts = splitNormalizedPathParts(prefix);
+  const basename = parts.at(-1);
+  const parent = parts.at(-2);
+  const grandparent = parts.at(-3);
+
+  if (isNodeVersionPathPart(basename) && grandparent === "cellar") {
+    return true;
+  }
+  if (
+    isNodeVersionPathPart(basename) &&
+    (hasPathSequence(parts, [".nvm", "versions", "node"]) ||
+      hasPathSequence(parts, ["n", "versions", "node"]) ||
+      hasPathSequence(parts, [".asdf", "installs", "nodejs"]) ||
+      hasPathSequence(parts, [".volta", "tools", "image", "node"]))
+  ) {
+    return true;
+  }
+  return (
+    basename === "installation" && isNodeVersionPathPart(parent) && grandparent === "node-versions"
+  );
+}
+
+function resolveNpmCommandBesidePackageRoot(pkgRoot?: string | null): string | null {
   const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
   if (!prefix) {
     return null;
@@ -534,6 +579,14 @@ function resolvePreferredNpmCommand(pkgRoot?: string | null): string | null {
   const candidate =
     process.platform === "win32" ? path.join(prefix, "npm.cmd") : path.join(prefix, "bin", "npm");
   return fsSync.existsSync(candidate) ? candidate : null;
+}
+
+function resolvePreferredNpmCommand(pkgRoot?: string | null): string | null {
+  const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
+  if (prefix && isEphemeralNodeManagedNpmPrefix(prefix)) {
+    return null;
+  }
+  return resolveNpmCommandBesidePackageRoot(pkgRoot);
 }
 
 function inferGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null {
@@ -809,7 +862,7 @@ export async function detectGlobalInstallManagerForRoot(
     }
   }
 
-  if (resolvePreferredNpmCommand(pkgRoot)) {
+  if (resolveNpmCommandBesidePackageRoot(pkgRoot)) {
     return "npm";
   }
 


### PR DESCRIPTION
Fixes #80387 by repairing the existing contributor PR #80386 from @yaanfpv.

This keeps the same narrow behavior: OpenClaw should still detect npm ownership for the current global install, but the reinstall command should avoid Homebrew Cellar and version-manager per-Node npm prefixes so a later Node major upgrade does not delete the command shim target. Stable npm global prefixes should continue to resolve as before.

Repair checklist for Clownfish:
- Rebase or refresh #80386 onto current main c45c87acca255764046c5877cfe2346b5f98ef64.
- Address the ClawSweeper merge-prep finding by removing/moving the release-owned CHANGELOG.md edit if still present.
- Keep regression coverage for Homebrew Cellar, nvm, asdf, volta, fnm, and n layouts, including ownership detection staying npm while install argv falls back to PATH npm.
- Run `pnpm -s vitest run src/infra/update-global.test.ts` and `pnpm check:changed`.
- Run Codex `/review` and address every finding before merge preflight.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-159-autonomous-terminal-gap
- Source PRs: https://github.com/openclaw/openclaw/pull/80386
- Credit: Repair contributor branch for https://github.com/openclaw/openclaw/pull/80386 by @yaanfpv; preserve attribution in the PR body and eventual changelog/release note.; Do not keep a direct CHANGELOG.md edit if release policy treats that file as generated; carry the user-facing changelog note in the PR body for release tooling instead.
- Validation: pnpm -s vitest run src/infra/update-global.test.ts; pnpm check:changed
- Repair fallback: source PR #80386 is a fork branch requiring rebase; use replacement branch because GitHub App pushes to contributor forks can be rejected when rebased upstream history includes workflow files

fish notes: model gpt-5.5, reasoning medium; reviewed against 82c8b7cf5af1.
