### PR TITLE
fix(feishu): detect card JSON in plain message param for proactive sends (fixes #53486)

### DIFF
--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -8,7 +8,7 @@ import {
   listFeishuDirectoryGroupsLive as listFeishuDirectoryGroupsLiveImpl,
   listFeishuDirectoryPeersLive as listFeishuDirectoryPeersLiveImpl,
 } from "./directory.js";
-import { feishuOutbound as feishuOutboundImpl } from "./outbound.js";
+import { feishuOutbound as feishuOutboundImpl, tryParseFeishuCardFromText as tryParseFeishuCardFromTextImpl } from "./outbound.js";
 import {
   createPinFeishu as createPinFeishuImpl,
   listPinsFeishu as listPinsFeishuImpl,
@@ -45,4 +45,5 @@ export const feishuChannelRuntime = {
   getMessageFeishu: getMessageFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,
+  tryParseFeishuCardFromText: tryParseFeishuCardFromTextImpl,
 };

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -360,6 +360,49 @@ describe("feishuPlugin actions", () => {
     expect(details.chatId).toBe("oc_group_1");
   });
 
+  it("sends card JSON from the message parameter as a native card", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: JSON.stringify({
+          header: { title: { tag: "plain_text", content: "Status" } },
+          elements: [
+            { tag: "div", text: { tag: "lark_md", content: "**Build completed**" } },
+            {
+              tag: "div",
+              text: { tag: "plain_text", content: "*literal*\n1. Restart" },
+              fields: [
+                { is_short: true, text: { tag: "plain_text", content: "Owner: *ops*" } },
+                { is_short: true, text: { tag: "lark_md", content: "**Healthy**" } },
+              ],
+            },
+          ],
+        }),
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.body).toEqual({
+      elements: [
+        { tag: "markdown", content: "**Build completed**" },
+        { tag: "markdown", content: "\\*literal\\*\n1\\. Restart" },
+        { tag: "markdown", content: "Owner: \\*ops\\*" },
+        { tag: "markdown", content: "**Healthy**" },
+      ],
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("renders presentation messages as cards", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -31,30 +31,34 @@ vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
 }));
 
-vi.mock("./channel.runtime.js", () => ({
-  feishuChannelRuntime: {
-    addReactionFeishu: addReactionFeishuMock,
-    createPinFeishu: createPinFeishuMock,
-    editMessageFeishu: editMessageFeishuMock,
-    getChatInfo: getChatInfoMock,
-    getChatMembers: getChatMembersMock,
-    getFeishuMemberInfo: getFeishuMemberInfoMock,
-    getMessageFeishu: getMessageFeishuMock,
-    listFeishuDirectoryGroupsLive: listFeishuDirectoryGroupsLiveMock,
-    listFeishuDirectoryPeersLive: listFeishuDirectoryPeersLiveMock,
-    listPinsFeishu: listPinsFeishuMock,
-    listReactionsFeishu: listReactionsFeishuMock,
-    probeFeishu: probeFeishuMock,
-    removePinFeishu: removePinFeishuMock,
-    removeReactionFeishu: removeReactionFeishuMock,
-    sendCardFeishu: sendCardFeishuMock,
-    sendMessageFeishu: sendMessageFeishuMock,
-    feishuOutbound: {
-      sendText: vi.fn(),
-      sendMedia: feishuOutboundSendMediaMock,
+vi.mock("./channel.runtime.js", async () => {
+  const outbound = await vi.importActual<typeof import("./outbound.js")>("./outbound.js");
+  return {
+    feishuChannelRuntime: {
+      addReactionFeishu: addReactionFeishuMock,
+      createPinFeishu: createPinFeishuMock,
+      editMessageFeishu: editMessageFeishuMock,
+      getChatInfo: getChatInfoMock,
+      getChatMembers: getChatMembersMock,
+      getFeishuMemberInfo: getFeishuMemberInfoMock,
+      getMessageFeishu: getMessageFeishuMock,
+      listFeishuDirectoryGroupsLive: listFeishuDirectoryGroupsLiveMock,
+      listFeishuDirectoryPeersLive: listFeishuDirectoryPeersLiveMock,
+      listPinsFeishu: listPinsFeishuMock,
+      listReactionsFeishu: listReactionsFeishuMock,
+      probeFeishu: probeFeishuMock,
+      removePinFeishu: removePinFeishuMock,
+      removeReactionFeishu: removeReactionFeishuMock,
+      sendCardFeishu: sendCardFeishuMock,
+      sendMessageFeishu: sendMessageFeishuMock,
+      tryParseFeishuCardFromText: outbound.tryParseFeishuCardFromText,
+      feishuOutbound: {
+        sendText: vi.fn(),
+        sendMedia: feishuOutboundSendMediaMock,
+      },
     },
-  },
-}));
+  };
+});
 
 function getDescribedActions(cfg: OpenClawConfig, accountId?: string): string[] {
   return [...(feishuPlugin.actions?.describeMessageTool?.({ cfg, accountId })?.actions ?? [])];

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -781,16 +781,19 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             const text = readFirstString(ctx.params, ["text", "message"]);
             const mediaUrl = readFeishuMediaParam(ctx.params);
             const audioAsVoice = readBooleanParam(ctx.params, ["asVoice", "audioAsVoice"]);
-            const card = presentation
+            const runtime = await loadFeishuChannelRuntime();
+            let card = presentation
               ? buildFeishuPresentationCard({ presentation, fallbackText: text })
               : undefined;
+            if (!card && text) {
+              card = runtime.tryParseFeishuCardFromText(text);
+            }
             if (card && mediaUrl) {
               throw new Error(`Feishu ${ctx.action} does not support card with media.`);
             }
             if (!card && !text && !mediaUrl) {
               throw new Error(`Feishu ${ctx.action} requires text/message, media, or card.`);
             }
-            const runtime = await loadFeishuChannelRuntime();
             const maybeSendMedia = runtime.feishuOutbound.sendMedia;
             if (mediaUrl && !maybeSendMedia) {
               throw new Error("Feishu media sending is not available.");

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -108,6 +108,29 @@ function escapeFeishuCardMarkdownText(text: string): string {
   });
 }
 
+function escapeFeishuCardPlainText(text: string): string {
+  return escapeFeishuCardMarkdownText(text)
+    .replace(/([\\`*_{}[\]()#+\-!|~])/g, "\\$1")
+    .replace(/(^|\r?\n)([ \t]*\d+)\./g, "$1$2\\.");
+}
+
+function sanitizeLegacyFeishuCardText(text: unknown): Record<string, unknown> | undefined {
+  if (
+    !isRecord(text) ||
+    (text.tag !== "lark_md" && text.tag !== "plain_text") ||
+    typeof text.content !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    tag: "markdown",
+    content:
+      text.tag === "plain_text"
+        ? escapeFeishuCardPlainText(text.content)
+        : escapeFeishuCardMarkdownText(text.content),
+  };
+}
+
 function resolveSafeFeishuButtonUrl(url: unknown): string | undefined {
   const trimmed = typeof url === "string" ? url.trim() : "";
   if (!trimmed) {
@@ -191,13 +214,25 @@ function sanitizeNativeFeishuCardElements(element: unknown): Record<string, unkn
   if (element.tag === "hr") {
     return [{ tag: "hr" }];
   }
-  if (element.tag === "markdown" && typeof element.content === "string") {
+  if (
+    (element.tag === "markdown" || element.tag === "lark_md") &&
+    typeof element.content === "string"
+  ) {
     return [
       {
         tag: "markdown",
         content: escapeFeishuCardMarkdownText(element.content),
       },
     ];
+  }
+  if (element.tag === "div") {
+    const text = sanitizeLegacyFeishuCardText(element.text);
+    const fields = Array.isArray(element.fields)
+      ? element.fields
+          .map((field) => (isRecord(field) ? sanitizeLegacyFeishuCardText(field.text) : undefined))
+          .filter((field): field is Record<string, unknown> => Boolean(field))
+      : [];
+    return text ? [text, ...fields] : fields;
   }
   if (element.tag === "button") {
     const button = sanitizeNativeFeishuCardButton(element);

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -246,6 +246,47 @@ function sanitizeNativeFeishuCard(
   });
 }
 
+const FEISHU_CARD_TEXT_MAX_LENGTH = 16_384;
+
+function normalizeFeishuCardShape(
+  card: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (card.type === "interactive" && isRecord(card.card)) {
+    return normalizeFeishuCardShape(card.card);
+  }
+  if (isRecord(card.body) && Array.isArray(card.body.elements)) {
+    return card;
+  }
+  if (Array.isArray(card.elements)) {
+    return { ...card, body: { elements: card.elements } };
+  }
+  return undefined;
+}
+
+export function tryParseFeishuCardFromText(text: string): Record<string, unknown> | undefined {
+  if (text.length > FEISHU_CARD_TEXT_MAX_LENGTH) {
+    return undefined;
+  }
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{")) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+  const normalized = normalizeFeishuCardShape(parsed);
+  if (!normalized) {
+    return undefined;
+  }
+  return sanitizeNativeFeishuCard(normalized);
+}
+
 function readNativeFeishuCard(payload: { channelData?: Record<string, unknown> }) {
   const feishuData = payload.channelData?.feishu;
   if (!isRecord(feishuData)) {


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** Feishu `message(action=send)` renders card JSON as plain text instead of interactive card. The `sendText` path in `outbound.ts` checks `shouldUseCard()` which only detects markdown code blocks and tables, not Feishu card JSON structures. This adds `tryParseFeishuCardFromText` to detect card JSON in the text parameter and route it through the card send path.

- **Environment tested:** macOS, Node.js v22, OpenClaw main branch (commit c236e4d9), Feishu extension

- **Steps run after the patch:**
  1. Verified `tryParseFeishuCardFromText` correctly parses v2 body.elements card JSON
  2. Verified legacy top-level `elements` card shape is normalized to v2 format
  3. Verified wrapped `{type:interactive, card:{...}}` shape is unwrapped and normalized
  4. Verified malformed JSON, non-card JSON, and oversized payloads fall through to plain text
  5. Verified card+media combination throws an error
  6. Ran `node scripts/run-vitest.mjs run extensions/feishu/src/outbound.test.ts` — 42 tests passed
  7. Ran `node scripts/run-vitest.mjs run extensions/feishu/src/channel.test.ts` — 61 tests passed
  8. TypeScript compilation passed without errors

- **Evidence after fix:**
```
$ node scripts/run-vitest.mjs run extensions/feishu/src/outbound.test.ts
 ✓  extension-feishu  extensions/feishu/src/outbound.test.ts (42 tests) 31ms
 Test Files  1 passed (1)
      Tests  42 passed (42)

$ node scripts/run-vitest.mjs run extensions/feishu/src/channel.test.ts
 ✓  extension-feishu  extensions/feishu/src/channel.test.ts (61 tests) 213ms
 Test Files  1 passed (1)
      Tests  61 passed (61)

$ grep -n "tryParseFeishuCardFromText" extensions/feishu/src/outbound.ts
264:export function tryParseFeishuCardFromText(text: string): Record<string, unknown> | undefined {
288:  return sanitizeNativeFeishuCard(normalized);

$ grep -n "tryParseFeishuCardFromText" extensions/feishu/src/channel.ts
789:              card = runtime.tryParseFeishuCardFromText(text);
```

- **Observed result after fix:** Card JSON in the message parameter is now detected and routed through `sendCardFeishu`, restoring the pre-regression behavior. Three card shapes are supported: v2 `body.elements`, legacy top-level `elements`, and wrapped `{type:interactive, card:{...}}`.

- **What was not tested:** Live Feishu API integration (requires Feishu channel setup with real credentials). The fix was verified through unit verification of the parsing logic and existing test suite.
