### PR TITLE
fix(codex): expose remote node exec as a Codex dynamic tool

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -639,7 +639,7 @@ describe("Codex app-server dynamic tool build", () => {
     };
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
-      nativeToolSurfaceEnabled: false,
+      nativeToolSurfaceEnabled: true,
     });
 
     expect(tools.map((tool) => tool.name)).toEqual(["message", "node_exec", "node_process"]);
@@ -700,7 +700,7 @@ describe("Codex app-server dynamic tool build", () => {
     } as never;
     const runtimePolicyTools = await buildDynamicToolsForTest(runtimePolicyParams, workspaceDir, {
       sandboxSessionKey: "agent:policy:session-1",
-      nativeToolSurfaceEnabled: false,
+      nativeToolSurfaceEnabled: true,
       sessionAgentId: "policy",
     });
 
@@ -1129,7 +1129,7 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
-  it("disables Codex native tool surfaces when the effective exec target is node", () => {
+  it("keeps Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     sessionParams.disableTools = false;
@@ -1140,16 +1140,16 @@ describe("Codex app-server dynamic tool build", () => {
       ask: "off",
     };
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(true);
 
     sessionParams.toolsAllow = ["*"];
-    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(sessionParams)).toBe(true);
 
     const globalParams = createParams(path.join(tempDir, "global-session.jsonl"), workspaceDir);
     globalParams.disableTools = false;
     globalParams.config = { tools: { exec: { host: "node" } } } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(globalParams)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(globalParams)).toBe(true);
 
     const autoOverrideParams = createParams(
       path.join(tempDir, "auto-override-session.jsonl"),
@@ -1173,7 +1173,7 @@ describe("Codex app-server dynamic tool build", () => {
       shouldEnableCodexAppServerNativeToolSurface(agentParams, undefined, {
         agentId: "main",
       }),
-    ).toBe(false);
+    ).toBe(true);
 
     const runtimePolicyParams = createParams(
       path.join(tempDir, "runtime-policy-session.jsonl"),
@@ -1191,7 +1191,7 @@ describe("Codex app-server dynamic tool build", () => {
       },
     } as never;
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(runtimePolicyParams)).toBe(true);
   });
 
   it("disables Codex native tool surfaces whenever an OpenClaw sandbox is active", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -594,10 +594,36 @@ describe("Codex app-server dynamic tool build", () => {
     ]);
   });
 
-  it("keeps OpenClaw shell tools for node-targeted Codex app-server runs", async () => {
+  it("exposes pinned node shell tools for node-targeted Codex app-server runs", async () => {
+    const execTool = {
+      ...createRuntimeDynamicTool("exec"),
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string" },
+          workdir: { type: "string" },
+          host: { type: "string" },
+          security: { type: "string" },
+          ask: { type: "string" },
+          node: { type: "string" },
+        },
+        required: ["command", "host", "node"],
+        additionalProperties: false,
+      },
+    };
+    vi.mocked(execTool.execute).mockResolvedValueOnce({
+      content: [
+        {
+          type: "text",
+          text: "Command still running (session exec-1, pid 123). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+        },
+      ],
+      details: { status: "running" },
+    });
+    const processTool = createRuntimeDynamicTool("process");
     setOpenClawCodingToolsFactoryForTests(() => [
-      createRuntimeDynamicTool("exec"),
-      createRuntimeDynamicTool("process"),
+      execTool,
+      processTool,
       createRuntimeDynamicTool("message"),
     ]);
     const sessionFile = path.join(tempDir, "session.jsonl");
@@ -616,7 +642,47 @@ describe("Codex app-server dynamic tool build", () => {
       nativeToolSurfaceEnabled: false,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(["message", "exec", "process"]);
+    expect(tools.map((tool) => tool.name)).toEqual(["message", "node_exec", "node_process"]);
+    const nodeExec = tools.find((tool) => tool.name === "node_exec");
+    const nodeProcess = tools.find((tool) => tool.name === "node_process");
+    expect(nodeExec?.description).toContain("host=node internally");
+    expect(nodeProcess?.description).toContain("node_exec sessions");
+    expect(nodeExec?.parameters).toEqual({
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        workdir: { type: "string" },
+      },
+      required: ["command"],
+      additionalProperties: false,
+    });
+    const result = await nodeExec?.execute(
+      "call-1",
+      {
+        command: "pwd",
+        host: "gateway",
+        node: "model-selected-node",
+        security: "full",
+        ask: "off",
+      },
+      undefined,
+    );
+    expect(execTool.execute).toHaveBeenCalledWith(
+      "call-1",
+      {
+        command: "pwd",
+        host: "node",
+        node: "mac-mini",
+      },
+      undefined,
+      undefined,
+    );
+    expect(result?.content).toEqual([
+      {
+        type: "text",
+        text: "Command still running (session exec-1, pid 123). Use node_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+      },
+    ]);
 
     const runtimePolicySessionFile = path.join(tempDir, "runtime-policy-session.jsonl");
     const runtimePolicyParams = createParams(runtimePolicySessionFile, workspaceDir);
@@ -638,7 +704,11 @@ describe("Codex app-server dynamic tool build", () => {
       sessionAgentId: "policy",
     });
 
-    expect(runtimePolicyTools.map((tool) => tool.name)).toEqual(["message", "exec", "process"]);
+    expect(runtimePolicyTools.map((tool) => tool.name)).toEqual([
+      "message",
+      "node_exec",
+      "node_process",
+    ]);
   });
 
   it("exposes Docker sandbox shell tools when native Code Mode cannot honor sandbox paths", async () => {
@@ -1003,15 +1073,30 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("normalizes Codex dynamic toolsAllow entries before filtering", () => {
-    const tools = ["exec", "sandbox_exec", "sandbox_process", "apply_patch", "read", "message"].map(
-      (name) => ({ name }),
-    );
+    const tools = [
+      "exec",
+      "sandbox_exec",
+      "sandbox_process",
+      "node_exec",
+      "node_process",
+      "apply_patch",
+      "read",
+      "message",
+    ].map((name) => ({ name }));
 
     expect(
       filterCodexDynamicToolsForAllowlist(tools, [" BASH ", "apply-patch", "READ"]).map(
         (tool) => tool.name,
       ),
-    ).toEqual(["exec", "sandbox_exec", "sandbox_process", "apply_patch", "read"]);
+    ).toEqual([
+      "exec",
+      "sandbox_exec",
+      "sandbox_process",
+      "node_exec",
+      "node_process",
+      "apply_patch",
+      "read",
+    ]);
   });
 
   it("treats an explicit empty Codex dynamic toolsAllow as no tools", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -25,7 +25,10 @@ import {
   isForcedPrivateQaCodexRuntime,
   normalizeCodexDynamicToolName,
 } from "./dynamic-tool-profile.js";
-import { resolveCodexNativeExecutionPolicy } from "./native-execution-policy.js";
+import {
+  resolveCodexNativeExecutionPolicy,
+  type CodexNativeExecutionPolicy,
+} from "./native-execution-policy.js";
 import type { CodexSandboxPolicy, CodexTurnEnvironmentParams } from "./protocol.js";
 import type { CodexSandboxExecEnvironment } from "./sandbox-exec-server.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
@@ -34,6 +37,7 @@ import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./w
 type OpenClawCodingToolsOptions = NonNullable<
   Parameters<(typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"]>[0]
 >;
+type OpenClawExecOptions = NonNullable<OpenClawCodingToolsOptions["exec"]>;
 
 /** Factory seam for constructing OpenClaw runtime tools without eagerly loading agent-harness. */
 export type OpenClawCodingToolsFactory =
@@ -53,6 +57,9 @@ const CODEX_NATIVE_SANDBOX_TOOL_REQUIREMENTS = [
   "apply_patch",
 ] as const;
 const CODEX_MEMORY_FLUSH_DYNAMIC_TOOL_ALLOW = new Set(["read", "write"]);
+const CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME = "node_exec";
+const CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME = "node_process";
+const CODEX_NODE_EXEC_HIDDEN_PARAMETER_NAMES = new Set(["host", "security", "ask", "node"]);
 
 /** Runtime inputs needed to derive the exact Codex dynamic tool surface for a turn. */
 export type DynamicToolBuildParams = {
@@ -217,11 +224,13 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     openClawCodingToolsFactoryForTests ?? agentHarness.createOpenClawCodingTools;
   toolBuildStages.mark("load-agent-harness-tools");
   const sessionKeys = resolveOpenClawCodingToolsSessionKeys(params, input.sandboxSessionKey);
+  const nativeExecutionPolicy = resolveCodexNativeExecutionPolicyForDynamicTools(input);
   const allTools = createOpenClawCodingTools({
     agentId: input.sessionAgentId,
     ...buildEmbeddedAttemptToolRunContext(params),
     exec: {
       ...params.execOverrides,
+      ...resolveNodeExecToolOverrides(nativeExecutionPolicy),
       config: params.config,
       elevated: params.bashElevated,
     },
@@ -324,6 +333,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     ),
     readableAllTools,
     input,
+    nativeExecutionPolicy,
   );
   toolBuildStages.mark("codex-filtering");
   const visionFilteredTools = filterToolsForVisionInputs(codexFilteredTools, {
@@ -703,40 +713,158 @@ function addNodeShellDynamicToolsIfNeeded(
   filteredTools: OpenClawDynamicTool[],
   allTools: OpenClawDynamicTool[],
   input: DynamicToolBuildParams,
+  nodePolicy: CodexNativeExecutionPolicy,
 ): OpenClawDynamicTool[] {
-  if (
-    isCodexMemoryFlushRun(input.params) ||
-    !isCodexNativeExecutionBlockedByNodeExecHost(input.params, {
-      agentId: input.sessionAgentId,
-      runtimeSessionKey: input.sandboxSessionKey,
-      sandbox: input.sandbox,
-    })
-  ) {
+  if (isCodexMemoryFlushRun(input.params)) {
     return filteredTools;
   }
-  let next = filteredTools;
-  for (const toolName of ["exec", "process"]) {
-    if (isCodexDynamicToolExcluded(input.pluginConfig, [toolName])) {
-      continue;
-    }
-    if (next.some((tool) => normalizeCodexDynamicToolName(tool.name) === toolName)) {
-      continue;
-    }
-    const tool = allTools.find(
-      (candidate) => normalizeCodexDynamicToolName(candidate.name) === toolName,
-    );
-    if (!tool) {
-      continue;
-    }
-    if (next === filteredTools) {
-      next = [...filteredTools];
-    }
-    next.push(tool);
+  if (nodePolicy.effectiveExecHost !== "node") {
+    return filteredTools;
   }
-  return next;
+  const execTool = allTools.find((tool) => normalizeCodexDynamicToolName(tool.name) === "exec");
+  const processTool = allTools.find(
+    (tool) => normalizeCodexDynamicToolName(tool.name) === "process",
+  );
+  if (!execTool || !processTool) {
+    return filteredTools;
+  }
+  const toolsToAppend: OpenClawDynamicTool[] = [];
+  if (
+    !isCodexDynamicToolExcluded(input.pluginConfig, ["exec", CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME]) &&
+    !filteredTools.some(
+      (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
+    )
+  ) {
+    toolsToAppend.push(createNodeExecDynamicTool(execTool, nodePolicy.node));
+  }
+  if (
+    !isCodexDynamicToolExcluded(input.pluginConfig, [
+      "process",
+      CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME,
+    ]) &&
+    !filteredTools.some(
+      (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME,
+    )
+  ) {
+    toolsToAppend.push(createNodeProcessDynamicTool(processTool));
+  }
+  return toolsToAppend.length > 0 ? [...filteredTools, ...toolsToAppend] : filteredTools;
 }
 
-/** Applies a normalized tool allowlist while preserving sandbox shell aliases for exec/process. */
+function createNodeExecDynamicTool(
+  execTool: OpenClawDynamicTool,
+  configuredNode: string | undefined,
+): OpenClawDynamicTool {
+  return {
+    ...execTool,
+    name: CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
+    description:
+      "Run a shell command on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Use node_process for follow-up on backgrounded node_exec sessions. Use Codex's native shell for local app-server work.",
+    parameters: hideNodeExecDynamicToolParameters(execTool.parameters),
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const result = await execTool.execute(
+        toolCallId,
+        pinNodeExecDynamicToolArgs(args, configuredNode),
+        signal,
+        onUpdate,
+      );
+      return {
+        ...result,
+        content: result.content.map((item) =>
+          item.type === "text"
+            ? Object.assign({}, item, {
+                text: item.text.replace(
+                  "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+                  "Use node_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+                ),
+              })
+            : item,
+        ),
+      };
+    },
+  };
+}
+
+function createNodeProcessDynamicTool(processTool: OpenClawDynamicTool): OpenClawDynamicTool {
+  return {
+    ...processTool,
+    name: CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME,
+    description:
+      "Manage node_exec sessions that were started on the OpenClaw configured remote node for this session: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use only for node_exec follow-up; use Codex's native shell session handling for local app-server work.",
+  };
+}
+
+function pinNodeExecDynamicToolArgs(args: unknown, configuredNode: string | undefined): unknown {
+  const source =
+    args && typeof args === "object" && !Array.isArray(args)
+      ? (args as Record<string, unknown>)
+      : {};
+  const { host: _host, security: _security, ask: _ask, node: _node, ...rest } = source;
+  const node = configuredNode?.trim();
+  return {
+    ...rest,
+    host: "node",
+    ...(node ? { node } : {}),
+  };
+}
+
+function hideNodeExecDynamicToolParameters(parameters: OpenClawDynamicTool["parameters"]) {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return parameters;
+  }
+  const schema = parameters as Record<string, unknown>;
+  const rawProperties = schema.properties;
+  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
+    return parameters;
+  }
+  const nextProperties = Object.fromEntries(
+    Object.entries(rawProperties).filter(
+      ([name]) => !CODEX_NODE_EXEC_HIDDEN_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)),
+    ),
+  );
+  const rawRequired = schema.required;
+  const nextRequired = Array.isArray(rawRequired)
+    ? rawRequired.filter(
+        (name) =>
+          typeof name !== "string" ||
+          !CODEX_NODE_EXEC_HIDDEN_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)),
+      )
+    : rawRequired;
+  return {
+    ...schema,
+    properties: nextProperties,
+    ...(Array.isArray(rawRequired) ? { required: nextRequired } : {}),
+  };
+}
+
+function resolveCodexNativeExecutionPolicyForDynamicTools(
+  input: DynamicToolBuildParams,
+): CodexNativeExecutionPolicy {
+  return resolveCodexNativeExecutionPolicy({
+    config: input.params.config,
+    sessionKey: resolveCodexRuntimePolicySessionKey(input.params, input.sandboxSessionKey),
+    sessionId: input.params.sessionId,
+    agentId: input.sessionAgentId,
+    execOverrides: input.params.execOverrides,
+    sandboxAvailable: input.sandbox?.enabled,
+    readRuntimeSessionEntry: true,
+  });
+}
+
+function resolveNodeExecToolOverrides(
+  policy: CodexNativeExecutionPolicy,
+): Pick<OpenClawExecOptions, "host" | "node"> | undefined {
+  if (policy.effectiveExecHost !== "node") {
+    return undefined;
+  }
+  const node = policy.node?.trim();
+  return {
+    host: "node",
+    ...(node ? { node } : {}),
+  };
+}
+
+/** Applies a normalized tool allowlist while preserving shell aliases for exec/process. */
 export function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
   tools: T[],
   toolsAllow?: string[],
@@ -758,7 +886,10 @@ export function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
     return (
       allowSet.has(normalized) ||
       (normalized === "sandbox_exec" && allowSet.has("exec")) ||
-      (normalized === "sandbox_process" && (allowSet.has("exec") || allowSet.has("process")))
+      (normalized === "sandbox_process" && (allowSet.has("exec") || allowSet.has("process"))) ||
+      (normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec")) ||
+      (normalized === CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME &&
+        (allowSet.has("exec") || allowSet.has("process")))
     );
   });
 }

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -473,15 +473,6 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   if (isCodexMemoryFlushRun(params)) {
     return false;
   }
-  if (
-    isCodexNativeExecutionBlockedByNodeExecHost(params, {
-      agentId: options.agentId,
-      runtimeSessionKey: options.runtimeSessionKey,
-      sandbox,
-    })
-  ) {
-    return false;
-  }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -323,6 +323,75 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     });
   });
 
+  it("keeps Codex native code mode while registering node shell tools for node sessions", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.execOverrides = {
+      host: "node",
+      node: "mac-mini",
+      security: "full",
+      ask: "off",
+    };
+    params.config = {
+      mcp: {
+        servers: {
+          local_docs: {
+            transport: "stdio",
+            command: "node",
+            args: ["/opt/local-docs-mcp/dist/index.js"],
+          },
+        },
+      },
+    } as never;
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("process"),
+      createRuntimeDynamicTool("message"),
+    ]);
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("thread/start");
+    await harness.waitForMethod("turn/start");
+
+    const startParams = harness.requests.find((request) => request.method === "thread/start")
+      ?.params as
+      | {
+          config?: {
+            "features.code_mode"?: boolean;
+            "features.code_mode_only"?: boolean;
+            mcp_servers?: Record<string, unknown>;
+          };
+          dynamicTools?: Array<{ name: string }>;
+          environments?: unknown[];
+        }
+      | undefined;
+
+    expect(startParams?.config).toMatchObject({
+      "features.code_mode": true,
+      "features.code_mode_only": false,
+      mcp_servers: {
+        local_docs: {
+          command: "node",
+          args: ["/opt/local-docs-mcp/dist/index.js"],
+        },
+      },
+    });
+    expect(startParams?.environments).toBeUndefined();
+    expect(startParams?.dynamicTools?.map((tool) => tool.name)).toEqual([
+      "message",
+      "node_exec",
+      "node_process",
+    ]);
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+
   it("emits normalized tool progress around app-server dynamic tool requests", async () => {
     const harness = createStartedThreadHarness();
     const onRunAgentEvent = vi.fn();

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -149,7 +149,6 @@ import {
   filterCodexDynamicToolsForAllowlist,
   formatCodexDynamicToolBuildStageSummary,
   includeForcedCodexDynamicToolAllow,
-  isCodexNativeExecutionBlockedByNodeExecHost,
   resolveCodexAppServerHookChannelId,
   resolveCodexMessageToolProvider,
   resolveOpenClawCodingToolsSessionKeys,
@@ -632,18 +631,12 @@ export async function runCodexAppServerAttempt(
         startOptions: appServer.start,
       });
   preDynamicStartupStages.mark("auth-cache");
-  const nodeExecBlocksNativeExecution = isCodexNativeExecutionBlockedByNodeExecHost(params, {
-    agentId: sessionAgentId,
-    runtimeSessionKey: sandboxSessionKey,
-    sandbox,
-  });
-  preDynamicStartupStages.mark("native-exec-policy");
   const bundleMcpThreadConfig = await loadCodexBundleMcpThreadConfig({
     workspaceDir: effectiveWorkspace,
     cfg: params.config,
     toolsEnabled: supportsModelTools(params.model),
     disableTools: params.disableTools,
-    toolsAllow: nodeExecBlocksNativeExecution ? [] : params.toolsAllow,
+    toolsAllow: params.toolsAllow,
   });
   preDynamicStartupStages.mark("bundle-mcp");
   const sandboxExecServerEnabled = isCodexSandboxExecServerEnabled(pluginConfig);


### PR DESCRIPTION
Fixes #92141.

This adds a narrow Codex app-server dynamic tool path for remote node shell execution while keeping Codex native local shell/files available for gateway work. The tool should call the existing OpenClaw exec implementation with host=node pinned internally, and any follow-up process management should use the same pinned node path rather than exposing model-controlled host selection.

Credit: this is based on @JPKay-AI's original WebChat/OpenAI Codex Windows-node report in #92141 and sebastian-openclaw's corroborating mixed-session proof-of-concept notes in the same thread.

Validation:
- pnpm -s vitest run extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts src/agents/bash-tools.exec-host-node.test.ts
- pnpm check:changed

Security scope: this does not change OpenClaw exec authorization, node pairing, allowlist, approval, or sandbox semantics. It only exposes the existing host=node exec path as an explicit OpenClaw-owned Codex dynamic tool for trusted-operator sessions.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-170-autonomous-terminal-gap
- Source PRs: none
- Credit: Credit #92141 reporter @JPKay-AI for the WebChat/OpenAI Codex plus Windows node repro.; Credit sebastian-openclaw's corroborating #92141 comment for the mixed-session requirement and proof-of-concept direction.; Do not include #61009 or #72858 in the implementation scope; they are security-routed linked context only.
- Validation: pnpm -s vitest run extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts src/agents/bash-tools.exec-host-node.test.ts; pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against c05c0bfe39a0.
