### PR TITLE
feat: add MegaBrain provider

### DIFF
--- a/extensions/megabrain/index.ts
+++ b/extensions/megabrain/index.ts
@@ -1,0 +1,37 @@
+// MegaBrain plugin entrypoint registers its OpenClaw integration.
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { applyMegaBrainConfig, MEGABRAIN_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildMegaBrainProvider, buildStaticMegaBrainProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "megabrain";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "MegaBrain Provider",
+  description: "Bundled MegaBrain provider plugin",
+  provider: {
+    label: "MegaBrain",
+    docsPath: "/providers/megabrain",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "MegaBrain API key",
+        hint: "API key from getmegabrain.com",
+        optionKey: "megabrainApiKey",
+        flagName: "--megabrain-api-key",
+        envVar: "MEGABRAIN_API_KEY",
+        promptMessage: "Enter MegaBrain API key",
+        defaultModel: MEGABRAIN_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyMegaBrainConfig(cfg),
+        wizard: {
+          choiceId: "megabrain-api-key",
+          groupId: "megabrain",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildMegaBrainProvider,
+      buildStaticProvider: buildStaticMegaBrainProvider,
+    },
+  },
+});

--- a/extensions/megabrain/models.ts
+++ b/extensions/megabrain/models.ts
@@ -1,0 +1,140 @@
+// MegaBrain plugin module implements models behavior.
+import {
+  getCachedLiveProviderModelRows,
+  LiveModelCatalogHttpError,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export const MEGABRAIN_PROVIDER_ID = "megabrain";
+export const MEGABRAIN_BASE_URL = "https://getmegabrain.com/api/gateway/v1";
+export const MEGABRAIN_DEFAULT_MODEL_ID = "openai/gpt-4o";
+export const MEGABRAIN_DEFAULT_CONTEXT_WINDOW = 128_000;
+export const MEGABRAIN_DEFAULT_MAX_TOKENS = 8_192;
+export const MEGABRAIN_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+const log = createSubsystemLogger("agents/megabrain");
+const MEGABRAIN_DISCOVERY_CACHE_TTL_MS = 60_000;
+const MEGABRAIN_DISCOVERY_TIMEOUT_MS = 5_000;
+
+type OpenAIModelShape = {
+  id?: string;
+  object?: string;
+  context_window?: number;
+  max_tokens?: number;
+};
+
+// A minimal static catalog so the provider works out-of-the-box without a
+// network call.  MegaBrain exposes 500+ models via its /v1/models endpoint;
+// the live discovery below will supersede this list at runtime.
+const STATIC_MEGABRAIN_MODEL_CATALOG: readonly ModelDefinitionConfig[] = [
+  {
+    id: "openai/gpt-4o",
+    name: "GPT-4o",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    cost: MEGABRAIN_DEFAULT_COST,
+  },
+  {
+    id: "openai/gpt-4o-mini",
+    name: "GPT-4o Mini",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 128_000,
+    maxTokens: 16_384,
+    cost: MEGABRAIN_DEFAULT_COST,
+  },
+  {
+    id: "anthropic/claude-opus-4.6",
+    name: "Claude Opus 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1_000_000,
+    maxTokens: 128_000,
+    cost: MEGABRAIN_DEFAULT_COST,
+  },
+  {
+    id: "anthropic/claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1_000_000,
+    maxTokens: 64_000,
+    cost: MEGABRAIN_DEFAULT_COST,
+  },
+  {
+    id: "google/gemini-2.5-pro",
+    name: "Gemini 2.5 Pro",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+    cost: MEGABRAIN_DEFAULT_COST,
+  },
+] as const;
+
+function buildDiscoveredModelDefinition(model: OpenAIModelShape): ModelDefinitionConfig | null {
+  const id = typeof model.id === "string" ? model.id.trim() : "";
+  if (!id) {
+    return null;
+  }
+  const contextWindow =
+    asPositiveSafeInteger(model.context_window) ?? MEGABRAIN_DEFAULT_CONTEXT_WINDOW;
+  const maxTokens = asPositiveSafeInteger(model.max_tokens) ?? MEGABRAIN_DEFAULT_MAX_TOKENS;
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    contextWindow,
+    maxTokens,
+    cost: MEGABRAIN_DEFAULT_COST,
+  };
+}
+
+function asOpenAIModelShape(value: unknown): OpenAIModelShape {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("MegaBrain model list: malformed JSON response");
+  }
+  return value as OpenAIModelShape;
+}
+
+export function getStaticMegaBrainModelCatalog(): ModelDefinitionConfig[] {
+  return [...STATIC_MEGABRAIN_MODEL_CATALOG];
+}
+
+export async function discoverMegaBrainModels(): Promise<ModelDefinitionConfig[]> {
+  if (process.env.VITEST || process.env.NODE_ENV === "test") {
+    return getStaticMegaBrainModelCatalog();
+  }
+
+  try {
+    const data = await getCachedLiveProviderModelRows({
+      providerId: MEGABRAIN_PROVIDER_ID,
+      endpoint: `${MEGABRAIN_BASE_URL}/models`,
+      timeoutMs: MEGABRAIN_DISCOVERY_TIMEOUT_MS,
+      ttlMs: MEGABRAIN_DISCOVERY_CACHE_TTL_MS,
+      auditContext: "megabrain.models",
+    });
+    const discovered = data
+      .map(asOpenAIModelShape)
+      .map(buildDiscoveredModelDefinition)
+      .filter((entry): entry is ModelDefinitionConfig => entry !== null);
+    return discovered.length > 0 ? discovered : getStaticMegaBrainModelCatalog();
+  } catch (error) {
+    if (error instanceof LiveModelCatalogHttpError) {
+      log.warn(`Failed to discover MegaBrain models: HTTP ${error.status}`);
+      return getStaticMegaBrainModelCatalog();
+    }
+    log.warn(`Failed to discover MegaBrain models: ${String(error)}`);
+    return getStaticMegaBrainModelCatalog();
+  }
+}

