### PR TITLE
fix(discord): protect mention aliases in code fences

### DIFF
--- a/extensions/discord/src/mentions.test.ts
+++ b/extensions/discord/src/mentions.test.ts
@@ -103,6 +103,19 @@ describe("rewriteDiscordKnownMentions", () => {
     expect(rewritten).toBe("inline `@alice` fence ```\n@alice\n``` text <@123456789>");
   });
 
+  it("does not end longer code fences at triple-backtick literals inside the body", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const text = '````ts\nconst fence = "```";\n@alice\n```` text @alice';
+    const rewritten = rewriteDiscordKnownMentions(text, {
+      accountId: "default",
+    });
+    expect(rewritten).toBe('````ts\nconst fence = "```";\n@alice\n```` text <@123456789>');
+  });
+
   it("is account-scoped", () => {
     rememberDiscordDirectoryUser({
       accountId: "ops",

--- a/extensions/discord/src/mentions.ts
+++ b/extensions/discord/src/mentions.ts
@@ -8,7 +8,6 @@ import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
 
 type DiscordMentionAliasesConfig = Record<string, string>;
 
-const MARKDOWN_CODE_SEGMENT_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
 const MENTION_CANDIDATE_PATTERN = /(^|[\s([{"'.,;:!?])@([a-z0-9_.-]{2,32}(?:#[0-9]{4})?)/gi;
 const DISCORD_RESERVED_MENTIONS = new Set(["everyone", "here"]);
 const DISCORD_DISCRIMINATOR_SUFFIX = /#\d{4}$/;
@@ -126,6 +125,72 @@ function rewritePlainTextMentions(
   });
 }
 
+function countBacktickRun(text: string, index: number): number {
+  let cursor = index;
+  while (text[cursor] === "`") {
+    cursor += 1;
+  }
+  return cursor - index;
+}
+
+function findSameLineBacktickRun(
+  text: string,
+  startIndex: number,
+  runLength: number,
+): number | null {
+  const delimiter = "`".repeat(runLength);
+  const newlineIndex = text.indexOf("\n", startIndex);
+  const lineEnd = newlineIndex === -1 ? text.length : newlineIndex;
+  const closeIndex = text.indexOf(delimiter, startIndex);
+  return closeIndex !== -1 && closeIndex < lineEnd ? closeIndex + runLength : null;
+}
+
+function findFenceEnd(text: string, startIndex: number, runLength: number): number {
+  let searchIndex = startIndex + runLength;
+  while (searchIndex < text.length) {
+    const newlineIndex = text.indexOf("\n", searchIndex);
+    if (newlineIndex === -1) {
+      return text.length;
+    }
+    let lineCursor = newlineIndex + 1;
+    while (text[lineCursor] === " " && lineCursor - newlineIndex <= 3) {
+      lineCursor += 1;
+    }
+    const closingRunLength = countBacktickRun(text, lineCursor);
+    if (closingRunLength >= runLength) {
+      return lineCursor + closingRunLength;
+    }
+    searchIndex = lineCursor + Math.max(closingRunLength, 1);
+  }
+  return text.length;
+}
+
+function findNextMarkdownCodeSegment(
+  text: string,
+  startIndex: number,
+): { startIndex: number; endIndex: number } | null {
+  let searchIndex = startIndex;
+  while (searchIndex < text.length) {
+    const segmentStart = text.indexOf("`", searchIndex);
+    if (segmentStart === -1) {
+      return null;
+    }
+    const runLength = countBacktickRun(text, segmentStart);
+    const inlineEndIndex = findSameLineBacktickRun(text, segmentStart + runLength, runLength);
+    if (inlineEndIndex !== null) {
+      return { startIndex: segmentStart, endIndex: inlineEndIndex };
+    }
+    if (runLength >= 3) {
+      return {
+        startIndex: segmentStart,
+        endIndex: findFenceEnd(text, segmentStart, runLength),
+      };
+    }
+    searchIndex = segmentStart + runLength;
+  }
+  return null;
+}
+
 export function rewriteDiscordKnownMentions(
   text: string,
   params: {
@@ -138,12 +203,12 @@ export function rewriteDiscordKnownMentions(
   }
   let rewritten = "";
   let offset = 0;
-  MARKDOWN_CODE_SEGMENT_PATTERN.lastIndex = 0;
-  for (const match of text.matchAll(MARKDOWN_CODE_SEGMENT_PATTERN)) {
-    const matchIndex = match.index ?? 0;
-    rewritten += rewritePlainTextMentions(text.slice(offset, matchIndex), params);
-    rewritten += match[0];
-    offset = matchIndex + match[0].length;
+  let segment = findNextMarkdownCodeSegment(text, offset);
+  while (segment) {
+    rewritten += rewritePlainTextMentions(text.slice(offset, segment.startIndex), params);
+    rewritten += text.slice(segment.startIndex, segment.endIndex);
+    offset = segment.endIndex;
+    segment = findNextMarkdownCodeSegment(text, offset);
   }
   rewritten += rewritePlainTextMentions(text.slice(offset), params);
   return rewritten;


### PR DESCRIPTION
## Summary
Repair and finalize #90648 for #90643. Discord mention alias rewriting should skip Markdown fenced code regions even when the code body contains a triple-backtick literal, while still rewriting handles after the real closing fence.

## Credit
This carries forward @rohitjavvadi's source PR: https://github.com/openclaw/openclaw/pull/90648.

## Validation
- pnpm -s vitest run extensions/discord/src/mentions.test.ts
- pnpm check:changed

## Merge-prep requirements
Refresh the branch against current main, run Codex /review on the latest head, address any findings, and merge only after review comments and bot findings are resolved.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-252-autonomous-terminal-gap
- Source PRs: https://github.com/openclaw/openclaw/pull/90648
- Credit: Repair the existing contributor PR from @rohitjavvadi and preserve attribution to https://github.com/openclaw/openclaw/pull/90648.; The PR body should state that the scanner approach and regression coverage come from source PR #90648.
- Validation: pnpm -s vitest run extensions/discord/src/mentions.test.ts; pnpm check:changed
- Repair fallback: source PR #90648 is a fork branch requiring rebase; use replacement branch because GitHub App pushes to contributor forks can be rejected when rebased upstream history includes workflow files

fish notes: model gpt-5.5, reasoning medium; reviewed against 3204295ff399.
