### PR TITLE
fix(respawn): rewrite pnpm versioned entry paths to stable wrapper (fixes #52313)

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -25,6 +25,7 @@ vi.mock("./container-environment.js", () => ({
 }));
 
 import {
+  rewritePnpmVersionedEntryPath,
   respawnGatewayProcessForUpdate,
   restartGatewayProcessWithFreshPid,
 } from "./process-respawn.js";
@@ -367,5 +368,41 @@ describe("respawnGatewayProcessForUpdate", () => {
 
     expect(result.mode).toBe("failed");
     expect(result.detail).toContain("spawn failed");
+  });
+});
+
+describe("rewritePnpmVersionedEntryPath", () => {
+  it("rewrites unscoped pnpm versioned path to stable wrapper", () => {
+    const input =
+      "/app/node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js";
+    expect(rewritePnpmVersionedEntryPath(input)).toBe(
+      "/app/node_modules/openclaw/openclaw.mjs",
+    );
+  });
+
+  it("rewrites scoped pnpm versioned path to stable wrapper", () => {
+    const input =
+      "/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js";
+    expect(rewritePnpmVersionedEntryPath(input)).toBe(
+      "/app/node_modules/@anthropic/sdk/openclaw.mjs",
+    );
+  });
+
+  it("returns non-pnpm paths unchanged", () => {
+    const input = "/repo/src/entry.ts";
+    expect(rewritePnpmVersionedEntryPath(input)).toBe(input);
+  });
+
+  it("returns non-pnpm node_modules paths unchanged", () => {
+    const input = "/app/node_modules/openclaw/dist/entry.js";
+    expect(rewritePnpmVersionedEntryPath(input)).toBe(input);
+  });
+
+  it("handles pnpm versioned path with additional flags in the string", () => {
+    const input =
+      "/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js";
+    expect(rewritePnpmVersionedEntryPath(input)).toBe(
+      "/home/user/.local/share/pnpm/global/5/node_modules/openclaw/openclaw.mjs",
+    );
   });
 });

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -25,7 +25,6 @@ vi.mock("./container-environment.js", () => ({
 }));
 
 import {
-  rewritePnpmVersionedEntryPath,
   respawnGatewayProcessForUpdate,
   restartGatewayProcessWithFreshPid,
 } from "./process-respawn.js";
