### PR TITLE
fix(control-ui): copy code blocks over plain HTTP via clipboard fallback

### DIFF
--- a/ui/src/ui/chat/clipboard.test.ts
+++ b/ui/src/ui/chat/clipboard.test.ts
@@ -1,0 +1,84 @@
+// Control UI tests cover clipboard copy fallback behavior.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "./clipboard.ts";
+
+// jsdom does not implement document.execCommand, so install a controllable mock
+// per test and remove it afterwards to keep the fallback path observable.
+function mockExecCommand(result: boolean): ReturnType<typeof vi.fn> {
+  const exec = vi.fn().mockReturnValue(result);
+  (document as unknown as { execCommand: unknown }).execCommand = exec;
+  return exec;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete (document as unknown as { execCommand?: unknown }).execCommand;
+});
+
+describe("copyToClipboard", () => {
+  it("returns false without touching the clipboard for empty text", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const exec = mockExecCommand(true);
+
+    expect(await copyToClipboard("")).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("uses the async Clipboard API in secure contexts", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const exec = mockExecCommand(true);
+
+    expect(await copyToClipboard("hello")).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand when the Clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const exec = mockExecCommand(true);
+
+    expect(await copyToClipboard("hello")).toBe(true);
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("falls back to execCommand over plain HTTP where navigator.clipboard is undefined", async () => {
+    vi.stubGlobal("navigator", {});
+    const exec = mockExecCommand(true);
+
+    expect(await copyToClipboard("hello")).toBe(true);
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("returns false when both clipboard paths fail", async () => {
+    vi.stubGlobal("navigator", {});
+    const exec = mockExecCommand(false);
+
+    expect(await copyToClipboard("hello")).toBe(false);
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("restores focus after the execCommand fallback", async () => {
+    vi.stubGlobal("navigator", {});
+    mockExecCommand(true);
+    const button = document.createElement("button");
+    document.body.append(button);
+    button.focus();
+    button.disabled = true;
+
+    expect(await copyToClipboard("hello")).toBe(true);
+    button.disabled = false;
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+    expect(document.activeElement).toBe(button);
+
+    button.remove();
+  });
+});

--- a/ui/src/ui/chat/clipboard.ts
+++ b/ui/src/ui/chat/clipboard.ts
@@ -1,0 +1,52 @@
+// Clipboard copy helper shared by chat copy affordances.
+//
+// The async Clipboard API is only exposed in secure contexts (HTTPS or
+// localhost). On plain-HTTP deployments (e.g. LAN access) `navigator.clipboard`
+// is undefined, so calling it throws synchronously rather than rejecting. Guard
+// the secure-context path and fall back to the legacy execCommand copy so the
+// copy buttons keep working over HTTP. Returns whether the copy succeeded.
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!text) {
+    return false;
+  }
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Secure-context API present but rejected (e.g. denied permission);
+      // fall through to the execCommand path before giving up.
+    }
+  }
+  return copyWithExecCommand(text);
+}
+
+function copyWithExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  const previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : undefined;
+  textarea.value = text;
+  // Keep the scratch node off-screen so the selection does not scroll or flash.
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+    if (previouslyFocused?.isConnected) {
+      window.setTimeout(() => {
+        const activeElement = document.activeElement;
+        if (
+          previouslyFocused.isConnected &&
+          (!activeElement || activeElement === document.body)
+        ) {
+          previouslyFocused.focus();
+        }
+      }, 0);
+    }
+  }
+}

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -1,6 +1,7 @@
 // Control UI chat module implements copy as markdown behavior.
 import { html, type TemplateResult } from "lit";
 import { icons } from "../icons.ts";
+import { copyToClipboard } from "./clipboard.ts";
 
 const COPIED_FOR_MS = 1500;
 const ERROR_FOR_MS = 2000;
@@ -12,19 +13,6 @@ type CopyButtonOptions = {
   text: () => string;
   label?: string;
 };
