### PR TITLE
fix(usage): reject invalid explicit dates in usage RPC date parsing

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -94,6 +94,49 @@ describe("gateway usage helpers", () => {
     expect(testApi.parseDateToMs(undefined)).toBeUndefined();
   });
 
+  it("parseDateToMs rejects out-of-range calendar dates instead of rolling them over", () => {
+    // Impossible dates that still match the YYYY-MM-DD shape must not silently shift to a real day.
+    expect(testApi.parseDateToMs("2026-02-30")).toBeUndefined(); // would roll to Mar 2
+    expect(testApi.parseDateToMs("2026-04-31")).toBeUndefined(); // would roll to May 1
+    expect(testApi.parseDateToMs("2025-02-29")).toBeUndefined(); // non-leap Feb 29
+    expect(testApi.parseDateToMs("2026-13-01")).toBeUndefined(); // month too large
+    expect(testApi.parseDateToMs("2026-00-10")).toBeUndefined(); // month zero
+    expect(testApi.parseDateToMs("2026-01-00")).toBeUndefined(); // day zero
+    // Real leap day must stay valid (guard against over-rejection).
+    expect(testApi.parseDateToMs("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
+  });
+
+  it("findInvalidExplicitDate flags provided-but-unparseable dates and ignores absent/valid ones", () => {
+    // Explicitly provided invalid dates (bad format or impossible calendar date) are reported.
+    expect(testApi.findInvalidExplicitDate({ startDate: "2026-02-30" })).toBe("startDate");
+    expect(testApi.findInvalidExplicitDate({ endDate: "2026-2-5" })).toBe("endDate");
+    expect(
+      testApi.findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-13-01" }),
+    ).toBe("endDate");
+    // Absent or valid dates are not flagged, so they still fall through to the default range.
+    expect(testApi.findInvalidExplicitDate({})).toBeUndefined();
+    expect(testApi.findInvalidExplicitDate({ startDate: "", endDate: undefined })).toBeUndefined();
+    expect(
+      testApi.findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-02-02" }),
+    ).toBeUndefined();
+  });
+
+  it("usage.cost rejects an explicitly provided invalid date with INVALID_REQUEST", async () => {
+    const respond = vi.fn();
+    await usageHandlers["usage.cost"]({
+      respond,
+      params: { startDate: "2026-02-30" },
+      context: { getRuntimeConfig: () => ({}) },
+    } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+    expect(respond).toHaveBeenCalledTimes(1);
+    const [ok, payload, error] = respond.mock.calls[0];
+    expect(ok).toBe(false);
+    expect(payload).toBeUndefined();
+    expect(JSON.stringify(error)).toContain("startDate");
+    // A rejected request must not query the cost loader for an unrelated range.
+    expect(vi.mocked(loadCostUsageSummaryFromCache)).not.toHaveBeenCalled();
+  });
+
   it("parseUtcOffsetToMinutes supports whole-hour and half-hour offsets", () => {
     expect(testApi.parseUtcOffsetToMinutes("UTC-4")).toBe(-240);
     expect(testApi.parseUtcOffsetToMinutes("UTC+5:30")).toBe(330);
@@ -327,7 +370,8 @@ describe("gateway usage helpers", () => {
 
     expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(3);
     expect(
-      vi.mocked(loadCostUsageSummaryFromCache)
+      vi
+        .mocked(loadCostUsageSummaryFromCache)
         .mock.calls.slice(1)
         .map((call) => call[0]?.agentId),
     ).toEqual(["main", "opus"]);

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -110,12 +110,14 @@ describe("gateway usage helpers", () => {
     // Explicitly provided invalid dates (bad format or impossible calendar date) are reported.
     expect(testApi.findInvalidExplicitDate({ startDate: "2026-02-30" })).toBe("startDate");
     expect(testApi.findInvalidExplicitDate({ endDate: "2026-2-5" })).toBe("endDate");
+    expect(testApi.findInvalidExplicitDate({ startDate: 0 })).toBe("startDate");
+    expect(testApi.findInvalidExplicitDate({ endDate: [] })).toBe("endDate");
     expect(
       testApi.findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-13-01" }),
     ).toBe("endDate");
     // Absent or valid dates are not flagged, so they still fall through to the default range.
     expect(testApi.findInvalidExplicitDate({})).toBeUndefined();
-    expect(testApi.findInvalidExplicitDate({ startDate: "", endDate: undefined })).toBeUndefined();
+    expect(testApi.findInvalidExplicitDate({ startDate: "", endDate: null })).toBeUndefined();
     expect(
       testApi.findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-02-02" }),
     ).toBeUndefined();
@@ -125,7 +127,7 @@ describe("gateway usage helpers", () => {
     const respond = vi.fn();
     await usageHandlers["usage.cost"]({
       respond,
-      params: { startDate: "2026-02-30" },
+      params: { startDate: 0 },
       context: { getRuntimeConfig: () => ({}) },
     } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
     expect(respond).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -180,7 +180,36 @@ const parseDateParts = (
   if (!Number.isFinite(year) || !Number.isFinite(monthIndex) || !Number.isFinite(day)) {
     return undefined;
   }
+  // The regex only checks shape; Date.* silently rolls impossible calendar dates over
+  // (e.g. 2026-02-30 -> 2026-03-02), so a typo'd day would return usage for the wrong day.
+  // Reject parts that don't round-trip through a UTC probe (also catches the JS 2-digit-year remap).
+  const probe = new Date(Date.UTC(year, monthIndex, day));
+  if (
+    probe.getUTCFullYear() !== year ||
+    probe.getUTCMonth() !== monthIndex ||
+    probe.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
   return { year, monthIndex, day };
+};
+
+// usage.cost / sessions.usage accept optional startDate/endDate. parseDateParts returns
+// undefined for both absent and invalid input, so an explicitly supplied but unparseable
+// date (bad format or impossible calendar date like 2026-02-30) would otherwise silently
+// fall through to the default range and return a successful response for an unrelated range.
+// Return the offending field so handlers can reject it instead of querying the wrong window.
+const findInvalidExplicitDate = (params: {
+  startDate?: unknown;
+  endDate?: unknown;
+}): "startDate" | "endDate" | undefined => {
+  for (const field of ["startDate", "endDate"] as const) {
+    const raw = params[field];
+    if (typeof raw === "string" && raw.trim() !== "" && parseDateParts(raw) === undefined) {
+      return field;
+    }
+  }
+  return undefined;
 };
 
 /**
@@ -902,6 +931,7 @@ function mergeUsageCacheStatus(
 // Exposed for unit tests (kept as a single export to avoid widening the public API surface).
 export const testApi = {
   parseDateParts,
+  findInvalidExplicitDate,
   parseUtcOffsetToMinutes,
   resolveDateInterpretation,
   parseDateToMs,
@@ -922,6 +952,21 @@ export const usageHandlers: GatewayRequestHandlers = {
     respond(true, summary, undefined);
   },
   "usage.cost": async ({ respond, params, context }) => {
+    const invalidDate = findInvalidExplicitDate({
+      startDate: params?.startDate,
+      endDate: params?.endDate,
+    });
+    if (invalidDate) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
+        ),
+      );
+      return;
+    }
     const config = context.getRuntimeConfig();
     const { startMs, endMs } = parseDateRange({
       startDate: params?.startDate,
@@ -956,6 +1001,18 @@ export const usageHandlers: GatewayRequestHandlers = {
     }
 
     const p = params;
+    const invalidDate = findInvalidExplicitDate({ startDate: p.startDate, endDate: p.endDate });
+    if (invalidDate) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
+        ),
+      );
+      return;
+    }
     const config = context.getRuntimeConfig();
     const { startMs, endMs } = parseDateRange({
       startDate: p.startDate,
@@ -1335,7 +1392,8 @@ export const usageHandlers: GatewayRequestHandlers = {
         }
         const hiddenSession = hiddenSessions[hiddenIndex];
         const merged = mergedEntries[hiddenSession.entryIndex];
-        const usage = usageByEntryIndex[hiddenSession.entryIndex] ?? createEmptySessionCostSummary();
+        const usage =
+          usageByEntryIndex[hiddenSession.entryIndex] ?? createEmptySessionCostSummary();
         usage.sessionId = merged.sessionId;
         usage.sessionFile = merged.sessionFile;
         mergeSessionUsageInto(usage, summary);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -205,7 +205,10 @@ const findInvalidExplicitDate = (params: {
 }): "startDate" | "endDate" | undefined => {
   for (const field of ["startDate", "endDate"] as const) {
     const raw = params[field];
-    if (typeof raw === "string" && raw.trim() !== "" && parseDateParts(raw) === undefined) {
+    if (raw === undefined || raw === null || (typeof raw === "string" && raw.trim() === "")) {
+      continue;
+    }
+    if (parseDateParts(raw) === undefined) {
       return field;
     }
   }


### PR DESCRIPTION
## Summary

`usage.cost` and `sessions.usage` accepted shape-valid but **impossible** dates
(e.g. `2026-02-30`). `parseDateParts` validated only the `YYYY-MM-DD` regex, so
`Date.*` silently rolled them over (`2026-02-30` → `2026-03-02`) and the RPC
returned cost/usage for the **wrong day** with `success: true`.

This PR:

- Rejects out-of-range calendar dates in `parseDateParts` via a UTC round-trip probe (kills the silent rollover; also catches the JS 2-digit-year remap).
- Returns `INVALID_REQUEST` from `usage.cost` / `sessions.usage` when an explicitly provided `startDate`/`endDate` is unparseable (bad format **or** impossible calendar date), instead of silently falling back to the default 30-day range. This completes the fail-closed contract `sessions.usage` already had for malformed-format dates (its schema rejects format but not out-of-range), and adds it to `usage.cost`, which had no date validation.
- Leaves absent/valid dates unchanged.

Out of scope: the `gateway-protocol` schema (pattern-only) is unchanged — validation lives at the single choke point both RPCs share. Two incidental oxfmt-0.52 line-wraps on pre-existing >100-char lines in the touched files.

## Linked context

No linked issue — self-found bug. Closes: none.

## Real behavior proof

- Behavior or issue addressed: `usage.cost` / `sessions.usage` silently returned cost/usage for the wrong day when given an impossible-but-shape-valid date (e.g. `2026-02-30` → `2026-03-02`); now rejected with `INVALID_REQUEST`.
- Real environment tested: local checkout at `upstream/main` `3630ce6cbb`, Node 22.22.3, isolated git worktree; drove the **real** `usage.cost` RPC handler and the exported date helpers via `tsx` (no mocks of the parse/handler logic), importing the actual `src/gateway/server-methods/usage.ts` from current `main` (before) and this branch (after).
- Exact steps or command run after this patch: ran a `tsx` script invoking `usageHandlers["usage.cost"]({ params: { startDate: "2026-02-30" }, context: { getRuntimeConfig: () => ({}) } })` plus the `findInvalidExplicitDate` / `parseDateToMs` helpers, against both the unfixed `main` copy and this branch.
- Evidence after fix (copied live output from the real handler):

```text
== BEFORE (current main, unfixed) ==
  usage.cost would query startDate "2026-02-30" as day = 2026-03-02   <-- WRONG day, silent, success

== AFTER (this branch) ==
  findInvalidExplicitDate({ startDate: "2026-02-30" })                         -> "startDate"
  findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-02-02" })  -> undefined   (valid dates untouched)
  usage.cost RPC for startDate "2026-02-30"  ->  ok=false,
      error = {"code":"INVALID_REQUEST","message":"invalid startDate: expected a valid YYYY-MM-DD calendar date"}
```

- Observed result after fix: the impossible date is rejected at the RPC boundary with `INVALID_REQUEST` instead of returning a successful response for the wrong/default range; valid dates and the real leap day `2024-02-29` are unaffected.
- What was not tested: a full live gateway server with an over-the-wire client roundtrip (drove the real handler function directly instead).
- Proof limitations or environment constraints: this is a gateway RPC with no UI surface, so the evidence is copied live terminal output from the real handler rather than a screenshot; an end-to-end gateway + client deployment was not stood up locally.

## Tests and validation

- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts` — 38/38 pass (added: out-of-range rejection + leap-day guard, `findInvalidExplicitDate` unit test, handler-level `INVALID_REQUEST` test).
- `tsgo:core` + `tsgo:core:test`, `oxlint`, `oxfmt --check` — clean.
- Cross-model review: `codex review` — clean, 0 findings (Claude implemented → Codex reviewed).

## Risk checklist

- User-visible behavior change? **Yes** — invalid explicit dates now return `INVALID_REQUEST` instead of a silent default-range success.
- Config, environment, or migration change? No.
- Security, auth, secrets, network, or tool-execution change? No.
- Highest-risk area / mitigation: `usage.cost` previously had no date validation, so this adds a fail-closed path. Mitigated by rejecting only *explicitly provided* unparseable dates — absent/valid dates behave exactly as before — and covered by the handler-level test.

AI-assisted: planned and implemented by Claude (Opus 4.8), reviewed by Codex (gpt-5.5).
