### PR TITLE
fix(i18n): retain Codex error tails in logs

### DIFF
--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -315,11 +315,16 @@ func previewCommandOutput(stdout, stderr string) string {
 		return "no output"
 	}
 	combined = strings.Join(strings.Fields(combined), " ")
-	const limit = 500
+	const (
+		limit      = 1200
+		headLength = 300
+		tailLength = 800
+	)
 	if len(combined) <= limit {
 		return combined
 	}
-	return combined[:limit] + "..."
+	// Codex prints API failures after its header and prompt, so the tail carries the actionable error.
+	return combined[:headLength] + " ... [truncated] ... " + combined[len(combined)-tailLength:]
 }
 
 func sleepWithContext(ctx context.Context, delay time.Duration) error {

--- a/scripts/docs-i18n/translator_test.go
+++ b/scripts/docs-i18n/translator_test.go
@@ -336,7 +336,7 @@ sleep 10
 }
 
 func TestPreviewCommandOutputFlattensAndTruncates(t *testing.T) {
-	input := "line one\n\nline   two\tline three " + strings.Repeat("x", 600)
+	input := "line one\n\nline   two\tline three " + strings.Repeat("x", 1200) + " final api error 429"
 	preview := previewCommandOutput(input, "")
 	if strings.Contains(preview, "\n") {
 		t.Fatalf("expected flattened whitespace, got %q", preview)
@@ -344,7 +344,10 @@ func TestPreviewCommandOutputFlattensAndTruncates(t *testing.T) {
 	if !strings.HasPrefix(preview, "line one line two line three ") {
 		t.Fatalf("unexpected preview prefix: %q", preview)
 	}
-	if !strings.HasSuffix(preview, "...") {
-		t.Fatalf("expected truncation suffix, got %q", preview)
+	if !strings.Contains(preview, "... [truncated] ...") {
+		t.Fatalf("expected truncation marker, got %q", preview)
+	}
+	if !strings.HasSuffix(preview, "final api error 429") {
+		t.Fatalf("expected retained error tail, got %q", preview)
 	}
 }


### PR DESCRIPTION
## Summary

- preserve the tail of Codex CLI stdout/stderr in docs i18n error previews
- keep a short output prefix for context while retaining the final API error details that currently get truncated away
- update the focused unit test to cover the retained tail error text

## Verification

- `git diff --check -- scripts/docs-i18n/translator.go scripts/docs-i18n/translator_test.go`
- `cd scripts/docs-i18n && go test ./...`
- `$autoreview --mode local --parallel-tests <diff check + docs-i18n go test>`
  - result: `autoreview clean: no accepted/actionable findings reported`
