### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM cold-load (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,7 +1064,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -97,10 +97,11 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom while still capping worst case at two minutes.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## Summary

ARM devices with 600+ skills need ~57 seconds just to cold-load tool definitions on the first narrative phase, leaving almost no headroom for the LLM call within the current 60-second timeout. This causes consistent timeouts for light and REM phases on resource-constrained environments.

Increase `NARRATIVE_TIMEOUT_MS` from 60s to 120s to accommodate ARM cold-load latency while still bounding worst case at two minutes.

Fixes #92494

## Real behavior proof

- **Behavior addressed:** Dreaming narrative phases timeout on ARM devices with 600+ skills due to cold-load latency consuming most of the 60s budget
- **Environment tested:** macOS aarch64, Node v22, OpenClaw main branch (3cbb50f8)
- **Steps run after the patch:**
```
node -e "const fs = require('fs'); const src = fs.readFileSync('extensions/memory-core/src/dreaming-narrative.ts', 'utf8'); const m = src.match(/NARRATIVE_TIMEOUT_MS\s*=\s*(\d+)/); console.log('NARRATIVE_TIMEOUT_MS =', m[1]);"
```
- **Evidence after fix:**
```
$ grep -n "NARRATIVE_TIMEOUT_MS" extensions/memory-core/src/dreaming-narrative.ts
103:const NARRATIVE_TIMEOUT_MS = 120_000;
1051:            timeoutMs: NARRATIVE_TIMEOUT_MS,

$ node scripts/run-vitest.mjs run extensions/memory-core/src/dreaming-narrative.test.ts
 ✓  extension-memory  extensions/memory-core/src/dreaming-narrative.test.ts (58 tests) 532ms
 Test Files  1 passed (1)
      Tests  58 passed (58)
```
- **Observed result after fix:** Timeout constant updated to 120s, all 58 dreaming-narrative tests pass, build succeeds
- **What was not tested:** Actual ARM device with 600+ skills (no ARM hardware available); the timeout increase is a safe upper bound that doesn't change behavior for environments that complete within 60s
