### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM cold-load (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,7 +1064,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -97,10 +97,11 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom while still capping worst case at two minutes.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## Summary

Increase `NARRATIVE_TIMEOUT_MS` from 60s to 120s in `dreaming-narrative.ts` to accommodate ARM devices with 600+ skills where cold-loading tool definitions takes ~57s, leaving almost no headroom for the LLM call itself within the 60s timeout.

## Changes Made

- `extensions/memory-core/src/dreaming-narrative.ts`: Changed `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000` and updated the comment to explain the ARM cold-load rationale.
- `extensions/memory-core/src/dreaming-narrative.test.ts`: Updated the expected timeout assertion from `60_000` to `120_000`.

## Root Cause

On ARM devices with 600+ installed skills, the first narrative phase (light) cold-loads all skill tool definitions, which takes ~57 seconds. With the 60s timeout, this leaves almost no headroom for the actual LLM call, causing consistent timeouts on light and rem phases. Deep phase usually succeeds because it benefits from tool caching from earlier phases.

## How to Test

```
node scripts/run-vitest.mjs run extensions/memory-core/src/dreaming-narrative.test.ts
```

All 58 existing tests pass with the updated timeout value.

## Real behavior proof

- **Behavior addressed:** Dreaming narrative phases timeout on ARM devices with 600+ skills due to cold-loading tool definitions consuming most of the 60s budget.
- **Environment tested:** macOS, Node v22, OpenClaw main branch (b8369468+).
- **Steps run after the patch:** Built the project and verified the constant change, then ran the full dreaming-narrative test suite.
- **Evidence after fix:**

```
$ grep -n "NARRATIVE_TIMEOUT_MS" extensions/memory-core/src/dreaming-narrative.ts
104:const NARRATIVE_TIMEOUT_MS = 120_000;
1052:            timeoutMs: NARRATIVE_TIMEOUT_MS,

$ node scripts/run-vitest.mjs run extensions/memory-core/src/dreaming-narrative.test.ts
 ✓  extension-memory  extensions/memory-core/src/dreaming-narrative.test.ts (58 tests) 515ms
 Test Files  1 passed (1)
      Tests  58 passed (58)
```

- **Observed result after fix:** The timeout constant is now 120_000ms (120s), providing sufficient headroom for ARM cold-load + LLM call. All 58 existing tests pass unchanged (except the expected-value assertion updated to match).
- **What was not tested:** Not tested on actual ARM hardware with 600+ skills (requires specific device). The timeout increase is a safe, conservative change — it only extends the ceiling, does not change behavior for fast-completing runs.
