### PR TITLE
fix(codex): strip cwd failure traces

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -231,6 +231,27 @@ function agentMessageDelta(delta: string, itemId = "msg-1"): ProjectorNotificati
   return forCurrentTurn("item/agentMessage/delta", { itemId, delta });
 }
 
+function commandExecutionCompleted(params: {
+  id?: string;
+  command: string;
+  status?: "completed" | "failed";
+  cwd?: string;
+  aggregatedOutput?: string;
+  exitCode?: number | null;
+}): ProjectorNotification {
+  return forCurrentTurn("item/completed", {
+    item: {
+      id: params.id ?? "cmd-1",
+      type: "commandExecution",
+      command: params.command,
+      status: params.status ?? "completed",
+      ...(params.cwd ? { cwd: params.cwd } : {}),
+      ...(params.aggregatedOutput ? { aggregatedOutput: params.aggregatedOutput } : {}),
+      ...(params.exitCode !== undefined ? { exitCode: params.exitCode } : {}),
+    },
+  });
+}
+
 function appServerError(params: { message: string; willRetry: boolean }): ProjectorNotification {
   return forCurrentTurn("error", {
     error: {
@@ -274,6 +295,33 @@ function turnWithStatus(status: string, items: unknown[] = []): ProjectorNotific
 }
 
 describe("CodexAppServerEventProjector", () => {
+  it("projects commandExecution items as bash tool events", async () => {
+    const onAgentEvent = vi.fn();
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      onAgentEvent,
+    });
+
+    await projector.handleNotification(
+      commandExecutionCompleted({
+        command: "git status",
+        status: "failed",
+        cwd: "/repo",
+        aggregatedOutput: "Command exited with code 1",
+        exitCode: 1,
+      }),
+    );
+
+    const toolResult = findAgentEvent(onAgentEvent, {
+      stream: "tool",
+      phase: "result",
+      itemId: "cmd-1",
+      name: "bash",
+    });
+    expect(toolResult.data.name).toBe("bash");
+  });
+
   it("projects assistant deltas and usage into embedded attempt results", async () => {
     const { onAssistantMessageStart, onPartialReply, projector } =
       await createProjectorWithAssistantHooks();

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -314,6 +314,8 @@ describe("sanitizeUserFacingText", () => {
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open --no-search-pages.jsonl /tmp/openclaw_open_unlabeled_current.json (agent) failed",
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open (agent) failed: command timed out",
+      "⚠️ 🛠️ systemctl --user status missing.service (in /tmp/openclaw) failed",
+      "⚠️ 🛠️ grep -n needle README.md (in /repo) failed: exit code 1",
       "🛠️ run git status",
       "📖 Read: lines 1-40 from secret.md",
       "Visible outro.",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -17,7 +17,7 @@ const INTERNAL_TRACE_LINE_QUICK_RE =
 const INTERNAL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:⚠️\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
 const INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE =
-  /^(?:>\s*)?⚠️\s*🛠️\s+\S[\s\S]*\s+\(agent\)`{0,2}\s+failed(?:\s*:.*)?\s*$/i;
+  /^(?:>\s*)?⚠️\s*🛠️\s+\S[\s\S]*\s+(?:\(agent\)|\(in\s+[^()]+\))`{0,2}\s+failed(?:\s*:.*)?\s*$/i;
 const INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
   /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
 const INTERNAL_CHANNEL_TRACE_LINE_RE =


### PR DESCRIPTION
## Summary
- strip compact tool-failure trace lines when Codex/native command failures are formatted as `⚠️ 🛠️ <cmd> (in <cwd>) failed`
- add a Codex app-server projector regression showing `commandExecution` items currently project to `bash`, not raw `exec_command`
- keep the fix scoped to the still-reproducible text leak instead of widening exec-like aliasing on an unproven path

## Verification
- `node scripts/run-vitest.mjs src/shared/text/assistant-visible-text.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts`
- `git diff --check`

## Refs
- Fixes #93717
- Related: #93482

## Notes
Current `main` projects Codex app-server `commandExecution` items to `bash` in `extensions/codex/src/app-server/event-projector.ts`, so the issue's reported `exec_command` warning-helper path is not the current proven native app-server route. This patch fixes the still-observable leak where compact failure traces using `(in <cwd>) failed` were not stripped from user-facing error-context text.
