### PR TITLE
fix(compaction): ignore stale persisted totalTokens in preflight gate

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  clearMemoryPluginState,
+  registerMemoryCapability,
+  type MemoryFlushPlanResolver,
+} from "../../plugins/memory-state.js";
+import {
+  runPreflightCompactionIfNeeded,
+  setAgentRunnerMemoryTestDeps,
+} from "./agent-runner-memory.js";
+import { createTestFollowupRun, writeTestSessionStore } from "./agent-runner.test-fixtures.js";
+import type { ReplyOperation } from "./reply-run-registry.js";
+
+const compactEmbeddedAgentSessionMock = vi.fn();
+
+function createReplyOperation(): ReplyOperation {
+  return {
+    key: "test",
+    sessionId: "session",
+    abortSignal: new AbortController().signal,
+    resetTriggered: false,
+    phase: "queued",
+    result: null,
+    setPhase: vi.fn(),
+    updateSessionId: vi.fn(),
+    attachBackend: vi.fn(),
+    detachBackend: vi.fn(),
+    retainFailureUntilComplete: vi.fn(),
+    complete: vi.fn(),
+    completeThen: vi.fn((afterClear: () => void) => {
+      afterClear();
+    }),
+    completeWithAfterClearBarrier: vi.fn(),
+    fail: vi.fn(),
+    abortByUser: vi.fn(),
+    abortForRestart: vi.fn(),
+  } as unknown as ReplyOperation;
+}
+
+function registerMemoryFlushPlanResolverForTest(resolver: MemoryFlushPlanResolver): void {
+  registerMemoryCapability("memory-core", { flushPlanResolver: resolver });
+}
+
+describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
+  let rootDir = "";
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-preflight-stale-"));
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 20_000,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedAgentSessionMock.mockReset().mockResolvedValue({
+      ok: true,
+      compacted: true,
+      result: { tokensAfter: 42 },
+    });
+    setAgentRunnerMemoryTestDeps({
+      compactEmbeddedAgentSession: compactEmbeddedAgentSessionMock as never,
+      incrementCompactionCount: vi.fn() as never,
+      refreshQueuedFollowupSession: vi.fn() as never,
+      registerAgentRunContext: vi.fn() as never,
+      emitAgentEvent: vi.fn() as never,
+    });
+  });
+
+  afterEach(async () => {
+    setAgentRunnerMemoryTestDeps();
+    cliBackendsTesting.resetDepsForTest();
+    clearMemoryPluginState();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  async function runWithEntry(sessionEntry: SessionEntry, sessionFile: string) {
+    return await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+  }
+
+  it("does not compact when totalTokens is large but stale and the real transcript is small", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(2_000) } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+      totalTokensFresh: false,
+    };
+    await writeTestSessionStore(path.join(rootDir, "sessions.json"), "agent:main:main", sessionEntry);
+
+    const entry = await runWithEntry(sessionEntry, sessionFile);
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("compacts when totalTokens is large and fresh", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(2_000) } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+      totalTokensFresh: true,
+    };
+    await writeTestSessionStore(path.join(rootDir, "sessions.json"), "agent:main:main", sessionEntry);
+
+    await runWithEntry(sessionEntry, sessionFile);
+
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -849,9 +849,10 @@ export async function runPreflightCompactionIfNeeded(params: {
     typeof activeTranscriptBytes === "number" &&
     typeof maxActiveTranscriptBytes === "number" &&
     activeTranscriptBytes >= maxActiveTranscriptBytes;
-  const stalePersistedPromptTokens = hasPersistedTotalTokens
-    ? Math.floor(persistedTotalTokens)
-    : undefined;
+  const stalePersistedPromptTokens =
+    hasPersistedTotalTokens && entry.totalTokensFresh !== false
+      ? Math.floor(persistedTotalTokens)
+      : undefined;
   const transcriptPromptTokens = transcriptUsageTokens?.promptTokens;
   const transcriptOutputTokens = transcriptUsageTokens?.outputTokens;
   const usageProjectedTokenCount =


### PR DESCRIPTION
## Summary

`runPreflightCompactionIfNeeded` decides whether to compact by taking the `Math.max` of three token estimates: the transcript-usage projection, the fresh persisted total, and a raw persisted total (`stalePersistedPromptTokens`). The first two respect the session freshness flag, but the third reads `entry.totalTokens` directly with no `totalTokensFresh` check:

```ts
const stalePersistedPromptTokens = hasPersistedTotalTokens
  ? Math.floor(persistedTotalTokens)
  : undefined;
```

When a compaction completes without a `tokensAfter` figure, `incrementCompactionCount` (src/auto-reply/reply/session-updates.ts:310) sets `totalTokensFresh = false` but deliberately keeps the old large `totalTokens`. `resolveFreshSessionTotalTokens` (src/config/sessions/types.ts:629) returns `undefined` in that state by design, so `freshProjectedTokenCount` correctly drops out, but the raw `stalePersistedPromptTokens` still feeds the `Math.max` gate. The stale large value then overrides the small fresh transcript estimate and force-fires another preflight compaction on a session that is actually small, producing an unnecessary (lossy, user-visible) summarization and a "compacting" stall on the next turn.

This is the persisted-total leg of the same symptom tracked in #81178. PR #81916 bounds the transcript-usage leg (`usageProjectedTokenCount` / snapshot tail bytes); it does not touch `stalePersistedPromptTokens`, so even with #81916 merged the stale persisted total still trips the gate. It is also the opposite direction of the rejected #82919, which wanted `resolveFreshSessionTotalTokens` to return stale values; this change instead keeps the existing freshness contract and extends it to the one consumer that bypassed it.

## Fix

```ts
const stalePersistedPromptTokens =
  hasPersistedTotalTokens && entry.totalTokensFresh !== false
    ? Math.floor(persistedTotalTokens)
    : undefined;
```

The fresh-large path is unaffected: when `totalTokensFresh` is `true` or absent, the persisted total still counts, so a genuinely large session still compacts.

## Real behavior proof

Behavior addressed: after a compaction that reports no `tokensAfter` (`totalTokensFresh = false`, large `totalTokens` retained), the next preflight check must not force another compaction when the real active transcript is small. A genuinely large fresh session must still compact.

Real environment tested: local OpenClaw source runtime at `origin/main` head `617c9d4b7f`, Linux, Node 22. A standalone `node --import tsx` script drove the real `runPreflightCompactionIfNeeded` path against a real temporary JSONL transcript and session store; the compaction dependency was instrumented only to count whether the runtime attempted compaction.

Exact steps or command run after this patch: ran the proof script twice, once with the source fix reverted (`git stash`) and once with it applied, each invoking `runPreflightCompactionIfNeeded` with `totalTokens=200000`, a ~2KB transcript, and a 100000-token context window, for both `totalTokensFresh: false` (stale) and `totalTokensFresh: true` (fresh).

Evidence after fix (copied terminal output):

```
===== BEFORE FIX (origin/main behavior) =====
STALE (post-compaction, tokensAfter omitted): totalTokens=200000 totalTokensFresh=false small-transcript=~2KB -> compactAttempts=1
FRESH (genuinely large session)             : totalTokens=200000 totalTokensFresh=true small-transcript=~2KB -> compactAttempts=1
stale-case compactAttempts = 1 (want 0: small session must NOT re-compact)
RESULT: FAIL

===== AFTER FIX =====
STALE (post-compaction, tokensAfter omitted): totalTokens=200000 totalTokensFresh=false small-transcript=~2KB -> compactAttempts=0
FRESH (genuinely large session)             : totalTokens=200000 totalTokensFresh=true small-transcript=~2KB -> compactAttempts=1
stale-case compactAttempts = 0 (want 0)
fresh-case compactAttempts = 1 (want 1)
RESULT: PASS
```

Observed result after fix: the stale small session no longer compacts; the fresh large session still compacts.

Regression test: `src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts`. Case A (large but stale total, small transcript) fails before the fix and passes after; Case B (large fresh total) confirms the gate still fires. Run with `node scripts/run-vitest.mjs`.

What was not tested: no full `pnpm check` / build run (memory-constrained box). Scope is one expression in a single decision path; existing colocated suites were run as regression coverage.