@@ -299,7 +298,7 @@ describe("respawnGatewayProcessForUpdate", () => {
     process.execArgv = [];
     process.argv = [
       "C:\\Program Files\\node.exe",
-      "C:\\openclaw\\dist\\index.js",
+      "C:\\openclaw\\node_modules\\.pnpm\\openclaw@2026.6.5\\node_modules\\openclaw\\dist\\index.js",
       "gateway",
       "run",
     ];
@@ -311,13 +310,57 @@ describe("respawnGatewayProcessForUpdate", () => {
     expect(result.pid).toBe(5151);
     expect(spawnMock).toHaveBeenCalledWith(
       process.execPath,
-      ["C:\\openclaw\\dist\\index.js", "gateway", "run"],
+      ["C:\\openclaw\\node_modules\\openclaw\\openclaw.mjs", "gateway", "run"],
       {
         detached: true,
         env: process.env,
         stdio: "inherit",
       },
     );
+  });
+
+  it("rewrites a pnpm-versioned OpenClaw entry before detached update respawn", () => {
+    clearSupervisorHints();
+    setPlatform("linux");
+    process.execArgv = [];
+    process.argv = [
+      "/usr/local/bin/node",
+      "/app/node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js",
+      "gateway",
+      "run",
+    ];
+    spawnMock.mockReturnValue({ pid: 7171, unref: vi.fn(), kill: vi.fn() });
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result.mode).toBe("spawned");
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      ["/app/node_modules/openclaw/openclaw.mjs", "gateway", "run"],
+      {
+        detached: true,
+        env: process.env,
+        stdio: "inherit",
+      },
+    );
+  });
+
+  it("does not rewrite another package's pnpm-versioned entry", () => {
+    clearSupervisorHints();
+    setPlatform("linux");
+    process.execArgv = [];
+    const entry =
+      "/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js";
+    process.argv = ["/usr/local/bin/node", entry, "gateway", "run"];
+    spawnMock.mockReturnValue({ pid: 8181, unref: vi.fn(), kill: vi.fn() });
+
+    respawnGatewayProcessForUpdate();
+
+    expect(spawnMock).toHaveBeenCalledWith(process.execPath, [entry, "gateway", "run"], {
+      detached: true,
+      env: process.env,
+      stdio: "inherit",
+    });
   });
 
   it("spawns a detached update process when macOS only has inherited XPC state", () => {
@@ -368,41 +411,5 @@ describe("respawnGatewayProcessForUpdate", () => {
 
     expect(result.mode).toBe("failed");
     expect(result.detail).toContain("spawn failed");
-  });
-});
-
-describe("rewritePnpmVersionedEntryPath", () => {
-  it("rewrites unscoped pnpm versioned path to stable wrapper", () => {
-    const input =
-      "/app/node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js";
-    expect(rewritePnpmVersionedEntryPath(input)).toBe(
-      "/app/node_modules/openclaw/openclaw.mjs",
-    );
-  });
-
-  it("rewrites scoped pnpm versioned path to stable wrapper", () => {
-    const input =
-      "/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js";
-    expect(rewritePnpmVersionedEntryPath(input)).toBe(
-      "/app/node_modules/@anthropic/sdk/openclaw.mjs",
-    );
-  });
-
-  it("returns non-pnpm paths unchanged", () => {
-    const input = "/repo/src/entry.ts";
-    expect(rewritePnpmVersionedEntryPath(input)).toBe(input);
-  });
-
-  it("returns non-pnpm node_modules paths unchanged", () => {
-    const input = "/app/node_modules/openclaw/dist/entry.js";
-    expect(rewritePnpmVersionedEntryPath(input)).toBe(input);
-  });
-
-  it("handles pnpm versioned path with additional flags in the string", () => {
-    const input =
-      "/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js";
-    expect(rewritePnpmVersionedEntryPath(input)).toBe(
-      "/home/user/.local/share/pnpm/global/5/node_modules/openclaw/openclaw.mjs",
-    );
   });
 });

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -1,6 +1,5 @@
 // Respawns the gateway process when no supervisor handles restart.
 import { spawn, type ChildProcess } from "node:child_process";
-import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { isContainerEnvironment } from "./container-environment.js";
 import { formatErrorMessage } from "./errors.js";
@@ -27,44 +26,27 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-const pnpmVersionedMarker = "node_modules/.pnpm/";
-const pnpmVersionedEntryPattern =
-  /^(?:@([^/+]+)\+)?([^@/]+)@[^/]+\/node_modules\/(?:@([^/]+)\/)?([^/]+)\/(.+)$/;
+const PNPM_VERSIONED_OPENCLAW_ENTRY_PATTERN =
+  /^(.*?)([\\/])node_modules\2\.pnpm\2openclaw@[^\\/]+\2node_modules\2openclaw\2.+$/;
 
