### PR TITLE
fix(matrix): deliver reasoning replies as m.notice instead of suppressing

### DIFF
--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -18,6 +18,7 @@ vi.mock("../send.js", () => ({
   chunkMatrixText: (text: string, opts?: unknown) => chunkMatrixTextMock(text, opts),
   sendMessageMatrix: (to: string, message: string, opts?: unknown) =>
     sendMessageMatrixMock(to, message, opts),
+  MsgType: { Text: "m.text", Notice: "m.notice", Image: "m.image", Audio: "m.audio" },
 }));
 
 import { setMatrixRuntime } from "../../runtime.js";
@@ -177,7 +178,7 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(1).threadId).toBe("thread-77");
   });
 
-  it("suppresses reasoning-only text before Matrix sends", async () => {
+  it("delivers reasoning-only text as m.notice and normal text as m.text", async () => {
     await deliverMatrixReplies({
       cfg,
       replies: [
@@ -192,10 +193,21 @@ describe("deliverMatrixReplies", () => {
       replyToMode: "off",
     });
 
-    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    // All 3 replies are now delivered: reasoning as m.notice, normal as m.text
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(3);
+
+    // First reply (reasoning prefix) -> m.notice
     expect(sendCall(0)[0]).toBe("room:5");
-    expect(sendCall(0)[1]).toBe("Visible answer");
-    expect(sendOptions(0).cfg).toBe(cfg);
+    expect(sendCall(0)[1]).toBe("Reasoning:\n_hidden_");
+    expect(sendOptions(0).msgtype).toBe("m.notice");
+
+    // Second reply (thinking tags only) -> m.notice
+    expect(sendCall(1)[1]).toBe("<think>still hidden</think>");
+    expect(sendOptions(1).msgtype).toBe("m.notice");
+
+    // Third reply (normal text) -> undefined (defaults to m.text)
+    expect(sendCall(2)[1]).toBe("Visible answer");
+    expect(sendOptions(2).msgtype).toBeUndefined();
   });
 
   it("uses supplied cfg for chunking and send delivery without reloading runtime config", async () => {
@@ -254,5 +266,56 @@ describe("deliverMatrixReplies", () => {
     expect(sendCall(0)[0]).toBe("room:6");
     expect(sendCall(0)[1]).toBe("caption");
     expect(sendOptions(0).mediaUrl).toBe("https://example.com/a.jpg");
+  });
+
+  it("delivers reasoning payloads as m.notice instead of suppressing (regression #81892)", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "Thinking about the answer...", isReasoning: true }],
+      roomId: "room:7",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[0]).toBe("room:7");
+    expect(sendCall(0)[1]).toBe("Thinking about the answer...");
+    expect(sendOptions(0).msgtype).toBe("m.notice");
+  });
+
+  it("delivers reasoning text with thinking tags as m.notice", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "<thinking>internal reasoning</thinking> Here is my answer." }],
+      roomId: "room:8",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    // Text with thinking tags that also has non-thinking content should be delivered normally
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[0]).toBe("room:8");
+    // msgtype should be undefined (default m.text) since it's not pure reasoning
+    expect(sendOptions(0).msgtype).toBeUndefined();
+  });
+
+  it("delivers pure thinking-tag-only text as m.notice", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "<thinking>only thinking content here</thinking>" }],
+      roomId: "room:9",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[0]).toBe("room:9");
+    expect(sendOptions(0).msgtype).toBe("m.notice");
   });
 });

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -2,7 +2,8 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
-import { chunkMatrixText, MsgType, sendMessageMatrix } from "../send.js";
+import { chunkMatrixText, sendMessageMatrix } from "../send.js";
+import { MsgType } from "../send/types.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
 const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -2,7 +2,7 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
-import { chunkMatrixText, sendMessageMatrix } from "../send.js";
+import { chunkMatrixText, MsgType, sendMessageMatrix } from "../send.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
 const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
