### PR TITLE
fix(browser): recover stale managed Chrome CDP listener

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -66,6 +66,8 @@ import {
 } from "./chrome.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 
+const CHROME_TEST_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+
 /**
  * Covers the parts of chrome.ts that the mainline chrome.test.ts does
  * not exercise: launchOpenClawChrome (with child_process.spawn mocked),
@@ -154,7 +156,7 @@ async function withMockChromeCdpServer(params: {
     res.writeHead(404);
     res.end();
   });
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES });
   server.on("upgrade", (req, socket, head) => {
     if (req.url !== params.wsPath) {
       socket.destroy();
@@ -746,6 +748,107 @@ describe("chrome.ts internal", () => {
       });
     });
 
+    it("stops a lock-owned stale managed CDP listener before relaunching", async () => {
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      const existsSync = fs.existsSync.bind(fs);
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return existsSync(p);
+      });
+      const portBusy = new Error("Port is already in use.");
+      portBusy.name = "PortInUseError";
+      ensurePortAvailableMock.mockRejectedValueOnce(portBusy).mockResolvedValue(undefined);
+
+      const stalePid = 43210;
+      let staleProcessAlive = true;
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid, signal) => {
+        if (pid !== stalePid) {
+          return true;
+        }
+        if (signal === 0) {
+          if (staleProcessAlive) {
+            return true;
+          }
+          const err = new Error("no such process") as NodeJS.ErrnoException;
+          err.code = "ESRCH";
+          throw err;
+        }
+        if (signal === "SIGTERM") {
+          staleProcessAlive = false;
+          return true;
+        }
+        return true;
+      }) as typeof process.kill);
+
+      const fakeProc = makeFakeProc();
+      spawnMock.mockReturnValue(fakeProc);
+
+      await withMockChromeCdpServer({
+        wsPath: "/devtools/browser/STALE_OWNER",
+        onConnection: (wss) => {
+          wss.on("connection", (_ws) => {
+            // The stale listener accepts the WebSocket but never answers
+            // Browser.getVersion, matching the recovery gate in chrome.ts.
+          });
+        },
+        run: async (baseUrl) => {
+          const port = Number(new URL(baseUrl).port);
+          const profile = {
+            ...makeProfile(port),
+            cdpUrl: baseUrl,
+            executablePath,
+          } as ResolvedBrowserProfile;
+          const userDataDir = resolveOpenClawUserDataDir(profile.name);
+          await fsp.mkdir(userDataDir, { recursive: true });
+          await fsp.writeFile(path.join(userDataDir, "SingletonCookie"), "cookie");
+          await fsp.writeFile(path.join(userDataDir, "SingletonSocket"), "socket");
+          await fsp.symlink(
+            `${os.hostname()}-${stalePid}`,
+            path.join(userDataDir, "SingletonLock"),
+          );
+
+          try {
+            const running = await launchOpenClawChrome(makeResolved(), profile);
+            expect(running.proc).toBe(fakeProc);
+            expect(ensurePortAvailableMock).toHaveBeenCalledTimes(2);
+            expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+            expect(spawnMock).toHaveBeenCalledTimes(1);
+            expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
+            expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
+            running.proc.kill?.("SIGTERM");
+          } finally {
+            await fsp.rm(userDataDir, { recursive: true, force: true });
+          }
+        },
+      });
+    });
+
+    it("does not stop a stale CDP listener without current-host profile ownership proof", async () => {
+      const portBusy = new Error("Port is already in use.");
+      portBusy.name = "PortInUseError";
+      ensurePortAvailableMock.mockRejectedValue(portBusy);
+      const killSpy = vi.spyOn(process, "kill");
+
+      const profile = makeProfile(55554);
+      const userDataDir = resolveOpenClawUserDataDir(profile.name);
+      await fsp.mkdir(userDataDir, { recursive: true });
+      await fsp.symlink("remote-host-43210", path.join(userDataDir, "SingletonLock"));
+
+      try {
+        await expect(launchOpenClawChrome(makeResolved(), profile)).rejects.toThrow(
+          "Port is already in use.",
+        );
+        expect(killSpy).not.toHaveBeenCalledWith(43210, "SIGTERM");
+        expect(spawnMock).not.toHaveBeenCalled();
+      } finally {
+        await fsp.rm(userDataDir, { recursive: true, force: true });
+      }
+    });
+
     it("throws with stderr hint + sandbox hint when CDP never becomes reachable", async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, "platform", { value: "linux" });
@@ -956,7 +1059,11 @@ describe("chrome.ts internal", () => {
   describe("canOpenWebSocket", () => {
     it("resolves false when the direct-ws probe cannot connect", async () => {
       // Bind a ws server and then close it, so connecting to it fails.
-      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      const wss = new WebSocketServer({
+        port: 0,
+        host: "127.0.0.1",
+        maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES,
+      });
       await new Promise<void>((resolve) => {
         wss.once("listening", () => resolve());
       });
@@ -970,7 +1077,11 @@ describe("chrome.ts internal", () => {
     });
 
     it("resolves true when the direct-ws handshake succeeds", async () => {
-      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      const wss = new WebSocketServer({
+        port: 0,
+        host: "127.0.0.1",
+        maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES,
+      });
       await new Promise<void>((resolve) => {
         wss.once("listening", () => resolve());
       });
@@ -1006,7 +1117,11 @@ describe("chrome.ts internal", () => {
       // Serve /json/version pointing at a port that's not actually
       // accepting ws upgrades — the canRunCdpHealthCommand probe will
       // fire its 'error' handler during handshake.
-      const dead = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      const dead = new WebSocketServer({
+        port: 0,
+        host: "127.0.0.1",
+        maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES,
+      });
       await new Promise<void>((resolve) => {
         dead.once("listening", () => resolve());
       });

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -137,6 +137,94 @@ function mockExpiredLaunchPollingClock(): void {
   });
 }
 
+function linuxProcStatLine(pid: number, startTime: string): string {
+  const fieldsAfterCommand = [
+    "S",
+    "1",
+    "1",
+    "1",
+    "0",
+    "-1",
+    "4194560",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "0",
+    "20",
+    "0",
+    "1",
+    "0",
+    startTime,
+    "0",
+    "0",
+  ];
+  return `${pid} (chrome) ${fieldsAfterCommand.join(" ")}`;
+}
+
+function linuxTcpTableForPort(port: number, inode: string): string {
+  const portHex = port.toString(16).toUpperCase().padStart(4, "0");
+  return [
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+    `   0: 0100007F:${portHex} 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 ${inode}`,
+  ].join("\n");
+}
+
+function mockLinuxManagedChromeOwnership(params: {
+  pid: number;
+  port: number;
+  executablePath: string;
+  userDataDir: string;
+  argvExecutablePath?: string;
+  ownsPort?: boolean;
+  extraArgs?: string[];
+}) {
+  const ownsPort = params.ownsPort ?? true;
+  const inode = "889001";
+  const argv = [
+    params.argvExecutablePath ?? params.executablePath,
+    `--remote-debugging-port=${params.port}`,
+    `--user-data-dir=${params.userDataDir}`,
+    ...(params.extraArgs ?? []),
+  ];
+  const readFileSync = fs.readFileSync.bind(fs);
+  vi.spyOn(fs, "readFileSync").mockImplementation(((filePath, options) => {
+    const s = String(filePath);
+    if (s === `/proc/${params.pid}/cmdline`) {
+      return Buffer.from(`${argv.join("\0")}\0`);
+    }
+    if (s === `/proc/${params.pid}/stat`) {
+      return linuxProcStatLine(params.pid, "1234567");
+    }
+    if (s === "/proc/net/tcp") {
+      return ownsPort ? linuxTcpTableForPort(params.port, inode) : linuxTcpTableForPort(1, inode);
+    }
+    if (s === "/proc/net/tcp6") {
+      return "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+    }
+    return readFileSync(filePath, options as never);
+  }) as typeof fs.readFileSync);
+
+  const readdirSync = fs.readdirSync.bind(fs);
+  vi.spyOn(fs, "readdirSync").mockImplementation(((dirPath, options) => {
+    if (String(dirPath) === `/proc/${params.pid}/fd`) {
+      return ownsPort ? (["7"] as never) : ([] as never);
+    }
+    return readdirSync(dirPath, options as never);
+  }) as typeof fs.readdirSync);
+
+  const readlinkSync = fs.readlinkSync.bind(fs);
+  vi.spyOn(fs, "readlinkSync").mockImplementation(((linkPath, options) => {
+    if (String(linkPath) === `/proc/${params.pid}/fd/7`) {
+      return `socket:[${inode}]`;
+    }
+    return readlinkSync(linkPath, options as never);
+  }) as typeof fs.readlinkSync);
+}
+
 async function withMockChromeCdpServer(params: {
   wsPath: string;
   onConnection?: (wss: WebSocketServer) => void;
@@ -749,6 +837,7 @@ describe("chrome.ts internal", () => {
     });
 
     it("stops a lock-owned stale managed CDP listener before relaunching", async () => {
+      const originalPlatform = process.platform;
       const executablePath = path.join(tmpDir, "chrome");
       await fsp.writeFile(executablePath, "");
       const existsSync = fs.existsSync.bind(fs);
@@ -787,44 +876,138 @@ describe("chrome.ts internal", () => {
       const fakeProc = makeFakeProc();
       spawnMock.mockReturnValue(fakeProc);
 
-      await withMockChromeCdpServer({
-        wsPath: "/devtools/browser/STALE_OWNER",
-        onConnection: (wss) => {
-          wss.on("connection", (_ws) => {
-            // The stale listener accepts the WebSocket but never answers
-            // Browser.getVersion, matching the recovery gate in chrome.ts.
-          });
-        },
-        run: async (baseUrl) => {
-          const port = Number(new URL(baseUrl).port);
-          const profile = {
-            ...makeProfile(port),
-            cdpUrl: baseUrl,
-            executablePath,
-          } as ResolvedBrowserProfile;
-          const userDataDir = resolveOpenClawUserDataDir(profile.name);
-          await fsp.mkdir(userDataDir, { recursive: true });
-          await fsp.writeFile(path.join(userDataDir, "SingletonCookie"), "cookie");
-          await fsp.writeFile(path.join(userDataDir, "SingletonSocket"), "socket");
-          await fsp.symlink(
-            `${os.hostname()}-${stalePid}`,
-            path.join(userDataDir, "SingletonLock"),
-          );
+      Object.defineProperty(process, "platform", { value: "linux" });
+      try {
+        await withMockChromeCdpServer({
+          wsPath: "/devtools/browser/STALE_OWNER",
+          onConnection: (wss) => {
+            wss.on("connection", (_ws) => {
+              // The stale listener accepts the WebSocket but never answers
+              // Browser.getVersion, matching the recovery gate in chrome.ts.
+            });
+          },
+          run: async (baseUrl) => {
+            const port = Number(new URL(baseUrl).port);
+            const profile = {
+              ...makeProfile(port),
+              cdpUrl: baseUrl,
+              executablePath,
+            } as ResolvedBrowserProfile;
+            const userDataDir = resolveOpenClawUserDataDir(profile.name);
+            mockLinuxManagedChromeOwnership({
+              pid: stalePid,
+              port,
+              executablePath,
+              userDataDir,
+            });
+            await fsp.mkdir(userDataDir, { recursive: true });
+            await fsp.writeFile(path.join(userDataDir, "SingletonCookie"), "cookie");
+            await fsp.writeFile(path.join(userDataDir, "SingletonSocket"), "socket");
+            await fsp.symlink(
+              `${os.hostname()}-${stalePid}`,
+              path.join(userDataDir, "SingletonLock"),
+            );
 
-          try {
-            const running = await launchOpenClawChrome(makeResolved(), profile);
-            expect(running.proc).toBe(fakeProc);
-            expect(ensurePortAvailableMock).toHaveBeenCalledTimes(2);
-            expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
-            expect(spawnMock).toHaveBeenCalledTimes(1);
-            expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
-            expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
-            running.proc.kill?.("SIGTERM");
-          } finally {
-            await fsp.rm(userDataDir, { recursive: true, force: true });
-          }
-        },
+            try {
+              const running = await launchOpenClawChrome(makeResolved(), profile);
+              expect(running.proc).toBe(fakeProc);
+              expect(ensurePortAvailableMock).toHaveBeenCalledTimes(2);
+              expect(killSpy).toHaveBeenCalledWith(stalePid, "SIGTERM");
+              expect(spawnMock).toHaveBeenCalledTimes(1);
+              expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
+              expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
+              running.proc.kill?.("SIGTERM");
+            } finally {
+              await fsp.rm(userDataDir, { recursive: true, force: true });
+            }
+          },
+        });
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
+    });
+
+    it("does not stop a current-host lock pid without managed Chrome ownership proof", async () => {
+      const originalPlatform = process.platform;
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      const existsSync = fs.existsSync.bind(fs);
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return existsSync(p);
       });
+      const portBusy = new Error("Port is already in use.");
+      portBusy.name = "PortInUseError";
+      ensurePortAvailableMock.mockRejectedValue(portBusy);
+
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid, signal) => {
+        if ((pid === 43211 || pid === 43212) && signal === 0) {
+          return true;
+        }
+        return true;
+      }) as typeof process.kill);
+
+      Object.defineProperty(process, "platform", { value: "linux" });
+      try {
+        for (const testCase of [
+          { pid: 43211, ownsPort: false, argvExecutablePath: executablePath },
+          { pid: 43212, ownsPort: true, argvExecutablePath: path.join(tmpDir, "other-browser") },
+        ]) {
+          await withMockChromeCdpServer({
+            wsPath: `/devtools/browser/STALE_NON_OWNER_${testCase.pid}`,
+            onConnection: (wss) => {
+              wss.on("connection", () => {
+                // Keep the WebSocket stale so the only missing proof is process
+                // ownership of the exact managed Chrome launch.
+              });
+            },
+            run: async (baseUrl) => {
+              const port = Number(new URL(baseUrl).port);
+              const profile = {
+                ...makeProfile(port),
+                cdpUrl: baseUrl,
+                executablePath,
+              } as ResolvedBrowserProfile;
+              const userDataDir = resolveOpenClawUserDataDir(`${profile.name}-${testCase.pid}`);
+              const profileWithUniqueName = {
+                ...profile,
+                name: `${profile.name}-${testCase.pid}`,
+              } as ResolvedBrowserProfile;
+              mockLinuxManagedChromeOwnership({
+                pid: testCase.pid,
+                port,
+                executablePath,
+                argvExecutablePath: testCase.argvExecutablePath,
+                userDataDir,
+                ownsPort: testCase.ownsPort,
+              });
+              await fsp.mkdir(userDataDir, { recursive: true });
+              await fsp.symlink(
+                `${os.hostname()}-${testCase.pid}`,
+                path.join(userDataDir, "SingletonLock"),
+              );
+
+              try {
+                await expect(
+                  launchOpenClawChrome(makeResolved(), profileWithUniqueName),
+                ).rejects.toThrow("Port is already in use.");
+                expect(killSpy).not.toHaveBeenCalledWith(testCase.pid, "SIGTERM");
+                expect(spawnMock).not.toHaveBeenCalled();
+                await expect(
+                  fsp.lstat(path.join(userDataDir, "SingletonLock")),
+                ).resolves.toBeTruthy();
+              } finally {
+                await fsp.rm(userDataDir, { recursive: true, force: true });
+              }
+            },
+          });
+        }
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
     });
 
     it("does not stop a stale CDP listener without current-host profile ownership proof", async () => {

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -36,6 +36,8 @@ import {
 import { BrowserCdpEndpointBlockedError } from "./errors.js";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 
+const CHROME_TEST_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+
 type StopChromeTarget = Parameters<typeof stopOpenClawChrome>[0];
 type ChromeCdpDiagnostic = Awaited<ReturnType<typeof diagnoseChromeCdp>>;
 
@@ -90,7 +92,7 @@ async function withMockChromeCdpServer(params: {
     res.writeHead(404);
     res.end();
   });
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES });
   server.on("upgrade", (req, socket, head) => {
     if (!req.url?.startsWith(params.wsPath)) {
       socket.destroy();
@@ -730,7 +732,10 @@ describe("browser chrome helpers", () => {
       res.writeHead(404);
       res.end();
     });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({
+      noServer: true,
+      maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES,
+    });
     server.on("upgrade", (req, socket, head) => {
       if (req.url?.startsWith("/e/bad")) {
         socket.destroy();
@@ -795,7 +800,11 @@ describe("browser chrome helpers", () => {
       } as unknown as Response),
     );
     // A real WS server accepts the handshake.
-    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    const wss = new WebSocketServer({
+      port: 0,
+      host: "127.0.0.1",
+      maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES,
+    });
     await new Promise<void>((resolve) => {
       wss.once("listening", () => resolve());
     });
@@ -817,7 +826,11 @@ describe("browser chrome helpers", () => {
         json: async () => ({}),
       } as unknown as Response),
     );
-    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    const wss = new WebSocketServer({
+      port: 0,
+      host: "127.0.0.1",
+      maxPayload: CHROME_TEST_WS_MAX_PAYLOAD_BYTES,
+    });
     wss.on("connection", (ws) => {
       ws.on("message", (raw) => {
         const message = JSON.parse(rawDataToString(raw)) as { id?: number; method?: string };

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -4,7 +4,12 @@
  * Builds launch args, starts/stops managed Chrome, probes CDP readiness, and
  * resolves WebSocket endpoints for browser control.
  */
