### PR TITLE
fix(agents): preserve re-sent user prompt during compaction transcript rotation

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.duplicate-prompt-loss.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.duplicate-prompt-loss.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { afterEach, describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { rotateTranscriptAfterCompaction } from "./compaction-successor-transcript.js";
+import { readTranscriptFileState } from "./transcript-file-state.js";
+
+let tmpDir: string | undefined;
+afterEach(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    tmpDir = undefined;
+  }
+});
+
+function makeAssistant(text: string, timestamp: number) {
+  return makeAgentAssistantMessage({ content: [{ type: "text", text }], timestamp });
+}
+
+function readUserTexts(entries: { type: string; message?: unknown }[]): string[] {
+  return entries
+    .filter(
+      (entry) =>
+        entry.type === "message" &&
+        (entry.message as { role?: unknown } | undefined)?.role === "user",
+    )
+    .map((entry) => {
+      const content = (entry.message as { content?: unknown } | undefined)?.content;
+      if (typeof content === "string") {
+        return content;
+      }
+      if (Array.isArray(content)) {
+        return content.map((block) => (block as { text?: string })?.text ?? "").join("");
+      }
+      return "";
+    });
+}
+
+const PROMPT = "Please refactor the authentication module right now";
+
+describe("rotateTranscriptAfterCompaction duplicate-prompt preservation", () => {
+  it("keeps a kept-tail prompt whose earlier copy was summarized away", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "successor-dup-loss-"));
+    const manager = SessionManager.create(tmpDir, tmpDir);
+
+    manager.appendMessage({ role: "user", content: PROMPT, timestamp: 1000 });
+    manager.appendMessage(makeAssistant("Working on it.", 1001));
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: "go on",
+      timestamp: 1002,
+    });
+    manager.appendMessage(makeAssistant("Continuing.", 1003));
+    manager.appendCompaction("Summary of earlier turns.", firstKeptId, 5000);
+    manager.appendMessage({ role: "user", content: PROMPT, timestamp: 40000 });
+    manager.appendMessage(makeAssistant("On it again.", 40001));
+
+    const sessionFile = manager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("no session file");
+    }
+
+    const result = await rotateTranscriptAfterCompaction({ sessionManager: manager, sessionFile });
+    expect(result.rotated).toBe(true);
+    const successorFile = result.sessionFile;
+    if (!successorFile) {
+      throw new Error("no successor file");
+    }
+
+    const successor = await readTranscriptFileState(successorFile);
+    const userPromptTexts = readUserTexts(
+      successor.getEntries() as { type: string; message?: unknown }[],
+    );
+
+    expect(userPromptTexts.some((text) => text.includes(PROMPT))).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -174,7 +174,9 @@ function buildSuccessorEntries(params: {
   }
 
   const removedIds = new Set<string>();
-  const duplicateUserMessageIds = collectDuplicateUserMessageEntryIdsForCompaction(branch);
+  const keptBranchEntries = branch.filter((entry) => !summarizedBranchIds.has(entry.id));
+  const duplicateUserMessageIds =
+    collectDuplicateUserMessageEntryIdsForCompaction(keptBranchEntries);
   for (const entry of allEntries) {
     if (
       (summarizedBranchIds.has(entry.id) && entry.type === "message") ||


### PR DESCRIPTION
## Summary

With `agents.defaults.compaction.truncateAfterCompaction` enabled, a compaction can silently drop the user's most recent request from the successor transcript. The agent then continues having lost what the user asked for.

The trigger is a re-sent prompt: the user sends prompt `P`, the agent responds, the conversation continues, and the user re-sends an identical `P` (>=24 chars, within the 60s window). When compaction then fires with the boundary falling between the two copies, both copies are removed and `P` never appears in the successor.

## Root cause

`buildSuccessorEntries` in `src/agents/embedded-agent-runner/compaction-successor-transcript.ts` collects ids to drop:

```ts
// before
const removedIds = new Set<string>();
const duplicateUserMessageIds = collectDuplicateUserMessageEntryIdsForCompaction(branch);
for (const entry of allEntries) {
  if (
    (summarizedBranchIds.has(entry.id) && entry.type === "message") ||
    staleStateEntryIds.has(entry.id) ||
    duplicateUserMessageIds.has(entry.id)
  ) {
    removedIds.add(entry.id);
  }
}
```

`collectDuplicateUserMessageEntryIdsForCompaction` (`src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts`) keeps the first occurrence of a user message and flags later same-window repeats. Running it over the full `branch` means: when `P`'s first copy lives in the summarized prefix and the later copy lives in the kept tail, the helper treats the kept-tail copy as the duplicate and adds it to `duplicateUserMessageIds`.

That kept-tail copy is then removed via `duplicateUserMessageIds`, while the earlier copy is independently removed via `summarizedBranchIds` (summarized prefix message). Both verbatim instances are gone. The compaction summary is generic prose that does not contain the prompt text, so the request is lost entirely.

## Fix

Anchor dedup within the kept region only. The summarized prefix is already dropped via `summarizedBranchIds`, so the dedup pass should not consider those entries when deciding which kept-tail copy is the "first" surviving instance:

```ts
// after
const keptBranchEntries = branch.filter((entry) => !summarizedBranchIds.has(entry.id));
const duplicateUserMessageIds =
  collectDuplicateUserMessageEntryIdsForCompaction(keptBranchEntries);
```

Now the first surviving copy in the kept tail is preserved; only genuine later repeats within the kept region are still dropped, which is exactly the deduplication the helper was added for.

## Why this is the right boundary

- The defect is in how `buildSuccessorEntries` feeds the helper, not in the helper itself. `collectDuplicateUserMessageEntryIdsForCompaction` correctly keeps the first occurrence and drops later repeats; it was just being shown entries (the summarized prefix) that are already removed by a different rule, so its "first occurrence" anchored on a copy that no longer survives. Filtering the input to the kept region fixes the input contract without changing the helper's semantics.
- The other two removal rules are untouched: summarized-prefix messages and stale state entries are still removed exactly as before. Only the duplicate-detection input is narrowed.
- Within-kept-region dedup still works: a prompt re-sent twice inside the kept tail still drops the later copy, so the original duplicate-inflation fix is preserved.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.duplicate-prompt-loss.test.ts` -> 1 passed. This new regression test fails on pristine `main` (`expected false to be true`) and passes with this patch.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts` -> existing 12 tests still pass.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts` -> 3 tests still pass.
- `oxfmt --check` on the changed files -> clean.
- `run-oxlint.mjs` on the changed files -> 0 findings.
- `tsgo` core (`tsconfig.core.json`) and core test (`tsconfig.core.test.json`) -> clean.

## Real behavior proof

Behavior addressed: with `truncateAfterCompaction` enabled, a re-sent user prompt whose earlier copy lands in the summarized prefix and whose later copy lands in the kept tail is no longer dropped from the successor transcript.

Real environment tested: drove the real production function `rotateTranscriptAfterCompaction` end to end against a real `SessionManager`, building the transcript (prompt, assistant, "go on", assistant, compaction at that boundary, re-sent identical prompt, assistant), then read the written successor file back with the real `readTranscriptFileState` and extracted the successor's user turns. Run against pristine `main` and the patched branch with identical inputs.

Exact steps or command run after this patch: append the two-copy transcript through `SessionManager`, call `rotateTranscriptAfterCompaction({ sessionManager, sessionFile })`, load the resulting successor file, and list the `role === "user"` turn texts.

Evidence after fix:

```
# BEFORE (pristine main d1e20d2f29)
SUCCESSOR_USER_TURNS=["go on"]
PROMPT_PRESENT=false

# AFTER (this patch, identical inputs)
SUCCESSOR_USER_TURNS=["go on","Please refactor the authentication module right now"]
PROMPT_PRESENT=true
```

Observed result after fix: the successor transcript that previously contained only `"go on"` (the actual request `"Please refactor the authentication module right now"` absent) now retains the request.

What was not tested: a live gateway run that triggers real model-driven compaction with `truncateAfterCompaction` set; this change is at the transcript-rotation layer and is covered above by driving the real rotation/read functions plus the colocated regression test.
