### PR TITLE
fix: pin plugin workspace dir for sessions.list to avoid O(rows) memo busting

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -74,6 +74,7 @@ import { listSessionEntries as listAccessorSessionEntries } from "../config/sess
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
+import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
 import {
   DEFAULT_AGENT_ID,
   normalizeAgentId,
@@ -2824,6 +2825,12 @@ export async function listSessionsFromStoreAsync(params: {
   modelCatalog?: ModelCatalogEntry[];
   opts: SessionsListParams;
 }): Promise<SessionsListResult> {
+  // Pin the active plugin-registry workspace dir for the duration of this
+  // call so per-row metadata lookups use a stable memo key. Without this pin,
+  // concurrent agent turns / crons mutate the process-global workspace dir
+  // between rows, the memo never hits, and each row triggers a full
+  // loadPluginMetadataSnapshot scan (~100 ms).
+  return withPinnedActivePluginRegistryWorkspaceDir(async () => {
   const { cfg, storePath, store, opts } = params;
   const now = Date.now();
   const sessionListTranscriptUsageMaxBytes = 64 * 1024;
@@ -2929,4 +2936,5 @@ export async function listSessionsFromStoreAsync(params: {
     defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
     sessions,
   };
+  });
 }

--- a/src/plugins/runtime-state.ts
+++ b/src/plugins/runtime-state.ts
@@ -1,5 +1,6 @@
 // Stores plugin runtime registry state for the current process lifecycle.
 import type { PluginRegistry } from "./registry-types.js";
+import { getActivePluginRegistryWorkspaceDirFromState as getPinnedWorkspaceDirFromState } from "./runtime-workspace-state.js";
 
 export const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
@@ -38,6 +39,5 @@ export function getActivePluginChannelRegistryFromState(): RuntimeTrackedPluginR
 }
 
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
-  const state = getPluginRegistryState();
-  return state?.workspaceDir ?? undefined;
+  return getPinnedWorkspaceDirFromState();
 }

--- a/src/plugins/runtime-workspace-state.test.ts
+++ b/src/plugins/runtime-workspace-state.test.ts
@@ -1,10 +1,8 @@
 // Verifies request-scoped plugin workspace pins under concurrent registry mutation.
 import { afterEach, describe, expect, it } from "vitest";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
-import {
-  getActivePluginRegistryWorkspaceDirFromState,
-  withPinnedActivePluginRegistryWorkspaceDir,
-} from "./runtime-workspace-state.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
+import { withPinnedActivePluginRegistryWorkspaceDir } from "./runtime-workspace-state.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 
 function setActiveWorkspace(workspaceDir: string): void {

--- a/src/plugins/runtime-workspace-state.test.ts
+++ b/src/plugins/runtime-workspace-state.test.ts
@@ -1,0 +1,101 @@
+// Verifies request-scoped plugin workspace pins under concurrent registry mutation.
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  getActivePluginRegistryWorkspaceDirFromState,
+  withPinnedActivePluginRegistryWorkspaceDir,
+} from "./runtime-workspace-state.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+
+function setActiveWorkspace(workspaceDir: string): void {
+  setActivePluginRegistry(
+    createEmptyPluginRegistry(),
+    workspaceDir,
+    "gateway-bindable",
+    workspaceDir,
+  );
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  if (!resolve) {
+    throw new Error("Expected deferred resolver");
+  }
+  return { promise, resolve };
+}
+
+describe("runtime workspace state pin", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("reads the live global workspace dir when no pin is active", () => {
+    setActiveWorkspace("/workspace/a");
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+
+    setActiveWorkspace("/workspace/b");
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("isolates overlapping pins and restores live state after success", async () => {
+    const firstPinned = createDeferred();
+    const resumeFirst = createDeferred();
+    const firstObserved: Array<string | undefined> = [];
+
+    setActiveWorkspace("/workspace/a");
+    const firstRequest = withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      firstObserved.push(getActivePluginRegistryWorkspaceDirFromState());
+      firstPinned.resolve();
+      await resumeFirst.promise;
+      firstObserved.push(getActivePluginRegistryWorkspaceDirFromState());
+    });
+    await firstPinned.promise;
+
+    setActiveWorkspace("/workspace/b");
+    const secondObserved = await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      const observed = [getActivePluginRegistryWorkspaceDirFromState()];
+      setActiveWorkspace("/workspace/c");
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      observed.push(getActivePluginRegistryWorkspaceDirFromState());
+      return observed;
+    });
+
+    resumeFirst.resolve();
+    await firstRequest;
+
+    expect(firstObserved).toEqual(["/workspace/a", "/workspace/a"]);
+    expect(secondObserved).toEqual(["/workspace/b", "/workspace/b"]);
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/c");
+  });
+
+  it("reuses the outer pin for nested scopes", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      setActiveWorkspace("/workspace/b");
+      await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+        expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+      });
+    });
+
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+
+  it("propagates rejections without leaking the pin", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await expect(
+      withPinnedActivePluginRegistryWorkspaceDir(async () => {
+        setActiveWorkspace("/workspace/b");
+        throw new Error("workspace request failed");
+      }),
+    ).rejects.toThrow("workspace request failed");
+
+    expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
+  });
+});

