### PR TITLE
refactor: add compact trim lifecycle seam

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -41,6 +41,10 @@ const sessionCreateLifecycleWriterNames = new Set([
   "updateSessionStoreEntry",
   "ensureSessionTranscriptFile",
 ]);
+const legacyManualCompactTrimNames = new Set([
+  "archiveFileOnDisk",
+  "readRecentSessionTranscriptLines",
+]);
 
 export const migratedSessionAccessorFiles = new Set([
   "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
@@ -109,6 +113,10 @@ export const migratedTranscriptWriterFiles = new Set([
   "src/gateway/server-methods/chat.ts",
   "src/gateway/server-methods/chat-transcript-inject.ts",
   "src/sessions/user-turn-transcript.ts",
+]);
+
+export const migratedSessionCompactManualTrimFiles = new Set([
+  "src/gateway/server-methods/sessions.ts",
 ]);
 
 function normalizeRelativePath(filePath) {
@@ -280,6 +288,15 @@ export function findGatewaySessionCreateLifecycleViolations(content, fileName = 
   return violations;
 }
 
+export function findSessionCompactManualTrimBoundaryViolations(content, fileName = "source.ts") {
+  return findNamedSessionStoreViolations(
+    content,
+    fileName,
+    legacyManualCompactTrimNames,
+    "manual compact trim",
+  );
+}
+
 export async function main() {
   const repoRoot = resolveRepoRoot(import.meta.url);
   const readSourceRoots = resolveSourceRoots(repoRoot, [
@@ -342,11 +359,21 @@ export async function main() {
       "src/gateway/server-methods/sessions.ts",
     findViolations: findGatewaySessionCreateLifecycleViolations,
   });
+  const manualCompactTrimViolations = await collectFileViolations({
+    repoRoot,
+    sourceRoots: resolveSourceRoots(repoRoot, ["src/gateway/server-methods"]),
+    skipFile: (filePath) =>
+      !migratedSessionCompactManualTrimFiles.has(
+        normalizeRelativePath(path.relative(repoRoot, filePath)),
+      ),
+    findViolations: findSessionCompactManualTrimBoundaryViolations,
+  });
   const violations = [
     ...readViolations,
     ...writeViolations,
     ...transcriptWriterViolations,
     ...sessionCreateLifecycleViolations,
+    ...manualCompactTrimViolations,
   ];
 
   if (violations.length === 0) {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -20,6 +20,7 @@ import {
   replaceSessionEntry,
   resolveSessionTranscriptRuntimeReadTarget,
   resolveSessionTranscriptRuntimeTarget,
+  trimSessionTranscriptForManualCompact,
   updateSessionEntry,
   upsertSessionEntry,
 } from "./session-accessor.js";
@@ -541,6 +542,83 @@ describe("session accessor file-backed seam", () => {
     await expect(loadTranscriptEvents(scope)).resolves.toEqual([event]);
     // Explicit-artifact writes never touch entry metadata: no entry appears.
     expect(listSessionEntries({ storePath })).toEqual([]);
+  });
+
+  it("trims a manual compact transcript and clears stale token metadata", async () => {
+    const sessionId = "11111111-1111-4111-8111-111111111111";
+    const manualTranscriptPath = path.join(tempDir, `${sessionId}.jsonl`);
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    await upsertSessionEntry(scope, {
+      contextBudgetStatus: { route: "stale" } as NonNullable<SessionEntry["contextBudgetStatus"]>,
+      inputTokens: 10,
+      outputTokens: 20,
+      sessionFile: manualTranscriptPath,
+      sessionId,
+      totalTokens: 30,
+      totalTokensFresh: true,
+      updatedAt: 100,
+    });
+    fs.writeFileSync(manualTranscriptPath, "line 1\n\nline 2\nline 3\nline 4\n", "utf-8");
+    const updates: unknown[] = [];
+    const unsubscribe = onSessionTranscriptUpdate((update) => updates.push(update));
+
+    const result = await trimSessionTranscriptForManualCompact(scope, {
+      maxLines: 2,
+      nowMs: 500,
+    });
+
+    unsubscribe();
+    expect(result).toMatchObject({ compacted: true, kept: 2 });
+    const archived = result.compacted ? result.archived : "";
+    expect(path.basename(archived)).toMatch(new RegExp(`^${sessionId}\\.jsonl\\.bak\\.`));
+    expect(fs.readFileSync(archived, "utf-8")).toBe("line 1\n\nline 2\nline 3\nline 4\n");
+    expect(fs.readFileSync(manualTranscriptPath, "utf-8")).toBe("line 3\nline 4\n");
+    const updatedEntry = loadSessionEntry(scope);
+    expect(updatedEntry).toMatchObject({
+      sessionFile: manualTranscriptPath,
+      sessionId,
+      updatedAt: 500,
+    });
+    expect(updatedEntry?.contextBudgetStatus).toBeUndefined();
+    expect(updatedEntry?.inputTokens).toBeUndefined();
+    expect(updatedEntry?.outputTokens).toBeUndefined();
+    expect(updatedEntry?.totalTokens).toBeUndefined();
+    expect(updatedEntry?.totalTokensFresh).toBeUndefined();
+    expect(updates).toEqual([{ sessionFile: archived }]);
+  });
+
+  it("prefers the current generated transcript over a stale generated sessionFile", async () => {
+    const currentSessionId = "11111111-1111-4111-8111-111111111111";
+    const staleSessionId = "22222222-2222-4222-8222-222222222222";
+    const currentTranscriptPath = path.join(tempDir, `${currentSessionId}.jsonl`);
+    const staleTranscriptPath = path.join(tempDir, `${staleSessionId}.jsonl`);
+    const scope = {
+      agentId: "main",
+      sessionId: currentSessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    await upsertSessionEntry(scope, {
+      sessionFile: staleTranscriptPath,
+      sessionId: currentSessionId,
+      updatedAt: 100,
+    });
+    fs.writeFileSync(currentTranscriptPath, "current one\ncurrent two\n", "utf-8");
+    fs.writeFileSync(staleTranscriptPath, "stale one\nstale two\n", "utf-8");
+
+    const result = await trimSessionTranscriptForManualCompact(scope, {
+      maxLines: 1,
+      sessionFile: staleTranscriptPath,
+    });
+
+    expect(result).toMatchObject({ compacted: true, kept: 1 });
+    expect(fs.readFileSync(currentTranscriptPath, "utf-8")).toBe("current two\n");
+    expect(fs.readFileSync(staleTranscriptPath, "utf-8")).toBe("stale one\nstale two\n");
   });
 
   it("rejects transcript writes without a session key or explicit file", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -553,8 +553,27 @@ describe("session accessor file-backed seam", () => {
       sessionKey: "agent:main:main",
       storePath,
     };
+    const contextBudgetStatus: NonNullable<SessionEntry["contextBudgetStatus"]> = {
+      schemaVersion: 1,
+      source: "pre-prompt-estimate",
+      updatedAt: 90,
+      provider: "openai",
+      model: "gpt-5.5",
+      route: "fits",
+      shouldCompact: false,
+      estimatedPromptTokens: 10,
+      contextTokenBudget: 100,
+      promptBudgetBeforeReserve: 80,
+      reserveTokens: 20,
+      effectiveReserveTokens: 20,
+      remainingPromptBudgetTokens: 70,
+      overflowTokens: 0,
+      toolResultReducibleChars: 0,
+      messageCount: 1,
+      unwindowedMessageCount: 1,
+    };
     await upsertSessionEntry(scope, {
-      contextBudgetStatus: { route: "stale" } as NonNullable<SessionEntry["contextBudgetStatus"]>,
+      contextBudgetStatus,
       inputTokens: 10,
       outputTokens: 20,
       sessionFile: manualTranscriptPath,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1,16 +1,19 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   acquireSessionWriteLock,
   resolveSessionWriteLockOptions,
 } from "../../agents/session-write-lock.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
+import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -57,6 +60,7 @@ import {
 } from "./transcript-append.js";
 import { resolveSessionTranscriptFile } from "./transcript-file-resolve.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
+import { writeJsonlLines } from "./transcript-jsonl.js";
 import { streamSessionTranscriptLines } from "./transcript-stream.js";
 import {
   type OwnedSessionTranscriptPublishedEntry,
@@ -236,6 +240,21 @@ export type SessionTranscriptRuntimeTarget = {
   sessionId: string;
   sessionKey: string;
 };
+
+export type SessionTranscriptManualTrimResult =
+  | {
+      compacted: false;
+      reason: "no transcript";
+    }
+  | {
+      compacted: false;
+      kept: number;
+    }
+  | {
+      archived: string;
+      compacted: true;
+      kept: number;
+    };
 
 export type SessionEntryUpdateOptions = {
   /** Skip prune/cap/rotation maintenance for specialized internal updates. */
@@ -664,6 +683,219 @@ export async function publishTranscriptUpdate(
     ...update,
     sessionFile: transcript.sessionFile,
   });
+}
+
+/**
+ * Trims a transcript for manual sessions.compact and clears stale token metadata.
+ * This is one storage-sized mutation: future stores can trim transcript rows and
+ * update entry metadata inside the same backend transaction.
+ */
+export async function trimSessionTranscriptForManualCompact(
+  scope: SessionTranscriptRuntimeScope,
+  params: { maxLines: number; nowMs?: number; sessionFile?: string },
+): Promise<SessionTranscriptManualTrimResult> {
+  const transcript = await resolveManualCompactTranscriptTarget(scope, params.sessionFile);
+  if (!transcript) {
+    return { compacted: false, reason: "no transcript" };
+  }
+
+  const maxLines = Math.max(1, Math.floor(params.maxLines));
+  const lines: string[] = [];
+  let totalLines = 0;
+  try {
+    for await (const line of streamSessionTranscriptLines(transcript.sessionFile)) {
+      totalLines += 1;
+      lines.push(line);
+      if (lines.length > maxLines) {
+        lines.shift();
+      }
+    }
+  } catch {
+    return { compacted: false, kept: 0 };
+  }
+  if (totalLines <= maxLines) {
+    return { compacted: false, kept: totalLines };
+  }
+
+  const archived = await archiveTranscriptFileForManualCompact(transcript.sessionFile);
+  await writeJsonlLines(transcript.sessionFile, lines);
+  await patchSessionEntry(
+    {
+      ...scope,
+      sessionKey: transcript.sessionKey,
+      storePath: scope.storePath,
+    },
+    (entry) => {
+      delete entry.contextBudgetStatus;
+      delete entry.inputTokens;
+      delete entry.outputTokens;
+      delete entry.totalTokens;
+      delete entry.totalTokensFresh;
+      entry.updatedAt = params.nowMs ?? Date.now();
+      return entry;
+    },
+    { replaceEntry: true },
+  );
+
+  return { archived, compacted: true, kept: lines.length };
+}
+
+async function archiveTranscriptFileForManualCompact(filePath: string): Promise<string> {
+  const archived = `${filePath}.bak.${formatSessionArchiveTimestamp()}`;
+  await fs.promises.rename(filePath, archived);
+  emitSessionTranscriptUpdate({ sessionFile: archived });
+  return archived;
+}
+
+async function resolveManualCompactTranscriptTarget(
+  scope: SessionTranscriptRuntimeScope,
+  sessionFile?: string,
+): Promise<SessionTranscriptRuntimeTarget | null> {
+  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
+  if (!agentId) {
+    throw new Error(`Cannot resolve transcript scope without an agent id: ${scope.sessionKey}`);
+  }
+  const candidates = resolveManualCompactTranscriptCandidates({
+    agentId,
+    sessionFile,
+    sessionId: scope.sessionId,
+    storePath: scope.storePath,
+  });
+  for (const candidate of candidates) {
+    const stat = await fs.promises.stat(candidate).catch(() => null);
+    if (stat?.isFile()) {
+      return {
+        agentId,
+        sessionFile: candidate,
+        sessionId: scope.sessionId,
+        sessionKey: scope.sessionKey,
+      };
+    }
+  }
+  return null;
+}
+
+function resolveManualCompactTranscriptCandidates(params: {
+  agentId?: string;
+  sessionFile?: string;
+  sessionId: string;
+  storePath?: string;
+}): string[] {
+  const candidates: string[] = [];
+  const sessionFileState = classifyGeneratedTranscriptCandidate(
+    params.sessionId,
+    params.sessionFile,
+  );
+  const pushCandidate = (resolve: () => string): void => {
+    try {
+      const candidate = resolve();
+      if (!candidates.includes(candidate)) {
+        candidates.push(candidate);
+      }
+    } catch {
+      // Keep scanning the remaining file-backed candidates.
+    }
+  };
+
+  if (params.storePath) {
+    const sessionsDir = path.dirname(params.storePath);
+    if (params.sessionFile && sessionFileState !== "stale") {
+      pushCandidate(() =>
+        resolveSessionFilePath(
+          params.sessionId,
+          { sessionFile: params.sessionFile },
+          { sessionsDir, agentId: params.agentId },
+        ),
+      );
+    }
+    pushCandidate(() => resolveSessionTranscriptPathInDir(params.sessionId, sessionsDir));
+    if (params.sessionFile && sessionFileState === "stale") {
+      pushCandidate(() =>
+        resolveSessionFilePath(
+          params.sessionId,
+          { sessionFile: params.sessionFile },
+          { sessionsDir, agentId: params.agentId },
+        ),
+      );
+    }
+  } else if (params.sessionFile) {
+    if (params.agentId) {
+      if (sessionFileState !== "stale") {
+        pushCandidate(() =>
+          resolveSessionFilePath(
+            params.sessionId,
+            { sessionFile: params.sessionFile },
+            { agentId: params.agentId },
+          ),
+        );
+      }
+    } else {
+      const trimmed = params.sessionFile.trim();
+      if (trimmed) {
+        candidates.push(path.resolve(trimmed));
+      }
+    }
+  }
+
+  if (params.agentId) {
+    pushCandidate(() => resolveSessionTranscriptPath(params.sessionId, params.agentId));
+    if (params.sessionFile && sessionFileState === "stale") {
+      pushCandidate(() =>
+        resolveSessionFilePath(
+          params.sessionId,
+          { sessionFile: params.sessionFile },
+          { agentId: params.agentId },
+        ),
+      );
+    }
+  }
+
+  const legacyDir = path.join(
+    resolveRequiredHomeDir(process.env, os.homedir),
+    ".openclaw",
+    "sessions",
+  );
+  pushCandidate(() => resolveSessionTranscriptPathInDir(params.sessionId, legacyDir));
+  return candidates;
+}
+
+function classifyGeneratedTranscriptCandidate(
+  sessionId: string,
+  sessionFile?: string,
+): "current" | "stale" | "custom" {
+  const transcriptSessionId = extractGeneratedTranscriptSessionId(sessionFile);
+  if (!transcriptSessionId) {
+    return "custom";
+  }
+  return transcriptSessionId === sessionId ? "current" : "stale";
+}
+
+function extractGeneratedTranscriptSessionId(sessionFile?: string): string | undefined {
+  const trimmed = sessionFile?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const base = path.basename(trimmed);
+  if (!base.endsWith(".jsonl")) {
+    return undefined;
+  }
+  const withoutExt = base.slice(0, -".jsonl".length);
+  const topicIndex = withoutExt.indexOf("-topic-");
+  if (topicIndex > 0) {
+    const topicSessionId = withoutExt.slice(0, topicIndex);
+    return looksLikeGeneratedSessionId(topicSessionId) ? topicSessionId : undefined;
+  }
+  const forkMatch = withoutExt.match(
+    /^(\d{4}-\d{2}-\d{2}T[\w-]+(?:Z|[+-]\d{2}(?:-\d{2})?)?)_(.+)$/,
+  );
+  if (forkMatch?.[2]) {
+    return looksLikeGeneratedSessionId(forkMatch[2]) ? forkMatch[2] : undefined;
+  }
+  return looksLikeGeneratedSessionId(withoutExt) ? withoutExt : undefined;
+}
+
+function looksLikeGeneratedSessionId(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
 /**

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2629,7 +2629,18 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
     );
     if (!trimResult.compacted) {
-      if ("reason" in trimResult && trimResult.reason === "no transcript") {
+      if ("kept" in trimResult) {
+        respond(
+          true,
+          {
+            ok: true,
+            key: target.canonicalKey,
+            compacted: false,
+            kept: trimResult.kept,
+          },
+          undefined,
+        );
+      } else {
         respond(
           true,
           {
@@ -2640,18 +2651,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           },
           undefined,
         );
-        return;
       }
-      respond(
-        true,
-        {
-          ok: true,
-          key: target.canonicalKey,
-          compacted: false,
-          kept: trimResult.kept,
-        },
-        undefined,
-      );
       return;
     }
 

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -61,6 +61,7 @@ import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.j
 import {
   applySessionPatchProjection,
   createSessionEntryWithTranscript,
+  trimSessionTranscriptForManualCompact,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -98,12 +99,10 @@ import {
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
   readRecentSessionMessagesWithStatsAsync,
-  readRecentSessionTranscriptLines,
   readSessionMessageCountAsync,
   readSessionPreviewItemsFromTranscript,
 } from "../session-transcript-readers.js";
 import {
-  archiveFileOnDisk,
   buildGatewaySessionRow,
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
@@ -2465,27 +2464,27 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const filePath = resolveSessionTranscriptCandidates(
-      sessionId,
-      storePath,
-      entry?.sessionFile,
-      target.agentId,
-    ).find((candidate) => fs.existsSync(candidate));
-    if (!filePath) {
-      respond(
-        true,
-        {
-          ok: true,
-          key: target.canonicalKey,
-          compacted: false,
-          reason: "no transcript",
-        },
-        undefined,
-      );
-      return;
-    }
-
     if (maxLines === undefined) {
+      const filePath = resolveSessionTranscriptCandidates(
+        sessionId,
+        storePath,
+        entry?.sessionFile,
+        target.agentId,
+      ).find((candidate) => fs.existsSync(candidate));
+      if (!filePath) {
+        respond(
+          true,
+          {
+            ok: true,
+            key: target.canonicalKey,
+            compacted: false,
+            reason: "no transcript",
+          },
+          undefined,
+        );
+        return;
+      }
+
       const interruptResult = await interruptSessionRunIfActive({
         req,
         context,
@@ -2617,45 +2616,44 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const tail = readRecentSessionTranscriptLines({
-      sessionId,
-      storePath,
-      sessionFile: entry?.sessionFile,
-      agentId: target.agentId,
-      maxLines,
-    });
-    const lines = tail?.lines ?? [];
-    const totalLines = tail?.totalLines ?? 0;
-    if (totalLines <= maxLines) {
+    const trimResult = await trimSessionTranscriptForManualCompact(
+      {
+        sessionId,
+        storePath,
+        sessionKey: compactTarget.primaryKey,
+        agentId: target.agentId,
+      },
+      {
+        maxLines,
+        sessionFile: entry?.sessionFile,
+      },
+    );
+    if (!trimResult.compacted) {
+      if ("reason" in trimResult && trimResult.reason === "no transcript") {
+        respond(
+          true,
+          {
+            ok: true,
+            key: target.canonicalKey,
+            compacted: false,
+            reason: "no transcript",
+          },
+          undefined,
+        );
+        return;
+      }
       respond(
         true,
         {
           ok: true,
           key: target.canonicalKey,
           compacted: false,
-          kept: totalLines,
+          kept: trimResult.kept,
         },
         undefined,
       );
       return;
     }
-
-    const archived = archiveFileOnDisk(filePath, "bak");
-    fs.writeFileSync(filePath, `${lines.join("\n")}\n`, "utf-8");
-
-    await updateSessionStore(storePath, (store) => {
-      const entryKey = compactTarget.primaryKey;
-      const entryToUpdate = store[entryKey];
-      if (!entryToUpdate) {
-        return;
-      }
-      delete entryToUpdate.inputTokens;
-      delete entryToUpdate.outputTokens;
-      delete entryToUpdate.totalTokens;
-      delete entryToUpdate.totalTokensFresh;
-      delete entryToUpdate.contextBudgetStatus;
-      entryToUpdate.updatedAt = Date.now();
-    });
 
     respond(
       true,
@@ -2663,8 +2661,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         ok: true,
         key: target.canonicalKey,
         compacted: true,
-        archived,
-        kept: lines.length,
+        archived: trimResult.archived,
+        kept: trimResult.kept,
       },
       undefined,
     );

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -664,6 +664,70 @@ test("sessions.compact scopes selected global truncation to the requested agent"
   await resetConfiguredGlobalAgentSessionStore(globalStores);
 });
 
+test("sessions.compact trims default global agent when no agentId is supplied", async () => {
+  const globalStores = await createConfiguredGlobalAgentSessionStore({ withTranscripts: true });
+  const { broadcastToConnIds, responsePayload } = await invokeSessionsCompact({
+    getRuntimeConfig: globalStores.getRuntimeConfig,
+    params: {
+      key: "global",
+      maxLines: 1,
+    },
+  });
+
+  expectFields(responsePayload, { ok: true, key: "global", compacted: true, kept: 1 });
+  expectChangedBroadcast(broadcastToConnIds, {
+    sessionKey: "global",
+    agentId: "main",
+    reason: "compact",
+    compacted: true,
+  });
+  await expect(fs.readFile(globalStores.mainTranscript, "utf-8")).resolves.toBe("main two\n");
+  await expect(fs.readFile(globalStores.workTranscript, "utf-8")).resolves.toBe(
+    "work one\nwork two\n",
+  );
+  await resetConfiguredGlobalAgentSessionStore(globalStores);
+});
+
+test("sessions.compact keeps manual trim no-op response shape", async () => {
+  const globalStores = await createConfiguredGlobalAgentSessionStore({ withTranscripts: true });
+  const { broadcastToConnIds, responsePayload } = await invokeSessionsCompact({
+    getRuntimeConfig: globalStores.getRuntimeConfig,
+    params: {
+      key: "global",
+      agentId: "work",
+      maxLines: 5,
+    },
+  });
+
+  expectFields(responsePayload, { ok: true, key: "global", compacted: false, kept: 2 });
+  expect(broadcastToConnIds).not.toHaveBeenCalled();
+  await expect(fs.readFile(globalStores.workTranscript, "utf-8")).resolves.toBe(
+    "work one\nwork two\n",
+  );
+  await resetConfiguredGlobalAgentSessionStore(globalStores);
+});
+
+test("sessions.compact keeps manual trim no-transcript response shape", async () => {
+  const globalStores = await createConfiguredGlobalAgentSessionStore();
+  const { broadcastToConnIds, responsePayload } = await invokeSessionsCompact({
+    getRuntimeConfig: globalStores.getRuntimeConfig,
+    params: {
+      key: "global",
+      agentId: "work",
+      maxLines: 1,
+    },
+  });
+
+  expectFields(responsePayload, {
+    ok: true,
+    key: "global",
+    compacted: false,
+    reason: "no transcript",
+  });
+  expect(broadcastToConnIds).not.toHaveBeenCalled();
+  await resetConfiguredGlobalAgentSessionStore(globalStores);
+});
+
 test("sessions.compact passes the selected global agent into embedded compaction", async () => {
   const globalStores = await createConfiguredGlobalAgentSessionStore({ withTranscripts: true });
   const { responsePayload } = await invokeSessionsCompact({

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   findGatewaySessionCreateLifecycleViolations,
   findSessionAccessorBoundaryViolations,
+  findSessionCompactManualTrimBoundaryViolations,
   findSessionAccessorWriteBoundaryViolations,
   findTranscriptWriterBoundaryViolations,
   migratedBundledPluginSessionAccessorFiles,
+  migratedSessionCompactManualTrimFiles,
   migratedSessionAccessorFiles,
   migratedSessionAccessorWriteFiles,
   migratedTranscriptWriterFiles,
@@ -93,6 +95,12 @@ describe("session accessor boundary guard", () => {
         "src/gateway/server-methods/chat-transcript-inject.ts",
         "src/sessions/user-turn-transcript.ts",
       ]),
+    );
+  });
+
+  it("ratchets only compact manual trim gateway files", () => {
+    expect(migratedSessionCompactManualTrimFiles).toEqual(
+      new Set(["src/gateway/server-methods/sessions.ts"]),
     );
   });
 
@@ -274,6 +282,29 @@ describe("session accessor boundary guard", () => {
         };
       `),
     ).toEqual([]);
+  });
+
+  it("flags gateway manual compact trim file mutations", () => {
+    expect(
+      findSessionCompactManualTrimBoundaryViolations(`
+        import { archiveFileOnDisk } from "../session-utils.js";
+        import { readRecentSessionTranscriptLines } from "../session-transcript-readers.js";
+        const tail = readRecentSessionTranscriptLines(scope);
+        const archived = archiveFileOnDisk(filePath, "bak");
+      `),
+    ).toEqual([
+      { line: 2, reason: 'imports legacy session store manual compact trim "archiveFileOnDisk"' },
+      {
+        line: 3,
+        reason:
+          'imports legacy session store manual compact trim "readRecentSessionTranscriptLines"',
+      },
+      {
+        line: 4,
+        reason: 'calls legacy session store manual compact trim "readRecentSessionTranscriptLines"',
+      },
+      { line: 5, reason: 'calls legacy session store manual compact trim "archiveFileOnDisk"' },
+    ]);
   });
 
   it("ignores comments and strings that describe legacy readers", () => {


### PR DESCRIPTION
## What
Adds a storage-neutral accessor operation for manual `sessions.compact` transcript trimming. The gateway now calls one operation for transcript tail selection, `.bak` archive/rewrite, and stale token metadata cleanup.

## Why
Path 3 needs SQLite to trim transcript rows and update `session_entries.entry_json` metadata in one backend transaction, rather than composing transcript artifact mutation and entry metadata writes in the gateway.

## Changes
- Add compact trim accessor seam
- Route gateway manual trim
- Preserve file-backed candidate order
- Ratchet old trim composition
- Cover success/no-op/missing cases

## SQLite follow-up
The SQLite adapter should implement `trimSessionTranscriptForManualCompact` as one transaction: select/copy/delete transcript rows through the trim boundary and update entry JSON token/updated fields together. No SQLite schema or runtime storage flip is included here.

## Testing
- `/Users/phaedrus/Projects/clawdbot/node_modules/.bin/oxfmt --check --threads=1 scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/gateway/server-methods/sessions.ts src/gateway/server.sessions.list-changed.test.ts`
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/gateway/server.sessions.list-changed.test.ts test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/check-session-accessor-boundary.mjs`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Tracker: https://github.com/openclaw/openclaw/issues/88838

## Real behavior proof

Behavior addressed: Manual `sessions.compact` with `maxLines` trims the selected session transcript through the accessor seam, archives the original transcript, and clears stale token/context metadata.

Real environment tested: Local live LaunchAgent gateway from `clawdbot`, built from PR head `1877d0f48e489ee6ec6a798f2d780eaf65c17112`; `pnpm openclaw --version` reported `OpenClaw 2026.6.8 (1877d0f)`. HTTP `/healthz` returned `{"ok":true,"status":"live"}`; HTTP `/readyz` returned `{"ready":true,"failing":[]}`; `gateway status --json` reported RPC `ok: true` and gateway version `2026.6.8`.

Exact steps or command run after this patch:

```bash
git switch --detach 1877d0f48e489ee6ec6a798f2d780eaf65c17112
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
curl -fsS http://127.0.0.1:18789/healthz
curl -fsS http://127.0.0.1:18789/readyz
pnpm openclaw gateway status --json
pnpm openclaw gateway call health --json --timeout 5000
pnpm openclaw gateway call sessions.create --json --timeout 10000 --params '{"agentId":"main","label":"PR 93695 live proof"}'
# Seeded that returned session entry with four metadata JSONL transcript lines plus stale input/output/total token fields and contextBudgetStatus, then restarted so the live gateway loaded the seeded file-backed state.
pnpm openclaw gateway restart
pnpm openclaw gateway call sessions.compact --json --timeout 10000 --params '{"key":"agent:main:dashboard:911bdccc-ddc6-4350-8d0c-200bf2c35bf9","maxLines":2}'
# Verified the transcript file, archive file, and session store entry on disk.
pnpm openclaw gateway call sessions.delete --json --timeout 10000 --params '{"key":"agent:main:dashboard:911bdccc-ddc6-4350-8d0c-200bf2c35bf9"}'
# Removed proof-only archive/backup artifacts and verified no proof files remained.
```

Evidence after fix: `sessions.compact` returned `ok: true`, `compacted: true`, `kept: 2`, and archive `98ea11ca-b9f3-4d0b-a108-3683544b9a3c.jsonl.bak.2026-06-17T18-36-31.559Z` for key `agent:main:dashboard:911bdccc-ddc6-4350-8d0c-200bf2c35bf9`. On disk, the active transcript contained only `pr93695-created-line-3` and `pr93695-created-line-4`; the archive contained 4 original lines; the session store entry no longer had `inputTokens`, `outputTokens`, `totalTokens`, `totalTokensFresh`, or `contextBudgetStatus`; `updatedAt` changed to `1781721391567`. Cleanup deleted the proof session and a final artifact scan returned `leftovers: []`.

Observed result after fix: The live gateway preserved the previous manual compact response shape while moving transcript tail selection, archive/rewrite, and stale token metadata cleanup behind the session accessor boundary.

What was not tested: Future SQLite adapter implementation, SQLite transactionality, doctor migration, SDK compatibility, broad CI completion after later `main` movement, and live gateway behavior on a post-`1877d0f` rebased head.

