### PR TITLE
fix(agent-runner): retry same model on Gemini per-minute rate-limit 429s

### DIFF
--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -237,6 +237,40 @@ describe("handleAssistantFailover", () => {
       expect(advanceAuthProfile).not.toHaveBeenCalled();
     });
 
+    it("keeps a Gemini daily (RPD) quota on the long-window fallback despite the rate-limits URL", async () => {
+      // Google's /rate-limits docs URL also covers RPD (daily) quotas, so the
+      // shared link must not promote a daily exhaustion to a same-model retry.
+      // The explicit "requests per day" signal forces the long-window path.
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage:
+              "Google Generative AI API error (429): You exceeded your current quota for requests per day, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits.",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBeUndefined();
+      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeEscalateRateLimitProfileFallback).toHaveBeenCalledTimes(1);
+      expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
+    });
+
     it("does not treat bare 429 quota_exceeded as a short-window throttle", async () => {
       const maybeRetrySameModelRateLimit = vi.fn(async () => true);
       const maybeEscalateRateLimitProfileFallback = vi.fn();

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -202,6 +202,41 @@ describe("handleAssistantFailover", () => {
       expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
     });
 
+    it("spends same-model retry budget on Gemini per-minute quota rate limits", async () => {
+      // Gemini's TPM/RPM 429 says "current quota" but links to the
+      // .../docs/rate-limits page; the rate-limits signal must route it to the
+      // short-window same-model retry instead of the long-window fallback.
+      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeEscalateRateLimitProfileFallback = vi.fn();
+      const advanceAuthProfile = vi.fn(async () => true);
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          billingFailure: false,
+          rateLimitFailure: true,
+          lastAssistant: {
+            errorMessage:
+              "Google Generative AI API error (429): You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits.",
+          } as Params["lastAssistant"],
+          maybeRetrySameModelRateLimit,
+          maybeEscalateRateLimitProfileFallback,
+          advanceAuthProfile,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      if (outcome.action !== "retry") {
+        return;
+      }
+      expect(outcome.retryKind).toBe("same_model_rate_limit");
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({});
+      expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
+      expect(advanceAuthProfile).not.toHaveBeenCalled();
+    });
+
     it("does not treat bare 429 quota_exceeded as a short-window throttle", async () => {
       const maybeRetrySameModelRateLimit = vi.fn(async () => true);
       const maybeEscalateRateLimitProfileFallback = vi.fn();

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -40,10 +40,14 @@ type ShortWindowRateLimitRetry = {
 
 const LONG_WINDOW_RATE_LIMIT_RE =
   /\b(?:daily|weekly|monthly|tokens per day|requests per day|usage limit|subscription|insufficient[_ -]?quota|current quota|quota[_ -]?exceeded|quota exceeded)\b/i;
+// Gemini's per-minute TPM/RPM 429 says "current quota" (a long-window phrase)
+// but links to .../gemini-api/docs/rate-limits, so `rate-limits` is the only
+// short-window signal in the message. Without it the message is classified
+// long-window and the same-model retry loop never fires for Gemini throttles.
 const SHORT_RATE_LIMIT_WINDOW_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|rate-limits)\b/i;
 const SHORT_WINDOW_RATE_LIMIT_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown|rate-limits)\b|请求过于频繁|调用频率|频率限制/i;
 const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
 const RETRY_AFTER_SECONDS_RE =
   /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m))?\b/i;

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -40,9 +40,16 @@ type ShortWindowRateLimitRetry = {
 
 const LONG_WINDOW_RATE_LIMIT_RE =
   /\b(?:daily|weekly|monthly|tokens per day|requests per day|usage limit|subscription|insufficient[_ -]?quota|current quota|quota[_ -]?exceeded|quota exceeded)\b/i;
-// Gemini's per-minute TPM/RPM 429 says "current quota" (a long-window phrase)
-// but links to .../gemini-api/docs/rate-limits, so `rate-limits` is the only
-// short-window signal in the message. Without it the message is classified
+// Gemini's generic /rate-limits docs URL covers RPM, TPM, AND RPD (daily)
+// quotas, so the URL alone never proves a short window. When an explicit
+// daily/per-day/usage-limit signal is present, force the long-window path so a
+// daily quota does not burn same-model retry budget before model/profile
+// fallback. A short Retry-After under the cap still wins (provider-stated).
+const HARD_LONG_WINDOW_RATE_LIMIT_RE =
+  /\b(?:daily|weekly|monthly|tokens per day|requests per day|per[_ -]?day|rpd|usage limit|subscription)\b/i;
+// Gemini's per-minute TPM/RPM 429 says "current quota" (a soft long-window
+// phrase) but links to .../gemini-api/docs/rate-limits, so `rate-limits` is the
+// only short-window signal in the message. Without it the message is classified
 // long-window and the same-model retry loop never fires for Gemini throttles.
 const SHORT_RATE_LIMIT_WINDOW_RE =
   /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|rate-limits)\b/i;
@@ -98,6 +105,13 @@ function resolveShortWindowRateLimitRetry(
   }
   const shortRetryAfter =
     retryAfterSeconds !== null && retryAfterSeconds <= MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS;
+  // Explicit daily/RPD/usage-limit quotas stay long-window even when they carry
+  // the shared Gemini /rate-limits docs URL; only a short provider Retry-After
+  // overrides them. This keeps daily exhaustion on the model/profile fallback
+  // path instead of spending bounded same-model retry budget.
+  if (HARD_LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !shortRetryAfter) {
+    return null;
+  }
   const hasShortWindowSignal = SHORT_RATE_LIMIT_WINDOW_RE.test(raw);
   if (RETRY_AFTER_VALUE_RE.test(raw) && retryAfterSeconds === null && !hasShortWindowSignal) {
     return null;


### PR DESCRIPTION
## Summary

Gemini's per-minute TPM/RPM 429 was misclassified as a long-window (daily-style) rate limit, so OpenClaw never retried the same model and instead immediately fell back to a lower-tier model (e.g. `gemini-flash`) or failed the turn.

The provider error string is:

> `Google Generative AI API error (429): You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits.`

Because it contains `current quota`, it matches `LONG_WINDOW_RATE_LIMIT_RE`. With no short-window signal present, `resolveShortWindowRateLimitRetry` returns `null`, so the same-model short-window retry loop (10s/20s/30s progressive backoff) never fires for Gemini throttles — even though a 1-minute rolling window would have cleared on the next retry.

The only short-window hint in that message is the docs URL ending in `/rate-limits`. This adds `rate-limits` to both short-window classifiers so the Gemini per-minute 429 is routed to the same-model retry path.

### Update: guard the shared `/rate-limits` docs URL (addresses ClawSweeper Codex review)

The ClawSweeper Codex review correctly flagged that Google's `/gemini-api/docs/rate-limits` page covers **RPM, TPM, AND RPD (requests per day / daily)** quotas, so the URL alone cannot prove a short window: a daily (RPD) exhaustion that also links that URL would wrongly burn same-model retry budget before model/profile fallback.

To fix this, an explicit **hard long-window guard** (`daily | weekly | monthly | requests per day | tokens per day | per-day | RPD | usage limit | subscription`) now runs first and forces the long-window path whenever an explicit daily/RPD signal is present — even if the shared `/rate-limits` URL is in the message. Only a short provider `Retry-After` under the cap overrides it.

Result:
- Per-minute Gemini 429 (`current quota` + `/rate-limits`, no daily token) → same-model short-window retry.
- Daily/RPD Gemini 429 (`requests per day` + the same `/rate-limits` URL) → stays on long-window model/profile fallback (unchanged behavior).
- Bare `current quota` messages without the `rate-limits` signal stay on the long-window path (unchanged).

This PR deliberately does **not** add any config surface (e.g. `maxSameModelRateLimitRetries`); that is a separate product/config-policy decision, as the issue's review recommended splitting out.

Fixes #93120

## Files

* `src/agents/embedded-agent-runner/run/assistant-failover.ts` — add `rate-limits` to the short-window classifiers, plus a `HARD_LONG_WINDOW_RATE_LIMIT_RE` guard so explicit daily/RPD quotas keep the long-window fallback despite the shared docs URL.
* `src/agents/embedded-agent-runner/run/assistant-failover.test.ts` — regression test for the per-minute 429 (`retryKind: "same_model_rate_limit"`) **and** a negative regression test for a daily (RPD) 429 that includes the same `/rate-limits` URL (must stay on long-window fallback).

## Verification

Local, on top of latest `origin/main`:

* `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/assistant-failover.test.ts` — 27 passed.
* `pnpm tsgo:core` — pass.
* `oxfmt --check` and `oxlint` on changed files — clean.

## Real behavior proof

* **Behavior addressed:** Gemini per-minute (TPM/RPM) 429s were treated as long-window limits, so the same-model retry loop never fired and OpenClaw fell back to another model / failed the turn. The shared `/rate-limits` docs URL must not promote a daily (RPD) quota to a same-model retry.
* **Real environment tested:** Ran a runtime repro that drives the actual production `handleAssistantFailover` decision path (the same function the embedded agent runner calls), not a vitest mock, against the verbatim Gemini 429 strings, with real callbacks wired to console. No live Gemini key required to exercise the failover decision.
* **Exact steps or command run after this patch:** `node_modules/.bin/tsx /tmp/repro-93120.mts` (imports the production `assistant-failover.ts` and runs `handleAssistantFailover` for the per-minute 429 and for a daily/RPD 429 that includes the same `/rate-limits` URL).
* **Evidence after fix:** Live runtime console output from the production decision path (copied verbatim):

```
=== Gemini PER-MINUTE 429 (TPM/RPM, links to /rate-limits) ===
  classifier isShortWindowRateLimitMessage = true
  [runtime] -> SAME-MODEL rate-limit retry scheduled (short-window backoff)
  outcome.action = retry
  outcome.retryKind = same_model_rate_limit

=== Gemini DAILY (RPD) 429 WITH same /rate-limits URL ===
  classifier isShortWindowRateLimitMessage = false
  [runtime] -> escalate to OTHER-model fallback / profile rotation
  [runtime] -> advanceAuthProfile (other profile/model)
  [runtime] logAssistantFailoverDecision: "rotate_profile"
  outcome.action = retry
  outcome.retryKind = (none)
```

* **Observed result after fix:** The Gemini per-minute 429 resolves to `same_model_rate_limit` and schedules the same-model short-window retry; the Gemini daily (RPD) 429 — even with the identical `/rate-limits` URL — still escalates to other-model fallback / profile rotation (long-window behavior preserved).
* **What was not tested:** A live Gemini API TPM/RPM exhaustion against a real key (reproduced via the verbatim provider error strings through the real decision path instead).
