### PR TITLE
fix: isolate async model resolution mock from sync mock in flaky test

### DIFF
--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -476,7 +476,11 @@ describe("prepareSimpleCompletionModel", () => {
   });
 
   it("can preserve asynchronous provider model discovery", async () => {
-    hoisted.resolveModelAsyncMock.mockResolvedValueOnce({
+    // Use a standalone mock so the default beforeEach delegation from
+    // resolveModelAsyncMock → resolveModelMock does not pollute call
+    // history. The point of the test is that when useAsyncModelResolution
+    // is true, only the async resolver is invoked.
+    const resolveModelAsync = vi.fn().mockResolvedValue({
       model: {
         provider: "anthropic",
         id: "claude-opus-4-6",
@@ -486,18 +490,21 @@ describe("prepareSimpleCompletionModel", () => {
       },
       modelRegistry: {},
     });
+    // Reset the hoisted sync mock so any leftover calls from earlier tests
+    // or beforeEach setup don't cause a false positive.
+    hoisted.resolveModelMock.mockReset();
 
     const result = await prepareSimpleCompletionModel({
       cfg: undefined,
       provider: "anthropic",
       modelId: "claude-opus-4-6",
       useAsyncModelResolution: true,
-      modelResolver: hoisted.resolveModelAsyncMock,
+      modelResolver: resolveModelAsync,
     });
 
     expectPreparedModelResult(result);
     expect(hoisted.resolveModelMock).not.toHaveBeenCalled();
-    expect(hoisted.resolveModelAsyncMock).toHaveBeenCalledWith(
+    expect(resolveModelAsync).toHaveBeenCalledWith(
       "anthropic",
       "claude-opus-4-6",
       undefined,


### PR DESCRIPTION
## Summary

The `can preserve asynchronous provider model discovery` test was flaky/failing on CI because `resolveModelAsyncMock` in `beforeEach` delegated to `resolveModelMock`. When `useAsyncModelResolution=true`, the test asserted `resolveModelMock` was not called, but the delegation in the mock implementation caused it to be called.

## Fix

Use a standalone `vi.fn()` for the async resolver in this test instead of the hoisted mock that delegates to the sync mock. Also explicitly reset `resolveModelMock` before the assertion to guard against mock state leakage from prior tests.

Fixes #92117