### PR TITLE
refactor: add task session registry maintenance seam

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -68,6 +68,7 @@ export const migratedSessionAccessorFiles = new Set([
   "src/commands/sessions.ts",
   "src/commands/status.agent-local.ts",
   "src/commands/status.summary.ts",
+  "src/commands/tasks.ts",
   "src/config/sessions/combined-store-gateway.ts",
   "src/cron/isolated-agent/delivery-target.ts",
   "src/cron/service/timer.ts",
@@ -108,9 +109,10 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/auto-reply/reply/session-reset-model.ts",
   "src/auto-reply/reply/session-updates.ts",
   "src/auto-reply/reply/session-usage.ts",
-  "src/tui/embedded-backend.ts",
+  "src/commands/tasks.ts",
   "src/config/sessions/cleanup-service.ts",
   "src/plugins/host-hook-cleanup.ts",
+  "src/tui/embedded-backend.ts",
 ]);
 
 export const migratedTranscriptWriterFiles = new Set([
@@ -336,6 +338,7 @@ export async function main() {
   const writeSourceRoots = resolveSourceRoots(repoRoot, [
     "src/agents",
     "src/auto-reply",
+    "src/commands",
     "src/config/sessions",
     "src/plugins",
     "src/tui",

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -1,7 +1,6 @@
 // Human-facing background task commands.
 // Handles task listing/show/cancel/notify/audit plus registry maintenance for tasks, flows, and sessions.
 
-import fs from "node:fs";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
@@ -9,15 +8,11 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { formatLookupMiss } from "../cli/error-format.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
-  loadSessionStore,
-  pruneStaleEntries,
   resolveAllAgentSessionStoreTargetsSync,
-  updateSessionStore,
-  type SessionEntry,
+  runSessionRegistryMaintenanceForStore,
 } from "../config/sessions.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { getTaskById, updateTaskNotifyPolicyById } from "../tasks/runtime-internal.js";
 import { cancelDetachedTaskRunById } from "../tasks/task-executor.js";
 import { listTaskFlowAuditFindings } from "../tasks/task-flow-registry.audit.js";
@@ -133,14 +128,6 @@ type SessionRegistryMaintenanceSummary = {
   stores: SessionRegistryMaintenanceStoreSummary[];
 };
 
-function parseCronRunSessionJobId(sessionKey: string): string | undefined {
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (!parsed) {
-    return undefined;
-  }
-  return /^cron:([^:]+):run:[^:]+$/u.exec(parsed.rest)?.[1];
-}
-
 function readRunningCronJobIds(): Set<string> {
   try {
     const cronStorePath = resolveCronJobsStorePath(getRuntimeConfig().cron?.store);
@@ -155,27 +142,6 @@ function readRunningCronJobIds(): Set<string> {
   }
 }
 
-function buildSessionRegistryPreserveKeys(params: {
-  store: Record<string, SessionEntry>;
-  runningCronJobIds: ReadonlySet<string>;
-}): { preserveKeys: Set<string>; preservedRunning: number } {
-  const preserveKeys = new Set<string>();
-  let preservedRunning = 0;
-  for (const key of Object.keys(params.store)) {
-    const jobId = parseCronRunSessionJobId(key);
-    if (!jobId) {
-      // Non-cron session rows are outside this maintenance pass; preserve them.
-      preserveKeys.add(key);
-      continue;
-    }
-    if (params.runningCronJobIds.has(jobId)) {
-      preserveKeys.add(key);
-      preservedRunning += 1;
-    }
-  }
-  return { preserveKeys, preservedRunning };
-}
-
 async function runSessionRegistryMaintenance(params: {
   apply: boolean;
 }): Promise<SessionRegistryMaintenanceSummary> {
@@ -183,67 +149,19 @@ async function runSessionRegistryMaintenance(params: {
   const runningCronJobIds = readRunningCronJobIds();
   const stores: SessionRegistryMaintenanceStoreSummary[] = [];
   for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
-    if (!fs.existsSync(target.storePath)) {
-      stores.push({
-        agentId: target.agentId,
-        storePath: target.storePath,
-        beforeCount: 0,
-        afterCount: 0,
-        pruned: 0,
-        preservedRunning: 0,
-      });
-      continue;
-    }
-    const beforeStore = loadSessionStore(target.storePath, { skipCache: true });
-    const beforeCount = Object.keys(beforeStore).length;
-    if (params.apply) {
-      // Apply mode mutates each store atomically through updateSessionStore.
-      const applied = await updateSessionStore(
-        target.storePath,
-        (store) => {
-          const { preserveKeys, preservedRunning } = buildSessionRegistryPreserveKeys({
-            store,
-            runningCronJobIds,
-          });
-          const pruned = pruneStaleEntries(store, SESSION_REGISTRY_RETENTION_MS, {
-            log: false,
-            preserveKeys,
-          });
-          return {
-            pruned,
-            afterCount: Object.keys(store).length,
-            preservedRunning,
-          };
-        },
-        { skipMaintenance: true },
-      );
-      stores.push({
-        agentId: target.agentId,
-        storePath: target.storePath,
-        beforeCount,
-        afterCount: applied.afterCount,
-        pruned: applied.pruned,
-        preservedRunning: applied.preservedRunning,
-      });
-      continue;
-    }
-    const previewStore = structuredClone(beforeStore);
-    // Preview mode runs pruning against a clone so dry-run output cannot change stores.
-    const { preserveKeys, preservedRunning } = buildSessionRegistryPreserveKeys({
-      store: previewStore,
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: params.apply,
+      retentionMs: SESSION_REGISTRY_RETENTION_MS,
       runningCronJobIds,
-    });
-    const pruned = pruneStaleEntries(previewStore, SESSION_REGISTRY_RETENTION_MS, {
-      log: false,
-      preserveKeys,
+      storePath: target.storePath,
     });
     stores.push({
       agentId: target.agentId,
       storePath: target.storePath,
-      beforeCount,
-      afterCount: Object.keys(previewStore).length,
-      pruned,
-      preservedRunning,
+      beforeCount: result.beforeCount,
+      afterCount: result.afterCount,
+      pruned: result.pruned,
+      preservedRunning: result.preservedRunning,
     });
   }
   return {

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -26,6 +26,7 @@ export * from "./sessions/types.js";
 export * from "./sessions/transcript.js";
 export * from "./sessions/session-file.js";
 export * from "./sessions/session-file-rotation.js";
+export * from "./sessions/session-registry-maintenance.js";
 export * from "./sessions/delivery-info.js";
 export * from "./sessions/disk-budget.js";
 export * from "./sessions/targets.js";

--- a/src/config/sessions/session-registry-maintenance.test.ts
+++ b/src/config/sessions/session-registry-maintenance.test.ts
@@ -1,0 +1,126 @@
+// Session registry maintenance tests cover the task-owned cron-run pruning seam.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
+import { runSessionRegistryMaintenanceForStore } from "./session-registry-maintenance.js";
+import { loadSessionStore, saveSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const fixtureSuite = createFixtureSuite("openclaw-session-registry-maintenance-");
+
+beforeAll(async () => {
+  await fixtureSuite.setup();
+});
+
+afterAll(async () => {
+  await fixtureSuite.cleanup();
+});
+
+function sessionEntry(sessionId: string, updatedAt: number): SessionEntry {
+  return { sessionId, updatedAt };
+}
+
+async function createStore(entries: Record<string, SessionEntry>): Promise<string> {
+  const dir = await fixtureSuite.createCaseDir("store");
+  const storePath = path.join(dir, "sessions.json");
+  await fs.mkdir(dir, { recursive: true });
+  await saveSessionStore(storePath, entries, { skipMaintenance: true });
+  return storePath;
+}
+
+describe("runSessionRegistryMaintenanceForStore", () => {
+  it("summarizes a missing store without creating it", async () => {
+    const dir = await fixtureSuite.createCaseDir("missing-store");
+    const storePath = path.join(dir, "sessions.json");
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: true,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(),
+      storePath,
+    });
+
+    expect(result).toEqual({
+      beforeCount: 0,
+      afterCount: 0,
+      preservedRunning: 0,
+      pruned: 0,
+    });
+    await expect(fs.stat(storePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("previews stale cron-run pruning without mutating the store", async () => {
+    const now = Date.now();
+    const storePath = await createStore({
+      "agent:main:cron:done-job:run:old-run": sessionEntry("old-run", now - 8 * DAY_MS),
+      "agent:main:cron:done-job:run:recent-run": sessionEntry("recent-run", now),
+    });
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: false,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(),
+      storePath,
+    });
+
+    expect(result).toEqual({
+      beforeCount: 2,
+      afterCount: 1,
+      preservedRunning: 0,
+      pruned: 1,
+    });
+    expect(loadSessionStore(storePath, { skipCache: true })).toHaveProperty(
+      "agent:main:cron:done-job:run:old-run",
+    );
+  });
+
+  it("applies one store-sized pruning transaction and preserves running cron rows", async () => {
+    const now = Date.now();
+    const storePath = await createStore({
+      "agent:main:cron:done-job:run:old-run": sessionEntry("done-run", now - 8 * DAY_MS),
+      "agent:main:cron:running-job:run:old-run": sessionEntry("running-run", now - 8 * DAY_MS),
+      "agent:main:cron:done-job:run:recent-run": sessionEntry("recent-run", now),
+    });
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: true,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(["running-job"]),
+      storePath,
+    });
+
+    expect(result).toEqual({
+      beforeCount: 3,
+      afterCount: 2,
+      preservedRunning: 1,
+      pruned: 1,
+    });
+    const updated = loadSessionStore(storePath, { skipCache: true });
+    expect(updated["agent:main:cron:done-job:run:old-run"]).toBeUndefined();
+    expect(updated).toHaveProperty("agent:main:cron:running-job:run:old-run");
+    expect(updated).toHaveProperty("agent:main:cron:done-job:run:recent-run");
+  });
+
+  it("skips generic session maintenance while applying task registry pruning", async () => {
+    const now = Date.now();
+    const oldOrdinaryKey = "agent:main:subagent:old-worker";
+    const storePath = await createStore({
+      "agent:main:cron:done-job:run:old-run": sessionEntry("done-run", now - 8 * DAY_MS),
+      [oldOrdinaryKey]: sessionEntry("old-worker", now - 40 * DAY_MS),
+    });
+
+    const result = await runSessionRegistryMaintenanceForStore({
+      apply: true,
+      retentionMs: 7 * DAY_MS,
+      runningCronJobIds: new Set(),
+      storePath,
+    });
+
+    expect(result.pruned).toBe(1);
+    const updated = loadSessionStore(storePath, { skipCache: true });
+    expect(updated["agent:main:cron:done-job:run:old-run"]).toBeUndefined();
+    expect(updated).toHaveProperty(oldOrdinaryKey);
+  });
+});

--- a/src/config/sessions/session-registry-maintenance.ts
+++ b/src/config/sessions/session-registry-maintenance.ts
@@ -1,0 +1,119 @@
+// Storage-neutral session registry maintenance for task-owned cron run cleanup.
+import fs from "node:fs";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import { loadSessionStore, pruneStaleEntries, updateSessionStore } from "./store.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionRegistryMaintenanceStoreSummary = {
+  afterCount: number;
+  beforeCount: number;
+  preservedRunning: number;
+  pruned: number;
+};
+
+export type SessionRegistryMaintenanceStoreOptions = {
+  /** Apply pruning to the backing store; false previews against a clone. */
+  apply: boolean;
+  /** Retention window for cron-run session entries. */
+  retentionMs: number;
+  /** Currently running cron job ids, normalized to lowercase. */
+  runningCronJobIds: ReadonlySet<string>;
+  /** Resolved session registry store path for one agent. */
+  storePath: string;
+};
+
+function parseCronRunSessionJobId(sessionKey: string): string | undefined {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return undefined;
+  }
+  return /^cron:([^:]+):run:[^:]+$/u.exec(parsed.rest)?.[1];
+}
+
+function buildSessionRegistryPreserveKeys(params: {
+  runningCronJobIds: ReadonlySet<string>;
+  store: Record<string, SessionEntry>;
+}): { preserveKeys: Set<string>; preservedRunning: number } {
+  const preserveKeys = new Set<string>();
+  let preservedRunning = 0;
+  for (const key of Object.keys(params.store)) {
+    const jobId = parseCronRunSessionJobId(key);
+    if (!jobId) {
+      // This sweep owns only cron-run rows; all ordinary sessions are preserved.
+      preserveKeys.add(key);
+      continue;
+    }
+    if (params.runningCronJobIds.has(jobId)) {
+      preserveKeys.add(key);
+      preservedRunning += 1;
+    }
+  }
+  return { preserveKeys, preservedRunning };
+}
+
+function pruneSessionRegistryStore(params: {
+  retentionMs: number;
+  runningCronJobIds: ReadonlySet<string>;
+  store: Record<string, SessionEntry>;
+}): Omit<SessionRegistryMaintenanceStoreSummary, "beforeCount"> {
+  const { preserveKeys, preservedRunning } = buildSessionRegistryPreserveKeys({
+    runningCronJobIds: params.runningCronJobIds,
+    store: params.store,
+  });
+  const pruned = pruneStaleEntries(params.store, params.retentionMs, {
+    log: false,
+    preserveKeys,
+  });
+  return {
+    afterCount: Object.keys(params.store).length,
+    preservedRunning,
+    pruned,
+  };
+}
+
+/**
+ * Runs task session-registry maintenance for one resolved agent store.
+ * Preview prunes a clone; apply uses one store-sized write transaction and
+ * skips generic session maintenance so non-cron rows stay outside this sweep.
+ */
+export async function runSessionRegistryMaintenanceForStore(
+  params: SessionRegistryMaintenanceStoreOptions,
+): Promise<SessionRegistryMaintenanceStoreSummary> {
+  if (!fs.existsSync(params.storePath)) {
+    return {
+      afterCount: 0,
+      beforeCount: 0,
+      preservedRunning: 0,
+      pruned: 0,
+    };
+  }
+
+  const beforeStore = loadSessionStore(params.storePath, { skipCache: true });
+  const beforeCount = Object.keys(beforeStore).length;
+  if (!params.apply) {
+    const previewStore = structuredClone(beforeStore);
+    return {
+      beforeCount,
+      ...pruneSessionRegistryStore({
+        retentionMs: params.retentionMs,
+        runningCronJobIds: params.runningCronJobIds,
+        store: previewStore,
+      }),
+    };
+  }
+
+  const applied = await updateSessionStore(
+    params.storePath,
+    (store) =>
+      pruneSessionRegistryStore({
+        retentionMs: params.retentionMs,
+        runningCronJobIds: params.runningCronJobIds,
+        store,
+      }),
+    { skipMaintenance: true },
+  );
+  return {
+    beforeCount,
+    ...applied,
+  };
+}

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -35,6 +35,7 @@ describe("session accessor boundary guard", () => {
         "src/commands/sessions.ts",
         "src/commands/status.agent-local.ts",
         "src/commands/status.summary.ts",
+        "src/commands/tasks.ts",
         "src/config/sessions/combined-store-gateway.ts",
         "src/cron/isolated-agent/delivery-target.ts",
         "src/cron/service/timer.ts",
@@ -83,9 +84,10 @@ describe("session accessor boundary guard", () => {
         "src/auto-reply/reply/session-reset-model.ts",
         "src/auto-reply/reply/session-updates.ts",
         "src/auto-reply/reply/session-usage.ts",
+        "src/commands/tasks.ts",
+        "src/config/sessions/cleanup-service.ts",
         "src/plugins/host-hook-cleanup.ts",
         "src/tui/embedded-backend.ts",
-        "src/config/sessions/cleanup-service.ts",
       ]),
     );
   });


### PR DESCRIPTION
## Summary

- Adds a named session-registry maintenance helper for task-owned cron-run session pruning.
- Keeps `openclaw tasks maintenance` responsible for task and flow registry maintenance while delegating each session store prune to the new per-store boundary.
- Preserves dry-run/apply summaries, running cron job preservation, missing-store behavior, retention semantics, and `skipMaintenance` on apply.
- Intentionally leaves SQLite runtime flip, migrations, doctor repair, plugin SDK surfaces, and broader session maintenance ownership out of scope.
- Review focus: whether `runSessionRegistryMaintenanceForStore` is the right transaction-sized boundary for the SQLite follow-up.

## Linked context

Which issue does this close?

Part of #88838

Which issues, PRs, or discussions are related?

Related Pebbles `clawdbot-d02.1.9.1.39`

Was this requested by a maintainer or owner?

Maintainer-delegated OpenClaw Path 3 task.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `openclaw tasks maintenance --apply` no longer owns direct mutable session-store pruning; the prune runs through a named per-store session-registry maintenance helper.
- Real environment tested: Local Codex OpenClaw worktree on macOS, rebased onto `upstream/main` `fdb042b9ce09cdd8a2eff786f779e0f3004d955a` with head `1153f94ef45d0a51daac074b91488f98cef5c875`.
- Exact steps or command run after this patch: seeded disposable `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` with four session rows and two cron jobs through `saveCronStore`; ran `pnpm --silent openclaw tasks maintenance --apply --json`; inspected `agents/main/sessions/sessions.json` afterward. Also ran focused Vitest, boundary guard, oxfmt, oxlint, both tsgo wrappers, `git diff --check`, and `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`.
- Evidence after fix: Real command output reported `runningCronJobs: 1`, `pruned: 1`, store `beforeCount: 4`, `afterCount: 3`, and `preservedRunning: 1`. Focused Vitest passed 3 shards; boundary guard passed; oxfmt check passed; oxlint passed; both tsgo wrappers exited 0; autoreview reported no accepted/actionable findings.
- Observed result after fix: The stale completed cron-run row was removed; the stale running cron-run row, recent cron-run row, and ordinary old non-cron session row were preserved.
- What was not tested: Live Gateway against a real user state directory.
- Proof limitations or environment constraints: The real command proof used disposable local state under `/tmp`; SQLite runtime flip, migrations, and doctor repair remain follow-up work under #88838.
- Before evidence (optional but encouraged): `src/commands/tasks.ts` previously imported `loadSessionStore`, `pruneStaleEntries`, and `updateSessionStore` directly for this maintenance path.

## Tests and validation

- `node scripts/run-vitest.mjs src/config/sessions/session-registry-maintenance.test.ts src/commands/tasks.test.ts test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/check-session-accessor-boundary.mjs`
- `pnpm exec oxfmt --check src/config/sessions/session-registry-maintenance.ts src/config/sessions/session-registry-maintenance.test.ts src/config/sessions.ts src/commands/tasks.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/run-oxlint.mjs src/config/sessions/session-registry-maintenance.ts src/config/sessions/session-registry-maintenance.test.ts src/config/sessions.ts src/commands/tasks.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check upstream/main..HEAD`
- Disposable real command proof: `pnpm --silent openclaw tasks maintenance --apply --json` with isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Regression coverage added in `src/config/sessions/session-registry-maintenance.test.ts`; boundary ratchet updated in `scripts/check-session-accessor-boundary.mjs` and `test/scripts/check-session-accessor-boundary.test.ts`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Preserving the exact task-maintenance pruning semantics while moving the store write behind a helper.

How is that risk mitigated?

Existing command tests still cover task maintenance JSON behavior, and new helper tests cover dry-run/apply, running cron preservation, missing stores, and skip-maintenance preservation of non-cron rows.

## Current review state

What is the next action?

Draft PR ready for maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI and maintainer decision after the rebased branch push. Local focused proof, real disposable command proof, and autoreview are complete.

Which bot or reviewer comments were addressed?

ClawSweeper posted an infrastructure/schema failure rather than actionable code feedback. Local autoreview completed cleanly after rebase.



