### PR TITLE
fix: resolve stale peer dep pins conflicting with managed overrides

### DIFF
--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -802,6 +802,17 @@ export async function syncManagedNpmRootPeerDependencies(params: {
   const managedOverrides = params.omitUnsupportedManagedOverrides
     ? filterUnsupportedManagedNpmRootOverrides(params.managedOverrides)
     : readOverrideRecord(params.managedOverrides);
+  // Resolve conflicts: if a direct dependency pin differs from a managed
+  // override, update the pin to match. npm rejects manifests where an
+  // override changes the effective spec of a root direct dependency
+  // (EOVERRIDE). This happens when a stale managed peer pin from an older
+  // OpenClaw version survives while the host ships a newer override spec.
+  for (const [key, overrideSpec] of Object.entries(managedOverrides)) {
+    const depPin = nextDependencies[key];
+    if (depPin !== undefined && String(depPin) !== String(overrideSpec)) {
+      nextDependencies[key] = String(overrideSpec);
+    }
+  }
   const managedOverrideKeys = Object.keys(managedOverrides).toSorted();
   const overrides = readOverrideRecord(manifest.overrides);
   for (const key of readManagedOverrideKeys(manifest.openclaw)) {


### PR DESCRIPTION
## Summary

`openclaw plugins install` fails with npm `EOVERRIDE` when a managed npm root has a stale peer dependency pin from an older OpenClaw version that conflicts with a newer override spec shipped by the host.

## Root Cause

`syncManagedNpmRootPeerDependencies` keeps existing dependency pins via `dependencies[name] ?? newSpec`. When an older version pinned `hono@4.12.23` and the host ships `overrides.hono: 4.12.18`, npm rejects the manifest because an override may not change the effective spec of a root direct dependency.

## Fix

Before applying managed overrides, align any conflicting direct dependency pins to match the override spec. This resolves the `EOVERRIDE` conflict so `plugins install` succeeds.

Fixes #91772