-import { type ChildProcess, type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import {
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+  execFileSync,
+  spawn,
+} from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -86,6 +91,7 @@ const CHROME_HTTP_DISCOVERY_FAILURE_CODES = new Set([
   "http_status_failed",
   "invalid_json",
 ]);
+const TCP_LISTEN_STATE_HEX = "0A";
 
 export type { BrowserExecutable } from "./chrome.executables.js";
 export {
@@ -139,6 +145,288 @@ function processExists(pid: number): boolean {
   }
 }
 
+function readSingletonLockTarget(userDataDir: string): { hostname: string; pid: number } | null {
+  let target: string;
+  try {
+    target = fs.readlinkSync(path.join(userDataDir, "SingletonLock"));
+  } catch {
+    return null;
+  }
+  const match = /^(?<lockHost>.+)-(?<pid>\d+)$/.exec(target);
+  if (!match?.groups) {
+    return null;
+  }
+  const hostname = normalizeOptionalString(match.groups.lockHost) ?? "";
+  const pid = Number.parseInt(match.groups.pid ?? "", 10);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+  return { hostname, pid };
+}
+
+function readLinuxProcessStartTime(pid: number): string | null {
+  let stat: string;
+  try {
+    stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+  } catch {
+    return null;
+  }
+  const afterCommand = stat.slice(stat.lastIndexOf(")") + 2);
+  const fields = afterCommand.split(/\s+/);
+  return normalizeOptionalString(fields[19]) ?? null;
+}
+
+function readLinuxProcessArgv(pid: number): string[] | null {
+  let cmdline: Buffer;
+  try {
+    cmdline = fs.readFileSync(`/proc/${pid}/cmdline`);
+  } catch {
+    return null;
+  }
+  const argv = cmdline
+    .toString("utf8")
+    .split("\0")
+    .filter((arg) => arg.length > 0);
+  return argv.length > 0 ? argv : null;
+}
+
+function readPsCommandLine(pid: number): string | null {
+  try {
+    return (
+      normalizeOptionalString(
+        execFileSync("ps", ["-ww", "-p", String(pid), "-o", "command="], {
+          encoding: "utf8",
+          timeout: 1000,
+          maxBuffer: 64 * 1024,
+        }),
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function readPsStartTime(pid: number): string | null {
+  try {
+    return (
+      normalizeOptionalString(
+        execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
+          encoding: "utf8",
+          timeout: 1000,
+          maxBuffer: 64 * 1024,
+        }),
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+function readManagedProcessCommandLine(pid: number): {
+  argv: string[] | null;
+  text: string;
+  startTime: string | null;
+} | null {
+  if (process.platform === "linux") {
+    const argv = readLinuxProcessArgv(pid);
+    if (!argv) {
+      return null;
+    }
+    const startTime = readLinuxProcessStartTime(pid);
+    if (!startTime) {
+      return null;
+    }
+    return {
+      argv,
+      text: argv.join(" "),
+      startTime,
+    };
+  }
+  if (process.platform === "darwin") {
+    const text = readPsCommandLine(pid);
+    const startTime = readPsStartTime(pid);
+    if (!text || !startTime) {
+      return null;
+    }
+    return { argv: null, text, startTime };
+  }
+  return null;
+}
+
+function isChromeExecutableFamilyMatch(commandText: string, exe: BrowserExecutable): boolean {
+  const normalizedCommand = commandText.toLowerCase();
+  const configuredPath = exe.path.toLowerCase();
+  const configuredBase = path.basename(exe.path).toLowerCase();
+  if (
+    normalizedCommand.includes(configuredPath) ||
+    (configuredBase.length > 0 && normalizedCommand.includes(configuredBase))
+  ) {
+    return true;
+  }
+  if (exe.kind === "chrome" || exe.kind === "canary") {
+    return /\b(google chrome|google-chrome|chrome|chromium)\b/i.test(commandText);
+  }
+  if (exe.kind === "chromium") {
+    return /\b(chromium|chromium-browser)\b/i.test(commandText);
+  }
+  if (exe.kind === "brave") {
+    return /\b(brave browser|brave-browser|brave)\b/i.test(commandText);
+  }
+  if (exe.kind === "edge") {
+    return /\b(microsoft edge|microsoft-edge|msedge)\b/i.test(commandText);
+  }
+  return false;
+}
+
+function processCommandHasArg(
+  command: { argv: string[] | null; text: string },
+  expected: string,
+): boolean {
+  if (command.argv) {
+    return command.argv.includes(expected);
+  }
+  return command.text.includes(expected);
+}
+
+function commandLineMatchesManagedChrome(params: {
+  command: { argv: string[] | null; text: string };
+  exe: BrowserExecutable;
+  profile: ResolvedBrowserProfile;
+  userDataDir: string;
+}): boolean {
+  return (
+    isChromeExecutableFamilyMatch(params.command.text, params.exe) &&
+    processCommandHasArg(params.command, `--remote-debugging-port=${params.profile.cdpPort}`) &&
+    processCommandHasArg(params.command, `--user-data-dir=${params.userDataDir}`)
+  );
+}
+
+function parseLinuxTcpListenInodesForPort(table: string, port: number): Set<string> {
+  const expectedPort = port.toString(16).toUpperCase().padStart(4, "0");
+  const inodes = new Set<string>();
+  for (const line of table.split(/\r?\n/).slice(1)) {
+    const fields = line.trim().split(/\s+/);
+    const localAddress = fields[1] ?? "";
+    const state = fields[3] ?? "";
+    const inode = fields[9] ?? "";
+    const localPort = localAddress.split(":").at(-1)?.toUpperCase();
+    if (localPort === expectedPort && state === TCP_LISTEN_STATE_HEX && inode) {
+      inodes.add(inode);
+    }
+  }
+  return inodes;
+}
+
+function readLinuxTcpListenInodesForPort(port: number): Set<string> {
+  const inodes = new Set<string>();
+  for (const tablePath of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    try {
+      for (const inode of parseLinuxTcpListenInodesForPort(
+        fs.readFileSync(tablePath, "utf8"),
+        port,
+      )) {
+        inodes.add(inode);
+      }
+    } catch {
+      // Missing proc tables mean this platform cannot prove listener ownership.
+    }
+  }
+  return inodes;
+}
+
+function linuxPidOwnsAnySocketInode(pid: number, inodes: Set<string>): boolean {
+  if (inodes.size === 0) {
+    return false;
+  }
+  let descriptors: string[];
+  try {
+    descriptors = fs.readdirSync(`/proc/${pid}/fd`);
+  } catch {
+    return false;
+  }
+  for (const descriptor of descriptors) {
+    let target: string;
+    try {
+      target = fs.readlinkSync(`/proc/${pid}/fd/${descriptor}`);
+    } catch {
+      continue;
+    }
+    const match = /^socket:\[(?<inode>\d+)\]$/.exec(target);
+    if (match?.groups?.inode && inodes.has(match.groups.inode)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function linuxPidListensOnPort(pid: number, port: number): boolean {
+  return linuxPidOwnsAnySocketInode(pid, readLinuxTcpListenInodesForPort(port));
+}
+
+function lsofShowsPidListeningOnPort(pid: number, port: number): boolean {
+  try {
+    const output = execFileSync(
+      "lsof",
+      ["-nP", "-a", "-p", String(pid), `-iTCP:${port}`, "-sTCP:LISTEN", "-Fp"],
+      { encoding: "utf8", timeout: 1000, maxBuffer: 64 * 1024 },
+    );
+    return output.split(/\r?\n/).some((line) => line === `p${pid}`);
+  } catch {
+    return false;
+  }
+}
+
+function pidListensOnPort(pid: number, port: number): boolean {
+  if (process.platform === "linux") {
+    return linuxPidListensOnPort(pid, port);
+  }
+  if (process.platform === "darwin") {
+    return lsofShowsPidListeningOnPort(pid, port);
+  }
+  return false;
+}
+
+type ManagedChromeProcessIdentity = {
+  pid: number;
+  startTime: string | null;
+  commandLine: string;
+};
+
+function sameManagedChromeIdentity(
+  a: ManagedChromeProcessIdentity,
+  b: ManagedChromeProcessIdentity,
+): boolean {
+  return a.pid === b.pid && a.commandLine === b.commandLine && a.startTime === b.startTime;
+}
+
+function readOwnedManagedChromeIdentity(params: {
+  pid: number;
+  exe: BrowserExecutable;
+  profile: ResolvedBrowserProfile;
+  userDataDir: string;
+}): ManagedChromeProcessIdentity | null {
+  if (!processExists(params.pid) || !pidListensOnPort(params.pid, params.profile.cdpPort)) {
+    return null;
+  }
+  const command = readManagedProcessCommandLine(params.pid);
+  if (
+    !command ||
+    !commandLineMatchesManagedChrome({
+      command,
+      exe: params.exe,
+      profile: params.profile,
+      userDataDir: params.userDataDir,
+    })
+  ) {
+    return null;
+  }
+  return {
+    pid: params.pid,
+    startTime: command.startTime,
+    commandLine: command.text,
+  };
+}
+
 function isPortInUseError(err: unknown): boolean {
   const errno = (err as NodeJS.ErrnoException | undefined)?.code;
   const name = err instanceof Error ? err.name : "";
@@ -151,22 +439,11 @@ function isPortInUseError(err: unknown): boolean {
 }
 
 function readCurrentHostSingletonPid(userDataDir: string, hostname = os.hostname()): number | null {
-  let target: string;
-  try {
-    target = fs.readlinkSync(path.join(userDataDir, "SingletonLock"));
-  } catch {
+  const lock = readSingletonLockTarget(userDataDir);
+  if (!lock || lock.hostname !== hostname || !processExists(lock.pid)) {
     return null;
   }
-  const match = /^(?<lockHost>.+)-(?<pid>\d+)$/.exec(target);
-  if (!match?.groups) {
-    return null;
-  }
-  const lockHost = normalizeOptionalString(match.groups.lockHost) ?? "";
-  const pid = Number.parseInt(match.groups.pid ?? "", 10);
-  if (lockHost !== hostname || !processExists(pid)) {
-    return null;
-  }
-  return pid;
+  return lock.pid;
 }
 
 function clearChromeSingletonArtifacts(userDataDir: string) {
@@ -250,26 +527,56 @@ async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> 
 }
 
 async function terminateOwnedStaleChromeProcess(
-  pid: number,
+  params: {
+    identity: ManagedChromeProcessIdentity;
+    exe: BrowserExecutable;
+    profile: ResolvedBrowserProfile;
+    userDataDir: string;
+  },
   timeoutMs = CHROME_STOP_TIMEOUT_MS,
 ): Promise<boolean> {
+  const readCurrentIdentity = () =>
+    readOwnedManagedChromeIdentity({
+      pid: params.identity.pid,
+      exe: params.exe,
+      profile: params.profile,
+      userDataDir: params.userDataDir,
+    });
+  const beforeSigterm = readCurrentIdentity();
+  if (!beforeSigterm || !sameManagedChromeIdentity(params.identity, beforeSigterm)) {
+    return false;
+  }
   try {
-    process.kill(pid, "SIGTERM");
+    process.kill(params.identity.pid, "SIGTERM");
   } catch {
     return false;
   }
-  if (await waitForPidExit(pid, timeoutMs)) {
+  if (await waitForPidExit(params.identity.pid, timeoutMs)) {
     return true;
   }
+  const beforeSigkill = readCurrentIdentity();
+  if (!beforeSigkill || !sameManagedChromeIdentity(params.identity, beforeSigkill)) {
+    return false;
+  }
   try {
-    process.kill(pid, "SIGKILL");
+    process.kill(params.identity.pid, "SIGKILL");
   } catch {
     return false;
   }
-  return await waitForPidExit(pid, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS);
+  return await waitForPidExit(params.identity.pid, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS);
+}
+
+function clearRecoveredChromeSingletonArtifacts(userDataDir: string, pid: number): boolean {
+  const lock = readSingletonLockTarget(userDataDir);
+  if (!lock || lock.hostname !== os.hostname() || lock.pid !== pid || processExists(pid)) {
+    return false;
+  }
+  clearChromeSingletonArtifacts(userDataDir);
+  return true;
 }
 
 async function recoverOwnedStaleManagedChromeCdpListener(params: {
+  exe: BrowserExecutable;
   profile: ResolvedBrowserProfile;
   userDataDir: string;
 }): Promise<boolean> {
@@ -293,10 +600,28 @@ async function recoverOwnedStaleManagedChromeCdpListener(params: {
   if (diagnostic.ok || diagnostic.code !== "websocket_health_command_timeout") {
     return false;
   }
-  if (!(await terminateOwnedStaleChromeProcess(pid))) {
+  const identity = readOwnedManagedChromeIdentity({
+    pid,
+    exe: params.exe,
+    profile: params.profile,
+    userDataDir: params.userDataDir,
+  });
+  if (!identity) {
     return false;
   }
-  clearChromeSingletonArtifacts(params.userDataDir);
+  if (
+    !(await terminateOwnedStaleChromeProcess({
+      identity,
+      exe: params.exe,
+      profile: params.profile,
+      userDataDir: params.userDataDir,
+    }))
+  ) {
+    return false;
+  }
+  if (!clearRecoveredChromeSingletonArtifacts(params.userDataDir, pid)) {
+    return false;
+  }
   log.warn(
     `Stopped stale managed Chrome CDP listener for profile "${params.profile.name}" (pid ${pid}) and retrying launch.`,
   );
@@ -304,6 +629,7 @@ async function recoverOwnedStaleManagedChromeCdpListener(params: {
 }
 
 async function ensureManagedChromePortAvailable(
+  resolved: ResolvedBrowserConfig,
   profile: ResolvedBrowserProfile,
   userDataDir: string,
 ): Promise<void> {
@@ -311,10 +637,11 @@ async function ensureManagedChromePortAvailable(
     await ensurePortAvailable(profile.cdpPort);
     return;
   } catch (err) {
-    if (
-      !isPortInUseError(err) ||
-      !(await recoverOwnedStaleManagedChromeCdpListener({ profile, userDataDir }))
-    ) {
+    const exe = resolveBrowserExecutable(resolved, profile);
+    if (!isPortInUseError(err) || !exe) {
+      throw err;
+    }
+    if (!(await recoverOwnedStaleManagedChromeCdpListener({ exe, profile, userDataDir }))) {
       throw err;
     }
   }
@@ -583,7 +910,7 @@ export async function launchOpenClawChrome(
   }
 
   const userDataDir = resolveOpenClawUserDataDir(profile.name);
-  await ensureManagedChromePortAvailable(profile, userDataDir);
+  await ensureManagedChromePortAvailable(resolved, profile, userDataDir);
 
   const exe = resolveBrowserExecutable(resolved, profile);
   if (!exe) {

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -139,6 +139,36 @@ function processExists(pid: number): boolean {
   }
 }
 
+function isPortInUseError(err: unknown): boolean {
+  const errno = (err as NodeJS.ErrnoException | undefined)?.code;
+  const name = err instanceof Error ? err.name : "";
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    errno === "EADDRINUSE" ||
+    name === "PortInUseError" ||
+    /\bEADDRINUSE\b|already in use/i.test(message)
+  );
+}
+
+function readCurrentHostSingletonPid(userDataDir: string, hostname = os.hostname()): number | null {
+  let target: string;
+  try {
+    target = fs.readlinkSync(path.join(userDataDir, "SingletonLock"));
+  } catch {
+    return null;
+  }
+  const match = /^(?<lockHost>.+)-(?<pid>\d+)$/.exec(target);
+  if (!match?.groups) {
+    return null;
+  }
+  const lockHost = normalizeOptionalString(match.groups.lockHost) ?? "";
+  const pid = Number.parseInt(match.groups.pid ?? "", 10);
+  if (lockHost !== hostname || !processExists(pid)) {
+    return null;
+  }
+  return pid;
+}
+
 function clearChromeSingletonArtifacts(userDataDir: string) {
   for (const basename of CHROME_SINGLETON_LOCK_PATHS) {
     try {
@@ -204,6 +234,91 @@ async function terminateChromeForRetry(proc: ChildProcess, userDataDir: string) 
   }
   await waitForChromeProcessExit(proc, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS);
   clearStaleChromeSingletonLocks(userDataDir);
+}
+
+async function waitForPidExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processExists(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, CHROME_BOOTSTRAP_EXIT_POLL_MS);
+    });
+  }
+  return !processExists(pid);
+}
+
+async function terminateOwnedStaleChromeProcess(
+  pid: number,
+  timeoutMs = CHROME_STOP_TIMEOUT_MS,
+): Promise<boolean> {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return false;
+  }
+  if (await waitForPidExit(pid, timeoutMs)) {
+    return true;
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    return false;
+  }
+  return await waitForPidExit(pid, CHROME_BOOTSTRAP_EXIT_TIMEOUT_MS);
+}
+
+async function recoverOwnedStaleManagedChromeCdpListener(params: {
+  profile: ResolvedBrowserProfile;
+  userDataDir: string;
+}): Promise<boolean> {
+  if (!params.profile.cdpIsLoopback) {
+    return false;
+  }
+  const pid = readCurrentHostSingletonPid(params.userDataDir);
+  if (pid == null) {
+    return false;
+  }
+  let diagnostic: ChromeCdpDiagnostic;
+  try {
+    diagnostic = await diagnoseChromeCdp(
+      params.profile.cdpUrl,
+      CHROME_REACHABILITY_TIMEOUT_MS,
+      CHROME_WS_READY_TIMEOUT_MS,
+    );
+  } catch {
+    return false;
+  }
+  if (diagnostic.ok || diagnostic.code !== "websocket_health_command_timeout") {
+    return false;
+  }
+  if (!(await terminateOwnedStaleChromeProcess(pid))) {
+    return false;
+  }
+  clearChromeSingletonArtifacts(params.userDataDir);
+  log.warn(
+    `Stopped stale managed Chrome CDP listener for profile "${params.profile.name}" (pid ${pid}) and retrying launch.`,
+  );
+  return true;
+}
+
+async function ensureManagedChromePortAvailable(
+  profile: ResolvedBrowserProfile,
+  userDataDir: string,
+): Promise<void> {
+  try {
+    await ensurePortAvailable(profile.cdpPort);
+    return;
+  } catch (err) {
+    if (
+      !isPortInUseError(err) ||
+      !(await recoverOwnedStaleManagedChromeCdpListener({ profile, userDataDir }))
+    ) {
+      throw err;
+    }
+  }
+  await ensurePortAvailable(profile.cdpPort);
 }
 
 function chromeLaunchHints(params: {
@@ -467,7 +582,8 @@ export async function launchOpenClawChrome(
     );
   }
 
-  await ensurePortAvailable(profile.cdpPort);
+  const userDataDir = resolveOpenClawUserDataDir(profile.name);
+  await ensureManagedChromePortAvailable(profile, userDataDir);
 
   const exe = resolveBrowserExecutable(resolved, profile);
   if (!exe) {
@@ -476,7 +592,6 @@ export async function launchOpenClawChrome(
     );
   }
 
-  const userDataDir = resolveOpenClawUserDataDir(profile.name);
   fs.mkdirSync(userDataDir, { recursive: true });
   await ensureOutputDirectory(DEFAULT_DOWNLOAD_DIR);
 


### PR DESCRIPTION
## Summary
Repair and finalize #89168 for #41750. This keeps @rohitjavvadi's contributor branch as the canonical fix path and preserves attribution for the guarded managed Chrome CDP recovery work.

## Repair plan
- Rebase or refresh `fix-browser-stale-managed-cdp` onto current `main`.
- Keep the production change scoped to `extensions/browser/src/browser/chrome.ts`.
- Confirm the stale listener recovery only applies to loopback managed profiles and proves profile/process ownership before signaling.
- Re-check the prior test-only WebSocket `maxPayload` finding and keep the test mocks capped.
- Run `pnpm check:changed` and the focused browser Chrome tests.
- Run Codex `/review`, address every finding, then produce merge preflight before any merge.

## Credit
Based on source PR https://github.com/openclaw/openclaw/pull/89168 by @rohitjavvadi. Fixes #41750.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-387-autonomous-terminal-gap
- Source PRs: https://github.com/openclaw/openclaw/pull/89168
- Credit: Repair contributor branch from @rohitjavvadi in https://github.com/openclaw/openclaw/pull/89168.; Preserve #89168 author attribution in commits and PR/merge notes; the branch already carries the contributor's implementation and proof notes.; Keep #41750 by @kissman911 linked as the source reproduction.
- Validation: pnpm check:changed; node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts
- Repair fallback: source PR #89168 is a fork branch requiring rebase; use replacement branch because GitHub App pushes to contributor forks can be rejected when rebased upstream history includes workflow files

fish notes: model gpt-5.5, reasoning medium; reviewed against 81121292a891.
