### PR TITLE
fix(minimax): surface TTS envelope errors so fallback fires (#76904) [AI]

### DIFF
--- a/extensions/minimax/base-resp.ts
+++ b/extensions/minimax/base-resp.ts
@@ -1,0 +1,22 @@
+// Minimax shares one response envelope across every API surface. Centralize the
+// shape + assertion so tts/music/video fail identically instead of re-deriving
+// the check per provider file.
+export type MinimaxBaseResp = {
+  status_code?: number;
+  status_msg?: string;
+};
+
+// MiniMax returns HTTP 200 even for quota/billing/validation failures;
+// base_resp.status_code is the only error signal (0 = success). Throwing lets
+// callers treat envelope errors like transport errors (e.g. TTS fallback).
+export function assertMinimaxBaseResp(
+  baseResp: MinimaxBaseResp | undefined,
+  context: string,
+): void {
+  if (!baseResp || typeof baseResp.status_code !== "number" || baseResp.status_code === 0) {
+    return;
+  }
+  throw new Error(
+    `${context} (${baseResp.status_code}): ${baseResp.status_msg ?? "unknown error"}`,
+  );
+}

--- a/extensions/minimax/music-generation-provider.ts
+++ b/extensions/minimax/music-generation-provider.ts
@@ -18,6 +18,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { assertMinimaxBaseResp, type MinimaxBaseResp } from "./base-resp.js";
 
 const DEFAULT_MINIMAX_MUSIC_BASE_URL = "https://api.minimax.io";
 const DEFAULT_MINIMAX_MUSIC_MODEL = "music-2.6";
@@ -26,11 +27,6 @@ const DEFAULT_OPERATION_TIMEOUT_MS = 300_000;
 const DEFAULT_GENERATED_MUSIC_MAX_BYTES = 16 * 1024 * 1024;
 const STREAM_ENVELOPE_MAX_BYTES_MULTIPLIER = 5;
 const STREAM_ENVELOPE_OVERHEAD_BYTES = 64 * 1024;
-
-type MinimaxBaseResp = {
-  status_code?: number;
-  status_msg?: string;
-};
 
 type MinimaxMusicCreateResponse = {
   task_id?: string;
@@ -66,15 +62,6 @@ function resolveMinimaxMusicBaseUrl(
   } catch {
     return DEFAULT_MINIMAX_MUSIC_BASE_URL;
   }
-}
-
-function assertMinimaxBaseResp(baseResp: MinimaxBaseResp | undefined, context: string): void {
-  if (!baseResp || typeof baseResp.status_code !== "number" || baseResp.status_code === 0) {
-    return;
-  }
-  throw new Error(
-    `${context} (${baseResp.status_code}): ${baseResp.status_msg ?? "unknown error"}`,
-  );
 }
 
 function decodePossibleBinaryWithLimit(data: string, maxBytes: number): Buffer {

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -610,6 +610,32 @@ describe("buildMinimaxSpeechProvider", () => {
         }),
       ).rejects.toThrow("MiniMax TTS API error (401): Unauthorized");
     });