-
-async function copyTextToClipboard(text: string): Promise<boolean> {
-  if (!text) {
-    return false;
-  }
-
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function setButtonLabel(button: HTMLButtonElement, label: string) {
   button.title = label;
@@ -50,7 +38,7 @@ function createCopyButton(options: CopyButtonOptions): TemplateResult {
         btn.setAttribute("aria-busy", "true");
         btn.disabled = true;
 
-        const copied = await copyTextToClipboard(options.text());
+        const copied = await copyToClipboard(options.text());
         if (!btn.isConnected) {
           return;
         }

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -221,6 +221,64 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("copies a code block over a non-secure context via the execCommand fallback", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    // Simulate a plain-HTTP (non-secure) deployment: navigator.clipboard is
+    // undefined there, so the Clipboard API path throws. Capture the legacy
+    // execCommand copy the fallback should use instead.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+      (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec = [];
+      document.execCommand = ((command: string) => {
+        if (command !== "copy") {
+          return false;
+        }
+        // execCommand("copy") copies the active selection; the fallback selects
+        // its off-screen scratch textarea, so the focused element holds the text.
+        const active = document.activeElement as HTMLTextAreaElement | null;
+        (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec.push(
+          active?.value ?? "",
+        );
+        return true;
+      }) as typeof document.execCommand;
+    });
+    const code = "const hello = 1;";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: `\`\`\`js\n${code}\n\`\`\``, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const copyButton = page.locator(".code-block-copy").first();
+      await copyButton.waitFor({ timeout: 10_000 });
+      await copyButton.click();
+
+      await expect
+        .poll(() => copyButton.evaluate((el) => el.classList.contains("copied")), {
+          timeout: 10_000,
+        })
+        .toBe(true);
+      const copied = await page.evaluate(
+        () => (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec,
+      );
+      expect(copied).toContain(code);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("starts the workspace files panel collapsed and toggles it open", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -19,6 +19,7 @@ import { buildChatItems, type BuildChatItemsProps } from "../chat/build-chat-ite
 import { renderChatQueue } from "../chat/chat-queue.ts";
 import { buildRawSidebarContent } from "../chat/chat-sidebar-raw.ts";
 import { renderWelcomeState, resolveAssistantDisplayAvatar } from "../chat/chat-welcome.ts";
+import { copyToClipboard } from "../chat/clipboard.ts";
 import { renderContextNotice } from "../chat/context-notice.ts";
 import { DeletedMessages } from "../chat/deleted-messages.ts";
 import { exportChatMarkdown } from "../chat/export.ts";
@@ -1989,13 +1990,13 @@ export function renderChat(props: ChatProps) {
       return;
     }
     const code = (btn as HTMLElement).dataset.code ?? "";
-    navigator.clipboard.writeText(code).then(
-      () => {
-        btn.classList.add("copied");
-        setTimeout(() => btn.classList.remove("copied"), 1500);
-      },
-      () => {},
-    );
+    void copyToClipboard(code).then((copied) => {
+      if (!copied) {
+        return;
+      }
+      btn.classList.add("copied");
+      setTimeout(() => btn.classList.remove("copied"), 1500);
+    });
   };
   const handleChatThreadScroll = (event: Event) => {
     maybeExpandChatHistoryRenderWindow(event, requestUpdate);


### PR DESCRIPTION
## Summary

The code block copy button silently fails when OpenClaw is accessed over a plain-HTTP LAN address (e.g. a NAS at `http://192.168.x.x:9090`). The async Clipboard API is only exposed in **secure contexts** (HTTPS or `localhost`), so on plain HTTP `navigator.clipboard` is `undefined` and the existing `navigator.clipboard.writeText(...)` call throws synchronously, leaving the user with no feedback.

This adds a shared `copyToClipboard` helper that:

- uses the async Clipboard API when it is actually available (secure context),
- falls back to the legacy `document.execCommand("copy")` path (off-screen textarea) when the Clipboard API is missing or rejects,
- returns whether the copy succeeded so callers can show the "Copied" state only on success.

The helper is reused by both copy affordances so the behavior cannot drift:

- the code block copy button (`ui/src/ui/views/chat.ts`),
- the "copy as markdown" affordance (`ui/src/ui/chat/copy-as-markdown.ts`), which previously had its own private copy implementation that is now deleted.

Net diff stays small (one new helper + one test + a deduplication that removes the duplicate copy logic).

Fixes #93628

## Files

- `ui/src/ui/chat/clipboard.ts` (new) — shared `copyToClipboard` helper with secure-context guard + execCommand fallback.
- `ui/src/ui/views/chat.ts` — code block copy button uses the helper; only marks `.copied` on success.
- `ui/src/ui/chat/copy-as-markdown.ts` — reuses the shared helper, drops its private duplicate.
- `ui/src/ui/chat/clipboard.test.ts` (new) — unit coverage.
- `ui/src/ui/e2e/chat-flow.e2e.test.ts` — real-browser e2e proof.

## Verification

Local, on top of latest `origin/main`:

- `node scripts/run-vitest.mjs run ui/src/ui/chat/clipboard.test.ts` — 5 passed (secure-context path, execCommand fallback, `navigator.clipboard` undefined, execCommand failure, empty input).
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "execCommand fallback"` — 1 passed (real Chromium).
- `pnpm tsgo:core` and UI test typecheck — pass.
- `oxfmt --check` and `oxlint` on changed files — clean.

## Real behavior proof

- **Behavior addressed:** Code block copy button does nothing over plain HTTP because `navigator.clipboard` is undefined in a non-secure context, throwing synchronously with no fallback and no user feedback.
- **Real environment tested:** Real Chromium browser via the Control UI e2e harness (Playwright + mocked Gateway), with `navigator.clipboard` forced to `undefined` to reproduce the exact non-secure-context condition reported on HTTP LAN access.
- **Exact steps or command run after this patch:** Render an assistant message containing a fenced code block, with `navigator.clipboard` set to `undefined` via an init script, then click the `.code-block-copy` button. The test captures what `execCommand("copy")` would copy via the focused selection.
- **Evidence after fix:** The captured copy text equals the code block content (`const hello = 1;`), the button enters the `.copied` ("Copied!") state, and no errors are thrown. A screenshot of the green "Copied!" badge in the non-secure context was captured locally during the e2e run.
- **Observed result after fix:** Copy succeeds via the execCommand fallback over a non-secure (HTTP-equivalent) context; the secure-context path is unchanged for HTTPS/localhost.
- **What was not tested:** A literal physical NAS deployment over an HTTP LAN IP (reproduced the underlying mechanism in a real browser instead); manual paste-target verification of OS clipboard contents inside headless Chromium.

## Notes

A few other call sites still call `navigator.clipboard.writeText` directly (outside the chat copy affordances). I kept this PR scoped to the reported code block path plus the adjacent copy-as-markdown duplicate; migrating the remaining sites to the shared helper can be a small follow-up.
