### PR TITLE
fix: request Telegram reaction count updates

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -803,11 +803,12 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - `own` means user reactions to bot-sent messages only (best-effort via sent-message cache).
     - Reaction events still respect Telegram access controls (`dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`); unauthorized senders are dropped.
+    - Telegram only delivers reaction updates when the Bot API can expose them to the bot. In practice, bots must be administrators in the chat, so reactions in 1:1 private DMs may not arrive even when `reactionNotifications` is enabled.
     - Telegram does not provide thread IDs in reaction updates.
       - non-forum groups route to group chat session
       - forum groups route to the group general-topic session (`:topic:1`), not the exact originating topic
 
-    `allowed_updates` for polling/webhook include `message_reaction` automatically.
+    `allowed_updates` for polling/webhook include `message_reaction` and `message_reaction_count` automatically.
 
   </Accordion>
 

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -51,6 +51,7 @@ tool with the `react` action. Reaction behavior varies by channel and transport.
   <Accordion title="Telegram">
     - Empty `emoji` removes the bot's reactions.
     - `remove: true` also removes reactions but still requires a non-empty `emoji` for tool validation.
+    - Inbound reaction notifications depend on Telegram Bot API delivery. Bots generally must be administrators in the chat to receive reaction updates, so 1:1 DM reactions can be unavailable even with `channels.telegram.reactionNotifications` enabled.
 
   </Accordion>
 

--- a/extensions/telegram/src/allowed-updates.test.ts
+++ b/extensions/telegram/src/allowed-updates.test.ts
@@ -35,6 +35,10 @@ describe("resolveTelegramAllowedUpdates", () => {
       "chat_boost",
       "removed_chat_boost",
     ]);
-    expect(updates).toEqual([...DEFAULT_TELEGRAM_UPDATE_TYPES, "message_reaction"]);
+    expect(updates).toEqual([
+      ...DEFAULT_TELEGRAM_UPDATE_TYPES,
+      "message_reaction",
+      "message_reaction_count",
+    ]);
   });
 });

--- a/extensions/telegram/src/allowed-updates.ts
+++ b/extensions/telegram/src/allowed-updates.ts
@@ -11,6 +11,9 @@ export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateTyp
   if (!updates.includes("message_reaction")) {
     updates.push("message_reaction");
   }
+  if (!updates.includes("message_reaction_count")) {
+    updates.push("message_reaction_count");
+  }
   if (!updates.includes("channel_post")) {
     updates.push("channel_post");
   }


### PR DESCRIPTION
## Summary
- request both Telegram message_reaction and message_reaction_count updates in polling/webhook allowed updates
- document that Telegram reaction notifications depend on Bot API delivery and may not arrive in 1:1 private DMs because bots cannot be chat administrators there
- clarify the Telegram reactions tool docs with the same limitation

## Why
While investigating missing Telegram reaction events in a direct bot chat, OpenClaw was already requesting message_reaction, but not message_reaction_count. The Bot API reaction delivery rules are also easy to misread: even with reactionNotifications enabled, Telegram can withhold reaction updates unless the bot is an administrator in the chat. That makes private DM reactions appear broken even when OpenClaw config is correct.

## Tests
- pnpm vitest run extensions/telegram/src/allowed-updates.test.ts
- pnpm format:docs:check
- pnpm lint:extensions:telegram-grammy-types
- pnpm lint:docs