### PR TITLE
fix(gateway): send approval route notices with write scope

### DIFF
--- a/src/infra/approval-native-runtime.test.ts
+++ b/src/infra/approval-native-runtime.test.ts
@@ -7,6 +7,35 @@ import {
   deliverApprovalRequestViaChannelNativePlan,
 } from "./approval-native-runtime.js";
 
+const hoisted = vi.hoisted(() => ({
+  callGatewayLeastPrivilege: vi.fn(async () => ({ ok: true })),
+  createOperatorApprovalsGatewayClient: vi.fn(
+    async (params: { onHelloOk?: (hello: unknown) => void }) => {
+      queueMicrotask(() => params.onHelloOk?.({ type: "hello-ok" }));
+      return {
+        request: vi.fn(async () => ({ ok: true })),
+        stop: vi.fn(),
+      };
+    },
+  ),
+  startGatewayClientWhenEventLoopReady: vi.fn(async () => ({
+    ready: true,
+    aborted: false,
+  })),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGatewayLeastPrivilege: hoisted.callGatewayLeastPrivilege,
+}));
+
+vi.mock("../gateway/operator-approvals-client.js", () => ({
+  createOperatorApprovalsGatewayClient: hoisted.createOperatorApprovalsGatewayClient,
+}));
+
+vi.mock("../gateway/client-start-readiness.js", () => ({
+  startGatewayClientWhenEventLoopReady: hoisted.startGatewayClientWhenEventLoopReady,
+}));
+
 const execRequest = {
   id: "approval-1",
   request: {
@@ -17,6 +46,9 @@ const execRequest = {
 };
 
 afterEach(() => {
+  hoisted.callGatewayLeastPrivilege.mockClear();
+  hoisted.createOperatorApprovalsGatewayClient.mockClear();
+  hoisted.startGatewayClientWhenEventLoopReady.mockClear();
   clearApprovalNativeRouteStateForTest();
   vi.useRealTimers();
 });
@@ -224,6 +256,75 @@ describe("createChannelNativeApprovalRuntime", () => {
       ts: 1,
     });
     expect(resolvedCall.entries).toEqual([{ chatId: "plugin:secondary", messageId: "m1" }]);
+  });
+
+  it("sends route notices over least-privilege gateway calls", async () => {
+    const runtime = createChannelNativeApprovalRuntime({
+      label: "test/native-runtime-route-notice",
+      clientDisplayName: "Test",
+      channel: "slack",
+      channelLabel: "Slack",
+      cfg: { gateway: { auth: { token: "configured-token" } } } as never,
+      accountId: "default",
+      nativeAdapter: {
+        describeDeliveryCapabilities: () => ({
+          enabled: true,
+          preferredSurface: "approver-dm",
+          supportsOriginSurface: true,
+          supportsApproverDmSurface: true,
+          notifyOriginWhenDmOnly: true,
+        }),
+        resolveOriginTarget: async () => ({
+          to: "channel:C123",
+          threadId: "1712345678.123456",
+        }),
+        resolveApproverDmTargets: async () => [{ to: "user:owner" }],
+      },
+      isConfigured: () => true,
+      shouldHandle: () => true,
+      buildPendingContent: async () => "pending exec",
+      prepareTarget: async ({ plannedTarget }) => ({
+        dedupeKey: plannedTarget.target.to,
+        target: { chatId: plannedTarget.target.to },
+      }),
+      deliverTarget: async () => ({ chatId: "user:owner", messageId: "m1" }),
+      finalizeResolved: async () => {},
+    });
+
+    await runtime.start();
+    try {
+      await runtime.handleRequested({
+        id: "approval-route-notice",
+        request: {
+          command: "echo hi",
+          turnSourceChannel: "slack",
+          turnSourceTo: "channel:C123",
+          turnSourceAccountId: "default",
+          turnSourceThreadId: "1712345678.123456",
+        },
+        createdAtMs: 0,
+        expiresAtMs: Date.now() + 60_000,
+      });
+    } finally {
+      await runtime.stop();
+    }
+
+    expect(hoisted.callGatewayLeastPrivilege).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: { gateway: { auth: { token: "configured-token" } } },
+        method: "send",
+        clientName: "gateway-client",
+        mode: "backend",
+        params: {
+          channel: "slack",
+          to: "channel:C123",
+          accountId: "default",
+          threadId: "1712345678.123456",
+          message: "Approval required. I sent the approval request to Slack DMs, not this chat.",
+          idempotencyKey: "approval-route-notice:approval-route-notice",
+        },
+      }),
+    );
   });
 
   it("runs expiration through the shared runtime factory", async () => {

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -1,6 +1,8 @@
 // Creates channel-native approval runtimes and delivery flows.
 import type { ChannelApprovalNativeAdapter } from "../channels/plugins/approval-native.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { callGatewayLeastPrivilege } from "../gateway/call.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
   resolveChannelNativeApprovalDeliveryPlan,
   type ChannelApprovalNativePlannedTarget,
@@ -192,9 +194,6 @@ export function createChannelNativeApprovalRuntime<
   const nowMs = adapter.nowMs ?? Date.now;
   const resolveApprovalKind =
     adapter.resolveApprovalKind ?? ((request: TRequest) => defaultResolveApprovalKind(request));
-  let runtimeRequest:
-    | ((method: string, params: Record<string, unknown>) => Promise<unknown>)
-    | null = null;
   const handledEventKinds = new Set<ExecApprovalChannelRuntimeEventKind>(
     adapter.eventKinds ?? ["exec"],
   );
@@ -203,12 +202,15 @@ export function createChannelNativeApprovalRuntime<
     channel: adapter.channel,
     channelLabel: adapter.channelLabel,
     accountId: adapter.accountId,
-    requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> => {
-      if (!runtimeRequest) {
-        throw new Error(`${adapter.label}: gateway client not connected`);
-      }
-      return (await runtimeRequest(method, params)) as T;
-    },
+    requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> =>
+      await callGatewayLeastPrivilege<T>({
+        config: adapter.cfg,
+        ...(adapter.gatewayUrl ? { url: adapter.gatewayUrl } : {}),
+        method,
+        params,
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      }),
   });
 
   const runtime = createExecApprovalChannelRuntime<TPendingEntry, TRequest, TResolved>({
@@ -333,8 +335,6 @@ export function createChannelNativeApprovalRuntime<
       }
     },
   });