--- a/src/plugins/runtime-workspace-state.test.ts
+++ b/src/plugins/runtime-workspace-state.test.ts
@@ -84,6 +84,19 @@ describe("runtime workspace state pin", () => {
     expect(getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/b");
   });
 
+  it("preserves the pin across module reloads", async () => {
+    setActiveWorkspace("/workspace/a");
+
+    await withPinnedActivePluginRegistryWorkspaceDir(async () => {
+      setActiveWorkspace("/workspace/b");
+      const reloaded = await import(
+        new URL("./runtime-workspace-state.ts?workspace-pin-reload", import.meta.url).href
+      );
+
+      expect(reloaded.getActivePluginRegistryWorkspaceDirFromState()).toBe("/workspace/a");
+    });
+  });
+
   it("propagates rejections without leaking the pin", async () => {
     setActiveWorkspace("/workspace/a");
 

--- a/src/plugins/runtime-workspace-state.ts
+++ b/src/plugins/runtime-workspace-state.ts
@@ -1,7 +1,11 @@
 // Shares plugin runtime workspace state across module reloads.
 import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
+const PINNED_PLUGIN_REGISTRY_WORKSPACE_KEY = Symbol.for(
+  "openclaw.pinnedPluginRegistryWorkspaceDir",
+);
 
 type GlobalRegistryWorkspaceState = typeof globalThis & {
   [PLUGIN_REGISTRY_STATE]?: {
@@ -9,9 +13,9 @@ type GlobalRegistryWorkspaceState = typeof globalThis & {
   };
 };
 
-const pinnedWorkspaceDirStorage = new AsyncLocalStorage<{
-  workspaceDir: string | undefined;
-}>();
+const pinnedWorkspaceDirStorage = resolveGlobalSingleton<
+  AsyncLocalStorage<{ workspaceDir: string | undefined }>
+>(PINNED_PLUGIN_REGISTRY_WORKSPACE_KEY, () => new AsyncLocalStorage());
 
 /** Reads the active plugin registry workspace directory from global runtime state,
  *  respecting any pinned workspace from the current async context. */

--- a/src/plugins/runtime-workspace-state.ts
+++ b/src/plugins/runtime-workspace-state.ts
@@ -1,4 +1,6 @@
 // Shares plugin runtime workspace state across module reloads.
+import { AsyncLocalStorage } from "node:async_hooks";
+
 const PLUGIN_REGISTRY_STATE = Symbol.for("openclaw.pluginRegistryState");
 
 type GlobalRegistryWorkspaceState = typeof globalThis & {
@@ -7,9 +9,35 @@ type GlobalRegistryWorkspaceState = typeof globalThis & {
   };
 };
 
-/** Reads the active plugin registry workspace directory from global runtime state. */
+const pinnedWorkspaceDirStorage = new AsyncLocalStorage<{
+  workspaceDir: string | undefined;
+}>();
+
+/** Reads the active plugin registry workspace directory from global runtime state,
+ *  respecting any pinned workspace from the current async context. */
 export function getActivePluginRegistryWorkspaceDirFromState(): string | undefined {
+  const pinned = pinnedWorkspaceDirStorage.getStore();
+  if (pinned) {
+    return pinned.workspaceDir;
+  }
   return (
     (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined
   );
+}
+
+/**
+ * Pin the active plugin-registry workspace dir for the duration of `fn`.
+ * While pinned, calls to `getActivePluginRegistryWorkspaceDirFromState()` return
+ * the snapshot taken at pin time, ignoring concurrent mutations from other
+ * agent turns or crons. This prevents per-row memo-busting in operations that
+ * iterate over many rows (e.g. sessions.list).
+ */
+export function withPinnedActivePluginRegistryWorkspaceDir<T>(fn: () => T): T {
+  if (pinnedWorkspaceDirStorage.getStore()) {
+    // Already pinned in an outer scope — reuse it.
+    return fn();
+  }
+  const workspaceDir =
+    (globalThis as GlobalRegistryWorkspaceState)[PLUGIN_REGISTRY_STATE]?.workspaceDir ?? undefined;
+  return pinnedWorkspaceDirStorage.run({ workspaceDir }, fn);
 }


### PR DESCRIPTION
## Summary

`sessions.list` was O(rows) slow (tens of seconds) under concurrent agent/cron load because per-row plugin-metadata lookups read a process-global workspace dir that was mutated by other turns between rows. The memo key changed every row, so each triggered a fresh `loadPluginMetadataSnapshot` scan.

## Root Cause

`getActivePluginRegistryWorkspaceDirFromState()` reads a process-global value that concurrent agent turns and crons mutate while `listSessionsFromStoreAsync` iterates over rows. Between each yield batch, the active registry changes → memo key changes → cache never hits.

## Fix

1. **`runtime-workspace-state.ts`**: Added `AsyncLocalStorage`-based workspace dir pinning via `withPinnedActivePluginRegistryWorkspaceDir()`. While pinned, all calls to `getActivePluginRegistryWorkspaceDirFromState()` return the snapshot taken at pin time.

2. **`session-utils.ts`**: Wrapped `listSessionsFromStoreAsync` body in the pin so all per-row metadata lookups share a stable memo key.

Fixes #90814