### PR TITLE
fix: log warning when tool hidden by unsupported availability signal

### DIFF
--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -1,4 +1,5 @@
 // Plans usable tools from descriptors, availability, and request constraints.
+import { logWarn } from "../logger.js";
 import { evaluateToolAvailability } from "./availability.js";
 import { ToolPlanContractError } from "./diagnostics.js";
 import type {
@@ -49,6 +50,14 @@ export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
       ...evaluateToolAvailability({ descriptor, context: options.availability }),
     ];
     if (diagnostics.length > 0) {
+      for (const diag of diagnostics) {
+        if (diag.reason === "unsupported-signal") {
+          logWarn(
+            `tool "${descriptor.name}" hidden: ${diag.message || diag.reason}. ` +
+              "This is likely an authoring error — check the descriptor's availability expression.",
+          );
+        }
+      }
       hidden.push({ descriptor, diagnostics });
       continue;
     }


### PR DESCRIPTION
## Summary

Empty `allOf`/`anyOf` arrays in tool availability expressions silently hid tools with no actionable diagnostic. Developers had no way to detect the authoring mistake.

## Change

`buildToolPlan()` now emits a `logWarn` for each tool hidden by an `unsupported-signal` diagnostic. The warning includes the tool name and reason message:

```
tool "my-tool" hidden: Empty availability anyOf group. This is likely an authoring error — check the descriptor's availability expression.
```

## Before

- Tool with `availability: { anyOf: [] }` → silently hidden
- No log, no diagnostic visible to developer
- Hours wasted debugging why a tool never appears

## After

- Tool still hidden (it's invalid)
- Warning logged at gateway startup so author catches the mistake immediately

Fixes #92361