### PR TITLE
feat(inbound-meta): expose message_type in trusted inbound metadata (fixes #50482)

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -248,6 +248,44 @@ describe("buildInboundMetaSystemPrompt", () => {
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["response_format"]).toBeUndefined();
   });
+
+  it("includes message_type derived from MediaType", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      MediaType: "audio/ogg",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["message_type"]).toBe("audio");
+  });
+
+  it("includes message_type derived from MediaTypes when MediaType is absent", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingChannel: "discord",
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+      MediaTypes: ["video/mp4", "image/png"],
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["message_type"]).toBe("video");
+  });
+
+  it("omits message_type for plain text messages", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["message_type"]).toBeUndefined();
+  });
 });
 
 describe("buildInboundUserContextPrefix", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -461,6 +461,22 @@ function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   return channelValue;
 }
 
+function resolveInboundMessageType(ctx: TemplateContext): string | undefined {
+  const mediaType = normalizePromptMetadataString(ctx.MediaType);
+  if (mediaType) {
+    const slash = mediaType.indexOf("/");
+    return slash > 0 ? mediaType.slice(0, slash) : mediaType;
+  }
+  const firstMediaType = Array.isArray(ctx.MediaTypes)
+    ? ctx.MediaTypes.find((t): t is string => typeof t === "string" && t.length > 0)
+    : undefined;
+  if (firstMediaType) {
+    const slash = firstMediaType.indexOf("/");
+    return slash > 0 ? firstMediaType.slice(0, slash) : firstMediaType;
+  }
+  return undefined;
+}
+
 function resolveInboundFormattingHints(ctx: TemplateContext):
   | {
       text_markup: string;
@@ -505,6 +521,7 @@ export function buildInboundMetaSystemPrompt(
     provider: normalizePromptMetadataString(ctx.Provider),
     surface: normalizePromptMetadataString(ctx.Surface),
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
+    message_type: resolveInboundMessageType(ctx),
     response_format:
       options?.includeFormattingHints === false ? undefined : resolveInboundFormattingHints(ctx),
   };


### PR DESCRIPTION
## What does this PR do?

Adds `message_type` to the inbound metadata payload so agents can distinguish voice messages from typed text. Extracts the media type prefix (e.g. "audio" from "audio/ogg") from `MediaType` or the first entry of `MediaTypes`.

## Related Issue

Fixes #50482

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `src/auto-reply/reply/inbound-meta.ts`: Added `resolveInboundMessageType()` helper and wired it into `buildInboundMetaSystemPrompt` payload as `message_type`
- `src/auto-reply/reply/inbound-meta.test.ts`: Added 3 verification cases — single MediaType, MediaTypes array fallback, and plain text omission

## How to Test

1. Run the auto-reply verification suite — all 56 pass
2. `pnpm build` succeeds
3. `grep -n 'resolveInboundMessageType\|message_type' src/auto-reply/reply/inbound-meta.ts` shows the new function and its usage

## Real behavior proof

- **Behavior addressed:** Agent has no way to know if an inbound message was voice or typed text. Voice messages need different handling (wait for turn-completion, shorter responses). This adds `message_type` to the inbound metadata payload so the agent can distinguish them.
- **Environment tested:** macOS 26.4.1, Node v25.8.2, pnpm build
- **Steps run after the patch:**
```
node -e "const fs=require('fs'); const c=fs.readFileSync('dist/get-reply-Bd5Qps5u.js','utf8'); console.log('resolveInboundMessageType:', c.includes('resolveInboundMessageType')); console.log('message_type:', c.includes('message_type'));"
grep -n 'resolveInboundMessageType\|message_type' src/auto-reply/reply/inbound-meta.ts
```
- **Evidence after fix:**
```
resolveInboundMessageType: true
message_type: true

464:function resolveInboundMessageType(ctx: TemplateContext): string | undefined {
524:    message_type: resolveInboundMessageType(ctx),
```
- **Observed result after fix:** The bundled output contains `resolveInboundMessageType` and `message_type`. Source shows the new function at line 464 and its usage at line 524. `pnpm build` succeeds with no errors.
- **What was not tested:** Live channel message delivery (requires running OpenClaw with a channel provider). The logic is exercised through the template rendering path in verification.

## Checklist

- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Verification passes
- [x] Added verification cases
- [x] Tested on macOS
