### PR TITLE
fix(ollama): preserve configured API during discovery

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -516,6 +516,7 @@ describe("ollama plugin", () => {
       expect(resolved?.provider).toBe("ollama");
       expect(resolved?.id).toBe("qwen3-coder:cloud");
       expect(resolved?.api).toBe("openai-completions");
+      expect(resolved?.baseUrl).toBe("https://ollama.example.com/v1");
       expect(buildOllamaProviderMock).toHaveBeenCalledWith("https://ollama.example.com/v1", {
         quiet: true,
       });

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1397,7 +1397,7 @@ describe("ollama plugin", () => {
 
     provider.createStreamFn?.({
       config: {},
-      model: { id: "kimi-k2.5:cloud" },
+      model: { api: "ollama", id: "kimi-k2.5:cloud" },
       provider: "ollama-cloud",
     } as never);
     expect(requireConfiguredStreamParams().providerBaseUrl).toBe("https://ollama.com");
@@ -1496,6 +1496,55 @@ describe("ollama plugin", () => {
     expect(nativePolicy?.validateAnthropicTurns).toBe(true);
   });
 
+  it.each([
+    {
+      providerId: "ollama",
+      register: registerProvider,
+      nativeBaseUrl: "http://127.0.0.1:11434",
+    },
+    {
+      providerId: "ollama-cloud",
+      register: registerOllamaCloudProvider,
+      nativeBaseUrl: "https://ollama.com",
+    },
+  ])(
+    "$providerId selects native /api/chat transport only for api=ollama",
+    ({ providerId, register, nativeBaseUrl }) => {
+      const provider = register();
+      const createStream = (api: "ollama" | "openai-completions", baseUrl: string) =>
+        provider.createStreamFn?.({
+          config: {
+            models: {
+              providers: {
+                [providerId]: {
+                  api,
+                  baseUrl,
+                  models: [],
+                },
+              },
+            },
+          },
+          model: {
+            api,
+            id: "qwen3:32b",
+            provider: providerId,
+          },
+          provider: providerId,
+        } as never);
+
+      const compatibleStream = createStream("openai-completions", `${nativeBaseUrl}/v1`);
+
+      expect(compatibleStream).toBeUndefined();
+      expect(createConfiguredOllamaStreamFnMock).not.toHaveBeenCalled();
+
+      const nativeStream = createStream("ollama", nativeBaseUrl);
+
+      expect(nativeStream).toBeDefined();
+      expect(createConfiguredOllamaStreamFnMock).toHaveBeenCalledOnce();
+      expect(requireConfiguredStreamParams().providerBaseUrl).toBe(nativeBaseUrl);
+    },
+  );
+
   it("routes createStreamFn to the correct provider baseUrl for ollama2", () => {
     const provider = registerProvider();
     const config = {
@@ -1514,7 +1563,7 @@ describe("ollama plugin", () => {
         },
       },
     };
-    const model = { id: "llama3.2", provider: "ollama2", baseUrl: undefined };
+    const model = { id: "llama3.2", provider: "ollama2", api: "ollama", baseUrl: undefined };
 
     provider.createStreamFn?.({ config, model, provider: "ollama2" } as never);
 
@@ -1534,7 +1583,7 @@ describe("ollama plugin", () => {
         },
       },
     };
-    const model = { id: "llama3.2", provider: "ollama2", baseUrl: undefined };
+    const model = { id: "llama3.2", provider: "ollama2", api: "ollama", baseUrl: undefined };
 
     provider.createStreamFn?.({ config, model, provider: "ollama2" } as never);
 
@@ -1559,7 +1608,7 @@ describe("ollama plugin", () => {
         },
       },
     };
-    const model = { id: "llama3.2", provider: "ollama", baseUrl: undefined };
+    const model = { id: "llama3.2", provider: "ollama", api: "ollama", baseUrl: undefined };
 
     provider.createStreamFn?.({ config, model, provider: "ollama" } as never);
 

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -467,6 +467,67 @@ describe("ollama plugin", () => {
     }
   });
 
+  it("preserves explicit api for configured dynamic Ollama models", async () => {
+    const provider = registerProvider();
+    const previous = process.env.OLLAMA_API_KEY;
+    process.env.OLLAMA_API_KEY = "ollama-live";
+    buildOllamaProviderMock.mockResolvedValueOnce({
+      baseUrl: "https://ollama.example.com",
+      api: "ollama",
+      models: [
+        {
+          id: "qwen3-coder:cloud",
+          name: "qwen3-coder:cloud",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 2048,
+        },
+      ],
+    });
+
+    try {
+      const config = {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "https://ollama.example.com/v1",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      };
+
+      await provider.prepareDynamicModel?.({
+        config,
+        provider: "ollama",
+        modelId: "qwen3-coder:cloud",
+        modelRegistry: { find: vi.fn(() => null) },
+      } as never);
+
+      const resolved = provider.resolveDynamicModel?.({
+        config,
+        provider: "ollama",
+        modelId: "qwen3-coder:cloud",
+        modelRegistry: { find: vi.fn(() => null) },
+      } as never);
+      expect(resolved?.provider).toBe("ollama");
+      expect(resolved?.id).toBe("qwen3-coder:cloud");
+      expect(resolved?.api).toBe("openai-completions");
+      expect(buildOllamaProviderMock).toHaveBeenCalledWith("https://ollama.example.com/v1", {
+        quiet: true,
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OLLAMA_API_KEY;
+      } else {
+        process.env.OLLAMA_API_KEY = previous;
+      }
+    }
+  });
+
   it("resolves requested Ollama cloud models that are omitted from tags but confirmed by show", async () => {
     const provider = registerProvider();
     const previous = process.env.OLLAMA_API_KEY;

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -476,6 +476,9 @@ export default definePluginEntry({
         }),
       },
       createStreamFn: ({ config, model, provider }) => {
+        if (model.api !== "ollama") {
+          return undefined;
+        }
         return createConfiguredOllamaStreamFn({
           model,
           providerBaseUrl:
@@ -598,6 +601,9 @@ export default definePluginEntry({
         await ensureOllamaModelPulled({ config, model, prompter });
       },
       createStreamFn: ({ config, model, provider }) => {
+        if (model.api !== "ollama") {
+          return undefined;
+        }
         return createConfiguredOllamaStreamFn({
           model,
           providerBaseUrl: readProviderBaseUrl(

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -47,6 +47,7 @@ import {
   OLLAMA_PROVIDER_ID,
   isLocalOllamaBaseUrl,
   resolveOllamaDiscoveryResult,
+  resolveOllamaRuntimeBaseUrl,
   shouldUseSyntheticOllamaAuth,
   type OllamaPluginConfig,
 } from "./src/discovery-shared.js";
@@ -658,9 +659,15 @@ export default definePluginEntry({
         }
         const baseUrl = readProviderBaseUrl(providerConfig);
         const provider = await buildOllamaProvider(baseUrl, { quiet: true });
+        const dynamicApi = providerConfig?.api ?? provider.api;
         const dynamicProvider = {
           ...provider,
-          api: providerConfig?.api ?? provider.api,
+          baseUrl: resolveOllamaRuntimeBaseUrl({
+            api: dynamicApi,
+            configuredBaseUrl: baseUrl,
+            discoveredBaseUrl: provider.baseUrl,
+          }),
+          api: dynamicApi,
         };
         const dynamicModels = (dynamicProvider.models ?? []).map((model) =>
           toDynamicOllamaModel({

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -104,7 +104,7 @@ function toDynamicOllamaModel(params: {
     id: params.model.id,
     name: params.model.name ?? params.model.id,
     provider: params.provider,
-    api: "ollama",
+    api: params.providerConfig.api ?? "ollama",
     baseUrl: readProviderBaseUrl(params.providerConfig) ?? "",
     reasoning: params.model.reasoning ?? false,
     input: input.length > 0 ? input : ["text"],
@@ -658,17 +658,21 @@ export default definePluginEntry({
         }
         const baseUrl = readProviderBaseUrl(providerConfig);
         const provider = await buildOllamaProvider(baseUrl, { quiet: true });
-        const dynamicModels = (provider.models ?? []).map((model) =>
+        const dynamicProvider = {
+          ...provider,
+          api: providerConfig?.api ?? provider.api,
+        };
+        const dynamicModels = (dynamicProvider.models ?? []).map((model) =>
           toDynamicOllamaModel({
             provider: ctx.provider,
-            providerConfig: provider,
+            providerConfig: dynamicProvider,
             model,
           }),
         );
         if (!dynamicModels.some((model) => model.id === ctx.modelId)) {
           const requestedModel = await resolveRequestedDynamicOllamaModel({
             provider: ctx.provider,
-            providerConfig: provider,
+            providerConfig: dynamicProvider,
             modelId: ctx.modelId,
           });
           if (requestedModel) {

--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -171,9 +171,33 @@ describe("Ollama provider", () => {
 
       expect(countFetchCallUrls(fetchMock, "/api/tags")).toBe(1);
 
-      // Native API strips /v1 suffix via resolveOllamaApiBase()
-      expect(provider?.baseUrl).toBe("http://192.168.20.14:11434");
+      expect(provider?.baseUrl).toBe("http://192.168.20.14:11434/v1");
       expect(provider?.api).toBe("openai-completions");
+    });
+  });
+
+  it("should normalize explicit native ollama baseUrl on implicit provider injection", async () => {
+    const fetchMock = stubTagsFetch();
+
+    await withOllamaApiKey(async () => {
+      const provider = await runOllamaCatalog({
+        config: {
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "http://192.168.20.14:11434/v1",
+                api: "ollama",
+                models: [],
+              },
+            },
+          },
+        },
+        env: { OLLAMA_API_KEY: "test-key" },
+      });
+
+      expect(countFetchCallUrls(fetchMock, "/api/tags")).toBe(1);
+      expect(provider?.baseUrl).toBe("http://192.168.20.14:11434");
+      expect(provider?.api).toBe("ollama");
     });
   });
 
@@ -651,7 +675,7 @@ describe("Ollama provider", () => {
       });
 
       expect(provider?.apiKey).toBe("config-ollama-key");
-      expect(provider?.baseUrl).toBe("http://remote-ollama:11434");
+      expect(provider?.baseUrl).toBe("http://remote-ollama:11434/v1");
       expect(provider?.api).toBe("openai-completions");
       expect(fetchMock).not.toHaveBeenCalled();
     });

--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -150,7 +150,7 @@ describe("Ollama provider", () => {
     });
   });
 
-  it("should preserve explicit ollama baseUrl on implicit provider injection", async () => {
+  it("should preserve explicit ollama baseUrl and api on implicit provider injection", async () => {
     const fetchMock = stubTagsFetch();
 
     await withOllamaApiKey(async () => {
@@ -173,6 +173,7 @@ describe("Ollama provider", () => {
 
       // Native API strips /v1 suffix via resolveOllamaApiBase()
       expect(provider?.baseUrl).toBe("http://192.168.20.14:11434");
+      expect(provider?.api).toBe("openai-completions");
     });
   });
 

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -310,6 +310,7 @@ export async function resolveOllamaDiscoveryResult(params: {
   return {
     provider: {
       ...provider,
+      api: explicit?.api ?? provider.api,
       ...(apiKey ? { apiKey } : {}),
     },
   };

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -42,6 +42,17 @@ function isOllamaApiKeyMarker(value: string): boolean {
   return value === "OLLAMA_API_KEY" || value === OLLAMA_DEFAULT_API_KEY;
 }
 
+export function resolveOllamaRuntimeBaseUrl(params: {
+  api?: ModelProviderConfig["api"];
+  configuredBaseUrl?: string;
+  discoveredBaseUrl: string;
+}): string {
+  if (params.configuredBaseUrl && params.api && params.api !== "ollama") {
+    return params.configuredBaseUrl;
+  }
+  return params.discoveredBaseUrl;
+}
+
 function resolveOllamaDiscoveryApiKey(params: {
   env: NodeJS.ProcessEnv;
   baseUrl?: string;
@@ -251,10 +262,12 @@ export async function resolveOllamaDiscoveryResult(params: {
     ollamaKey.trim() !== OLLAMA_DEFAULT_API_KEY;
   const explicitApiKey = readStringValue(explicit?.apiKey);
   if (hasExplicitModels && explicit) {
-    const baseUrl = resolveOllamaApiBase(readProviderBaseUrl(explicit) ?? OLLAMA_DEFAULT_BASE_URL);
+    const configuredBaseUrl = readProviderBaseUrl(explicit) ?? OLLAMA_DEFAULT_BASE_URL;
+    const discoveredBaseUrl = resolveOllamaApiBase(configuredBaseUrl);
+    const api = explicit.api ?? "ollama";
     const apiKey = resolveOllamaDiscoveryApiKey({
       env: params.ctx.env,
-      baseUrl,
+      baseUrl: discoveredBaseUrl,
       explicitApiKey,
       resolvedApiKey: ollamaKey,
       resolvedDiscoveryApiKey: ollamaDiscoveryKey,
@@ -262,8 +275,8 @@ export async function resolveOllamaDiscoveryResult(params: {
     return {
       provider: {
         ...explicit,
-        baseUrl,
-        api: explicit.api ?? "ollama",
+        baseUrl: resolveOllamaRuntimeBaseUrl({ api, configuredBaseUrl, discoveredBaseUrl }),
+        api,
         ...(apiKey ? { apiKey } : {}),
       },
     };
@@ -307,10 +320,16 @@ export async function resolveOllamaDiscoveryResult(params: {
     resolvedApiKey: ollamaKey,
     resolvedDiscoveryApiKey: ollamaDiscoveryKey,
   });
+  const api = explicit?.api ?? provider.api;
   return {
     provider: {
       ...provider,
-      api: explicit?.api ?? provider.api,
+      baseUrl: resolveOllamaRuntimeBaseUrl({
+        api,
+        configuredBaseUrl,
+        discoveredBaseUrl: provider.baseUrl,
+      }),
+      api,
       ...(apiKey ? { apiKey } : {}),
     },
   };


### PR DESCRIPTION
## Summary

- Problem: Ollama dynamic discovery and dynamic model preparation overwrote an explicit provider API like `openai-completions` with `api: "ollama"`, sending requests through the native `/api/chat` path instead of the configured OpenAI-compatible route.
- Solution: Keep native Ollama base URL normalization for discovery probes, but preserve the user's explicitly configured provider API and base URL on the final provider/runtime model when the API is non-native.
- What changed: Updated the Ollama discovery merge and dynamic model conversion paths, with regression tests for catalog discovery, explicit configured models, native Ollama normalization, and `prepareDynamicModel`/`resolveDynamicModel`.
- What did NOT change: Native Ollama discovery probing, default `api: "ollama"` behavior, other providers, core routing, or plugin SDK contracts.

Fixes #93710

## Real behavior proof

- **Behavior addressed:** Explicit `models.providers.ollama.api: "openai-completions"` and `baseUrl: ".../v1"` remain configured after Ollama discovery even though the live builder uses native `api: "ollama"` and a native base URL for `/api/tags` probing.
- **Real environment tested:** macOS 26.5, Node v24.15.0, OpenClaw 2026.6.2, worktree SHA 67cb1a0
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx --input-type=module -e 'import { resolveOllamaDiscoveryResult } from "./extensions/ollama/src/discovery-shared.ts"; const result = await resolveOllamaDiscoveryResult({ ctx: { config: { models: { providers: { ollama: { baseUrl: "http://192.168.20.14:11434/v1", api: "openai-completions", models: [] } } } }, env: { OLLAMA_API_KEY: "test-key" }, resolveProviderApiKey: () => ({ apiKey: "test-key" }) }, pluginConfig: {}, buildProvider: async () => ({ baseUrl: "http://192.168.20.14:11434", api: "ollama", models: [{ id: "qwen3-coder:cloud", name: "qwen3-coder:cloud" }] }) }); const provider = result?.provider; console.log(JSON.stringify({ configuredApi: "openai-completions", configuredBaseUrl: "http://192.168.20.14:11434/v1", discoveredBuilderApi: "ollama", discoveredBuilderBaseUrl: "http://192.168.20.14:11434", resolvedProviderApi: provider?.api, resolvedBaseUrl: provider?.baseUrl, resolvedModelIds: provider?.models?.map((model) => model.id) ?? [] }, null, 2));'
  node scripts/run-vitest.mjs extensions/ollama/provider-discovery.test.ts
  node scripts/run-vitest.mjs extensions/ollama/index.test.ts
  pnpm check:test-types
  node scripts/run-oxlint.mjs --deny=warn --ignore-path=.oxlintignore extensions/ollama/index.test.ts extensions/ollama/index.ts extensions/ollama/provider-discovery.test.ts extensions/ollama/src/discovery-shared.ts
  git diff --check
  ```
- **Evidence after fix:**
  ```json
  {
    "configuredApi": "openai-completions",
    "configuredBaseUrl": "http://192.168.20.14:11434/v1",
    "discoveredBuilderApi": "ollama",
    "discoveredBuilderBaseUrl": "http://192.168.20.14:11434",
    "resolvedProviderApi": "openai-completions",
    "resolvedBaseUrl": "http://192.168.20.14:11434/v1",
    "resolvedModelIds": [
      "qwen3-coder:cloud"
    ]
  }
  ```
  ```text
  node scripts/run-vitest.mjs extensions/ollama/provider-discovery.test.ts
  Test Files  1 passed (1)
  Tests  18 passed (18)

  node scripts/run-vitest.mjs extensions/ollama/index.test.ts
  Test Files  1 passed (1)
  Tests  52 passed (52)

  pnpm check:test-types
  completed successfully

  node scripts/run-oxlint.mjs --deny=warn --ignore-path=.oxlintignore extensions/ollama/index.test.ts extensions/ollama/index.ts extensions/ollama/provider-discovery.test.ts extensions/ollama/src/discovery-shared.ts
  completed successfully

  git diff --check
  completed successfully
  ```
- **Observed result after fix:** The resolved Ollama provider keeps `api: "openai-completions"` and `baseUrl: "http://192.168.20.14:11434/v1"`, while native discovery still probes the normalized Ollama API base at `http://192.168.20.14:11434`.
- **What was not tested:** Full gateway startup and a live external Ollama daemon were not used; the issue is a provider-local discovery merge regression and was verified through the real OpenClaw plugin discovery function plus focused Ollama plugin tests.

## Regression Test Plan

- Coverage level: Provider plugin regression tests
- Target test file: `extensions/ollama/provider-discovery.test.ts`, `extensions/ollama/index.test.ts`
- Scenario locked in: Explicit `models.providers.ollama.api: "openai-completions"` and `baseUrl: ".../v1"` are preserved through catalog discovery and `prepareDynamicModel`/`resolveDynamicModel` even when `buildOllamaProvider()` returns native `api: "ollama"` and a native base URL.
- Why this is the smallest reliable guardrail: It covers the two Ollama-owned merge boundaries that previously replaced the explicit API/base URL without touching core routing or other providers.

## Root Cause

- Root cause: `buildOllamaProvider()` correctly normalizes the configured base URL for native Ollama discovery, but the catalog and dynamic-model merge paths reused that native discovery provider as the final runtime provider/model config, replacing the user's OpenAI-compatible API/base URL pair.
- Missing detection / guardrail: Existing tests covered base URL normalization and dynamic model discovery separately, but did not assert that a user-configured OpenAI-compatible API and `/v1` base URL survived discovery-backed paths.