+
+    it("throws on MiniMax envelope errors instead of transcoding placeholder audio", async () => {
+      // MiniMax answers HTTP 200 with a nonzero base_resp on quota/billing
+      // failures; synthesize must reject so the shared TTS fallback loop tries
+      // the configured backup provider, and never transcode the placeholder.
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            base_resp: { status_code: 1002, status_msg: "Quota exceeded" },
+            data: { audio: Buffer.from("placeholder").toString("hex") },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      await expect(
+        provider.synthesize({
+          text: "Test",
+          cfg: {} as never,
+          providerConfig: { apiKey: "sk-test" },
+          target: "voice-note",
+          timeoutMs: 30000,
+        }),
+      ).rejects.toThrow("MiniMax TTS API error (1002): Quota exceeded");
+      expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("listVoices", () => {

--- a/extensions/minimax/tts.test.ts
+++ b/extensions/minimax/tts.test.ts
@@ -15,6 +15,29 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
 import { minimaxTTS } from "./tts.js";
 
 describe("minimaxTTS", () => {
+  function mockMinimaxResponse(payload: unknown): ReturnType<typeof vi.fn> {
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release,
+    });
+    return release;
+  }
+
+  function baseRequest() {
+    return {
+      text: "hello",
+      apiKey: "sk-test",
+      baseUrl: "https://api.minimax.io",
+      model: "speech-2.8-hd",
+      voiceId: "English_expressive_narrator",
+      timeoutMs: 30000,
+    };
+  }
+
   afterEach(() => {
     fetchWithSsrFGuardMock.mockReset();
     vi.restoreAllMocks();
@@ -47,5 +70,39 @@ describe("minimaxTTS", () => {
       timeoutMs: MAX_TIMER_TIMEOUT_MS,
     });
     expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]?.init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws envelope errors before decoding placeholder audio", async () => {
+    const release = mockMinimaxResponse({
+      base_resp: { status_code: 1002, status_msg: "Quota exceeded" },
+      data: { audio: Buffer.from("placeholder").toString("hex") },
+    });
+
+    await expect(minimaxTTS(baseRequest())).rejects.toThrow(
+      "MiniMax TTS API error (1002): Quota exceeded",
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("prefers envelope errors over missing audio errors", async () => {
+    mockMinimaxResponse({
+      base_resp: { status_code: 1039 },
+      data: {},
+    });
+
+    await expect(minimaxTTS(baseRequest())).rejects.toThrow(
+      "MiniMax TTS API error (1039): unknown error",
+    );
+  });
+
+  it("decodes audio when the MiniMax envelope is successful", async () => {
+    mockMinimaxResponse({
+      base_resp: { status_code: 0 },
+      data: { audio: Buffer.from("audio").toString("hex") },
+    });
+
+    const audio = await minimaxTTS(baseRequest());
+
+    expect(audio.toString()).toBe("audio");
   });
 });

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -5,6 +5,7 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
 } from "openclaw/plugin-sdk/ssrf-runtime";
+import { assertMinimaxBaseResp, type MinimaxBaseResp } from "./base-resp.js";
 
 export const DEFAULT_MINIMAX_TTS_BASE_URL = "https://api.minimax.io";
 
@@ -27,6 +28,11 @@ export const MINIMAX_TTS_VOICES = [
   "Chinese (Mandarin)_Gentle_Boy",
   "Chinese (Mandarin)_Steady_Boy",
 ] as const;
+
+type MinimaxTtsResponse = {
+  data?: { audio?: string };
+  base_resp?: MinimaxBaseResp;
+};
 
 export function normalizeMinimaxTtsBaseUrl(baseUrl?: string): string {
   const trimmed = baseUrl?.trim();
@@ -103,7 +109,10 @@ export async function minimaxTTS(params: {
     try {
       await assertOkOrThrowProviderError(response, "MiniMax TTS API error");
 
-      const body = (await response.json()) as { data?: { audio?: string } };
+      const body = (await response.json()) as MinimaxTtsResponse;
+      // Surface MiniMax envelope errors (HTTP 200 + nonzero status_code) so the
+      // shared TTS fallback loop can advance to the configured backup provider.
+      assertMinimaxBaseResp(body.base_resp, "MiniMax TTS API error");
       const hexAudio = body?.data?.audio;
       if (!hexAudio) {
         throw new Error("MiniMax TTS API returned no audio data");

--- a/extensions/minimax/video-generation-provider.ts
+++ b/extensions/minimax/video-generation-provider.ts
@@ -21,6 +21,7 @@ import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
 } from "openclaw/plugin-sdk/video-generation";
+import { assertMinimaxBaseResp, type MinimaxBaseResp } from "./base-resp.js";
 
 const DEFAULT_MINIMAX_VIDEO_BASE_URL = "https://api.minimax.io";
 const DEFAULT_MINIMAX_VIDEO_MODEL = "MiniMax-Hailuo-2.3";
@@ -39,11 +40,6 @@ const MINIMAX_MODEL_ALLOWED_RESOLUTIONS: Readonly<Record<string, readonly string
   "MiniMax-Hailuo-02": ["768P", "1080P"],
 };
 const MINIMAX_RESOLUTION_ORDER = ["480P", "720P", "768P", "1080P"] as const;
-
-type MinimaxBaseResp = {
-  status_code?: number;
-  status_msg?: string;
-};
 
 type MinimaxCreateResponse = {
   task_id?: string;
@@ -87,15 +83,6 @@ function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
     return Math.floor(configured * 1024 * 1024);
   }
   return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
-}
-
-function assertMinimaxBaseResp(baseResp: MinimaxBaseResp | undefined, context: string): void {
-  if (!baseResp || typeof baseResp.status_code !== "number" || baseResp.status_code === 0) {
-    return;
-  }
-  throw new Error(
-    `${context} (${baseResp.status_code}): ${baseResp.status_msg ?? "unknown error"}`,
-  );
 }
 
 function toDataUrl(buffer: Buffer, mimeType: string): string {


### PR DESCRIPTION
## Summary

MiniMax TTS does not fail over to a configured fallback provider (Microsoft, etc.) when the MiniMax code‑plan / billing quota is exhausted. MiniMax answers `POST /v1/t2a_v2` with **HTTP 200** and signals quota/billing failures only through a nonzero `base_resp.status_code`, often alongside a **non‑empty placeholder `data.audio`**. The provider decoded `data.audio` without inspecting the envelope, so a quota‑exceeded response resolved as a *successful* synthesis and returned bogus bytes. Because the shared speech‑core fallback loop only advances to the next/fallback provider when a provider's `synthesize()` **throws** (a successful return ends the loop — `packages/speech-core/src/tts.ts`), the failover never fired.

This makes `minimaxTTS()` **throw on a nonzero `base_resp` before decoding audio**, so `synthesize()` rejects and the existing fallback loop tries the configured backup provider. The check is provider‑local: the HTTP‑200‑envelope contract is MiniMax‑specific, so the shared HTTP helper and the speech‑core loop stay provider‑agnostic.

The same `MinimaxBaseResp` type + `assertMinimaxBaseResp` helper was already byte‑identical in `music-generation-provider.ts` and `video-generation-provider.ts`; rather than add a third copy, this extracts a plugin‑local `extensions/minimax/base-resp.ts` and migrates all three call sites in the same change (per `extensions/AGENTS.md`: "stop copying the logic. Extract one shared helper and migrate both call sites in the same change"). `image`/`oauth`/`web-search` are intentionally left alone — their envelope handling has different message contracts (folding them in would change observable error text).

> **AI‑assisted PR (disclosure).** Implemented with Codex + Claude Code under human review; I understand and own the diff. Session context available on request.

## Linked context

Closes #76904.

Supersedes #81489 by **@ottodeng** (same root cause and provider‑local approach; that PR was closed by its author for lack of real‑behavior proof, not because the approach was wrong). This PR omits the `CHANGELOG.md` edit #81489 made, per current release‑owned changelog policy. Adjacent (not duplicate): #73079 touches the same `minimaxTTS` request body to request hex output explicitly — independent of this response‑handling change.

## Real behavior proof

- **Behavior addressed:** MiniMax TTS now fails over to the configured fallback provider when MiniMax returns an HTTP‑200 quota/billing envelope (`base_resp.status_code != 0`), instead of returning placeholder audio as success.
- **Real environment tested:** Local `openclaw infer tts convert` (real CLI → speech‑core auto‑select → provider runtime), macOS, Node 22. MiniMax's `POST /v1/t2a_v2` was served by a loopback stub returning the live broken shape (HTTP 200 + `base_resp.status_code: 1002` "insufficient balance" + non‑empty placeholder `data.audio`); the credential‑free `tts-local-cli` provider was configured as the fallback. (A live quota‑exhausted MiniMax account could not be provisioned — see "What was not tested".)
- **Exact steps or command run after this patch:**
  ```
  # config: messages.tts.provider=minimax (baseUrl→loopback stub), fallback tts-local-cli
  openclaw infer tts convert --local \
    --text "MiniMax fallback proof for issue 76904" \
    --output out.wav --json
  # (no --provider/--model/--voice, so auto-select + fallback stay enabled)
  ```
- **Evidence after fix:** `infer tts convert` JSON now reports the failover:
  ```json
  {
    "provider": "tts-local-cli",
    "attempts": [
      { "provider": "minimax", "outcome": "failed", "reasonCode": "provider_error",
        "error": "minimax: MiniMax TTS API error (1002): insufficient balance, please recharge" },
      { "provider": "tts-local-cli", "outcome": "success", "reasonCode": "success" }
    ],
    "outputs": [{ "path": "out.wav", "format": "wav" }]
  }
  ```
  The saved file is real fallback audio (`RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 8000 Hz`, 1644 bytes), not the placeholder.
- **Observed result after fix:** MiniMax's HTTP‑200 envelope is surfaced as `provider_error`, the loop advances, and `tts-local-cli` synthesizes the output. `provider` resolves to the fallback (`tts-local-cli`), not MiniMax.
- **Before (same config, pre‑patch bundle = current `main`):** the same command resolved successfully on MiniMax and never failed over:
  ```json
  { "provider": "minimax",
    "attempts": [{ "provider": "minimax", "outcome": "success", "reasonCode": "success" }],
    "outputs": [{ "format": "mp3" }] }
  ```
  The saved file was the 26‑byte placeholder (`Buffer.from(data.audio, "hex")` of the envelope's bogus audio) — bogus output returned as success, no fallback.
- **What was not tested:** A live MiniMax account in a real quota‑exhausted/zero‑balance state, and a real cloud fallback provider (e.g. Microsoft/Azure) end‑to‑end — no such credentials were available. The upstream MiniMax response was reproduced via a loopback stub matching the documented/observed shape; the fallback target was the local `tts-local-cli` provider rather than a cloud TTS.

## Tests and validation

- `extensions/minimax/tts.test.ts` — envelope throws before decoding placeholder audio (and `release()` still runs); envelope error preferred over "no audio data"; `status_code: 0` still decodes.
- `extensions/minimax/speech-provider.test.ts` — wrapper `synthesize()` (target `voice-note`) rejects on the envelope error and never transcodes the placeholder.
- Sibling migration is behavior‑preserving: `music-generation-provider.test.ts` and `video-generation-provider.test.ts` pass unchanged against the shared helper.
- Commands: `node scripts/run-vitest.mjs extensions/minimax/tts.test.ts extensions/minimax/speech-provider.test.ts extensions/minimax/video-generation-provider.test.ts extensions/minimax/music-generation-provider.test.ts packages/speech-core/src/tts.test.ts` → all pass (60 extension + 42 speech‑core). `oxfmt --check` + `oxlint` clean on touched files.

## Risk

Provider‑local behavior change; no core/config/fallback‑loop changes. Net non‑test LOC negative (removed a duplicated concept). The new throw only triggers on a nonzero numeric `base_resp.status_code`; `status_code: 0` and absent `base_resp` are unaffected, so normal success is unchanged.
