### PR TITLE
fix(agents): hydrate truncated session replies

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -244,6 +244,72 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("A\n[tool calls omitted]\n[tool calls omitted]\nB")).toBe("A\nB");
   });
 
+  it.each([
+    "...(truncated)...",
+    "... (truncated)",
+    "...<truncated>",
+    "...[truncated]...",
+    "...[additional startup memory truncated]...",
+    "...(live output truncated)...",
+    "…(truncated AGENTS.md: kept 100+policy 8+50 chars of 500)…",
+    "[...truncated, read AGENTS.md for full content...]",
+    "[...truncated, read src/agents/example file.ts for full content...]",
+    "[…truncated 100+50/500]",
+    "[... 42 more characters truncated]",
+    "[... 123 more characters truncated; rerun with narrower args if needed]",
+    "[... 4 chars truncated; narrow args]",
+    "…9 tokens truncated…",
+  ])("preserves standalone truncation-marker text without producer provenance: %s", (input) => {
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
+  it("preserves copied-log truncation marker lines without producer provenance", () => {
+    const input = [
+      "Visible before.",
+      "",
+      "[... 42 more characters truncated]",
+      "...(truncated)...",
+      "Visible after.",
+      "",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
+  it("preserves chat-history display marker text without producer provenance", () => {
+    const input = ["Visible prefix.", "...(truncated)..."].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
+  it.each([
+    "Wait... let me think.",
+    "What does [... 42 more characters truncated] mean?",
+    "The literal marker is `...(truncated)...`.",
+    "abc…1 chars truncated…def",
+  ])("preserves ordinary truncation-marker prose: %s", (input) => {
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
+  it("preserves truncation sentinel examples inside fenced code", () => {
+    const input = [
+      "Example:",
+      "```",
+      "...(truncated)...",
+      "[... 42 more characters truncated]",
+      "[...truncated, read AGENTS.md for full content...]",
+      "```",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
+  it("preserves truncation sentinel examples inside longer Markdown fences", () => {
+    const input = ["````md", "```", "[... 42 more characters truncated]", "```", "````"].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(input);
+  });
+
   it("strips legacy uppercase TOOL_CALL blocks before user-facing delivery", () => {
     const input = [
       "Before",

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -380,6 +380,10 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
   return result;
 }
 
+type SanitizeUserFacingTextOptions = {
+  errorContext?: boolean;
+};
+
 function collapseConsecutiveDuplicateBlocks(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -424,7 +428,10 @@ export function isLikelyHttpErrorText(raw: string): boolean {
   return HTTP_ERROR_HINTS.some((hint) => message.includes(hint));
 }
 
-export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: boolean }): string {
+export function sanitizeUserFacingText(
+  text: unknown,
+  opts?: SanitizeUserFacingTextOptions,
+): string {
   const raw = coerceChatContentText(text);
   if (!raw) {
     return raw;

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1396,6 +1396,89 @@ describe("sessions tools", () => {
     expect(sendParams.message).toBe("announce now");
   });
 
+  it("sessions_send hydrates a truncated delayed same-session reply before delivery", async () => {
+    const calls: Array<{ method?: string; params?: Record<string, unknown> }> = [];
+    const targetKey = "agent:main:discord:channel:target-room";
+    const fullReply = `${"a".repeat(8_000)}\ncomplete reply tail`;
+    let historyCallCount = 0;
+    let sentMessage: string | undefined;
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      calls.push(request);
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "previous reply" }],
+                    timestamp: 1,
+                  },
+                ]
+              : [
+                  {
+                    role: "assistant",
+                    content: [
+                      { type: "text", text: `${fullReply.slice(0, 8_000)}\n...(truncated)...` },
+                    ],
+                    __openclaw: { id: "reply-full" },
+                    timestamp: 2,
+                  },
+                ],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-truncated", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "run-truncated", status: "ok" };
+      }
+      if (request.method === "chat.message.get") {
+        return {
+          ok: true,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: fullReply }],
+            __openclaw: { id: "reply-full" },
+          },
+        };
+      }
+      if (request.method === "send") {
+        sentMessage = request.params?.message as string | undefined;
+        return { messageId: "delivered" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: targetKey,
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-truncated-delivery", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    expect(sessionsSendDetails(result.details).status).toBe("accepted");
+    await waitForCalls(() => calls.filter((call) => call.method === "send").length, 1);
+    const messageGetCall = calls.find((call) => call.method === "chat.message.get");
+    expect(messageGetCall?.params).toEqual({
+      sessionKey: targetKey,
+      messageId: "reply-full",
+      maxChars: 2_000_000,
+    });
+    expect(sentMessage).toBe(fullReply);
+    expect(sentMessage).not.toContain("...(truncated)...");
+  });
+
   it("sessions_send keeps delayed requester replies alive after a wait timeout", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:main:main";

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -190,6 +190,253 @@ describe("readLatestAssistantReply", () => {
 
     expect(result).toBe("Hi there");
   });
+
+  it("keeps chat.history display markers for generic reply reads", async () => {
+    callGatewayMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Partial reply\n...(truncated)..." }],
+        },
+      ],
+    });
+
+    const result = await readLatestAssistantReply({ sessionKey: "agent:main:child" });
+
+    expect(result).toContain("Partial reply");
+    expect(result).toContain("...(truncated)...");
+  });
+
+  it("keeps fullText marker text when there is no history row provenance", async () => {
+    callGatewayMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Copied log\n...(truncated)...\nDone" }],
+        },
+      ],
+    });
+
+    const result = await readLatestAssistantReplySnapshot({
+      sessionKey: "agent:main:child",
+      fullText: true,
+    });
+
+    expect(result.text).toBe("Copied log\n...(truncated)...\nDone");
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates a full assistant reply when the delivery history row is truncated", async () => {
+    const fullText = `${"a".repeat(8_000)}\ncomplete reply tail`;
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: `${fullText.slice(0, 8_000)}\n...(truncated)...` }],
+              __openclaw: { id: "reply-full" },
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.message.get") {
+        return {
+          ok: true,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: fullText }],
+            __openclaw: { id: "reply-full" },
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method: ${request.method}`);
+    });
+
+    const result = await readLatestAssistantReplySnapshot({
+      sessionKey: "agent:main:child",
+      fullText: true,
+    });
+
+    expect(result.text).toBe(fullText);
+    expect(callGatewayMock).toHaveBeenLastCalledWith({
+      method: "chat.message.get",
+      params: {
+        sessionKey: "agent:main:child",
+        messageId: "reply-full",
+        maxChars: 2_000_000,
+      },
+    });
+  });
+
+  it("hydrates split final-answer history rows when one block has the display truncation marker", async () => {
+    const fullText = `${"a".repeat(8_000)}\ncomplete reply tail`;
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                {
+                  type: "text",
+                  text: `${fullText.slice(0, 8_000)}\n...(truncated)...`,
+                  textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+                },
+                {
+                  type: "text",
+                  text: "trailing display block",
+                  textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+                },
+              ],
+              __openclaw: { id: "reply-split-full" },
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.message.get") {
+        return {
+          ok: true,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: fullText }],
+            __openclaw: { id: "reply-split-full" },
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method: ${request.method}`);
+    });
+
+    const result = await readLatestAssistantReplySnapshot({
+      sessionKey: "agent:main:child",
+      fullText: true,
+    });
+
+    expect(result.text).toBe(fullText);
+    expect(callGatewayMock).toHaveBeenLastCalledWith({
+      method: "chat.message.get",
+      params: {
+        sessionKey: "agent:main:child",
+        messageId: "reply-split-full",
+        maxChars: 2_000_000,
+      },
+    });
+  });
+
+  it("returns hydrated full replies that include literal truncation-marker text", async () => {
+    const fullText = "Here is the exact marker:\n...(truncated)...\nKeep this line.";
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: fullText }],
+              __openclaw: { id: "reply-literal-marker" },
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.message.get") {
+        return {
+          ok: true,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: fullText }],
+            __openclaw: { id: "reply-literal-marker" },
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method: ${request.method}`);
+    });
+
+    const result = await readLatestAssistantReplySnapshot({
+      sessionKey: "agent:main:child",
+      fullText: true,
+    });
+
+    expect(result.text).toBe(fullText);
+    expect(callGatewayMock).toHaveBeenLastCalledWith({
+      method: "chat.message.get",
+      params: {
+        sessionKey: "agent:main:child",
+        messageId: "reply-literal-marker",
+        maxChars: 2_000_000,
+      },
+    });
+  });
+
+  it("does not return a truncated reply when full delivery hydration is unavailable", async () => {
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Partial reply\n...(truncated)..." }],
+              __openclaw: { id: "reply-missing" },
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.message.get") {
+        return { ok: false, unavailableReason: "not_found" };
+      }
+      throw new Error(`unexpected gateway method: ${request.method}`);
+    });
+
+    await expect(
+      readLatestAssistantReplySnapshot({
+        sessionKey: "agent:main:child",
+        fullText: true,
+      }),
+    ).resolves.toEqual({});
+  });
+
+  it("keeps truncated message-tool mirror rows when hydration resolves to a tool row", async () => {
+    const truncatedMirror = "Long message-tool reply\n...(truncated)...";
+    callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: truncatedMirror }],
+              openclawMessageToolMirror: { toolName: "message" },
+              __openclaw: { id: "tool-result-row" },
+            },
+          ],
+        };
+      }
+      if (request.method === "chat.message.get") {
+        return {
+          ok: true,
+          message: {
+            role: "toolResult",
+            toolName: "message",
+            content: { ok: true, messageId: "delivered" },
+            __openclaw: { id: "tool-result-row" },
+          },
+        };
+      }
+      throw new Error(`unexpected gateway method: ${request.method}`);
+    });
+
+    const result = await readLatestAssistantReplySnapshot({
+      sessionKey: "agent:main:child",
+      fullText: true,
+    });
+
+    expect(result.text).toBe(truncatedMirror);
+    expect(callGatewayMock).toHaveBeenLastCalledWith({
+      method: "chat.message.get",
+      params: {
+        sessionKey: "agent:main:child",
+        messageId: "tool-result-row",
+        maxChars: 2_000_000,
+      },
+    });
+  });
 });
 
 describe("waitForAgentRun", () => {

--- a/src/agents/run-wait.ts
+++ b/src/agents/run-wait.ts
@@ -23,7 +23,11 @@ import {
   normalizeProviderStarted,
   type AgentRunTimeoutPhase,
 } from "./run-timeout-attribution.js";
-import { extractAssistantText, stripToolMessages } from "./tools/chat-history-text.js";
+import {
+  extractAssistantText,
+  hasDisplayTruncationMarker,
+  stripToolMessages,
+} from "./tools/chat-history-text.js";
 
 type GatewayCaller = typeof callGateway;
 
@@ -160,7 +164,48 @@ function normalizePendingRunIds(runIds: Iterable<string>): string[] {
   return [...seen];
 }
 
-function resolveLatestAssistantReplySnapshot(messages: unknown[]): AssistantReplySnapshot {
+const FULL_REPLY_MAX_CHARS = 2_000_000;
+
+function readChatHistoryMessageId(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const metadata = (message as Record<string, unknown>)["__openclaw"];
+  if (!metadata || typeof metadata !== "object") {
+    return undefined;
+  }
+  const id = (metadata as { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+function isChatHistoryMessageToolMirror(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const mirror = (message as Record<string, unknown>).openclawMessageToolMirror;
+  return Boolean(mirror && typeof mirror === "object" && !Array.isArray(mirror));
+}
+
+function createAssistantReplySnapshot(candidate: unknown): AssistantReplySnapshot {
+  const text = extractAssistantText(candidate);
+  if (!text?.trim()) {
+    return {};
+  }
+  let fingerprint: string | undefined;
+  try {
+    fingerprint = JSON.stringify(candidate);
+  } catch {
+    fingerprint = text;
+  }
+  return { text, fingerprint };
+}
+
+function resolveLatestAssistantReply(messages: unknown[]):
+  | {
+      candidate: unknown;
+      snapshot: AssistantReplySnapshot;
+    }
+  | undefined {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const candidate = messages[i];
     if (!candidate || typeof candidate !== "object") {
@@ -169,36 +214,66 @@ function resolveLatestAssistantReplySnapshot(messages: unknown[]): AssistantRepl
     if ((candidate as { role?: unknown }).role !== "assistant") {
       continue;
     }
-    const text = extractAssistantText(candidate);
-    if (!text?.trim()) {
+    const snapshot = createAssistantReplySnapshot(candidate);
+    if (!snapshot.text?.trim()) {
       continue;
     }
-    let fingerprint: string | undefined;
-    try {
-      fingerprint = JSON.stringify(candidate);
-    } catch {
-      fingerprint = text;
-    }
-    return { text, fingerprint };
+    return { candidate, snapshot };
   }
-  return {};
+  return undefined;
 }
 
 /** Read the latest non-tool assistant message for a session. */
 export async function readLatestAssistantReplySnapshot(params: {
   sessionKey: string;
   limit?: number;
+  fullText?: boolean;
   callGateway?: GatewayCaller;
 }): Promise<AssistantReplySnapshot> {
-  const history = await (params.callGateway ?? runWaitDeps.callGateway)<{
+  const gateway = params.callGateway ?? runWaitDeps.callGateway;
+  const history = await gateway<{
     messages: Array<unknown>;
   }>({
     method: "chat.history",
     params: { sessionKey: params.sessionKey, limit: params.limit ?? 50 },
   });
-  return resolveLatestAssistantReplySnapshot(
+  const latest = resolveLatestAssistantReply(
     stripToolMessages(Array.isArray(history?.messages) ? history.messages : []),
   );
+  if (!latest) {
+    return {};
+  }
+  if (!params.fullText || !hasDisplayTruncationMarker(latest.candidate)) {
+    return latest.snapshot;
+  }
+
+  const messageId = readChatHistoryMessageId(latest.candidate);
+  if (!messageId) {
+    return latest.snapshot;
+  }
+  try {
+    const full = await gateway<{
+      ok?: boolean;
+      message?: unknown;
+    }>({
+      method: "chat.message.get",
+      params: {
+        sessionKey: params.sessionKey,
+        messageId,
+        maxChars: FULL_REPLY_MAX_CHARS,
+      },
+    });
+    if (!full?.ok || !full.message) {
+      return isChatHistoryMessageToolMirror(latest.candidate) ? latest.snapshot : {};
+    }
+    const fullSnapshot = createAssistantReplySnapshot(full.message);
+    if (fullSnapshot.text?.trim()) {
+      return fullSnapshot;
+    }
+    return isChatHistoryMessageToolMirror(latest.candidate) ? latest.snapshot : {};
+  } catch {
+    return isChatHistoryMessageToolMirror(latest.candidate) ? latest.snapshot : {};
+  }
 }
 
 /** Read only the latest assistant text for call sites that do not need fingerprints. */
@@ -257,6 +332,7 @@ export async function waitForAgentRunAndReadUpdatedAssistantReply(params: {
   sessionKey: string;
   timeoutMs: number;
   limit?: number;
+  fullText?: boolean;
   baseline?: AssistantReplySnapshot;
   callGateway?: GatewayCaller;
 }): Promise<AgentWaitResult & { replyText?: string }> {
@@ -272,6 +348,7 @@ export async function waitForAgentRunAndReadUpdatedAssistantReply(params: {
   const latestReply = await readLatestAssistantReplySnapshot({
     sessionKey: params.sessionKey,
     limit: params.limit,
+    fullText: params.fullText,
     callGateway: params.callGateway,
   });
   const baselineFingerprint = params.baseline?.fingerprint;

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -7,6 +7,8 @@ import { extractAssistantTextForPhase } from "../../shared/chat-message-content.
 import { sanitizeAssistantVisibleTextWithProfile } from "../../shared/text/assistant-visible-text.js";
 import { sanitizeUserFacingText } from "../embedded-agent-helpers/sanitize-user-facing-text.js";
 
+const DISPLAY_TRUNCATION_MARKER_LINE_RE = /(^|\r?\n)\s*\.\.\.\(truncated\)\.\.\.\s*(?=\r?\n|$)/i;
+
 export function stripToolMessages(messages: unknown[]): unknown[] {
   return messages.filter((msg) => {
     if (!msg || typeof msg !== "object") {
@@ -48,4 +50,24 @@ export function extractAssistantText(message: unknown): string | undefined {
   const errorContext = stopReason === "error";
 
   return joined ? sanitizeUserFacingText(joined, { errorContext }) : undefined;
+}
+
+export function hasDisplayTruncationMarker(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if ((message as { role?: unknown }).role !== "assistant") {
+    return false;
+  }
+  const joined =
+    extractAssistantTextForPhase(message, {
+      phase: "final_answer",
+      sanitizeText: (text) => text,
+      joinWith: "\n",
+    }) ??
+    extractAssistantTextForPhase(message, {
+      sanitizeText: (text) => text,
+      joinWith: "\n",
+    });
+  return typeof joined === "string" && DISPLAY_TRUNCATION_MARKER_LINE_RE.test(joined);
 }

--- a/src/agents/tools/embedded-gateway-stub.runtime.ts
+++ b/src/agents/tools/embedded-gateway-stub.runtime.ts
@@ -7,6 +7,7 @@
 export { resolveSessionAgentId } from "../../agents/agent-scope.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export {
+  projectChatDisplayMessage,
   projectRecentChatDisplayMessages,
   resolveEffectiveChatHistoryMaxChars,
 } from "../../gateway/chat-display-projection.js";

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -19,6 +19,7 @@ const runtime = vi.hoisted(() => ({
   ),
   resolveEffectiveChatHistoryMaxChars: vi.fn(() => 100_000),
   projectRecentChatDisplayMessages: vi.fn((messages: unknown[]): unknown[] => messages),
+  projectChatDisplayMessage: vi.fn((message: unknown): unknown => message),
   augmentChatHistoryWithCanvasBlocks: vi.fn((messages: unknown[]) => messages),
   getMaxChatHistoryMessagesBytes: vi.fn(() => 100_000),
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES: 100_000,
@@ -41,6 +42,7 @@ describe("embedded gateway stub", () => {
     runtime.getRuntimeConfig.mockClear();
     runtime.resolveSessionKeyFromResolveParams.mockReset();
     runtime.projectRecentChatDisplayMessages.mockClear();
+    runtime.projectChatDisplayMessage.mockClear();
     runtime.readSessionMessagesAsync.mockClear();
     runtime.loadSessionEntry.mockClear();
     runtime.resolveSessionAgentId.mockClear();
@@ -254,5 +256,80 @@ describe("embedded gateway stub", () => {
       }),
     ).rejects.toThrow("limit must be a positive integer");
     expect(runtime.readSessionMessagesAsync).not.toHaveBeenCalled();
+  });
+
+  it("hydrates only transcript rows exposed by embedded chat history", async () => {
+    const fullMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "complete response" }],
+      __openclaw: { id: "reply-full" },
+    };
+    runtime.readSessionMessagesAsync.mockResolvedValueOnce([fullMessage]);
+    runtime.projectRecentChatDisplayMessages.mockReturnValueOnce([
+      {
+        ...fullMessage,
+        content: [{ type: "text", text: "partial\n...(truncated)..." }],
+      },
+    ]);
+
+    const callGateway = createEmbeddedCallGateway();
+    await callGateway({
+      method: "chat.history",
+      params: { sessionKey: "agent:main:main" },
+    });
+    const result = await callGateway<{ ok: boolean; message?: unknown }>({
+      method: "chat.message.get",
+      params: {
+        sessionKey: "agent:main:main",
+        messageId: "reply-full",
+        maxChars: 2_000_000,
+      },
+    });
+
+    expect(result).toEqual({ ok: true, message: fullMessage });
+    expect(runtime.projectChatDisplayMessage).toHaveBeenCalledWith(fullMessage, {
+      maxChars: 2_000_000,
+    });
+  });
+
+  it("does not hydrate embedded rows that history did not expose", async () => {
+    const callGateway = createEmbeddedCallGateway();
+
+    await expect(
+      callGateway({
+        method: "chat.message.get",
+        params: {
+          sessionKey: "agent:main:main",
+          messageId: "not-exposed",
+        },
+      }),
+    ).resolves.toEqual({ ok: false, unavailableReason: "not_found" });
+  });
+
+  it("keeps embedded global chat hydration isolated by agent scope", async () => {
+    const workMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "work-only response" }],
+      __openclaw: { id: "reply-global" },
+    };
+    runtime.readSessionMessagesAsync.mockResolvedValueOnce([workMessage]);
+    runtime.projectRecentChatDisplayMessages.mockReturnValueOnce([workMessage]);
+
+    const callGateway = createEmbeddedCallGateway();
+    await callGateway({
+      method: "chat.history",
+      params: { sessionKey: "global", agentId: "work" },
+    });
+
+    await expect(
+      callGateway({
+        method: "chat.message.get",
+        params: {
+          sessionKey: "global",
+          agentId: "main",
+          messageId: "reply-global",
+        },
+      }),
+    ).resolves.toEqual({ ok: false, unavailableReason: "not_found" });
   });
 });

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -43,6 +43,10 @@ interface EmbeddedGatewayRuntime {
     maxSingleMessageBytes: number;
   }) => { messages: unknown[] };
   resolveEffectiveChatHistoryMaxChars: (cfg: OpenClawConfig) => number;
+  projectChatDisplayMessage: (
+    message: unknown,
+    opts?: { maxChars?: number },
+  ) => Record<string, unknown> | undefined;
   projectRecentChatDisplayMessages: (
     msgs: unknown[],
     opts?: { maxChars?: number; maxMessages?: number },
@@ -125,7 +129,67 @@ async function handleSessionsResolve(params: Record<string, unknown>) {
   return { ok: true, key: resolved.key };
 }
 
-async function handleChatHistory(params: Record<string, unknown>): Promise<{
+function readChatHistoryMessageId(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const metadata = (message as Record<string, unknown>)["__openclaw"];
+  if (!metadata || typeof metadata !== "object") {
+    return undefined;
+  }
+  const id = (metadata as { id?: unknown }).id;
+  return typeof id === "string" ? id : undefined;
+}
+
+function readRequestedAgentId(
+  params: Record<string, unknown>,
+  sessionKey: string,
+): string | undefined {
+  const agentId = typeof params.agentId === "string" ? params.agentId : undefined;
+  return agentId ?? parseAgentSessionKey(sessionKey)?.agentId;
+}
+
+function historyMessageCacheKey(
+  sessionKey: string,
+  requestedAgentId: string | undefined,
+  messageId: string,
+): string {
+  return `${sessionKey}\u0000${requestedAgentId ?? ""}\u0000${messageId}`;
+}
+
+function cacheExposedHistoryMessages(
+  historyMessageCache: Map<string, unknown>,
+  sessionKey: string,
+  requestedAgentId: string | undefined,
+  rawMessages: unknown[],
+  exposedMessages: unknown[],
+): void {
+  const prefix = `${sessionKey}\u0000${requestedAgentId ?? ""}\u0000`;
+  for (const key of historyMessageCache.keys()) {
+    if (key.startsWith(prefix)) {
+      historyMessageCache.delete(key);
+    }
+  }
+  const rawById = new Map<string, unknown>();
+  for (const message of rawMessages) {
+    const id = readChatHistoryMessageId(message);
+    if (id) {
+      rawById.set(id, message);
+    }
+  }
+  for (const message of exposedMessages) {
+    const id = readChatHistoryMessageId(message);
+    const raw = id ? rawById.get(id) : undefined;
+    if (id && raw) {
+      historyMessageCache.set(historyMessageCacheKey(sessionKey, requestedAgentId, id), raw);
+    }
+  }
+}
+
+async function handleChatHistory(
+  params: Record<string, unknown>,
+  historyMessageCache: Map<string, unknown>,
+): Promise<{
   sessionKey: string;
   sessionId: string | undefined;
   messages: unknown[];
@@ -136,9 +200,7 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   const rt = await getRuntime();
 
   const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey : "";
-  const agentId = typeof params.agentId === "string" ? params.agentId : undefined;
-  const parsedAgentId = parseAgentSessionKey(sessionKey)?.agentId;
-  const requestedAgentId = agentId ?? parsedAgentId;
+  const requestedAgentId = readRequestedAgentId(params, sessionKey);
   const limit = readPositiveIntegerParam(params, "limit");
 
   const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
@@ -197,6 +259,13 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   });
   const capped = rt.capArrayByJsonBytes(replaced.messages, maxHistoryBytes).items;
   const bounded = rt.enforceChatHistoryFinalBudget({ messages: capped, maxBytes: maxHistoryBytes });
+  cacheExposedHistoryMessages(
+    historyMessageCache,
+    sessionKey,
+    requestedAgentId,
+    rawMessages,
+    bounded.messages,
+  );
 
   return {
     sessionKey,
@@ -208,8 +277,34 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   };
 }
 
+async function handleChatMessageGet(
+  params: Record<string, unknown>,
+  historyMessageCache: Map<string, unknown>,
+): Promise<{ ok: boolean; message?: unknown; unavailableReason?: "not_found" | "not_visible" }> {
+  const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey : "";
+  const messageId = typeof params.messageId === "string" ? params.messageId : "";
+  const requestedAgentId = readRequestedAgentId(params, sessionKey);
+  const source = historyMessageCache.get(
+    historyMessageCacheKey(sessionKey, requestedAgentId, messageId),
+  );
+  if (!source) {
+    return { ok: false, unavailableReason: "not_found" };
+  }
+  const maxChars = readPositiveIntegerParam(params, "maxChars") ?? 1_000_000;
+  const rt = await getRuntime();
+  const projected = rt.projectChatDisplayMessage(source, { maxChars });
+  if (!projected) {
+    return { ok: false, unavailableReason: "not_visible" };
+  }
+  return {
+    ok: true,
+    message: rt.augmentChatHistoryWithCanvasBlocks([projected])[0],
+  };
+}
+
 /** Creates a local callGateway replacement for supported session methods. */
 export function createEmbeddedCallGateway(): EmbeddedCallGateway {
+  const historyMessageCache = new Map<string, unknown>();
   return async <T = Record<string, unknown>>(opts: CallGatewayOptions): Promise<T> => {
     const method = opts.method?.trim();
     const params = (opts.params ?? {}) as Record<string, unknown>;
@@ -220,7 +315,9 @@ export function createEmbeddedCallGateway(): EmbeddedCallGateway {
       case "sessions.resolve":
         return (await handleSessionsResolve(params)) as T;
       case "chat.history":
-        return (await handleChatHistory(params)) as T;
+        return (await handleChatHistory(params, historyMessageCache)) as T;
+      case "chat.message.get":
+        return (await handleChatMessageGet(params, historyMessageCache)) as T;
       default:
         throw new Error(
           `Method "${method}" requires a running gateway (unavailable in local embedded mode).`,

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -97,6 +97,7 @@ export async function runSessionsSendA2AFlow(params: {
       if (wait.status === "ok") {
         const latestSnapshot = await readLatestAssistantReplySnapshot({
           sessionKey: params.targetSessionKey,
+          fullText: true,
           callGateway: sessionsSendA2ADeps.callGateway,
         });
         const baselineFingerprint = params.baseline?.fingerprint;

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -567,12 +567,14 @@ export function createSessionsSendTool(opts?: {
           ? await readLatestAssistantReplySnapshot({
               sessionKey: resolvedKey,
               limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+              fullText: true,
               callGateway: gatewayCall,
             })
           : sameSessionA2A
             ? await readLatestAssistantReplySnapshot({
                 sessionKey: resolvedKey,
                 limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+                fullText: true,
                 callGateway: gatewayCall,
               }).catch(() => undefined)
             : undefined;
@@ -707,6 +709,7 @@ export function createSessionsSendTool(opts?: {
         sessionKey: resolvedKey,
         timeoutMs,
         limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+        fullText: true,
         baseline: baselineReply,
         callGateway: gatewayCall,
       });


### PR DESCRIPTION
## Summary

This PR keeps session-delivered replies from treating a shortened `chat.history` preview as the complete assistant reply.

- Uses the existing `chat.message.get` path to hydrate a full assistant message when a session-delivery read sees a `chat.history` display truncation marker on a row with OpenClaw message provenance.
- Preserves legitimate literal truncation-marker text such as `...(truncated)...`, copied logs, and `[... 42 more characters truncated]` in normal user-facing sanitizer output.
- Keeps no-provenance marker text intact; if a marker-looking row has no `__openclaw.id`, the generic reply snapshot is returned instead of being deleted.
- Keeps the unavailable-hydration case conservative: if a proven display-shortened history row has an id but `chat.message.get` cannot return the full message, the delivery path does not send the shortened row as a complete reply.

AI-assisted: yes. Codex was used locally to draft and review the patch; markoub is the submitting author and reviewed the resulting diff and validation.

## Linked context

Which issue does this close?

None.

Related context: #82121. This PR is the narrow session-delivery hydration fix. The broader central-sanitizer path is being handled separately in #94094, so this PR should leave #82121 open unless maintainers choose otherwise.

Which issues, PRs, or discussions are related?

Related #82128

Was this requested by a maintainer or owner?

Yes. This update addresses Vincent Koc's maintainer blocker on this PR from June 16, 2026.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: session delivery no longer sends a display-truncated `chat.history` preview as a full reply. When `chat.history` exposes a display-shortened row with OpenClaw message provenance, the delivery read hydrates the full text through `chat.message.get`; literal marker text remains part of the full reply when it was real assistant content.
- Real environment tested: local OpenClaw checkout on macOS, branch `markoub/pr93694-maintainer-fix`, commit `ea291399a3088b1c26c121dfa9f01d00ca2a3ad9`.
- Real gateway path tested: isolated temp `HOME` / `OPENCLAW_STATE_DIR`, synthetic redacted session transcript, token-authenticated local WebSocket gateway subprocess started through the real CLI entrypoint.
- Exact gateway entrypoint used by the proof command:

```bash
node scripts/run-node.mjs gateway run --port <ephemeral> --bind loopback --allow-unconfigured --token <redacted> --ws-log compact
```

- Exact steps or command run after this patch:

```text
1. Create isolated temp HOME, OPENCLAW_STATE_DIR, OPENCLAW_CONFIG_PATH, and sessions.json.
2. Append a synthetic assistant message through appendAssistantMessageToSessionTranscript({
     sessionKey: "agent:main:proof-session",
     expectedSessionId: "proof-session",
     updateMode: "inline"
   }).
