### PR TITLE
ci(release): sync stable package version to main

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -452,7 +452,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm-release
     permissions:
-      actions: read
+      actions: write
       contents: read
       id-token: write
     steps:
@@ -710,3 +710,20 @@ jobs:
             publish_target="./${publish_target}"
           fi
           bash scripts/openclaw-npm-publish.sh --publish "${publish_target}"
+
+      - name: Dispatch stable main version sync
+        id: main-version-sync
+        if: ${{ !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh workflow run sync-main-release-version.yml --ref main -f tag="${RELEASE_TAG}"
+
+      - name: Warn when stable main version sync dispatch fails
+        if: steps.main-version-sync.outcome == 'failure'
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          echo "::warning::Stable npm publish succeeded, but the main version sync workflow could not be dispatched for ${RELEASE_TAG}."
+          echo "Manually run Sync Stable Version To Main for ${RELEASE_TAG}." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-main-release-version.yml
+++ b/.github/workflows/sync-main-release-version.yml
@@ -1,0 +1,243 @@
+name: Sync Stable Version To Main
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published stable OpenClaw release tag to synchronize onto main
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: sync-main-release-version
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  sync:
+    name: Open or refresh main version sync PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      base_sha: ${{ steps.pr.outputs.base_sha }}
+      changed: ${{ steps.sync.outputs.changed }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      pr_url: ${{ steps.pr.outputs.pr_url }}
+    steps:
+      - name: Checkout current main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: main
+
+      - name: Validate stable tag input
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*(-[1-9][0-9]*)?$ ]]; then
+            echo "Invalid stable release tag: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Sync stable package metadata
+        id: sync
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          pnpm release:sync-main-version -- --tag "${RELEASE_TAG}"
+          package_version="$(node -p "require('./package.json').version")"
+          echo "package_version=${package_version}" >> "$GITHUB_OUTPUT"
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release sync app token
+        id: app-token
+        if: steps.sync.outputs.changed == 'true'
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Create fallback release sync app token
+        id: app-token-fallback
+        if: steps.sync.outputs.changed == 'true' && steps.app-token.outcome == 'failure'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: "2971289"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Open or refresh main version sync PR
+        id: pr
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          PACKAGE_VERSION: ${{ steps.sync.outputs.package_version }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          branch="automation/sync-main-${PACKAGE_VERSION}"
+          title="chore(release): sync ${PACKAGE_VERSION} metadata to main"
+          body_file="${RUNNER_TEMP}/main-version-sync-pr.md"
+          base_sha="$(git rev-parse HEAD)"
+
+          git config user.name "openclaw-release-bot"
+          git config user.email "release-bot@openclaw.ai"
+          gh auth setup-git
+          git switch -c "${branch}"
+          git add -A
+          git commit -m "${title}"
+          git fetch origin "${branch}:refs/remotes/origin/${branch}" || true
+          git push --force-with-lease origin "HEAD:refs/heads/${branch}"
+
+          cat > "${body_file}" <<EOF
+          ## Summary
+
+          - syncs current \`main\` package and official plugin metadata to published stable \`openclaw@${PACKAGE_VERSION}\`
+          - generated after successful npm publication for \`${RELEASE_TAG}\`
+          - automatically squash-merges after its pull request checks pass
+
+          ## Verification
+
+          - \`pnpm release:prep\`
+          - \`pnpm deps:shrinkwrap:generate\`
+          - \`pnpm deps:shrinkwrap:check\`
+          EOF
+
+          pr_url="$(gh pr list --head "${branch}" --base main --state open --json url --jq '.[0].url // empty')"
+          if [[ -z "${pr_url}" ]]; then
+            pr_url="$(gh pr create --head "${branch}" --base main --title "${title}" --body-file "${body_file}")"
+          else
+            gh pr edit "${pr_url}" --title "${title}" --body-file "${body_file}"
+          fi
+          echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+          echo "Stable package metadata sync PR: ${pr_url}" >> "$GITHUB_STEP_SUMMARY"
+
+  merge:
+    name: Merge generated main version sync PR
+    needs: sync
+    if: needs.sync.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+      pull-requests: read
+      statuses: read
+    steps:
+      - name: Wait for generated PR checks
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.sync.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ needs.sync.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+
+          read -r pr_state pr_base pr_head < <(
+            gh pr view "${PR_URL}" --json baseRefName,headRefOid,state --jq '[.state, .baseRefName, .headRefOid] | @tsv'
+          )
+          if [[ "${pr_state}" != "OPEN" || "${pr_base}" != "main" || "${pr_head}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "Generated PR identity changed before checks started." >&2
+            exit 1
+          fi
+
+          for attempt in $(seq 1 60); do
+            checks_json="$(gh pr checks "${PR_URL}" --json bucket,name,state,workflow 2>/dev/null || true)"
+            if jq -e 'any(.[]; .name == "preflight" and .workflow == "CI")' <<<"${checks_json}" >/dev/null; then
+              break
+            fi
+            if [[ "${attempt}" == "60" ]]; then
+              echo "Timed out waiting for the generated PR CI preflight check." >&2
+              exit 1
+            fi
+            sleep 10
+          done
+
+          gh pr checks "${PR_URL}" --watch --fail-fast --interval 10
+          sleep 30
+          gh pr checks "${PR_URL}" --watch --fail-fast --interval 10
+
+          current_head="$(gh pr view "${PR_URL}" --json headRefOid --jq '.headRefOid')"
+          if [[ "${current_head}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "Generated PR head changed while checks were running." >&2
+            exit 1
+          fi
+
+      - name: Create release sync merge app token
+        id: app-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Create fallback release sync merge app token
+        id: app-token-fallback
+        if: steps.app-token.outcome == 'failure'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: "2971289"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Squash-merge exact generated PR head
+        env:
+          EXPECTED_BASE_SHA: ${{ needs.sync.outputs.base_sha }}
+          EXPECTED_HEAD_SHA: ${{ needs.sync.outputs.head_sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          PR_URL: ${{ needs.sync.outputs.pr_url }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          WORKFLOW_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          read -r pr_state pr_base pr_head < <(
+            gh pr view "${PR_URL}" --json baseRefName,headRefOid,state --jq '[.state, .baseRefName, .headRefOid] | @tsv'
+          )
+          if [[ "${pr_state}" != "OPEN" || "${pr_base}" != "main" || "${pr_head}" != "${EXPECTED_HEAD_SHA}" ]]; then
+            echo "Generated PR identity changed before merge." >&2
+            exit 1
+          fi
+
+          GH_TOKEN="${WORKFLOW_TOKEN}" gh pr checks "${PR_URL}"
+          current_main="$(GH_TOKEN="${WORKFLOW_TOKEN}" gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          if [[ "${current_main}" != "${EXPECTED_BASE_SHA}" ]]; then
+            echo "main advanced before merge; queueing a fresh stable version sync." >> "$GITHUB_STEP_SUMMARY"
+            GH_TOKEN="${WORKFLOW_TOKEN}" gh workflow run sync-main-release-version.yml \
+              --repo "${GITHUB_REPOSITORY}" \
+              --ref main \
+              -f tag="${RELEASE_TAG}"
+            exit 0
+          fi
+
+          gh pr merge "${PR_URL}" --squash --delete-branch --match-head-commit "${EXPECTED_HEAD_SHA}"
+          echo "Merged stable package metadata sync PR: ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -120,7 +120,16 @@ the maintainer-only release runbook.
    created with GitHub `latest=false`. The workflow also uploads the preflight
    dependency evidence to the GitHub release as
    `openclaw-<version>-dependency-evidence.zip` for post-release incident
-   response. The publish workflow prints child run IDs immediately, auto-approves
+   response. After a stable OpenClaw npm publish succeeds, the npm workflow
+   dispatches `Sync Stable Version To Main`, which opens or refreshes a PR that
+   synchronizes the published package version, official plugin metadata, and
+   npm shrinkwraps onto current `main`. The sync waits for the generated PR's
+   checks and squash-merges the exact checked head automatically. If `main`
+   advances while checks run, it queues a fresh sync instead of merging stale
+   generated metadata. Prerelease publishes do not change `main` package
+   metadata. If dispatch fails after npm succeeds, run that workflow manually
+   with the stable release tag. The publish workflow prints
+   child run IDs immediately, auto-approves
    release environment gates the workflow token is allowed to approve, summarizes
    failed child jobs with log tails, closes out the GitHub release and dependency
    evidence as soon as OpenClaw npm publish succeeds, waits for ClawHub whenever
@@ -721,7 +730,14 @@ orchestrates the trusted-publisher workflows in the order the release needs:
 6. Dispatch `OpenClaw NPM Release` with the release tag, npm dist-tag, and
    saved `preflight_run_id` after verifying the saved
    `full_release_validation_run_id`.
-7. For stable releases, create or update the GitHub release as a draft, dispatch
+7. After a stable OpenClaw npm publish succeeds, dispatch
+   `Sync Stable Version To Main` to open or refresh the generated `main`
+   package metadata sync PR. The sync derives the package version from the
+   stable release tag, skips prereleases and downgrades, then runs
+   `pnpm release:prep` and npm shrinkwrap generation against current `main`.
+   It waits for the generated PR checks and squash-merges the exact checked
+   head automatically; if `main` advances first, it queues a fresh sync run.
+8. For stable releases, create or update the GitHub release as a draft, dispatch
    `Windows Node Release` with the explicit `windows_node_tag` and
    candidate-approved `windows_node_installer_digests`, and verify the canonical
    installer/checksum assets before publishing the draft.

--- a/package.json
+++ b/package.json
@@ -1688,6 +1688,7 @@
     "release:plugins:clawhub:plan": "node --import tsx scripts/plugin-clawhub-release-plan.ts",
     "release:plugins:npm:check": "node --import tsx scripts/plugin-npm-release-check.ts",
     "release:plugins:npm:plan": "node --import tsx scripts/plugin-npm-release-plan.ts",
+    "release:sync-main-version": "node scripts/sync-main-release-version.mjs",
     "release:verify-beta": "node --import tsx scripts/release-verify-beta.ts",
     "release:prep": "node scripts/release-preflight.mjs --fix",
     "runtime-sidecars:check": "node --import tsx scripts/generate-runtime-sidecar-paths-baseline.ts --check",

--- a/scripts/sync-main-release-version.mjs
+++ b/scripts/sync-main-release-version.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Synchronizes published stable package metadata onto a current main checkout.
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { runManagedCommand } from "./lib/managed-child-process.mjs";
+import { compareReleaseVersions, parseReleaseVersion } from "./lib/npm-publish-plan.mjs";
+
+const SYNC_COMMANDS = [
+  { name: "release metadata", args: ["release:prep"] },
+  { name: "npm shrinkwrap generation", args: ["deps:shrinkwrap:generate"] },
+  { name: "npm shrinkwrap verification", args: ["deps:shrinkwrap:check"] },
+];
+
+export function parseArgs(argv) {
+  let tag = "";
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--tag") {
+      tag = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!tag) {
+    throw new Error("Usage: node scripts/sync-main-release-version.mjs --tag <stable-release-tag>");
+  }
+  return { tag };
+}
+
+export function planMainReleaseVersionSync({ tag, currentVersion, releasePackageVersion }) {
+  const parsedTag = parseStableReleaseTag(tag);
+  const expectedPackageVersions = new Set([parsedTag.baseVersion, parsedTag.version]);
+  if (!expectedPackageVersions.has(releasePackageVersion)) {
+    throw new Error(
+      `Release tag ${tag} expects package version ${[...expectedPackageVersions].join(" or ")}, found ${releasePackageVersion}.`,
+    );
+  }
+
+  const comparison = compareReleaseVersions(currentVersion, releasePackageVersion);
+  if (comparison === null) {
+    throw new Error(
+      `Unable to compare main package version ${currentVersion} with release package version ${releasePackageVersion}.`,
+    );
+  }
+
+  return {
+    currentVersion,
+    releasePackageVersion,
+    shouldSync: comparison < 0,
+    tag,
+  };
+}
+
+function parseStableReleaseTag(tag) {
+  if (!tag.startsWith("v")) {
+    throw new Error(`Release tag must start with "v": ${tag}`);
+  }
+
+  const parsedTag = parseReleaseVersion(tag.slice(1));
+  if (parsedTag === null) {
+    throw new Error(`Unsupported release tag: ${tag}`);
+  }
+  if (parsedTag.channel !== "stable") {
+    throw new Error(`Main version sync only supports stable release tags: ${tag}`);
+  }
+  return parsedTag;
+}
+
+function readPackageVersion(packagePath) {
+  const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+  if (typeof pkg.version !== "string" || !pkg.version.trim()) {
+    throw new Error(`${packagePath} is missing a package version.`);
+  }
+  return pkg.version;
+}
+
+function readReleasePackageVersion(rootDir, tag) {
+  const raw = execFileSync("git", ["show", `${tag}:package.json`], {
+    cwd: rootDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const pkg = JSON.parse(raw);
+  if (typeof pkg.version !== "string" || !pkg.version.trim()) {
+    throw new Error(`${tag}:package.json is missing a package version.`);
+  }
+  return pkg.version;
+}
+
+function writePackageVersion(packagePath, version) {
+  const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+  pkg.version = version;
+  writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+export async function syncMainReleaseVersion({
+  rootDir = process.cwd(),
+  tag,
+  readReleaseVersion = readReleasePackageVersion,
+  runCommand = runManagedCommand,
+}) {
+  parseStableReleaseTag(tag);
+  const packagePath = path.join(rootDir, "package.json");
+  const currentVersion = readPackageVersion(packagePath);
+  const releasePackageVersion = readReleaseVersion(rootDir, tag);
+  const plan = planMainReleaseVersionSync({
+    tag,
+    currentVersion,
+    releasePackageVersion,
+  });
+
+  if (!plan.shouldSync) {
+    return plan;
+  }
+
+  writePackageVersion(packagePath, releasePackageVersion);
+  for (const command of SYNC_COMMANDS) {
+    console.log(`[main-version-sync] ${command.name}: pnpm ${command.args.join(" ")}`);
+    const status = await runCommand({
+      args: command.args,
+      bin: "pnpm",
+      cwd: rootDir,
+    });
+    if (status !== 0) {
+      throw new Error(`${command.name} failed with exit ${status}.`);
+    }
+  }
+
+  return plan;
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const { tag } = parseArgs(argv);
+  const result = await syncMainReleaseVersion({ tag });
+  if (result.shouldSync) {
+    console.log(
+      `[main-version-sync] synchronized main package metadata from ${result.currentVersion} to ${result.releasePackageVersion}.`,
+    );
+  } else {
+    console.log(
+      `[main-version-sync] main package version ${result.currentVersion} is already at or ahead of ${result.releasePackageVersion}.`,
+    );
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename)) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -417,6 +417,20 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
     ".github/workflows/openclaw-release-checks.yml",
     ["test/scripts/package-acceptance-workflow.test.ts"],
   ],
+  [
+    ".github/workflows/openclaw-npm-release.yml",
+    [
+      "test/scripts/package-acceptance-workflow.test.ts",
+      "test/scripts/sync-main-release-version.test.ts",
+    ],
+  ],
+  [
+    ".github/workflows/sync-main-release-version.yml",
+    [
+      "test/scripts/package-acceptance-workflow.test.ts",
+      "test/scripts/sync-main-release-version.test.ts",
+    ],
+  ],
   ["scripts/build-all.mjs", ["test/scripts/build-all.test.ts"]],
   ["scripts/crabbox-wrapper.mjs", ["test/scripts/crabbox-wrapper.test.ts"]],
   ["scripts/github/barnacle-auto-response.mjs", ["test/scripts/barnacle-auto-response.test.ts"]],
@@ -567,6 +581,7 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/docker-e2e-rerun.mjs", ["test/scripts/docker-e2e-helper-cli.test.ts"]],
   ["scripts/docker-e2e-timings.mjs", ["test/scripts/docker-e2e-helper-cli.test.ts"]],
   ["scripts/generate-npm-shrinkwrap.mjs", ["test/scripts/generate-npm-shrinkwrap.test.ts"]],
+  ["scripts/sync-main-release-version.mjs", ["test/scripts/sync-main-release-version.test.ts"]],
   ["scripts/ios-run.sh", ["test/scripts/ios-run.test.ts"]],
   ["scripts/create-dmg.sh", ["test/scripts/create-dmg.test.ts"]],
   ["scripts/kova-ci-summary.mjs", ["test/scripts/kova-ci-summary.test.ts"]],

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -880,6 +880,7 @@ describe("test-projects args", () => {
           "test/scripts/ios-team-id.test.ts",
           "test/scripts/ios-version.test.ts",
           "test/scripts/report-test-temp-creations.test.ts",
+          "test/scripts/sync-main-release-version.test.ts",
           "test/test-env.test.ts",
           "test/vitest-scoped-config.test.ts",
         ],

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2008,6 +2008,7 @@ describe("package artifact reuse", () => {
       NPM_TELEGRAM_WORKFLOW,
       ".github/workflows/openclaw-release-publish.yml",
       ".github/workflows/openclaw-npm-release.yml",
+      ".github/workflows/sync-main-release-version.yml",
       ".github/workflows/macos-release.yml",
       ".github/workflows/plugin-clawhub-release.yml",
       PACKAGE_ACCEPTANCE_WORKFLOW,

--- a/test/scripts/sync-main-release-version.test.ts
+++ b/test/scripts/sync-main-release-version.test.ts
@@ -1,0 +1,290 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  parseArgs,
+  planMainReleaseVersionSync,
+  syncMainReleaseVersion,
+} from "../../scripts/sync-main-release-version.mjs";
+import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+function createRoot(version: string): string {
+  const rootDir = makeTempDir(tempDirs, "openclaw-main-version-sync-");
+  writeFileSync(
+    path.join(rootDir, "package.json"),
+    `${JSON.stringify({ name: "openclaw", version, private: true }, null, 2)}\n`,
+  );
+  return rootDir;
+}
+
+describe("parseArgs", () => {
+  it("requires one stable release tag", () => {
+    expect(parseArgs(["--tag", "v2026.6.8"])).toEqual({ tag: "v2026.6.8" });
+    expect(() => parseArgs([])).toThrow("Usage:");
+    expect(() => parseArgs(["--version", "2026.6.8"])).toThrow("Unknown argument: --version");
+  });
+});
+
+describe("planMainReleaseVersionSync", () => {
+  it("syncs an older main version to a stable release package version", () => {
+    expect(
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8",
+        currentVersion: "2026.6.2",
+        releasePackageVersion: "2026.6.8",
+      }),
+    ).toMatchObject({
+      releasePackageVersion: "2026.6.8",
+      shouldSync: true,
+    });
+  });
+
+  it("accepts correction tags with a base or correction package version", () => {
+    expect(
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8-1",
+        currentVersion: "2026.6.7",
+        releasePackageVersion: "2026.6.8",
+      }),
+    ).toMatchObject({
+      releasePackageVersion: "2026.6.8",
+      shouldSync: true,
+    });
+    expect(
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8-1",
+        currentVersion: "2026.6.8",
+        releasePackageVersion: "2026.6.8-1",
+      }),
+    ).toMatchObject({
+      releasePackageVersion: "2026.6.8-1",
+      shouldSync: true,
+    });
+  });
+
+  it("does not downgrade main or replace a matching version", () => {
+    expect(
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8",
+        currentVersion: "2026.6.8",
+        releasePackageVersion: "2026.6.8",
+      }).shouldSync,
+    ).toBe(false);
+    expect(
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8",
+        currentVersion: "2026.6.9-beta.1",
+        releasePackageVersion: "2026.6.8",
+      }).shouldSync,
+    ).toBe(false);
+  });
+
+  it("rejects prerelease tags and tag/package mismatches", () => {
+    expect(() =>
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8-beta.2",
+        currentVersion: "2026.6.2",
+        releasePackageVersion: "2026.6.8-beta.2",
+      }),
+    ).toThrow("only supports stable release tags");
+    expect(() =>
+      planMainReleaseVersionSync({
+        tag: "v2026.6.8",
+        currentVersion: "2026.6.2",
+        releasePackageVersion: "2026.6.7",
+      }),
+    ).toThrow("expects package version 2026.6.8");
+  });
+});
+
+describe("syncMainReleaseVersion", () => {
+  it("updates the root version and runs the canonical generators and checks", async () => {
+    const rootDir = createRoot("2026.6.2");
+    const calls: string[][] = [];
+
+    const result = await syncMainReleaseVersion({
+      rootDir,
+      tag: "v2026.6.8",
+      readReleaseVersion: () => "2026.6.8",
+      runCommand: async ({ args }: { args: string[] }) => {
+        calls.push(args);
+        return 0;
+      },
+    });
+
+    expect(result.shouldSync).toBe(true);
+    expect(JSON.parse(readFileSync(path.join(rootDir, "package.json"), "utf8")).version).toBe(
+      "2026.6.8",
+    );
+    expect(calls).toEqual([
+      ["release:prep"],
+      ["deps:shrinkwrap:generate"],
+      ["deps:shrinkwrap:check"],
+    ]);
+  });
+
+  it("leaves an equal or newer main version untouched", async () => {
+    const rootDir = createRoot("2026.6.8");
+    let commandRan = false;
+
+    const result = await syncMainReleaseVersion({
+      rootDir,
+      tag: "v2026.6.8",
+      readReleaseVersion: () => "2026.6.8",
+      runCommand: async () => {
+        commandRan = true;
+        return 0;
+      },
+    });
+
+    expect(result.shouldSync).toBe(false);
+    expect(commandRan).toBe(false);
+  });
+
+  it("validates a stable tag before reading it from git", async () => {
+    const rootDir = createRoot("2026.6.2");
+    let releaseRead = false;
+
+    await expect(
+      syncMainReleaseVersion({
+        rootDir,
+        tag: "--help",
+        readReleaseVersion: () => {
+          releaseRead = true;
+          return "2026.6.8";
+        },
+      }),
+    ).rejects.toThrow('must start with "v"');
+
+    expect(releaseRead).toBe(false);
+  });
+});
+
+describe("stable main version sync workflows", () => {
+  it("dispatches the repairable sync workflow only after a stable npm publish", () => {
+    const npmWorkflow = parse(
+      readFileSync(".github/workflows/openclaw-npm-release.yml", "utf8"),
+    ) as {
+      jobs?: Record<
+        string,
+        {
+          permissions?: Record<string, string>;
+          steps?: Array<{
+            "continue-on-error"?: boolean;
+            if?: string;
+            name?: string;
+            run?: string;
+          }>;
+        }
+      >;
+    };
+    const publishJob = npmWorkflow.jobs?.publish_openclaw_npm;
+    const dispatchStep = publishJob?.steps?.find(
+      (step) => step.name === "Dispatch stable main version sync",
+    );
+
+    expect(publishJob?.permissions?.actions).toBe("write");
+    expect(dispatchStep?.if).toContain("!contains(inputs.tag, '-alpha.')");
+    expect(dispatchStep?.if).toContain("!contains(inputs.tag, '-beta.')");
+    expect(dispatchStep?.["continue-on-error"]).toBe(true);
+    expect(dispatchStep?.run).toContain(
+      'gh workflow run sync-main-release-version.yml --ref main -f tag="${RELEASE_TAG}"',
+    );
+  });
+
+  it("runs the generated metadata sync on current main and opens a PR", () => {
+    const syncWorkflow = parse(
+      readFileSync(".github/workflows/sync-main-release-version.yml", "utf8"),
+    ) as {
+      jobs?: Record<
+        string,
+        {
+          if?: string;
+          needs?: string;
+          outputs?: Record<string, string>;
+          permissions?: Record<string, string>;
+          steps?: Array<{
+            if?: string;
+            name?: string;
+            run?: string;
+            with?: Record<string, string>;
+          }>;
+        }
+      >;
+    };
+    const syncJob = syncWorkflow.jobs?.sync;
+    const checkoutStep = syncJob?.steps?.find((step) => step.name === "Checkout current main");
+    const validateStep = syncJob?.steps?.find((step) => step.name === "Validate stable tag input");
+    const setupStep = syncJob?.steps?.find((step) => step.name === "Setup Node environment");
+    const syncStep = syncJob?.steps?.find((step) => step.name === "Sync stable package metadata");
+    const appTokenStep = syncJob?.steps?.find(
+      (step) => step.name === "Create release sync app token",
+    );
+    const prStep = syncJob?.steps?.find(
+      (step) => step.name === "Open or refresh main version sync PR",
+    );
+    const mergeJob = syncWorkflow.jobs?.merge;
+    const waitStep = mergeJob?.steps?.find((step) => step.name === "Wait for generated PR checks");
+    const mergeTokenStep = mergeJob?.steps?.find(
+      (step) => step.name === "Create release sync merge app token",
+    );
+    const mergeStep = mergeJob?.steps?.find(
+      (step) => step.name === "Squash-merge exact generated PR head",
+    );
+
+    expect(checkoutStep?.with?.ref).toBe("main");
+    expect(checkoutStep?.with?.["persist-credentials"]).toBe(false);
+    expect(checkoutStep?.with?.token).toBeUndefined();
+    expect(validateStep?.run).toContain("Invalid stable release tag");
+    expect(syncJob?.steps?.indexOf(validateStep ?? {})).toBeLessThan(
+      syncJob?.steps?.indexOf(setupStep ?? {}) ?? -1,
+    );
+    expect(setupStep?.with?.["node-version"]).toBe("${{ env.NODE_VERSION }}");
+    expect(syncStep?.run).toContain("git fetch");
+    expect(syncStep?.run).toContain('pnpm release:sync-main-version -- --tag "${RELEASE_TAG}"');
+    expect(appTokenStep?.if).toContain("steps.sync.outputs.changed == 'true'");
+    expect(syncJob?.steps?.indexOf(appTokenStep ?? {})).toBeGreaterThan(
+      syncJob?.steps?.indexOf(syncStep ?? {}) ?? -1,
+    );
+    expect(prStep?.run).toContain('branch="automation/sync-main-${PACKAGE_VERSION}"');
+    expect(prStep?.run).not.toContain('branch="release/');
+    expect(prStep?.run).toContain("gh auth setup-git");
+    expect(prStep?.run).toContain('git push --force-with-lease origin "HEAD:refs/heads/${branch}"');
+    expect(prStep?.run).toContain("gh pr create");
+    expect(prStep?.run).toContain("gh pr edit");
+    expect(syncJob?.outputs?.base_sha).toBe("${{ steps.pr.outputs.base_sha }}");
+    expect(syncJob?.outputs?.head_sha).toBe("${{ steps.pr.outputs.head_sha }}");
+    expect(syncJob?.outputs?.pr_url).toBe("${{ steps.pr.outputs.pr_url }}");
+    expect(prStep?.run).toContain('echo "base_sha=${base_sha}" >> "$GITHUB_OUTPUT"');
+    expect(prStep?.run).toContain('echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"');
+    expect(prStep?.run).toContain('echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"');
+
+    expect(mergeJob?.needs).toBe("sync");
+    expect(mergeJob?.if).toContain("needs.sync.outputs.changed == 'true'");
+    expect(mergeJob?.permissions?.actions).toBe("write");
+    expect(mergeJob?.permissions?.checks).toBe("read");
+    expect(mergeJob?.permissions?.contents).toBe("read");
+    expect(mergeJob?.permissions?.["pull-requests"]).toBe("read");
+    expect(waitStep?.run).toContain('.name == "preflight" and .workflow == "CI"');
+    expect(waitStep?.run).toContain('gh pr checks "${PR_URL}" --watch --fail-fast');
+    expect(mergeTokenStep?.if).toBeUndefined();
+    expect(mergeJob?.steps?.indexOf(mergeTokenStep ?? {})).toBeGreaterThan(
+      mergeJob?.steps?.indexOf(waitStep ?? {}) ?? -1,
+    );
+    expect(mergeStep?.run).toContain('GH_TOKEN="${WORKFLOW_TOKEN}" gh pr checks "${PR_URL}"');
+    expect(mergeStep?.run).toContain('current_main="$(GH_TOKEN="${WORKFLOW_TOKEN}" gh api');
+    expect(mergeStep?.run).toContain("main advanced before merge");
+    expect(mergeStep?.run).toContain("gh workflow run sync-main-release-version.yml");
+    expect(mergeStep?.run).toContain('--repo "${GITHUB_REPOSITORY}"');
+    expect(mergeStep?.run).toContain(
+      'gh pr merge "${PR_URL}" --squash --delete-branch --match-head-commit "${EXPECTED_HEAD_SHA}"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- dispatch a repairable main-version sync after successful stable OpenClaw npm publication
- align the root package, official plugin versions/metadata/changelogs, plugin inventory, and npm shrinkwraps on current `main`
- open or refresh an app-token-authored PR, wait for its checks, and automatically squash-merge the exact checked head
- queue a fresh sync instead of merging when `main` advances during validation

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --maxWorkers=1`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts src/scripts/test-projects.test.ts test/scripts/sync-main-release-version.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/test-projects.test.ts --maxWorkers=1`
- `pnpm exec oxfmt --check .github/workflows/openclaw-npm-release.yml .github/workflows/sync-main-release-version.yml docs/reference/RELEASING.md package.json scripts/test-projects.test-support.mjs scripts/sync-main-release-version.mjs src/scripts/test-projects.test.ts test/scripts/package-acceptance-workflow.test.ts test/scripts/sync-main-release-version.test.ts`
- `git diff upstream/main...HEAD --check`
- `node --check scripts/sync-main-release-version.mjs`
- workflow YAML parse with `yaml`
- `node scripts/report-test-temp-creations.mjs --base upstream/main --head HEAD --json --fail-on-findings`
- `pnpm docs:list`
- `$autoreview --mode branch --base upstream/main` (clean)

Behavior addressed: stable npm publishes now dispatch a repairable current-main metadata sync that automatically merges after its generated PR checks pass
Real environment tested: local OpenClaw checkout on the freshly fetched canonical base
Exact steps or command run after this patch: full tooling shard, focused release/tooling tests, formatting, YAML parse, script syntax check, temp-directory guard, docs inventory, and branch autoreview
Evidence after fix: the full tooling shard and focused tests pass; the generated workflow requires green PR checks, exact head identity, and a current-main base before squash merge
Observed result after fix: the sync derives the published package version from the release tag, aligns official plugins and shrinkwraps, opens or refreshes a PR, and automatically merges it when green without human interaction
What was not tested: no real npm publication, workflow dispatch, GitHub App-generated sync PR, or automated merge was performed; local workflow lint is unavailable because actionlint, the Go fallback, and pre-commit are not installed
