### PR TITLE
fix(typing): start typing on reasoning deltas in thinking mode before visible text

### DIFF
--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -755,7 +755,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
   });
 
-  it("starts typing and refreshes ttl on text for thinking mode", async () => {
+  it("starts typing on reasoning delta and refreshes ttl on text for thinking mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -763,8 +763,15 @@ describe("createTypingSignaler", () => {
       isHeartbeat: false,
     });
 
+    // Reasoning delta starts the typing loop and refreshes TTL,
+    // even before any renderable assistant text has arrived.
     await signaler.signalReasoningDelta();
-    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
+    expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
+
+    // Once typing is active, text delta only refreshes TTL.
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
     await signaler.signalTextDelta("hi");
     expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
     expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -132,10 +132,8 @@ export function createTypingSignaler(params: {
     if (disabled || !shouldStartOnReasoning) {
       return;
     }
-    // Reasoning-only streams should not expose typing until visible text exists.
-    if (!hasRenderableText) {
-      return;
-    }
+    // Reasoning deltas are the signal to show typing in thinking mode,
+    // even before any visible assistant text has arrived.
     await typing.startTypingLoop();
     typing.refreshTypingTtl();
   };


### PR DESCRIPTION
## Root Cause

`signalReasoningDelta()` in `typing-mode.ts` had an early return gated on `hasRenderableText`. In thinking mode, the model emits reasoning deltas before any visible assistant text appears. The gate prevented typing from starting during the reasoning phase, causing the Telegram typing indicator to disappear or never appear while the agent was actively "thinking" — only appearing belatedly when visible text finally arrived.

## Summary

- Telegram typing indicator was not staying visible during the reasoning/thinking phase of agent responses in thinking mode
- Removed the `hasRenderableText` early return gate from `signalReasoningDelta()` so typing starts on the first reasoning delta, matching the documented contract of "start typing on the first reasoning delta"
- Fixed test assertion to verify that `signalReasoningDelta()` starts the typing loop and refreshes TTL, and text delta afterward only refreshes TTL
- Fixes #79681

## Verification

- `pnpm test src/auto-reply/reply/reply-utils.test.ts` — 74 tests passed, including the updated thinking mode typing test
- Autoreview: clean, no findings
- Only 2 files changed: `typing-mode.ts` (4 lines removed/adjusted) and `reply-utils.test.ts` (test updated)

## Real behavior proof

Behavior addressed: Telegram typing indicator disappears during agent's reasoning/thinking phase in thinking mode, reappearing only when visible text is emitted

Real environment tested: Linux (kernel 4.19.112, Node 22+), branch `fix/issue-79681-typing-thinking-mode`, commit `9ae6d65fc3`

Exact steps or command run after this patch:

```bash
pnpm test src/auto-reply/reply/reply-utils.test.ts
```

Evidence after fix:

```console
 RUN  v4.1.7 /home/0668000452/codes/OPENSOURCES/openclaw

 Test Files  1 passed (1)
      Tests  74 passed (74)
   Start at  01:22:43
   Duration  1.47s (transform 690ms, setup 468ms, import 489ms, tests 168ms, environment 0ms)
```

Observed result after fix: `signalReasoningDelta()` now calls `startTypingLoop()` and `refreshTypingTtl()` immediately on the first reasoning delta in thinking mode, keeping the typing indicator visible throughout the entire agent response lifecycle. The old behavior skipped starting typing until `hasRenderableText` was true.

What was not tested: Live Telegram end-to-end roundtrip. The fix is scoped to the typing-mode logic unit test.