### PR TITLE
fix(sessions): release retained locks after takeover

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.test.ts
@@ -3882,6 +3882,97 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releases).toEqual(["release", "release", "release"]);
   });
 
+  it("releases a retained post-prompt lock after takeover so the next inbound can acquire it", async () => {
+    const sessionFile = await createTempSessionFile();
+    const options = { ...lockOptions, sessionFile, timeoutMs: 250 };
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+
+    await controller.releaseForPrompt();
+    await controller.reacquireAfterPrompt();
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+
+    await expect(
+      controller.withSessionWriteLock(async () => {
+        await fs.appendFile(sessionFile, '{"type":"message","id":"late"}\n', "utf8");
+      }),
+    ).rejects.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+    expect(controller.hasSessionTakeover()).toBe(true);
+
+    const nextController = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: options,
+    });
+    await nextController.withSessionWriteLock(async () => {
+      await fs.appendFile(sessionFile, '{"type":"message","id":"next-inbound"}\n', "utf8");
+    });
+    await nextController.dispose();
+    await controller.dispose();
+
+    const transcript = await fs.readFile(sessionFile, "utf8");
+    expect(transcript).toContain('"id":"next-inbound"');
+    expect(transcript).not.toContain('"id":"late"');
+  });
+
+  it("waits for active retained writers before releasing a takeover lock", async () => {
+    const sessionFile = await createTempSessionFile();
+    const events: string[] = [];
+    let releaseActiveWrite!: () => void;
+    const activeWriteStarted = new Promise<void>((resolve) => {
+      releaseActiveWrite = () => {
+        events.push("active-finish");
+        resolve();
+      };
+    });
+    const releasePrep = vi.fn(async () => events.push("prep-release"));
+    const releaseRetained = vi.fn(async () => events.push("retained-release"));
+    const acquireSessionWriteLockLocal = vi
+      .fn()
+      .mockResolvedValueOnce({ release: releasePrep })
+      .mockResolvedValueOnce({ release: releaseRetained });
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: acquireSessionWriteLockLocal,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await controller.reacquireAfterPrompt();
+    const activeWrite = controller.withSessionWriteLock(async () => {
+      events.push("active-start");
+      await activeWriteStarted;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    await fs.appendFile(sessionFile, '{"type":"message","id":"external"}\n', "utf8");
+
+    let takeoverSettled = false;
+    const takeoverWrite = controller
+      .withSessionWriteLock(async () => {
+        events.push("late-write");
+      })
+      .catch((error: unknown) => error)
+      .finally(() => {
+        takeoverSettled = true;
+      });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(takeoverSettled).toBe(false);
+    expect(releaseRetained).not.toHaveBeenCalled();
+
+    releaseActiveWrite();
+    await expect(activeWrite).resolves.toBeUndefined();
+    await expect(takeoverWrite).resolves.toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+
+    expect(releaseRetained).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(["prep-release", "active-start", "active-finish", "retained-release"]);
+    expect(acquireSessionWriteLockLocal).toHaveBeenCalledTimes(2);
+  });
+
   it("returns a no-op cleanup lock after prompt lock reacquisition times out", async () => {
     const releases: string[] = [];
     const acquireSessionWriteLockResult = vi

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1669,6 +1669,13 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     }
   }
 
+  async function releaseHeldLockAfterTakeover(): Promise<void> {
+    if (!takeoverDetected) {
+      return;
+    }
+    await disposeHeldLockAfterRetainedIdle();
+  }
+
   async function acquireCleanupLock(): Promise<SessionLock | undefined> {
     const retainedLock = await takeHeldLockAfterRetainedIdle();
     if (retainedLock) {
@@ -1709,6 +1716,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         }
       }
     }
+    await releaseHeldLockAfterTakeover();
     if (!outcome.ok) {
       throw outcome.error;
     }


### PR DESCRIPTION
Refs #93383.

Releases the embedded-attempt controller's retained session write lock after a takeover is detected, once active retained writers have drained. Adds regressions for takeover-to-next-inbound lock acquisition and for not releasing the retained lock while an active holder is still running.

## Real behavior proof

- Behavior or issue addressed: `EmbeddedAttemptSessionTakeoverError` no longer leaves the controller's retained session write lock blocking the next inbound turn.
- Real environment tested: Local OpenClaw source checkout on macOS with Node 24, using the real `acquireSessionWriteLock` against a temp session transcript.
- Exact steps or command run after this patch: Ran a local `pnpm exec tsx` proof that creates a temp transcript, releases and reacquires the embedded attempt lock, appends an external transcript event to trigger takeover, then starts a second controller for the next inbound write.
- Evidence after fix: Terminal transcript:

```text
{
  "takeoverDetected": true,
  "nextInboundPersisted": true,
  "lateWriteSuppressed": true,
  "lockFileExistsAfterDispose": false
}
```

- Observed result after fix: The takeover was detected, the stale late write was not persisted, the next inbound write was persisted through a newly acquired controller, and no session lock file remained after disposal.
- What was not tested: No Telegram message-delivery UI proof; this PR is limited to the embedded session-lock ownership boundary.

