### PR TITLE
fix(control-ui): apply seamColor bootstrap config

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -20,6 +20,7 @@ export type ControlUiBootstrapConfig = {
   embedSandbox?: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls?: boolean;
   chatMessageMaxWidth?: string;
+  seamColor?: string;
   /** Resolved `agents.defaults.timeFormat`; "auto" keeps the browser locale default. */
   timeFormat?: "auto" | "12" | "24";
 };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -47,6 +47,7 @@ describe("handleControlUiHttpRequest", () => {
       assistantAgentId: string;
       localMediaPreviewRoots?: string[];
       chatMessageMaxWidth?: string;
+      seamColor?: string;
       timeFormat?: "auto" | "12" | "24";
     };
   }
@@ -799,7 +800,10 @@ describe("handleControlUiHttpRequest", () => {
             config: {
               agents: { defaults: { workspace: tmp, timeFormat: "24" } },
               gateway: { controlUi: { chatMessageMaxWidth: "min(1280px, 82%)" } },
-              ui: { assistant: { name: "</script><script>alert(1)//", avatar: "</script>.png" } },
+              ui: {
+                seamColor: "#1A2b3C",
+                assistant: { name: "</script><script>alert(1)//", avatar: "</script>.png" },
+              },
             },
           },
         );
@@ -810,6 +814,7 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantAvatar).toBe("/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
         expect(parsed.chatMessageMaxWidth).toBe("min(1280px, 82%)");
+        expect(parsed.seamColor).toBe("#1A2b3C");
         expect(parsed.timeFormat).toBe("24");
         expect(Array.isArray(parsed.localMediaPreviewRoots)).toBe(true);
       },

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -979,6 +979,7 @@ export async function handleControlUiHttpRequest(
             : "scripts",
       allowExternalEmbedUrls: config?.gateway?.controlUi?.allowExternalEmbedUrls === true,
       chatMessageMaxWidth: config?.gateway?.controlUi?.chatMessageMaxWidth,
+      seamColor: config?.ui?.seamColor,
       timeFormat: config?.agents?.defaults?.timeFormat,
     } satisfies ControlUiBootstrapConfig);
     return true;

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -16,6 +16,7 @@ function requireFetchCall(fetchMock: ReturnType<typeof vi.fn>, index = 0) {
 describe("loadControlUiBootstrapConfig", () => {
   afterEach(() => {
     setUiTimeFormatPreference("auto");
+    document.documentElement.removeAttribute("style");
   });
 
   it("threads agents.defaults.timeFormat into the UI hour-cycle preference", async () => {
@@ -104,6 +105,101 @@ describe("loadControlUiBootstrapConfig", () => {
     expect(state.embedSandboxMode).toBe("scripts");
     expect(state.allowExternalEmbedUrls).toBe(true);
     expect(state.chatMessageMaxWidth).toBe("min(1280px, 82%)");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("applies configured seamColor to Control UI accent variables", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        basePath: "",
+        assistantName: "Main",
+        assistantAvatar: "M",
+        assistantAgentId: "main",
+        seamColor: "#1A2b3C",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAvatarSource: null,
+      assistantAvatarStatus: null,
+      assistantAvatarReason: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      chatMessageMaxWidth: null,
+      serverVersion: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+
+    const rootStyle = document.documentElement.style;
+    expect(rootStyle.getPropertyValue("--accent")).toBe("#1A2b3C");
+    expect(rootStyle.getPropertyValue("--ring")).toBe("#1A2b3C");
+    expect(rootStyle.getPropertyValue("--primary")).toBe("#1A2b3C");
+    expect(rootStyle.getPropertyValue("--accent-hover")).toBe(
+      "color-mix(in srgb, var(--accent) 82%, white 18%)",
+    );
+    expect(rootStyle.getPropertyValue("--accent-subtle")).toBe(
+      "color-mix(in srgb, var(--accent) 16%, transparent)",
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("removes server seamColor variables when bootstrap color is missing or invalid", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          basePath: "",
+          assistantName: "Main",
+          assistantAvatar: "M",
+          assistantAgentId: "main",
+          seamColor: "00aaee",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          basePath: "",
+          assistantName: "Main",
+          assistantAvatar: "M",
+          assistantAgentId: "main",
+          seamColor: "lobster",
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const state = {
+      basePath: "",
+      assistantName: "Assistant",
+      assistantAvatar: null,
+      assistantAvatarSource: null,
+      assistantAvatarStatus: null,
+      assistantAvatarReason: null,
+      assistantAgentId: null,
+      localMediaPreviewRoots: [],
+      embedSandboxMode: "scripts" as const,
+      allowExternalEmbedUrls: false,
+      chatMessageMaxWidth: null,
+      serverVersion: null,
+    };
+
+    await loadControlUiBootstrapConfig(state);
+    expect(document.documentElement.style.getPropertyValue("--accent")).toBe("#00aaee");
+
+    await loadControlUiBootstrapConfig(state);
+    expect(document.documentElement.style.getPropertyValue("--accent")).toBe("");
+    expect(document.documentElement.style.getPropertyValue("--ring")).toBe("");
+    expect(document.documentElement.style.getPropertyValue("--focus-ring")).toBe("");
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -12,6 +12,19 @@ import { normalizeAgentId, parseAgentSessionKey } from "../session-key.ts";
 import { loadLocalAssistantIdentity } from "../storage.ts";
 import { normalizeOptionalString } from "../string-coerce.ts";
 
+const SEAM_COLOR_CSS_VARIABLES = [
+  "--ring",
+  "--accent",
+  "--accent-hover",
+  "--accent-muted",
+  "--accent-subtle",
+  "--accent-glow",
+  "--primary",
+  "--focus",
+  "--focus-ring",
+  "--focus-glow",
+] as const;
+
 export type ControlUiBootstrapState = {
   basePath: string;
   assistantName: string;
@@ -30,6 +43,45 @@ export type ControlUiBootstrapState = {
   settings?: { token?: string | null } | null;
   password?: string | null;
 };
+
+function normalizeSeamColor(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const hex = value.trim().replace(/^#/, "");
+  return /^[0-9a-fA-F]{6}$/.test(hex) ? `#${hex}` : null;
+}
+
+function applyControlUiSeamColor(value: unknown) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const root = document.documentElement;
+  const color = normalizeSeamColor(value);
+  if (!color) {
+    for (const property of SEAM_COLOR_CSS_VARIABLES) {
+      root.style.removeProperty(property);
+    }
+    return;
+  }
+
+  root.style.setProperty("--ring", color);
+  root.style.setProperty("--accent", color);
+  root.style.setProperty("--accent-hover", "color-mix(in srgb, var(--accent) 82%, white 18%)");
+  root.style.setProperty("--accent-muted", color);
+  root.style.setProperty("--accent-subtle", "color-mix(in srgb, var(--accent) 16%, transparent)");
+  root.style.setProperty("--accent-glow", "color-mix(in srgb, var(--accent) 30%, transparent)");
+  root.style.setProperty("--primary", color);
+  root.style.setProperty("--focus", "color-mix(in srgb, var(--ring) 22%, transparent)");
+  root.style.setProperty(
+    "--focus-ring",
+    "0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 80%, transparent)",
+  );
+  root.style.setProperty(
+    "--focus-glow",
+    "0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow)",
+  );
+}
 
 function resolveActiveAgentId(state: ControlUiBootstrapState): string | null {
   const sessionAgentId = parseAgentSessionKey(state.sessionKey)?.agentId;
@@ -137,6 +189,7 @@ export async function loadControlUiBootstrapConfig(
       typeof parsed.chatMessageMaxWidth === "string" && parsed.chatMessageMaxWidth.trim()
         ? parsed.chatMessageMaxWidth
         : null;
+    applyControlUiSeamColor(parsed.seamColor);
     setUiTimeFormatPreference(parsed.timeFormat);
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Wires the existing `ui.seamColor` config value into the Control UI bootstrap payload.
- Applies validated seam color values to Control UI accent CSS variables during browser bootstrap.
- Removes server-applied accent variables when the bootstrap color is absent or invalid so theme defaults recover cleanly.

Why does this matter now?

- #56068 is open, unassigned, P2, source-reproducible, and marked queueable with clear acceptance checks.
- The backend already validates and exposes `ui.seamColor` through `talk.config`, but the Control UI path ignored it.

What is the intended outcome?

- A configured `ui.seamColor` changes Control UI accent styling through the existing bootstrap config path.

What is intentionally out of scope?

- No new config keys, theme picker changes, docs rewrites, or broader theme refactor.
- No changes to macOS/TUI seam color behavior.

What does success look like?

- `/control-ui-config.json` includes `seamColor` when configured.
- The browser loader applies the accent variables for valid hex colors and removes them for invalid or missing values.
- Existing bootstrap identity, media, embed, width, and time-format behavior remains unchanged.

What should reviewers focus on?

- Whether the CSS variables covered are the right Control UI accent surface.
- The strict hex validation and cleanup behavior in the browser loader.
- The gateway bootstrap payload contract.

## Linked context

Which issue does this close?

Closes #56068

Which issues, PRs, or discussions are related?

Related #84599

Was this requested by a maintainer or owner?

No direct maintainer request. ClawSweeper marked #56068 as source-reproducible, queueable, and fix-shape-clear.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `ui.seamColor` was accepted by config and exposed through `talk.config`, but the Control UI bootstrap JSON and browser loader did not carry or apply it.
- Real environment tested: Local OpenClaw checkout on the rebased branch, using the real Control UI HTTP bootstrap handler and production Control UI build.
- Exact steps or command run after this patch: Started a one-shot local Node HTTP server that invoked `handleControlUiHttpRequest` with `ui.seamColor: "#1A2b3C"`, then fetched `/control-ui-config.json`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from a local OpenClaw runtime HTTP handler:
  ```json
  {"status":200,"seamColor":"#1A2b3C","assistantName":"Proof","assistantAvatar":"P"}
  ```
- Observed result after fix: The bootstrap response now returns the configured `seamColor`, which gives the browser loader a valid server-provided accent color to apply.
- What was not tested: Full `pnpm check`, full `pnpm test`, and a manual browser screenshot from a long-running packaged gateway.
- Proof limitations or environment constraints: Proof used a local runtime HTTP handler plus focused browser-loader coverage rather than a screenshot from a persistent local Gateway session.
- Before evidence (optional but encouraged): On current main, `ControlUiBootstrapConfig`, the bootstrap JSON payload, and `loadControlUiBootstrapConfig` had no `seamColor` field/application path.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs ui/src/ui/controllers/control-ui-bootstrap.test.ts`
- `node scripts/run-vitest.mjs src/gateway/control-ui.http.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server.talk-config.test.ts src/config/config-misc.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/gateway/control-ui-contract.ts src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/controllers/control-ui-bootstrap.ts ui/src/ui/controllers/control-ui-bootstrap.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/control-ui-contract.ts src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/controllers/control-ui-bootstrap.ts ui/src/ui/controllers/control-ui-bootstrap.test.ts`
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs qaRuntime`
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build`

What regression coverage was added or updated?

- Gateway HTTP bootstrap coverage now asserts configured `ui.seamColor` is included in the JSON payload.
- Control UI bootstrap coverage now asserts valid seam colors apply accent CSS variables and invalid/missing values remove them.

What failed before this fix, if known?

- Source-level repro: the Control UI bootstrap contract/payload omitted `seamColor`, and the frontend loader had no CSS variable application path.

If no test was added, why not?

- Tests were added for both the gateway payload and frontend loader behavior.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Configured `ui.seamColor` now affects Control UI accent styling.

Did config, environment, or migration behavior change? (`Yes/No`)

No. This uses the existing validated `ui.seamColor` config key.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. This adds a non-secret theme color to the existing Control UI bootstrap payload.

What is the highest-risk area?

The highest-risk area is overriding theme CSS variables too broadly or leaving stale inline variables after the server stops sending a valid color.

How is that risk mitigated?

The loader accepts only 6-digit hex colors, sets a bounded list of accent variables, and removes that same list when the value is invalid or absent. Focused tests cover both apply and cleanup paths.

## Current review state

What is the next action?

Ready for maintainer review after GitHub checks finish.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on GitHub CI and maintainer review. A manual browser screenshot can be added if reviewers want visual proof beyond the local HTTP/bootstrap and browser-loader evidence.

Which bot or reviewer comments were addressed?

The PR body now includes copied live output in the Real behavior proof section so the proof gate can evaluate after-fix evidence from the PR description.