-/**
- * Detects pnpm versioned realpaths (e.g. `node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js`)
- * and rewrites them to the stable `node_modules/<pkg>/openclaw.mjs` wrapper.
- *
- * During self-update the versioned directory may be removed, causing the
- * respawned child to fail. The stable symlink/wrapper survives package updates.
- */
-export function rewritePnpmVersionedEntryPath(entryPath: string): string {
-  const markerIndex = entryPath.indexOf(pnpmVersionedMarker);
-  if (markerIndex === -1) {
-    return entryPath;
-  }
-  const prefix = entryPath.slice(0, markerIndex);
-  const afterMarker = entryPath.slice(markerIndex + pnpmVersionedMarker.length);
-  const match = afterMarker.match(pnpmVersionedEntryPattern);
-  if (!match) {
-    return entryPath;
-  }
-  const scope = match[1] ? `@${match[1]}` : "";
-  const pkgName = match[2];
-  const pkgDir = scope ? `${scope}/${pkgName}` : pkgName;
-  return path.join(prefix, "node_modules", pkgDir, "openclaw.mjs");
+function rewritePnpmVersionedOpenClawEntryPath(entryPath: string): string {
+  // pnpm can expose argv[1] as a versioned realpath that self-update removes.
+  // Respawn through the stable OpenClaw package wrapper instead.
+  return entryPath.replace(
+    PNPM_VERSIONED_OPENCLAW_ENTRY_PATTERN,
+    "$1$2node_modules$2openclaw$2openclaw.mjs",
+  );
 }
 
 function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
   child: ChildProcess;
   pid?: number;
 } {
-  const entryArg = process.argv[1] ?? "";
-  const rewrittenEntry = rewritePnpmVersionedEntryPath(entryArg);
+  const [entryArg, ...entryArgs] = process.argv.slice(1);
   const args = [
     ...process.execArgv,
-    rewrittenEntry,
-    ...process.argv.slice(2),
+    ...(entryArg ? [rewritePnpmVersionedOpenClawEntryPath(entryArg)] : []),
+    ...entryArgs,
   ];
   const child = spawn(process.execPath, args, {
     env: opts.env ? { ...process.env, ...opts.env } : process.env,

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -1,5 +1,6 @@
 // Respawns the gateway process when no supervisor handles restart.
 import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { isContainerEnvironment } from "./container-environment.js";
 import { formatErrorMessage } from "./errors.js";
@@ -26,11 +27,45 @@ function isTruthy(value: string | undefined): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+const pnpmVersionedMarker = "node_modules/.pnpm/";
+const pnpmVersionedEntryPattern =
+  /^(?:@([^/+]+)\+)?([^@/]+)@[^/]+\/node_modules\/(?:@([^/]+)\/)?([^/]+)\/(.+)$/;
+
+/**
+ * Detects pnpm versioned realpaths (e.g. `node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js`)
+ * and rewrites them to the stable `node_modules/<pkg>/openclaw.mjs` wrapper.
+ *
+ * During self-update the versioned directory may be removed, causing the
+ * respawned child to fail. The stable symlink/wrapper survives package updates.
+ */
+export function rewritePnpmVersionedEntryPath(entryPath: string): string {
+  const markerIndex = entryPath.indexOf(pnpmVersionedMarker);
+  if (markerIndex === -1) {
+    return entryPath;
+  }
+  const prefix = entryPath.slice(0, markerIndex);
+  const afterMarker = entryPath.slice(markerIndex + pnpmVersionedMarker.length);
+  const match = afterMarker.match(pnpmVersionedEntryPattern);
+  if (!match) {
+    return entryPath;
+  }
+  const scope = match[1] ? `@${match[1]}` : "";
+  const pkgName = match[2];
+  const pkgDir = scope ? `${scope}/${pkgName}` : pkgName;
+  return path.join(prefix, "node_modules", pkgDir, "openclaw.mjs");
+}
+
 function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
   child: ChildProcess;
   pid?: number;
 } {
-  const args = [...process.execArgv, ...process.argv.slice(1)];
+  const entryArg = process.argv[1] ?? "";
+  const rewrittenEntry = rewritePnpmVersionedEntryPath(entryArg);
+  const args = [
+    ...process.execArgv,
+    rewrittenEntry,
+    ...process.argv.slice(2),
+  ];
   const child = spawn(process.execPath, args, {
     env: opts.env ? { ...process.env, ...opts.env } : process.env,
     detached: true,


### PR DESCRIPTION
## Summary

During gateway self-update, the pnpm versioned directory (`node_modules/.pnpm/openclaw@<version>/`) may be replaced or removed. If `process.argv` contains the versioned path, the respawned child process fails to start because the entrypoint no longer exists.

This fix detects pnpm versioned realpaths in `spawnDetachedGatewayProcess` and rewrites them to the stable `node_modules/<pkg>/openclaw.mjs` wrapper before spawning.

## Changes

- **`src/infra/process-respawn.ts`**: Added `rewritePnpmVersionedEntryPath()` that detects pnpm `.pnpm/` versioned paths and rewrites them to the stable wrapper. Called in `spawnDetachedGatewayProcess()` before `spawn()`. Handles both unscoped (`openclaw@ver`) and scoped (`@scope+name@ver`) pnpm path formats.
- **`src/infra/process-respawn.test.ts`**: Added 5 test cases covering unscoped rewrite, scoped rewrite, non-pnpm passthrough, non-pnpm node_modules passthrough, and deep prefix paths.

## Real behavior proof

- **Behavior addressed:** Gateway self-restart fails when spawned from pnpm versioned realpath because the versioned directory is removed during self-update.
- **Environment tested:** macOS 26.4.1, Node.js v25.8.2, OpenClaw workdir at `/Users/liuhao/.hermes/workdir/openclaw`
- **Steps run after the patch:**
  1. `node scripts/run-vitest.mjs run src/infra/process-respawn.test.ts` — 28 tests passed
  2. `pnpm build` — build succeeded
  3. Inline verification of `rewritePnpmVersionedEntryPath` with unscoped, scoped, and non-pnpm paths
- **Evidence after fix:**

```
$ node scripts/run-vitest.mjs run src/infra/process-respawn.test.ts
 ✓  infra  src/infra/process-respawn.test.ts (28 tests) 75ms
 Test Files  1 passed (1)
      Tests  28 passed (28)

$ grep -n "rewritePnpmVersionedEntryPath\|pnpmVersionedMarker" src/infra/process-respawn.ts
30:const pnpmVersionedMarker = "node_modules/.pnpm/";
31:const pnpmVersionedEntryPattern =
41:export function rewritePnpmVersionedEntryPath(entryPath: string): string {
42:  const markerIndex = entryPath.indexOf(pnpmVersionedMarker);
47:  const afterMarker = entryPath.slice(markerIndex + pnpmVersionedMarker.length);
48:  const match = afterMarker.match(pnpmVersionedEntryPattern);
63:  const rewrittenEntry = rewritePnpmVersionedEntryPath(entryArg);

$ node --input-type=module -e "import path from 'node:path'; const marker='node_modules/.pnpm/'; const re=/^(?:@([^/+]+)\\+)?([^@/]+)@[^/]+\\/node_modules\\/(?:@([^/]+)\\/)?([^/]+)\\/(.+)$/; function r(p){const i=p.indexOf(marker);if(i===-1)return p;const pre=p.slice(0,i);const a=p.slice(i+marker.length);const m=a.match(re);if(!m)return p;const s=m[1]?'@'+m[1]:'';const d=s?s+'/'+m[2]:m[2];return path.join(pre,'node_modules',d,'openclaw.mjs');} console.log('Unscoped:',r('/app/node_modules/.pnpm/openclaw@2026.6.5/node_modules/openclaw/dist/entry.js')); console.log('Scoped:',r('/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js')); console.log('Non-pnpm:',r('/repo/src/entry.ts'));"
Unscoped: /app/node_modules/openclaw/openclaw.mjs
Scoped: /app/node_modules/@anthropic/sdk/openclaw.mjs
Non-pnpm: /repo/src/entry.ts
```

- **Observed result after fix:** `rewritePnpmVersionedEntryPath` correctly rewrites pnpm versioned paths to stable wrappers. Unscoped paths like `openclaw@2026.6.5` become `node_modules/openclaw/openclaw.mjs`. Scoped paths like `@anthropic+sdk@1.0.0` become `node_modules/@anthropic/sdk/openclaw.mjs`. Non-pnpm paths pass through unchanged. All 28 tests pass including 5 new test cases.
- **What was not tested:** Live gateway self-update restart (requires a full pnpm install + update cycle). The fix was verified through unit tests and inline path rewriting verification.
