### PR TITLE
fix(whatsapp): extract GIF metadata and distinguish gifPlayback in media placeholders (fixes #49099)

### DIFF
--- a/extensions/whatsapp/src/inbound.test.ts
+++ b/extensions/whatsapp/src/inbound.test.ts
@@ -247,6 +247,89 @@ describe("web inbound helpers", () => {
     ).toBe("<media:audio>");
   });
 
+  it("distinguishes GIFs from videos using gifPlayback flag", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: { gifPlayback: true },
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe("<media:gif>");
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: { gifPlayback: false },
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe("<media:video>");
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {},
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe("<media:video>");
+  });
+
+  it("extracts externalAdReply metadata from video GIF messages", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {
+          gifPlayback: true,
+          contextInfo: {
+            externalAdReply: {
+              title: "This Is Fine",
+              sourceUrl: "https://giphy.com/gifs/this-is-fine-3o7TK",
+              body: "A dog in a burning room",
+            },
+          },
+        },
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe(
+      '<media:gif title="This Is Fine" source="https://giphy.com/gifs/this-is-fine-3o7TK" description="A dog in a burning room">',
+    );
+  });
+
+  it("extracts externalAdReply metadata from image messages", () => {
+    expect(
+      extractMediaPlaceholder({
+        imageMessage: {
+          contextInfo: {
+            externalAdReply: {
+              title: "Product Photo",
+              sourceUrl: "https://example.com/product",
+            },
+          },
+        },
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe('<media:image title="Product Photo" source="https://example.com/product">');
+  });
+
+  it("escapes quotes and angle brackets in externalAdReply attributes", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {
+          gifPlayback: true,
+          contextInfo: {
+            externalAdReply: {
+              title: 'Say "hello"',
+              sourceUrl: "https://example.com",
+            },
+          },
+        },
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe('<media:gif title="Say &quot;hello&quot;" source="https://example.com">');
+  });
+
+  it("omits empty externalAdReply fields", () => {
+    expect(
+      extractMediaPlaceholder({
+        videoMessage: {
+          gifPlayback: true,
+          contextInfo: {
+            externalAdReply: {
+              title: "Only Title",
+            },
+          },
+        },
+      } as unknown as import("baileys").proto.IMessage),
+    ).toBe('<media:gif title="Only Title">');
+  });
+
   it("extracts WhatsApp location messages", () => {
     const location = extractLocationData({
       locationMessage: {

--- a/extensions/whatsapp/src/inbound.test.ts
+++ b/extensions/whatsapp/src/inbound.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractContactContext,
+  extractExternalAdReplyContext,
   extractLocationData,
   extractMediaPlaceholder,
   extractText,
@@ -265,69 +266,26 @@ describe("web inbound helpers", () => {
     ).toBe("<media:video>");
   });
 
-  it("extracts externalAdReply metadata from video GIF messages", () => {
-    expect(
-      extractMediaPlaceholder({
-        videoMessage: {
-          gifPlayback: true,
-          contextInfo: {
-            externalAdReply: {
-              title: "This Is Fine",
-              sourceUrl: "https://giphy.com/gifs/this-is-fine-3o7TK",
-              body: "A dog in a burning room",
-            },
+  it("keeps externalAdReply metadata out of the media placeholder", () => {
+    const message = {
+      videoMessage: {
+        gifPlayback: true,
+        contextInfo: {
+          externalAdReply: {
+            title: "This Is Fine",
+            sourceUrl: "https://giphy.com/gifs/this-is-fine-3o7TK",
+            body: "A dog in a burning room",
           },
         },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe(
-      '<media:gif title="This Is Fine" source="https://giphy.com/gifs/this-is-fine-3o7TK" description="A dog in a burning room">',
-    );
-  });
+      },
+    } as unknown as import("baileys").proto.IMessage;
 
-  it("extracts externalAdReply metadata from image messages", () => {
-    expect(
-      extractMediaPlaceholder({
-        imageMessage: {
-          contextInfo: {
-            externalAdReply: {
-              title: "Product Photo",
-              sourceUrl: "https://example.com/product",
-            },
-          },
-        },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe('<media:image title="Product Photo" source="https://example.com/product">');
-  });
-
-  it("escapes quotes and angle brackets in externalAdReply attributes", () => {
-    expect(
-      extractMediaPlaceholder({
-        videoMessage: {
-          gifPlayback: true,
-          contextInfo: {
-            externalAdReply: {
-              title: 'Say "hello"',
-              sourceUrl: "https://example.com",
-            },
-          },
-        },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe('<media:gif title="Say &quot;hello&quot;" source="https://example.com">');
-  });
-
-  it("omits empty externalAdReply fields", () => {
-    expect(
-      extractMediaPlaceholder({
-        videoMessage: {
-          gifPlayback: true,
-          contextInfo: {
-            externalAdReply: {
-              title: "Only Title",
-            },
-          },
-        },
-      } as unknown as import("baileys").proto.IMessage),
-    ).toBe('<media:gif title="Only Title">');
+    expect(extractMediaPlaceholder(message)).toBe("<media:gif>");
+    expect(extractExternalAdReplyContext(message)).toEqual({
+      title: "This Is Fine",
+      sourceUrl: "https://giphy.com/gifs/this-is-fine-3o7TK",
+      body: "A dog in a burning room",
+    });
   });
 
   it("extracts WhatsApp location messages", () => {

--- a/extensions/whatsapp/src/inbound.ts
+++ b/extensions/whatsapp/src/inbound.ts
@@ -2,6 +2,7 @@
 export { resetWebInboundDedupe } from "./inbound/dedupe.js";
 export {
   extractContactContext,
+  extractExternalAdReplyContext,
   extractLocationData,
   extractMediaPlaceholder,
   extractText,

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -268,28 +268,24 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
   return undefined;
 }
 
-function escapeAttr(value: string): string {
-  return value.replace(/"/g, "&quot;").replace(/>/g, "&gt;");
-}
-
-function extractExternalAdReplyMetadata(
-  contextInfo: proto.IContextInfo | null | undefined,
-): string {
-  const adReply = contextInfo?.externalAdReply;
+export function extractExternalAdReplyContext(rawMessage: proto.IMessage | undefined):
+  | {
+      title?: string;
+      sourceUrl?: string;
+      body?: string;
+    }
+  | undefined {
+  const message = unwrapMessage(rawMessage);
+  const adReply =
+    message?.imageMessage?.contextInfo?.externalAdReply ??
+    message?.videoMessage?.contextInfo?.externalAdReply;
   if (!adReply) {
-    return "";
+    return undefined;
   }
-  const attrs: string[] = [];
-  if (adReply.title) {
-    attrs.push(`title="${escapeAttr(adReply.title)}"`);
-  }
-  if (adReply.sourceUrl) {
-    attrs.push(`source="${escapeAttr(adReply.sourceUrl)}"`);
-  }
-  if (adReply.body) {
-    attrs.push(`description="${escapeAttr(adReply.body)}"`);
-  }
-  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+  const title = adReply.title?.trim() || undefined;
+  const sourceUrl = adReply.sourceUrl?.trim() || undefined;
+  const body = adReply.body?.trim() || undefined;
+  return title || sourceUrl || body ? { title, sourceUrl, body } : undefined;
 }
 
 export function extractMediaPlaceholder(
@@ -300,14 +296,10 @@ export function extractMediaPlaceholder(
     return undefined;
   }
   if (message.imageMessage) {
-    const metadata = extractExternalAdReplyMetadata(message.imageMessage.contextInfo);
-    return `<media:image${metadata}>`;
+    return "<media:image>";
   }
   if (message.videoMessage) {
-    const isGif = message.videoMessage.gifPlayback === true;
-    const tag = isGif ? "media:gif" : "media:video";
-    const metadata = extractExternalAdReplyMetadata(message.videoMessage.contextInfo);
-    return `<${tag}${metadata}>`;
+    return message.videoMessage.gifPlayback === true ? "<media:gif>" : "<media:video>";
   }
   if (message.audioMessage) {
     return "<media:audio>";

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -268,6 +268,30 @@ export function extractText(rawMessage: proto.IMessage | undefined): string | un
   return undefined;
 }
 
+function escapeAttr(value: string): string {
+  return value.replace(/"/g, "&quot;").replace(/>/g, "&gt;");
+}
+
+function extractExternalAdReplyMetadata(
+  contextInfo: proto.IContextInfo | null | undefined,
+): string {
+  const adReply = contextInfo?.externalAdReply;
+  if (!adReply) {
+    return "";
+  }
+  const attrs: string[] = [];
+  if (adReply.title) {
+    attrs.push(`title="${escapeAttr(adReply.title)}"`);
+  }
+  if (adReply.sourceUrl) {
+    attrs.push(`source="${escapeAttr(adReply.sourceUrl)}"`);
+  }
+  if (adReply.body) {
+    attrs.push(`description="${escapeAttr(adReply.body)}"`);
+  }
+  return attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+}
+
 export function extractMediaPlaceholder(
   rawMessage: proto.IMessage | undefined,
 ): string | undefined {
@@ -276,10 +300,14 @@ export function extractMediaPlaceholder(
     return undefined;
   }
   if (message.imageMessage) {
-    return "<media:image>";
+    const metadata = extractExternalAdReplyMetadata(message.imageMessage.contextInfo);
+    return `<media:image${metadata}>`;
   }
   if (message.videoMessage) {
-    return "<media:video>";
+    const isGif = message.videoMessage.gifPlayback === true;
+    const tag = isGif ? "media:gif" : "media:video";
+    const metadata = extractExternalAdReplyMetadata(message.videoMessage.contextInfo);
+    return `<${tag}${metadata}>`;
   }
   if (message.audioMessage) {
     return "<media:audio>";

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -61,6 +61,7 @@ import {
 } from "./durable-receive.js";
 import {
   describeReplyContext,
+  extractExternalAdReplyContext,
   extractLocationData,
   extractContactContext,
   extractMediaPlaceholder,
@@ -1001,6 +1002,7 @@ export async function attachWebInboxToSocket(
     body: string;
     location?: ReturnType<typeof extractLocationData>;
     contactContext?: ReturnType<typeof extractContactContext>;
+    externalAdReplyContext?: ReturnType<typeof extractExternalAdReplyContext>;
     replyContext?: ReturnType<typeof describeReplyContext>;
     mediaPath?: string;
     mediaType?: string;
@@ -1011,6 +1013,7 @@ export async function attachWebInboxToSocket(
     const location = extractLocationData(msg.message ?? undefined);
     const locationText = location ? formatLocationText(location) : undefined;
     const contactContext = extractContactContext(msg.message ?? undefined);
+    const externalAdReplyContext = extractExternalAdReplyContext(msg.message ?? undefined);
     let body = extractText(msg.message ?? undefined);
     if (locationText) {
       body = [body, locationText].filter(Boolean).join("\n").trim();
@@ -1055,6 +1058,7 @@ export async function attachWebInboxToSocket(
       body,
       location: location ?? undefined,
       contactContext,
+      externalAdReplyContext,
       replyContext,
       mediaPath,
       mediaType,
@@ -1137,6 +1141,28 @@ export async function attachWebInboxToSocket(
             mentions: groupMentions,
           }
         : undefined;
+    const untrustedStructuredContext = [
+      ...(enriched.contactContext
+        ? [
+            {
+              label: "WhatsApp contact",
+              source: "whatsapp",
+              type: enriched.contactContext.kind,
+              payload: enriched.contactContext,
+            },
+          ]
+        : []),
+      ...(enriched.externalAdReplyContext
+        ? [
+            {
+              label: "WhatsApp external ad reply",
+              source: "whatsapp",
+              type: "external_ad_reply",
+              payload: enriched.externalAdReplyContext,
+            },
+          ]
+        : []),
+    ];
     const inboundMessage: QueuedInboundMessage = withDeprecatedWebInboundMessageFlatAliases({
       admission: inbound.access.admission,
       event: {
@@ -1146,16 +1172,8 @@ export async function attachWebInboxToSocket(
       payload: {
         body: enriched.body,
         location: enriched.location ?? undefined,
-        untrustedStructuredContext: enriched.contactContext
-          ? [
-              {
-                label: "WhatsApp contact",
-                source: "whatsapp",
-                type: enriched.contactContext.kind,
-                payload: enriched.contactContext,
-              },
-            ]
-          : undefined,
+        untrustedStructuredContext:
+          untrustedStructuredContext.length > 0 ? untrustedStructuredContext : undefined,
         media,
       },
       platform: {


### PR DESCRIPTION
## Summary

- Distinguish GIFs from regular videos using `videoMessage.gifPlayback` (`<media:gif>` vs `<media:video>`)
- Extract `title`, `sourceUrl`, and `body` from `contextInfo.externalAdReply` on video and image messages
- Add `escapeAttr` helper to sanitize `"` and `>` in attribute values
- Enrich media placeholders with metadata when available (e.g. `<media:gif title="This Is Fine" source="https://giphy.com/...">`)

## Real behavior proof

- **Behavior addressed:** WhatsApp inbound GIF messages are indistinguishable from regular videos in the media placeholder. GIF metadata (title, source URL) from Giphy/Tenor integration is lost.
- **Environment tested:** macOS 26.4.1, Node v25.8.2, OpenClaw local build from `upstream/main` (75cdf221)
- **Steps run after the patch:**
  1. `pnpm build` — successful build
  2. `node scripts/run-vitest.mjs run extensions/whatsapp/src/inbound.test.ts` — all 20 tests passed
  3. `grep -n` verification of source changes
- **Evidence after fix:**
```
$ grep -n 'escapeAttr\|extractExternalAdReplyMetadata\|gifPlayback\|media:gif' extensions/whatsapp/src/inbound/extract.ts
271:function escapeAttr(value: string): string {
275:function extractExternalAdReplyMetadata(
284:    attrs.push(`title="${escapeAttr(adReply.title)}"`);
287:    attrs.push(`source="${escapeAttr(adReply.sourceUrl)}"`);
290:    attrs.push(`description="${escapeAttr(adReply.body)}"`);
303:    const metadata = extractExternalAdReplyMetadata(message.imageMessage.contextInfo);
307:    const isGif = message.videoMessage.gifPlayback === true;
308:    const tag = isGif ? "media:gif" : "media:video";
309:    const metadata = extractExternalAdReplyMetadata(message.videoMessage.contextInfo);

$ node scripts/run-vitest.mjs run extensions/whatsapp/src/inbound.test.ts
 ✓  extension-whatsapp  extensions/whatsapp/src/inbound.test.ts (20 tests) 9ms
 Test Files  1 passed (1)
      Tests  20 passed (20)
```
- **Observed result after fix:** GIF messages produce `<media:gif>` instead of `<media:video>`. When `externalAdReply` metadata is present (from Giphy/Tenor), it's included in the placeholder as XML attributes. Existing video/image/audio/document/sticker placeholders are unchanged.
- **What was not tested:** Live WhatsApp integration (requires real WhatsApp connection). The fix uses baileys proto types and is covered by unit tests.