--- a/extensions/megabrain/onboard.ts
+++ b/extensions/megabrain/onboard.ts
@@ -1,0 +1,34 @@
+// MegaBrain setup module handles plugin onboarding behavior.
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { MEGABRAIN_DEFAULT_MODEL_ID, MEGABRAIN_PROVIDER_ID } from "./models.js";
+
+export const MEGABRAIN_DEFAULT_MODEL_REF = `${MEGABRAIN_PROVIDER_ID}/${MEGABRAIN_DEFAULT_MODEL_ID}`;
+
+function applyMegaBrainProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[MEGABRAIN_DEFAULT_MODEL_REF] = {
+    ...models[MEGABRAIN_DEFAULT_MODEL_REF],
+    alias: models[MEGABRAIN_DEFAULT_MODEL_REF]?.alias ?? "MegaBrain",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyMegaBrainConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyMegaBrainProviderConfig(cfg),
+    MEGABRAIN_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/megabrain/openclaw.plugin.json
+++ b/extensions/megabrain/openclaw.plugin.json
@@ -1,0 +1,54 @@
+{
+  "id": "megabrain",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["megabrain"],
+  "modelIdNormalization": {
+    "providers": {
+      "megabrain": {
+        "prefixWhenBare": "megabrain"
+      }
+    }
+  },
+  "modelPricing": {
+    "providers": {
+      "megabrain": {
+        "openRouter": {
+          "passthroughProviderModel": true
+        },
+        "liteLLM": false
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "megabrain",
+        "envVars": ["MEGABRAIN_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "megabrain",
+      "method": "api-key",
+      "choiceId": "megabrain-api-key",
+      "choiceLabel": "MegaBrain API key",
+      "groupId": "megabrain",
+      "groupLabel": "MegaBrain",
+      "groupHint": "API key from getmegabrain.com",
+      "onboardingScopes": ["text-inference"],
+      "optionKey": "megabrainApiKey",
+      "cliFlag": "--megabrain-api-key",
+      "cliOption": "--megabrain-api-key <key>",
+      "cliDescription": "MegaBrain API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/megabrain/package.json
+++ b/extensions/megabrain/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/megabrain-provider",
+  "version": "2026.6.9",
+  "private": true,
+  "description": "OpenClaw MegaBrain provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/megabrain/provider-catalog.ts
+++ b/extensions/megabrain/provider-catalog.ts
@@ -1,0 +1,23 @@
+// MegaBrain provider module implements model/runtime integration.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  discoverMegaBrainModels,
+  getStaticMegaBrainModelCatalog,
+  MEGABRAIN_BASE_URL,
+} from "./models.js";
+
+export function buildStaticMegaBrainProvider(): ModelProviderConfig {
+  return {
+    baseUrl: MEGABRAIN_BASE_URL,
+    api: "openai-completions",
+    models: getStaticMegaBrainModelCatalog(),
+  };
+}
+
+export async function buildMegaBrainProvider(): Promise<ModelProviderConfig> {
+  return {
+    baseUrl: MEGABRAIN_BASE_URL,
+    api: "openai-completions",
+    models: await discoverMegaBrainModels(),
+  };
+}

--- a/extensions/megabrain/tsconfig.json
+++ b/extensions/megabrain/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds first-class provider support for [MegaBrain](https://getmegabrain.com) — an OpenAI-compatible AI gateway that exposes 500+ models from leading AI providers through a single API.

### What is MegaBrain?

MegaBrain is an OpenAI-compatible AI gateway available at `https://getmegabrain.com`. It provides:
- Access to 500+ models from Anthropic, OpenAI, Google, Meta, Mistral, and more
- A single unified API key for all models
- Standard OpenAI-compatible `/v1/chat/completions` and `/v1/models` endpoints
- Base URL: `https://getmegabrain.com/api/gateway/v1`

### What this PR adds

A new `extensions/megabrain/` provider plugin that gives MegaBrain the same level of first-class integration as OpenRouter and Vercel AI Gateway. The implementation follows the exact same structure as `extensions/vercel-ai-gateway/`:

- **`openclaw.plugin.json`** — plugin manifest with `choiceId: "megabrain-api-key"` and CLI flag `--megabrain-api-key`
- **`index.ts`** — plugin entrypoint using `defineSingleProviderPluginEntry`
- **`models.ts`** — static model catalog + live discovery from `/v1/models`
- **`provider-catalog.ts`** — builds `ModelProviderConfig` with `api: "openai-completions"`
- **`onboard.ts`** — applies config and sets default model ref
- **`package.json`** + **`tsconfig.json`** — standard package scaffolding

### How to use after merging

```bash
# Onboard with a MegaBrain API key
openclaw onboard --auth-choice megabrain-api-key --megabrain-api-key "$MEGABRAIN_API_KEY"

# Or via environment variable
export MEGABRAIN_API_KEY="your-key-here"
openclaw onboard --auth-choice megabrain-api-key
```

Get your API key at https://getmegabrain.com.

### Implementation notes

- Uses `api: "openai-completions"` since MegaBrain is fully OpenAI-compatible
- `passthroughProviderModel: true` in `modelPricing` (same as OpenRouter) since MegaBrain is a passthrough gateway
- Includes a minimal static model catalog (GPT-4o, Claude Opus/Sonnet, Gemini 2.5 Pro) for zero-network startup, with live discovery from `/v1/models` at runtime
- No OAuth — API key only, matching MegaBrain's auth model

🤖 Generated with [Claude Code](https://claude.com/claude-code)