### PR TITLE
test(macos): cover root command dispatch

### DIFF
--- a/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
@@ -21,15 +21,15 @@ struct OpenClawMacCLI {
         switch resolveRootCommandAction(args) {
         case .usage:
             printUsage()
-        case .connect(let commandArgs):
+        case let .connect(commandArgs):
             await runConnect(commandArgs)
-        case .configureRemote(let commandArgs):
+        case let .configureRemote(commandArgs):
             runConfigureRemote(commandArgs)
-        case .discover(let commandArgs):
+        case let .discover(commandArgs):
             await runDiscover(commandArgs)
-        case .wizard(let commandArgs):
+        case let .wizard(commandArgs):
             await runWizardCommand(commandArgs)
-        case .unknown(let exitCode):
+        case let .unknown(exitCode):
             fputs("openclaw-mac: unknown command\n", stderr)
             printUsage()
             exit(exitCode)

--- a/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
@@ -1,39 +1,66 @@
 import Foundation
 
-private struct RootCommand {
+struct RootCommand: Equatable {
     var name: String
     var args: [String]
+}
+
+enum RootCommandAction: Equatable {
+    case usage
+    case connect([String])
+    case configureRemote([String])
+    case discover([String])
+    case wizard([String])
+    case unknown(exitCode: Int32)
 }
 
 @main
 struct OpenClawMacCLI {
     static func main() async {
         let args = Array(CommandLine.arguments.dropFirst())
-        let command = parseRootCommand(args)
-        switch command?.name {
-        case nil:
+        switch resolveRootCommandAction(args) {
+        case .usage:
             printUsage()
-        case "-h", "--help", "help":
-            printUsage()
-        case "connect":
-            await runConnect(command?.args ?? [])
-        case "configure-remote":
-            runConfigureRemote(command?.args ?? [])
-        case "discover":
-            await runDiscover(command?.args ?? [])
-        case "wizard":
-            await runWizardCommand(command?.args ?? [])
-        default:
+        case .connect(let commandArgs):
+            await runConnect(commandArgs)
+        case .configureRemote(let commandArgs):
+            runConfigureRemote(commandArgs)
+        case .discover(let commandArgs):
+            await runDiscover(commandArgs)
+        case .wizard(let commandArgs):
+            await runWizardCommand(commandArgs)
+        case .unknown(let exitCode):
             fputs("openclaw-mac: unknown command\n", stderr)
             printUsage()
-            exit(1)
+            exit(exitCode)
         }
     }
 }
 
-private func parseRootCommand(_ args: [String]) -> RootCommand? {
+func parseRootCommand(_ args: [String]) -> RootCommand? {
     guard let first = args.first else { return nil }
     return RootCommand(name: first, args: Array(args.dropFirst()))
+}
+
+func resolveRootCommandAction(_ args: [String]) -> RootCommandAction {
+    guard let command = parseRootCommand(args) else {
+        return .usage
+    }
+
+    switch command.name {
+    case "-h", "--help", "help":
+        return .usage
+    case "connect":
+        return .connect(command.args)
+    case "configure-remote":
+        return .configureRemote(command.args)
+    case "discover":
+        return .discover(command.args)
+    case "wizard":
+        return .wizard(command.args)
+    default:
+        return .unknown(exitCode: 1)
+    }
 }
 
 private func printUsage() {

--- a/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import OpenClawMacCLI
+
+struct RootCommandParserTests {
+    @Test func `parse root command returns nil for empty args`() {
+        #expect(parseRootCommand([]) == nil)
+    }
+
+    @Test func `parse root command splits command name and args`() throws {
+        let command = try #require(parseRootCommand(["connect", "--json", "--timeout", "3000"]))
+
+        #expect(command.name == "connect")
+        #expect(command.args == ["--json", "--timeout", "3000"])
+    }
+
+    @Test func `help aliases resolve to usage`() {
+        for args in [[], ["-h"], ["--help"], ["help"]] {
+            #expect(resolveRootCommandAction(args) == .usage)
+        }
+    }
+
+    @Test func `known commands preserve trailing args`() {
+        #expect(resolveRootCommandAction(["connect", "--json"]) == .connect(["--json"]))
+        #expect(
+            resolveRootCommandAction(["configure-remote", "--ssh-target", "alice@example.com"])
+                == .configureRemote(["--ssh-target", "alice@example.com"]),
+        )
+        #expect(resolveRootCommandAction(["discover", "--include-local"]) == .discover(["--include-local"]))
+        #expect(resolveRootCommandAction(["wizard", "--mode", "local"]) == .wizard(["--mode", "local"]))
+    }
+
+    @Test func `unknown command resolves to nonzero exit action`() {
+        #expect(resolveRootCommandAction(["nope"]) == .unknown(exitCode: 1))
+    }
+
+    @Test func `command names remain case sensitive`() {
+        #expect(resolveRootCommandAction(["Connect"]) == .unknown(exitCode: 1))
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
@@ -23,8 +23,7 @@ struct RootCommandParserTests {
         #expect(resolveRootCommandAction(["connect", "--json"]) == .connect(["--json"]))
         #expect(
             resolveRootCommandAction(["configure-remote", "--ssh-target", "alice@example.com"])
-                == .configureRemote(["--ssh-target", "alice@example.com"]),
-        )
+                == .configureRemote(["--ssh-target", "alice@example.com"]))
         #expect(resolveRootCommandAction(["discover", "--include-local"]) == .discover(["--include-local"]))
         #expect(resolveRootCommandAction(["wizard", "--mode", "local"]) == .wizard(["--mode", "local"]))
     }


### PR DESCRIPTION
## Summary

- Adds focused regression coverage for the macOS `openclaw-mac` root command parser and dispatch decision.
- Extracts the root dispatch decision into an internal `RootCommandAction` helper so the behavior can be tested without spawning a process or intercepting `exit(1)`.
- Keeps the runtime dispatch behavior equivalent to the existing entry point: help and empty args print usage, known commands receive trailing args, and unknown commands exit nonzero.
- Intentionally does not change any command-specific option parsing or runtime behavior.
- AI-assisted: yes. I understand the code path and verified the focused macOS Swift tests locally.

## Linked context

Closes #83879

Related #83879

Was this requested by a maintainer or owner?

- No direct maintainer request; this addresses an open ClawSweeper-triaged test-gap issue.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: #83879 reported that `parseRootCommand` and the root command-dispatch switch in `OpenClawMacCLI.main()` had no focused tests.
- Real environment tested: Local macOS source checkout on arm64e, Swift Package Manager via `swift test --package-path apps/macos --filter RootCommandParserTests`.
- Exact steps or command run after this patch: `swift test --package-path apps/macos --filter RootCommandParserTests`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal output copied from the local macOS run after this patch:

```text
Building for debugging...
[0/6] Write swift-version--58304C5D6DBC2206.txt
Build complete! (0.32s)
Test Suite 'Selected tests' started at 2026-06-16 18:29:34.084.
Test Suite 'OpenClawPackageTests.xctest' started at 2026-06-16 18:29:34.085.
Test Suite 'OpenClawPackageTests.xctest' passed at 2026-06-16 18:29:34.085.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.000) seconds
Test Suite 'Selected tests' passed at 2026-06-16 18:29:34.085.
         Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
◇ Suite RootCommandParserTests started.
◇ Test "help aliases resolve to usage" started.
◇ Test "parse root command returns nil for empty args" started.
◇ Test "known commands preserve trailing args" started.
◇ Test "command names remain case sensitive" started.
◇ Test "parse root command splits command name and args" started.
◇ Test "unknown command resolves to nonzero exit action" started.
✔ Test "parse root command returns nil for empty args" passed after 0.001 seconds.
✔ Test "help aliases resolve to usage" passed after 0.001 seconds.
✔ Test "parse root command splits command name and args" passed after 0.001 seconds.
✔ Test "unknown command resolves to nonzero exit action" passed after 0.001 seconds.
✔ Test "command names remain case sensitive" passed after 0.001 seconds.
✔ Test "known commands preserve trailing args" passed after 0.001 seconds.
✔ Suite RootCommandParserTests passed after 0.001 seconds.
✔ Test run with 6 tests in 1 suite passed after 0.001 seconds.
```

- Observed result after fix: The new tests cover empty args, command/argument splitting, help aliases, all known root commands preserving trailing args, unknown command resolving to exit code 1, and case-sensitive command names.
- What was not tested: I did not run the built `openclaw-mac` executable manually, and I did not validate command-specific option parsing beyond preserving the trailing args handed to each command.
- Proof limitations or environment constraints: `swift test --package-path apps/macos --filter OpenClawIPCTests` currently fails in unrelated `ExecApprovalsStoreRefactorTests.ensure file migrates default approvals into custom state dir` expectations; the new `RootCommandParserTests` pass in that broader run before the unrelated suite failure.
- Before evidence (optional but encouraged): Before this patch, there was no test file covering `EntryPoint.swift`, and `parseRootCommand` was private to the entry point.

## Tests and validation

- `swift test --package-path apps/macos --filter RootCommandParserTests` passed.
- `git diff --check origin/main...HEAD` passed.
- `codex review --base origin/main` reported no actionable correctness issues and confirmed dispatch behavior appears equivalent to the base implementation.
- `swift test --package-path apps/macos --filter OpenClawIPCTests` failed due an unrelated existing `ExecApprovalsStoreRefactorTests` migration expectation, not in files touched by this PR.

Regression coverage added:

- `apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift` covers the parser split and dispatch action mapping described in #83879.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

- No.

Did config, environment, or migration behavior change? (`Yes/No`)

- No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

- No.

What is the highest-risk area?

- Accidentally changing root command dispatch while extracting it for tests.

How is that risk mitigated?

- The new `RootCommandAction` mapping mirrors the previous switch cases, and the focused tests assert the existing behavior for empty args, help aliases, known commands, unknown command exit action, and case sensitivity.

## Current review state

What is the next action?

- Draft PR for maintainer/user review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI and human review.

Which bot or reviewer comments were addressed?

- Real behavior proof bot rejected the initial inline evidence as insufficient. This body now includes copied terminal output from the local after-patch run.
