### PR TITLE
fix(dreaming): increase narrative timeout from 60s to 120s for ARM cold-load (fixes #92494)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,7 +1064,7 @@ describe("generateAndAppendDreamNarrative", () => {
     });
 
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(60_000);
+    expect(mockObjectArg(subagent.waitForRun, "wait for run").timeoutMs).toBe(120_000);
     expectLogIncludes(logger.warn, "narrative session cleanup failed for rem phase");
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -97,10 +97,11 @@ const NARRATIVE_SYSTEM_PROMPT = [
 // many minutes after the reports have already been written. The previous 15 s
 // limit was empirically too tight for warm-gateway runs across light, REM, and
 // deep phases — even unblocked LLM calls hit it on the first sweep after a
-// restart. 60 s gives realistic latency headroom while still capping the
-// worst case at one minute, well below the multi-minute stall the original
-// comment warned against.
-const NARRATIVE_TIMEOUT_MS = 60_000;
+// restart. 60 s was still too tight for ARM devices with 600+ skills where
+// cold-loading tool definitions takes ~57 s on the first narrative phase,
+// leaving almost no headroom for the LLM call itself. 120 s gives realistic
+// latency headroom while still capping worst case at two minutes.
+const NARRATIVE_TIMEOUT_MS = 120_000;
 const NARRATIVE_MESSAGE_FETCH_LIMIT = 5;
 // A completed run can reach the session reader before the final assistant text
 // is visible, so retry briefly before falling back to synthetic diary text.


### PR DESCRIPTION
## Summary

Increase `NARRATIVE_TIMEOUT_MS` from 60s to 120s in `dreaming-narrative.ts` to accommodate ARM devices with 600+ skills where cold-loading tool definitions takes ~57s, leaving almost no headroom for the LLM call itself within the 60s timeout.

## Changes Made

- `extensions/memory-core/src/dreaming-narrative.ts`: bump `NARRATIVE_TIMEOUT_MS` from `60_000` to `120_000`, update comment to document ARM cold-load scenario
- `extensions/memory-core/src/dreaming-narrative.test.ts`: update timeout expectation from `60_000` to `120_000`

## How to Test

- Run the dreaming narrative verification suite and confirm all 58 cases pass
- Build passes: `pnpm build`

## Real behavior proof

- **Behavior addressed:** `NARRATIVE_TIMEOUT_MS` was 60s, too tight for ARM devices with 600+ skills where cold-loading tool definitions takes ~57s
- **Environment tested:** macOS 26.4.1, Node.js, openclaw main branch
- **Steps run after the patch:** Built the project, ran the dreaming narrative verification suite, verified the constant value via node -e
- **Evidence after fix:**
```
$ node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/memory-core/src/dreaming-narrative.ts','utf8'); const m=c.match(/NARRATIVE_TIMEOUT_MS\s*=\s*(\d[\d_]*)/); console.log('NARRATIVE_TIMEOUT_MS =', m ? m[1] : 'NOT FOUND');"
NARRATIVE_TIMEOUT_MS = 120_000
$ grep -n "NARRATIVE_TIMEOUT_MS" extensions/memory-core/src/dreaming-narrative.ts
104:const NARRATIVE_TIMEOUT_MS = 120_000;
1052:            timeoutMs: NARRATIVE_TIMEOUT_MS,
```
- **Observed result after fix:** Constant is now 120_000 (120s). All 58 dreaming narrative cases pass. Build completes successfully.
- **What was not tested:** Actual ARM device cold-load timing (requires ARM hardware with 600+ skills)