-
-  runtimeRequest = (method, params) => runtime.request(method, params);
 
   return {
     ...runtime,

--- a/src/infra/approval-native-runtime.ts
+++ b/src/infra/approval-native-runtime.ts
@@ -1,7 +1,6 @@
 // Creates channel-native approval runtimes and delivery flows.
 import type { ChannelApprovalNativeAdapter } from "../channels/plugins/approval-native.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { callGatewayLeastPrivilege } from "../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
   resolveChannelNativeApprovalDeliveryPlan,
@@ -202,15 +201,17 @@ export function createChannelNativeApprovalRuntime<
     channel: adapter.channel,
     channelLabel: adapter.channelLabel,
     accountId: adapter.accountId,
-    requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> =>
-      await callGatewayLeastPrivilege<T>({
+    requestGateway: async <T>(method: string, params: Record<string, unknown>): Promise<T> => {
+      const { callGatewayLeastPrivilege } = await import("../gateway/call.js");
+      return await callGatewayLeastPrivilege<T>({
         config: adapter.cfg,
         ...(adapter.gatewayUrl ? { url: adapter.gatewayUrl } : {}),
         method,
         params,
         clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
         mode: GATEWAY_CLIENT_MODES.BACKEND,
-      }),
+      });
+    },
   });
 
   const runtime = createExecApprovalChannelRuntime<TPendingEntry, TRequest, TResolved>({

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -319,6 +319,7 @@ describe("createExecApprovalChannelRuntime", () => {
 
     await runtime.start();
     await runtime.request("exec.approval.resolve", { id: "abc", decision: "deny" });
+    await runtime.request("exec.approval.list", {});
 
     expect(mockGatewayClientStarts).toHaveBeenCalledTimes(1);
     expectStartGatewayClientCall();
@@ -326,6 +327,7 @@ describe("createExecApprovalChannelRuntime", () => {
       id: "abc",
       decision: "deny",
     });
+    expect(mockGatewayClientRequests).toHaveBeenCalledWith("exec.approval.list", {});
   });
 
   it("rejects write RPCs before they reach the approvals-only gateway client", async () => {

--- a/src/infra/exec-approval-channel-runtime.test.ts
+++ b/src/infra/exec-approval-channel-runtime.test.ts
@@ -328,6 +328,32 @@ describe("createExecApprovalChannelRuntime", () => {
     });
   });
 
+  it("rejects write RPCs before they reach the approvals-only gateway client", async () => {
+    const runtime = createExecApprovalChannelRuntime({
+      label: "test/exec-approvals",
+      clientDisplayName: "Test Exec Approvals",
+      cfg: {} as never,
+      isConfigured: () => true,
+      shouldHandle: () => true,
+      deliverRequested: async () => [],
+      finalizeResolved: async () => undefined,
+    });
+
+    await runtime.start();
+    mockGatewayClientRequests.mockClear();
+
+    await expect(
+      runtime.request("send", {
+        channel: "slack",
+        to: "channel:C123",
+        message: "hello",
+      }),
+    ).rejects.toThrow(
+      "test/exec-approvals: operator approvals runtime cannot dispatch send; use a write-capable gateway client",
+    );
+    expect(mockGatewayClientRequests).not.toHaveBeenCalled();
+  });
+
   it("fails startup when gateway client readiness times out before start", async () => {
     mockStartGatewayClientWhenEventLoopReady.mockResolvedValueOnce({
       ready: false,

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -22,6 +22,15 @@ export type {
 type ApprovalRequestEvent = ExecApprovalRequest | PluginApprovalRequest;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
 
+const APPROVAL_RUNTIME_REQUEST_METHODS = new Set([
+  "exec.approval.resolve",
+  "plugin.approval.resolve",
+]);
+
+function isApprovalRuntimeRequestMethod(method: string): boolean {
+  return APPROVAL_RUNTIME_REQUEST_METHODS.has(method);
+}
+
 /** Error raised when the gateway pauses approval reconnects after a terminal startup failure. */
 export class ExecApprovalChannelRuntimeTerminalStartError extends Error {
   readonly detailCode: string | null;
@@ -425,6 +434,11 @@ export function createExecApprovalChannelRuntime<
     handleExpired,
 
     async request<T = unknown>(method: string, params: Record<string, unknown>): Promise<T> {
+      if (!isApprovalRuntimeRequestMethod(method)) {
+        throw new Error(
+          `${adapter.label}: operator approvals runtime cannot dispatch ${method}; use a write-capable gateway client`,
+        );
+      }
       if (!gatewayClient) {
         throw new Error(`${adapter.label}: gateway client not connected`);
       }

--- a/src/infra/exec-approval-channel-runtime.ts
+++ b/src/infra/exec-approval-channel-runtime.ts
@@ -3,6 +3,7 @@ import { readConnectErrorDetailCode } from "../../packages/gateway-protocol/src/
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-readiness.js";
 import type { GatewayClient, GatewayReconnectPausedInfo } from "../gateway/client.js";
+import { isApprovalMethod } from "../gateway/method-scopes.js";
 import { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { formatErrorMessage } from "./errors.js";
@@ -21,15 +22,6 @@ export type {
 
 type ApprovalRequestEvent = ExecApprovalRequest | PluginApprovalRequest;
 type ApprovalResolvedEvent = ExecApprovalResolved | PluginApprovalResolved;
-
-const APPROVAL_RUNTIME_REQUEST_METHODS = new Set([
-  "exec.approval.resolve",
-  "plugin.approval.resolve",
-]);
-
-function isApprovalRuntimeRequestMethod(method: string): boolean {
-  return APPROVAL_RUNTIME_REQUEST_METHODS.has(method);
-}
 
 /** Error raised when the gateway pauses approval reconnects after a terminal startup failure. */
 export class ExecApprovalChannelRuntimeTerminalStartError extends Error {
@@ -434,7 +426,7 @@ export function createExecApprovalChannelRuntime<
     handleExpired,
 
     async request<T = unknown>(method: string, params: Record<string, unknown>): Promise<T> {
-      if (!isApprovalRuntimeRequestMethod(method)) {
+      if (!isApprovalMethod(method)) {
         throw new Error(
           `${adapter.label}: operator approvals runtime cannot dispatch ${method}; use a write-capable gateway client`,
         );


### PR DESCRIPTION
## Summary

- Problem: native approval route notices could send origin-chat notices through the long-lived operator-approvals runtime connection, which only has `operator.approvals`.
- Solution: route those notices through a fresh least-privilege gateway call and keep the approvals runtime restricted to approval resolution RPCs.
- What changed: `approval-native-runtime` now calls `callGatewayLeastPrivilege` for route notice `send`, and `exec-approval-channel-runtime` rejects non-approval methods before they reach the approvals-only client.
- What did NOT change: the operator-approvals runtime still requests only `operator.approvals`; no approval connection scope was widened.
- Why it matters / User impact: approval route notices no longer fail with `missing scope: operator.write` just because the approvals runtime connection was selected as transport.
- Fixes #93563

## Real behavior proof

- **Behavior or issue addressed:**
```text
Native approval route notices could call `send` through the operator-approvals runtime connection.
That connection requests only ["operator.approvals"], while `send` requires `operator.write`, so the server rejects the request with `missing scope: operator.write`.
```

- **Real environment tested:**
```text
Local OpenClaw worktree: /media/vdc/code/ai/aispace/openclaw-worktrees/issue-93563
HEAD: c62d19d9446e3f0a4526b509d72741145a34b1e0
Runtime proof: Node with tsx against the current source tree and gateway/call test dependency injection.
```

- **Exact steps or command run after this patch:**
```bash
pnpm check:architecture
node scripts/run-vitest.mjs src/infra/approval-native-route-coordinator.test.ts src/infra/approval-native-runtime.test.ts src/infra/exec-approval-channel-runtime.test.ts
node --import tsx /media/vdc/code/ai/aispace/openclaw-issue-93563-evidence/gateway-send-scope-proof.mjs
git diff --check HEAD~1..HEAD
```

- **Evidence after fix:**
```text
Import cycle check: 0 runtime value cycle(s).
Madge import cycle check: 0 cycle(s).
deprecated API usage guard passed
Database-first legacy-store guard passed.

Test Files  3 passed (3)
Tests  31 passed (31)

PROOF_RESULT={"ok":true,"method":"send","params":{"channel":"slack","to":"channel:C123","message":"approval routed elsewhere","idempotencyKey":"proof-approval-route-notice"}}
PROOF_CLIENT_NAME=gateway-client
PROOF_CLIENT_MODE=backend
PROOF_CLIENT_SCOPES=["operator.write"]
PROOF_APPROVAL_RUNTIME_TOKEN=absent
```

- **Observed result after fix:**
```text
The approval route notice path now dispatches `send` through `callGatewayLeastPrivilege`, which creates a backend gateway-client scoped to ["operator.write"].
The operator-approvals runtime no longer forwards `send` or other non-approval methods to its approvals-only client; it fails locally with a message telling callers to use a write-capable gateway client.
`git diff --check HEAD~1..HEAD` produced no output.
```

- **What was not tested:**
```text
No live Slack/Discord/Telegram/WhatsApp channel account was used.
No full gateway server was started; the runtime proof exercises the actual gateway call scope resolution with an injected GatewayClient constructor and confirms the outgoing client scopes.
```

- **Fix classification:** Root cause fix

## Review findings addressed

- **RF-001:** N/A for new issue PR; no existing review findings.

## Regression Test Plan

- **Target test file:** `src/infra/approval-native-runtime.test.ts`, `src/infra/exec-approval-channel-runtime.test.ts`, and `src/infra/approval-native-route-coordinator.test.ts`.
- **Scenario locked in:** native approval route notices use a least-privilege write-capable gateway call for `send`, and the operator-approvals runtime rejects write RPCs before touching its approvals-only client.
- **Why this is the smallest reliable guardrail:** the tests cover the transport-selection call site and the runtime misuse boundary without requiring a live external channel account.

## Merge risk

- **Risk labels considered:** message-delivery / security-boundary / availability.
- **Risk explanation:** this touches gateway transport selection for native approval route notices and deliberately preserves least-privilege approval scopes.
- **Why acceptable:** the diff is limited to the native approval route notice path and an approvals-runtime guard; targeted tests and runtime proof confirm `send` resolves to `operator.write` on a backend gateway-client without an approval runtime token.

## Root Cause

- **Root cause:** The root/source defect was a caller transport-selection contract violation: `createChannelNativeApprovalRuntime` injected `runtime.request` into the native approval route reporter, and that request method always used the long-lived operator-approvals runtime client. Because that connection only requested `operator.approvals`, the origin route notice tried to perform the `send`/`operator.write` RPC on a transport that cannot satisfy the gateway method-scope invariant.
- **Why this is root-cause fix:** This fixes the source invariant instead of masking the server error because route notice `send` now selects transport from the gateway method contract via `callGatewayLeastPrivilege`, producing a fresh backend `gateway-client` scoped to `operator.write`. The approvals runtime also rejects non-approval RPCs locally, so future `send`/`message.action` misuse cannot leak onto the approvals-only WebSocket.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High
- **Patch quality notes:** Focused transport fix with regression coverage; no scope widening and no fallback masking.
- **Architecture / source-of-truth check:** Gateway method scope ownership remains in `src/gateway/method-scopes.ts` / core descriptors; this patch changes the caller transport selection before server authorization, not the gateway authorization contract.

## Public contract review

- **Contract surface:** The public contract surface is the gateway protocol scope contract for operator RPCs: `send` / `message.action` require `operator.write`, and approval resolution RPCs use `operator.approvals`.
- **Compatibility / default behavior:** This is backward compatible with the existing default behavior because it does not change method descriptors, method scopes, config schema, migration behavior, or breaking/upgrade semantics. It keeps the operator-approvals runtime at `operator.approvals` and only chooses a write-capable backend client for the existing `send` RPC.
- **Related open PR / competition scan:** Current submission recheck found linked open PR #93643. That PR only changes `approval-native-runtime.ts`; this submission is intentionally broader at the actual misuse boundary because it also adds runtime regression coverage and makes the operator-approvals runtime reject non-approval RPCs before they reach its approvals-only gateway client. The difference matters for #93563 because `send`/`message.action` are `operator.write` methods and future callers should fail locally with an explicit write-capable-client error instead of leaking another write RPC onto the approvals-only WebSocket. The previous linked PR #93614 is closed and unmerged. This PR does not attempt a broader canonical PR for gateway protocol scopes or config defaults.
- **Out of scope:** Out of scope and intentionally left unchanged: server authorization, gateway method-scope descriptors, `send` / `message.action` required scopes, approval runtime token semantics, and live external channel transport behavior.
