### PR TITLE
fix: scope assistant avatar override to agent ID

### DIFF
--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -239,7 +239,7 @@ beforeEach(async () => {
 describe("renderApp assistant avatar routing", () => {
   it("passes the browser-local assistant override to Quick Settings ahead of stale identity metadata", () => {
     const dataUrl = "data:image/png;base64,bG9jYWwtYXNzaXN0YW50";
-    saveLocalAssistantIdentity({ avatar: dataUrl });
+    saveLocalAssistantIdentity({ avatar: dataUrl, agentId: "main" });
 
     renderApp(createState());
 
@@ -249,6 +249,80 @@ describe("renderApp assistant avatar routing", () => {
     expect(quickSettingsProps.current?.assistantAvatarStatus).toBe("data");
     expect(quickSettingsProps.current?.assistantAvatarReason).toBeNull();
     expect(quickSettingsProps.current?.assistantAvatarOverride).toBe(dataUrl);
+  });
+
+  it("uses the active session agent override while identity metadata is stale", () => {
+    saveLocalAssistantIdentity({
+      avatar: "data:image/png;base64,bWFpbg==",
+      agentId: "main",
+    });
+    saveLocalAssistantIdentity({
+      avatar: "data:image/png;base64,d29ya2Vy",
+      agentId: "worker",
+    });
+
+    renderApp(
+      createState({
+        sessionKey: "agent:worker:main",
+        assistantAgentId: "main",
+      }),
+    );
+
+    expect(quickSettingsProps.current?.assistantAvatarOverride).toBe(
+      "data:image/png;base64,d29ya2Vy",
+    );
+  });
+
+  it("uses the default agent override for a bare main session while identity metadata is stale", () => {
+    saveLocalAssistantIdentity({
+      avatar: "data:image/png;base64,bWFpbg==",
+      agentId: "main",
+    });
+    saveLocalAssistantIdentity({
+      avatar: "data:image/png;base64,d29ya2Vy",
+      agentId: "worker",
+    });
+
+    renderApp(
+      createState({
+        sessionKey: "main",
+        assistantAgentId: "worker",
+      }),
+    );
+
+    expect(quickSettingsProps.current?.assistantAvatarOverride).toBe(
+      "data:image/png;base64,bWFpbg==",
+    );
+  });
+
+  it("reloads the default agent identity after clearing its override from a bare main session", () => {
+    const loadAssistantIdentity = vi.fn(async () => undefined);
+    saveLocalAssistantIdentity({
+      avatar: "data:image/png;base64,YWxwaGE=",
+      agentId: "alpha",
+    });
+
+    renderApp(
+      createState({
+        sessionKey: "main",
+        assistantAgentId: "worker",
+        agentsList: {
+          defaultId: "alpha",
+          agents: [
+            { id: "alpha", name: "Alpha" },
+            { id: "worker", name: "Worker" },
+          ],
+        } as AppViewState["agentsList"],
+        loadAssistantIdentity,
+      }),
+    );
+
+    quickSettingsProps.current?.onAssistantAvatarClearOverride?.();
+
+    expect(loadAssistantIdentity).toHaveBeenCalledWith({
+      sessionKey: "agent:alpha:main",
+      expectedSessionKey: "main",
+    });
   });
 
   it("applies the configured chat message width as a shell CSS variable", () => {

--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -295,7 +295,7 @@ describe("renderApp assistant avatar routing", () => {
     );
   });
 
-  it("reloads the default agent identity after clearing its override from a bare main session", () => {
+  it("reloads the default agent identity after clearing its override from a bare main session", async () => {
     const loadAssistantIdentity = vi.fn(async () => undefined);
     saveLocalAssistantIdentity({
       avatar: "data:image/png;base64,YWxwaGE=",
@@ -317,7 +317,7 @@ describe("renderApp assistant avatar routing", () => {
       }),
     );
 
-    quickSettingsProps.current?.onAssistantAvatarClearOverride?.();
+    await quickSettingsProps.current?.onAssistantAvatarClearOverride?.();
 
     expect(loadAssistantIdentity).toHaveBeenCalledWith({
       sessionKey: "agent:alpha:main",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1404,8 +1404,10 @@ export function renderApp(state: AppViewState) {
   const dashboardHeaderContext = resolveDashboardHeaderContext(state);
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const showToolCalls = state.onboarding ? true : state.settings.chatShowToolCalls;
+  const activeAssistantAgentId = resolveSidebarSelectedAgentId(state);
   const localAssistantAvatarOverride =
-    normalizeOptionalString(loadLocalAssistantIdentity().avatar) ?? null;
+    normalizeOptionalString(loadLocalAssistantIdentity({ agentId: activeAssistantAgentId }).avatar) ??
+    null;
   const assistantAvatarUrl = resolveAssistantAvatarUrl(state);
   const chatAssistantAvatarStatus = localAssistantAvatarOverride
     ? "data"
@@ -1905,7 +1907,7 @@ export function renderApp(state: AppViewState) {
             assistantAvatarUploadBusy: state.assistantAvatarUploadBusy,
             assistantAvatarUploadError: state.assistantAvatarUploadError,
             onAssistantAvatarOverrideChange: (dataUrl) => {
-              setAssistantAvatarOverride(state, dataUrl, state.assistantAgentId);
+              setAssistantAvatarOverride(state, dataUrl, activeAssistantAgentId);
               state.chatAvatarUrl = dataUrl;
               state.chatAvatarSource = dataUrl;
               state.chatAvatarStatus = "data";
@@ -1914,13 +1916,21 @@ export function renderApp(state: AppViewState) {
               requestHostUpdate?.();
             },
             onAssistantAvatarClearOverride: () => {
-              setAssistantAvatarOverride(state, null, state.assistantAgentId);
+              setAssistantAvatarOverride(state, null, activeAssistantAgentId);
               state.chatAvatarUrl = null;
               state.chatAvatarSource = null;
               state.chatAvatarStatus = null;
               state.chatAvatarReason = null;
               state.assistantAvatarUploadError = null;
-              void state.loadAssistantIdentity?.().finally(() => requestHostUpdate?.());
+              const identitySessionKey = buildAgentMainSessionKey({
+                agentId: activeAssistantAgentId,
+              });
+              void state
+                .loadAssistantIdentity?.({
+                  sessionKey: identitySessionKey,
+                  expectedSessionKey: state.sessionKey,
+                })
+                .finally(() => requestHostUpdate?.());
               requestHostUpdate?.();
             },
             basePath: state.basePath ?? "",

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1905,7 +1905,7 @@ export function renderApp(state: AppViewState) {
             assistantAvatarUploadBusy: state.assistantAvatarUploadBusy,
             assistantAvatarUploadError: state.assistantAvatarUploadError,
             onAssistantAvatarOverrideChange: (dataUrl) => {
-              setAssistantAvatarOverride(state, dataUrl);
+              setAssistantAvatarOverride(state, dataUrl, state.assistantAgentId);
               state.chatAvatarUrl = dataUrl;
               state.chatAvatarSource = dataUrl;
               state.chatAvatarStatus = "data";
@@ -1914,7 +1914,7 @@ export function renderApp(state: AppViewState) {
               requestHostUpdate?.();
             },
             onAssistantAvatarClearOverride: () => {
-              setAssistantAvatarOverride(state, null);
+              setAssistantAvatarOverride(state, null, state.assistantAgentId);
               state.chatAvatarUrl = null;
               state.chatAvatarSource = null;
               state.chatAvatarStatus = null;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -487,7 +487,10 @@ export type AppViewState = {
     applySettings: (next: UiSettings) => void;
     applyLocalUserIdentity?: (next: { name?: string | null; avatar?: string | null }) => void;
     loadOverview: (opts?: { refresh?: boolean }) => Promise<void>;
-    loadAssistantIdentity: () => Promise<void>;
+    loadAssistantIdentity: (opts?: {
+      sessionKey?: string;
+      expectedSessionKey?: string;
+    }) => Promise<void>;
     loadCron: () => Promise<void>;
     handleWhatsAppStart: (force: boolean) => Promise<void>;
     handleWhatsAppWait: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -928,8 +928,8 @@ export class OpenClawApp extends LitElement {
     );
   }
 
-  async loadAssistantIdentity() {
-    await loadAssistantIdentityInternal(this);
+  async loadAssistantIdentity(opts?: { sessionKey?: string; expectedSessionKey?: string }) {
+    await loadAssistantIdentityInternal(this, opts);
   }
 
   applySettings(next: UiSettings) {

--- a/ui/src/ui/controllers/assistant-identity.test.ts
+++ b/ui/src/ui/controllers/assistant-identity.test.ts
@@ -58,6 +58,34 @@ describe("loadAssistantIdentity", () => {
       sessionKey: "agent:worker:main",
     });
   });
+
+  it("applies a scoped identity request while its expected UI session remains active", async () => {
+    const request = vi.fn().mockResolvedValue({
+      agentId: "alpha",
+      name: "Alpha",
+      avatar: "A",
+    });
+    const state: Parameters<typeof loadAssistantIdentity>[0] = {
+      client: { request } as never,
+      connected: true,
+      sessionKey: "main",
+      assistantName: "Worker",
+      assistantAvatar: null,
+      assistantAgentId: "worker",
+    };
+
+    await loadAssistantIdentity(state, {
+      sessionKey: "agent:alpha:main",
+      expectedSessionKey: "main",
+    });
+
+    expect(state.assistantName).toBe("Alpha");
+    expect(state.assistantAvatar).toBe("A");
+    expect(state.assistantAgentId).toBe("alpha");
+    expect(request).toHaveBeenCalledWith("agent.identity.get", {
+      sessionKey: "agent:alpha:main",
+    });
+  });
 });
 
 describe("setAssistantAvatarOverride", () => {
@@ -71,13 +99,15 @@ describe("setAssistantAvatarOverride", () => {
   it("persists the assistant avatar locally and mirrors the user avatar pattern", () => {
     const state: Parameters<typeof setAssistantAvatarOverride>[0] = {};
 
-    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy");
+    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy", "main");
 
     expect(state.assistantAvatar).toBe("data:image/png;base64,YXZhdGFy");
     expect(state.assistantAvatarSource).toBe("data:image/png;base64,YXZhdGFy");
     expect(state.assistantAvatarStatus).toBe("data");
     expect(state.assistantAvatarReason).toBeNull();
-    expect(loadLocalAssistantIdentity().avatar).toBe("data:image/png;base64,YXZhdGFy");
+    expect(loadLocalAssistantIdentity({ agentId: "main" }).avatar).toBe(
+      "data:image/png;base64,YXZhdGFy",
+    );
   });
 
   it("clears the local override", () => {
@@ -86,14 +116,58 @@ describe("setAssistantAvatarOverride", () => {
       assistantAvatarSource: "data:image/png;base64,YXZhdGFy",
       assistantAvatarStatus: "data",
     };
-    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy");
+    setAssistantAvatarOverride(state, "data:image/png;base64,YXZhdGFy", "main");
 
-    setAssistantAvatarOverride(state, null);
+    setAssistantAvatarOverride(state, null, "main");
 
     expect(state.assistantAvatar).toBeNull();
     expect(state.assistantAvatarSource).toBeNull();
     expect(state.assistantAvatarStatus).toBeNull();
     expect(state.assistantAvatarReason).toBeNull();
-    expect(loadLocalAssistantIdentity().avatar).toBeNull();
+    expect(loadLocalAssistantIdentity({ agentId: "main" }).avatar).toBeNull();
+  });
+
+  it("keeps assistant avatar overrides isolated by agent", () => {
+    setAssistantAvatarOverride({}, "data:image/png;base64,bWFpbg==", "main");
+    setAssistantAvatarOverride({}, "data:image/png;base64,d29ya2Vy", "worker");
+
+    expect(loadLocalAssistantIdentity({ agentId: "main" }).avatar).toBe(
+      "data:image/png;base64,bWFpbg==",
+    );
+    expect(loadLocalAssistantIdentity({ agentId: "worker" }).avatar).toBe(
+      "data:image/png;base64,d29ya2Vy",
+    );
+
+    setAssistantAvatarOverride({}, null, "worker");
+
+    expect(loadLocalAssistantIdentity({ agentId: "main" }).avatar).toBe(
+      "data:image/png;base64,bWFpbg==",
+    );
+    expect(loadLocalAssistantIdentity({ agentId: "worker" }).avatar).toBeNull();
+  });
+
+  it("migrates the legacy global override to the first loaded agent", () => {
+    localStorage.setItem(
+      "openclaw.control.assistant.v1",
+      JSON.stringify({ avatar: "data:image/png;base64,bGVnYWN5" }),
+    );
+
+    expect(loadLocalAssistantIdentity({ agentId: "main" }).avatar).toBe(
+      "data:image/png;base64,bGVnYWN5",
+    );
+    expect(loadLocalAssistantIdentity({ agentId: "worker" }).avatar).toBeNull();
+  });
+
+  it("supports prototype-like agent IDs without inherited avatar values", () => {
+    setAssistantAvatarOverride({}, "data:image/png;base64,Y29uc3RydWN0b3I=", "constructor");
+    setAssistantAvatarOverride({}, "data:image/png;base64,cHJvdG8=", "__proto__");
+
+    expect(loadLocalAssistantIdentity({ agentId: "constructor" }).avatar).toBe(
+      "data:image/png;base64,Y29uc3RydWN0b3I=",
+    );
+    expect(loadLocalAssistantIdentity({ agentId: "__proto__" }).avatar).toBe(
+      "data:image/png;base64,cHJvdG8=",
+    );
+    expect(loadLocalAssistantIdentity({ agentId: "toString" }).avatar).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/assistant-identity.ts
+++ b/ui/src/ui/controllers/assistant-identity.ts
@@ -67,8 +67,11 @@ export async function loadAssistantIdentity(
     state.assistantAvatarStatus = normalized.avatarStatus ?? null;
     state.assistantAvatarReason = normalized.avatarReason ?? null;
     state.assistantAgentId = normalized.agentId ?? null;
-    // Local override always wins — same pattern as the user avatar.
-    const localAvatar = loadLocalAssistantIdentity().avatar;
+    // Local override only applies when saved for the current agent (or when
+    // no agentId was saved, for backward compatibility with pre-scoped saves).
+    const localAvatar = loadLocalAssistantIdentity({
+      agentId: state.assistantAgentId,
+    }).avatar;
     if (localAvatar) {
       state.assistantAvatar = localAvatar;
       state.assistantAvatarSource = localAvatar;
@@ -83,8 +86,9 @@ export async function loadAssistantIdentity(
 export function setAssistantAvatarOverride(
   state: AssistantAvatarOverrideState,
   avatar: string | null,
+  agentId?: string | null,
 ) {
-  saveLocalAssistantIdentity({ avatar });
+  saveLocalAssistantIdentity({ avatar, agentId });
   if (avatar) {
     state.assistantAvatar = avatar;
     state.assistantAvatarSource = avatar;

--- a/ui/src/ui/controllers/assistant-identity.ts
+++ b/ui/src/ui/controllers/assistant-identity.ts
@@ -44,17 +44,18 @@ function shouldApplyAssistantIdentityResult(
 
 export async function loadAssistantIdentity(
   state: AssistantIdentityState,
-  opts?: { sessionKey?: string },
+  opts?: { sessionKey?: string; expectedSessionKey?: string },
 ) {
   if (!state.client || !state.connected) {
     return;
   }
   const sessionKey = opts?.sessionKey?.trim() || state.sessionKey.trim();
+  const expectedSessionKey = opts?.expectedSessionKey?.trim() || sessionKey;
   const params = sessionKey ? { sessionKey } : {};
   const requestVersion = beginAssistantIdentityRequest(state);
   try {
     const res = await state.client.request("agent.identity.get", params);
-    if (!shouldApplyAssistantIdentityResult(state, requestVersion, sessionKey)) {
+    if (!shouldApplyAssistantIdentityResult(state, requestVersion, expectedSessionKey)) {
       return;
     }
     if (!res) {
@@ -67,8 +68,6 @@ export async function loadAssistantIdentity(
     state.assistantAvatarStatus = normalized.avatarStatus ?? null;
     state.assistantAvatarReason = normalized.avatarReason ?? null;
     state.assistantAgentId = normalized.agentId ?? null;
-    // Local override only applies when saved for the current agent (or when
-    // no agentId was saved, for backward compatibility with pre-scoped saves).
     const localAvatar = loadLocalAssistantIdentity({
       agentId: state.assistantAgentId,
     }).avatar;

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -46,7 +46,7 @@ function resolveBootstrapAgentId(value: string | null | undefined): string | nul
 }
 
 function applyLocalAssistantAvatarOverride(state: ControlUiBootstrapState) {
-  const localAvatar = loadLocalAssistantIdentity().avatar;
+  const localAvatar = loadLocalAssistantIdentity({ agentId: resolveActiveAgentId(state) }).avatar;
   if (!localAvatar) {
     return;
   }
@@ -119,7 +119,6 @@ export async function loadControlUiBootstrapConfig(
         state.assistantAvatarReason = normalized.avatarReason ?? null;
         state.assistantAgentId = normalized.agentId ?? null;
       }
-      // Local override always wins — same pattern as the user avatar.
       applyLocalAssistantAvatarOverride(state);
     }
     state.serverVersion = parsed.serverVersion ?? null;

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -391,7 +391,7 @@ function parseLocalAssistantAvatarMap(raw: string): {
   if (legacyAvatar && legacyAgentId && !Object.hasOwn(avatars, legacyAgentId)) {
     avatars[legacyAgentId] = legacyAvatar;
   }
-  return { avatars, legacyAvatar: legacyAgentId ? null : legacyAvatar };
+  return { avatars, legacyAvatar: legacyAgentId ? null : (legacyAvatar ?? null) };
 }
 
 function persistLocalAssistantAvatarMap(storage: Storage | null, avatars: Record<string, string>) {

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -363,9 +363,11 @@ export function saveLocalUserIdentity(next: LocalUserIdentity) {
   }
 }
 
-export type LocalAssistantIdentity = { avatar: string | null };
+export type LocalAssistantIdentity = { avatar: string | null; agentId?: string | null };
 
-export function loadLocalAssistantIdentity(): LocalAssistantIdentity {
+export function loadLocalAssistantIdentity(opts?: {
+  agentId?: string | null;
+}): LocalAssistantIdentity {
   const storage = getSafeLocalStorage();
   try {
     const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
@@ -373,7 +375,13 @@ export function loadLocalAssistantIdentity(): LocalAssistantIdentity {
       return { avatar: null };
     }
     const parsed = JSON.parse(raw) as Partial<LocalAssistantIdentity>;
-    return { avatar: typeof parsed.avatar === "string" ? parsed.avatar : null };
+    const avatar = typeof parsed.avatar === "string" ? parsed.avatar : null;
+    // Only return the avatar if it was saved for the requested agent (or if no
+    // agentId filter is provided, for backward compatibility).
+    if (opts?.agentId && parsed.agentId && parsed.agentId !== opts.agentId) {
+      return { avatar: null };
+    }
+    return { avatar, agentId: parsed.agentId ?? null };
   } catch {
     return { avatar: null };
   }
@@ -386,7 +394,10 @@ export function saveLocalAssistantIdentity(next: LocalAssistantIdentity) {
       storage?.removeItem(LOCAL_ASSISTANT_IDENTITY_KEY);
       return;
     }
-    storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify({ avatar: next.avatar }));
+    storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify({
+      avatar: next.avatar,
+      agentId: next.agentId ?? null,
+    }));
   } catch {
     // best-effort — quota exceeded or security restrictions should not
     // prevent in-memory identity updates from being applied

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -365,39 +365,86 @@ export function saveLocalUserIdentity(next: LocalUserIdentity) {
 
 export type LocalAssistantIdentity = { avatar: string | null; agentId?: string | null };
 
+type PersistedLocalAssistantIdentities = {
+  avatars?: Record<string, unknown>;
+  avatar?: unknown;
+  agentId?: unknown;
+};
+
+function parseLocalAssistantAvatarMap(raw: string): {
+  avatars: Record<string, string>;
+  legacyAvatar: string | null;
+} {
+  const parsed = JSON.parse(raw) as PersistedLocalAssistantIdentities;
+  const avatars = Object.create(null) as Record<string, string>;
+  if (parsed.avatars && typeof parsed.avatars === "object" && !Array.isArray(parsed.avatars)) {
+    for (const [agentId, avatar] of Object.entries(parsed.avatars)) {
+      const normalizedAgentId = normalizeOptionalString(agentId);
+      const normalizedAvatar = normalizeOptionalString(avatar);
+      if (normalizedAgentId && normalizedAvatar) {
+        avatars[normalizedAgentId] = normalizedAvatar;
+      }
+    }
+  }
+  const legacyAvatar = normalizeOptionalString(parsed.avatar);
+  const legacyAgentId = normalizeOptionalString(parsed.agentId);
+  if (legacyAvatar && legacyAgentId && !Object.hasOwn(avatars, legacyAgentId)) {
+    avatars[legacyAgentId] = legacyAvatar;
+  }
+  return { avatars, legacyAvatar: legacyAgentId ? null : legacyAvatar };
+}
+
+function persistLocalAssistantAvatarMap(storage: Storage | null, avatars: Record<string, string>) {
+  if (Object.keys(avatars).length === 0) {
+    storage?.removeItem(LOCAL_ASSISTANT_IDENTITY_KEY);
+    return;
+  }
+  storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify({ avatars }));
+}
+
 export function loadLocalAssistantIdentity(opts?: {
   agentId?: string | null;
 }): LocalAssistantIdentity {
+  const agentId = normalizeOptionalString(opts?.agentId);
+  if (!agentId) {
+    return { avatar: null };
+  }
   const storage = getSafeLocalStorage();
   try {
     const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
     if (!raw) {
       return { avatar: null };
     }
-    const parsed = JSON.parse(raw) as Partial<LocalAssistantIdentity>;
-    const avatar = typeof parsed.avatar === "string" ? parsed.avatar : null;
-    // Only return the avatar if it was saved for the requested agent (or if no
-    // agentId filter is provided, for backward compatibility).
-    if (opts?.agentId && parsed.agentId && parsed.agentId !== opts.agentId) {
-      return { avatar: null };
+    const { avatars, legacyAvatar } = parseLocalAssistantAvatarMap(raw);
+    if (!Object.hasOwn(avatars, agentId) && legacyAvatar) {
+      // Assign the old global override to the first concrete agent that loads it.
+      avatars[agentId] = legacyAvatar;
+      persistLocalAssistantAvatarMap(storage, avatars);
     }
-    return { avatar, agentId: parsed.agentId ?? null };
+    return { avatar: Object.hasOwn(avatars, agentId) ? avatars[agentId] : null, agentId };
   } catch {
     return { avatar: null };
   }
 }
 
 export function saveLocalAssistantIdentity(next: LocalAssistantIdentity) {
+  const agentId = normalizeOptionalString(next.agentId);
+  if (!agentId) {
+    return;
+  }
   const storage = getSafeLocalStorage();
   try {
-    if (!next.avatar) {
-      storage?.removeItem(LOCAL_ASSISTANT_IDENTITY_KEY);
-      return;
+    const raw = storage?.getItem(LOCAL_ASSISTANT_IDENTITY_KEY);
+    const avatars = raw
+      ? parseLocalAssistantAvatarMap(raw).avatars
+      : (Object.create(null) as Record<string, string>);
+    const avatar = normalizeOptionalString(next.avatar);
+    if (avatar) {
+      avatars[agentId] = avatar;
+    } else {
+      delete avatars[agentId];
     }
-    storage?.setItem(LOCAL_ASSISTANT_IDENTITY_KEY, JSON.stringify({
-      avatar: next.avatar,
-      agentId: next.agentId ?? null,
-    }));
+    persistLocalAssistantAvatarMap(storage, avatars);
   } catch {
     // best-effort — quota exceeded or security restrictions should not
     // prevent in-memory identity updates from being applied


### PR DESCRIPTION
## Summary

The local assistant avatar override was stored globally in localStorage without an `agentId`, causing the same avatar to apply to all agents. Setting a custom avatar for one agent would overwrite the avatar for every other agent.

## Root Cause

`saveLocalAssistantIdentity()` stored `{ avatar }` with no agent identification. `loadLocalAssistantIdentity()` returned the same avatar regardless of which agent was currently selected.

## Fix

1. `LocalAssistantIdentity` now includes `agentId`
2. `saveLocalAssistantIdentity` stores the current agent's ID alongside the avatar
3. `loadLocalAssistantIdentity` accepts an optional `agentId` filter — only returns the avatar if it matches (or if no agentId was saved, for backward compatibility)
4. `setAssistantAvatarOverride` now accepts and passes through `agentId`
5. Callers in `app-render.ts` pass `state.assistantAgentId`

Fixes #90890