### PR TITLE
fix(llm): handle string assistant content on the OpenAI-compatible completion path

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2524,7 +2524,11 @@ function hasToolHistory(messages: Context["messages"]): boolean {
   return messages.some(
     (message) =>
       message.role === "toolResult" ||
-      (message.role === "assistant" && message.content.some((block) => block.type === "toolCall")),
+      // Assistant content can be a raw string from transcript replay; a string
+      // never carries tool calls, so it should not count toward tool history.
+      (message.role === "assistant" &&
+        Array.isArray(message.content) &&
+        message.content.some((block) => block.type === "toolCall")),
   );
 }
 

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -63,7 +63,9 @@ function hasToolHistory(messages: Message[]): boolean {
       return true;
     }
     if (msg.role === "assistant") {
-      if (msg.content.some((block) => block.type === "toolCall")) {
+      // Assistant content can be a raw string from transcript replay; a string
+      // never carries tool calls, so it should not count toward tool history.
+      if (Array.isArray(msg.content) && msg.content.some((block) => block.type === "toolCall")) {
         return true;
       }
     }

--- a/src/llm/providers/transform-messages.ts
+++ b/src/llm/providers/transform-messages.ts
@@ -117,7 +117,15 @@ export function transformMessages<TApi extends Api>(
           assistantMsg.api === model.api &&
           assistantMsg.model === model.id);
 
-      const transformedContent = assistantMsg.content.flatMap((block) => {
+      // Assistant content is typed as a block array, but transcript replay can
+      // hand us a raw string (JSONL passthrough). Normalize it to an equivalent
+      // single text block before transforming, matching the string->text block
+      // handling already used in anthropic-payload-policy.ts.
+      const contentBlocks = Array.isArray(assistantMsg.content)
+        ? assistantMsg.content
+        : [{ type: "text" as const, text: assistantMsg.content as unknown as string }];
+
+      const transformedContent = contentBlocks.flatMap((block) => {
         if (block.type === "thinking") {
           if (modelBoundThinkingReplayMode === "drop") {
             return [];


### PR DESCRIPTION
## Summary

OpenAI-compatible providers crash with `TypeError: ... is not a function` when an assistant message in the conversation history has **string** `content` instead of an array of blocks. Assistant `content` is typed as a block array, but at runtime it can be a string — JSONL transcript entries are passed through verbatim, and the codebase already acknowledges this elsewhere (`anthropic-payload-policy.ts` normalizes `typeof content === "string"`; the user-message branch in `convertMessages` already guards it; #93456 / #93646 handled the same string-content shape on the session/tool-call side).

Three sites on the OpenAI-compatible completion path assume the array shape and throw when fed string content from history:
- `src/llm/providers/transform-messages.ts:120` — `assistantMsg.content.flatMap(...)` (the **first crash**, reached via `buildOpenAICompletionsParams` → `convertMessages` → `transformMessages`).
- `src/agents/openai-transport-stream.ts:2527` — `hasToolHistory`: `message.content.some(...)`.
- `src/llm/providers/openai-completions.ts:66` — the sibling `hasToolHistory`: `msg.content.some(...)`.

So any OpenAI-compatible provider call whose history contains a string-content assistant turn crashes before the request is built.

## Changes

- `transform-messages.ts` — normalize string assistant content to `[{ type: "text", text: content }]` before `flatMap`, **mirroring the existing `anthropic-payload-policy.ts` pattern** (no new mechanism). Array content takes the original path byte-for-byte.
- `openai-transport-stream.ts` / `openai-completions.ts` — guard both `hasToolHistory` with `Array.isArray(content) && ...` (string content carries no tool calls, so `false` is correct).

+17/-3 across 3 files; only the string (error) path changes.

## Real behavior proof

**Behavior addressed**: an OpenAI-compatible completion whose history contains a string-content assistant message no longer crashes; the string is normalized to text and tool-history detection is correct.

**Real environment**: local, Node v22, `node --import tsx`, driving the **real exported** `buildOpenAICompletionsParams` and `streamOpenAICompletions` (the latter captures the built params via the project's `onPayload` test seam before any network call — no mocks).

**Evidence (real entrypoints, string-content + toolResult history)**:
```
post-fix:  buildOpenAICompletionsParams / streamOpenAICompletions -> params built OK, string kept as text, tool-history correct -> RESULT: PASS
```
**Negative controls (each crash point isolated via git stash of the real source)**:
```
revert all                     -> buildOpenAICompletionsParams throws  TypeError: assistantMsg.content.flatMap is not a function   (transform-messages:120)
revert only the hasToolHistory -> streamOpenAICompletions throws        TypeError: msg.content.some is not a function               (openai-completions:66)
revert only transport guard    -> buildOpenAICompletionsParams throws   TypeError: message.content.some is not a function           (openai-transport-stream:2527)
```

**What was not tested**: no live provider network call (the proof captures the built request params before send); the change only affects the string-content path.

## Tests and validation

- `openai-completions.test.ts` 27/27, `openai-transport-stream.test.ts` 270/270, `anthropic-transport-stream.test.ts` 74/74 (transformMessages is shared across providers — no cross-provider regression).
- `npx oxlint --import-plugin` clean on all three changed files.
