### PR TITLE
fix(browser): accept top-level act fields with nested requests

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1435,6 +1435,73 @@ describe("browser tool act compatibility", () => {
     expect(opts.profile).toBeUndefined();
   });
 
+  it("backfills missing flattened fields into nested act requests", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "act",
+      kind: "click",
+      ref: "f1e3",
+      selector: "#title",
+      targetId: "tab-1",
+      timeoutMs: 5000,
+      request: {
+        kind: "click",
+        doubleClick: true,
+      },
+    });
+
+    const request = lastMockCallArg<{
+      kind?: string;
+      ref?: string;
+      selector?: string;
+      targetId?: string;
+      timeoutMs?: number;
+      doubleClick?: boolean;
+    }>(browserActionsMocks.browserAct, 1);
+    expect(request).toEqual({
+      kind: "click",
+      ref: "f1e3",
+      selector: "#title",
+      targetId: "tab-1",
+      timeoutMs: 5000,
+      doubleClick: true,
+    });
+  });
+
+  it("keeps nested act request fields authoritative when flattened fields differ", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "act",
+      kind: "click",
+      ref: "legacy-ref",
+      selector: "#legacy",
+      targetId: "legacy-tab",
+      timeoutMs: 5000,
+      request: {
+        kind: "click",
+        ref: "nested-ref",
+        selector: "#nested",
+        targetId: "nested-tab",
+        timeoutMs: 7000,
+      },
+    });
+
+    const request = lastMockCallArg<{
+      kind?: string;
+      ref?: string;
+      selector?: string;
+      targetId?: string;
+      timeoutMs?: number;
+    }>(browserActionsMocks.browserAct, 1);
+    expect(request).toEqual({
+      kind: "click",
+      ref: "nested-ref",
+      selector: "#nested",
+      targetId: "nested-tab",
+      timeoutMs: 7000,
+    });
+  });
+
   it("applies configured browser action timeout when act timeout is omitted", async () => {
     configMocks.loadConfig.mockReturnValue({ browser: { actionTimeoutMs: 45_000 } });
 

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -163,6 +163,7 @@ function readTargetUrlParam(params: Record<string, unknown>) {
 }
 
 const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
+  "kind",
   "targetId",
   "ref",
   "doubleClick",
@@ -193,7 +194,14 @@ const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
 function readActRequestParam(params: Record<string, unknown>) {
   const requestParam = params.request;
   if (requestParam && typeof requestParam === "object") {
-    return requestParam as Parameters<typeof browserAct>[1];
+    const request = { ...(requestParam as Record<string, unknown>) };
+    for (const key of LEGACY_BROWSER_ACT_REQUEST_KEYS) {
+      if (Object.hasOwn(request, key) || !Object.hasOwn(params, key)) {
+        continue;
+      }
+      request[key] = params[key];
+    }
+    return request as Parameters<typeof browserAct>[1];
   }
 
   const kind = readStringParam(params, "kind");
@@ -201,7 +209,7 @@ function readActRequestParam(params: Record<string, unknown>) {
     return undefined;
   }
 
-  const request: Record<string, unknown> = { kind };
+  const request: Record<string, unknown> = {};
   for (const key of LEGACY_BROWSER_ACT_REQUEST_KEYS) {
     if (!Object.hasOwn(params, key)) {
       continue;

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -191,12 +191,26 @@ const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
   "timeoutMs",
 ] as const;
 
+const LEGACY_BROWSER_ACT_SHARED_REQUEST_KEYS = new Set<
+  (typeof LEGACY_BROWSER_ACT_REQUEST_KEYS)[number]
+>(["targetId"]);
+
 function readActRequestParam(params: Record<string, unknown>) {
   const requestParam = params.request;
   if (requestParam && typeof requestParam === "object") {
     const request = { ...(requestParam as Record<string, unknown>) };
+    const hasMismatchedKind =
+      typeof request.kind === "string" &&
+      typeof params.kind === "string" &&
+      request.kind !== params.kind;
     for (const key of LEGACY_BROWSER_ACT_REQUEST_KEYS) {
       if (Object.hasOwn(request, key) || !Object.hasOwn(params, key)) {
+        continue;
+      }
+      // Flattened act fields are legacy shape repair. Only the tab scope is
+      // safe across kind mismatches; action-specific fields can corrupt the
+      // explicit nested request.
+      if (hasMismatchedKind && !LEGACY_BROWSER_ACT_SHARED_REQUEST_KEYS.has(key)) {
         continue;
       }
       request[key] = params[key];


### PR DESCRIPTION
Fixes #38762 by repairing #81076 on the contributor branch.

Summary:
- Backfill supported top-level browser act fields into nested request payloads only when the nested request is missing that field.
- Preserve nested request values as authoritative.
- Add focused regression coverage for top-level ref/request compatibility and nested precedence.
- Add concrete after-fix proof for the top-level ref + nested request shape that ClawSweeper requested.

Credit:
- Thanks @angelusbr for the narrow fix in https://github.com/openclaw/openclaw/pull/81076.
- The related OpenAI/OpenRouter reproduction in #81051 remains credited as supporting evidence.
- Prior stale work in https://github.com/openclaw/openclaw/pull/38790 helped establish the intended compatibility behavior.

Validation:
- pnpm -s vitest run extensions/browser/src/browser-tool.test.ts
- pnpm check:changed
- Codex /review clean before merge

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-416-autonomous-terminal-gap
- Source PRs: https://github.com/openclaw/openclaw/pull/81076
- Credit: Repair contributor branch from @angelusbr in https://github.com/openclaw/openclaw/pull/81076; preserve PR authorship and credit in the final merge/PR body.; Mention that #81051 supplied OpenAI/OpenRouter reproduction evidence for the same canonical issue.; Historical stale PR https://github.com/openclaw/openclaw/pull/38790 by @JAVA-LW showed the earlier intended compatibility behavior but targeted the old browser tool path.
- Validation: pnpm -s vitest run extensions/browser/src/browser-tool.test.ts; pnpm check:changed
- Repair fallback: source PR #81076 is a fork branch requiring rebase; use replacement branch because GitHub App pushes to contributor forks can be rejected when rebased upstream history includes workflow files

fish notes: model gpt-5.5, reasoning medium; reviewed against 252ef97739ad.
