### PR TITLE
fix: route deleted-agent session purge through lifecycle seam

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -108,6 +108,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/auto-reply/reply/session-updates.ts",
   "src/auto-reply/reply/session-usage.ts",
   "src/tui/embedded-backend.ts",
+  "src/config/sessions/cleanup-service.ts",
 ]);
 
 export const migratedTranscriptWriterFiles = new Set([
@@ -333,6 +334,7 @@ export async function main() {
   const writeSourceRoots = resolveSourceRoots(repoRoot, [
     "src/agents",
     "src/auto-reply",
+    "src/config/sessions",
     "src/tui",
   ]);
   const transcriptWriterSourceRoots = resolveSourceRoots(repoRoot, [

--- a/src/config/sessions/cleanup-service.agent-purge.test.ts
+++ b/src/config/sessions/cleanup-service.agent-purge.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import { purgeAgentSessionStoreEntries } from "./cleanup-service.js";
+
+const sessionAccessorMocks = vi.hoisted(() => ({
+  applySessionEntryLifecycleMutation: vi.fn(async () => ({
+    removedEntries: 0,
+    removedSessionKeys: [],
+    archivedTranscriptDirectories: [],
+    unreferencedArtifacts: null,
+    maintenanceReport: null,
+    afterCount: 0,
+  })),
+  purgeDeletedAgentSessionEntries: vi.fn(async () => ({
+    removedEntries: 0,
+    removedSessionKeys: [],
+    archivedTranscriptDirectories: [],
+    unreferencedArtifacts: null,
+    maintenanceReport: null,
+    afterCount: 0,
+  })),
+}));
+
+vi.mock("./session-accessor.js", () => sessionAccessorMocks);
+
+describe("purgeAgentSessionStoreEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("purges deleted-agent entries through the storage boundary", async () => {
+    const cfg = {
+      session: { store: "/tmp/openclaw-agent-purge-sessions.json" },
+      agents: {
+        list: [
+          { id: "main", workspace: "/workspace/main" },
+          { id: "ops", workspace: "/workspace/ops" },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    await purgeAgentSessionStoreEntries(cfg, "ops");
+
+    expect(sessionAccessorMocks.purgeDeletedAgentSessionEntries).toHaveBeenCalledWith({
+      cfg,
+      agentId: "ops",
+      storeAgentId: "main",
+      storePath: "/tmp/openclaw-agent-purge-sessions.json",
+    });
+    expect(sessionAccessorMocks.applySessionEntryLifecycleMutation).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -4,7 +4,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { resolveStoredSessionOwnerAgentId } from "../../gateway/session-store-key.js";
 import { getLogger } from "../../logging/logger.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
@@ -21,6 +20,7 @@ import {
 } from "./paths.js";
 import {
   applySessionEntryLifecycleMutation,
+  purgeDeletedAgentSessionEntries,
   type SessionEntryLifecycleRemoval,
 } from "./session-accessor.js";
 import { cloneSessionStoreRecord } from "./store-cache.js";
@@ -31,7 +31,7 @@ import {
   pruneStaleEntries,
   type ResolvedSessionMaintenanceConfig,
 } from "./store-maintenance.js";
-import { loadSessionStore, updateSessionStore } from "./store.js";
+import { loadSessionStore } from "./store.js";
 import {
   resolveSessionStoreTargets,
   type SessionStoreTarget,
@@ -634,18 +634,11 @@ export async function purgeAgentSessionStoreEntries(
         ? normalizedAgentId
         : normalizeAgentId(resolveDefaultAgentId(cfg));
     const storePath = resolveStorePath(cfg.session?.store, { agentId: normalizedAgentId });
-    await updateSessionStore(storePath, (store) => {
-      for (const key of Object.keys(store)) {
-        if (
-          resolveStoredSessionOwnerAgentId({
-            cfg,
-            agentId: storeAgentId,
-            sessionKey: key,
-          }) === normalizedAgentId
-        ) {
-          delete store[key];
-        }
-      }
+    await purgeDeletedAgentSessionEntries({
+      cfg,
+      agentId: normalizedAgentId,
+      storeAgentId,
+      storePath,
     });
   } catch (err) {
     getLogger().debug("session store purge skipped during agent delete", err);

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
@@ -16,6 +17,7 @@ import {
   loadTranscriptEvents,
   patchSessionEntry,
   persistSessionTranscriptTurn,
+  purgeDeletedAgentSessionEntries,
   publishTranscriptUpdate,
   readSessionUpdatedAt,
   replaceSessionEntry,
@@ -79,6 +81,39 @@ describe("session accessor file-backed seam", () => {
       model: "sonnet-4.6",
       sessionId: "session-1",
       updatedAt: expect.any(Number),
+    });
+  });
+
+  it("purges deleted-agent entries from the current locked store", async () => {
+    const cfg = {
+      session: { store: storePath },
+      agents: {
+        list: [
+          { id: "main", workspace: path.join(tempDir, "main") },
+          { id: "ops", workspace: path.join(tempDir, "ops") },
+        ],
+      },
+    } satisfies OpenClawConfig;
+    const now = Date.now();
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        main: { sessionId: "main-legacy", updatedAt: now },
+        "agent:ops:main": { sessionId: "ops-session", updatedAt: now },
+      }),
+      "utf8",
+    );
+
+    const result = await purgeDeletedAgentSessionEntries({
+      cfg,
+      agentId: "ops",
+      storeAgentId: "main",
+      storePath,
+    });
+
+    expect(result.removedSessionKeys).toEqual(["agent:ops:main"]);
+    expect(loadSessionStore(storePath)).toEqual({
+      main: expect.objectContaining({ sessionId: "main-legacy" }),
     });
   });
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -32,6 +32,7 @@ import {
   loadSessionStore,
   applySessionEntryPatchProjection as applyFileSessionEntryPatchProjection,
   patchSessionEntry as patchFileSessionEntry,
+  purgeDeletedAgentSessionEntries as purgeFileDeletedAgentSessionEntries,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   resetSessionEntryLifecycle as resetFileSessionEntryLifecycle,
@@ -40,6 +41,7 @@ import {
   type DeleteSessionEntryLifecycleResult,
   type ResetSessionEntryLifecycleMutation,
   type ResetSessionEntryLifecycleResult,
+  type DeletedAgentSessionEntryPurgeParams,
   type SessionArchivedTranscriptCleanupRule,
   type SessionEntryLifecycleMutationResult,
   type SessionEntryLifecycleRemoval,
@@ -321,6 +323,7 @@ export type {
 };
 
 export type {
+  DeletedAgentSessionEntryPurgeParams,
   SessionArchivedTranscriptCleanupRule,
   SessionEntryLifecycleMutationResult,
   SessionEntryLifecycleRemoval,
@@ -628,6 +631,13 @@ export async function applySessionEntryLifecycleMutation(params: {
   captureArtifactCleanupError?: boolean;
 }): Promise<SessionEntryLifecycleMutationResult> {
   return await applyFileSessionEntryLifecycleMutation(params);
+}
+
+/** Purges session entries owned by a deleted agent at the storage boundary. */
+export async function purgeDeletedAgentSessionEntries(
+  params: DeletedAgentSessionEntryPurgeParams,
+): Promise<SessionEntryLifecycleMutationResult> {
+  return await purgeFileDeletedAgentSessionEntries(params);
 }
 
 /** Reads parsed transcript records from an explicit or derived transcript target. */

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { resolveStoredSessionOwnerAgentId } from "../../gateway/session-store-key.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -20,6 +21,7 @@ import {
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { getRuntimeConfig } from "../io.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import {
   enforceSessionDiskBudget,
@@ -326,6 +328,17 @@ export type SessionEntryLifecycleMutationResult = {
   maintenanceReport: SessionMaintenanceApplyReport | null;
   afterCount: number;
   artifactCleanupError?: unknown;
+};
+
+export type DeletedAgentSessionEntryPurgeParams = {
+  /** Runtime config used to preserve legacy default-agent key ownership rules. */
+  cfg: OpenClawConfig;
+  /** Deleted agent whose session entries should be purged. */
+  agentId: string;
+  /** Agent id represented by the current store path for legacy unscoped keys. */
+  storeAgentId: string;
+  /** Resolved session store path to mutate. */
+  storePath: string;
 };
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
@@ -1515,6 +1528,50 @@ export async function applySessionEntryLifecycleMutation(params: {
     maintenanceReport,
     afterCount,
     artifactCleanupError,
+  };
+}
+
+/**
+ * Purges entries owned by a deleted agent while holding the store writer lock.
+ * This preserves the old delete-time current-store owner check without
+ * exposing a mutable whole-store callback to callers.
+ */
+export async function purgeDeletedAgentSessionEntries(
+  params: DeletedAgentSessionEntryPurgeParams,
+): Promise<SessionEntryLifecycleMutationResult> {
+  const storePath = path.resolve(params.storePath);
+  const removedSessionKeys: string[] = [];
+  let maintenanceReport: SessionMaintenanceApplyReport | null = null;
+  let afterCount = 0;
+
+  await runExclusiveSessionStoreWrite(storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(storePath);
+    for (const sessionKey of Object.keys(store)) {
+      const ownerAgentId = resolveStoredSessionOwnerAgentId({
+        cfg: params.cfg,
+        agentId: params.storeAgentId,
+        sessionKey,
+      });
+      if (ownerAgentId === params.agentId) {
+        delete store[sessionKey];
+        removedSessionKeys.push(sessionKey);
+      }
+    }
+    await saveSessionStoreUnlocked(storePath, store, {
+      onMaintenanceApplied: (report) => {
+        maintenanceReport = report;
+      },
+    });
+    afterCount = Object.keys(store).length;
+  });
+
+  return {
+    removedEntries: removedSessionKeys.length,
+    removedSessionKeys,
+    archivedTranscriptDirectories: [],
+    unreferencedArtifacts: null,
+    maintenanceReport,
+    afterCount,
   };
 }
 

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -58,7 +58,7 @@ describe("session accessor boundary guard", () => {
     );
   });
 
-  it("ratchets only the auto-reply files migrated to session accessor writes", () => {
+  it("ratchets only files migrated to session accessor writes", () => {
     expect(migratedSessionAccessorWriteFiles).toEqual(
       new Set([
         "src/agents/command/attempt-execution.shared.ts",
@@ -83,6 +83,7 @@ describe("session accessor boundary guard", () => {
         "src/auto-reply/reply/session-updates.ts",
         "src/auto-reply/reply/session-usage.ts",
         "src/tui/embedded-backend.ts",
+        "src/config/sessions/cleanup-service.ts",
       ]),
     );
   });


### PR DESCRIPTION
## What
Routes deleted-agent session-entry purge through a storage-boundary operation instead of a raw whole-store writer callback.

## Why
PR #93704 moved cleanup/reaper entry lifecycle mutations behind `applySessionEntryLifecycleMutation(...)`, but `purgeAgentSessionStoreEntries(...)` still owned a direct `updateSessionStore(...)` delete loop for `agents.delete`. This follow-up closes that remaining transaction-boundary gap while preserving deleted-agent behavior.

## Changes
- Add locked deleted-agent purge operation
- Preserve current-store owner scan semantics
- Preserve delete file trashing
- Extend writer boundary ratchet
- Add purge regression tests

## Tracking
- Tracker: #88838
- Pebbles: `clawdbot-d02.1.9.1.34`
- Branch: `clawdbot-d02.1.9.1.36/31b-agent-delete-session-purge-lifecycle`
- Head SHA: `de2eb6fa2f8bab9c49d9b14313e311f73839f021`
- Base: `upstream/main` at `d7866fc89b9851567641cad3c2dfc278624ac6e4`

## Scope
Confirmed gap: `src/config/sessions/cleanup-service.ts` used `updateSessionStore(...)` for deleted-agent session-entry purge after #93704 introduced the lifecycle mutation seam.

This PR keeps CLI/gateway delete behavior, best-effort purge behavior, legacy default-agent key handling, shared-store preservation, store maintenance behavior, and caller-owned filesystem trashing intact.

## Exclusions
- No SQLite schema/runtime flip
- No doctor migration
- No runtime JSON fallback
- No plugin SDK change
- No transcript/archive cleanup moved into deleted-agent purge
- No maniple/worker use

## SQLite Adapter Instructions
The future SQLite adapter should implement `purgeDeletedAgentSessionEntries(...)` as a transaction-sized operation: choose deleted-agent rows from the current locked/transactional store state using the same default-agent/shared-store ownership semantics, delete those rows, and keep store maintenance semantics equivalent to the file backend. Do not reintroduce a pre-lock exact-entry removal plan or expose a broad mutable whole-store callback. Keep agent directory and session directory trashing in the CLI/gateway delete callers.

## Testing
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/config/sessions/cleanup-service.agent-purge.test.ts src/commands/agents.delete.test.ts src/gateway/server-methods/agents-mutate.test.ts test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/check-session-accessor-boundary.mjs`
- `pnpm exec oxfmt --check scripts/check-session-accessor-boundary.mjs src/config/sessions/cleanup-service.ts src/config/sessions/cleanup-service.agent-purge.test.ts src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/store.ts test/scripts/check-session-accessor-boundary.test.ts`
- `git diff --check upstream/main...HEAD`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --no-web-search --thinking codex=low`

## Real behavior proof

Behavior addressed: Gateway `agents.delete` purges session-store rows owned by the deleted agent while preserving rows owned by another agent in the same current store.

Real environment tested: Local live LaunchAgent gateway from `/Users/phaedrus/Projects/clawdbot`, SHA `de2eb6fa2f8bab9c49d9b14313e311f73839f021`, OpenClaw `2026.6.8 (de2eb6f)`, gateway port `18789`, Node service command `/opt/homebrew/bin/node /Users/phaedrus/Projects/clawdbot/dist/index.js gateway --port 18789`.

Exact steps or command run after this patch:

```bash
pnpm build
pnpm openclaw agents add path3-proof-20260617165045 --non-interactive --workspace /tmp/openclaw-pr-93713-proof-path3-proof-20260617165045/workspace --agent-dir /Users/phaedrus/.openclaw/agents/path3-proof-20260617165045/agent --json
node <seed proof store> # wrote agent:path3-proof-20260617165045:proof-delete and agent:main:proof-retain to the temp agent sessions.json
pnpm openclaw gateway restart
pnpm openclaw --version
pnpm openclaw gateway status --json
curl -fsS http://127.0.0.1:18789/healthz
curl -fsS http://127.0.0.1:18789/readyz
pnpm openclaw gateway call agents.list --json --params '{}'
pnpm openclaw gateway call agents.delete --json --params '{"agentId":"path3-proof-20260617165045","deleteFiles":false}'
node <verify proof store>
pnpm openclaw gateway call agents.list --json --params '{}'
rm -rf /Users/phaedrus/.openclaw/agents/path3-proof-20260617165045 /tmp/openclaw-pr-93713-proof-path3-proof-20260617165045/workspace
```

Evidence after fix: Before delete, `/Users/phaedrus/.openclaw/agents/path3-proof-20260617165045/sessions/sessions.json` contained `agent:path3-proof-20260617165045:proof-delete` and `agent:main:proof-retain`. The Gateway delete returned `{ "ok": true, "agentId": "path3-proof-20260617165045", "removedBindings": 0 }`. After delete, the same store had `afterCount: 1`, `hasDeleted: false`, `hasRetained: true`, and keys `["agent:main:proof-retain"]`. A follow-up `agents.list` Gateway call returned `agentIds: ["main"]`, `tempPresent: false`. Cleanup removed the temp agent dir and workspace (`agent_dir_exists=no`, `workspace_exists=no`).

Observed result after fix: The live Gateway `agents.delete` path removed only the deleted agent's session-store row and left the retained row intact, matching the locked current-store owner-scan contract that replaces the raw whole-store writer callback.

What was not tested: Future SQLite runtime flip, SQLite adapter implementation, doctor migration, runtime JSON fallback, plugin SDK compatibility, transcript/archive cleanup movement, and `deleteFiles:true` filesystem trashing. This proof used `deleteFiles:false` so filesystem cleanup stayed reversible while still exercising the Gateway `agents.delete` session purge path.
