### PR TITLE
fix(memory): await search-sync before returning results to prevent stale index (fixes #52115)

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -1,17 +1,19 @@
 // Memory Core plugin module implements manager async state behavior.
-export function startAsyncSearchSync(params: {
+export async function startAsyncSearchSync(params: {
   enabled: boolean;
   dirty: boolean;
   sessionsDirty: boolean;
   sync: (params: { reason: string }) => Promise<void>;
   onError: (err: unknown) => void;
-}): void {
+}): Promise<void> {
   if (!params.enabled || (!params.dirty && !params.sessionsDirty)) {
     return;
   }
-  void params.sync({ reason: "search" }).catch((err: unknown) => {
+  try {
+    await params.sync({ reason: "search" });
+  } catch (err: unknown) {
     params.onError(err);
-  });
+  }
 }
 
 export async function awaitPendingManagerWork(params: {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -630,7 +630,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     const cleaned = preflight.normalizedQuery;
     void this.warmSession(opts?.sessionKey);
-    startAsyncSearchSync({
+    await startAsyncSearchSync({
       enabled: this.settings.sync.onSearch,
       dirty: this.dirty,
       sessionsDirty: this.sessionsDirty,


### PR DESCRIPTION
## Summary

The `startAsyncSearchSync` call in `MemoryIndexManager.search()` was fire-and-forget (`void`), meaning the search returned results from the current index state while the filesystem sync ran in the background. When the gateway process runs for a long time and memory files are created, renamed, or deleted, the first search after a change returned stale results (including ghost paths for deleted files) because the background sync hadn't completed yet.

Changed `startAsyncSearchSync` from synchronous fire-and-forget to `async` (returning `Promise<void>`) and `await` it in the search method. This ensures the index is synced with the filesystem before returning results, matching the CLI behavior which creates a fresh manager each time.

Fixes #52115

## Real behavior proof

- **Behavior addressed:** `memory_search` tool returns stale/invalid results (including ghost paths for deleted files) when the gateway process has been running for a while and memory files have changed on disk.
- **Environment tested:** macOS 26.4.1, Node.js, openclaw/openclaw upstream/main at f046d7aa
- **Steps run after the patch:**
  1. Changed `startAsyncSearchSync` in `extensions/memory-core/src/memory/manager-async-state.ts` from `void` fire-and-forget to `async` returning `Promise<void>`, with `try/catch` error handling replacing `.catch()`
  2. Changed `extensions/memory-core/src/memory/manager.ts:633` to `await startAsyncSearchSync(...)` so search waits for sync completion
  3. Ran memory-core tests: `node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager.async-search.test.ts` — 3 tests passed
  4. Ran search-manager tests: `node scripts/run-vitest.mjs run extensions/memory-core/src/memory/search-manager.test.ts` — 35 tests passed
  5. Ran memory-core index tests: `node scripts/run-vitest.mjs run extensions/memory-core/index.test.ts` — 14 tests passed
  6. Ran `pnpm build` — build succeeded
- **Evidence after fix:**

```
$ node -e "
const fs = require('fs');
const content = fs.readFileSync('extensions/memory-core/src/memory/manager-async-state.ts', 'utf8');
console.log('startAsyncSearchSync is async:', content.includes('export async function startAsyncSearchSync'));
console.log('awaits sync call:', content.includes('await params.sync'));
const managerContent = fs.readFileSync('extensions/memory-core/src/memory/manager.ts', 'utf8');
const lines = managerContent.split('\n');
for (let i = 0; i < lines.length; i++) {
  if (lines[i].includes('await startAsyncSearchSync')) {
    console.log('manager.ts line', i + 1, ':', lines[i].trim());
  }
}
"
startAsyncSearchSync is async: true
awaits sync call: true
manager.ts line 633 : await startAsyncSearchSync({

$ node scripts/run-vitest.mjs run extensions/memory-core/src/memory/manager.async-search.test.ts
 ✓  extension-memory  extensions/memory-core/src/memory/manager.async-search.test.ts (3 tests) 92ms
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ node scripts/run-vitest.mjs run extensions/memory-core/src/memory/search-manager.test.ts
 ✓  extension-memory  extensions/memory-core/src/memory/search-manager.test.ts (35 tests) 437ms
 Test Files  1 passed (1)
      Tests  35 passed (35)
```

- **Observed result after fix:** All 52 related tests pass. The `startAsyncSearchSync` function now returns a `Promise<void>` that the search method awaits, ensuring the memory index is synced with the filesystem before returning search results. This eliminates both stale index results and ghost paths for deleted files.
- **What was not tested:** Live gateway with actual memory file changes over time. The sync-await behavior is verified through unit tests covering the async state machine. The fix is a minimal control-flow change (fire-and-forget → await) that preserves all existing error handling.
