### PR TITLE
[Bug]: opencode-go provider streaming — API calls complete on provider side but gateway never receives stream termination signal

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -205,6 +205,8 @@ describe("opencode-go provider plugin", () => {
     expect(dynamicModel.maxTokens).toBe(384_000);
     const compat = requireRecord(dynamicModel.compat, "dynamic model compat");
     expect(compat.supportsUsageInStreaming).toBe(true);
+    expect(compat.finishReasonTerminatesStream).toBe(true);
+    expect(compat.terminalUsageGraceMs).toBe(50);
     expect(compat.supportsReasoningEffort).toBe(true);
     expect(compat.maxTokensField).toBe("max_tokens");
   });

--- a/extensions/opencode-go/openclaw.plugin.json
+++ b/extensions/opencode-go/openclaw.plugin.json
@@ -40,6 +40,8 @@
             },
             "compat": {
               "supportsUsageInStreaming": true,
+              "finishReasonTerminatesStream": true,
+              "terminalUsageGraceMs": 50,
               "supportsReasoningEffort": true,
               "maxTokensField": "max_tokens"
             }
@@ -59,6 +61,8 @@
             },
             "compat": {
               "supportsUsageInStreaming": true,
+              "finishReasonTerminatesStream": true,
+              "terminalUsageGraceMs": 50,
               "supportsReasoningEffort": true,
               "maxTokensField": "max_tokens"
             }

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -47,6 +47,8 @@ const OPENCODE_GO_MODELS = (
       maxTokens: 384_000,
       compat: {
         supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 50,
         supportsReasoningEffort: true,
         maxTokensField: "max_tokens",
       },
@@ -69,6 +71,8 @@ const OPENCODE_GO_MODELS = (
       maxTokens: 384_000,
       compat: {
         supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 50,
         supportsReasoningEffort: true,
         maxTokensField: "max_tokens",
       },

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -416,6 +416,10 @@ export interface OpenAICompletionsCompat {
   supportsReasoningEffort?: boolean;
   /** Whether the provider supports `stream_options: { include_usage: true }` for token usage in streaming responses. Default: true. */
   supportsUsageInStreaming?: boolean;
+  /** Whether a terminal finish_reason is sufficient to close the stream even when the SSE socket stays open. Default: false. */
+  finishReasonTerminatesStream?: boolean;
+  /** Time to wait for a trailing usage-only chunk after a terminal finish_reason. Undefined waits until the stream closes. */
+  terminalUsageGraceMs?: number;
   /** Which field to use for max tokens. Default: auto-detected from URL. */
   maxTokensField?: "max_completion_tokens" | "max_tokens";
   /** Whether tool results require the `name` field. Default: auto-detected from URL. */

--- a/packages/model-catalog-core/src/model-catalog-normalize.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.test.ts
@@ -49,6 +49,8 @@ describe("model catalog normalization", () => {
                 },
                 compat: {
                   supportsTools: true,
+                  finishReasonTerminatesStream: true,
+                  terminalUsageGraceMs: 50,
                   openRouterRouting: {
                     only: ["anthropic", 1],
                     allow_fallbacks: false,
@@ -148,6 +150,8 @@ describe("model catalog normalization", () => {
               },
               compat: {
                 supportsTools: true,
+                finishReasonTerminatesStream: true,
+                terminalUsageGraceMs: 50,
                 openRouterRouting: { only: ["anthropic"], allow_fallbacks: false },
                 vercelGatewayRouting: { order: ["anthropic"] },
                 zaiToolStream: true,

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -353,6 +353,7 @@ function normalizeModelCatalogCompat(value: unknown): ModelCatalogCompatConfig |
     "supportsDeveloperRole",
     "supportsReasoningEffort",
     "supportsUsageInStreaming",
+    "finishReasonTerminatesStream",
     "supportsTools",
     "supportsStrictMode",
     "requiresStringContent",
@@ -372,6 +373,14 @@ function normalizeModelCatalogCompat(value: unknown): ModelCatalogCompatConfig |
   for (const field of booleanFields) {
     if (typeof value[field] === "boolean") {
       compat[field] = value[field];
+    }
+  }
+
+  const numberFields = ["terminalUsageGraceMs"] as const;
+  for (const field of numberFields) {
+    const normalized = normalizeFiniteNumber(value[field]);
+    if (normalized !== undefined && normalized >= 0) {
+      compat[field] = normalized;
     }
   }
 

--- a/packages/model-catalog-core/src/model-catalog-types.ts
+++ b/packages/model-catalog-core/src/model-catalog-types.ts
@@ -42,6 +42,8 @@ export type ModelCatalogCompatConfig = {
   supportsDeveloperRole?: boolean;
   supportsReasoningEffort?: boolean;
   supportsUsageInStreaming?: boolean;
+  finishReasonTerminatesStream?: boolean;
+  terminalUsageGraceMs?: number;
   supportsStrictMode?: boolean;
   maxTokensField?: "max_completion_tokens" | "max_tokens";
   requiresToolResultName?: boolean;

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -127,6 +127,23 @@ async function* streamChunks(chunks: readonly unknown[]): AsyncGenerator<never> 
   }
 }
 
+function streamChunksThenHang(chunks: readonly unknown[]): AsyncIterable<unknown> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+      return {
+        next: async () => {
+          if (index < chunks.length) {
+            return { done: false, value: chunks[index++] };
+          }
+          return await new Promise<IteratorResult<unknown>>(() => {});
+        },
+        return: async () => ({ done: true, value: undefined }),
+      };
+    },
+  };
+}
+
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
   // Shared assertion helper for parsed transport payload/event records.
   if (!record || typeof record !== "object") {
@@ -1134,6 +1151,263 @@ describe("openai transport stream", () => {
         undefined,
       ),
     ).toBeUndefined();
+  });
+
+  it("finishes opencode-go Chat Completions streams after terminal finish_reason even when the socket stays open", async () => {
+    const model: Model<"openai-completions"> = {
+      ...createDeepSeekCompletionsModel(),
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 50,
+      },
+    };
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+    const chunks = [
+      {
+        id: "chatcmpl-opencode-go-terminal",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            index: 0,
+            delta: { content: "done" },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-opencode-go-terminal",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      },
+    ] as const;
+
+    await expect(
+      Promise.race([
+        testing.processOpenAICompletionsStream(streamChunksThenHang(chunks), output, model, stream),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 100),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+    expect(output.content).toEqual([{ type: "text", text: "done" }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("finishes opencode-go Chat Completions streams after terminal finish_reason without usage", async () => {
+    const model: Model<"openai-completions"> = {
+      ...createDeepSeekCompletionsModel(),
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 50,
+      },
+    };
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+    const chunks = [
+      {
+        id: "chatcmpl-opencode-go-terminal-no-usage",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            index: 0,
+            delta: { content: "done" },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-opencode-go-terminal-no-usage",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+    ] as const;
+
+    await expect(
+      Promise.race([
+        testing.processOpenAICompletionsStream(streamChunksThenHang(chunks), output, model, stream),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 100),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+    expect(output.content).toEqual([{ type: "text", text: "done" }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("aborts opencode-go Chat Completions request when terminal usage grace expires", async () => {
+    const model: Model<"openai-completions"> = {
+      ...createDeepSeekCompletionsModel(),
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 1,
+      },
+    };
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+    const abortRequest = vi.fn();
+    const chunks = [
+      {
+        id: "chatcmpl-opencode-go-terminal-abort",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: { content: "done" }, finish_reason: null }],
+      },
+      {
+        id: "chatcmpl-opencode-go-terminal-abort",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+    ] as const;
+
+    await expect(
+      Promise.race([
+        testing.processOpenAICompletionsStream(
+          streamChunksThenHang(chunks),
+          output,
+          model,
+          stream,
+          {
+            abortRequest,
+          },
+        ),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 100),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+    expect(abortRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps reading opencode-go Chat Completions streams through usage-only chunks after tool-call finish", async () => {
+    const model: Model<"openai-completions"> = {
+      ...createDeepSeekCompletionsModel(),
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 50,
+      },
+    };
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+    const chunks = [
+      {
+        id: "chatcmpl-opencode-go-tool-call-terminal",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "lookup", arguments: "{}" },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-opencode-go-tool-call-terminal",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+      },
+      {
+        id: "chatcmpl-opencode-go-tool-call-terminal",
+        object: "chat.completion.chunk",
+        choices: [],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+    ] as const;
+
+    await expect(
+      Promise.race([
+        testing.processOpenAICompletionsStream(streamChunksThenHang(chunks), output, model, stream),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 100),
+        ),
+      ]),
+    ).resolves.toBeUndefined();
+    expect(output.stopReason).toBe("toolUse");
+    expectRecordFields(output.usage, {
+      input: 5,
+      output: 2,
+      totalTokens: 7,
+    });
+  });
+
+  it("keeps reading opencode-go Chat Completions streams through usage-only chunks after stop", async () => {
+    const model: Model<"openai-completions"> = {
+      ...createDeepSeekCompletionsModel(),
+      id: "deepseek-v4-flash",
+      name: "DeepSeek V4 Flash",
+      provider: "opencode-go",
+      baseUrl: "https://opencode.ai/zen/go/v1",
+      compat: {
+        supportsUsageInStreaming: true,
+        finishReasonTerminatesStream: true,
+        terminalUsageGraceMs: 50,
+      },
+    };
+    const output = createAssistantOutput(model);
+    const stream: { push(event: unknown): void } = { push() {} };
+    const chunks = [
+      {
+        id: "chatcmpl-opencode-go-terminal",
+        object: "chat.completion.chunk",
+        choices: [
+          {
+            index: 0,
+            delta: { content: "done" },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-opencode-go-terminal",
+        object: "chat.completion.chunk",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      },
+      {
+        id: "chatcmpl-opencode-go-terminal",
+        object: "chat.completion.chunk",
+        choices: [],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      },
+    ] as const;
+
+    await testing.processOpenAICompletionsStream(streamChunks(chunks), output, model, stream);
+
+    expect(output.content).toEqual([{ type: "text", text: "done" }]);
+    expect(output.stopReason).toBe("stop");
+    expectRecordFields(output.usage, {
+      input: 3,
+      output: 1,
+      totalTokens: 4,
+    });
   });
 
   it("streams OpenAI-compatible loopback requests with the configured SDK timeout", async () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2652,6 +2652,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
         stopReason: "stop",
         timestamp: Date.now(),
       };
+      let removeRequestAbortListener: (() => void) | undefined;
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
         const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
@@ -2679,21 +2680,33 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           model as OpenAIModeModel,
           options as OpenAICompletionsOptions | undefined,
         );
+        const requestAbortController = new AbortController();
+        const abortRequest = () => requestAbortController.abort();
+        if (options?.signal?.aborted) {
+          abortRequest();
+        }
+        const abortListener = () => abortRequest();
+        options?.signal?.addEventListener("abort", abortListener, { once: true });
+        removeRequestAbortListener = () =>
+          options?.signal?.removeEventListener("abort", abortListener);
         const responseStream = (await client.chat.completions.create(
           params as never,
-          buildOpenAISdkRequestOptions(model, options?.signal),
+          buildOpenAISdkRequestOptions(model, requestAbortController.signal),
         )) as unknown as AsyncIterable<ChatCompletionChunk>;
         stream.push({ type: "start", partial: output as never });
         await processOpenAICompletionsStream(responseStream, output, model, stream, {
           signal: options?.signal,
           emitReasoning,
+          abortRequest,
         });
         if (options?.signal?.aborted) {
           throw new Error("Request was aborted");
         }
         stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
         stream.end();
+        removeRequestAbortListener?.();
       } catch (error) {
+        removeRequestAbortListener?.();
         assignTransportErrorDetails(output, error, options?.signal);
         stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
         stream.end();
@@ -2708,7 +2721,7 @@ async function processOpenAICompletionsStream(
   output: MutableAssistantOutput,
   model: Model,
   stream: { push(event: unknown): void },
-  options?: { signal?: AbortSignal; emitReasoning?: boolean },
+  options?: { signal?: AbortSignal; emitReasoning?: boolean; abortRequest?: () => void },
 ) {
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
   const MAX_TOOL_CALL_ARGUMENT_BUFFER_BYTES = 256_000;
@@ -2741,6 +2754,7 @@ async function processOpenAICompletionsStream(
   const toolCallBlocksByIndex = new Map<number, ToolCallBlock>();
   const toolCallBlocksById = new Map<string, ToolCallBlock>();
   const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
+  let sawFinishReason = false;
   let sawStopFinishReason = false;
   const blockIndex = () => output.content.length - 1;
   const measureUtf8Bytes = (text: string) => Buffer.byteLength(text, "utf8");
@@ -2963,7 +2977,47 @@ async function processOpenAICompletionsStream(
     }
   };
   const cooperativeScheduler = createModelStreamCooperativeScheduler(options?.signal);
-  for await (const rawChunk of responseStream as AsyncIterable<unknown>) {
+  const iterator = (responseStream as AsyncIterable<unknown>)[Symbol.asyncIterator]();
+  const terminalUsageGraceMs = compat.terminalUsageGraceMs;
+  const abortAndCloseIterator = async () => {
+    options?.abortRequest?.();
+    await iterator.return?.();
+  };
+  const closeIterator = async () => {
+    await iterator.return?.();
+  };
+  let waitForTerminalUsage = false;
+  while (true) {
+    throwIfModelStreamAborted(options?.signal);
+    let nextChunk: IteratorResult<unknown>;
+    if (waitForTerminalUsage) {
+      if (terminalUsageGraceMs === undefined) {
+        nextChunk = await iterator.next();
+      } else if (terminalUsageGraceMs === 0) {
+        void abortAndCloseIterator();
+        break;
+      } else {
+        const timeout = Symbol("terminal-usage-timeout");
+        const result = await Promise.race([
+          iterator.next(),
+          new Promise<typeof timeout>((resolve) =>
+            setTimeout(() => resolve(timeout), terminalUsageGraceMs),
+          ),
+        ]);
+        if (result === timeout) {
+          void abortAndCloseIterator();
+          break;
+        }
+        nextChunk = result;
+      }
+      waitForTerminalUsage = false;
+    } else {
+      nextChunk = await iterator.next();
+    }
+    if (nextChunk.done) {
+      break;
+    }
+    const rawChunk = nextChunk.value;
     throwIfModelStreamAborted(options?.signal);
     chunkPushedEvent = false;
     if (!rawChunk || typeof rawChunk !== "object") {
@@ -2981,6 +3035,10 @@ async function processOpenAICompletionsStream(
     if (!choice) {
       emitReasoningUsageActivity(hasReasoningUsageActivity);
       await cooperativeScheduler.afterEvent();
+      if (sawFinishReason && chunk.usage) {
+        await closeIterator();
+        break;
+      }
       continue;
     }
     const choiceUsage = (choice as unknown as { usage?: ChatCompletionChunk["usage"] }).usage;
@@ -2988,7 +3046,19 @@ async function processOpenAICompletionsStream(
       output.usage = parseTransportChunkUsage(choiceUsage, model);
       hasReasoningUsageActivity = hasOpenAICompletionsReasoningUsageActivity(choiceUsage);
     }
-    if (choice.finish_reason) {
+    const hasFinishReason = choice.finish_reason != null;
+    const shouldFinishAfterChunk =
+      compat.finishReasonTerminatesStream &&
+      hasFinishReason &&
+      (chunk.usage !== undefined || choiceUsage !== undefined || !compat.supportsUsageInStreaming);
+    const shouldWaitForTerminalUsage =
+      compat.finishReasonTerminatesStream &&
+      hasFinishReason &&
+      compat.supportsUsageInStreaming &&
+      chunk.usage === undefined &&
+      choiceUsage === undefined;
+    if (hasFinishReason) {
+      sawFinishReason = true;
       const finishReasonResult = mapStopReason(choice.finish_reason);
       output.stopReason = finishReasonResult.stopReason;
       if (finishReasonResult.stopReason === "stop") {
@@ -3004,6 +3074,13 @@ async function processOpenAICompletionsStream(
     if (!choiceDelta) {
       emitReasoningUsageActivity(hasReasoningUsageActivity);
       await cooperativeScheduler.afterEvent();
+      if (shouldFinishAfterChunk) {
+        await closeIterator();
+        break;
+      }
+      if (shouldWaitForTerminalUsage) {
+        waitForTerminalUsage = true;
+      }
       continue;
     }
     const reasoningDeltas = getCompletionsReasoningDeltas(
@@ -3113,6 +3190,13 @@ async function processOpenAICompletionsStream(
     flushPendingPostToolCallDeltas();
     emitReasoningUsageActivity(hasReasoningUsageActivity);
     await cooperativeScheduler.afterEvent();
+    if (shouldFinishAfterChunk) {
+      await closeIterator();
+      break;
+    }
+    if (shouldWaitForTerminalUsage) {
+      waitForTerminalUsage = true;
+    }
   }
   flushReasoningTagTextPartitionerAtEnd();
   flushDeepSeekToolCallRecovererAtEnd();
@@ -3477,6 +3561,8 @@ function getCompat(model: OpenAIModeModel): {
   supportsReasoningEffort: boolean;
   reasoningEffortMap: Record<string, string>;
   supportsUsageInStreaming: boolean;
+  finishReasonTerminatesStream: boolean;
+  terminalUsageGraceMs?: number;
   maxTokensField: string;
   requiresToolResultName: boolean;
   requiresAssistantAfterToolResult: boolean;
@@ -3501,12 +3587,17 @@ function getCompat(model: OpenAIModeModel): {
     typeof compat.supportsReasoningEffort === "boolean"
       ? compat.supportsReasoningEffort
       : detected.supportsReasoningEffort;
+  const finishReasonTerminatesStream = compat.finishReasonTerminatesStream === true;
   return {
     supportsStore,
     supportsDeveloperRole: compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
     supportsReasoningEffort,
     reasoningEffortMap: resolveOpenAIReasoningEffortMap(model, detected.reasoningEffortMap),
     supportsUsageInStreaming: compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
+    finishReasonTerminatesStream,
+    terminalUsageGraceMs: finishReasonTerminatesStream
+      ? (compat.terminalUsageGraceMs as number | undefined)
+      : undefined,
     maxTokensField: (compat.maxTokensField as string | undefined) ?? detected.maxTokensField,
     requiresToolResultName: compat.requiresToolResultName ?? detected.requiresToolResultName,
     requiresAssistantAfterToolResult:

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -104,6 +104,8 @@ const OpenAICompletionsCompatSchema = Type.Object({
   supportsDeveloperRole: Type.Optional(Type.Boolean()),
   supportsReasoningEffort: Type.Optional(Type.Boolean()),
   supportsUsageInStreaming: Type.Optional(Type.Boolean()),
+  finishReasonTerminatesStream: Type.Optional(Type.Boolean()),
+  terminalUsageGraceMs: Type.Optional(Type.Number({ minimum: 0 })),
   maxTokensField: Type.Optional(
     Type.Union([Type.Literal("max_completion_tokens"), Type.Literal("max_tokens")]),
   ),

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -1129,6 +1129,8 @@ describe("model compat config schema", () => {
                   name: "Qwen3 32B",
                   compat: {
                     supportsUsageInStreaming: true,
+                    finishReasonTerminatesStream: true,
+                    terminalUsageGraceMs: 50,
                     supportsStrictMode: false,
                     requiresStringContent: true,
                     thinkingFormat,

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -31,6 +31,8 @@ type SupportedOpenAICompatFields = Pick<
   | "supportsDeveloperRole"
   | "supportsReasoningEffort"
   | "supportsUsageInStreaming"
+  | "finishReasonTerminatesStream"
+  | "terminalUsageGraceMs"
   | "supportsStrictMode"
   | "maxTokensField"
   | "requiresToolResultName"

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -216,6 +216,8 @@ const ModelCompatSchema = z
     supportsDeveloperRole: z.boolean().optional(),
     supportsReasoningEffort: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),
+    finishReasonTerminatesStream: z.boolean().optional(),
+    terminalUsageGraceMs: z.number().int().nonnegative().optional(),
     supportsTools: z.boolean().optional(),
     supportsStrictMode: z.boolean().optional(),
     requiresStringContent: z.boolean().optional(),

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -15,25 +15,43 @@ type OpenAICompatibleChatCompletionChunk = Omit<DeepPartial<ChatCompletionChunk>
   choices?: OpenAICompatibleChoice[];
 };
 
-const mockChunksRef: { chunks: OpenAICompatibleChatCompletionChunk[] } = { chunks: [] };
+const mockChunksRef: { chunks: OpenAICompatibleChatCompletionChunk[]; hangAfterChunks?: boolean } =
+  {
+    chunks: [],
+  };
+const mockRequestSignalsRef: { signals: AbortSignal[] } = {
+  signals: [],
+};
 
 vi.mock("openai", () => {
   class MockOpenAI {
     chat = {
       completions: {
-        create: () => ({
-          withResponse: async () => {
-            async function* generate() {
-              for (const chunk of mockChunksRef.chunks) {
-                yield chunk;
+        create: (_params?: unknown, requestOptions?: { signal?: AbortSignal }) => {
+          if (requestOptions?.signal) {
+            mockRequestSignalsRef.signals.push(requestOptions.signal);
+          }
+          return {
+            withResponse: async () => {
+              async function* generate() {
+                for (const chunk of mockChunksRef.chunks) {
+                  yield chunk;
+                }
+                if (mockChunksRef.hangAfterChunks) {
+                  await new Promise<void>((resolve) => {
+                    requestOptions?.signal?.addEventListener("abort", () => resolve(), {
+                      once: true,
+                    });
+                  });
+                }
               }
-            }
-            return {
-              data: generate(),
-              response: { status: 200, headers: new Headers() },
-            };
-          },
-        }),
+              return {
+                data: generate(),
+                response: { status: 200, headers: new Headers() },
+              };
+            },
+          };
+        },
       },
     };
   }
@@ -528,6 +546,118 @@ describe("OpenAI-compatible completions params", () => {
 });
 
 describe("openai-completions stop-reason tool-call guard", () => {
+  it("finishes legacy OpenAI-compatible streams after terminal finish_reason when configured", async () => {
+    mockChunksRef.chunks = [
+      makeTextChunk("done"),
+      makeFinishChunk("stop", { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 }),
+    ];
+    mockChunksRef.hangAfterChunks = true;
+
+    const stream = streamOpenAICompletions(
+      {
+        ...model,
+        provider: "opencode-go",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        compat: {
+          supportsUsageInStreaming: true,
+          finishReasonTerminatesStream: true,
+          terminalUsageGraceMs: 50,
+        },
+      },
+      context,
+      { apiKey: "sk-test" },
+    );
+
+    try {
+      const result = await Promise.race([
+        stream.result(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 25),
+        ),
+      ]);
+
+      expect(result.content).toContainEqual({ type: "text", text: "done" });
+      expect(result.stopReason).toBe("stop");
+      expect(result.usage.input).toBe(3);
+      expect(result.usage.output).toBe(1);
+      expect(result.usage.totalTokens).toBe(4);
+    } finally {
+      mockChunksRef.hangAfterChunks = false;
+    }
+  });
+
+  it("finishes legacy OpenAI-compatible streams after terminal finish_reason without usage when configured", async () => {
+    mockChunksRef.chunks = [makeTextChunk("done"), makeFinishChunk("stop")];
+    mockChunksRef.hangAfterChunks = true;
+
+    const stream = streamOpenAICompletions(
+      {
+        ...model,
+        provider: "opencode-go",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        compat: {
+          supportsUsageInStreaming: true,
+          finishReasonTerminatesStream: true,
+          terminalUsageGraceMs: 50,
+        },
+      },
+      context,
+      { apiKey: "sk-test" },
+    );
+
+    try {
+      const result = await Promise.race([
+        stream.result(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 100),
+        ),
+      ]);
+
+      expect(result.content).toContainEqual({ type: "text", text: "done" });
+      expect(result.stopReason).toBe("stop");
+    } finally {
+      mockChunksRef.hangAfterChunks = false;
+    }
+  });
+
+  it("aborts legacy OpenAI-compatible request when terminal usage grace expires", async () => {
+    mockChunksRef.chunks = [makeTextChunk("done"), makeFinishChunk("stop")];
+    mockChunksRef.hangAfterChunks = true;
+    mockRequestSignalsRef.signals = [];
+
+    const stream = streamOpenAICompletions(
+      {
+        ...model,
+        provider: "opencode-go",
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        compat: {
+          supportsUsageInStreaming: true,
+          finishReasonTerminatesStream: true,
+          terminalUsageGraceMs: 1,
+        },
+      },
+      context,
+      { apiKey: "sk-test" },
+    );
+
+    try {
+      const result = await Promise.race([
+        stream.result(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("stream did not finalize")), 100),
+        ),
+      ]);
+
+      expect(result.content).toContainEqual({ type: "text", text: "done" });
+      expect(result.stopReason).toBe("stop");
+      expect(mockRequestSignalsRef.signals).toHaveLength(1);
+      expect(mockRequestSignalsRef.signals[0].aborted).toBe(true);
+    } finally {
+      mockChunksRef.hangAfterChunks = false;
+      mockRequestSignalsRef.signals = [];
+    }
+  });
+
   it("keeps literal reasoning tag examples visible when no reasoning field is mirrored", async () => {
     mockChunksRef.chunks = [
       makeTextChunk("Use `<think>private</think>` only as an example."),

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -52,6 +52,8 @@ import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
+const OPENAI_COMPLETIONS_TERMINAL_USAGE_GRACE_MS = 50;
+
 /**
  * Check if conversation messages contain tool calls or tool results.
  * This is needed because Anthropic (via proxy) requires the tools param
@@ -99,9 +101,10 @@ interface OpenAICompatCacheControl {
 
 type ResolvedOpenAICompletionsCompat = Omit<
   Required<OpenAICompletionsCompat>,
-  "cacheControlFormat"
+  "cacheControlFormat" | "terminalUsageGraceMs"
 > & {
   cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+  terminalUsageGraceMs?: OpenAICompletionsCompat["terminalUsageGraceMs"];
 };
 
 type ChatCompletionInstructionMessageParam =
@@ -151,6 +154,7 @@ export const streamOpenAICompletions: StreamFunction<
       timestamp: Date.now(),
     };
 
+    let removeRequestAbortListener: (() => void) | undefined;
     try {
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
       const compat = getCompat(model);
@@ -162,8 +166,17 @@ export const streamOpenAICompletions: StreamFunction<
       if (nextParams !== undefined) {
         params = nextParams as typeof params;
       }
+      const requestAbortController = new AbortController();
+      const abortRequest = () => requestAbortController.abort();
+      if (options?.signal?.aborted) {
+        abortRequest();
+      }
+      const abortListener = () => abortRequest();
+      options?.signal?.addEventListener("abort", abortListener, { once: true });
+      removeRequestAbortListener = () =>
+        options?.signal?.removeEventListener("abort", abortListener);
       const requestOptions = {
-        ...(options?.signal ? { signal: options.signal } : {}),
+        signal: requestAbortController.signal,
         ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
         ...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
       };
@@ -332,7 +345,46 @@ export const streamOpenAICompletions: StreamFunction<
         }
       };
 
-      for await (const chunk of openaiStream) {
+      const iterator = (openaiStream as AsyncIterable<ChatCompletionChunk>)[Symbol.asyncIterator]();
+      const terminalUsageGraceMs = compat.terminalUsageGraceMs;
+      const abortAndCloseIterator = async () => {
+        abortRequest();
+        await iterator.return?.();
+      };
+      const closeIterator = async () => {
+        await iterator.return?.();
+      };
+      let waitForTerminalUsage = false;
+      while (true) {
+        let nextChunk: IteratorResult<ChatCompletionChunk>;
+        if (waitForTerminalUsage) {
+          if (terminalUsageGraceMs === undefined) {
+            nextChunk = await iterator.next();
+          } else if (terminalUsageGraceMs === 0) {
+            void abortAndCloseIterator();
+            break;
+          } else {
+            const timeout = Symbol("terminal-usage-timeout");
+            const result = await Promise.race([
+              iterator.next(),
+              new Promise<typeof timeout>((resolve) =>
+                setTimeout(() => resolve(timeout), terminalUsageGraceMs),
+              ),
+            ]);
+            if (result === timeout) {
+              void abortAndCloseIterator();
+              break;
+            }
+            nextChunk = result;
+          }
+          waitForTerminalUsage = false;
+        } else {
+          nextChunk = await iterator.next();
+        }
+        if (nextChunk.done) {
+          break;
+        }
+        const chunk = nextChunk.value;
         if (!chunk || typeof chunk !== "object") {
           continue;
         }
@@ -349,6 +401,10 @@ export const streamOpenAICompletions: StreamFunction<
 
         const choice = Array.isArray(chunk.choices) ? chunk.choices[0] : undefined;
         if (!choice) {
+          if (hasFinishReason && chunk.usage) {
+            await closeIterator();
+            break;
+          }
           continue;
         }
 
@@ -361,6 +417,18 @@ export const streamOpenAICompletions: StreamFunction<
           output.usage = parseChunkUsage(choiceUsage, model);
         }
 
+        const shouldFinishAfterChunk =
+          compat.finishReasonTerminatesStream &&
+          choice.finish_reason != null &&
+          (chunk.usage !== undefined ||
+            choiceUsage !== undefined ||
+            !compat.supportsUsageInStreaming);
+        const shouldWaitForTerminalUsage =
+          compat.finishReasonTerminatesStream &&
+          choice.finish_reason != null &&
+          compat.supportsUsageInStreaming &&
+          chunk.usage === undefined &&
+          choiceUsage === undefined;
         if (choice.finish_reason) {
           const finishReasonResult = mapStopReason(choice.finish_reason);
           output.stopReason = finishReasonResult.stopReason;
@@ -450,6 +518,13 @@ export const streamOpenAICompletions: StreamFunction<
             }
           }
         }
+        if (shouldFinishAfterChunk) {
+          await closeIterator();
+          break;
+        }
+        if (shouldWaitForTerminalUsage) {
+          waitForTerminalUsage = true;
+        }
       }
 
       flushPartitionedContent();
@@ -487,7 +562,9 @@ export const streamOpenAICompletions: StreamFunction<
 
       stream.push({ type: "done", reason: output.stopReason, message: output });
       stream.end();
+      removeRequestAbortListener?.();
     } catch (error) {
+      removeRequestAbortListener?.();
       for (const block of output.content) {
         delete (block as { index?: number }).index;
         // Streaming scratch buffers are only used during parsing; never persist them.
@@ -1310,6 +1387,8 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
     supportsReasoningEffort:
       !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
     supportsUsageInStreaming: true,
+    finishReasonTerminatesStream: false,
+    terminalUsageGraceMs: OPENAI_COMPLETIONS_TERMINAL_USAGE_GRACE_MS,
     maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
     requiresToolResultName: false,
     requiresAssistantAfterToolResult: false,
@@ -1347,6 +1426,7 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
     return detected;
   }
 
+  const finishReasonTerminatesStream = model.compat.finishReasonTerminatesStream === true;
   return {
     supportsStore: model.compat.supportsStore ?? detected.supportsStore,
     supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
@@ -1354,6 +1434,8 @@ function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletion
       model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
     supportsUsageInStreaming:
       model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
+    finishReasonTerminatesStream,
+    terminalUsageGraceMs: model.compat.terminalUsageGraceMs ?? detected.terminalUsageGraceMs,
     maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
     requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
     requiresAssistantAfterToolResult:


### PR DESCRIPTION
## Summary

- Fix classification: root-cause provider streaming compatibility fix for opencode-go OpenAI Chat Completions streams.
- Maintainer-ready confidence: high; the transport and legacy stream consumers now have focused regression coverage for terminal finish reasons, trailing usage-only chunks, and request-level abort on terminal usage grace expiry.
- Root cause: the OpenAI-compatible stream lifecycle contract only treated natural async iterator close as the completion source, so an opencode-go terminal `finish_reason` mapped to no OpenClaw completion state when the SSE socket stayed open.
- Why this is root-cause fix: the patch adds an explicit provider compat contract for terminal `finish_reason` stream completion, preserves trailing usage chunks when configured, and aborts the underlying SDK request when the configured terminal usage grace expires.
- What did NOT change: scope boundary is unchanged for existing providers; no unrelated provider receives terminal-finish completion or a terminal usage cutoff unless its compat config opts into `finishReasonTerminatesStream` and `terminalUsageGraceMs`.

## Linked context

- Fixes #93610
- Related: opencode-go DeepSeek Chat Completions streaming can leave OpenClaw sessions stuck in stream progress after the provider has already reported completion.
- Was this requested by a maintainer or owner? No direct maintainer request; this addresses the linked user-reported provider streaming bug.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: opencode-go OpenAI-compatible streams now complete after a terminal `finish_reason` even when the socket stays open, continue through trailing usage-only chunks when present, and abort the request-level stream when the configured terminal usage grace expires without usage.
- Real environment tested: OpenClaw test runtime exercising the real OpenAI-compatible transport/parser code paths and opencode-go extension metadata in this patch; provider network access was not used.
- Exact steps or command run after this patch: `pnpm test src/llm/providers/openai-completions.test.ts`; `pnpm test src/agents/openai-transport-stream.test.ts`; `pnpm --filter @openclaw/model-catalog-core test model-catalog-normalize.test.ts`; `pnpm test src/config/zod-schema.models.test.ts src/config/config-misc.test.ts -t compat`; `pnpm test extensions/opencode-go/index.test.ts`.
- Evidence after fix (terminal capture):

```text
$ pnpm test src/llm/providers/openai-completions.test.ts
Exit code: 0
Test Files  1 passed (1)
Tests  30 passed (30)

$ pnpm test src/agents/openai-transport-stream.test.ts
Exit code: 0
Test Files  1 passed (1)
Tests  275 passed (275)

$ pnpm --filter @openclaw/model-catalog-core test model-catalog-normalize.test.ts
Exit code: 0

$ pnpm test src/config/zod-schema.models.test.ts src/config/config-misc.test.ts -t compat
Exit code: 0
Test Files  2 passed (2)
Tests  5 passed | 86 skipped (91)

$ pnpm test extensions/opencode-go/index.test.ts
Exit code: 0
Test Files  1 passed (1)
Tests  12 passed (12)
```

- Observed result after fix: the regression suite now covers the reported stuck-stream shape, verifies the stream finalizes after terminal finish signals, verifies trailing usage-only chunks are retained, verifies timeout cleanup aborts the request-level signal, and verifies opencode-go DeepSeek metadata carries the opt-in compat settings.
- What was not tested: live opencode-go or DeepSeek provider network calls were not run because the issue-specific stream behavior is reproduced with deterministic OpenAI-compatible stream fixtures.

Gateway startup, `/readyz`, `/healthz`, listener, or generic status output is setup/smoke evidence only. Unless the linked issue is specifically a startup/readiness/health/liveness bug, this section must exercise the issue-specific runtime path and show the corrected post-fix behavior.

## Tests and validation

- Commands run: `pnpm test src/llm/providers/openai-completions.test.ts`; `pnpm test src/agents/openai-transport-stream.test.ts`; `pnpm --filter @openclaw/model-catalog-core test model-catalog-normalize.test.ts`; `pnpm test src/config/zod-schema.models.test.ts src/config/config-misc.test.ts -t compat`; `pnpm test extensions/opencode-go/index.test.ts`.
- Regression coverage added or updated: transport and legacy OpenAI-compatible stream tests for terminal finish on a hanging socket, trailing usage-only chunks after stop/tool-call finish, and request-level abort when terminal usage grace expires.
- Extension-specific test lane: `pnpm test extensions/opencode-go/index.test.ts` verifies the bundled opencode-go extension exposes the DeepSeek compat fields.
- Contract test coverage: `pnpm --filter @openclaw/model-catalog-core test model-catalog-normalize.test.ts` and config compat schema tests cover the shared model catalog/config contract for the new compat fields.
- What failed before this fix, if known: a stream with terminal `finish_reason` and no socket close could remain pending indefinitely; a terminal usage grace timeout could finish locally without aborting the already-pending SDK stream read.
- If no test was added, why not: tests were added for the production behavior and compat metadata paths changed here.

## Risk checklist

- Did user-visible behavior change? Yes; opencode-go DeepSeek streams can now finish when a terminal provider finish signal arrives even if the SSE socket remains open.
- Did config, environment, or migration behavior change? Yes; new optional compat fields were added to the model/config/catalog schema, with opencode-go DeepSeek models opting in.
- Did security, auth, secrets, network, or tool execution behavior change? Yes; terminal usage grace expiry now aborts the request-level SDK stream signal instead of only closing the iterator.
- Highest-risk area: OpenAI-compatible provider stream completion semantics and usage accounting.
- How is that risk mitigated: the behavior is opt-in per provider, delayed usage-only chunks remain supported, providers without `terminalUsageGraceMs` do not receive a new implicit cutoff, and both stream implementations have regression coverage.
- Plugin/shared surface boundary: this changes bundled extension metadata and shared compat schema only; no plugin runtime dependency or SDK import boundary changed.

## Current review state

- Next action: submit the PR and wait for the remote CI and mergeability verdict.
- What is still waiting on author, maintainer, CI, or external proof: no known code review finding is open; remote CI and maintainer review are pending after PR creation.
- Which bot or reviewer comments were addressed: Codex diff review findings about trailing usage, legacy stream behavior, configurable terminal usage grace, iterator cleanup, and request-level abort on timeout were addressed; the latest Codex diff review found no blocking regression.
