### PR TITLE
fix(weixin): startAccount preserves session routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- **WeChat account routing:** `startAccount` preserves session routing by resolving manifest channel account config from raw account keys with opaque provider ids, while still ignoring manifest account keys that normalize to blocked object keys. (#93686) Thanks @zhangguiping-xydt.
+
 ## 2026.6.10
 
 ### Highlights

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -1075,6 +1075,42 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(inheritedAccount?.config?.token).not.toBe("prototype-token");
   });
 
+  it("ignores manifest account keys that normalize to blocked object keys", () => {
+    const { pluginDir } = writeExternalSetupChannelPlugin({
+      setupEntry: false,
+      pluginId: "external-chat-plugin",
+      channelId: "external-chat",
+      manifestChannelConfig: true,
+    });
+    const cfg = {
+      channels: {
+        "external-chat": {
+          accounts: {
+            "constructor ": {
+              token: "blocked-token",
+            },
+          },
+        },
+      },
+      plugins: {
+        load: { paths: [pluginDir] },
+        allow: ["external-chat-plugin"],
+      },
+    } as never;
+    const plugin = listReadOnlyChannelPluginsForConfig(cfg, {
+      env: { ...process.env },
+      includePersistedAuthState: false,
+    }).find((entry) => entry.id === "external-chat");
+
+    expect(plugin?.config.listAccountIds(cfg)).toEqual([]);
+    const account = plugin?.config.resolveAccount(cfg, "default");
+    const accountFields = expectRecordFields(account, {
+      accountId: "default",
+    });
+    const configFields = expectRecordFields(accountFields.config, {});
+    expect(configFields.token).toBeUndefined();
+  });
+
   it("resolves manifest channel account config from raw account keys with opaque provider ids", () => {
     const { pluginDir } = writeExternalSetupChannelPlugin({
       setupEntry: false,

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -1075,6 +1075,45 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(inheritedAccount?.config?.token).not.toBe("prototype-token");
   });
 
+  it("resolves manifest channel account config from raw account keys with opaque provider ids", () => {
+    const { pluginDir } = writeExternalSetupChannelPlugin({
+      setupEntry: false,
+      pluginId: "external-chat-plugin",
+      channelId: "external-chat",
+      manifestChannelConfig: true,
+    });
+    const cfg = {
+      channels: {
+        "external-chat": {
+          accounts: {
+            "59000514e8ad@im.bot": {
+              enabled: true,
+              baseUrl: "https://ilinkai.weixin.qq.com",
+            },
+          },
+        },
+      },
+      plugins: {
+        load: { paths: [pluginDir] },
+        allow: ["external-chat-plugin"],
+      },
+    } as never;
+    const plugin = listReadOnlyChannelPluginsForConfig(cfg, {
+      env: { ...process.env },
+      includePersistedAuthState: false,
+    }).find((entry) => entry.id === "external-chat");
+
+    expect(plugin?.config.listAccountIds(cfg)).toEqual(["59000514e8ad-im-bot"]);
+    const account = plugin?.config.resolveAccount(cfg, "59000514e8ad-im-bot");
+    const fields = expectRecordFields(account, {
+      accountId: "59000514e8ad-im-bot",
+    });
+    expectRecordFields(fields.config, {
+      enabled: true,
+      baseUrl: "https://ilinkai.weixin.qq.com",
+    });
+  });
+
   it("keeps setup-entry precedence when channel config descriptors are not runtime cutoffs", () => {
     const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
       pluginId: "external-chat-plugin",

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -35,6 +35,7 @@ import {
   type PluginModuleLoaderCache,
 } from "../../plugins/plugin-module-loader-cache.js";
 import { getActivePluginChannelRegistryVersion } from "../../plugins/runtime.js";
+import { resolveNormalizedAccountEntry } from "../../routing/account-lookup.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { getBundledChannelSetupPlugin } from "./bundled.js";
 import {
@@ -372,9 +373,10 @@ function resolveManifestChannelAccountConfig(params: {
   const resolvedAccountId = normalizeAccountId(params.accountId);
   const accounts = channelConfig.accounts;
   if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
-    const accountConfig = readOwnRecordValue(
+    const accountConfig = resolveNormalizedAccountEntry(
       accounts as Record<string, unknown>,
       resolvedAccountId,
+      normalizeAccountId,
     );
     if (accountConfig && typeof accountConfig === "object" && !Array.isArray(accountConfig)) {
       return accountConfig as Record<string, unknown>;

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -36,7 +36,11 @@ import {
 } from "../../plugins/plugin-module-loader-cache.js";
 import { getActivePluginChannelRegistryVersion } from "../../plugins/runtime.js";
 import { resolveNormalizedAccountEntry } from "../../routing/account-lookup.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  normalizeOptionalAccountId,
+} from "../../routing/session-key.js";
 import { getBundledChannelSetupPlugin } from "./bundled.js";
 import {
   isSafeManifestChannelId,
@@ -350,6 +354,10 @@ function getChannelConfigRecord(cfg: OpenClawConfig, channelId: string): Record<
     : {};
 }
 
+function normalizeManifestAccountConfigKey(accountId: string): string {
+  return normalizeOptionalAccountId(accountId) ?? "";
+}
+
 function listManifestChannelAccountIds(cfg: OpenClawConfig, channelId: string): string[] {
   const channelConfig = getChannelConfigRecord(cfg, channelId);
   const accounts = channelConfig.accounts;
@@ -357,8 +365,8 @@ function listManifestChannelAccountIds(cfg: OpenClawConfig, channelId: string): 
     return sortUniqueStrings(
       Object.keys(accounts)
         .filter((accountId) => !isBlockedObjectKey(accountId))
-        .map((accountId) => normalizeAccountId(accountId))
-        .filter((accountId) => !isBlockedObjectKey(accountId)),
+        .map((accountId) => normalizeOptionalAccountId(accountId))
+        .filter((accountId): accountId is string => Boolean(accountId)),
     );
   }
   return hasExplicitChannelConfig({ config: cfg, channelId }) ? [DEFAULT_ACCOUNT_ID] : [];
@@ -376,7 +384,7 @@ function resolveManifestChannelAccountConfig(params: {
     const accountConfig = resolveNormalizedAccountEntry(
       accounts as Record<string, unknown>,
       resolvedAccountId,
-      normalizeAccountId,
+      normalizeManifestAccountConfigKey,
     );
     if (accountConfig && typeof accountConfig === "object" && !Array.isArray(accountConfig)) {
       return accountConfig as Record<string, unknown>;

--- a/src/routing/account-lookup.test.ts
+++ b/src/routing/account-lookup.test.ts
@@ -95,6 +95,15 @@ describe("resolveNormalizedAccountEntry", () => {
       expected: undefined,
     },
     {
+      name: "does not resolve invalid raw keys through the default account fallback",
+      accounts: {
+        "constructor ": { id: "blocked" },
+      } as Record<string, { id: string }>,
+      resolve: (accounts: Record<string, { id: string }>) =>
+        resolveNormalizedAccountEntry(accounts, "default", normalizeRoutingAccountId),
+      expected: undefined,
+    },
+    {
       name: "ignores prototype-chain values",
       resolve: () => undefined,
       expected: undefined,

--- a/src/routing/account-lookup.test.ts
+++ b/src/routing/account-lookup.test.ts
@@ -84,6 +84,17 @@ describe("resolveNormalizedAccountEntry", () => {
       expected: undefined,
     },
     {
+      name: "does not resolve keys that normalize to blocked object keys",
+      accounts: {
+        "constructor ": { id: "blocked" },
+      },
+      resolve: (accounts: Record<string, { id: string }>) =>
+        resolveNormalizedAccountEntry(accounts, "constructor", (accountId) =>
+          accountId.trim().toLowerCase(),
+        ),
+      expected: undefined,
+    },
+    {
       name: "ignores prototype-chain values",
       resolve: () => undefined,
       expected: undefined,

--- a/src/routing/account-lookup.test.ts
+++ b/src/routing/account-lookup.test.ts
@@ -87,7 +87,7 @@ describe("resolveNormalizedAccountEntry", () => {
       name: "does not resolve keys that normalize to blocked object keys",
       accounts: {
         "constructor ": { id: "blocked" },
-      },
+      } as Record<string, { id: string }>,
       resolve: (accounts: Record<string, { id: string }>) =>
         resolveNormalizedAccountEntry(accounts, "constructor", (accountId) =>
           accountId.trim().toLowerCase(),

--- a/src/routing/account-lookup.test.ts
+++ b/src/routing/account-lookup.test.ts
@@ -1,5 +1,6 @@
 // Account lookup tests cover account matching by id, alias, and chat metadata.
 import { describe, expect, it } from "vitest";
+import { normalizeAccountId as normalizeRoutingAccountId } from "./account-id.js";
 import { resolveAccountEntry, resolveNormalizedAccountEntry } from "./account-lookup.js";
 
 function createAccountsWithPrototypePollution() {
@@ -74,6 +75,13 @@ describe("resolveNormalizedAccountEntry", () => {
       expected: {
         id: "ops",
       },
+    },
+    {
+      name: "does not resolve blocked raw keys as the default account",
+      accounts: JSON.parse('{"__proto__":{"id":"blocked"}}') as Record<string, { id: string }>,
+      resolve: (accounts: Record<string, { id: string }>) =>
+        resolveNormalizedAccountEntry(accounts, "default", normalizeRoutingAccountId),
+      expected: undefined,
     },
     {
       name: "ignores prototype-chain values",

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -1,6 +1,7 @@
 // Account lookup helpers resolve route accounts from normalized account ids.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import { normalizeOptionalAccountId } from "./account-id.js";
 
 // Case-insensitive account lookup for config maps that may preserve user
 // casing. Exact keys win so callers can still distinguish intentional entries.
@@ -39,8 +40,12 @@ export function resolveNormalizedAccountEntry<T>(
     if (isBlockedObjectKey(key)) {
       return false;
     }
-    const normalizedKey = normalizeAccountId(key);
-    return !isBlockedObjectKey(normalizedKey) && normalizedKey === normalized;
+    const candidate = normalizeAccountId(key);
+    return (
+      Boolean(normalizeOptionalAccountId(key)) &&
+      !isBlockedObjectKey(candidate) &&
+      candidate === normalized
+    );
   });
   return matchKey ? accounts[matchKey] : undefined;
 }

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -31,12 +31,16 @@ export function resolveNormalizedAccountEntry<T>(
   if (!accounts || typeof accounts !== "object") {
     return undefined;
   }
-  if (Object.hasOwn(accounts, accountId)) {
+  if (Object.hasOwn(accounts, accountId) && !isBlockedObjectKey(accountId)) {
     return accounts[accountId];
   }
   const normalized = normalizeAccountId(accountId);
-  const matchKey = Object.keys(accounts).find(
-    (key) => !isBlockedObjectKey(key) && normalizeAccountId(key) === normalized,
-  );
+  const matchKey = Object.keys(accounts).find((key) => {
+    if (isBlockedObjectKey(key)) {
+      return false;
+    }
+    const normalizedKey = normalizeAccountId(key);
+    return !isBlockedObjectKey(normalizedKey) && normalizedKey === normalized;
+  });
   return matchKey ? accounts[matchKey] : undefined;
 }

--- a/src/routing/account-lookup.ts
+++ b/src/routing/account-lookup.ts
@@ -1,5 +1,6 @@
 // Account lookup helpers resolve route accounts from normalized account ids.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 
 // Case-insensitive account lookup for config maps that may preserve user
 // casing. Exact keys win so callers can still distinguish intentional entries.
@@ -34,6 +35,8 @@ export function resolveNormalizedAccountEntry<T>(
     return accounts[accountId];
   }
   const normalized = normalizeAccountId(accountId);
-  const matchKey = Object.keys(accounts).find((key) => normalizeAccountId(key) === normalized);
+  const matchKey = Object.keys(accounts).find(
+    (key) => !isBlockedObjectKey(key) && normalizeAccountId(key) === normalized,
+  );
   return matchKey ? accounts[matchKey] : undefined;
 }


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Root cause: manifest channel account listing normalized raw config keys into route-safe IDs, but manifest account resolution used a different mapping contract and looked up that normalized route ID directly in the raw `accounts` object. A raw key like `59000514e8ad@im.bot` could be listed as `59000514e8ad-im-bot` but then fail to resolve before `startAccount`.
- This PR makes manifest account resolution use the same normalized account lookup invariant as listing, and tightens the shared lookup helper so invalid config-map candidate keys such as `"constructor "` cannot collapse through `normalizeAccountId` to `default`.

Why does this matter now?

- User impact: a configured external Weixin account can be dropped before startup, which prevents the channel from handling inbound or outbound messages.
- The maintainer follow-up identified one remaining shared-helper edge case after the main Weixin/session-routing fix: invalid raw account keys could still be selected as the default account through fallback normalization.

What is the intended outcome?

- Fix classification: root-cause bug fix, scoped to external channel/plugin account config resolution.
- Maintainer-ready confidence: high. The fix is covered by focused routing and read-only plugin tests, plus the existing live openclaw-weixin proof that the external account starts and reaches running state.
- Why this is root-cause fix: the resolver and lister now share one account-id mapping contract, and fallback matching only considers candidate config keys that have a valid optional canonical account ID instead of letting invalid keys silently select `default`.

What is intentionally out of scope?

- What did NOT change: plugin manifest format, gateway startup flow, generated metadata, provider-specific openclaw-weixin code, account ID normalization rules for route inputs, config schema, migration behavior, and permissions are unchanged.
- Related open PR / same-contract scan: this is an update to the existing PR #93686 that already owns the focused fix for issue #93556; no replacement or competing same-contract PR is being opened.

What does success look like?

- A raw provider account key that normalizes to a route-safe ID resolves back to its original config entry.
- Invalid/prototype-like config-map keys do not resolve as `default` through the shared normalized lookup helper.
- Focused tests pass for the helper and the manifest/read-only plugin path.

What should reviewers focus on?

- Architecture / source-of-truth check: `resolveNormalizedAccountEntry` is the source-of-truth helper for normalized config-map account lookup, and manifest account resolution calls it with the optional validating normalizer for config keys.
- Patch quality notes: this is not a fallback workaround; it rejects invalid candidate keys before fallback comparison while preserving valid exact-key and route-safe ID behavior.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #93556.

Which issues, PRs, or discussions are related?

Related #93686.

Was this requested by a maintainer or owner?

Yes. A maintainer requested tightening the shared lookup helper so invalid raw config-map keys do not collapse to `default`.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a live external `openclaw-weixin` channel account whose raw provider ID normalizes to a route-safe account ID can be loaded by the Gateway, started through the channel plugin, and reported as running instead of being dropped before `startAccount`.
- Real environment tested: macOS Darwin 25.5.0, Node v24.15.0, OpenClaw 2026.6.2, external `@tencent-weixin/openclaw-weixin@2.4.3`, isolated OpenClaw home, live QR login with Weixin.
- Exact steps or command run after this patch:

  ```bash
  pnpm openclaw plugins install "@tencent-weixin/openclaw-weixin@2.4.3" --force
  pnpm openclaw config set plugins.entries.openclaw-weixin.enabled true
  pnpm openclaw channels login --channel openclaw-weixin
  pnpm openclaw config set gateway.mode local
  pnpm openclaw config set gateway.port 18790
  pnpm dev gateway --port 18790
  pnpm openclaw channels status --probe
  pnpm test src/channels/plugins/read-only.test.ts src/routing/account-lookup.test.ts
  ```

- Evidence after fix (sanitized live output from the existing PR proof):

  ```text
  Installed plugin: openclaw-weixin
  Restart the gateway to load plugins.

  已将此 OpenClaw 连接到微信。
  ```

  ```text
  $ node scripts/run-node.mjs gateway --port 18790
  [gateway] auto-enabled plugins for this runtime without writing config:
  - openclaw-weixin configured, enabled automatically.
  [plugins] loading openclaw-weixin from <proof-home>/.openclaw/npm/projects/tencent-weixin-openclaw-weixin-.../node_modules/@tencent-weixin/openclaw-weixin/dist/index.js
  [gateway] http server listening (... plugins ...)
  [gateway] starting channels and sidecars...
  [openclaw-weixin] [<route-safe-weixin-account-id>] starting weixin provider (https://ilinkai.weixin.qq.com/...)
  [gateway] ready
  [openclaw-weixin] weixin monitor started (https://ilinkai.weixin.qq.com/..., account=<route-safe-weixin-account-id>)
  [openclaw-weixin] [weixin] no previous sync buf, starting fresh
  ```

  ```text
  $ node scripts/run-node.mjs channels status --probe
  Checking channel status (probe)…
  Gateway reachable.
  - openclaw-weixin <route-safe-weixin-account-id>: enabled, configured, running
  ```

- Observed result after fix: the external Weixin manifest account is listed with the route-safe ID, resolves back to the raw configured account entry, enters provider startup, starts the Weixin monitor, and is reported by `channels status --probe` as `enabled, configured, running`; the issue-specific `unable to resolve` account failure before `startAccount` is no longer present.
- What was not tested: a fresh live Weixin login was not re-run for the small maintainer follow-up commit; the follow-up is a shared helper guard for invalid config-map candidate keys and is covered by focused regression tests below.
- Proof limitations or environment constraints: local dependency installation reports a `node-llama-cpp` postinstall build failure because this machine has CMake 3.18.2 while that package asks for CMake 3.19+, but the focused Vitest suites needed for this PR ran successfully from the installed workspace.
- Before evidence (optional but encouraged): the new regression test failed before the helper guard with `expected { id: 'blocked' } to deeply equal undefined` for `resolveNormalizedAccountEntry({ "constructor ": cfg }, "default", normalizeAccountId)`.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

- Target test file: `src/routing/account-lookup.test.ts` via `pnpm exec vitest run src/routing/account-lookup.test.ts` — pass, 8 tests.
- Target test file: `src/channels/plugins/read-only.test.ts` via `pnpm exec vitest run src/channels/plugins/read-only.test.ts` — pass, 31 tests.
- ClawSweeper local commit review — pass.

What regression coverage was added or updated?

- Scenario locked in: `resolveNormalizedAccountEntry({ "constructor ": cfg }, "default", normalizeAccountId)` returns `undefined` instead of selecting the invalid raw key as the default account.
- Existing manifest/read-only plugin tests continue to cover opaque raw provider IDs like `59000514e8ad@im.bot` resolving through their route-safe account IDs.

What failed before this fix, if known?

- The new regression test failed before the fix because the shared helper returned `{ id: "blocked" }` for the invalid `"constructor "` key when resolving `default`.
- Why this is the smallest reliable guardrail: it exercises the shared helper contract directly and keeps the manifest plugin path covered without adding provider-specific code or broader fixture churn.

If no test was added, why not?

- Not applicable; a focused regression test was added.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, only for invalid account config keys that previously collapsed to `default` during normalized fallback lookup.

Did config, environment, or migration behavior change? (`Yes/No`)

No migration or schema change. Existing valid account keys keep the same matching behavior.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, the account lookup helper is stricter about invalid/prototype-like config-map keys so they cannot be selected through fallback matching.

What is the highest-risk area?

- Risk labels considered: `merge-risk: compatibility`, `merge-risk: security-boundary`, and session/account routing state.
- Risk explanation: `resolveNormalizedAccountEntry` is exported through plugin SDK account surfaces, so the compatibility-sensitive behavior is that invalid raw account keys which only matched through fallback normalization now stop matching.

How is that risk mitigated?

- Why acceptable: the guard uses the existing optional account-id normalizer as the validating source-of-truth for config-map candidate keys, preserves valid exact-key lookup, and preserves the route-safe opaque provider ID behavior covered by tests.
- The change does not alter the public manifest schema, account ID route normalization, gateway lifecycle, or provider-specific code.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Maintainer review after this PR update; local submit checks, focused validations, and remote exact-head CI are complete.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on author: no known author-side code, proof, or CI gap after this update.
- Waiting on maintainer: final acceptance of the exported-helper compatibility/security-boundary tradeoff.
- Waiting on CI: none at the latest checked exact head; visible remote checks are complete with no failures.

Which bot or reviewer comments were addressed?

- RF-001: ClawSweeper's exact-head CI wait is satisfied by the latest remote status: visible checks are complete with no failures.
- RF-002: The exported-helper compatibility risk is mitigated by using the existing optional account-id validity check for fallback candidates, while preserving valid exact-key and route-safe ID behavior.
- RF-003: ClawSweeper's earlier pending `checks-node-compact-small-whole-2` validation state is stale because the exact-head check has completed successfully.
- RF-004: The remaining shared-helper compatibility/security-boundary choice is documented for maintainer acceptance; there is no separate narrow author repair unless maintainers prefer a localized-guard direction.
- RF-005: The `checking` maintainer signal is superseded by the later concrete follow-up and no longer has a separate author action.
- RF-006: sliverp's follow-up about `"constructor "` collapsing to `default` is fixed by the helper guard and regression test.
- RF-007: The author sync/comment thread is addressed by the pushed PR update; no separate code action is required beyond RF-006.
- RF-008: The latest author comment summarizes the completed fix and does not introduce a new code or proof action.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
