### PR TITLE
fix(gateway): warn at startup when a configured channel is blocked from loading

### DIFF
--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -2,11 +2,13 @@
 // summaries, bind URLs, ANSI output, and dangerous config reporting.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import * as manifestRegistry from "../plugins/manifest-registry.js";
 import { formatAgentModelStartupDetails, logGatewayStartup } from "./server-startup-log.js";
 
 describe("gateway startup log", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("warns when dangerous config flags are enabled", async () => {
@@ -196,5 +198,85 @@ describe("gateway startup log", () => {
     expect(listeningMessages).toEqual([
       "http server listening (3 plugins: alpha, beta, delta; 16.0s)",
     ]);
+  });
+
+  // Regression coverage for https://github.com/openclaw/openclaw/issues/91873:
+  // an upgrade-time trust gate would silently drop a configured Slack channel.
+  // Startup must now loudly warn instead of omitting it without any log.
+  it("warns loudly when a configured channel plugin was filtered from startup", async () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "slack",
+          origin: "global",
+          channels: ["slack"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        // Old-style config that worked before the upgrade: Slack channel is
+        // configured with credentials, but plugins.allow is not set.
+        channels: {
+          slack: { enabled: true, botToken: "xoxb-FAKE", appToken: "xapp-FAKE" },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    const channelWarnings = warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((message) => message.startsWith("configured channel not loaded:"));
+    expect(channelWarnings).toHaveLength(1);
+    expect(channelWarnings[0]).toContain("channels.slack");
+    expect(channelWarnings[0]).toContain("slack");
+    expect(channelWarnings[0]).toContain("plugins.entries.slack.enabled=true");
+  });
+
+  it("does not warn when a configured channel plugin is explicitly trusted", async () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "slack",
+          origin: "global",
+          channels: ["slack"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          slack: { enabled: true, botToken: "xoxb-FAKE", appToken: "xapp-FAKE" },
+        },
+        // The reporter's confirmed workaround makes the channel trusted again.
+        plugins: { allow: ["slack"] },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: ["slack"],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    const channelWarnings = warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((message) => message.startsWith("configured channel not loaded:"));
+    expect(channelWarnings).toEqual([]);
   });
 });

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -64,6 +64,12 @@ export async function logGatewayStartup(params: {
     params.log.info("gateway: running in Nix mode (config managed externally)");
   }
 
+  // Surface configured channels whose backing plugin was filtered out of the
+  // startup plan (e.g. an untrusted global/npm-installed channel plugin), so an
+  // upgrade no longer silently drops a configured channel with no failure log.
+  // See https://github.com/openclaw/openclaw/issues/91873.
+  await warnAboutBlockedConfiguredChannels({ cfg: params.cfg, log: params.log });
+
   const enabledDangerousFlags =
     collectEnabledInsecureOrDangerousFlagsFromCurrentSnapshot(params.cfg) ??
     (await import("../security/dangerous-config-flags.js")).collectEnabledInsecureOrDangerousFlags(
@@ -74,6 +80,34 @@ export async function logGatewayStartup(params: {
       `security warning: dangerous config flags enabled: ${enabledDangerousFlags.join(", ")}. ` +
       "Run `openclaw security audit`.";
     params.log.warn(warning);
+  }
+}
+
+/**
+ * Emit a loud warning for every configured channel whose backing plugin cannot
+ * load at startup (e.g. installed-but-untrusted external channel plugin after an
+ * upgrade), instead of silently omitting it from the ready banner.
+ */
+async function warnAboutBlockedConfiguredChannels(params: {
+  cfg: OpenClawConfig;
+  log: { warn: (msg: string) => void };
+}): Promise<void> {
+  try {
+    const channelPluginRuntime = await import(
+      "../commands/doctor/shared/channel-plugin-blockers.js"
+    );
+    const hits = channelPluginRuntime.scanConfiguredChannelPluginBlockers(params.cfg);
+    if (hits.length === 0) {
+      return;
+    }
+    const warnings = channelPluginRuntime.collectConfiguredChannelPluginBlockerWarnings(hits);
+    for (const warning of warnings) {
+      // collectConfiguredChannelPluginBlockerWarnings returns leading "- " bullets
+      // for doctor output; strip them for a single-line gateway warning.
+      params.log.warn(`configured channel not loaded: ${warning.replace(/^[\s-]+/, "")}`);
+    }
+  } catch {
+    // Startup warnings are advisory; never let blocker detection break gateway boot.
   }
 }
 


### PR DESCRIPTION
## Summary

Re #91873. After upgrading to 2026.6.x, a Slack (or any global/config-origin) channel that the user had configured under `channels.*` but did **not** list in `plugins.allow` (or enable via `plugins.entries.<id>.enabled`) is dropped by the plugin trust gate — and the gateway startup is **completely silent about it**. The user sees the ready banner (`http server listening (N plugins: ...)`) with no error, no warning, and their Slack channel just stops working. The reporter confirmed the workaround is `plugins.allow=["slack"]`.

The trust gate itself (`channel-presence-policy` / `gateway-startup-plugin-ids`) is intentional and unchanged here — **whether to restore implicit loading for upgraded configs is a product decision and is out of scope for this PR.** This change only makes the silent drop **loud**, which is what reviewers asked for on the issue ("surface blocked configured channels in gateway startup/status/doctor before users miss messages").

## Changes

- `src/gateway/server-startup-log.ts` — `logGatewayStartup` now reuses the existing doctor blocker scan (`scanConfiguredChannelPluginBlockers` / `collectConfiguredChannelPluginBlockerWarnings`) and emits a startup warning for each configured channel that was blocked from loading, e.g. `configured channel not loaded: channels.slack: <reason>. Add plugins.entries.slack.enabled=true ...`. Wrapped in try/catch — the warning is advisory and never blocks startup. No change to trust-gate semantics, no restored implicit loading, no fallback shim.

## Real behavior proof

**Behavior addressed**: a configured-but-untrusted channel that the gateway drops now produces a startup warning instead of disappearing silently.

**Real environment**: local, Node v22. Drove the real `logGatewayStartup` → real `scanConfiguredChannelPluginBlockers` / blocker-warning collection → real trust-gate decision (`evaluateEffectiveChannelPlugin`), with only the on-disk manifest discovery injected via the project's standard test seam (`vi.spyOn(loadPluginManifestRegistry)` with a real global-origin slack manifest record).

**Evidence (before/after, real functions)**:
```
pre-fix (real source via git stash):  warnings for channels.slack = []        → SILENT (reproduces the bug)
post-fix:                             warnings for channels.slack = 1 warning  → "configured channel not loaded: channels.slack: ... Add plugins.entries.slack.enabled=true ..."
with plugins.allow=["slack"]:         no warning (channel loads)
```

**Observed result**: the blocked channel is surfaced at startup after the fix; the pre-fix function emits nothing. A trust-pre-check (`resolveConfiguredChannelPresencePolicy`) confirms global-origin slack is `effective:false / blockedReasons:["untrusted-plugin"]` without `plugins.allow` and `effective:true` once it's listed — matching the reporter's workaround exactly.

**What was not tested**: no live Slack connection (not needed — this is the config/discovery/startup-logging path); restoring implicit auto-load is deliberately not attempted (product decision).

## Tests and validation

- `src/gateway/server-startup-log.test.ts` (+2): warns with `channels.slack` + the enable hint when the channel is blocked; no warning once `plugins.allow` includes it. **10/10 pass.**
- Negative control: reverting the change makes the positive test fail (empty warnings = silent), confirming the warning comes from this fix.
- `npx oxlint --import-plugin` clean on both changed files.
