### PR TITLE
refactor: add session maintenance transaction seam

### DIFF
--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -1,0 +1,303 @@
+// Storage-neutral session maintenance operations for the file-backed session store.
+import path from "node:path";
+import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
+import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
+import {
+  capEntryCount,
+  getActiveSessionMaintenanceWarning,
+  pruneQuotaSuspensions,
+  pruneStaleEntries,
+  shouldRunSessionEntryMaintenance,
+  type QuotaSuspensionMaintenanceResult,
+  type ResolvedSessionMaintenanceConfig,
+  type SessionMaintenanceWarning,
+} from "./store-maintenance.js";
+import type { SessionEntry } from "./types.js";
+
+export type SessionMaintenanceApplyReport = {
+  mode: ResolvedSessionMaintenanceConfig["mode"];
+  beforeCount: number;
+  afterCount: number;
+  pruned: number;
+  capped: number;
+  diskBudget: SessionDiskBudgetSweepResult | null;
+};
+
+type SessionMaintenanceLogger = {
+  warn: (message: string, context?: Record<string, unknown>) => void;
+  info: (message: string, context?: Record<string, unknown>) => void;
+};
+
+type RemovedSessionFiles = Map<string, string | undefined>;
+
+type RemovedSessionArtifactCleanup = {
+  archiveRemovedSessionTranscripts: (params: {
+    removedSessionFiles: Iterable<[string, string | undefined]>;
+    referencedSessionIds: ReadonlySet<string>;
+    storePath: string;
+    reason: "deleted";
+    restrictToStoreDir: true;
+  }) => Promise<Set<string>>;
+  removeRemovedSessionTrajectoryArtifacts: (params: {
+    removedSessionFiles: RemovedSessionFiles;
+    referencedSessionIds: ReadonlySet<string>;
+    storePath: string;
+    restrictToStoreDir: true;
+  }) => Promise<void>;
+  cleanupArchivedSessionTranscripts: (params: {
+    directories: string[];
+    rules: Array<{ reason: "deleted" | "reset"; olderThanMs: number }>;
+  }) => Promise<void>;
+};
+
+export type FileBackedSessionStoreMaintenanceParams = {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  activeSessionKey?: string;
+  onWarn?: (warning: SessionMaintenanceWarning) => void | Promise<void>;
+  onMaintenanceApplied?: (report: SessionMaintenanceApplyReport) => void | Promise<void>;
+  maintenanceOverride?: Partial<ResolvedSessionMaintenanceConfig>;
+  maintenanceConfig?: ResolvedSessionMaintenanceConfig;
+  log: SessionMaintenanceLogger;
+  artifacts: RemovedSessionArtifactCleanup;
+};
+
+export type FileBackedSessionStoreMaintenanceResult = {
+  changedStore: boolean;
+};
+
+function resolveMaintenanceForOperation(
+  params: Pick<
+    FileBackedSessionStoreMaintenanceParams,
+    "maintenanceConfig" | "maintenanceOverride"
+  >,
+): ResolvedSessionMaintenanceConfig {
+  return params.maintenanceConfig
+    ? { ...params.maintenanceConfig, ...params.maintenanceOverride }
+    : { ...resolveMaintenanceConfig(), ...params.maintenanceOverride };
+}
+
+function collectReferencedSessionIds(store: Record<string, SessionEntry>): Set<string> {
+  return new Set(
+    Object.values(store)
+      .map((entry) => entry?.sessionId)
+      .filter((id): id is string => Boolean(id)),
+  );
+}
+
+function rememberRemovedSessionFile(
+  removedSessionFiles: RemovedSessionFiles,
+  entry: SessionEntry,
+): void {
+  if (!removedSessionFiles.has(entry.sessionId) || entry.sessionFile) {
+    removedSessionFiles.set(entry.sessionId, entry.sessionFile);
+  }
+}
+
+async function applyWarnOnlyMaintenance(params: {
+  operation: FileBackedSessionStoreMaintenanceParams;
+  maintenance: ResolvedSessionMaintenanceConfig;
+  beforeCount: number;
+  shouldRunEntryMaintenance: boolean;
+}): Promise<void> {
+  const activeSessionKey = params.operation.activeSessionKey?.trim();
+  if (activeSessionKey && params.shouldRunEntryMaintenance) {
+    const warning = getActiveSessionMaintenanceWarning({
+      store: params.operation.store,
+      activeSessionKey,
+      pruneAfterMs: params.maintenance.pruneAfterMs,
+      maxEntries: params.maintenance.maxEntries,
+    });
+    if (warning) {
+      params.operation.log.warn(
+        "session maintenance would evict active session; skipping enforcement",
+        {
+          activeSessionKey: warning.activeSessionKey,
+          wouldPrune: warning.wouldPrune,
+          wouldCap: warning.wouldCap,
+          pruneAfterMs: warning.pruneAfterMs,
+          maxEntries: warning.maxEntries,
+        },
+      );
+      await params.operation.onWarn?.(warning);
+    }
+  }
+  const diskBudget = await enforceSessionDiskBudget({
+    store: params.operation.store,
+    storePath: params.operation.storePath,
+    activeSessionKey: params.operation.activeSessionKey,
+    maintenance: params.maintenance,
+    warnOnly: true,
+    log: params.operation.log,
+  });
+  await params.operation.onMaintenanceApplied?.({
+    mode: params.maintenance.mode,
+    beforeCount: params.beforeCount,
+    afterCount: Object.keys(params.operation.store).length,
+    pruned: 0,
+    capped: 0,
+    diskBudget,
+  });
+}
+
+async function cleanupRemovedSessionArtifacts(params: {
+  operation: FileBackedSessionStoreMaintenanceParams;
+  maintenance: ResolvedSessionMaintenanceConfig;
+  removedSessionFiles: RemovedSessionFiles;
+  referencedSessionIds: ReadonlySet<string>;
+}): Promise<void> {
+  // SQLite should commit entry-retention rows before this named artifact cleanup.
+  // The cleanup needs the final referenced-session set so shared transcripts and
+  // trajectory sidecars survive until the last referring row is gone.
+  const archivedDirs = await params.operation.artifacts.archiveRemovedSessionTranscripts({
+    removedSessionFiles: params.removedSessionFiles,
+    referencedSessionIds: params.referencedSessionIds,
+    storePath: params.operation.storePath,
+    reason: "deleted",
+    restrictToStoreDir: true,
+  });
+  if (params.removedSessionFiles.size > 0) {
+    await params.operation.artifacts.removeRemovedSessionTrajectoryArtifacts({
+      removedSessionFiles: params.removedSessionFiles,
+      referencedSessionIds: params.referencedSessionIds,
+      storePath: params.operation.storePath,
+      restrictToStoreDir: true,
+    });
+  }
+  if (archivedDirs.size === 0 && params.maintenance.resetArchiveRetentionMs == null) {
+    return;
+  }
+  const targetDirs =
+    archivedDirs.size > 0
+      ? [...archivedDirs]
+      : [path.dirname(path.resolve(params.operation.storePath))];
+  // Both retention reasons ride one cleanup call so each save enumerates the
+  // sessions dir at most once; reset retention defaults on, so a listing per
+  // reason would scan twice per save.
+  await params.operation.artifacts.cleanupArchivedSessionTranscripts({
+    directories: targetDirs,
+    rules:
+      params.maintenance.resetArchiveRetentionMs != null
+        ? [
+            { reason: "deleted", olderThanMs: params.maintenance.pruneAfterMs },
+            { reason: "reset", olderThanMs: params.maintenance.resetArchiveRetentionMs },
+          ]
+        : [{ reason: "deleted", olderThanMs: params.maintenance.pruneAfterMs }],
+  });
+}
+
+async function applyEnforcedMaintenance(params: {
+  operation: FileBackedSessionStoreMaintenanceParams;
+  maintenance: ResolvedSessionMaintenanceConfig;
+  beforeCount: number;
+  forceMaintenance: boolean;
+}): Promise<FileBackedSessionStoreMaintenanceResult> {
+  const preserveSessionKeys = collectSessionMaintenancePreserveKeys([
+    params.operation.activeSessionKey,
+  ]);
+  const removedSessionFiles = new Map<string, string | undefined>();
+  const pruned = pruneStaleEntries(params.operation.store, params.maintenance.pruneAfterMs, {
+    onPruned: ({ entry }) => {
+      rememberRemovedSessionFile(removedSessionFiles, entry);
+    },
+    preserveKeys: preserveSessionKeys,
+  });
+  const countAfterPrune = Object.keys(params.operation.store).length;
+  const shouldRunCapMaintenance =
+    params.forceMaintenance ||
+    shouldRunSessionEntryMaintenance({
+      entryCount: countAfterPrune,
+      maxEntries: params.maintenance.maxEntries,
+    });
+  const capped = shouldRunCapMaintenance
+    ? capEntryCount(params.operation.store, params.maintenance.maxEntries, {
+        onCapped: ({ entry }) => {
+          rememberRemovedSessionFile(removedSessionFiles, entry);
+        },
+        preserveKeys: preserveSessionKeys,
+      })
+    : 0;
+  const referencedSessionIds = collectReferencedSessionIds(params.operation.store);
+  await cleanupRemovedSessionArtifacts({
+    operation: params.operation,
+    maintenance: params.maintenance,
+    removedSessionFiles,
+    referencedSessionIds,
+  });
+
+  // Disk-budget eviction is its own transaction-sized boundary: it may delete
+  // additional rows plus owned artifacts after prune/cap has settled, while
+  // preserving the active session and protected runtime-provided keys.
+  const diskBudget = await enforceSessionDiskBudget({
+    store: params.operation.store,
+    storePath: params.operation.storePath,
+    activeSessionKey: params.operation.activeSessionKey,
+    preserveKeys: preserveSessionKeys,
+    maintenance: params.maintenance,
+    warnOnly: false,
+    log: params.operation.log,
+  });
+  await params.operation.onMaintenanceApplied?.({
+    mode: params.maintenance.mode,
+    beforeCount: params.beforeCount,
+    afterCount: Object.keys(params.operation.store).length,
+    pruned,
+    capped,
+    diskBudget,
+  });
+  return {
+    changedStore: pruned > 0 || capped > 0 || (diskBudget?.removedEntries ?? 0) > 0,
+  };
+}
+
+/**
+ * Applies automatic session-store maintenance to the in-memory file-store image.
+ *
+ * Future SQLite adapters should map this into named boundaries: entry retention,
+ * removed-session artifact cleanup, disk-budget eviction, and archive retention cleanup.
+ */
+export async function applyFileBackedSessionStoreMaintenance(
+  params: FileBackedSessionStoreMaintenanceParams,
+): Promise<FileBackedSessionStoreMaintenanceResult> {
+  const maintenance = resolveMaintenanceForOperation(params);
+  const beforeCount = Object.keys(params.store).length;
+  const forceMaintenance = params.maintenanceOverride !== undefined;
+  const shouldRunEntryMaintenance = shouldRunSessionEntryMaintenance({
+    entryCount: beforeCount,
+    maxEntries: maintenance.maxEntries,
+    force: forceMaintenance,
+  });
+
+  if (maintenance.mode === "warn") {
+    await applyWarnOnlyMaintenance({
+      operation: params,
+      maintenance,
+      beforeCount,
+      shouldRunEntryMaintenance,
+    });
+    return { changedStore: false };
+  }
+
+  return await applyEnforcedMaintenance({
+    operation: params,
+    maintenance,
+    beforeCount,
+    forceMaintenance,
+  });
+}
+
+/**
+ * Applies quota-suspension TTL maintenance to a store image.
+ *
+ * SQLite should implement this as a row transaction that returns the resumed
+ * lane records and clear count before callers resume in-process quota lanes.
+ */
+export function applyQuotaSuspensionTtlMaintenance(params: {
+  store: Record<string, SessionEntry>;
+  now: number;
+  ttlMs?: number;
+  log?: boolean;
+}): QuotaSuspensionMaintenanceResult {
+  return pruneQuotaSuspensions(params);
+}

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -3,6 +3,10 @@ import crypto from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import {
+  applyFileBackedSessionStoreMaintenance,
+  applyQuotaSuspensionTtlMaintenance,
+} from "./store-maintenance-operations.js";
+import {
   collectSessionMaintenancePreserveKeys,
   registerSessionMaintenancePreserveKeysProvider,
 } from "./store-maintenance-preserve.js";
