### PR TITLE
Fix Telegram rich progress detail updates

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2626,7 +2626,11 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     const lastUpdate = answerDraftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastUpdate?.text).toContain("completed");
-    expect(lastUpdate?.text).not.toContain("install dependencies");
+    expect(lastUpdate?.text).toContain("install dependencies");
+    expect(lastUpdate?.richMessage).toEqual({
+      html: "<b>Shelling</b><br><b>🛠️ Exec</b> <code>install dependencies</code> <i>completed</i>",
+      skip_entity_detection: true,
+    });
   });
 
   it("sends trailing verbose status after a progress-mode final answer", async () => {

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -1,9 +1,10 @@
 // Telegram helper module supports draft stream helpers behavior.
 import { vi } from "vitest";
+import type { TelegramDraftPreview } from "./draft-stream.js";
 
 type TestDraftStream = {
   update: ReturnType<typeof vi.fn<(text: string) => void>>;
-  updatePreview: ReturnType<typeof vi.fn<(preview: { text: string }) => void>>;
+  updatePreview: ReturnType<typeof vi.fn<(preview: TelegramDraftPreview) => void>>;
   flush: ReturnType<typeof vi.fn<() => Promise<void>>>;
   messageId: ReturnType<typeof vi.fn<() => number | undefined>>;
   visibleSinceMs: ReturnType<typeof vi.fn<() => number | undefined>>;
@@ -41,7 +42,7 @@ export function createTestDraftStream(params?: {
       lastDeliveredText = text.trimEnd();
       params?.onUpdate?.(text);
     }),
-    updatePreview: vi.fn().mockImplementation((preview: { text: string }) => {
+    updatePreview: vi.fn().mockImplementation((preview: TelegramDraftPreview) => {
       if (stopped) {
         return;
       }
@@ -95,7 +96,7 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
       previewRevision += 1;
       lastDeliveredText = text.trimEnd();
     }),
-    updatePreview: vi.fn().mockImplementation((preview: { text: string }) => {
+    updatePreview: vi.fn().mockImplementation((preview: TelegramDraftPreview) => {
       if (activeMessageId == null) {
         activeMessageId = nextMessageId++;
         visibleSinceMs = Date.now();

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -632,6 +632,20 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
+  it("keeps rich preview html out of plain preview gating", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { richMessages: true, minInitialChars: 10 });
+
+    stream.updatePreview({
+      text: "Plan",
+      richMessage: { html: "<h2>Plan</h2><table><tr><td>A</td></tr></table>" },
+    });
+    await stream.flush();
+
+    expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
+    expect(api.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("clamps rich previews to the block limit", async () => {
     const api = createMockDraftApi();
     const text = Array.from({ length: 501 }, (_, index) => `paragraph ${index}`).join("\n\n");

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -135,6 +135,13 @@ function telegramDraftRichPayloadLength(preview: TelegramDraftPreview): number {
   return richMessage.html?.length ?? richMessage.markdown?.length ?? 0;
 }
 
+function resolveTelegramDraftRenderedText(
+  preview: TelegramDraftPreview,
+  richMessages: boolean,
+): string {
+  return richMessages ? preview.text : normalizeTelegramDraftTransportPreview(preview).text;
+}
+
 function findTelegramDraftChunkLength(
   text: string,
   maxChars: number,
@@ -147,7 +154,7 @@ function findTelegramDraftChunkLength(
   while (low <= high) {
     const mid = Math.floor((low + high) / 2);
     const preview = renderTelegramDraftPreview(text.slice(0, mid), renderText);
-    const renderedText = normalizeTelegramDraftTransportPreview(preview).text.trimEnd();
+    const renderedText = resolveTelegramDraftRenderedText(preview, richMessages).trimEnd();
     const payloadLength = richMessages
       ? telegramDraftRichPayloadLength(preview)
       : renderedText.length;
@@ -254,7 +261,6 @@ export function createTelegramDraftStream(params: {
     preview,
     sendGeneration,
   }: PreviewSendParams): Promise<boolean> => {
-    const transportPreview = normalizeTelegramDraftTransportPreview(preview);
     if (typeof streamMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
       if (richMessages) {
@@ -265,6 +271,7 @@ export function createTelegramDraftStream(params: {
         });
         return true;
       }
+      const transportPreview = normalizeTelegramDraftTransportPreview(preview);
       if (transportPreview.parseMode === "HTML") {
         try {
           await params.api.editMessageText(chatId, streamMessageId, transportPreview.text, {
@@ -340,8 +347,7 @@ export function createTelegramDraftStream(params: {
       deliveredTextOffset === 0 && lastRequestedPreview?.text === trimmed
         ? lastRequestedPreview
         : renderTelegramDraftPreview(currentText, params.renderText);
-    const transportPreview = normalizeTelegramDraftTransportPreview(rendered);
-    const renderedText = transportPreview.text.trimEnd();
+    const renderedText = resolveTelegramDraftRenderedText(rendered, richMessages).trimEnd();
     const renderedPayloadLength = richMessages
       ? telegramDraftRichPayloadLength(rendered)
       : renderedText.length;

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1111,11 +1111,13 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
       resolveProgressDraftLineMergeKeys(entry).some((entryKey) => lineKeys.includes(entryKey)),
     );
     if (existingIndex >= 0) {
-      if (normalizeChannelProgressDraftLineIdentity(lines[existingIndex]) === normalized) {
+      const replacement = mergeProgressDraftLineUpdate(lines[existingIndex], line);
+      const replacementIdentity = normalizeChannelProgressDraftLineIdentity(replacement);
+      if (normalizeChannelProgressDraftLineIdentity(lines[existingIndex]) === replacementIdentity) {
         return lines;
       }
       const next = [...lines];
-      next[existingIndex] = line;
+      next[existingIndex] = replacement;
       return next.slice(-maxLines);
     }
   }
@@ -1124,6 +1126,36 @@ export function mergeChannelProgressDraftLine<TLine extends string | ChannelProg
     return lines;
   }
   return [...lines, line].slice(-maxLines);
+}
+
+function mergeProgressDraftLineUpdate<TLine extends string | ChannelProgressDraftLine>(
+  previous: TLine,
+  line: TLine,
+): TLine {
+  if (typeof previous !== "object" || typeof line !== "object") {
+    return line;
+  }
+  if (
+    line.kind !== "command-output" ||
+    !line.status ||
+    (line.detail && line.detail !== line.status)
+  ) {
+    return line;
+  }
+  const previousDetail = previous.detail?.trim();
+  if (!previousDetail || previousDetail === previous.status) {
+    return line;
+  }
+  const replacement = {
+    ...line,
+    detail: previousDetail,
+  };
+  replacement.text = getProgressDraftLineText(replacement);
+  setProgressDraftLineCorrelationKey(
+    replacement,
+    progressDraftLineCorrelationKeys.get(line) ?? progressDraftLineCorrelationKeys.get(previous),
+  );
+  return replacement;
 }
 
 function resolveProgressDraftLineMergeKeys(line: string | ChannelProgressDraftLine): string[] {

--- a/src/plugin-sdk/channel-streaming.test.ts
+++ b/src/plugin-sdk/channel-streaming.test.ts
@@ -602,6 +602,8 @@ describe("channel-streaming", () => {
       id: "tool:call-1-output",
       kind: "command-output",
       status: "completed",
+      detail: "install dependencies",
+      text: "🛠️ completed; install dependencies",
     });
 
     const recoveredItemLine = buildChannelProgressDraftLine({
@@ -633,6 +635,8 @@ describe("channel-streaming", () => {
         id: "command-2",
         kind: "command-output",
         status: "completed",
+        detail: "install dependencies failed",
+        text: "🛠️ completed; install dependencies failed",
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- Preserve command details when a terminal command-output update replaces an earlier progress line, so Telegram rich progress no longer collapses to `Bash completed`.
- Keep rich Telegram draft previews on the rich-message path for sizing/dedupe instead of projecting rich HTML through legacy `parse_mode: HTML` text.
- Flip/add regression tests for both bugs.

## Verification

- `node scripts/run-vitest.mjs src/plugin-sdk/channel-streaming.test.ts src/channels/streaming.test.ts extensions/telegram/src/draft-stream.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `pnpm exec oxfmt --check --threads=1 src/channels/streaming.ts src/plugin-sdk/channel-streaming.test.ts extensions/telegram/src/draft-stream.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- Telegram E2E basic: driver message `34408`, SUT reply `34409`, `OPENCLAW_E2E_OK`
- Telegram E2E with `richMessages: true` and rich progress config: driver message `34413`, SUT reply `34414`, `OPENCLAW_E2E_OK`

Known unrelated main drift: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts` currently fails on `origin/main` with the same two existing assertions (`keeps same-message block chunks...`, `suppresses non-terminal final error warnings...`).