3. Start the real OpenClaw gateway CLI subprocess shown above.
4. Call the gateway over WebSocket with callGateway({ method: "chat.history", params: { maxChars: 240 } }).
5. Verify the returned history row is display-truncated and carries the appended OpenClaw message id.
6. Call callGateway({ method: "chat.message.get", params: { messageId, maxChars: 10000 } }).
7. Call readLatestAssistantReplySnapshot({ sessionKey, limit: 5, fullText: true }) without passing callGateway.
8. Assert chat.message.get and readLatestAssistantReplySnapshot both return the full assistant text, including a literal "...(truncated)..." line.
```

- Evidence after fix:

```json
{
  "proof": "real OpenClaw CLI gateway subprocess + WebSocket transport",
  "commandEntrypoint": "node scripts/run-node.mjs gateway run --bind loopback --allow-unconfigured --token <redacted>",
  "commit": "ea291399a3088b1c26c121dfa9f01d00ca2a3ad9",
  "gatewayUrl": "ws://127.0.0.1:64042",
  "auth": "token auth, token redacted",
  "sessionKey": "agent:main:proof-session",
  "appendedMessageId": "8dca3ccc-00a3-49af-ba31-789412d88719",
  "historyMessageId": "8dca3ccc-00a3-49af-ba31-789412d88719",
  "sameMessageId": true,
  "historyWasDisplayTruncated": true,
  "historyLength": 258,
  "fullLength": 1980,
  "directGetOk": true,
  "directGetMatchesFull": true,
  "hydratedMatchesFull": true,
  "hydratedPreservesLiteralMarker": true,
  "hydratedEndsWith": "wer:\n...(truncated)...\nEND_OF_FULL_REPLY",
  "noCallGatewayOverrideUsed": true,
  "privateData": "none; isolated temp HOME/OPENCLAW_STATE_DIR and synthetic redacted content"
}
```

- Observed result after fix: the real gateway `chat.history` response was display-truncated, but the same message id was hydrated through `chat.message.get` and `readLatestAssistantReplySnapshot({ fullText: true })` returned the full reply.
- What was not tested: a live external LLM/provider turn and browser UI screenshot.
- Proof limitations or environment constraints: provider/channel startup was skipped in the isolated local gateway because the behavior under test is session transcript delivery and gateway history/message hydration, not provider generation.
- Before evidence: the previous PR shape globally stripped marker-looking lines, and maintainer review showed that this could delete legitimate plaintext/copy-log replies.

## Tests and validation

Commands run:

```bash
pnpm install --frozen-lockfile
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts src/agents/run-wait.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts src/agents/run-wait.test.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tools/embedded-gateway-stub.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json --noEmit
git diff --check
PATH="$HOME/.local/node_modules/corepack/shims:$HOME/.local/node_modules/.bin:$PATH" OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed
codex review --base origin/main
```

Results:

- Focused Vitest passed: `140` sanitizer tests and `31` run-wait tests.
- Broader focused Vitest passed: `140` unit-fast tests and `79` agents tests across sanitizer, run-wait, sessions, and embedded gateway stub.
- Agent test typecheck passed.
- `git diff --check` passed.
- Local `pnpm check:changed` passed for `core, coreTests`.
- Final `codex review --base origin/main` reported: `No actionable regressions were found in the changed session reply hydration paths, embedded gateway stub support, or sanitizer coverage.`

Regression coverage added/updated:

- Preserving standalone marker-looking text without producer provenance.
- Preserving copied-log and `chat.history` marker text in generic reply reads.
- Hydrating full assistant replies when a delivery history row is display-truncated.
- Returning hydrated full replies even when the real full reply contains a literal marker line.
- Avoiding shortened-row delivery when full-message hydration is unavailable.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Session delivery could either drop legitimate marker text or deliver a display-shortened history preview as complete text.

How is that risk mitigated?

The global sanitizer no longer strips marker-looking plaintext. Full-message hydration is limited to the internal `chat.history` projection boundary and requires an OpenClaw message id before calling `chat.message.get`. Tests cover no-provenance preservation, successful hydration, literal-marker full replies, and unavailable hydration.

## Current review state

What is the next action?

ClawSweeper and maintainer re-review on commit `ea291399a3088b1c26c121dfa9f01d00ca2a3ad9` after adding real gateway proof and moving #82121 to related context without a closing reference.

What is still waiting on author, maintainer, CI, or external proof?

Checks are green on the current head. Maintainer re-review is needed after the proof/body update.

Which bot or reviewer comments were addressed?

- Addressed Vincent Koc's June 16, 2026 blocker: removed the global truncation-marker deletion path from `sanitizeUserFacingText` and limited cleanup/recovery to the provenance-backed history hydration boundary.
- Addressed local `codex review --base origin/main` P2 finding: hydrated full replies that contain literal marker text are now returned instead of dropped.


