### PR TITLE
fix: demote auth mode=none log to debug on loopback deployments

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -902,7 +902,11 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
     return;
   }
   if (resolvedAuthMode === "none") {
-    gatewayLog.warn(
+    // On loopback-only deployments, auth=none is expected and classified as
+    // "trusted-local only" by the security audit tool. Demote to debug so the
+    // message does not drown out legitimate warnings during normal operation.
+    const logFn = bind === "loopback" ? gatewayLog.debug : gatewayLog.warn;
+    logFn(
       "Gateway auth mode=none explicitly configured; all gateway connections are unauthenticated.",
     );
   }


### PR DESCRIPTION
## Summary

On loopback-only deployments, `auth.mode=none` produces an info-level warning on every startup saying _"all gateway connections are unauthenticated"_. This contradicts the security audit tool which classifies `gateway.loopback_no_auth` as "trusted-local only" and safe for local use.

## Change

Demote the log message from `warn` to `debug` level when `bind=loopback`. The warning is preserved for `lan`/`auto`/`tailnet`/`custom` bind modes where unauthenticated connections are a genuine concern.

## Before
```
[gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
```

## After (loopback)
```
# No output at default log level. Message only visible at debug level.
```

Fixes #91151