### PR TITLE
fix: correct tautological uppercase check in tool description summarizer

### DIFF
--- a/src/agents/tool-description-summary.ts
+++ b/src/agents/tool-description-summary.ts
@@ -40,7 +40,7 @@ function isToolDocBlockStart(line: string): boolean {
     return true;
   }
   return (
-    normalized.endsWith(":") && normalized === normalized.toUpperCase() && normalized.length > 12
+    normalized.endsWith(":") && line.trim() === line.trim().toUpperCase() && normalized.length > 12
   );
 }
 


### PR DESCRIPTION
## Summary

The `isToolDocBlockStart` function in `src/agents/tool-description-summary.ts` had a tautological condition that made it incorrectly classify mixed-case lines as doc block headings.

**The bug:** Line 43 checked `normalized === normalized.toUpperCase()`, but `normalized` was already set to `line.trim().toUpperCase()` on line 24, making this condition always `true`. This meant any line ending with `:` and longer than 12 characters would be treated as a doc block start — even if it wasn't all uppercase.

**Example:** A tool description containing a line like `"My Custom Section Title:"` would be incorrectly skipped during summarization, causing the tool's description to be truncated when it shouldn't be.

## Fix

Changed the comparison from `normalized === normalized.toUpperCase()` to `line.trim() === line.trim().toUpperCase()` so it correctly checks whether the *original* line is all uppercase, matching the intent of the other explicit checks for known heading patterns like `"ACTIONS:"`, `"JOB SCHEMA:"`, etc.

## Verification

- The fix is a one-line change in `src/agents/tool-description-summary.ts:43`
- Existing behavior for all-uppercase headings (e.g., `"ACTIONS:"`, `"CRITICAL CONSTRAINTS:"`) is preserved — these still match via the explicit checks on lines 29-38
- Mixed-case lines like `"My Custom Section Title:"` no longer incorrectly match the fallback uppercase check