### PR TITLE
refactor: add session cleanup lifecycle seam

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -45,6 +45,10 @@ const legacyManualCompactTrimNames = new Set([
   "archiveFileOnDisk",
   "readRecentSessionTranscriptLines",
 ]);
+const legacyLifecycleCleanupNames = new Set([
+  "archiveRemovedSessionTranscripts",
+  "cleanupArchivedSessionTranscripts",
+]);
 
 export const migratedSessionAccessorFiles = new Set([
   "src/agents/embedded-agent-runner/compaction-successor-transcript.ts",
@@ -117,6 +121,12 @@ export const migratedTranscriptWriterFiles = new Set([
 
 export const migratedSessionCompactManualTrimFiles = new Set([
   "src/gateway/server-methods/sessions.ts",
+]);
+
+export const migratedSessionLifecycleCleanupFiles = new Set([
+  "src/config/sessions/cleanup-service.ts",
+  "src/cron/session-reaper.ts",
+  "src/infra/heartbeat-runner.ts",
 ]);
 
 function normalizeRelativePath(filePath) {
@@ -297,6 +307,15 @@ export function findSessionCompactManualTrimBoundaryViolations(content, fileName
   );
 }
 
+export function findSessionLifecycleCleanupBoundaryViolations(content, fileName = "source.ts") {
+  return findNamedSessionStoreViolations(
+    content,
+    fileName,
+    legacyLifecycleCleanupNames,
+    "lifecycle cleanup",
+  );
+}
+
 export async function main() {
   const repoRoot = resolveRepoRoot(import.meta.url);
   const readSourceRoots = resolveSourceRoots(repoRoot, [
@@ -368,12 +387,22 @@ export async function main() {
       ),
     findViolations: findSessionCompactManualTrimBoundaryViolations,
   });
+  const lifecycleCleanupViolations = await collectFileViolations({
+    repoRoot,
+    sourceRoots: readSourceRoots,
+    skipFile: (filePath) =>
+      !migratedSessionLifecycleCleanupFiles.has(
+        normalizeRelativePath(path.relative(repoRoot, filePath)),
+      ),
+    findViolations: findSessionLifecycleCleanupBoundaryViolations,
+  });
   const violations = [
     ...readViolations,
     ...writeViolations,
     ...transcriptWriterViolations,
     ...sessionCreateLifecycleViolations,
     ...manualCompactTrimViolations,
+    ...lifecycleCleanupViolations,
   ];
 
   if (violations.length === 0) {

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -19,6 +19,10 @@ import {
   resolveSessionFilePathOptions,
   resolveStorePath,
 } from "./paths.js";
+import {
+  applySessionEntryLifecycleMutation,
+  type SessionEntryLifecycleRemoval,
+} from "./session-accessor.js";
 import { cloneSessionStoreRecord } from "./store-cache.js";
 import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
@@ -27,12 +31,7 @@ import {
   pruneStaleEntries,
   type ResolvedSessionMaintenanceConfig,
 } from "./store-maintenance.js";
-import {
-  archiveRemovedSessionTranscripts,
-  loadSessionStore,
-  updateSessionStore,
-  type SessionMaintenanceApplyReport,
-} from "./store.js";
+import { loadSessionStore, updateSessionStore } from "./store.js";
 import {
   resolveSessionStoreTargets,
   type SessionStoreTarget,
@@ -217,15 +216,6 @@ function isMainScopeStaleDirectSessionKey(params: {
   );
 }
 
-function rememberRemovedSessionFile(
-  removedSessionFiles: Map<string, string | undefined>,
-  entry: SessionEntry | undefined,
-): void {
-  if (entry?.sessionId) {
-    removedSessionFiles.set(entry.sessionId, entry.sessionFile);
-  }
-}
-
 function retireMainScopeDirectSessionEntries(params: {
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
@@ -270,7 +260,7 @@ export function serializeSessionCleanupResult(params: {
 function pruneMissingTranscriptEntries(params: {
   store: Record<string, SessionEntry>;
   storePath: string;
-  onPruned?: (key: string) => void;
+  onPruned?: (key: string, entry: SessionEntry) => void;
 }): number {
   const sessionPathOpts = resolveSessionFilePathOptions({
     storePath: params.storePath,
@@ -284,7 +274,7 @@ function pruneMissingTranscriptEntries(params: {
       }
       delete params.store[key];
       removed += 1;
-      params.onPruned?.(key);
+      params.onPruned?.(key, entry);
       continue;
     }
     let transcriptPath: string | undefined;
@@ -300,7 +290,7 @@ function pruneMissingTranscriptEntries(params: {
     ) {
       delete params.store[key];
       removed += 1;
-      params.onPruned?.(key);
+      params.onPruned?.(key, entry);
     }
   }
   return removed;
@@ -500,64 +490,63 @@ export async function runSessionsCleanup(params: {
   const appliedSummaries: SessionCleanupSummary[] = [];
   if (!opts.dryRun) {
     for (const target of targets) {
-      const appliedReportRef: { current: SessionMaintenanceApplyReport | null } = {
-        current: null,
-      };
-      const dmScopeRemovedSessionFiles = new Map<string, string | undefined>();
-      let missingApplied = 0;
-      let dmScopeRetiredApplied = 0;
-      await updateSessionStore(
-        target.storePath,
-        async (store) => {
-          let removed = 0;
-          if (opts.fixMissing) {
-            missingApplied = pruneMissingTranscriptEntries({
-              store,
-              storePath: target.storePath,
-            });
-            removed += missingApplied;
-          }
-          if (opts.fixDmScope) {
-            // DM-scope retirement removes stale main-scope direct entries during apply.
-            dmScopeRetiredApplied = retireMainScopeDirectSessionEntries({
-              cfg,
-              store,
-              targetAgentId: target.agentId,
-              activeKey: opts.activeKey,
-              onRetired: (_key, entry) => {
-                rememberRemovedSessionFile(dmScopeRemovedSessionFiles, entry);
-              },
-            });
-            removed += dmScopeRetiredApplied;
-          }
-          return removed;
-        },
-        {
-          activeSessionKey: opts.activeKey,
-          maintenanceOverride: {
-            mode,
-          },
-          onMaintenanceApplied: (report) => {
-            appliedReportRef.current = report;
-          },
-        },
-      );
-      if (dmScopeRemovedSessionFiles.size > 0) {
-        // Archive removed direct-session transcripts unless still referenced by surviving entries.
-        const storeAfterDmScopeRetire = loadSessionStore(target.storePath, { skipCache: true });
-        await archiveRemovedSessionTranscripts({
-          removedSessionFiles: dmScopeRemovedSessionFiles,
-          referencedSessionIds: new Set(
-            Object.values(storeAfterDmScopeRetire)
-              .map((entry) => entry?.sessionId)
-              .filter((id): id is string => Boolean(id)),
-          ),
+      const applyStore = loadSessionStore(target.storePath, { skipCache: true });
+      const missingRemovals: SessionEntryLifecycleRemoval[] = [];
+      const dmScopeRetiredRemovals: SessionEntryLifecycleRemoval[] = [];
+      if (opts.fixMissing) {
+        pruneMissingTranscriptEntries({
+          store: applyStore,
           storePath: target.storePath,
-          reason: "deleted",
-          restrictToStoreDir: true,
+          onPruned: (sessionKey, entry) => {
+            missingRemovals.push({
+              sessionKey,
+              expectedEntry: cloneSessionStoreRecord({ entry }).entry,
+            });
+          },
         });
       }
-      const afterStore = loadSessionStore(target.storePath, { skipCache: true });
+      if (opts.fixDmScope) {
+        retireMainScopeDirectSessionEntries({
+          cfg,
+          store: applyStore,
+          targetAgentId: target.agentId,
+          activeKey: opts.activeKey,
+          onRetired: (sessionKey, entry) => {
+            dmScopeRetiredRemovals.push({
+              sessionKey,
+              expectedEntry: cloneSessionStoreRecord({ entry }).entry,
+              archiveRemovedTranscript: true,
+            });
+          },
+        });
+      }
+      const removals: SessionEntryLifecycleRemoval[] = [
+        ...missingRemovals,
+        ...dmScopeRetiredRemovals,
+      ];
+      const lifecycleResult = await applySessionEntryLifecycleMutation({
+        storePath: target.storePath,
+        removals,
+        activeSessionKey: opts.activeKey,
+        maintenanceOverride: {
+          mode,
+        },
+        restrictArchivedTranscriptsToStoreDir: true,
+        pruneUnreferencedArtifacts:
+          mode === "warn"
+            ? undefined
+            : {
+                olderThanMs: maintenance.pruneAfterMs,
+                dryRun: false,
+              },
+      });
+      const removedSessionKeys = new Set(lifecycleResult.removedSessionKeys);
+      const missingApplied = missingRemovals.filter(({ sessionKey }) =>
+        removedSessionKeys.has(sessionKey),
+      ).length;
+      const dmScopeRetiredApplied = dmScopeRetiredRemovals.filter(({ sessionKey }) =>
+        removedSessionKeys.has(sessionKey),
+      ).length;
       const unreferencedArtifacts =
         mode === "warn"
           ? {
@@ -566,16 +555,16 @@ export async function runSessionsCleanup(params: {
               freedBytes: 0,
               olderThanMs: maintenance.pruneAfterMs,
             }
-          : await pruneUnreferencedSessionArtifacts({
-              store: afterStore,
-              storePath: target.storePath,
+          : (lifecycleResult.unreferencedArtifacts ?? {
+              scannedFiles: 0,
+              removedFiles: 0,
+              freedBytes: 0,
               olderThanMs: maintenance.pruneAfterMs,
-              dryRun: false,
             });
       const preview = previewResults.find(
         (result) => result.summary.storePath === target.storePath,
       );
-      const appliedReport = appliedReportRef.current;
+      const appliedReport = lifecycleResult.maintenanceReport;
       const summary: SessionCleanupSummary =
         appliedReport === null
           ? {
@@ -599,7 +588,7 @@ export async function runSessionsCleanup(params: {
               wouldMutate:
                 (preview?.summary.wouldMutate ?? false) || unreferencedArtifacts.removedFiles > 0,
               applied: true,
-              appliedCount: Object.keys(afterStore).length,
+              appliedCount: lifecycleResult.afterCount,
             }
           : {
               agentId: target.agentId,
@@ -623,7 +612,7 @@ export async function runSessionsCleanup(params: {
                 (appliedReport.diskBudget?.removedEntries ?? 0) > 0 ||
                 (appliedReport.diskBudget?.removedFiles ?? 0) > 0,
               applied: true,
-              appliedCount: Object.keys(afterStore).length,
+              appliedCount: lifecycleResult.afterCount,
             };
       appliedSummaries.push(summary);
     }

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,7 @@ import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
+  applySessionEntryLifecycleMutation,
   applySessionPatchProjection,
   cleanupSessionLifecycleArtifacts,
   createSessionEntryWithTranscript,
@@ -524,6 +525,152 @@ describe("session accessor file-backed seam", () => {
       event,
     ]);
     expect(fs.statSync(transcriptPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("applies keyed lifecycle removals and artifact cleanup from the final store", async () => {
+    const removedTranscriptPath = path.join(tempDir, "removed-session.jsonl");
+    const sharedTranscriptPath = path.join(tempDir, "shared-session.jsonl");
+    const orphanTranscriptPath = path.join(tempDir, "orphan-session.jsonl");
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:removed": {
+            sessionId: "removed-session",
+          },
+          "agent:main:shared-remove": {
+            sessionId: "shared-session",
+          },
+          "agent:main:shared-keep": {
+            sessionId: "shared-session",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(removedTranscriptPath, '{"type":"session"}\n', "utf-8");
+    fs.writeFileSync(sharedTranscriptPath, '{"type":"session"}\n', "utf-8");
+    fs.writeFileSync(orphanTranscriptPath, "orphan", "utf-8");
+    const oldDate = new Date(Date.now() - 60_000);
+    fs.utimesSync(orphanTranscriptPath, oldDate, oldDate);
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      removals: [
+        { sessionKey: "agent:main:removed", archiveRemovedTranscript: true },
+        { sessionKey: "agent:main:shared-remove", archiveRemovedTranscript: true },
+      ],
+      upserts: [
+        {
+          sessionKey: "agent:main:new",
+          entry: { sessionId: "new-session", updatedAt: 123 },
+        },
+      ],
+      skipMaintenance: true,
+      restrictArchivedTranscriptsToStoreDir: true,
+      pruneUnreferencedArtifacts: { olderThanMs: 1 },
+    });
+
+    expect(result.removedEntries).toBe(2);
+    expect(result.unreferencedArtifacts?.removedFiles).toBe(1);
+    expect(loadSessionStore(storePath, { skipCache: true })).toEqual({
+      "agent:main:shared-keep": {
+        sessionId: "shared-session",
+      },
+      "agent:main:new": {
+        sessionId: "new-session",
+        updatedAt: 123,
+      },
+    });
+    expect(fs.existsSync(removedTranscriptPath)).toBe(false);
+    expect(fs.existsSync(sharedTranscriptPath)).toBe(true);
+    expect(fs.existsSync(orphanTranscriptPath)).toBe(false);
+    expect(
+      fs.readdirSync(tempDir).filter((file) => file.startsWith("removed-session.jsonl.deleted.")),
+    ).toHaveLength(1);
+  });
+
+  it("does not apply stale lifecycle removal plans to changed entries", async () => {
+    const stalePlanEntry: SessionEntry = {
+      sessionId: "planned-session",
+      updatedAt: 1,
+    };
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:planned": {
+            sessionId: "planned-session",
+            updatedAt: 2,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      removals: [
+        {
+          sessionKey: "agent:main:planned",
+          expectedEntry: stalePlanEntry,
+          archiveRemovedTranscript: true,
+        },
+      ],
+      skipMaintenance: true,
+    });
+
+    expect(result.removedEntries).toBe(0);
+    expect(loadSessionStore(storePath, { skipCache: true })).toEqual({
+      "agent:main:planned": {
+        sessionId: "planned-session",
+        updatedAt: 2,
+      },
+    });
+  });
+
+  it("builds lifecycle upsert entries from the locked store snapshot", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:existing": {
+            sessionId: "current-session",
+            updatedAt: 10,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const result = await applySessionEntryLifecycleMutation({
+      storePath,
+      upserts: [
+        {
+          sessionKey: "agent:main:existing",
+          buildEntry: ({ currentEntry }) => ({
+            ...currentEntry,
+            sessionId: currentEntry?.sessionId ?? "missing",
+            updatedAt: 20,
+          }),
+        },
+      ],
+      skipMaintenance: true,
+    });
+
+    expect(result.afterCount).toBe(1);
+    expect(loadSessionStore(storePath, { skipCache: true })).toEqual({
+      "agent:main:existing": {
+        sessionId: "current-session",
+        updatedAt: 20,
+      },
+    });
   });
 
   it("appends to an explicit transcript artifact without a session key", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -27,6 +27,7 @@ import {
   getSessionEntry,
   cleanupSessionLifecycleArtifacts as cleanupFileSessionLifecycleArtifacts,
   deleteSessionEntryLifecycle as deleteFileSessionEntryLifecycle,
+  applySessionEntryLifecycleMutation as applyFileSessionEntryLifecycleMutation,
   listSessionEntries as listFileSessionEntries,
   loadSessionStore,
   applySessionEntryPatchProjection as applyFileSessionEntryPatchProjection,
@@ -39,6 +40,10 @@ import {
   type DeleteSessionEntryLifecycleResult,
   type ResetSessionEntryLifecycleMutation,
   type ResetSessionEntryLifecycleResult,
+  type SessionArchivedTranscriptCleanupRule,
+  type SessionEntryLifecycleMutationResult,
+  type SessionEntryLifecycleRemoval,
+  type SessionEntryLifecycleUpsert,
   type SessionEntryPatchProjectionContext,
   type SessionEntryPatchProjectionFailure,
   type SessionEntryPatchProjectionResult,
@@ -313,6 +318,13 @@ export type {
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
   SessionLifecycleStoreTarget,
+};
+
+export type {
+  SessionArchivedTranscriptCleanupRule,
+  SessionEntryLifecycleMutationResult,
+  SessionEntryLifecycleRemoval,
+  SessionEntryLifecycleUpsert,
 };
 
 export type ResetSessionEntryLifecycleParams = {
@@ -593,6 +605,29 @@ export async function deleteSessionEntryLifecycle(
   params: DeleteSessionEntryLifecycleParams,
 ): Promise<DeleteSessionEntryLifecycleResult> {
   return await deleteFileSessionEntryLifecycle(params);
+}
+
+/** Applies exact entry lifecycle mutations and artifact cleanup at the storage boundary. */
+export async function applySessionEntryLifecycleMutation(params: {
+  storePath: string;
+  removals?: Iterable<SessionEntryLifecycleRemoval>;
+  upserts?: Iterable<SessionEntryLifecycleUpsert>;
+  activeSessionKey?: string;
+  maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
+  skipMaintenance?: boolean;
+  archiveReason?: "deleted" | "reset";
+  restrictArchivedTranscriptsToStoreDir?: boolean;
+  cleanupArchivedTranscripts?: {
+    rules: SessionArchivedTranscriptCleanupRule[];
+    nowMs?: number;
+  };
+  pruneUnreferencedArtifacts?: {
+    olderThanMs: number;
+    dryRun?: boolean;
+  };
+  captureArtifactCleanupError?: boolean;
+}): Promise<SessionEntryLifecycleMutationResult> {
+  return await applyFileSessionEntryLifecycleMutation(params);
 }
 
 /** Reads parsed transcript records from an explicit or derived transcript target. */

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -21,7 +21,12 @@ import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
-import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
+import {
+  enforceSessionDiskBudget,
+  pruneUnreferencedSessionArtifacts,
+  type SessionDiskBudgetSweepResult,
+  type SessionUnreferencedArtifactSweepResult,
+} from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import { resolveSessionFilePath, resolveStorePath } from "./paths.js";
 import {
@@ -273,6 +278,54 @@ export type DeleteSessionEntryLifecycleResult = {
   deletedEntry?: SessionEntry;
   deletedSessionFile?: string;
   deletedSessionId?: string;
+};
+
+export type SessionEntryLifecycleRemoval = {
+  /** Exact persisted key to remove from the store. */
+  sessionKey: string;
+  /** Optional full-entry guard for plans built before the writer lock. */
+  expectedEntry?: SessionEntry;
+  /** Archive the removed entry's transcript only when no final store entry still references it. */
+  archiveRemovedTranscript?: boolean;
+  /** Optional guard for stale plans built from a prior store read. */
+  expectedSessionId?: string;
+  /** Optional guard for stale plans built from a prior store read. */
+  expectedUpdatedAt?: number;
+};
+
+export type SessionEntryLifecycleUpsert = {
+  /** Exact persisted key to create or replace. */
+  sessionKey: string;
+} & (
+  | {
+      /** Entry to persist at the exact key. */
+      entry: SessionEntry;
+      buildEntry?: never;
+    }
+  | {
+      /** Builds the persisted entry after the storage writer lock is held. */
+      buildEntry: (context: {
+        currentEntry?: SessionEntry;
+        sessionKey: string;
+        store: Record<string, SessionEntry>;
+      }) => Promise<SessionEntry | null | undefined> | SessionEntry | null | undefined;
+      entry?: never;
+    }
+);
+
+export type SessionArchivedTranscriptCleanupRule = {
+  reason: "deleted" | "reset";
+  olderThanMs: number;
+};
+
+export type SessionEntryLifecycleMutationResult = {
+  removedEntries: number;
+  removedSessionKeys: string[];
+  archivedTranscriptDirectories: string[];
+  unreferencedArtifacts: SessionUnreferencedArtifactSweepResult | null;
+  maintenanceReport: SessionMaintenanceApplyReport | null;
+  afterCount: number;
+  artifactCleanupError?: unknown;
 };
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
@@ -1306,6 +1359,163 @@ export async function deleteSessionEntryLifecycle(params: {
     }
     return result;
   });
+}
+
+function shouldRemoveSessionEntry(
+  entry: SessionEntry | undefined,
+  removal: SessionEntryLifecycleRemoval,
+): entry is SessionEntry {
+  if (!entry) {
+    return false;
+  }
+  if (
+    removal.expectedEntry !== undefined &&
+    JSON.stringify(entry) !== JSON.stringify(removal.expectedEntry)
+  ) {
+    return false;
+  }
+  if (removal.expectedSessionId !== undefined && entry.sessionId !== removal.expectedSessionId) {
+    return false;
+  }
+  if (removal.expectedUpdatedAt !== undefined && entry.updatedAt !== removal.expectedUpdatedAt) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Applies exact entry removals/upserts and lifecycle artifact cleanup as one
+ * backend-owned operation. Callers choose domain keys; storage owns the final
+ * referenced-session set used for transcript/artifact cleanup.
+ */
+export async function applySessionEntryLifecycleMutation(params: {
+  storePath: string;
+  removals?: Iterable<SessionEntryLifecycleRemoval>;
+  upserts?: Iterable<SessionEntryLifecycleUpsert>;
+  activeSessionKey?: string;
+  maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
+  skipMaintenance?: boolean;
+  archiveReason?: "deleted" | "reset";
+  restrictArchivedTranscriptsToStoreDir?: boolean;
+  cleanupArchivedTranscripts?: {
+    rules: SessionArchivedTranscriptCleanupRule[];
+    nowMs?: number;
+  };
+  pruneUnreferencedArtifacts?: {
+    olderThanMs: number;
+    dryRun?: boolean;
+  };
+  captureArtifactCleanupError?: boolean;
+}): Promise<SessionEntryLifecycleMutationResult> {
+  const storePath = path.resolve(params.storePath);
+  const removedSessionFiles = new Map<string, string | undefined>();
+  const removedSessionKeys: string[] = [];
+  const archivedTranscriptDirectories: string[] = [];
+  let unreferencedArtifacts: SessionUnreferencedArtifactSweepResult | null = null;
+  let maintenanceReport: SessionMaintenanceApplyReport | null = null;
+  let afterCount = 0;
+  let artifactCleanupError: unknown;
+
+  await runExclusiveSessionStoreWrite(storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(storePath);
+    for (const removal of params.removals ?? []) {
+      const sessionKey = removal.sessionKey.trim();
+      if (!sessionKey) {
+        continue;
+      }
+      const entry = store[sessionKey];
+      if (!shouldRemoveSessionEntry(entry, removal)) {
+        continue;
+      }
+      if (removal.archiveRemovedTranscript === true && entry.sessionId) {
+        rememberRemovedSessionFile(removedSessionFiles, entry);
+      }
+      delete store[sessionKey];
+      removedSessionKeys.push(sessionKey);
+    }
+    for (const upsert of params.upserts ?? []) {
+      const sessionKey = upsert.sessionKey.trim();
+      if (!sessionKey) {
+        continue;
+      }
+      const entry =
+        upsert.buildEntry === undefined
+          ? upsert.entry
+          : await upsert.buildEntry({
+              currentEntry: store[sessionKey] ? cloneSessionEntry(store[sessionKey]) : undefined,
+              sessionKey,
+              store,
+            });
+      if (!entry) {
+        continue;
+      }
+      store[sessionKey] = cloneSessionEntry(entry);
+    }
+
+    await saveSessionStoreUnlocked(storePath, store, {
+      activeSessionKey: params.activeSessionKey,
+      maintenanceOverride: params.maintenanceOverride,
+      skipMaintenance: params.skipMaintenance,
+      onMaintenanceApplied: (report) => {
+        maintenanceReport = report;
+      },
+    });
+    afterCount = Object.keys(store).length;
+
+    const cleanupArtifacts = async () => {
+      const referencedSessionIds = new Set(
+        Object.values(store)
+          .map((entry) => entry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
+      if (removedSessionFiles.size > 0) {
+        const archivedDirs = await archiveRemovedSessionTranscripts({
+          removedSessionFiles,
+          referencedSessionIds,
+          storePath,
+          reason: params.archiveReason ?? "deleted",
+          restrictToStoreDir: params.restrictArchivedTranscriptsToStoreDir,
+        });
+        archivedTranscriptDirectories.push(...[...archivedDirs].toSorted());
+        if (archivedDirs.size > 0 && params.cleanupArchivedTranscripts) {
+          const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
+          await cleanupArchivedSessionTranscripts({
+            directories: [...archivedDirs],
+            rules: params.cleanupArchivedTranscripts.rules,
+            nowMs: params.cleanupArchivedTranscripts.nowMs,
+          });
+        }
+      }
+      if (params.pruneUnreferencedArtifacts) {
+        unreferencedArtifacts = await pruneUnreferencedSessionArtifacts({
+          store,
+          storePath,
+          olderThanMs: params.pruneUnreferencedArtifacts.olderThanMs,
+          dryRun: params.pruneUnreferencedArtifacts.dryRun,
+        });
+      }
+    };
+
+    try {
+      await cleanupArtifacts();
+    } catch (err) {
+      if (params.captureArtifactCleanupError === true) {
+        artifactCleanupError = err;
+      } else {
+        throw err;
+      }
+    }
+  });
+
+  return {
+    removedEntries: removedSessionKeys.length,
+    removedSessionKeys,
+    archivedTranscriptDirectories,
+    unreferencedArtifacts,
+    maintenanceReport,
+    afterCount,
+    artifactCleanupError,
+  };
 }
 
 async function archiveUnreferencedLifecycleTranscriptArtifacts(params: {

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -1,9 +1,12 @@
 /** Prunes expired per-run cron sessions and archives unreferenced transcripts. */
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { loadSessionStore } from "../config/sessions/store-load.js";
-import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
+import {
+  applySessionEntryLifecycleMutation,
+  listSessionEntries,
+  type SessionEntryLifecycleRemoval,
+} from "../config/sessions/session-accessor.js";
 import type { CronConfig } from "../config/types.cron.js";
-import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import type { Logger } from "./service/state.js";
 
@@ -67,28 +70,39 @@ export async function sweepCronRunSessions(params: {
   }
 
   let pruned = 0;
-  const prunedSessions = new Map<string, string | undefined>();
+  let transcriptCleanupError: unknown;
   try {
-    await updateSessionStore(storePath, (store) => {
-      const cutoff = now - retentionMs;
-      for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
-          continue;
-        }
-        const entry = store[key];
-        if (!entry) {
-          continue;
-        }
-        const updatedAt = entry.updatedAt ?? 0;
-        if (updatedAt < cutoff) {
-          if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
-            prunedSessions.set(entry.sessionId, entry.sessionFile);
-          }
-          delete store[key];
-          pruned++;
-        }
+    const cutoff = now - retentionMs;
+    const removals: SessionEntryLifecycleRemoval[] = [];
+    for (const { sessionKey, entry } of listSessionEntries({ storePath, clone: false })) {
+      if (!isCronRunSessionKey(sessionKey)) {
+        continue;
       }
-    });
+      const updatedAt = entry.updatedAt ?? 0;
+      if (updatedAt < cutoff) {
+        removals.push({
+          sessionKey,
+          expectedEntry: entry,
+          ...(entry.sessionId ? { expectedSessionId: entry.sessionId } : {}),
+          expectedUpdatedAt: entry.updatedAt,
+          archiveRemovedTranscript: true,
+        });
+      }
+    }
+    if (removals.length > 0) {
+      const result = await applySessionEntryLifecycleMutation({
+        storePath,
+        removals,
+        restrictArchivedTranscriptsToStoreDir: true,
+        cleanupArchivedTranscripts: {
+          rules: [{ reason: "deleted", olderThanMs: retentionMs }],
+          nowMs: now,
+        },
+        captureArtifactCleanupError: true,
+      });
+      pruned = result.removedEntries;
+      transcriptCleanupError = result.artifactCleanupError;
+    }
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
     return { swept: false, pruned: 0 };
@@ -96,33 +110,11 @@ export async function sweepCronRunSessions(params: {
 
   lastSweepAtMsByStore.set(storePath, now);
 
-  if (prunedSessions.size > 0) {
-    try {
-      const store = loadSessionStore(storePath, { skipCache: true });
-      // Archive only transcripts that no remaining session references; base
-      // cron sessions intentionally keep their transcript history.
-      const referencedSessionIds = new Set(
-        Object.values(store)
-          .map((entry) => entry?.sessionId)
-          .filter((id): id is string => Boolean(id)),
-      );
-      const archivedDirs = await archiveRemovedSessionTranscripts({
-        removedSessionFiles: prunedSessions,
-        referencedSessionIds,
-        storePath,
-        reason: "deleted",
-        restrictToStoreDir: true,
-      });
-      if (archivedDirs.size > 0) {
-        await cleanupArchivedSessionTranscripts({
-          directories: [...archivedDirs],
-          rules: [{ reason: "deleted", olderThanMs: retentionMs }],
-          nowMs: now,
-        });
-      }
-    } catch (err) {
-      params.log.warn({ err: String(err) }, "cron-reaper: transcript cleanup failed");
-    }
+  if (transcriptCleanupError) {
+    params.log.warn(
+      { err: formatErrorMessage(transcriptCleanupError) },
+      "cron-reaper: transcript cleanup failed",
+    );
   }
 
   if (pruned > 0) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -77,8 +77,12 @@ import {
   resolveAgentMainSessionKey,
 } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
+import {
+  applySessionEntryLifecycleMutation,
+  type SessionEntryLifecycleRemoval,
+} from "../config/sessions/session-accessor.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
-import { archiveRemovedSessionTranscripts, updateSessionStore } from "../config/sessions/store.js";
+import { updateSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -1604,49 +1608,52 @@ export async function runHeartbeatOnce(opts: {
       });
       return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
     }
-    const removedSessionFiles = new Map<string, string | undefined>();
-    let referencedSessionIds = new Set<string>();
-    await updateSessionStore(isolatedStorePath, (store) => {
-      const cronSession = resolveCronSession({
-        cfg,
-        sessionKey: isolatedSessionKey,
-        agentId,
-        nowMs: startedAt,
-        forceNew: true,
-        store,
-      });
-      if (staleIsolatedSessionKey) {
-        const staleEntry = store[staleIsolatedSessionKey];
-        if (staleEntry?.sessionId) {
-          removedSessionFiles.set(staleEntry.sessionId, staleEntry.sessionFile);
-        }
-        delete store[staleIsolatedSessionKey];
-      }
-      store[isolatedSessionKey] = {
-        ...cronSession.sessionEntry,
-        heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
-      };
-      referencedSessionIds = new Set(
-        Object.values(store)
-          .map((sessionEntry) => sessionEntry?.sessionId)
-          .filter((sessionId): sessionId is string => Boolean(sessionId)),
-      );
+    const isolatedStore = loadSessionStore(isolatedStorePath, { skipCache: true });
+    const staleIsolatedEntry = staleIsolatedSessionKey
+      ? isolatedStore[staleIsolatedSessionKey]
+      : undefined;
+    const removals: SessionEntryLifecycleRemoval[] = staleIsolatedSessionKey
+      ? [
+          {
+            sessionKey: staleIsolatedSessionKey,
+            ...(staleIsolatedEntry ? { expectedEntry: staleIsolatedEntry } : {}),
+            ...(staleIsolatedEntry?.sessionId
+              ? { expectedSessionId: staleIsolatedEntry.sessionId }
+              : {}),
+            archiveRemovedTranscript: true,
+          },
+        ]
+      : [];
+    const lifecycleResult = await applySessionEntryLifecycleMutation({
+      storePath: isolatedStorePath,
+      removals,
+      upserts: [
+        {
+          sessionKey: isolatedSessionKey,
+          buildEntry: ({ store }) => {
+            const cronSession = resolveCronSession({
+              cfg,
+              sessionKey: isolatedSessionKey,
+              agentId,
+              nowMs: startedAt,
+              forceNew: true,
+              store,
+            });
+            return {
+              ...cronSession.sessionEntry,
+              heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
+            };
+          },
+        },
+      ],
+      restrictArchivedTranscriptsToStoreDir: true,
+      captureArtifactCleanupError: true,
     });
-    if (removedSessionFiles.size > 0) {
-      try {
-        await archiveRemovedSessionTranscripts({
-          removedSessionFiles,
-          referencedSessionIds,
-          storePath: isolatedStorePath,
-          reason: "deleted",
-          restrictToStoreDir: true,
-        });
-      } catch (err) {
-        log.warn("heartbeat: failed to archive stale isolated session transcript", {
-          err: String(err),
-          sessionKey: staleIsolatedSessionKey,
-        });
-      }
+    if (lifecycleResult.artifactCleanupError) {
+      log.warn("heartbeat: failed to archive stale isolated session transcript", {
+        err: formatErrorMessage(lifecycleResult.artifactCleanupError),
+        sessionKey: staleIsolatedSessionKey,
+      });
     }
     runSessionKey = isolatedSessionKey;
     outboundPolicySessionKey = isolatedBaseSessionKey;

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -4,8 +4,10 @@ import {
   findSessionAccessorBoundaryViolations,
   findSessionCompactManualTrimBoundaryViolations,
   findSessionAccessorWriteBoundaryViolations,
+  findSessionLifecycleCleanupBoundaryViolations,
   findTranscriptWriterBoundaryViolations,
   migratedBundledPluginSessionAccessorFiles,
+  migratedSessionLifecycleCleanupFiles,
   migratedSessionCompactManualTrimFiles,
   migratedSessionAccessorFiles,
   migratedSessionAccessorWriteFiles,
@@ -101,6 +103,16 @@ describe("session accessor boundary guard", () => {
   it("ratchets only compact manual trim gateway files", () => {
     expect(migratedSessionCompactManualTrimFiles).toEqual(
       new Set(["src/gateway/server-methods/sessions.ts"]),
+    );
+  });
+
+  it("ratchets only the lifecycle cleanup files migrated to backend cleanup", () => {
+    expect(migratedSessionLifecycleCleanupFiles).toEqual(
+      new Set([
+        "src/config/sessions/cleanup-service.ts",
+        "src/cron/session-reaper.ts",
+        "src/infra/heartbeat-runner.ts",
+      ]),
     );
   });
 
@@ -304,6 +316,35 @@ describe("session accessor boundary guard", () => {
         reason: 'calls legacy session store manual compact trim "readRecentSessionTranscriptLines"',
       },
       { line: 5, reason: 'calls legacy session store manual compact trim "archiveFileOnDisk"' },
+    ]);
+  });
+
+  it("flags direct lifecycle cleanup helper usage", () => {
+    expect(
+      findSessionLifecycleCleanupBoundaryViolations(`
+        import { archiveRemovedSessionTranscripts } from "../config/sessions/store.js";
+        import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
+        archiveRemovedSessionTranscripts({ removedSessionFiles, referencedSessionIds, storePath, reason: "deleted" });
+        cleanupArchivedSessionTranscripts({ directories, rules });
+      `),
+    ).toEqual([
+      {
+        line: 2,
+        reason: 'imports legacy session store lifecycle cleanup "archiveRemovedSessionTranscripts"',
+      },
+      {
+        line: 3,
+        reason:
+          'imports legacy session store lifecycle cleanup "cleanupArchivedSessionTranscripts"',
+      },
+      {
+        line: 4,
+        reason: 'calls legacy session store lifecycle cleanup "archiveRemovedSessionTranscripts"',
+      },
+      {
+        line: 5,
+        reason: 'calls legacy session store lifecycle cleanup "cleanupArchivedSessionTranscripts"',
+      },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Adds `applySessionEntryLifecycleMutation(...)` as a file-backed session accessor/storage seam for exact keyed removals, upserts, final referenced-session calculation, removed-transcript archiving, archive retention cleanup, and optional unreferenced artifact pruning.
- Moves sessions cleanup apply mode, cron run-session reaping, and isolated heartbeat stale-session replacement off caller-composed entry deletion plus separate transcript/archive cleanup.
- Preserves caller-owned behavior: cleanup preview/reporting, warn-vs-enforce mode, cron retention/throttling/logging, heartbeat active-run skips/runtime behavior, and file-backed artifact restrictions.
- Intentionally excludes SQLite schema/runtime flip, doctor migration, runtime JSON fallback, whole-store mutable accessor callbacks, and plugin SDK changes.
- Review focus: stale-plan guards on pre-read cleanup/reaper/heartbeat plans, final referenced-session artifact cleanup semantics, and the narrow boundary guard scope.

## Linked context

Related #88838

Requested by maintainer coordination for OpenClaw Path 3 branch-by-abstraction `.35` cleanup/reaper lifecycle seam.

Head branch: `clawdbot-d02.1.9.1.35/31b-session-cleanup-reaper-lifecycle-seam`

Head SHA: `94515ab66b6c6cb8baf5ee91e0b4a619d61c69a3`

Pebbles: `clawdbot-d02.1.9.1.33` (`3.1b session cleanup reaper lifecycle seam (.35 branch)`), closed.

## Real behavior proof

Behavior addressed: Storage boundary now owns entry-removal artifact cleanup for sessions cleanup apply mode, including final referenced-session calculation and unreferenced artifact pruning.

Real environment tested: Local live gateway from `~/Projects/clawdbot`, exact PR head `94515ab66b6c6cb8baf5ee91e0b4a619d61c69a3` on base `f7e5132ffd5fc9642fb76e8c488ed6d9126a24e4`; `pnpm openclaw --version` reported `OpenClaw 2026.6.8 (94515ab)`.

Exact steps or command run after this patch:

```bash
pnpm build
pnpm openclaw gateway restart
pnpm openclaw --version
pnpm openclaw gateway health --json
pnpm openclaw gateway call health --json
pnpm openclaw gateway call status --json
pnpm openclaw config get gateway.port --json
curl -fsS http://127.0.0.1:18789/healthz
curl -fsS http://127.0.0.1:18789/readyz
pnpm openclaw gateway probe --json
pnpm openclaw gateway call sessions.cleanup --json --params '{"agent":"path3-proof-93704-94515ab6","enforce":true,"fixMissing":true}'
node -e 'read back proof sessions store/files'
```

Evidence after fix: `/healthz` returned `{"ok":true,"status":"live"}`; `/readyz` returned `{"ready":true,"failing":[]}`; gateway probe returned `ok: true`, `capability: "admin_capable"`, local target `ws://127.0.0.1:18789`, and server version `2026.6.8`. The cleanup RPC returned `missing: 1`, `afterCount: 1`, `unreferencedArtifacts.removedFiles: 1`, `freedBytes: 13`, `applied: true`, and `appliedCount: 1`. Readback showed the persisted proof store retained only `agent:path3-proof-93704-94515ab6:kept`; `orphan-session.jsonl` was removed and `kept-session.jsonl` remained.

Observed result after fix: A real gateway `sessions.cleanup` call executed the migrated cleanup apply path for a throwaway configured agent, removed the missing-transcript row through the lifecycle mutation seam, kept the valid referenced session row, and pruned an old unreferenced artifact from disk.

What was not tested: Future SQLite adapter behavior, doctor migration, plugin SDK compatibility, runtime JSON fallback or dual-read behavior, cron reaper runtime scheduling, and heartbeat stale-session runtime replacement.

## Tests and validation

Commands run:

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/config/sessions/store.pruning.integration.test.ts src/cron/session-reaper.test.ts src/infra/heartbeat-runner.isolated-key-stability.test.ts test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/check-session-accessor-boundary.mjs`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `pnpm exec oxfmt --check --threads=1 src/config/sessions/store.ts src/config/sessions/session-accessor.ts src/config/sessions/cleanup-service.ts src/cron/session-reaper.ts src/infra/heartbeat-runner.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts src/config/sessions/session-accessor.test.ts`
- `git diff --check`
- `pnpm lint --threads=8`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --no-web-search --thinking codex=low`
- `pnpm build`
- real live gateway proof commands listed above

Regression coverage added/updated:

- Accessor test for keyed lifecycle removals using the final referenced-session set.
- Accessor test preventing stale pre-read removal plans from deleting changed entries.
- Guard tests for the lifecycle cleanup ratchet.

Autoreview initially found stale-plan and heartbeat locked-upsert issues; the fixes added full-entry guards, a locked lifecycle upsert builder, and regression coverage. Final autoreview was clean.

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: Cleanup/reaper plans are selected before the storage operation, so stale plans must not delete updated entries.

Mitigation: `SessionEntryLifecycleRemoval.expectedEntry` guards exact pre-read entries; the accessor test covers stale-plan no-op behavior.

## Current review state

Next action: Ready PR awaiting maintainer review and CI.

Waiting on: GitHub CI / maintainer decision on whether additional live/Testbox proof is needed.

Addressed comments/findings: Autoreview stale-plan and heartbeat locked-upsert findings fixed before push.

SQLite adapter follow-up: implement `applySessionEntryLifecycleMutation(...)` as one SQLite transaction-sized operation: delete/replace rows, compute the post-mutation live session-id set from the final rows, then archive/export/delete no-longer-live transcript artifacts from that final set. Do not add a broad mutable whole-store callback, runtime JSON fallback, schema change, doctor migration, or plugin SDK surface in this slice.

