### PR TITLE
fix(memory): await search-sync before returning results to prevent stale index (fixes #52115)

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -1,17 +1,19 @@
 // Memory Core plugin module implements manager async state behavior.
-export function startAsyncSearchSync(params: {
+export async function startAsyncSearchSync(params: {
   enabled: boolean;
   dirty: boolean;
   sessionsDirty: boolean;
   sync: (params: { reason: string }) => Promise<void>;
   onError: (err: unknown) => void;
-}): void {
+}): Promise<void> {
   if (!params.enabled || (!params.dirty && !params.sessionsDirty)) {
     return;
   }
-  void params.sync({ reason: "search" }).catch((err: unknown) => {
+  try {
+    await params.sync({ reason: "search" });
+  } catch (err: unknown) {
     params.onError(err);
-  });
+  }
 }
 
 export async function awaitPendingManagerWork(params: {

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -13,7 +13,7 @@ describe("memory search async sync", () => {
     });
     const onError = vi.fn();
 
-    startAsyncSearchSync({
+    const searchPromise = startAsyncSearchSync({
       enabled: true,
       dirty: true,
       sessionsDirty: false,
@@ -23,7 +23,7 @@ describe("memory search async sync", () => {
 
     expect(syncMock).toHaveBeenCalledTimes(1);
     releaseSync();
-    await pending;
+    await searchPromise;
     expect(onError).not.toHaveBeenCalled();
   });
 
@@ -45,9 +45,9 @@ describe("memory search async sync", () => {
     await closePromise;
   });
 
-  it("skips background search sync when search-triggered sync is disabled", () => {
+  it("skips background search sync when search-triggered sync is disabled", async () => {
     const syncMock = vi.fn(async () => {});
-    startAsyncSearchSync({
+    await startAsyncSearchSync({
       enabled: false,
       dirty: true,
       sessionsDirty: false,

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -630,7 +630,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
     const cleaned = preflight.normalizedQuery;
     void this.warmSession(opts?.sessionKey);
-    startAsyncSearchSync({
+    await startAsyncSearchSync({
       enabled: this.settings.sync.onSearch,
       dirty: this.dirty,
       sessionsDirty: this.sessionsDirty,


### PR DESCRIPTION
## What

Await the search-sync before returning results in `MemoryIndexManager.search()`, so the index is fresh when the query runs. Previously `startAsyncSearchSync` was fire-and-forget — the sync ran in the background while stale results were returned immediately.

## Why

When `settings.sync.onSearch` is enabled and the manager is dirty, the first search after a content change would return results from the previous index state. The `startAsyncSearchSync` function used `void params.sync(...).catch(...)` — launching the sync as a detached promise without waiting for completion.

## How

- Changed `startAsyncSearchSync` from sync fire-and-forget (`void ... .catch()`) to `async function` with `try/await/catch`
- Updated the call site in `manager.ts:633` to `await startAsyncSearchSync(...)`
- Error handling preserved: sync failures still call `onError` but no longer swallow silently

## Changes

- `extensions/memory-core/src/memory/manager-async-state.ts`: `startAsyncSearchSync` is now async, awaits the sync
- `extensions/memory-core/src/memory/manager.ts`: call site uses `await`

## How to Test

```
pnpm build
```

## Real behavior proof

- **Behavior addressed:** Memory search returns stale results when `sync.onSearch` is enabled and the index is dirty — `startAsyncSearchSync` was fire-and-forget
- **Environment tested:** macOS 26.4.1, Node.js, openclaw repo at `fix/memory-search-stale-index-sync-v2`
- **Steps run after the patch:** Built the project with `pnpm build` and verified the function is now async with `grep -n`
- **Evidence after fix:**

```
extensions/memory-core/src/memory/manager-async-state.ts:2:export async function startAsyncSearchSync(params: {
extensions/memory-core/src/memory/manager-async-state.ts:13:    await params.sync({ reason: "search" });
extensions/memory-core/src/memory/manager.ts:633:    await startAsyncSearchSync({
```

- **Observed result after fix:** `startAsyncSearchSync` is now an async function that awaits the sync before returning, ensuring search results come from a fresh index
- **What was not tested:** End-to-end memory search with actual embedding provider (requires live environment); error path for sync failure (existing error handling preserved)
