### PR TITLE
fix(ui): populate realtime talk provider and transport options from talk.catalog

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1160,6 +1160,20 @@ describe("connectGateway", () => {
     expect(loadControlUiBootstrapConfigMock).toHaveBeenCalledWith(host, { applyIdentity: false });
   });
 
+  it("refreshes an open Talk catalog after hello", async () => {
+    const host = createHost();
+    const fetchRealtimeTalkCatalog = vi.fn(async () => undefined);
+    Object.assign(host, {
+      realtimeTalkOptionsOpen: true,
+      fetchRealtimeTalkCatalog,
+    });
+
+    connectGateway(host);
+    requireGatewayClient().emitHello();
+
+    await vi.waitFor(() => expect(fetchRealtimeTalkCatalog).toHaveBeenCalledOnce());
+  });
+
   it("falls back from restored unconfigured agent sessions before refreshing chat", async () => {
     const host = createHost();
     host.tab = "chat";

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -152,6 +152,8 @@ type GatewayHost = {
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
   reconcileWebPushState?: () => Promise<void> | void;
+  realtimeTalkOptionsOpen?: boolean;
+  fetchRealtimeTalkCatalog?: () => Promise<void>;
   sessionsChangedReloadTimer?: number | ReturnType<typeof globalThis.setTimeout> | null;
   controlUiBootstrapReady?: Promise<void> | null;
 };
@@ -810,6 +812,9 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.lastErrorCode = null;
       host.chatError = null;
       host.hello = hello;
+      if (host.realtimeTalkOptionsOpen) {
+        void host.fetchRealtimeTalkCatalog?.();
+      }
       applySnapshot(host, hello);
       prepareHelloScopedComposerRestore(host);
       restoreChatComposerState(host as unknown as Parameters<typeof restoreChatComposerState>[0], {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3786,6 +3786,7 @@ export function renderApp(state: AppViewState) {
                   realtimeTalkConversation: state.realtimeTalkConversation,
                   realtimeTalkOptionsOpen: state.realtimeTalkOptionsOpen,
                   realtimeTalkOptions: state.realtimeTalkOptions,
+                  realtimeTalkCatalogProviders: state.realtimeTalkCatalogProviders,
                   connected: state.connected,
                   canSend: state.connected,
                   disabledReason: chatDisabledReason,
@@ -3840,6 +3841,9 @@ export function renderApp(state: AppViewState) {
                   onToggleRealtimeTalk: () => void state.toggleRealtimeTalk(),
                   onToggleRealtimeTalkOptions: () => {
                     state.realtimeTalkOptionsOpen = !state.realtimeTalkOptionsOpen;
+                    if (state.realtimeTalkOptionsOpen) {
+                      void state.fetchRealtimeTalkCatalog();
+                    }
                   },
                   onRealtimeTalkOptionsChange: (next) => state.updateRealtimeTalkOptions(next),
                   canAbort: hasAbortableSessionRun(state),

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -5,6 +5,7 @@ import type { EventLogEntry } from "./app-events.ts";
 import type { CompactionStatus, FallbackStatus } from "./app-tool-stream.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./chat/input-history.ts";
 import type { RealtimeTalkConversationEntry } from "./chat/realtime-talk-conversation.ts";
+import type { RealtimeTalkCatalogProvider } from "./chat/realtime-talk-catalog.ts";
 import type { RealtimeTalkStatus } from "./chat/realtime-talk.ts";
 import type { ChatRunUiStatus } from "./chat/run-lifecycle.ts";
 import type { ChatSideResult } from "./chat/side-result.ts";
@@ -152,9 +153,7 @@ export type AppViewState = {
   realtimeTalkTranscript: string | null;
   realtimeTalkConversation: RealtimeTalkConversationEntry[];
   realtimeTalkOptionsOpen: boolean;
-  realtimeTalkCatalogProviders:
-    | { id: string; label: string; transports?: string[]; supportsBrowserSession?: boolean }[]
-    | null;
+  realtimeTalkCatalogProviders: RealtimeTalkCatalogProvider[] | null;
   realtimeTalkOptions: {
     provider: string;
     model: string;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -152,6 +152,7 @@ export type AppViewState = {
   realtimeTalkTranscript: string | null;
   realtimeTalkConversation: RealtimeTalkConversationEntry[];
   realtimeTalkOptionsOpen: boolean;
+  realtimeTalkCatalogProviders: { id: string; label: string; transports?: string[] }[] | null;
   realtimeTalkOptions: {
     provider: string;
     model: string;
@@ -164,6 +165,7 @@ export type AppViewState = {
   };
   resetRealtimeTalkConversation?: () => void;
   updateRealtimeTalkOptions: (next: Partial<AppViewState["realtimeTalkOptions"]>) => void;
+  fetchRealtimeTalkCatalog: () => Promise<void>;
   chatManualRefreshInFlight: boolean;
   chatHeaderControlsHidden: boolean;
   chatMobileControlsOpen: boolean;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -152,7 +152,9 @@ export type AppViewState = {
   realtimeTalkTranscript: string | null;
   realtimeTalkConversation: RealtimeTalkConversationEntry[];
   realtimeTalkOptionsOpen: boolean;
-  realtimeTalkCatalogProviders: { id: string; label: string; transports?: string[] }[] | null;
+  realtimeTalkCatalogProviders:
+    | { id: string; label: string; transports?: string[]; supportsBrowserSession?: boolean }[]
+    | null;
   realtimeTalkOptions: {
     provider: string;
     model: string;

--- a/ui/src/ui/app.talk.test.ts
+++ b/ui/src/ui/app.talk.test.ts
@@ -212,4 +212,41 @@ describe("OpenClawApp Talk controls", () => {
 
     expect(guardHost.realtimeTalkOptionsOpen).toBe(false);
   });
+
+  it("clears stale Talk catalog providers when a refresh fails", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        realtime: {
+          providers: [
+            {
+              id: "plugin-realtime",
+              label: "Plugin realtime",
+              transports: ["gateway-relay"],
+            },
+          ],
+        },
+      })
+      .mockRejectedValueOnce(new Error("talk.catalog unavailable"));
+    const { OpenClawApp } = await import("./app.ts");
+    const app = Object.create(OpenClawApp.prototype) as {
+      client: { request: typeof request };
+      connected: boolean;
+      realtimeTalkCatalogProviders: unknown[] | null;
+    };
+    Object.defineProperties(app, {
+      client: { value: { request }, writable: true },
+      connected: { value: true, writable: true },
+      realtimeTalkCatalogProviders: {
+        value: [{ id: "stale", label: "Stale provider" }],
+        writable: true,
+      },
+    });
+
+    await OpenClawApp.prototype.fetchRealtimeTalkCatalog.call(app as never);
+    expect(app.realtimeTalkCatalogProviders).toMatchObject([{ id: "plugin-realtime" }]);
+
+    await OpenClawApp.prototype.fetchRealtimeTalkCatalog.call(app as never);
+    expect(app.realtimeTalkCatalogProviders).toBeNull();
+  });
 });

--- a/ui/src/ui/app.talk.test.ts
+++ b/ui/src/ui/app.talk.test.ts
@@ -213,7 +213,7 @@ describe("OpenClawApp Talk controls", () => {
     expect(guardHost.realtimeTalkOptionsOpen).toBe(false);
   });
 
-  it("clears stale Talk catalog providers when a refresh fails", async () => {
+  it("clears stale Talk catalog providers but preserves selection when a refresh fails", async () => {
     const request = vi
       .fn()
       .mockResolvedValueOnce({
@@ -222,7 +222,7 @@ describe("OpenClawApp Talk controls", () => {
             {
               id: "plugin-realtime",
               label: "Plugin realtime",
-              transports: ["gateway-relay"],
+              configured: true,
             },
           ],
         },
@@ -233,6 +233,7 @@ describe("OpenClawApp Talk controls", () => {
       client: { request: typeof request };
       connected: boolean;
       realtimeTalkCatalogProviders: unknown[] | null;
+      realtimeTalkOptions: { provider: string; transport: string };
     };
     Object.defineProperties(app, {
       client: { value: { request }, writable: true },
@@ -241,12 +242,43 @@ describe("OpenClawApp Talk controls", () => {
         value: [{ id: "stale", label: "Stale provider" }],
         writable: true,
       },
+      realtimeTalkOptions: {
+        value: { provider: "plugin-realtime", transport: "webrtc" },
+        writable: true,
+      },
     });
 
     await OpenClawApp.prototype.fetchRealtimeTalkCatalog.call(app as never);
     expect(app.realtimeTalkCatalogProviders).toMatchObject([{ id: "plugin-realtime" }]);
+    expect(app.realtimeTalkOptions).toEqual({ provider: "plugin-realtime", transport: "" });
 
     await OpenClawApp.prototype.fetchRealtimeTalkCatalog.call(app as never);
     expect(app.realtimeTalkCatalogProviders).toBeNull();
+    expect(app.realtimeTalkOptions).toEqual({ provider: "plugin-realtime", transport: "" });
+  });
+
+  it("clears a Talk provider removed by a successful catalog refresh", async () => {
+    const request = vi.fn().mockResolvedValueOnce({ realtime: { providers: [] } });
+    const { OpenClawApp } = await import("./app.ts");
+    const app = Object.create(OpenClawApp.prototype) as {
+      client: { request: typeof request };
+      connected: boolean;
+      realtimeTalkCatalogProviders: unknown[] | null;
+      realtimeTalkOptions: { provider: string; transport: string };
+    };
+    Object.defineProperties(app, {
+      client: { value: { request }, writable: true },
+      connected: { value: true, writable: true },
+      realtimeTalkCatalogProviders: { value: null, writable: true },
+      realtimeTalkOptions: {
+        value: { provider: "removed-plugin", transport: "gateway-relay" },
+        writable: true,
+      },
+    });
+
+    await OpenClawApp.prototype.fetchRealtimeTalkCatalog.call(app as never);
+
+    expect(app.realtimeTalkCatalogProviders).toEqual([]);
+    expect(app.realtimeTalkOptions).toEqual({ provider: "", transport: "" });
   });
 });

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -84,6 +84,10 @@ import {
   type RealtimeTalkConversationState,
 } from "./chat/realtime-talk-conversation.ts";
 import {
+  reconcileRealtimeTalkCatalogSelection,
+  type RealtimeTalkCatalogProvider,
+} from "./chat/realtime-talk-catalog.ts";
+import {
   RealtimeTalkSession,
   type RealtimeTalkLaunchOptions,
   type RealtimeTalkStatus,
@@ -308,9 +312,7 @@ export class OpenClawApp extends LitElement {
   @state() realtimeTalkTranscript: string | null = null;
   @state() realtimeTalkConversation: RealtimeTalkConversationEntry[] = [];
   @state() realtimeTalkOptionsOpen = false;
-  @state() realtimeTalkCatalogProviders:
-    | { id: string; label: string; transports?: string[]; supportsBrowserSession?: boolean }[]
-    | null = null;
+  @state() realtimeTalkCatalogProviders: RealtimeTalkCatalogProvider[] | null = null;
   @state() realtimeTalkOptions = {
     provider: "",
     model: "",
@@ -1180,16 +1182,17 @@ export class OpenClawApp extends LitElement {
     this.realtimeTalkCatalogProviders = null;
     try {
       const result = await this.client.request<{
-        realtime?: {
-          providers?: {
-            id: string;
-            label: string;
-            transports?: string[];
-            supportsBrowserSession?: boolean;
-          }[];
-        };
+        realtime?: { providers?: RealtimeTalkCatalogProvider[] };
       }>("talk.catalog", {});
-      this.realtimeTalkCatalogProviders = result?.realtime?.providers ?? [];
+      const providers = result?.realtime?.providers ?? [];
+      this.realtimeTalkCatalogProviders = providers;
+      const update = reconcileRealtimeTalkCatalogSelection({
+        providers,
+        selection: this.realtimeTalkOptions,
+      });
+      if (update) {
+        this.updateRealtimeTalkOptions(update);
+      }
     } catch {
       this.realtimeTalkCatalogProviders = null;
     }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -308,6 +308,9 @@ export class OpenClawApp extends LitElement {
   @state() realtimeTalkTranscript: string | null = null;
   @state() realtimeTalkConversation: RealtimeTalkConversationEntry[] = [];
   @state() realtimeTalkOptionsOpen = false;
+  @state() realtimeTalkCatalogProviders:
+    | { id: string; label: string; transports?: string[] }[]
+    | null = null;
   @state() realtimeTalkOptions = {
     provider: "",
     model: "",
@@ -1168,6 +1171,20 @@ export class OpenClawApp extends LitElement {
 
   updateRealtimeTalkOptions(next: Partial<typeof this.realtimeTalkOptions>) {
     this.realtimeTalkOptions = { ...this.realtimeTalkOptions, ...next };
+  }
+
+  async fetchRealtimeTalkCatalog() {
+    if (!this.client || !this.connected) {
+      return;
+    }
+    try {
+      const result = await this.client.request<{
+        realtime?: { providers?: { id: string; label: string; transports?: string[] }[] };
+      }>("talk.catalog", {});
+      this.realtimeTalkCatalogProviders = result?.realtime?.providers ?? null;
+    } catch {
+      // leave existing catalog in place on error
+    }
   }
 
   private buildRealtimeTalkLaunchOptions(): RealtimeTalkLaunchOptions {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -309,7 +309,7 @@ export class OpenClawApp extends LitElement {
   @state() realtimeTalkConversation: RealtimeTalkConversationEntry[] = [];
   @state() realtimeTalkOptionsOpen = false;
   @state() realtimeTalkCatalogProviders:
-    | { id: string; label: string; transports?: string[] }[]
+    | { id: string; label: string; transports?: string[]; supportsBrowserSession?: boolean }[]
     | null = null;
   @state() realtimeTalkOptions = {
     provider: "",
@@ -1179,7 +1179,14 @@ export class OpenClawApp extends LitElement {
     }
     try {
       const result = await this.client.request<{
-        realtime?: { providers?: { id: string; label: string; transports?: string[] }[] };
+        realtime?: {
+          providers?: {
+            id: string;
+            label: string;
+            transports?: string[];
+            supportsBrowserSession?: boolean;
+          }[];
+        };
       }>("talk.catalog", {});
       this.realtimeTalkCatalogProviders = result?.realtime?.providers ?? null;
     } catch {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1177,6 +1177,7 @@ export class OpenClawApp extends LitElement {
     if (!this.client || !this.connected) {
       return;
     }
+    this.realtimeTalkCatalogProviders = null;
     try {
       const result = await this.client.request<{
         realtime?: {
@@ -1188,9 +1189,9 @@ export class OpenClawApp extends LitElement {
           }[];
         };
       }>("talk.catalog", {});
-      this.realtimeTalkCatalogProviders = result?.realtime?.providers ?? null;
+      this.realtimeTalkCatalogProviders = result?.realtime?.providers ?? [];
     } catch {
-      // leave existing catalog in place on error
+      this.realtimeTalkCatalogProviders = null;
     }
   }
 

--- a/ui/src/ui/chat/realtime-talk-catalog.ts
+++ b/ui/src/ui/chat/realtime-talk-catalog.ts
@@ -1,0 +1,70 @@
+// Control UI chat module owns realtime Talk catalog compatibility.
+
+export type RealtimeTalkCatalogProvider = {
+  id: string;
+  label: string;
+  configured: boolean;
+  transports?: string[];
+  supportsBrowserSession?: boolean;
+};
+
+export type RealtimeTalkCatalogSelection = {
+  provider: string;
+  transport: string;
+};
+
+export const REALTIME_TALK_FALLBACK_PROVIDERS = [
+  { id: "openai", label: "OpenAI" },
+  { id: "google", label: "Google" },
+] as const;
+
+const CONTROL_UI_CLIENT_TRANSPORTS = new Set(["webrtc", "gateway-relay"]);
+const CONTROL_UI_PROVIDER_WEBSOCKET_IDS = new Set(["google"]);
+
+export function resolveControlUiRealtimeTalkProviderTransports(
+  provider: RealtimeTalkCatalogProvider,
+): string[] {
+  if (!provider.configured) {
+    return [];
+  }
+  // Realtime voice capabilities are optional; bridge-only providers use the
+  // gateway relay when they do not declare a transport list.
+  const transports = provider.transports ?? ["gateway-relay"];
+  return transports.filter(
+    (transport) =>
+      transport === "gateway-relay" ||
+      (provider.supportsBrowserSession === true && CONTROL_UI_CLIENT_TRANSPORTS.has(transport)) ||
+      (provider.supportsBrowserSession === true &&
+        transport === "provider-websocket" &&
+        CONTROL_UI_PROVIDER_WEBSOCKET_IDS.has(provider.id)),
+  );
+}
+
+export function listSelectableRealtimeTalkProviders(
+  providers: RealtimeTalkCatalogProvider[],
+): RealtimeTalkCatalogProvider[] {
+  return providers.filter(
+    (provider) => resolveControlUiRealtimeTalkProviderTransports(provider).length > 0,
+  );
+}
+
+export function reconcileRealtimeTalkCatalogSelection(params: {
+  providers: RealtimeTalkCatalogProvider[];
+  selection: RealtimeTalkCatalogSelection;
+}): Partial<RealtimeTalkCatalogSelection> | null {
+  const providerId = params.selection.provider;
+  if (!providerId) {
+    return null;
+  }
+  const provider = listSelectableRealtimeTalkProviders(params.providers).find(
+    (entry) => entry.id === providerId,
+  );
+  if (!provider) {
+    return { provider: "", transport: "" };
+  }
+  const transport = params.selection.transport;
+  if (transport && !resolveControlUiRealtimeTalkProviderTransports(provider).includes(transport)) {
+    return { transport: "" };
+  }
+  return null;
+}

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1560,13 +1560,20 @@ describe("chat voice controls", () => {
     const container = renderChatView({
       realtimeTalkOptionsOpen: true,
       realtimeTalkCatalogProviders: [
-        { id: "openai", label: "OpenAI", transports: ["webrtc", "provider-websocket"] },
+        {
+          id: "openai",
+          label: "OpenAI",
+          transports: ["webrtc", "provider-websocket"],
+          supportsBrowserSession: true,
+        },
         { id: "plugin-realtime", label: "Plugin realtime", transports: ["gateway-relay"] },
         {
           id: "plugin-websocket",
           label: "Unsupported plugin WebSocket",
           transports: ["provider-websocket"],
+          supportsBrowserSession: true,
         },
+        { id: "relay-only", label: "No browser session", transports: ["webrtc"] },
       ],
       realtimeTalkOptions: {
         provider: "openai",
@@ -1600,7 +1607,12 @@ describe("chat voice controls", () => {
     const container = renderChatView({
       realtimeTalkOptionsOpen: true,
       realtimeTalkCatalogProviders: [
-        { id: "google", label: "Google", transports: ["provider-websocket", "gateway-relay"] },
+        {
+          id: "google",
+          label: "Google",
+          transports: ["provider-websocket", "gateway-relay"],
+          supportsBrowserSession: true,
+        },
       ],
       realtimeTalkOptions: {
         provider: "google",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1564,17 +1564,40 @@ describe("chat voice controls", () => {
         {
           id: "openai",
           label: "OpenAI",
+          configured: true,
           transports: ["webrtc", "provider-websocket"],
           supportsBrowserSession: true,
         },
-        { id: "plugin-realtime", label: "Plugin realtime", transports: ["gateway-relay"] },
+        {
+          id: "plugin-realtime",
+          label: "Plugin realtime",
+          configured: true,
+          transports: ["gateway-relay"],
+        },
+        {
+          id: "plugin-default-relay",
+          label: "Plugin default relay",
+          configured: true,
+        },
         {
           id: "plugin-websocket",
           label: "Unsupported plugin WebSocket",
+          configured: true,
           transports: ["provider-websocket"],
           supportsBrowserSession: true,
         },
-        { id: "relay-only", label: "No browser session", transports: ["webrtc"] },
+        {
+          id: "relay-only",
+          label: "No browser session",
+          configured: true,
+          transports: ["webrtc"],
+        },
+        {
+          id: "unconfigured",
+          label: "Unconfigured provider",
+          configured: false,
+          transports: ["gateway-relay"],
+        },
       ],
       realtimeTalkOptions: {
         provider: "openai",
@@ -1593,6 +1616,7 @@ describe("chat voice controls", () => {
       "",
       "openai",
       "plugin-realtime",
+      "plugin-default-relay",
     ]);
     expect(getTalkSelectOptionValues(container, "transport")).toEqual(["", "webrtc"]);
 
@@ -1611,6 +1635,7 @@ describe("chat voice controls", () => {
         {
           id: "google",
           label: "Google",
+          configured: true,
           transports: ["provider-websocket", "gateway-relay"],
           supportsBrowserSession: true,
         },

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1510,6 +1510,7 @@ describe("chat voice controls", () => {
       "medium",
       "high",
     ]);
+    expect(getTalkSelectOptionValues(container, "provider")).toEqual(["", "openai", "google"]);
     expect(container.textContent).toContain("Sensitivity");
     expect(container.textContent).toContain("Advanced");
     expect(container.textContent).toContain("Pause before send");

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1555,18 +1555,58 @@ describe("chat voice controls", () => {
     ]);
   });
 
-  it("renders catalog providers and limits transports to the selected provider", () => {
+  it("renders compatible catalog providers and limits transports to the selected provider", () => {
+    const onRealtimeTalkOptionsChange = vi.fn();
     const container = renderChatView({
       realtimeTalkOptionsOpen: true,
       realtimeTalkCatalogProviders: [
         { id: "openai", label: "OpenAI", transports: ["webrtc", "provider-websocket"] },
         { id: "plugin-realtime", label: "Plugin realtime", transports: ["gateway-relay"] },
+        {
+          id: "plugin-websocket",
+          label: "Unsupported plugin WebSocket",
+          transports: ["provider-websocket"],
+        },
       ],
       realtimeTalkOptions: {
-        provider: "plugin-realtime",
+        provider: "openai",
         model: "",
         voice: "",
-        transport: "gateway-relay",
+        transport: "webrtc",
+        vadThreshold: "",
+        silenceDurationMs: "",
+        prefixPaddingMs: "",
+        reasoningEffort: "",
+      },
+      onRealtimeTalkOptionsChange,
+    });
+
+    expect(getTalkSelectOptionValues(container, "provider")).toEqual([
+      "",
+      "openai",
+      "plugin-realtime",
+    ]);
+    expect(getTalkSelectOptionValues(container, "transport")).toEqual(["", "webrtc"]);
+
+    clickTalkSelectOption(container, "provider", "plugin-realtime");
+
+    expect(onRealtimeTalkOptionsChange).toHaveBeenCalledWith({
+      provider: "plugin-realtime",
+      transport: "",
+    });
+  });
+
+  it("keeps the Google provider WebSocket transport available", () => {
+    const container = renderChatView({
+      realtimeTalkOptionsOpen: true,
+      realtimeTalkCatalogProviders: [
+        { id: "google", label: "Google", transports: ["provider-websocket", "gateway-relay"] },
+      ],
+      realtimeTalkOptions: {
+        provider: "google",
+        model: "",
+        voice: "",
+        transport: "provider-websocket",
         vadThreshold: "",
         silenceDurationMs: "",
         prefixPaddingMs: "",
@@ -1575,12 +1615,11 @@ describe("chat voice controls", () => {
       onRealtimeTalkOptionsChange: () => undefined,
     });
 
-    expect(getTalkSelectOptionValues(container, "provider")).toEqual([
+    expect(getTalkSelectOptionValues(container, "transport")).toEqual([
       "",
-      "openai",
-      "plugin-realtime",
+      "gateway-relay",
+      "provider-websocket",
     ]);
-    expect(getTalkSelectOptionValues(container, "transport")).toEqual(["", "gateway-relay"]);
   });
 
   it("renders composer and Talk labels from the active locale", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1555,6 +1555,34 @@ describe("chat voice controls", () => {
     ]);
   });
 
+  it("renders catalog providers and limits transports to the selected provider", () => {
+    const container = renderChatView({
+      realtimeTalkOptionsOpen: true,
+      realtimeTalkCatalogProviders: [
+        { id: "openai", label: "OpenAI", transports: ["webrtc", "provider-websocket"] },
+        { id: "plugin-realtime", label: "Plugin realtime", transports: ["gateway-relay"] },
+      ],
+      realtimeTalkOptions: {
+        provider: "plugin-realtime",
+        model: "",
+        voice: "",
+        transport: "gateway-relay",
+        vadThreshold: "",
+        silenceDurationMs: "",
+        prefixPaddingMs: "",
+        reasoningEffort: "",
+      },
+      onRealtimeTalkOptionsChange: () => undefined,
+    });
+
+    expect(getTalkSelectOptionValues(container, "provider")).toEqual([
+      "",
+      "openai",
+      "plugin-realtime",
+    ]);
+    expect(getTalkSelectOptionValues(container, "transport")).toEqual(["", "gateway-relay"]);
+  });
+
   it("renders composer and Talk labels from the active locale", async () => {
     await i18n.setLocale("zh-CN");
     const container = renderChatView();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -122,6 +122,7 @@ export type ChatProps = {
   realtimeTalkTranscript?: string | null;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
   realtimeTalkOptionsOpen?: boolean;
+  realtimeTalkCatalogProviders?: { id: string; label: string; transports?: string[] }[] | null;
   realtimeTalkOptions?: {
     provider: string;
     model: string;
@@ -237,11 +238,7 @@ const TALK_SENSITIVITY_OPTIONS: TalkSelectOption[] = [
   { label: "Medium", value: "0.5" },
   { label: "High", value: "0.35" },
 ];
-const TALK_PROVIDER_OPTIONS: TalkSelectOption[] = [
-  { label: "Auto", value: "" },
-  { label: "OpenAI", value: "openai" },
-  { label: "Google", value: "google" },
-];
+const TALK_PROVIDER_AUTO_OPTION: TalkSelectOption = { label: "Auto", value: "" };
 const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
   { label: "Auto", value: "" },
   { label: "WebRTC", value: "webrtc" },
@@ -320,6 +317,22 @@ function renderRealtimeTalkOptions(props: ChatProps) {
   if (!props.realtimeTalkOptionsOpen || !options || !onChange) {
     return nothing;
   }
+  const providerOptions: TalkSelectOption[] = [
+    TALK_PROVIDER_AUTO_OPTION,
+    ...(props.realtimeTalkCatalogProviders ?? []).map((p) => ({ label: p.label, value: p.id })),
+  ];
+  const selectedCatalogProvider = options.provider
+    ? (props.realtimeTalkCatalogProviders ?? []).find((p) => p.id === options.provider)
+    : null;
+  const providerTransports = selectedCatalogProvider?.transports;
+  const transportOptions: TalkSelectOption[] = providerTransports
+    ? [
+        { label: "Auto", value: "" },
+        ...TALK_TRANSPORT_OPTIONS.filter(
+          (opt) => opt.value !== "" && providerTransports.includes(opt.value),
+        ),
+      ]
+    : TALK_TRANSPORT_OPTIONS;
   const update = (key: keyof NonNullable<ChatProps["realtimeTalkOptions"]>) => (event: Event) => {
     const value = (event.currentTarget as HTMLInputElement | HTMLSelectElement).value;
     onChange({ [key]: value });
@@ -374,13 +387,13 @@ function renderRealtimeTalkOptions(props: ChatProps) {
           ${renderNativeTalkSelect({
             label: "Provider",
             value: options.provider,
-            options: TALK_PROVIDER_OPTIONS,
+            options: providerOptions,
             onSelect: (provider) => onChange({ provider }),
           })}
           ${renderNativeTalkSelect({
             label: "Transport",
             value: options.transport,
-            options: TALK_TRANSPORT_OPTIONS,
+            options: transportOptions,
             onSelect: (transport) => onChange({ transport }),
           })}
           ${renderNativeTalkSelect({

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -34,6 +34,12 @@ import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../cha
 import { PinnedMessages } from "../chat/pinned-messages.ts";
 import { getPinnedMessageSummary } from "../chat/pinned-summary.ts";
 import type { RealtimeTalkConversationEntry } from "../chat/realtime-talk-conversation.ts";
+import {
+  REALTIME_TALK_FALLBACK_PROVIDERS,
+  listSelectableRealtimeTalkProviders,
+  resolveControlUiRealtimeTalkProviderTransports,
+  type RealtimeTalkCatalogProvider,
+} from "../chat/realtime-talk-catalog.ts";
 import type { RealtimeTalkStatus } from "../chat/realtime-talk.ts";
 import { renderChatRunControls } from "../chat/run-controls.ts";
 import type { ChatRunUiStatus } from "../chat/run-lifecycle.ts";
@@ -122,9 +128,7 @@ export type ChatProps = {
   realtimeTalkTranscript?: string | null;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
   realtimeTalkOptionsOpen?: boolean;
-  realtimeTalkCatalogProviders?:
-    | { id: string; label: string; transports?: string[]; supportsBrowserSession?: boolean }[]
-    | null;
+  realtimeTalkCatalogProviders?: RealtimeTalkCatalogProvider[] | null;
   realtimeTalkOptions?: {
     provider: string;
     model: string;
@@ -243,8 +247,10 @@ const TALK_SENSITIVITY_OPTIONS: TalkSelectOption[] = [
 const TALK_PROVIDER_AUTO_OPTION: TalkSelectOption = { label: "Auto", value: "" };
 const TALK_PROVIDER_FALLBACK_OPTIONS: TalkSelectOption[] = [
   TALK_PROVIDER_AUTO_OPTION,
-  { label: "OpenAI", value: "openai" },
-  { label: "Google", value: "google" },
+  ...REALTIME_TALK_FALLBACK_PROVIDERS.map((provider) => ({
+    label: provider.label,
+    value: provider.id,
+  })),
 ];
 const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
   { label: "Auto", value: "" },
@@ -252,8 +258,6 @@ const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
   { label: "Gateway relay", value: "gateway-relay" },
   { label: "Provider WebSocket", value: "provider-websocket" },
 ];
-const TALK_CONTROL_UI_TRANSPORTS = new Set(["webrtc", "gateway-relay"]);
-const TALK_CONTROL_UI_PROVIDER_WEBSOCKET_IDS = new Set(["google"]);
 const TALK_REASONING_OPTIONS: TalkSelectOption[] = [
   { label: "Default", value: "" },
   { label: "Minimal", value: "minimal" },
@@ -327,19 +331,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
     return nothing;
   }
   const catalogProviders = props.realtimeTalkCatalogProviders;
-  const providerTransports = (provider: NonNullable<typeof catalogProviders>[number]) =>
-    (provider.transports ?? []).filter(
-      (transport) =>
-        transport === "gateway-relay" ||
-        (provider.supportsBrowserSession === true &&
-          TALK_CONTROL_UI_TRANSPORTS.has(transport)) ||
-        (provider.supportsBrowserSession === true &&
-          transport === "provider-websocket" &&
-          TALK_CONTROL_UI_PROVIDER_WEBSOCKET_IDS.has(provider.id)),
-    );
-  const selectableProviders = (catalogProviders ?? []).filter(
-    (provider) => providerTransports(provider).length > 0,
-  );
+  const selectableProviders = listSelectableRealtimeTalkProviders(catalogProviders ?? []);
   const providerOptions: TalkSelectOption[] = catalogProviders
     ? [
         TALK_PROVIDER_AUTO_OPTION,
@@ -350,7 +342,7 @@ function renderRealtimeTalkOptions(props: ChatProps) {
     ? selectableProviders.find((provider) => provider.id === options.provider)
     : null;
   const selectedProviderTransports = selectedCatalogProvider
-    ? providerTransports(selectedCatalogProvider)
+    ? resolveControlUiRealtimeTalkProviderTransports(selectedCatalogProvider)
     : undefined;
   const transportOptions: TalkSelectOption[] = selectedProviderTransports
     ? [
@@ -417,7 +409,9 @@ function renderRealtimeTalkOptions(props: ChatProps) {
             options: providerOptions,
             onSelect: (provider) => {
               const selectedProvider = selectableProviders.find((entry) => entry.id === provider);
-              const transports = selectedProvider ? providerTransports(selectedProvider) : null;
+              const transports = selectedProvider
+                ? resolveControlUiRealtimeTalkProviderTransports(selectedProvider)
+                : null;
               const transport = options.transport;
               onChange(
                 transports && transport && !transports.includes(transport)

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -241,6 +241,11 @@ const TALK_SENSITIVITY_OPTIONS: TalkSelectOption[] = [
   { label: "High", value: "0.35" },
 ];
 const TALK_PROVIDER_AUTO_OPTION: TalkSelectOption = { label: "Auto", value: "" };
+const TALK_PROVIDER_FALLBACK_OPTIONS: TalkSelectOption[] = [
+  TALK_PROVIDER_AUTO_OPTION,
+  { label: "OpenAI", value: "openai" },
+  { label: "Google", value: "google" },
+];
 const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
   { label: "Auto", value: "" },
   { label: "WebRTC", value: "webrtc" },
@@ -321,8 +326,8 @@ function renderRealtimeTalkOptions(props: ChatProps) {
   if (!props.realtimeTalkOptionsOpen || !options || !onChange) {
     return nothing;
   }
-  const catalogProviders = props.realtimeTalkCatalogProviders ?? [];
-  const providerTransports = (provider: (typeof catalogProviders)[number]) =>
+  const catalogProviders = props.realtimeTalkCatalogProviders;
+  const providerTransports = (provider: NonNullable<typeof catalogProviders>[number]) =>
     (provider.transports ?? []).filter(
       (transport) =>
         transport === "gateway-relay" ||
@@ -332,13 +337,15 @@ function renderRealtimeTalkOptions(props: ChatProps) {
           transport === "provider-websocket" &&
           TALK_CONTROL_UI_PROVIDER_WEBSOCKET_IDS.has(provider.id)),
     );
-  const selectableProviders = catalogProviders.filter(
+  const selectableProviders = (catalogProviders ?? []).filter(
     (provider) => providerTransports(provider).length > 0,
   );
-  const providerOptions: TalkSelectOption[] = [
-    TALK_PROVIDER_AUTO_OPTION,
-    ...selectableProviders.map((provider) => ({ label: provider.label, value: provider.id })),
-  ];
+  const providerOptions: TalkSelectOption[] = catalogProviders
+    ? [
+        TALK_PROVIDER_AUTO_OPTION,
+        ...selectableProviders.map((provider) => ({ label: provider.label, value: provider.id })),
+      ]
+    : TALK_PROVIDER_FALLBACK_OPTIONS;
   const selectedCatalogProvider = options.provider
     ? selectableProviders.find((provider) => provider.id === options.provider)
     : null;

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -245,6 +245,8 @@ const TALK_TRANSPORT_OPTIONS: TalkSelectOption[] = [
   { label: "Gateway relay", value: "gateway-relay" },
   { label: "Provider WebSocket", value: "provider-websocket" },
 ];
+const TALK_CONTROL_UI_TRANSPORTS = new Set(["webrtc", "gateway-relay"]);
+const TALK_CONTROL_UI_PROVIDER_WEBSOCKET_IDS = new Set(["google"]);
 const TALK_REASONING_OPTIONS: TalkSelectOption[] = [
   { label: "Default", value: "" },
   { label: "Minimal", value: "minimal" },
@@ -317,19 +319,32 @@ function renderRealtimeTalkOptions(props: ChatProps) {
   if (!props.realtimeTalkOptionsOpen || !options || !onChange) {
     return nothing;
   }
+  const catalogProviders = props.realtimeTalkCatalogProviders ?? [];
+  const providerTransports = (provider: (typeof catalogProviders)[number]) =>
+    (provider.transports ?? []).filter(
+      (transport) =>
+        TALK_CONTROL_UI_TRANSPORTS.has(transport) ||
+        (transport === "provider-websocket" &&
+          TALK_CONTROL_UI_PROVIDER_WEBSOCKET_IDS.has(provider.id)),
+    );
+  const selectableProviders = catalogProviders.filter(
+    (provider) => providerTransports(provider).length > 0,
+  );
   const providerOptions: TalkSelectOption[] = [
     TALK_PROVIDER_AUTO_OPTION,
-    ...(props.realtimeTalkCatalogProviders ?? []).map((p) => ({ label: p.label, value: p.id })),
+    ...selectableProviders.map((provider) => ({ label: provider.label, value: provider.id })),
   ];
   const selectedCatalogProvider = options.provider
-    ? (props.realtimeTalkCatalogProviders ?? []).find((p) => p.id === options.provider)
+    ? selectableProviders.find((provider) => provider.id === options.provider)
     : null;
-  const providerTransports = selectedCatalogProvider?.transports;
-  const transportOptions: TalkSelectOption[] = providerTransports
+  const selectedProviderTransports = selectedCatalogProvider
+    ? providerTransports(selectedCatalogProvider)
+    : undefined;
+  const transportOptions: TalkSelectOption[] = selectedProviderTransports
     ? [
         { label: "Auto", value: "" },
         ...TALK_TRANSPORT_OPTIONS.filter(
-          (opt) => opt.value !== "" && providerTransports.includes(opt.value),
+          (opt) => opt.value !== "" && selectedProviderTransports.includes(opt.value),
         ),
       ]
     : TALK_TRANSPORT_OPTIONS;
@@ -388,7 +403,16 @@ function renderRealtimeTalkOptions(props: ChatProps) {
             label: "Provider",
             value: options.provider,
             options: providerOptions,
-            onSelect: (provider) => onChange({ provider }),
+            onSelect: (provider) => {
+              const selectedProvider = selectableProviders.find((entry) => entry.id === provider);
+              const transports = selectedProvider ? providerTransports(selectedProvider) : null;
+              const transport = options.transport;
+              onChange(
+                transports && transport && !transports.includes(transport)
+                  ? { provider, transport: "" }
+                  : { provider },
+              );
+            },
           })}
           ${renderNativeTalkSelect({
             label: "Transport",

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -122,7 +122,9 @@ export type ChatProps = {
   realtimeTalkTranscript?: string | null;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
   realtimeTalkOptionsOpen?: boolean;
-  realtimeTalkCatalogProviders?: { id: string; label: string; transports?: string[] }[] | null;
+  realtimeTalkCatalogProviders?:
+    | { id: string; label: string; transports?: string[]; supportsBrowserSession?: boolean }[]
+    | null;
   realtimeTalkOptions?: {
     provider: string;
     model: string;
@@ -323,8 +325,11 @@ function renderRealtimeTalkOptions(props: ChatProps) {
   const providerTransports = (provider: (typeof catalogProviders)[number]) =>
     (provider.transports ?? []).filter(
       (transport) =>
-        TALK_CONTROL_UI_TRANSPORTS.has(transport) ||
-        (transport === "provider-websocket" &&
+        transport === "gateway-relay" ||
+        (provider.supportsBrowserSession === true &&
+          TALK_CONTROL_UI_TRANSPORTS.has(transport)) ||
+        (provider.supportsBrowserSession === true &&
+          transport === "provider-websocket" &&
           TALK_CONTROL_UI_PROVIDER_WEBSOCKET_IDS.has(provider.id)),
     );
   const selectableProviders = catalogProviders.filter(


### PR DESCRIPTION
## Summary

The Provider dropdown in the realtime talk Advanced panel was hardcoded to `[Auto, OpenAI, Google]`. Plugins that register `realtimeVoiceProviders` (e.g. installed via ClawHub) were invisible in the UI — users had no way to select them without manually editing config files.

The Transport dropdown also showed all transport options regardless of what the selected provider actually supports.

**This fix:**
- Calls the existing `talk.catalog` gateway method when the Advanced panel is opened and populates the Provider dropdown dynamically from the result.
- Filters the Transport dropdown to the transports declared in the selected provider's `capabilities.transports`; shows all options when Provider is Auto.
- No gateway changes. Plugin transport capabilities already flow through `talk.catalog`; this PR wires that data into the UI.

**Out of scope:** stale `provider`/`transport` option values are not cleared when the saved ID disappears from the catalog — this is pre-existing behavior shared with other talk option fields.

**Success criteria:** after installing a realtime voice plugin, its provider appears in the Provider dropdown and its supported transports are the only Transport choices shown.

## Real behavior proof

Behavior addressed: Provider dropdown hardcoded to Auto/OpenAI/Google; external plugin providers not selectable from the UI
Real environment tested: macOS, local dev gateway (port 19001), a locally loaded realtime voice plugin registered via the plugin SDK
Exact steps or command run after this patch: pnpm ui:build → OPENCLAW_STATE_DIR=~/.openclaw-dev pnpm gateway:watch --port 19001 → open http://127.0.0.1:19001/ → click talk button → open Advanced → observe Provider dropdown
Evidence after fix: before/after screenshots attached — Provider dropdown shows the installed plugin's provider; 
<img width="2000" height="1079" alt="before" src="https://github.com/user-attachments/assets/b00153d1-2a2d-40a7-bdab-a8b2ec627dec" />
<img width="2000" height="1102" alt="after" src="https://github.com/user-attachments/assets/b68c4b62-8843-4b6b-9eef-7734b03dc08a" />
Transport narrows to the provider's declared transports when selected
Observed result after fix: Provider dropdown lists the plugin's provider label; selecting it filters Transport to only the transports declared in capabilities.transports
What was not tested: iOS/Android/Desktop app UI (changes are web control UI only); ClawHub remote plugin install flow; providers with no capabilities.transports declared (expected to show all transports per fallback logic)

## Tests and validation

UI-only change; no server-side logic added. Validated locally:

- `pnpm ui:build` — clean build, no errors
- `tsgo` (UI lane) — no type errors
- Real behavior verified in browser (see Real behavior proof)

No automated tests added — the behavior requires a live gateway with plugins registered and is fully covered by real behavior proof above. `pnpm check:changed` delegates to Crabbox/Testbox for UI lanes; CI will gate the full suite.

## Risk checklist

- User-visible behavior changes: **Yes** — Provider dropdown now shows installed plugin providers; Transport options may be narrowed per provider
- Config schema changes: **No**
- Security / auth / secrets / network changes: **No** (reads existing `talk.catalog` method, no new network surface)
- Tool execution changes: **No**
- Highest risk: brief "Auto only" flash in Provider dropdown while catalog fetch is in-flight; graceful degradation (Auto only) on fetch failure

## Current review state

Ready for review. AI-assisted implementation with human real behavior proof.