### PR TITLE
feat(memory): apply outputDimensionality truncation to local GGUF embeddings (fixes #58765)

### DIFF
--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -110,6 +110,49 @@ describe("llama.cpp provider plugin", () => {
     });
   });
 
+  it("includes output dimensionality in local cache and index identities", async () => {
+    memoryHostEmbeddingMocks.createLocalEmbeddingProvider.mockResolvedValue({
+      id: "local",
+      model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+      embedQuery: vi.fn(),
+      embedBatch: vi.fn(),
+    });
+
+    const result = await createLlamaCppMemoryEmbeddingProvider(
+      {
+        config: {},
+        provider: "local",
+        fallback: "none",
+        model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+        outputDimensionality: 512,
+      },
+      { nodeLlamaCppImportUrl: "file:///plugin/node-llama-cpp.js" },
+    );
+    const resolvedIdentity = llamaCppEmbeddingProviderAdapter.resolveIndexIdentity?.({
+      config: {},
+      provider: "local",
+      model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+      dimensions: 512,
+    });
+
+    expect(result.runtime?.cacheKeyData).toMatchObject({ outputDimensionality: 512 });
+    expect(result.runtime?.indexIdentityAliases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cacheKeyData: expect.objectContaining({ outputDimensionality: 512 }),
+        }),
+      ]),
+    );
+    expect(resolvedIdentity?.cacheKeyData).toMatchObject({ outputDimensionality: 512 });
+    expect(resolvedIdentity?.aliases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cacheKeyData: expect.objectContaining({ outputDimensionality: 512 }),
+        }),
+      ]),
+    );
+  });
+
   it("keeps the default model identity when configured with its exact cache artifact path", async () => {
     const modelPath = path.join(
       os.homedir(),

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -51,16 +51,21 @@ function readLocalOptions(options: { local?: unknown }): LlamaCppLocalOptions {
   return local ?? {};
 }
 
-function createLlamaCppCacheKeyData(model: string): Record<string, unknown> {
+function createLlamaCppCacheKeyData(
+  model: string,
+  outputDimensionality?: number,
+): Record<string, unknown> {
   return {
     provider: LLAMA_CPP_EMBEDDING_PROVIDER_ID,
     model,
+    ...(typeof outputDimensionality === "number" ? { outputDimensionality } : {}),
   };
 }
 
 function resolveLlamaCppModelIdentity(
   local: LlamaCppLocalOptions,
   modelPath: string,
+  outputDimensionality?: number,
 ): LlamaCppModelIdentity {
   const modelCacheDir =
     normalizeOptionalString(local.modelCacheDir) ??
@@ -80,7 +85,7 @@ function resolveLlamaCppModelIdentity(
   ) {
     return {
       model: modelPath,
-      cacheKeyData: createLlamaCppCacheKeyData(modelPath),
+      cacheKeyData: createLlamaCppCacheKeyData(modelPath, outputDimensionality),
       aliases: [],
     };
   }
@@ -93,10 +98,13 @@ function resolveLlamaCppModelIdentity(
   }
   return {
     model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
-    cacheKeyData: createLlamaCppCacheKeyData(DEFAULT_LLAMA_CPP_EMBEDDING_MODEL),
+    cacheKeyData: createLlamaCppCacheKeyData(
+      DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+      outputDimensionality,
+    ),
     aliases: Array.from(aliasModels, (aliasModel) => ({
       model: aliasModel,
-      cacheKeyData: createLlamaCppCacheKeyData(aliasModel),
+      cacheKeyData: createLlamaCppCacheKeyData(aliasModel, outputDimensionality),
     })),
   };
 }
@@ -194,7 +202,11 @@ export async function createLlamaCppMemoryEmbeddingProvider(
   const provider = await createLocalEmbeddingProvider(createOptions, {
     nodeLlamaCppImportUrl: runtimeOptions.nodeLlamaCppImportUrl ?? resolveNodeLlamaCppImportUrl(),
   });
-  const identity = resolveLlamaCppModelIdentity(local, provider.model);
+  const identity = resolveLlamaCppModelIdentity(
+    local,
+    provider.model,
+    createOptions.outputDimensionality,
+  );
   const identifiedProvider =
     identity.model === provider.model ? provider : { ...provider, model: identity.model };
   return {
@@ -262,6 +274,7 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
     return resolveLlamaCppModelIdentity(
       local,
       normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+      createOptions.outputDimensionality,
     );
   },
   create: async (options) => await createLlamaCppEmbeddingProviderResult(options),

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -88,6 +88,7 @@ function serializeLocalEmbeddingOptions(
     provider: "local",
     model: options.model,
     fallback: "none",
+    outputDimensionality: options.outputDimensionality,
     local: {
       ...options.local,
       ...(runtimeOptions?.nodeLlamaCppImportUrl

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -97,6 +97,20 @@ describe("local embedding provider", () => {
     expect(runtime.getEmbeddingFor).toHaveBeenCalledWith("test query");
   });
 
+  it("truncates local embeddings before normalizing them", async () => {
+    mockLocalEmbeddingRuntime(new Float32Array([3, 4, 12]));
+    const provider = await createLocalEmbeddingProviderInProcess({
+      config: {} as never,
+      provider: "local",
+      model: "",
+      fallback: "none",
+      outputDimensionality: 2,
+    });
+
+    await expect(provider.embedQuery("test query")).resolves.toEqual([0.6, 0.8]);
+    await expect(provider.embedBatch(["test document"])).resolves.toEqual([[0.6, 0.8]]);
+  });
+
   it("passes default contextSize (4096) to createEmbeddingContext when not configured", async () => {
     const runtime = mockLocalEmbeddingRuntime();
 
@@ -363,6 +377,10 @@ process.on("message", (message) => {
       process.send({ id: message.id, ok: false, error: "missing nodeLlamaCppImportUrl" });
       return;
     }
+    if (message.options.outputDimensionality !== 2) {
+      process.send({ id: message.id, ok: false, error: "missing outputDimensionality" });
+      return;
+    }
     process.send({ id: message.id, ok: true });
     return;
   }
@@ -385,6 +403,7 @@ process.on("message", (message) => {
         provider: "local",
         model: "",
         fallback: "none",
+        outputDimensionality: 2,
       },
       {
         workerScriptPath: workerScript,

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -141,6 +141,10 @@ export async function createLocalEmbeddingProviderInProcess(
     return initPromise;
   };
 
+  const outputDimensionality = typeof options.outputDimensionality === 'number' ? options.outputDimensionality : undefined;
+  const truncate = (vector: number[]): number[] =>
+    outputDimensionality ? vector.slice(0, outputDimensionality) : vector;
+
   return {
     id: "local",
     model: modelPath,
@@ -151,7 +155,7 @@ export async function createLocalEmbeddingProviderInProcess(
       throwIfClosed();
       optionsValue?.signal?.throwIfAborted();
       const embedding = await ctx.getEmbeddingFor(text);
-      return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
+      return truncate(sanitizeAndNormalizeEmbedding(Array.from(embedding.vector)));
     },
     embedBatch: async (texts, optionsLocal) => {
       throwIfClosed();
@@ -164,7 +168,7 @@ export async function createLocalEmbeddingProviderInProcess(
         throwIfClosed();
         optionsLocal?.signal?.throwIfAborted();
         const embedding = await ctx.getEmbeddingFor(text);
-        embeddings.push(sanitizeAndNormalizeEmbedding(Array.from(embedding.vector)));
+        embeddings.push(truncate(sanitizeAndNormalizeEmbedding(Array.from(embedding.vector))));
       }
       return embeddings;
     },

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -141,9 +141,12 @@ export async function createLocalEmbeddingProviderInProcess(
     return initPromise;
   };
 
-  const outputDimensionality = typeof options.outputDimensionality === 'number' ? options.outputDimensionality : undefined;
-  const truncate = (vector: number[]): number[] =>
-    outputDimensionality ? vector.slice(0, outputDimensionality) : vector;
+  const outputDimensionality =
+    typeof options.outputDimensionality === "number" ? options.outputDimensionality : undefined;
+  const normalize = (vector: ArrayLike<number>): number[] =>
+    sanitizeAndNormalizeEmbedding(
+      outputDimensionality ? Array.from(vector).slice(0, outputDimensionality) : Array.from(vector),
+    );
 
   return {
     id: "local",
@@ -155,7 +158,7 @@ export async function createLocalEmbeddingProviderInProcess(
       throwIfClosed();
       optionsValue?.signal?.throwIfAborted();
       const embedding = await ctx.getEmbeddingFor(text);
-      return truncate(sanitizeAndNormalizeEmbedding(Array.from(embedding.vector)));
+      return normalize(embedding.vector);
     },
     embedBatch: async (texts, optionsLocal) => {
       throwIfClosed();
@@ -168,7 +171,7 @@ export async function createLocalEmbeddingProviderInProcess(
         throwIfClosed();
         optionsLocal?.signal?.throwIfAborted();
         const embedding = await ctx.getEmbeddingFor(text);
-        embeddings.push(truncate(sanitizeAndNormalizeEmbedding(Array.from(embedding.vector))));
+        embeddings.push(normalize(embedding.vector));
       }
       return embeddings;
     },


### PR DESCRIPTION
## Summary

- Apply `outputDimensionality` truncation to local GGUF embeddings before normalization.
- Forward the setting through the local embedding worker boundary.
- Include output dimensionality in llama.cpp cache and index identities so dimension changes trigger reindexing instead of reusing incompatible vectors.

Fixes #58765

## Verification

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings.test.ts extensions/llama-cpp/index.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- `OPENCLAW_TESTBOX=1 node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed`

## Real behavior proof

Behavior addressed: Local GGUF embeddings now honor configured output dimensionality without reusing an index built for a different vector size.
Real environment tested: OpenClaw local embedding provider and llama.cpp adapter in the repository test harness.
Exact steps or command run after this patch: Ran the focused memory-host and llama.cpp Vitest shards listed above.
Evidence after fix: The provider tests return normalized two-dimensional query and batch vectors, the worker test proves the setting crosses process serialization, and the adapter test proves dimensionality participates in cache and index identities.
Observed result after fix: Query and batch embeddings use the requested dimensions and a dimension change produces a distinct local index identity.
What was not tested: A downloaded GGUF model in a live user configuration.
