### PR TITLE
fix(zalo): accept string chat ids for outbound sends

### DIFF
--- a/extensions/zalo/src/channel.directory.test.ts
+++ b/extensions/zalo/src/channel.directory.test.ts
@@ -55,7 +55,7 @@ describe("zalo directory", () => {
     expect(zaloPlugin.messaging?.normalizeTarget?.("  zl:234  ")).toBe("234");
   });
 
-  it("recognizes numeric and hex-like Bot API chat ids as direct targets", () => {
+  it("recognizes opaque Bot API chat ids as direct targets", () => {
     const looksLikeId = zaloPlugin.messaging?.targetResolver?.looksLikeId;
     if (!looksLikeId) {
       throw new Error("expected Zalo target resolver");
@@ -63,8 +63,12 @@ describe("zalo directory", () => {
 
     expect(looksLikeId("123456", "123456")).toBe(true);
     expect(looksLikeId("3becaa50ae12474c1e03", "3becaa50ae12474c1e03")).toBe(true);
+    expect(looksLikeId("abc.xyz", "abc.xyz")).toBe(true);
     expect(looksLikeId("zalo:49270a5f8f1c66423f0d", "49270a5f8f1c66423f0d")).toBe(true);
+    expect(looksLikeId("zalo:abc.xyz", "abc.xyz")).toBe(true);
     expect(looksLikeId("zl:3becaa50ae12474c1e03", "3becaa50ae12474c1e03")).toBe(true);
-    expect(looksLikeId("support", "support")).toBe(false);
+    expect(looksLikeId("zl:abc.xyz", "abc.xyz")).toBe(true);
+    expect(looksLikeId("support", "support")).toBe(true);
+    expect(looksLikeId("zalo:  ", "")).toBe(false);
   });
 });

--- a/extensions/zalo/src/channel.directory.test.ts
+++ b/extensions/zalo/src/channel.directory.test.ts
@@ -54,4 +54,17 @@ describe("zalo directory", () => {
     expect(zaloPlugin.pairing?.normalizeAllowEntry?.("  zalo:123  ")).toBe("123");
     expect(zaloPlugin.messaging?.normalizeTarget?.("  zl:234  ")).toBe("234");
   });
+
+  it("recognizes numeric and hex-like Bot API chat ids as direct targets", () => {
+    const looksLikeId = zaloPlugin.messaging?.targetResolver?.looksLikeId;
+    if (!looksLikeId) {
+      throw new Error("expected Zalo target resolver");
+    }
+
+    expect(looksLikeId("123456", "123456")).toBe(true);
+    expect(looksLikeId("3becaa50ae12474c1e03", "3becaa50ae12474c1e03")).toBe(true);
+    expect(looksLikeId("zalo:49270a5f8f1c66423f0d", "49270a5f8f1c66423f0d")).toBe(true);
+    expect(looksLikeId("zl:3becaa50ae12474c1e03", "3becaa50ae12474c1e03")).toBe(true);
+    expect(looksLikeId("support", "support")).toBe(false);
+  });
 });

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -30,10 +30,7 @@ import { createStaticReplyToModeResolver } from "openclaw/plugin-sdk/conversatio
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { listResolvedDirectoryUserEntriesFromAllowFrom } from "openclaw/plugin-sdk/directory-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import {
-  isNumericTargetId,
-  sendPayloadWithChunkedTextAndMedia,
-} from "openclaw/plugin-sdk/reply-payload";
+import { sendPayloadWithChunkedTextAndMedia } from "openclaw/plugin-sdk/reply-payload";
 import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
@@ -72,6 +69,13 @@ function normalizeZaloMessagingTarget(raw: string): string | undefined {
     return undefined;
   }
   return trimmed.replace(/^(zalo|zl):/i, "").trim();
+}
+
+const zaloChatIdPattern = /^(?:\d{3,}|(?=[a-f0-9]{12,}$)(?=.*[a-f])[a-f0-9]+)$/i;
+
+function looksLikeZaloChatId(raw: string, normalized?: string): boolean {
+  const target = normalizeZaloMessagingTarget(normalized ?? raw);
+  return target ? zaloChatIdPattern.test(target) : false;
 }
 
 const loadZaloChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
@@ -234,7 +238,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
         normalizeTarget: normalizeZaloMessagingTarget,
         resolveOutboundSessionRoute: (params) => resolveZaloOutboundSessionRoute(params),
         targetResolver: {
-          looksLikeId: isNumericTargetId,
+          looksLikeId: looksLikeZaloChatId,
           hint: "<chatId>",
         },
       },

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -71,11 +71,9 @@ function normalizeZaloMessagingTarget(raw: string): string | undefined {
   return trimmed.replace(/^(zalo|zl):/i, "").trim();
 }
 
-const zaloChatIdPattern = /^(?:\d{3,}|(?=[a-f0-9]{12,}$)(?=.*[a-f])[a-f0-9]+)$/i;
-
 function looksLikeZaloChatId(raw: string, normalized?: string): boolean {
   const target = normalizeZaloMessagingTarget(normalized ?? raw);
-  return target ? zaloChatIdPattern.test(target) : false;
+  return Boolean(target);
 }
 
 const loadZaloChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes Zalo proactive outbound sends rejecting valid Bot API `chat_id` string values before delivery.
