### PR TITLE
fix(usage): prune stale usage cache temp files

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -724,6 +724,72 @@ describe("session cost usage", () => {
     });
   });
 
+  it("reclaims stale usage cache temp files before refreshing", async () => {
+    const root = await makeSessionCostRoot("cost-cache-temp-cleanup");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-temp-cleanup.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      transcriptText("sess-cache-temp-cleanup", {
+        type: "message",
+        timestamp: "2026-02-05T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: {
+            input: 10,
+            output: 20,
+            totalTokens: 30,
+            cost: { total: 0.03 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const staleLegacyTempPath = path.join(sessionsDir, ".usage-cost-cache.json.12345.tmp");
+    const staleCurrentTempPath = path.join(sessionsDir, ".usage-cost-cache.12345.tmp");
+    const recentTempPath = path.join(sessionsDir, ".usage-cost-cache.67890.tmp");
+    const lockTempPath = path.join(sessionsDir, ".usage-cost-cache.json.lock.12345.tmp");
+    await Promise.all(
+      [staleLegacyTempPath, staleCurrentTempPath, recentTempPath, lockTempPath].map((tempPath) =>
+        fs.writeFile(tempPath, "partial\n", "utf-8"),
+      ),
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    await Promise.all(
+      [staleLegacyTempPath, staleCurrentTempPath, lockTempPath].map((tempPath) =>
+        fs.utimes(tempPath, staleTime, staleTime),
+      ),
+    );
+
+    const exists = async (filePath: string): Promise<boolean> =>
+      await fs.stat(filePath).then(
+        () => true,
+        () => false,
+      );
+
+    await withStateDir(root, async () => {
+      const result = await refreshCostUsageCache();
+      expect(result).toBe("refreshed");
+
+      expect(await exists(staleLegacyTempPath)).toBe(false);
+      expect(await exists(staleCurrentTempPath)).toBe(false);
+      expect(await exists(recentTempPath)).toBe(true);
+      expect(await exists(lockTempPath)).toBe(true);
+
+      const summary = await loadCostUsageSummaryFromCache({
+        startMs: Date.UTC(2026, 1, 5),
+        endMs: Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1,
+        requestRefresh: false,
+      });
+      expect(summary.totals.totalTokens).toBe(30);
+      expect(summary.cacheStatus?.status).toBe("fresh");
+    });
+  });
+
   it("keeps queued durable aggregate refresh state scoped to the cache path", async () => {
     const firstRoot = await makeSessionCostRoot("cost-cache-queued-first");
     const secondRoot = await makeSessionCostRoot("cost-cache-queued-second");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -90,6 +90,7 @@ const emptyTotals = (): CostUsageTotals => ({
 const USAGE_COST_CACHE_VERSION = 4;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
+const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
 const USAGE_COST_TRANSCRIPT_STAT_CONCURRENCY = 32;
 // Checkpoint policy for refreshCostUsageCache: bound the cost of full cache
 // serialization when scanning thousands of session files. Smaller of the two
@@ -374,6 +375,32 @@ async function writeUsageCostCache(cachePath: string, cache: UsageCostCacheFile)
     content: `${JSON.stringify(cache)}\n`,
     tempPrefix: ".usage-cost-cache",
   });
+}
+
+function isUsageCostCacheTempFileName(name: string): boolean {
+  if (!name.endsWith(".tmp") || name.startsWith(`${USAGE_COST_CACHE_FILE}.lock.`)) {
+    return false;
+  }
+  return name.startsWith(".usage-cost-cache.") || name.startsWith(`${USAGE_COST_CACHE_FILE}.`);
+}
+
+async function cleanupStaleUsageCostCacheTempFiles(cachePath: string): Promise<void> {
+  const dir = path.dirname(cachePath);
+  const cutoffMs = Date.now() - USAGE_COST_CACHE_TEMP_FILE_GRACE_MS;
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true }).catch(() => []);
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isFile() || !isUsageCostCacheTempFileName(entry.name)) {
+        return;
+      }
+      const tempPath = path.join(dir, entry.name);
+      const stats = await fs.promises.stat(tempPath).catch(() => null);
+      if (!stats || stats.mtimeMs > cutoffMs) {
+        return;
+      }
+      await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
+    }),
+  );
 }
 
 async function listUsageCountedTranscriptFileStats(
@@ -1518,6 +1545,7 @@ async function refreshCostUsageCacheForPath(params?: {
     return "busy";
   }
   try {
+    await cleanupStaleUsageCostCacheTempFiles(cachePath);
     const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config);
     const cache = await readUsageCostCache(cachePath);
     const files = await listUsageCountedTranscriptFiles(params?.agentId, {


### PR DESCRIPTION
## Summary

- Problem: stale `.usage-cost-cache*.tmp` files can remain beside the durable usage-cost cache after older cache writers or hard process termination.
- Why it matters: these orphaned files can silently consume disk in agent session directories.
- What changed: usage-cost cache refresh now prunes stale usage-cache temp files after acquiring the cache refresh lock, while preserving recent temp files and lock-write temp files.
- Scope boundary: cache contents, pricing calculations, transcript scanning, lock semantics, and normal atomic cache writes are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Closes #78939

## Real behavior proof

- Behavior or issue addressed: stale usage-cost cache temp files are reclaimed during cache refresh instead of remaining indefinitely in agent session directories.
- Real environment tested: macOS local source checkout, Node v26.3.0, pnpm v11.2.2, temporary `OPENCLAW_STATE_DIR`.
- Exact steps or command run after this patch: created a temporary OpenClaw state dir, seeded a real agent session transcript, wrote stale legacy/current usage-cache temp files plus a recent usage-cache temp file and a lock temp file, then imported and called `refreshCostUsageCache()` and `loadCostUsageSummaryFromCache()` with `node --import tsx`.
- Evidence after fix:

```json
{
  "result": "refreshed",
  "staleLegacyExists": false,
  "staleCurrentExists": false,
  "recentTempExists": true,
  "lockTempExists": true,
  "totalTokens": 30,
  "totalCost": 0.03,
  "cacheStatus": "fresh"
}
```

- Observed result after fix: both stale temp-file shapes were removed, the recent temp file and lock temp file were preserved, refresh returned `refreshed`, and the cache summary reported `fresh` with the expected totals.
- What was not tested: live production cleanup on the reporter's Windows session store.

## Root Cause

Current cache writes use the atomic replacement helper, which cleans up its own active temp path for ordinary failures. It does not sweep temp files left by older builds or hard exits, and the locked refresh path had no stale-temp reclamation step.

## Regression Test Plan

- Target test: `src/infra/session-cost-usage.test.ts`
- Scenario locked in: cache refresh removes stale legacy and current usage-cost temp-file shapes while preserving recent temp files, preserving lock temp files, and producing a fresh usable cache.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Validation

- `pnpm install --frozen-lockfile` passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts -t "reclaims stale usage cache temp files before refreshing" --reporter=verbose` passed: 1 test passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/session-cost-usage.test.ts` passed: 53 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` passed.
- `node scripts/test-projects.mjs --changed origin/main` passed: infra shard, 53 tests passed.
- `PATH="/opt/homebrew/opt/corepack/bin:$PATH" OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs` passed locally. The default Testbox delegation could not run because Blacksmith auth is not configured on this machine.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed: no accepted/actionable findings.

## AI Assistance

AI-assisted: yes. I used AI assistance to inspect the issue, implement the narrow fix, run local validation, and prepare this PR text. No assistant signature, co-author footer, or generated-by footer is included.