@@ -141,6 +145,128 @@ describe("resolveQuotaSuspensionEntryMaintenance", () => {
       patch: { quotaSuspension: undefined },
       cleared: true,
     });
+  });
+});
+
+describe("applyQuotaSuspensionTtlMaintenance", () => {
+  it("returns whole-store resume and clear results from the storage-neutral operation", () => {
+    const now = Date.now();
+    const store = makeStore([
+      [
+        "suspended",
+        {
+          ...makeEntry(now),
+          quotaSuspension: {
+            schemaVersion: 1,
+            suspendedAt: now - 30_000,
+            expectedResumeBy: now - 1,
+            state: "suspended",
+            reason: "quota_exhausted",
+            failedProvider: "anthropic",
+            failedModel: "claude-opus-4-6",
+            laneId: "main",
+          },
+        },
+      ],
+      [
+        "expired",
+        {
+          ...makeEntry(now),
+          quotaSuspension: {
+            schemaVersion: 1,
+            suspendedAt: now - 61_000,
+            expectedResumeBy: now - 31_000,
+            state: "active",
+            reason: "circuit_open",
+            failedProvider: "anthropic",
+            failedModel: "claude-opus-4-6",
+            laneId: "fallback",
+          },
+        },
+      ],
+    ]);
+
+    const result = applyQuotaSuspensionTtlMaintenance({
+      store,
+      now,
+      ttlMs: 30_000,
+      log: false,
+    });
+
+    expect(result).toEqual({ resumed: [{ sessionKey: "suspended", laneId: "main" }], cleared: 1 });
+    expect(store.suspended.quotaSuspension?.state).toBe("resuming");
+    expect(store.expired.quotaSuspension).toBeUndefined();
+  });
+});
+
+describe("applyFileBackedSessionStoreMaintenance", () => {
+  it("preserves the active session and cleans artifacts using the final referenced session set", async () => {
+    const now = Date.now();
+    const store = makeStore([
+      [
+        "stale",
+        { sessionId: "stale-session", sessionFile: "stale.jsonl", updatedAt: now - 30 * DAY_MS },
+      ],
+      [
+        "stale-shared",
+        {
+          sessionId: "shared-session",
+          sessionFile: "shared-old.jsonl",
+          updatedAt: now - 30 * DAY_MS,
+        },
+      ],
+      ["fresh-shared", { sessionId: "shared-session", updatedAt: now }],
+      ["active", { sessionId: "active-session", updatedAt: now - 30 * DAY_MS }],
+    ]);
+    const archiveCalls: Array<{
+      removedSessionFiles: Array<[string, string | undefined]>;
+      referencedSessionIds: Set<string>;
+    }> = [];
+    let trajectoryCleanupReferencedIds: Set<string> | undefined;
+
+    const result = await applyFileBackedSessionStoreMaintenance({
+      storePath: "/tmp/openclaw-sessions/sessions.json",
+      store,
+      activeSessionKey: "active",
+      maintenanceConfig: {
+        mode: "enforce",
+        pruneAfterMs: 7 * DAY_MS,
+        maxEntries: 500,
+        resetArchiveRetentionMs: null,
+        maxDiskBytes: null,
+        highWaterBytes: null,
+      },
+      log: { warn: () => {}, info: () => {} },
+      artifacts: {
+        archiveRemovedSessionTranscripts: async (params) => {
+          archiveCalls.push({
+            removedSessionFiles: [...params.removedSessionFiles],
+            referencedSessionIds: new Set(params.referencedSessionIds),
+          });
+          return new Set();
+        },
+        removeRemovedSessionTrajectoryArtifacts: async (params) => {
+          trajectoryCleanupReferencedIds = new Set(params.referencedSessionIds);
+        },
+        cleanupArchivedSessionTranscripts: async () => {},
+      },
+    });
+
+    expect(result.changedStore).toBe(true);
+    expect(store.stale).toBeUndefined();
+    expect(store["stale-shared"]).toBeUndefined();
+    expect(store).toHaveProperty("fresh-shared");
+    expect(store).toHaveProperty("active");
+    expect(archiveCalls).toEqual([
+      {
+        removedSessionFiles: [
+          ["stale-session", "stale.jsonl"],
+          ["shared-session", "shared-old.jsonl"],
+        ],
+        referencedSessionIds: new Set(["shared-session", "active-session"]),
+      },
+    ]);
+    expect(trajectoryCleanupReferencedIds).toEqual(new Set(["shared-session", "active-session"]));
   });
 });
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -24,9 +24,7 @@ import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import {
-  enforceSessionDiskBudget,
   pruneUnreferencedSessionArtifacts,
-  type SessionDiskBudgetSweepResult,
   type SessionUnreferencedArtifactSweepResult,
 } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