- Replaces the Zalo plugin's numeric-only target check with a Zalo-specific predicate that treats the normalized nonblank `chat_id` as opaque, matching Zalo's documented `String` field.
- Keeps the change plugin-local; shared outbound target heuristics and other channels are intentionally unchanged.

Why does this matter now?

- #57594 is still open and source-reproducible on current `main`.
- The current Zalo resolver rejects valid IDs like `3becaa50ae12474c1e03` and documented string examples like `abc.xyz`, which blocks proactive notifications even though Zalo Bot API delivery can work with string `chat_id` values.

What is the intended outcome?

- `openclaw message send --channel zalo --target <chat_id>` resolves any nonblank normalized Zalo target as a direct Zalo `chat_id` instead of failing with `Unknown target` because OpenClaw cannot infer the upstream ID grammar.

What is intentionally out of scope?

- Live Zalo Bot API delivery changes.
- Zalo auth, token, webhook, pairing, group policy, or directory behavior.
- Any shared outbound resolver behavior for other channels.

What does success look like?

- Bare, `zalo:`, and `zl:` Zalo string chat IDs pass target resolution.
- Existing numeric and reported hex-like Zalo chat IDs continue to pass.
- Blank and prefix-only Zalo targets remain rejected.

What should reviewers focus on?

- Whether treating Zalo `chat_id` as opaque is the right boundary given Zalo documents it as `String`.
- Whether the behavior is acceptably scoped to Zalo only.
- Whether the tests cover numeric, reported hex-like, documented dotted, prefixed, and blank target shapes.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #57594

Which issues, PRs, or discussions are related?

Related #84599

Was this requested by a maintainer or owner?

The review on #93689 requested avoiding an undocumented regex grammar and adding coverage for Zalo's documented `abc.xyz` string `chat_id` example.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Zalo proactive outbound sends rejected valid Bot API `chat_id` string values before send target resolution.
- Real environment tested: Local OpenClaw checkout on the updated branch, Node 24.14.0, CLI dry-run mode, no live Zalo credentials.
- Exact steps or command run after this patch: `openclaw message send --channel zalo --target abc.xyz --message test --dry-run --json`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live output:
  ```json
  {
    "action": "send",
    "channel": "zalo",
    "dryRun": true,
    "handledBy": "core",
    "payload": {
      "channel": "zalo",
      "to": "abc.xyz",
      "via": "direct",
      "mediaUrl": null,
      "dryRun": true
    }
  }
  ```
- Observed result after fix: The documented dotted string Zalo `chat_id` resolves to a direct outbound target instead of failing as an unknown target.
- What was not tested: Live Zalo Bot API delivery with real credentials.
- Proof limitations or environment constraints: Dry-run proves OpenClaw's pre-send target resolution path without contacting Zalo. Live delivery still depends on a valid bot token and upstream Zalo API access.
- Before evidence (optional but encouraged): On `origin/main`, `extensions/zalo/src/channel.ts` wired `targetResolver.looksLikeId` to `isNumericTargetId`; that helper only accepts `/^\d{3,}$/`, excluding reported hex-like IDs and documented dotted string IDs.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs extensions/zalo/src/channel.directory.test.ts src/infra/outbound/target-normalization.test.ts src/infra/outbound/target-resolver.test.ts`
- `node scripts/run-vitest.mjs extensions/zalo/src src/infra/outbound/outbound-session.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/zalo/src/channel.ts extensions/zalo/src/channel.directory.test.ts`
- `./node_modules/.bin/oxlint extensions/zalo/src/channel.ts extensions/zalo/src/channel.directory.test.ts`
- `git diff --check`
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs qaRuntime`

What regression coverage was added or updated?

- Added Zalo plugin coverage for numeric, reported hex-like, documented dotted, `zalo:`-prefixed, and `zl:`-prefixed chat IDs.
- Added blank/prefix-only coverage so empty normalized Zalo targets are still rejected.

What failed before this fix, if known?

- Current `main` uses `isNumericTargetId` for Zalo direct target detection, so reported Zalo `chat_id` values like `3becaa50ae12474c1e03` and documented string examples like `abc.xyz` do not qualify as id-like targets.

If no test was added, why not?

- Focused regression coverage was added.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes

Did config, environment, or migration behavior change? (`Yes/No`)

No

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

- The Zalo target-id heuristic now treats any nonblank normalized Zalo target as a direct `chat_id`, so ordinary-looking strings can be sent directly instead of being rejected as unknown targets.

How is that risk mitigated?

- The behavior is scoped only to Zalo.
- Zalo documents `chat_id` as `String` and shows a dotted string example, so OpenClaw should not invent a narrower grammar.
- Blank and prefix-only inputs still fail normalization.
- Tests cover numeric, reported hex-like, documented dotted, prefixed, ordinary nonblank, and blank target shapes.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

- Maintainer re-review.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on GitHub CI and maintainer re-review. Live Zalo delivery proof would require valid Zalo Bot API credentials; the included dry-run proof covers OpenClaw target resolution without sending a live message.

Which bot or reviewer comments were addressed?

- Addressed Vincent Koc's review on #93689 by removing the undocumented hex-only grammar, treating normalized nonblank Zalo `chat_id` values as opaque strings, and adding `abc.xyz` plus prefixed variants to the resolver test.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
