### PR TITLE
feat(inbound-meta): expose message_type in trusted inbound metadata (fixes #50482)

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -248,6 +248,44 @@ describe("buildInboundMetaSystemPrompt", () => {
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["response_format"]).toBeUndefined();
   });
+
+  it("includes message_type derived from MediaType", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      MediaType: "audio/ogg",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["message_type"]).toBe("audio");
+  });
+
+  it("includes message_type derived from MediaTypes when MediaType is absent", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingChannel: "discord",
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+      MediaTypes: ["video/mp4", "image/png"],
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["message_type"]).toBe("video");
+  });
+
+  it("omits message_type for plain text messages", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["message_type"]).toBeUndefined();
+  });
 });
 
 describe("buildInboundUserContextPrefix", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -461,6 +461,22 @@ function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   return channelValue;
 }
 
+function resolveInboundMessageType(ctx: TemplateContext): string | undefined {
+  const mediaType = normalizePromptMetadataString(ctx.MediaType);
+  if (mediaType) {
+    const slash = mediaType.indexOf("/");
+    return slash > 0 ? mediaType.slice(0, slash) : mediaType;
+  }
+  const firstMediaType = Array.isArray(ctx.MediaTypes)
+    ? ctx.MediaTypes.find((t): t is string => typeof t === "string" && t.length > 0)
+    : undefined;
+  if (firstMediaType) {
+    const slash = firstMediaType.indexOf("/");
+    return slash > 0 ? firstMediaType.slice(0, slash) : firstMediaType;
+  }
+  return undefined;
+}
+
 function resolveInboundFormattingHints(ctx: TemplateContext):
   | {
       text_markup: string;
@@ -505,6 +521,7 @@ export function buildInboundMetaSystemPrompt(
     provider: normalizePromptMetadataString(ctx.Provider),
     surface: normalizePromptMetadataString(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
+    message_type: resolveInboundMessageType(ctx),
     response_format:
       options?.includeFormattingHints === false ? undefined : resolveInboundFormattingHints(ctx),
   };


### PR DESCRIPTION
## Summary

Add `message_type` field to the `openclaw.inbound_meta.v2` trusted metadata payload so agents can distinguish voice/audio/image/video messages from plain text.

The media type information is already available in the channel context (`MediaType` / `MediaTypes` on `MsgContext`) — this change surfaces the top-level media category (e.g. `audio`, `image`, `video`) to the agent in the inbound metadata JSON.

## Motivation

When a user sends a voice message on Telegram (or other channels), OpenClaw correctly routes the audio through STT and injects the transcript. However, the agent has no way to know whether the original message was a voice note or typed text. This distinction matters for conversational flow — voice messages often come in bursts and may warrant different response timing than composed text.

## Changes

- `src/auto-reply/reply/inbound-meta.ts`: Add `resolveInboundMessageType()` helper that extracts the top-level media category from `MediaType` (singular) or the first entry of `MediaTypes` (plural). Add `message_type` field to the payload. Omitted for plain text messages.
- `src/auto-reply/reply/inbound-meta.test.ts`: 3 new test cases covering audio, video, and plain text scenarios.

## Example

For a Telegram voice message with `MediaType: "audio/ogg"`:
```json
{
  "schema": "openclaw.inbound_meta.v2",
  "channel": "telegram",
  "chat_type": "direct",
  "message_type": "audio"
}
```

For a plain text message (no media):
```json
{
  "schema": "openclaw.inbound_meta.v2",
  "channel": "telegram",
  "chat_type": "direct"
}
```

## Real behavior proof

- **Behavior addressed:** Add `message_type` field to `openclaw.inbound_meta.v2` payload derived from `MediaType`/`MediaTypes` context fields, so agents can distinguish audio/image/video messages from plain text.
- **Environment tested:** macOS 26.4.1, Node.js, OpenClaw repo at commit 9eb3ccc3.
- **Steps run after the patch:** Built the project with `pnpm build` (success, 98s). Ran `node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-meta.test.ts` — all 56 tests pass including 3 new tests for `message_type`.
- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-meta.test.ts
 ✓  auto-reply  src/auto-reply/reply/inbound-meta.test.ts (56 tests) 41ms
 Test Files  1 passed (1)
      Tests  56 passed (56)

$ grep -n "message_type\|resolveInboundMessageType" src/auto-reply/reply/inbound-meta.ts
464:function resolveInboundMessageType(ctx: TemplateContext): string | undefined {
524:    message_type: resolveInboundMessageType(ctx),
```

- **Observed result after fix:** `message_type` appears in the JSON payload when media is present (e.g. `"audio"` for voice messages, `"video"` for video). Omitted when no media type is available (plain text). All existing tests continue to pass.
- **What was not tested:** Live channel integration (Telegram/WhatsApp/Discord voice message → agent context). The fix uses the existing `MediaType`/`MediaTypes` fields that channels already populate; the resolution logic is verified by unit tests with direct context injection.
