### PR TITLE
refactor: add restart recovery lifecycle seam

### DIFF
--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -90,6 +90,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/agents/command/session-store.ts",
   "src/agents/embedded-agent-runner/run.ts",
   "src/agents/embedded-agent-runner/run/attempt.ts",
+  "src/agents/main-session-restart-recovery.ts",
   "src/auto-reply/reply/abort-cutoff.runtime.ts",
   "src/auto-reply/reply/agent-runner-cli-dispatch.ts",
   "src/auto-reply/reply/agent-runner-execution.ts",

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -15,8 +15,8 @@ import {
   resolveAllAgentSessionStoreTargetsSync,
   resolveSessionFilePath,
   resolveSessionTranscriptPathInDir,
-  updateSessionStore,
 } from "../config/sessions.js";
+import { applyRestartRecoveryLifecycle } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
@@ -213,13 +213,13 @@ export async function markRestartAbortedMainSessions(params: {
   }
 
   for (const storePath of storePaths) {
-    await updateSessionStore(
+    const storeResult = await applyRestartRecoveryLifecycle({
       storePath,
-      (store) => {
-        for (const [sessionKey, entry] of Object.entries(store)) {
-          if (!entry) {
-            continue;
-          }
+      requireWriteSuccess: true,
+      update: (entries) => {
+        const replacements: Array<{ sessionKey: string; entry: SessionEntry }> = [];
+        const counts = { marked: 0, skipped: 0 };
+        for (const { sessionKey, entry } of entries) {
           const registeredActiveRuns = listAgentRunsForSession({
             sessionKey,
             sessionId: entry.sessionId,
@@ -248,7 +248,7 @@ export async function markRestartAbortedMainSessions(params: {
             continue;
           }
           if (shouldSkipMainRecovery(entry, sessionKey)) {
-            result.skipped++;
+            counts.skipped++;
             continue;
           }
           const wasRunning = entry.status === "running";
@@ -288,12 +288,14 @@ export async function markRestartAbortedMainSessions(params: {
               : a.runId.localeCompare(b.runId),
           );
           entry.updatedAt = Date.now();
-          store[sessionKey] = entry;
-          result.marked++;
+          replacements.push({ sessionKey, entry });
+          counts.marked++;
         }
+        return { result: counts, replacements };
       },
-      { skipMaintenance: true, requireWriteSuccess: true },
-    );
+    });
+    result.marked += storeResult.marked;
+    result.skipped += storeResult.skipped;
   }
 
   if (result.marked > 0) {
@@ -327,18 +329,17 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
     providedActiveSessionKeys ?? normalizeStringSet(listActiveEmbeddedRunSessionKeys());
 
   for (const storePath of await resolveRestartRecoveryStorePaths(params)) {
-    await updateSessionStore(
+    const storeResult = await applyRestartRecoveryLifecycle({
       storePath,
-      (store) => {
-        for (const [sessionKey, entry] of Object.entries(store)) {
-          if (!entry) {
-            continue;
-          }
+      update: (entries) => {
+        const replacements: Array<{ sessionKey: string; entry: SessionEntry }> = [];
+        const counts = { marked: 0, skipped: 0 };
+        for (const { sessionKey, entry } of entries) {
           if (entry.status !== "running" || entry.abortedLastRun === true) {
             continue;
           }
           if (shouldSkipMainRecovery(entry, sessionKey)) {
-            result.skipped++;
+            counts.skipped++;
             continue;
           }
           const updatedAt = normalizeFiniteTimestamp(entry.updatedAt);
@@ -361,12 +362,14 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
           }
           entry.abortedLastRun = true;
           entry.updatedAt = Date.now();
-          store[sessionKey] = entry;
-          result.marked++;
+          replacements.push({ sessionKey, entry });
+          counts.marked++;
         }
+        return { result: counts, replacements };
       },
-      { skipMaintenance: true },
-    );
+    });
+    result.marked += storeResult.marked;
+    result.skipped += storeResult.skipped;
   }
 
   if (result.marked > 0) {
@@ -438,12 +441,13 @@ async function markSessionFailed(params: {
   sessionKey: string;
   reason: string;
 }): Promise<void> {
-  await updateSessionStore(
-    params.storePath,
-    (store) => {
-      const entry = store[params.sessionKey];
+  await applyRestartRecoveryLifecycle({
+    storePath: params.storePath,
+    update: (entries) => {
+      const current = entries.find((entry) => entry.sessionKey === params.sessionKey);
+      const entry = current?.entry;
       if (!entry || entry.status !== "running") {
-        return;
+        return { result: undefined };
       }
       entry.status = "failed";
       entry.abortedLastRun = true;
@@ -458,10 +462,12 @@ async function markSessionFailed(params: {
       entry.pendingFinalDeliveryContext = undefined;
       entry.restartRecoveryDeliveryContext = undefined;
       entry.restartRecoveryDeliveryRunId = undefined;
-      store[params.sessionKey] = entry;
+      return {
+        result: undefined,
+        replacements: [{ sessionKey: params.sessionKey, entry }],
+      };
     },
-    { skipMaintenance: true },
-  );
+  });
   log.warn(`marked interrupted main session failed: ${params.sessionKey} (${params.reason})`);
 }
 
@@ -594,12 +600,13 @@ async function resumeMainSession(params: {
       params: agentParams,
       timeoutMs: 10_000,
     });
-    await updateSessionStore(
-      params.storePath,
-      (store) => {
-        const entry = store[params.sessionKey];
+    await applyRestartRecoveryLifecycle({
+      storePath: params.storePath,
+      update: (entries) => {
+        const current = entries.find((entry) => entry.sessionKey === params.sessionKey);
+        const entry = current?.entry;
         if (!entry) {
-          return;
+          return { result: undefined };
         }
         const now = Date.now();
         entry.abortedLastRun = false;
@@ -621,10 +628,12 @@ async function resumeMainSession(params: {
             entry.pendingFinalDeliveryContext = undefined;
           }
         }
-        store[params.sessionKey] = entry;
+        return {
+          result: undefined,
+          replacements: [{ sessionKey: params.sessionKey, entry }],
+        };
       },
-      { skipMaintenance: true },
-    );
+    });
     log.info(
       `resumed interrupted main session: ${params.sessionKey}${
         sanitizedPendingText ? " (with pending payload)" : ""
@@ -653,15 +662,17 @@ export async function markRestartAbortedMainSessionsFromLocks(params: {
   }
 
   const storePath = path.join(sessionsDir, "sessions.json");
-  await updateSessionStore(
+  const storeResult = await applyRestartRecoveryLifecycle({
     storePath,
-    (store) => {
-      for (const [sessionKey, entry] of Object.entries(store)) {
-        if (!entry || entry.status !== "running") {
+    update: (entries) => {
+      const replacements: Array<{ sessionKey: string; entry: SessionEntry }> = [];
+      const counts = { marked: 0, skipped: 0 };
+      for (const { sessionKey, entry } of entries) {
+        if (entry.status !== "running") {
           continue;
         }
         if (shouldSkipMainRecovery(entry, sessionKey)) {
-          result.skipped++;
+          counts.skipped++;
           continue;
         }
         const entryLockPaths = resolveEntryTranscriptLockPaths({ entry, sessionsDir });
@@ -669,12 +680,14 @@ export async function markRestartAbortedMainSessionsFromLocks(params: {
           continue;
         }
         entry.abortedLastRun = true;
-        store[sessionKey] = entry;
-        result.marked++;
+        replacements.push({ sessionKey, entry });
+        counts.marked++;
       }
+      return { result: counts, replacements };
     },
-    { skipMaintenance: true },
-  );
+  });
+  result.marked += storeResult.marked;
+  result.skipped += storeResult.skipped;
 
   if (result.marked > 0) {
     log.warn(`marked ${result.marked} interrupted main session(s) from stale transcript locks`);

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
+  applyRestartRecoveryLifecycle,
   appendTranscriptMessage,
   appendTranscriptEvent,
   applySessionEntryLifecycleMutation,
@@ -445,6 +446,62 @@ describe("session accessor file-backed seam", () => {
       "agent:main:main": expect.objectContaining({
         sessionId: "legacy-session",
       }),
+    });
+  });
+
+  it("applies restart recovery replacements without exposing mutable store rows", async () => {
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:main": {
+            sessionId: "session-1",
+            status: "running",
+            updatedAt: 10,
+          },
+          "agent:main:other": {
+            sessionId: "session-2",
+            status: "running",
+            updatedAt: 20,
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = await applyRestartRecoveryLifecycle({
+      storePath,
+      update: (entries) => {
+        const main = entries.find((entry) => entry.sessionKey === "agent:main:main");
+        const other = entries.find((entry) => entry.sessionKey === "agent:main:other");
+        if (other) {
+          other.entry.status = "failed";
+        }
+        if (!main) {
+          return { result: { replaced: false } };
+        }
+        main.entry.abortedLastRun = true;
+        main.entry.updatedAt = 30;
+        return {
+          result: { replaced: true },
+          replacements: [{ sessionKey: main.sessionKey, entry: main.entry }],
+        };
+      },
+    });
+
+    expect(result).toEqual({ replaced: true });
+    const store = loadSessionStore(storePath);
+    expect(store["agent:main:main"]).toMatchObject({
+      abortedLastRun: true,
+      sessionId: "session-1",
+      updatedAt: 30,
+    });
+    expect(store["agent:main:other"]).toMatchObject({
+      sessionId: "session-2",
+      status: "running",
+      updatedAt: 20,
     });
   });
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -286,6 +286,27 @@ export type SessionEntryPatchContext = {
   existingEntry?: SessionEntry;
 };
 
+export type RestartRecoveryLifecycleEntry = {
+  /** Exact persisted key for the restart recovery candidate row. */
+  sessionKey: string;
+  /** Detached entry snapshot; mutating it does not persist unless returned as a replacement. */
+  entry: SessionEntry;
+};
+
+export type RestartRecoveryLifecycleReplacement = {
+  /** Exact persisted key to replace. Missing keys are ignored. */
+  sessionKey: string;
+  /** Full replacement row to persist for this restart recovery lifecycle step. */
+  entry: SessionEntry;
+};
+
+export type RestartRecoveryLifecycleUpdate<T> = {
+  /** Caller-owned result returned after replacements are persisted. */
+  result: T;
+  /** Exact rows to replace inside the storage transaction. */
+  replacements?: Iterable<RestartRecoveryLifecycleReplacement>;
+};
+
 export type SessionEntryCreateWithTranscriptContext = {
   /** Current entry under the requested key before creation, if any. */
   existingEntry?: SessionEntry;
@@ -587,6 +608,46 @@ export async function applySessionPatchProjection<
   ) => Promise<SessionPatchProjectionResult<TFailure>> | SessionPatchProjectionResult<TFailure>;
 }): Promise<SessionPatchProjectionResult<TFailure>> {
   return await applyFileSessionEntryPatchProjection(params);
+}
+
+/**
+ * Applies restart-recovery lifecycle replacements without exposing the backing
+ * store shape. The file backend runs selection and replacement under one writer
+ * lock; the SQLite backend can map the same callback to a transaction.
+ */
+export async function applyRestartRecoveryLifecycle<T>(params: {
+  storePath: string;
+  update: (
+    entries: RestartRecoveryLifecycleEntry[],
+  ) => Promise<RestartRecoveryLifecycleUpdate<T>> | RestartRecoveryLifecycleUpdate<T>;
+  requireWriteSuccess?: boolean;
+  skipMaintenance?: boolean;
+}): Promise<T> {
+  const writerResult = await updateSessionStore(
+    params.storePath,
+    async (store) => {
+      const entries = Object.entries(store).map(([sessionKey, entry]) => ({
+        sessionKey,
+        entry: structuredClone(entry),
+      }));
+      const operation = await params.update(entries);
+      let changed = false;
+      for (const replacement of operation.replacements ?? []) {
+        if (!Object.hasOwn(store, replacement.sessionKey)) {
+          continue;
+        }
+        store[replacement.sessionKey] = structuredClone(replacement.entry);
+        changed = true;
+      }
+      return { changed, result: operation.result };
+    },
+    {
+      requireWriteSuccess: params.requireWriteSuccess,
+      skipMaintenance: params.skipMaintenance ?? true,
+      skipSaveWhenResult: (result) => !result.changed,
+    },
+  );
+  return writerResult.result;
 }
 
 /** Removes entries and orphan transcript artifacts owned by a named session lifecycle. */

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -65,6 +65,7 @@ describe("session accessor boundary guard", () => {
         "src/agents/command/session-store.ts",
         "src/agents/embedded-agent-runner/run.ts",
         "src/agents/embedded-agent-runner/run/attempt.ts",
+        "src/agents/main-session-restart-recovery.ts",
         "src/auto-reply/reply/abort-cutoff.runtime.ts",
         "src/auto-reply/reply/agent-runner-cli-dispatch.ts",
         "src/auto-reply/reply/agent-runner-execution.ts",


### PR DESCRIPTION
## Summary

- Adds a storage-neutral restart-recovery lifecycle accessor for row replacement work.
- Migrates main-session restart recovery write paths off direct whole-store writer calls.
- Preserves current file-backed restart lock, startup orphan, failed-session, resume, pending-final-delivery, and stale-lock behavior.
- Adds ratchet coverage so migrated restart-recovery code cannot reintroduce legacy session store writers.
- Intentionally out of scope: SQLite runtime flip, JSON fallback, doctor migration, plugin SDK surface, and broader restart recovery cleanup.

## Linked context

Related #88838

Requested by maintainer Path 3 task `clawdbot-d02.1.9.1.36`.

## Real behavior proof

Behavior addressed: Main-session restart recovery lifecycle writes go through the storage-neutral accessor seam while preserving file-backed stale-lock restart behavior.

Real environment tested: Local OpenClaw LaunchAgent Gateway on macOS from SHA d58eb87e9802698661d3733c9d84b4645b9d2054, OpenClaw 2026.6.8, gateway port 18789, LaunchAgent pid 79932 after restart.

Exact steps or command run after this patch:

```bash
pnpm build
pnpm openclaw --version
# Seeded one synthetic live main-agent row and stale transcript lock:
# session key: agent:main:proof-93735-20260617201822
# store: $OPENCLAW_STATE_DIR/agents/main/sessions/sessions.json
# transcript: $OPENCLAW_STATE_DIR/agents/main/sessions/proof-93735-20260617201822.jsonl
# backup: /tmp/openclaw-pr-93735-proof-93735-20260617201822-sessions.backup.json
pnpm openclaw gateway restart
pnpm openclaw gateway health --json
pnpm openclaw gateway status --json
# Waited 10 seconds for the restart-recovery sidecar, inspected the seeded row and lock, then removed the seeded row/transcript/lock.
```

Evidence after fix: Gateway restarted LaunchAgent pid 79932 from the rebuilt dist; /healthz returned ok=true in 65ms with 11 plugins loaded; gateway status RPC was ok and reported OpenClaw 2026.6.8 from SHA d58eb87. The seeded restart-recovery row changed from status=running with a stale .jsonl.lock to status=failed, abortedLastRun=true, endedAt and updatedAt persisted as numbers, and lockExists=false. Cleanup verification after proof returned rowExists=false, transcriptExists=false, and lockExists=false.

Observed result after fix: The real Gateway startup stale-lock sweep exercised the migrated restart-recovery accessor path and persisted the expected restart-recovery failure marker without leaving the proof fixture behind.

What was not tested: SQLite runtime flip, doctor migration, plugin SDK compatibility, and a real interrupted model turn with provider output; this PR remains a file-backed lifecycle seam slice.

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/agents/main-session-restart-recovery.test.ts test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/check-session-accessor-boundary.mjs`
- `node scripts/run-oxlint.mjs src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/agents/main-session-restart-recovery.ts test/scripts/check-session-accessor-boundary.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/agents/main-session-restart-recovery.ts scripts/check-session-accessor-boundary.mjs test/scripts/check-session-accessor-boundary.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

Regression coverage added:

- Accessor seam test proving restart-recovery replacement rows are detached and only explicit replacements persist.
- Boundary ratchet coverage for `src/agents/main-session-restart-recovery.ts`.

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: Restart recovery can affect interrupted main-session resume/failure state.

Risk mitigation: The existing restart recovery regression suite still passes, and the accessor preserves writer-lock, skip-maintenance, require-write-success, pending-final-delivery, stale/current-row, and exact-key replacement semantics.

## Current review state

Next action: Draft review.

Still waiting on: Maintainer review and CI.

Bot/reviewer comments addressed: None yet.

SQLite follow-up: implement the same `applyRestartRecoveryLifecycle` semantics as transaction-sized row selection/replacement in the SQLite session accessor backend when the runtime flip slice reaches restart recovery.