@@ -58,14 +56,16 @@ import {
   readSessionEntries,
   readSessionEntry,
 } from "./store-load.js";
-import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import {
+  applyFileBackedSessionStoreMaintenance,
+  applyQuotaSuspensionTtlMaintenance,
+  type SessionMaintenanceApplyReport,
+} from "./store-maintenance-operations.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
-  pruneQuotaSuspensions,
   pruneStaleEntries,
-  shouldRunSessionEntryMaintenance,
   type QuotaSuspensionMaintenanceResult,
   type ResolvedSessionMaintenanceConfig,
   type SessionMaintenanceWarning,
@@ -164,15 +164,6 @@ export function readSessionUpdatedAt(params: {
 // Session Store Pruning, Capping & File Rotation
 // ============================================================================
 
-export type SessionMaintenanceApplyReport = {
-  mode: ResolvedSessionMaintenanceConfig["mode"];
-  beforeCount: number;
-  afterCount: number;
-  pruned: number;
-  capped: number;
-  diskBudget: SessionDiskBudgetSweepResult | null;
-};
-
 export {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
@@ -180,6 +171,7 @@ export {
   pruneStaleEntries,
   resolveMaintenanceConfig,
 };
+export type { SessionMaintenanceApplyReport } from "./store-maintenance-operations.js";
 export type { ResolvedSessionMaintenanceConfig, SessionMaintenanceWarning };
 
 type SaveSessionStoreOptions = {
@@ -823,144 +815,28 @@ async function saveSessionStoreUnlocked(
 
   let maintenanceChangedStore = false;
   if (!opts?.skipMaintenance) {
-    // Resolve maintenance config once (avoids repeated getRuntimeConfig() calls).
-    const maintenance = opts?.maintenanceConfig
-      ? { ...opts.maintenanceConfig, ...opts?.maintenanceOverride }
-      : { ...resolveMaintenanceConfig(), ...opts?.maintenanceOverride };
-    const shouldWarnOnly = maintenance.mode === "warn";
-    const beforeCount = Object.keys(store).length;
-    const forceMaintenance = opts?.maintenanceOverride !== undefined;
-    const shouldRunEntryMaintenance = shouldRunSessionEntryMaintenance({
-      entryCount: beforeCount,
-      maxEntries: maintenance.maxEntries,
-      force: forceMaintenance,
-    });
-
-    if (shouldWarnOnly) {
-      const activeSessionKey = opts?.activeSessionKey?.trim();
-      if (activeSessionKey && shouldRunEntryMaintenance) {
-        const warning = getActiveSessionMaintenanceWarning({
-          store,
-          activeSessionKey,
-          pruneAfterMs: maintenance.pruneAfterMs,
-          maxEntries: maintenance.maxEntries,
-        });
-        if (warning) {
-          log.warn("session maintenance would evict active session; skipping enforcement", {
-            activeSessionKey: warning.activeSessionKey,
-            wouldPrune: warning.wouldPrune,
-            wouldCap: warning.wouldCap,
-            pruneAfterMs: warning.pruneAfterMs,
-            maxEntries: warning.maxEntries,
-          });
-          await opts?.onWarn?.(warning);
-        }
-      }
-      const diskBudget = await enforceSessionDiskBudget({
-        store,
-        storePath,
-        activeSessionKey: opts?.activeSessionKey,
-        maintenance,
-        warnOnly: true,
-        log,
-      });
-      await opts?.onMaintenanceApplied?.({
-        mode: maintenance.mode,
-        beforeCount,
-        afterCount: Object.keys(store).length,
-        pruned: 0,
-        capped: 0,
-        diskBudget,
-      });
-    } else {
-      const preserveSessionKeys = collectSessionMaintenancePreserveKeys([opts?.activeSessionKey]);
-      // Prune stale entries and cap total count before serializing.
-      const removedSessionFiles = new Map<string, string | undefined>();
-      const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
-        onPruned: ({ entry }) => {
-          rememberRemovedSessionFile(removedSessionFiles, entry);
+    const maintenance = await applyFileBackedSessionStoreMaintenance({
+      storePath,
+      store,
+      activeSessionKey: opts?.activeSessionKey,
+      onWarn: opts?.onWarn,
+      onMaintenanceApplied: opts?.onMaintenanceApplied,
+      maintenanceOverride: opts?.maintenanceOverride,
+      maintenanceConfig: opts?.maintenanceConfig,
+      log,
+      artifacts: {
+        archiveRemovedSessionTranscripts,
+        removeRemovedSessionTrajectoryArtifacts: async (params) => {
+          const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
+          await removeRemovedSessionTrajectoryArtifacts(params);
         },
-        preserveKeys: preserveSessionKeys,
-      });
-      const countAfterPrune = Object.keys(store).length;
-      const shouldRunCapMaintenance =
-        forceMaintenance ||
-        shouldRunSessionEntryMaintenance({
-          entryCount: countAfterPrune,
-          maxEntries: maintenance.maxEntries,
-        });
-      const capped = shouldRunCapMaintenance
-        ? capEntryCount(store, maintenance.maxEntries, {
-            onCapped: ({ entry }) => {
-              rememberRemovedSessionFile(removedSessionFiles, entry);
-            },
-            preserveKeys: preserveSessionKeys,
-          })
-        : 0;
-      const archivedDirs = new Set<string>();
-      const referencedSessionIds = new Set(
-        Object.values(store)
-          .map((entry) => entry?.sessionId)
-          .filter((id): id is string => Boolean(id)),
-      );
-      // Archive/remove artifacts only after the final live session-id set is known.
-      const archivedForDeletedSessions = await archiveRemovedSessionTranscripts({
-        removedSessionFiles,
-        referencedSessionIds,
-        storePath,
-        reason: "deleted",
-        restrictToStoreDir: true,
-      });
-      if (removedSessionFiles.size > 0) {
-        const { removeRemovedSessionTrajectoryArtifacts } = await loadTrajectoryCleanupRuntime();
-        await removeRemovedSessionTrajectoryArtifacts({
-          removedSessionFiles,
-          referencedSessionIds,
-          storePath,
-          restrictToStoreDir: true,
-        });
-      }
-      for (const archivedDir of archivedForDeletedSessions) {
-        archivedDirs.add(archivedDir);
-      }
-      if (archivedDirs.size > 0 || maintenance.resetArchiveRetentionMs != null) {
-        const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
-        const targetDirs =
-          archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
-        // Both retention reasons ride one cleanup call so each save enumerates
-        // the sessions dir at most once; reset retention defaults on, so a
-        // listing per reason would scan twice per save (costly on NFS).
-        await cleanupArchivedSessionTranscripts({
-          directories: targetDirs,
-          rules:
-            maintenance.resetArchiveRetentionMs != null
-              ? [
-                  { reason: "deleted", olderThanMs: maintenance.pruneAfterMs },
-                  { reason: "reset", olderThanMs: maintenance.resetArchiveRetentionMs },
-                ]
-              : [{ reason: "deleted", olderThanMs: maintenance.pruneAfterMs }],
-        });
-      }
-
-      const diskBudget = await enforceSessionDiskBudget({
-        store,
-        storePath,
-        activeSessionKey: opts?.activeSessionKey,
-        preserveKeys: preserveSessionKeys,
-        maintenance,
-        warnOnly: false,
-        log,
-      });
-      maintenanceChangedStore = pruned > 0 || capped > 0 || (diskBudget?.removedEntries ?? 0) > 0;
-      await opts?.onMaintenanceApplied?.({
-        mode: maintenance.mode,
-        beforeCount,
-        afterCount: Object.keys(store).length,
-        pruned,
-        capped,
-        diskBudget,
-      });
-    }
+        cleanupArchivedSessionTranscripts: async (params) => {
+          const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
+          await cleanupArchivedSessionTranscripts(params);
+        },
+      },
+    });
+    maintenanceChangedStore = maintenance.changedStore;
   }
 
   if (
@@ -1739,17 +1615,17 @@ export async function runQuotaSuspensionMaintenance(params: {
   if (!fs.existsSync(params.storePath)) {
     return { resumed: [], cleared: 0 };
   }
-  return await updateSessionStore(
-    params.storePath,
-    (store) =>
-      pruneQuotaSuspensions({
-        store,
-        now: params.now ?? Date.now(),
-        ttlMs: params.ttlMs,
-        log: params.log,
-      }),
-    { skipMaintenance: true },
-  );
+  return await runExclusiveSessionStoreWrite(params.storePath, async () => {
+    const store = loadMutableSessionStoreForWriter(params.storePath);
+    const result = applyQuotaSuspensionTtlMaintenance({
+      store,
+      now: params.now ?? Date.now(),
+      ttlMs: params.ttlMs,
+      log: params.log,
+    });
+    await saveSessionStoreUnlocked(params.storePath, store, { skipMaintenance: true });
+    return result;
+  });
 }
 
 function getErrorCode(error: unknown): string | null {


### PR DESCRIPTION
## What
Extracts the file-backed session store's automatic maintenance side effects into named storage-neutral operations while keeping the JSON-backed runtime behavior unchanged.

## Why
Path 3 needs a transaction-sized seam for the future SQLite session adapter before flipping storage. This preserves the current prune/cap, disk-budget, artifact cleanup, cache, and quota-suspension behavior while making the future SQLite boundaries explicit.

## Changes
- Adds session maintenance operations module
- Routes save maintenance through seam
- Makes quota TTL maintenance standalone
- Keeps artifact cleanup named
- Adds focused operation ratchets

## SQLite follow-up
Map `applyFileBackedSessionStoreMaintenance` to transaction-sized SQLite boundaries for entry retention and disk-budget row eviction, then run removed-session transcript/trajectory cleanup as named artifact cleanup after the final referenced-session set is known. Map `applyQuotaSuspensionTtlMaintenance` to a row transaction that returns resumed lane records and clear counts before in-process quota lanes resume.

## Testing
- `node scripts/run-vitest.mjs src/config/sessions/store.pruning.test.ts src/config/sessions/store.pruning.integration.test.ts src/config/sessions/disk-budget.test.ts src/config/sessions.cache.test.ts` -> passed, 4 files / 105 tests
- `node scripts/check-session-accessor-boundary.mjs` -> passed
- `git diff --check upstream/main...HEAD` -> passed
- `pnpm exec oxfmt --check --threads=1 src/config/sessions/store.ts src/config/sessions/store-maintenance-operations.ts src/config/sessions/store.pruning.test.ts` -> passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/sessions/store.ts src/config/sessions/store-maintenance-operations.ts src/config/sessions/store.pruning.test.ts` -> passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` -> passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo` -> passed
- `pnpm build` -> passed
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` -> clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: File-backed automatic session maintenance still prunes stale session entries through the live Gateway `sessions.cleanup` RPC after maintenance side effects moved behind storage-neutral operations.

Real environment tested: Local live LaunchAgent gateway from `/Users/phaedrus/Projects/clawdbot`, OpenClaw `2026.6.8 (acafa74)`, head `acafa74d72e597eaa047b75a9c938f74fd92ea62`, base `bad21faf62002c9fbdbe4e923de13fc6e5f19b0a`, gateway port `18789`.

Exact steps or command run after this patch:

```bash
pnpm build
pnpm openclaw gateway restart
curl -sS http://127.0.0.1:18789/healthz
curl -sS http://127.0.0.1:18789/readyz
pnpm openclaw agents add path3-proof-20260618-0738 --non-interactive --workspace /tmp/openclaw-pr-93737-proof-path3-proof-20260618-0738/workspace --agent-dir /Users/phaedrus/.openclaw/agents/path3-proof-20260618-0738 --json
node -e '<seeded /Users/phaedrus/.openclaw/agents/path3-proof-20260618-0738/sessions/sessions.json with proof-stale and proof-fresh entries>'
pnpm openclaw gateway call sessions.list --json --timeout 10000 --params '{"agentId":"path3-proof-20260618-0738","limit":10}'
pnpm openclaw gateway call sessions.cleanup --json --timeout 10000 --params '{"agent":"path3-proof-20260618-0738","enforce":true}'
node -e '<read the temp sessions.json and verify remaining keys/session ids>'
pnpm openclaw gateway call sessions.list --json --timeout 10000 --params '{"agentId":"path3-proof-20260618-0738","limit":10}'
pnpm openclaw gateway call agents.delete --json --timeout 10000 --params '{"agentId":"path3-proof-20260618-0738","deleteFiles":true}'
```

Evidence after fix: `/healthz` returned `{"ok":true,"status":"live"}` and `/readyz` returned `{"ready":true,"failing":[]...}`. The seeded temp store contained two rows before cleanup: stale `proof-stale-session` and fresh `proof-fresh-session`. The live `sessions.cleanup` RPC returned `beforeCount: 2`, `afterCount: 1`, `mode: "enforce"`, `pruned: 1`, `capped: 0`, `diskBudget: null`, `wouldMutate: true`, `applied: true`, and `appliedCount: 1`. Direct persisted-store verification returned `keys: ["agent:path3-proof-20260618-0738:proof-fresh"]`, `hasStale: false`, `hasFresh: true`, `count: 1`. The stale transcript was archived as `stale-session.jsonl.deleted.2026-06-18T14-39-43.640Z` before the temp agent was deleted.

Observed result after fix: The live Gateway cleanup path pruned only the stale temp session, preserved the fresh temp session, wrote the updated file-backed store, and ran removed-session artifact cleanup through the extracted maintenance seam.

What was not tested: Future SQLite adapter implementation, doctor/import migration, runtime SQLite flip, row-level disk-budget eviction with non-null limits, and live quota-lane resume side effects. Quota-suspension TTL behavior is covered by the focused unit test in this PR.
