### PR TITLE
Docs/add cowork to code bridge 93609

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1178,5 +1178,9 @@
   {
     "source": "Z.AI (GLM)",
     "target": "Z.AI (GLM)"
+  },
+  {
+    "source": "Cowork-to-Code Bridge",
+    "target": "Cowork-to-Code Bridge"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1416,6 +1416,7 @@
                   "providers/claude-max-api-proxy",
                   "providers/cloudflare-ai-gateway",
                   "providers/comfy",
+                  "providers/cowork-to-code-bridge",
                   "providers/deepgram",
                   "providers/deepinfra",
                   "providers/deepseek",

--- a/docs/providers/cowork-to-code-bridge.md
+++ b/docs/providers/cowork-to-code-bridge.md
@@ -1,0 +1,101 @@
+---
+summary: "Community MCP bridge to run Claude Code on your local machine from Claude Cowork"
+read_when:
+  - You want Claude Cowork (cloud) to execute code on your local machine
+  - You want to use Claude Code without separate API keys or billing
+  - You want to connect cloud chat to your local repos, shell, and MCPs
+title: "Cowork-to-Code Bridge"
+---
+
+**cowork-to-code-bridge** is a community tool that connects Claude Cowork (cloud) to Claude Code (local). It allows you to run real execution workflows—building code, running tests, git operations, and shell inspection—on your own machine directly from a cloud chat, without needing API keys or separate billing.
+
+<Warning>
+This is a community tool and is not officially supported by Anthropic or OpenClaw. The bridge relies on Claude Code "channels", which are currently in research preview. You must run Claude Code with the `--dangerously-load-development-channels server:intercom` flag.
+</Warning>
+
+## Why use this?
+
+| Approach | Cost route | Best for |
+|---|---|---|
+| Anthropic API | Pay per token through Claude Console or cloud | Production apps, shared automation, volume |
+| Cowork-to-Code Bridge | Claude Code / `claude -p` plan and credit rules | Escalating cloud tasks to your local machine |
+
+If your workflow requires real execution (compiling, running tests, shell commands) and you want to use your existing Claude subscription without managing separate API billing, this bridge provides a secure, file-based way to hand tasks from the cloud down to your local machine.
+
+## How it works
+
+```text
+Claude Cowork → cowork-to-code-bridge → Claude Code CLI → Your Machine
+ (Cloud Agent)     (File-based queue)    (Local Agent)      (Shell/Repos)
+```
+
+The bridge:
+
+1. Uses a shared file folder as an asynchronous queue (no network ports opened).
+2. Cowork writes a task to the folder.
+3. A local daemon picks up the task and runs Claude Code locally.
+4. Claude Code executes the task and writes the result back through the bridge.
+
+## Getting started
+
+<Steps>
+  <Step title="Install the bridge">
+    Install the bridge on your local machine (macOS/Linux/WSL2).
+
+    **macOS / Linux / WSL2 (curl):**
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/abhinaykrupa/cowork-to-code-bridge/main/install.sh | bash
+    ```
+
+    **Manual installation (GitHub):**
+    ```bash
+    git clone https://github.com/abhinaykrupa/cowork-to-code-bridge.git
+    cd cowork-to-code-bridge
+    bun install
+    ```
+  </Step>
+
+  <Step title="Connect from Cowork">
+    The installer will print a connect line. Paste it into your Claude Cowork chat:
+
+    ```text
+    Connect to my machine via the cowork-to-code bridge at ~/.cowork-to-code-bridge — mount that folder, read its CLAUDE.md, and confirm the bridge is live.
+    ```
+  </Step>
+
+  <Step title="Test the connection">
+    Approve Cowork's request to read the folder. Once it confirms `BRIDGE LIVE`, ask it to run a task:
+
+    > *"build me a small web app on my machine"*
+    > *"run my tests and fix what fails"*
+    > *"check my machine's health"*
+  </Step>
+</Steps>
+
+## Notes
+
+- This is a **community tool**, not officially supported by Anthropic or OpenClaw
+- Opens **no network ports** and never uses `sudo`
+- Runs only approved scripts and is gated by a secret token
+- Survives crashes: every task is journaled and marked in-flight
+
+<Note>
+For native Anthropic integration with Claude CLI or API keys, see [Anthropic provider](/providers/anthropic). To learn about OpenClaw's own MCP server capabilities, see [MCP](/cli/mcp).
+</Note>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Anthropic provider" href="/providers/anthropic" icon="bolt">
+    Native OpenClaw integration with Claude CLI or API keys.
+  </Card>
+  <Card title="Claude Max API Proxy" href="/providers/claude-max-api-proxy" icon="server">
+    Community proxy for OpenAI-compatible tools.
+  </Card>
+  <Card title="MCP" href="/cli/mcp" icon="network-wired">
+    Expose OpenClaw channel conversations over MCP.
+  </Card>
+  <Card title="Configuration" href="/gateway/configuration" icon="gear">
+    Full config reference.
+  </Card>
+</CardGroup>

--- a/docs/providers/cowork-to-code-bridge.md
+++ b/docs/providers/cowork-to-code-bridge.md
@@ -15,9 +15,9 @@ This is a community tool and is not officially supported by Anthropic or OpenCla
 
 ## Why use this?
 
-| Approach | Cost route | Best for |
-|---|---|---|
-| Anthropic API | Pay per token through Claude Console or cloud | Production apps, shared automation, volume |
+| Approach              | Cost route                                      | Best for                                     |
+| --------------------- | ----------------------------------------------- | -------------------------------------------- |
+| Anthropic API         | Pay per token through Claude Console or cloud   | Production apps, shared automation, volume   |
 | Cowork-to-Code Bridge | Claude Code / `claude -p` plan and credit rules | Escalating cloud tasks to your local machine |
 
 If your workflow requires real execution (compiling, running tests, shell commands) and you want to use your existing Claude subscription without managing separate API billing, this bridge provides a secure, file-based way to hand tasks from the cloud down to your local machine.
@@ -53,6 +53,7 @@ The bridge:
     cd cowork-to-code-bridge
     bun install
     ```
+
   </Step>
 
   <Step title="Connect from Cowork">
@@ -61,6 +62,7 @@ The bridge:
     ```text
     Connect to my machine via the cowork-to-code bridge at ~/.cowork-to-code-bridge — mount that folder, read its CLAUDE.md, and confirm the bridge is live.
     ```
+
   </Step>
 
   <Step title="Test the connection">
@@ -69,6 +71,7 @@ The bridge:
     > *"build me a small web app on my machine"*
     > *"run my tests and fix what fails"*
     > *"check my machine's health"*
+
   </Step>
 </Steps>
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -100,6 +100,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 ## Community tools
 
 - [Claude Max API Proxy](/providers/claude-max-api-proxy) - Community proxy for Claude subscription credentials (verify Anthropic policy/terms before use)
+- [Cowork-to-Code Bridge](/providers/cowork-to-code-bridge) - Community bridge that lets Claude Cowork escalate tasks to Claude Code on your local machine (verify Anthropic policy before use)
 
 For the full provider catalog (xAI, Groq, Mistral, etc.) and advanced configuration,
 see [Model providers](/concepts/model-providers).


### PR DESCRIPTION
## Summary
Adds documentation for the `cowork-to-code-bridge` community tool as an MCP provider.

## Changes
- **New File:** Added `docs/providers/cowork-to-code-bridge.md` modeled after the existing community tool pages to ensure stylistic consistency.
- **Nav Update:** Registered the new page in `docs/docs.json` (alphabetically).
- **Index Update:** Added a link to the tool in the `docs/providers/index.md` community tools section.

## Root Cause
Issue #93609 requested that the OpenClaw documentation mention `cowork-to-code-bridge` as an option for users who want local Claude Code execution without API keys.

## Approach
Because this is a community-maintained tool, I followed the exact precedent set by `claude-max-api-proxy.md`. I included a `<Warning>` block noting that it is not officially supported, clearly outlined the cost/benefit routing, and provided the standard installation steps.

## Out of Scope
- No runtime code changes
- No new dependencies
- No test changes
- This PR is purely additive documentation — zero blast radius on existing functionality

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: Added documentation for the new cowork-to-code-bridge community tool.
- Real environment tested: macOS local development environment.
- Exact steps or command run after this patch: Ran the local documentation server and viewed the page in a browser.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
<img width="1270" height="830" alt="Screenshot 2026-06-17 at 12 34 44 AM" src="https://github.com/user-attachments/assets/1c194410-7716-4ef3-b4d0-155a3baa421f" />
<img width="1200" height="835" alt="Screenshot 2026-06-17 at 12 34 58 AM" src="https://github.com/user-attachments/assets/8b1125a7-d902-4752-97b5-690dcfda2d6b" />
- Observed result after fix: The documentation page renders perfectly with the correct formatting, table, and code blocks.
- What was not tested: Installation script of the bridge itself (only the documentation rendering was validated).
- Proof limitations or environment constraints: None.
- Before evidence (optional but encouraged):


Fixes #93609