### PR TITLE
fix(minimax): check base_resp envelope errors in TTS provider

### DIFF
--- a/extensions/minimax/tts.test.ts
+++ b/extensions/minimax/tts.test.ts
@@ -48,4 +48,75 @@ describe("minimaxTTS", () => {
     });
     expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.init?.signal).toBeInstanceOf(AbortSignal);
   });
+
+  it("throws on base_resp envelope error even when data.audio is present (regression #76904)", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({
+          data: { audio: Buffer.from("placeholder").toString("hex") },
+          base_resp: { status_code: 1002, status_msg: "Quota exceeded" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+      release: vi.fn(async () => undefined),
+    });
+
+    await expect(
+      minimaxTTS({
+        text: "hello",
+        apiKey: "sk-test",
+        baseUrl: "https://api.minimax.io",
+        model: "speech-2.8-hd",
+        voiceId: "English_expressive_narrator",
+        timeoutMs: 10_000,
+      }),
+    ).rejects.toThrow("MiniMax TTS API error (1002): Quota exceeded");
+  });
+
+  it("throws on base_resp envelope error with empty audio", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({
+          base_resp: { status_code: 1001, status_msg: "Rate limit" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+      release: vi.fn(async () => undefined),
+    });
+
+    await expect(
+      minimaxTTS({
+        text: "hello",
+        apiKey: "sk-test",
+        baseUrl: "https://api.minimax.io",
+        model: "speech-2.8-hd",
+        voiceId: "English_expressive_narrator",
+        timeoutMs: 10_000,
+      }),
+    ).rejects.toThrow("MiniMax TTS API error (1001): Rate limit");
+  });
+
+  it("succeeds when base_resp.status_code is 0", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({
+          data: { audio: Buffer.from("real-audio").toString("hex") },
+          base_resp: { status_code: 0, status_msg: "success" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+      release: vi.fn(async () => undefined),
+    });
+
+    const audio = await minimaxTTS({
+      text: "hello",
+      apiKey: "sk-test",
+      baseUrl: "https://api.minimax.io",
+      model: "speech-2.8-hd",
+      voiceId: "English_expressive_narrator",
+      timeoutMs: 10_000,
+    });
+
+    expect(audio.toString()).toBe("real-audio");
+  });
 });

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -103,7 +103,25 @@ export async function minimaxTTS(params: {
     try {
       await assertOkOrThrowProviderError(response, "MiniMax TTS API error");
 
-      const body = (await response.json()) as { data?: { audio?: string } };
+      const body = (await response.json()) as {
+        data?: { audio?: string };
+        base_resp?: { status_code?: number; status_msg?: string };
+      };
+
+      // Check base_resp for envelope errors (HTTP 200 with non-zero status_code).
+      // Other MiniMax providers (image, video, music, web-search) already check this.
+      // Without this check, quota/billing errors with placeholder audio are silently accepted.
+      if (
+        body.base_resp &&
+        typeof body.base_resp.status_code === "number" &&
+        body.base_resp.status_code !== 0
+      ) {
+        const msg = body.base_resp.status_msg ?? "unknown error";
+        throw new Error(
+          `MiniMax TTS API error (${body.base_resp.status_code}): ${msg}`,
+        );
+      }
+
       const hexAudio = body?.data?.audio;
       if (!hexAudio) {
         throw new Error("MiniMax TTS API returned no audio data");


### PR DESCRIPTION
fix(minimax): check base_resp envelope errors in TTS provider

## Summary

- **Problem:** MiniMax TTS API returns HTTP 200 even on quota/billing errors, with the error encoded in `base_resp.status_code`. Without this check, placeholder audio returned alongside the error is silently accepted, preventing the TTS dispatcher from falling back to a configured secondary provider.
- **Fix:** Add `base_resp.status_code !== 0` check after `assertOkOrThrowProviderError`, following the same pattern used by all other MiniMax providers (image, video, music, web-search).
- **Out of scope:** No changes to the TTS dispatcher/fallback loop, no changes to other providers.

## Linked context

Closes #76904

## Real behavior proof

- **Behavior or issue addressed:** When MiniMax TTS hits a quota/billing limit, the API returns HTTP 200 with `base_resp.status_code !== 0` and optional placeholder audio. Without this check, the dispatcher never tries the configured fallback provider.
- **Real environment tested:** Windows 10, Node.js v22.22.3, OpenClaw latest main, local checkout with the patch applied.
- **Exact steps or command run after this patch:**
  1. Ran `node scripts/run-vitest.mjs run extensions/minimax/tts.test.ts` with 3 new test cases covering envelope errors
  2. Tests verify: quota error (1002) with placeholder audio throws, rate limit (1001) with empty audio throws, success (status_code: 0) returns audio
- **Evidence after fix:**
```
$ node scripts/run-vitest.mjs run extensions/minimax/tts.test.ts
Test Files  1 passed (1)
     Tests  4 passed (4)
```
- **Observed result after fix:** Envelope errors with `base_resp.status_code !== 0` now throw structured errors with the actual MiniMax error code and message. The TTS dispatcher's fallback loop catches these errors and tries the next provider. Placeholder audio alongside errors is no longer silently accepted.
- **What was not tested:** Live MiniMax API call with real quota exceeded (requires paid MiniMax account). The test uses mocked HTTP responses matching the documented MiniMax API envelope format.

## Tests and validation

- `node scripts/run-vitest.mjs run extensions/minimax/tts.test.ts` — 4/4 passed (1 existing + 3 new)
- New tests:
  - "throws on base_resp envelope error even when data.audio is present (regression #76904)"
  - "throws on base_resp envelope error with empty audio"
  - "succeeds when base_resp.status_code is 0"
- No CHANGELOG.md edits

## Risk checklist

- userVisible: Yes (TTS failover now works when MiniMax quota is exceeded)
- configEnvMigration: No
- securityAuthNetwork: No
- Mitigation: Only affects MiniMax TTS provider error handling. Other providers unchanged. Follows established pattern from 4 sibling MiniMax providers.

## Current review state

- [x] AI-assisted (built with Claude Code)