@@ -60,10 +60,11 @@ export async function deliverMatrixReplies(params: {
   let hasReplied = false;
   let deliveredAny = false;
   for (const reply of params.replies) {
-    if (reply.isReasoning === true || shouldSuppressReasoningReplyText(reply.text)) {
-      logVerbose("matrix reply suppressed as reasoning-only");
-      continue;
-    }
+    // Deliver reasoning payloads as m.notice instead of suppressing.
+    // Matrix supports m.notice for non-intrusive messages (like typing indicators).
+    // This matches Telegram's reasoning delivery behavior.
+    const isReasoning = reply.isReasoning === true || shouldSuppressReasoningReplyText(reply.text);
+    const reasoningMsgType = isReasoning ? MsgType.Notice : undefined;
     const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
     if (!reply?.text && !hasMedia) {
       if (reply?.audioAsVoice) {
@@ -108,6 +109,7 @@ export async function deliverMatrixReplies(params: {
           replyToId: replyToIdForReply,
           threadId: params.threadId,
           accountId: params.accountId,
+          msgtype: reasoningMsgType,
         });
         deliveredAny = true;
         sentTextChunk = true;
@@ -130,6 +132,7 @@ export async function deliverMatrixReplies(params: {
         threadId: params.threadId,
         audioAsVoice: reply.audioAsVoice,
         accountId: params.accountId,
+        msgtype: reasoningMsgType,
       });
       deliveredAny = true;
       first = false;

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -338,7 +338,7 @@ export async function sendMessageMatrix(
           if (!text) {
             continue;
           }
-          const followup = buildTextContent(text, followupRelation);
+          const followup = buildTextContent(text, followupRelation, { msgtype: opts.msgtype });
           await enrichMatrixFormattedContent({
             client,
             content: followup,
@@ -356,7 +356,7 @@ export async function sendMessageMatrix(
           if (!text) {
             continue;
           }
-          const content = buildTextContent(text, relation);
+          const content = buildTextContent(text, relation, { msgtype: opts.msgtype });
           await enrichMatrixFormattedContent({
             client,
             content,

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -102,6 +102,8 @@ export type MatrixSendOpts = {
   extraContent?: MatrixExtraContentFields;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Override the text message type (e.g. MsgType.Notice for reasoning). Defaults to MsgType.Text. */
+  msgtype?: MatrixTextMsgType;
 };
 
 export type MatrixMediaMsgType =


### PR DESCRIPTION
## Summary

- **Problem:** Matrix channel suppresses all reasoning payloads (`isReasoning: true` and thinking-tag-only text), so `/reasoning on` has no effect. The web dashboard correctly shows thinking blocks, but Matrix users see nothing.
- **Fix:** Deliver reasoning payloads as `m.notice` messages instead of suppressing them. Matrix already supports `m.notice` for non-intrusive messages (draft streaming, handler notices). This matches Telegram's reasoning delivery behavior.
- **Out of scope:** No streaming reasoning support (no `onReasoningStream` callback). Only final reasoning payloads are delivered, not real-time streaming.

## Linked context

Closes #81892

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Matrix channel suppresses reasoning payloads when `/reasoning on` is set. Users see no reasoning blocks in Element, even though the web dashboard shows them.
- **Real environment tested:** Windows 10, Node.js v22.22.3, OpenClaw latest main, local checkout with the patch applied.
- **Exact steps or command run after this patch:** Ran `node scripts/run-vitest.mjs run extensions/matrix/src/matrix/monitor/replies.test.ts` with 3 new test cases + 1 updated test verifying reasoning payloads delivered as `m.notice`, thinking-tag-only text as `m.notice`, normal text as `m.text`.
- **Evidence after fix:**
```
$ node scripts/run-vitest.mjs run extensions/matrix/src/matrix/monitor/replies.test.ts
Test Files  1 passed (1)
     Tests  9 passed (9)
```
- **Observed result after fix:** Reasoning payloads (`isReasoning: true`) are delivered as `m.notice` messages instead of being suppressed. Thinking-tag-only text is also delivered as `m.notice`. Normal text remains `m.text`. The `m.notice` message type is non-intrusive in Matrix clients (shown differently from regular messages).
- **What was not tested:** Live Matrix/Element session with real reasoning model (requires Matrix server setup). The test uses mocked `sendMessageMatrix` to verify the `msgtype` parameter is passed correctly.

## Tests and validation

- `node scripts/run-vitest.mjs run extensions/matrix/src/matrix/monitor/replies.test.ts` -- 9/9 passed (5 existing + 3 new + 1 updated)
- New tests:
  - "delivers reasoning payloads as m.notice instead of suppressing (regression #81892)"
  - "delivers reasoning text with thinking tags as m.notice"
  - "delivers pure thinking-tag-only text as m.notice"
- Updated test:
  - "delivers reasoning-only text as m.notice and normal text as m.text" (was "suppresses reasoning-only text")
- No CHANGELOG.md edits

## Risk checklist

- userVisible: Yes (Matrix users will now see reasoning messages as m.notice)
- configEnvMigration: No
- securityAuthNetwork: No
- Mitigation: Uses existing `m.notice` message type already supported by Matrix. Only affects reasoning payloads, not normal messages. Follows Telegram's established reasoning delivery pattern.

## Current review state

- **Pre-existing CI failure (not from this PR):** `checks-node-core-tooling-docker` fails on `test/scripts/docker-build-helper.test.ts` > `stops the tracked build command without retrying when interrupted` -- this test is not in the PR diff and is a pre-existing issue on main. See CI logs: this failure exists on the base branch and is unrelated to this PR's changes.
- [x] AI-assisted (built with Claude Code)