### PR TITLE
[codex] fix Feishu reply footer rendering

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -191,6 +191,27 @@ openclaw pairing list feishu
 Feishu/Lark does not support native slash-command menus, so send these as plain text messages.
 </Note>
 
+## Reply card footer
+
+Enable `channels.feishu.footer` to append runtime state to the final footer note on Feishu cards, including streaming-card completions:
+
+```json5
+{
+  channels: {
+    feishu: {
+      footer: {
+        status: true,
+        elapsed: true,
+      },
+    },
+  },
+}
+```
+
+- `status: true` adds `已完成`, `出错`, or `已停止`
+- `elapsed: true` adds `耗时 X.Xs`
+- Built-in agent/model/provider footer text is preserved after the runtime segments
+
 ---
 
 ## Troubleshooting

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -299,6 +299,40 @@ describe("FeishuConfigSchema actions", () => {
   });
 });
 
+describe("FeishuConfigSchema footer", () => {
+  it("accepts top-level footer runtime flags", () => {
+    const result = FeishuConfigSchema.parse({
+      footer: {
+        status: true,
+        elapsed: true,
+      },
+    });
+
+    expect(result.footer).toEqual({
+      status: true,
+      elapsed: true,
+    });
+  });
+
+  it("accepts account-level footer runtime flags", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: {
+          footer: {
+            status: true,
+            elapsed: false,
+          },
+        },
+      },
+    });
+
+    expect(result.accounts?.main?.footer).toEqual({
+      status: true,
+      elapsed: false,
+    });
+  });
+});
+
 describe("FeishuConfigSchema defaultAccount", () => {
   it("accepts defaultAccount when it matches an account key", () => {
     const result = FeishuConfigSchema.safeParse({

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -88,6 +88,14 @@ const ChannelHeartbeatVisibilitySchema = z
   .strict()
   .optional();
 
+const FooterConfigSchema = z
+  .object({
+    status: z.boolean().optional(),
+    elapsed: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 /**
  * Dynamic agent creation configuration.
  * When enabled, a new agent is created for each unique DM user.
@@ -197,6 +205,7 @@ const FeishuSharedConfigShape = {
   mediaMaxMb: z.number().positive().optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
+  footer: FooterConfigSchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1580,6 +1580,130 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("renders configured footer status and elapsed on streaming card close", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+        footer: {
+          status: true,
+          elapsed: true,
+        },
+      },
+    });
+
+    try {
+      const { options } = createDispatcherHarness({
+        runtime: createRuntimeLogger(),
+      });
+      await options.onReplyStart?.();
+      vi.setSystemTime(13_300);
+      await options.deliver({ text: "final answer" }, { kind: "final" });
+      await options.onIdle?.();
+
+      expect(streamingInstances[0].close).toHaveBeenCalledWith("final answer", {
+        note: "已完成 | 耗时 12.3s | Agent: agent",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders configured stopped footer on abort replies", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+        footer: {
+          status: true,
+        },
+      },
+    });
+
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.onReplyStart?.();
+    await options.deliver({ text: "⚙️ Agent was aborted." }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("⚙️ Agent was aborted.", {
+      note: "已停止 | Agent: agent",
+    });
+  });
+
+  it("renders configured error footer on final error cards", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(5_000);
+
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: false,
+        footer: {
+          status: true,
+          elapsed: true,
+        },
+      },
+    });
+
+    try {
+      const { options } = createDispatcherHarness({
+        runtime: createRuntimeLogger(),
+      });
+      await options.onReplyStart?.();
+      vi.setSystemTime(7_500);
+      await options.deliver({ text: "Something broke", isError: true }, { kind: "final" });
+
+      expectLastMockArgFields(sendStructuredCardFeishuMock, "structured card params", {
+        note: "出错 | 耗时 2.5s | Agent: agent",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps non-final static cards on the base footer note", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: false,
+        footer: {
+          status: true,
+          elapsed: true,
+        },
+      },
+    });
+
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.deliver({ text: "tool summary" }, { kind: "tool" });
+
+    expectLastMockArgFields(sendStructuredCardFeishuMock, "structured card params", {
+      note: "Agent: agent",
+    });
+  });
+
   it("shows raw command detail in streaming card tool status", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -41,6 +41,7 @@ const MS_EPOCH_MIN = 1_000_000_000_000;
 const STREAMING_START_FAILURE_BACKOFF_MS = 60_000;
 const NO_VISIBLE_REPLY_FALLBACK_TEXT =
   "⚠️ This reply completed without visible content. The turn may have been interrupted; please retry or ask me to recover from recent context.";
+const ABORT_REPLY_TEXT_PREFIX = "⚙️ Agent was aborted.";
 const streamingStartBackoffUntilByAccount = new Map<string, number>();
 
 function isStreamingStartBackedOff(accountId: string, now = Date.now()): boolean {
@@ -65,6 +66,10 @@ function formatMediaFallbackText(text: string | undefined, mediaUrl: string): st
   const trimmedText = text?.trim() ?? "";
   const attachmentText = `📎 ${mediaUrl}`;
   return trimmedText ? `${trimmedText}\n\n${attachmentText}` : attachmentText;
+}
+
+function formatFooterElapsed(durationMs: number): string {
+  return `${(durationMs / 1000).toFixed(1)}s`;
 }
 
 export function clearFeishuStreamingStartBackoffForTests() {
@@ -112,6 +117,19 @@ function resolveCardNote(
     parts.push(`Provider: ${prefixCtx.provider}`);
   }
   return parts.join(" | ");
+}
+
+function resolveFooterStatusText(
+  payload: ReplyPayload | undefined,
+  text: string | undefined,
+): string {
+  if (payload?.isError === true) {
+    return "出错";
+  }
+  if ((text ?? "").startsWith(ABORT_REPLY_TEXT_PREFIX)) {
+    return "已停止";
+  }
+  return "已完成";
 }
 
 type CreateFeishuReplyDispatcherParams = {
@@ -258,6 +276,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let skippedFinalReason: string | null = null;
   let idleSideEffectsPromise: Promise<void> = Promise.resolve();
   let replyLifecycleStateInitialized = false;
+  let replyStartedAtMs: number | undefined;
+  let finalNoteContext:
+    | {
+        payload?: ReplyPayload;
+        text?: string;
+      }
+    | undefined;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
   const markVisibleReplySent = () => {
@@ -371,7 +396,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       );
       try {
         const cardHeader = resolveCardHeader(agentId, identity);
-        const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+        const cardNote = resolveResolvedCardNote();
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId,
           replyInThread: effectiveReplyInThread,
@@ -403,6 +428,46 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     statusLine = "";
     snapshotBaseText = "";
     lastSnapshotTextLength = 0;
+    finalNoteContext = undefined;
+  };
+
+  const initializeReplyLifecycleState = () => {
+    if (!replyLifecycleStateInitialized) {
+      replyLifecycleStateInitialized = true;
+      deliveredFinalTexts.clear();
+      streamingClosedForReply = false;
+      streamingCloseErroredForReply = false;
+      visibleReplySent = false;
+      skippedFinalReason = null;
+      replyStartedAtMs = Date.now();
+      finalNoteContext = undefined;
+      return;
+    }
+    replyStartedAtMs ??= Date.now();
+  };
+
+  const resolveResolvedCardNote = (noteContext?: {
+    payload?: ReplyPayload;
+    text?: string;
+  }): string => {
+    const baseNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+    if (!noteContext) {
+      return baseNote;
+    }
+    const footer = account.config?.footer;
+    if (!footer?.status && !footer?.elapsed) {
+      return baseNote;
+    }
+
+    const segments: string[] = [];
+    if (footer.status) {
+      segments.push(resolveFooterStatusText(noteContext?.payload, noteContext?.text));
+    }
+    if (footer.elapsed && replyStartedAtMs !== undefined) {
+      segments.push(`耗时 ${formatFooterElapsed(Math.max(0, Date.now() - replyStartedAtMs))}`);
+    }
+    segments.push(baseNote);
+    return segments.join(" | ");
   };
 
   const closeStreaming = async (options?: { markClosedForReply?: boolean }) => {
@@ -414,7 +479,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (streaming?.isActive()) {
         statusLine = "";
         const text = buildCombinedStreamText(reasoningText, streamText);
-        const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+        const finalNote = resolveResolvedCardNote(finalNoteContext);
         const contentVisible = await streaming.close(text, { note: finalNote });
         // Track the raw streamed text so the duplicate-final check in deliver()
         // can skip the redundant text delivery that arrives after onIdle closes
@@ -608,22 +673,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         }
       },
       onReplyStart: async () => {
-        if (!replyLifecycleStateInitialized) {
-          replyLifecycleStateInitialized = true;
-          deliveredFinalTexts.clear();
-          streamingClosedForReply = false;
-          streamingCloseErroredForReply = false;
-          visibleReplySent = false;
-          skippedFinalReason = null;
-        }
+        initializeReplyLifecycleState();
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
         await Promise.resolve(typingCallbacks?.onReplyStart?.());
       },
       deliver: async (payload: ReplyPayload, info) => {
+        initializeReplyLifecycleState();
         if (info?.kind === "final") {
           skippedFinalReason = null;
+          finalNoteContext = {
+            payload,
+            text: payload.text,
+          };
         }
         const payloadText =
           payload.isReasoning && payload.text ? formatReasoningMessage(payload.text) : payload.text;
@@ -722,7 +785,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
           if (useCard) {
             const cardHeader = resolveCardHeader(agentId, identity);
-            const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+            const cardNote = resolveResolvedCardNote(
+              info?.kind === "final" ? { payload, text } : undefined,
+            );
             await sendChunkedTextReply({
               text,
               useCard: true,


### PR DESCRIPTION
## Summary
- add `channels.feishu.footer.status` and `channels.feishu.footer.elapsed` to the built-in Feishu config schema
- render configured footer runtime segments on final static cards and streaming-card closeout while preserving the existing agent/model/provider note
- document the built-in Feishu footer options and cover completed, error, stopped, and non-final note behavior with regression tests

## Why
The built-in Feishu channel already supported note rendering on cards, but it never consumed a footer config surface or translated reply outcomes into footer text. That meant users could enable footer settings without seeing runtime status or elapsed time on final Feishu replies.

## Verification
- `node scripts/run-vitest.mjs extensions/feishu/src/config-schema.test.ts`
- `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts`
- `git diff --check HEAD^ HEAD`
