### PR TITLE
fix(skill-workshop): skip helper sessions during auto-capture

### DIFF
--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -28,6 +28,7 @@ import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
 } from "../sessions/user-turn-transcript.js";
+import { runSkillResearchAutoCapture } from "../skills/research/autocapture.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { runPreparedCliAgent } from "./cli-runner.js";
 import {
@@ -50,11 +51,16 @@ vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: vi.fn(() => null),
 }));
 
+vi.mock("../skills/research/autocapture.js", () => ({
+  runSkillResearchAutoCapture: vi.fn(async () => undefined),
+}));
+
 vi.mock("../tts/tts.js", () => ({
   buildTtsSystemPromptHint: vi.fn(() => undefined),
 }));
 
 const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+const mockAutoCapture = vi.mocked(runSkillResearchAutoCapture);
 const hookRunnerGlobalStateKey = Symbol.for("openclaw.plugins.hook-runner-global-state");
 let sessionFileEnvSnapshot: ReturnType<typeof captureEnv> | undefined;
 
@@ -292,6 +298,8 @@ describe("runCliAgent reliability", () => {
   afterEach(() => {
     replyRunTesting.resetReplyRunRegistry();
     mockGetGlobalHookRunner.mockReset();
+    mockAutoCapture.mockReset();
+    mockAutoCapture.mockResolvedValue(undefined);
     setHookRunnerForTest(null);
     vi.unstubAllEnvs();
     sessionFileEnvSnapshot?.restore();
@@ -2013,6 +2021,71 @@ describe("runCliAgent reliability", () => {
     expect(resolved).toBe(false);
 
     releaseAgentEnd();
+    await expect(run).resolves.toMatchObject({
+      payloads: [{ text: "hello from cli" }],
+    });
+    expect(resolved).toBe(true);
+  });
+
+  it("waits for eligible Skill Research auto-capture before resolving direct CLI runs", async () => {
+    let releaseAutoCapture: () => void = () => undefined;
+    const autoCaptureSettled = new Promise<void>((resolve) => {
+      releaseAutoCapture = resolve;
+    });
+    mockAutoCapture.mockReturnValueOnce(autoCaptureSettled);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "hello from cli",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const context = buildPreparedContext({ sessionKey: "agent:main:main" });
+    let resolved = false;
+    const run = runPreparedCliAgent({
+      ...context,
+      params: {
+        ...context.params,
+        agentId: "main",
+        trigger: "user",
+        config: {
+          skills: {
+            workshop: {
+              autonomous: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    }).then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await vi.waitFor(() => {
+      expect(mockAutoCapture).toHaveBeenCalledTimes(1);
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    expect(mockAutoCapture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          trigger: "user",
+        }),
+      }),
+    );
+
+    releaseAutoCapture();
     await expect(run).resolves.toMatchObject({
       payloads: [{ text: "hello from cli" }],
     });

--- a/src/agents/harness/agent-end-side-effects.test.ts
+++ b/src/agents/harness/agent-end-side-effects.test.ts
@@ -44,7 +44,9 @@ describe("agent end side effects", () => {
       },
       ctx: {
         runId: "run-1",
+        sessionKey: "agent:main:main",
         workspaceDir: "/workspace",
+        trigger: "user",
         config: {
           skills: {
             workshop: {
@@ -65,7 +67,9 @@ describe("agent end side effects", () => {
       },
       ctx: {
         runId: "run-1",
+        sessionKey: "agent:main:main",
         workspaceDir: "/workspace",
+        trigger: "user",
         config: {
           skills: {
             workshop: {

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -119,8 +119,20 @@ describe("skill research auto-capture", () => {
       ctx: { sessionKey: "hook:gmail:message-1" },
     },
     {
-      name: "Active Memory session",
+      name: "Active Memory trigger",
       ctx: { trigger: "memory", sessionKey: "explicit:user-session:active-memory:abc123" },
+    },
+    {
+      name: "Active Memory helper session with main suffix",
+      ctx: { trigger: "manual", sessionKey: "agent:main:main:active-memory:abc123" },
+    },
+    {
+      name: "Active Memory helper session without main suffix",
+      ctx: { trigger: "manual", sessionKey: "agent:main:active-memory:abc123" },
+    },
+    {
+      name: "Active Memory recall helper session",
+      ctx: { trigger: "manual", sessionKey: "active-memory-recall-87504" },
     },
   ])("skips $name before queuing proposals", async ({ ctx }) => {
     const workspaceDir = await makeWorkspace();

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -101,6 +101,56 @@ describe("skill research auto-capture", () => {
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
   });
 
+  it.each([
+    {
+      name: "subagent helper session",
+      ctx: { sessionKey: "agent:main:subagent:worker" },
+    },
+    {
+      name: "cron automation session",
+      ctx: { trigger: "cron", sessionKey: "agent:main:cron:daily:run:run-1" },
+    },
+    {
+      name: "heartbeat automation session",
+      ctx: { trigger: "heartbeat", sessionKey: "agent:main:main" },
+    },
+    {
+      name: "hook-scoped session",
+      ctx: { sessionKey: "hook:gmail:message-1" },
+    },
+    {
+      name: "Active Memory session",
+      ctx: { trigger: "memory", sessionKey: "explicit:user-session:active-memory:abc123" },
+    },
+  ])("skips $name before queuing proposals", async ({ ctx }) => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", ...ctx },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+  });
+
   it("preserves existing skill content when auto-capturing an update", async () => {
     const workspaceDir = await makeWorkspace();
     const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -14,16 +14,39 @@ type SkillResearchAgentEndEvent = {
 
 type SkillResearchAgentContext = {
   agentId?: string;
+  runId?: string;
+  sessionKey?: string;
+  trigger?: string;
   workspaceDir?: string;
 };
 
 const log = createSubsystemLogger("skills/research");
+const AUTO_CAPTURE_BLOCKED_TRIGGERS = new Set(["cron", "heartbeat", "memory", "overflow"]);
+const AUTO_CAPTURE_BLOCKED_SESSION_SEGMENTS = new Set(["cron", "hook", "subagent"]);
 
 // Captured updates append below existing skill text so learned context stays auditable.
 function buildAutoCaptureUpdateContent(existingSkill: string, capturedContent: string): string {
   return [existingSkill.trimEnd(), "", "## Captured Update", "", capturedContent.trim(), ""].join(
     "\n",
   );
+}
+
+function isSkillResearchAutoCaptureEligible(ctx: SkillResearchAgentContext): boolean {
+  const trigger = ctx.trigger?.trim().toLowerCase();
+  if (trigger && AUTO_CAPTURE_BLOCKED_TRIGGERS.has(trigger)) {
+    return false;
+  }
+
+  const sessionKey = ctx.sessionKey?.trim().toLowerCase();
+  if (!sessionKey) {
+    return true;
+  }
+  if (sessionKey.includes("active-memory")) {
+    return false;
+  }
+  return !sessionKey
+    .split(":")
+    .some((segment) => AUTO_CAPTURE_BLOCKED_SESSION_SEGMENTS.has(segment));
 }
 
 /** Captures durable skill research signals from a session transcript when enabled. */
@@ -41,6 +64,9 @@ export async function runSkillResearchAutoCapture(params: {
   }
   const workspaceDir = params.ctx.workspaceDir;
   if (!workspaceDir) {
+    return;
+  }
+  if (!isSkillResearchAutoCaptureEligible(params.ctx)) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Refresh contributor PR #87504 against current main and keep @zhangguiping-xydt's credited fix path.
- Ensure Skill Research auto-capture skips helper, automation, cron, hook-scoped, and Active Memory sessions before proposal extraction or workshop writes.
- Preserve direct CLI settlement behavior where eligible auto-capture should complete before command return.

## Credit
This carries forward the implementation and investigation from @zhangguiping-xydt in https://github.com/openclaw/openclaw/pull/87504 and the reproduction evidence from @Countermarch in #87352.

## Validation
- pnpm -s vitest run src/skills/research/autocapture.test.ts src/agents/harness/agent-end-side-effects.test.ts src/agents/cli-runner.reliability.test.ts
- pnpm check:changed
- Codex /review must pass cleanly before merge.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-164-autonomous-terminal-gap
- Source PRs: https://github.com/openclaw/openclaw/pull/87504
- Credit: Preserve contributor credit for @zhangguiping-xydt and source PR https://github.com/openclaw/openclaw/pull/87504.; Issue reporter @Countermarch supplied the original timeout report and Active Memory helper-session acceptance evidence in #87352.; Do not replace the PR unless branch repair fails; maintainer_can_modify=true and the hydrated diff is focused.
- Validation: pnpm -s vitest run src/skills/research/autocapture.test.ts src/agents/harness/agent-end-side-effects.test.ts src/agents/cli-runner.reliability.test.ts; pnpm check:changed
- Repair fallback: source PR #87504 is a fork branch requiring rebase; use replacement branch because GitHub App pushes to contributor forks can be rejected when rebased upstream history includes workflow files

fish notes: model gpt-5.5, reasoning medium; reviewed against 1b9afff9aaf3.
