### PR TITLE
fix(ios): fix quick setup sheet layout design

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -30,27 +30,13 @@ struct GatewayQuickSetupSheet: View {
                 }
 
                 if let candidate = self.bestCandidate {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text(verbatim: candidate.name)
-                            .font(.headline)
-                        Text(verbatim: candidate.debugID)
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            // Use verbatim strings so Bonjour-provided values can't be interpreted as
-                            // localized format strings (which can crash with Objective-C exceptions).
-                            Text(verbatim: "Discovery: \(self.gatewayController.discoveryStatusText)")
-                            Text(verbatim: "Status: \(self.appModel.gatewayDisplayStatusText)")
-                            Text(verbatim: "Node: \(self.appModel.nodeStatusText)")
-                            Text(verbatim: "Operator: \(self.appModel.operatorStatusText)")
-                        }
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                    }
-                    .padding(12)
-                    .background(.thinMaterial)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    GatewayQuickSetupCandidatePanel(
+                        name: candidate.name,
+                        debugID: candidate.debugID,
+                        discoveryStatusText: self.gatewayController.discoveryStatusText,
+                        gatewayDisplayStatusText: self.appModel.gatewayDisplayStatusText,
+                        nodeStatusText: self.appModel.nodeStatusText,
+                        operatorStatusText: self.appModel.operatorStatusText)
 
                     Button {
                         self.connectError = nil
@@ -167,5 +153,44 @@ struct GatewayQuickSetupSheet: View {
         let err = await self.gatewayController.connectWithDiagnostics(candidate)
         self.connecting = false
         self.connectError = err
+    }
+}
+
+private struct GatewayQuickSetupCandidatePanel: View {
+    private static let readableMonospaceWidth: CGFloat = 72 * 8
+
+    let name: String
+    let debugID: String
+    let discoveryStatusText: String
+    let gatewayDisplayStatusText: String
+    let nodeStatusText: String
+    let operatorStatusText: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(verbatim: self.name)
+                .font(.system(.headline, design: .monospaced))
+                .foregroundStyle(.primary)
+            Text(verbatim: self.debugID)
+                .font(.system(.footnote, design: .monospaced))
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 2) {
+                // Use verbatim strings so Bonjour-provided values can't be interpreted as
+                // localized format strings (which can crash with Objective-C exceptions).
+                Text(verbatim: "Discovery: \(self.discoveryStatusText)")
+                Text(verbatim: "Status: \(self.gatewayDisplayStatusText)")
+                Text(verbatim: "Node: \(self.nodeStatusText)")
+                Text(verbatim: "Operator: \(self.operatorStatusText)")
+            }
+            .font(.system(.footnote, design: .monospaced))
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: Self.readableMonospaceWidth, alignment: .leading)
+        .padding(.vertical, 14)
+        .padding(.horizontal, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .textSelection(.enabled)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
     }
 }

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -191,6 +191,7 @@ private struct GatewayQuickSetupCandidatePanel: View {
         .padding(.horizontal, 16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .textSelection(.enabled)
-        .background(Color(uiColor: .secondarySystemGroupedBackground))
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
     }
 }


### PR DESCRIPTION
## Summary

- Make the iOS quick setup gateway summary a full-width grey panel.
- Constrain the gateway text to a monospaced readable width and render the summary text in monospaced type.
- Make gateway details selectable.

## Verification

- `git diff --check`
- `pnpm ios:build` passed before moving the same patch onto this clean branch.

## Real behavior proof

Behavior or issue addressed: iOS Quick Setup sheet gateway summary layout was visually cramped; this patch makes the discovered-gateway summary full-width grey and keeps the text in a readable monospaced measure.

Real environment tested: iOS app Quick Setup sheet screenshots from a real rendered iPhone-sized UI.

Exact steps or command run after this patch: Open the iOS app with the Quick Setup sheet visible, compare the previous rendered sheet against this branch, and capture screenshots of both states.

Evidence after fix: Before screenshot: https://github.com/user-attachments/assets/1500e1e2-1be2-4f3b-ae83-60feb20a519f

After screenshot: https://github.com/user-attachments/assets/2cba918a-2e04-4de2-8daa-f13d277bcc21

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="200" alt="Before quick setup sheet" src="https://github.com/user-attachments/assets/1500e1e2-1be2-4f3b-ae83-60feb20a519f" /></td>
    <td><img width="200" alt="After quick setup sheet" src="https://github.com/user-attachments/assets/2cba918a-2e04-4de2-8daa-f13d277bcc21" /></td>
  </tr>
</table>

Observed result after fix: The after screenshot shows the gateway summary as a full-width grey panel with the gateway name, debug ID, and status lines aligned in monospaced text. The controls below remain visible and usable.

What was not tested: Automated device-interaction capture timed out in this environment. The gateway connect behavior was not changed.
