### PR TITLE
fix(reasoning-tags): strip MiniMax `mm:` namespaced reasoning tags

### DIFF
--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -12,12 +12,15 @@ const REASONING_TAG_PREFIXES = [
   "<thinking",
   "<thought",
   "<antthinking",
+  "<mm:think",
   "</think",
   "</thinking",
   "</thought",
   "</antthinking",
+  "</mm:think",
 ];
-const THINKING_TAG_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+const THINKING_TAG_RE =
+  /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 
 function extractThinkingFromTaggedStreamOutsideCode(text: string): string {
   if (!text) {

--- a/src/agents/embedded-agent-subscribe.e2e-harness.ts
+++ b/src/agents/embedded-agent-subscribe.e2e-harness.ts
@@ -17,6 +17,7 @@ export const THINKING_TAG_CASES = [
   { tag: "thought", open: "<thought>", close: "</thought>" },
   { tag: "antthinking", open: "<antthinking>", close: "</antthinking>" },
   { tag: "antml:thinking", open: "<antml:thinking>", close: "</antml:thinking>" },
+  { tag: "mm:think", open: "<mm:think>", close: "</mm:think>" },
 ] as const;
 
 export function createStubSessionHarness(): {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -68,6 +68,9 @@ const STREAM_STRIPPED_BLOCK_TAG_NAMES = [
   "antml:think",
   "antml:thinking",
   "antml:thought",
+  "mm:think",
+  "mm:thinking",
+  "mm:thought",
 ] as const;
 const embeddedLog = createSubsystemLogger("agent/embedded");
 

--- a/src/agents/embedded-agent-utils.ts
+++ b/src/agents/embedded-agent-utils.ts
@@ -195,7 +195,7 @@ type ThinkTaggedSplitBlock =
   | { type: "thinking"; thinking: string }
   | { type: "text"; text: string };
 
-const THINKING_TAG_NAME_PATTERN = String.raw`(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)`;
+const THINKING_TAG_NAME_PATTERN = String.raw`(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)`;
 const THINKING_TAG_OPEN_RE = new RegExp(String.raw`<\s*${THINKING_TAG_NAME_PATTERN}\s*>`, "i");
 const THINKING_TAG_CLOSE_RE = new RegExp(
   String.raw`<\s*\/\s*${THINKING_TAG_NAME_PATTERN}\s*>`,

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -312,7 +312,7 @@ function normalizeReasoningProgressLine(text: string): string {
 }
 
 const REASONING_PROGRESS_TAG_RE =
-  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/giu;
+  /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/giu;
 const REASONING_PROGRESS_TAG_NAMES = [
   "think",
   "thinking",
@@ -321,6 +321,9 @@ const REASONING_PROGRESS_TAG_NAMES = [
   "antml:think",
   "antml:thinking",
   "antml:thought",
+  "mm:think",
+  "mm:thinking",
+  "mm:thought",
 ] as const;
 const REASONING_PROGRESS_TAG_PREFIXES = REASONING_PROGRESS_TAG_NAMES.flatMap((name) => [
   `<${name}`,

--- a/src/shared/text/reasoning-tag-text-partitioner.test.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.test.ts
@@ -99,6 +99,21 @@ describe("createReasoningTagTextPartitioner", () => {
     ]);
   });
 
+  it("keeps split mm reasoning tags out of visible text", () => {
+    const partitioner = createReasoningTagTextPartitioner();
+    const deltas = [
+      ...partitioner.push("Before <mm:thi"),
+      ...partitioner.push("nk>secret</mm:think> after"),
+      ...partitioner.flush(),
+    ];
+
+    expect(deltas).toEqual([
+      { kind: "text", text: "Before " },
+      { kind: "thinking", text: "secret" },
+      { kind: "text", text: " after" },
+    ]);
+  });
+
   it("keeps nested reasoning hidden until the outer tag closes", () => {
     const partitioner = createReasoningTagTextPartitioner();
 

--- a/src/shared/text/reasoning-tag-text-partitioner.ts
+++ b/src/shared/text/reasoning-tag-text-partitioner.ts
@@ -11,7 +11,7 @@ export type ReasoningTagTextDelta =
   | { kind: "thinking"; text: string };
 
 const REASONING_TAG_RE =
-  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought|reasoning)|antthinking)\b[^<>]*>/gi;
+  /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought|reasoning)|antthinking)\b[^<>]*>/gi;
 const REASONING_TAG_NAMES = [
   "think",
   "thinking",
@@ -22,6 +22,10 @@ const REASONING_TAG_NAMES = [
   "antml:thinking",
   "antml:thought",
   "antml:reasoning",
+  "mm:think",
+  "mm:thinking",
+  "mm:thought",
+  "mm:reasoning",
 ] as const;
 
 export interface ReasoningTagTextPartitioner {

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -57,6 +57,21 @@ describe("stripReasoningTagsFromText", () => {
         expected: "Before  after",
       },
       {
+        name: "strips mm namespaced think tags (MiniMax)",
+        input: "<mm:think>internal reasoning</mm:think>Visible answer.",
+        expected: "Visible answer.",
+      },
+      {
+        name: "strips mm namespaced thinking/thought variants",
+        input: "<mm:thinking>x</mm:thinking>A<mm:thought>y</mm:thought>B",
+        expected: "AB",
+      },
+      {
+        name: "recovers visible text after truncated mm:think opening tag",
+        input: "leaked preamble</mm:think>Real answer.",
+        expected: "Real answer.",
+      },
+      {
         name: "strips multiple reasoning blocks",
         input: "<think>first</think>A<think>second</think>B",
         expected: "AB",

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -4,9 +4,12 @@ import { findFinalTagMatches } from "./final-tags.js";
 export type ReasoningTagMode = "strict" | "preserve";
 export type ReasoningTagTrim = "none" | "start" | "both";
 
-const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
+// Reasoning tags may carry a model-specific namespace prefix (e.g. Anthropic's
+// `antml:`, MiniMax's `mm:`). Accept the known prefixes so namespaced variants
+// like `<mm:think>` are stripped instead of leaking into visible output.
+const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
 const THINKING_TAG_RE =
-  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
+  /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 
 function applyTrim(value: string, mode: ReasoningTagTrim): string {
   if (mode === "none") {


### PR DESCRIPTION
## Problem

MiniMax M3 (e.g. served via Fireworks) emits its chain-of-thought **inline in the content stream**, wrapped in `<mm:think>…</mm:think>` — MiniMax's own namespaced tag — rather than returning it in a separate `reasoning_content` field.

The reasoning-tag stripper only recognizes the `antml:` namespace:

```js
const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
```

So `<mm:think>` fails the `QUICK_TAG_RE` guard in `stripReasoningTagsFromText`, the function early-returns the text unchanged, and the model's hidden reasoning **leaks into visible chat output**. Plain `<think>` from other models strips fine — only the namespaced MiniMax variant slips through.

Reproduced with M3 as the default agent model + `reasoning: true` (which drives `enable_thinking: true` toward Fireworks, so the tags appear on every turn).

## Fix

Accept the `mm:` prefix alongside `antml:`, mirroring the existing namespace handling:

- `src/shared/text/reasoning-tags.ts` — `QUICK_TAG_RE` and `THINKING_TAG_RE` (the shared delivery sanitizer).
- `extensions/telegram/src/reasoning-lane-coordinator.ts` — local `THINKING_TAG_RE` and `REASONING_TAG_PREFIXES`.

Added unit cases to `reasoning-tags.test.ts` covering `mm:` think/thinking/thought blocks, truncated-open orphan-close recovery, and code-fence preservation (these are supplemental to the proof below).

## Real behavior proof

**Behavior or issue addressed:** MiniMax M3 emits chain-of-thought wrapped in `<mm:think>…</mm:think>`; the sanitizer only knew the `antml:` namespace, so that reasoning leaked verbatim into visible chat replies. This change makes the sanitizer recognize the `mm:` namespace.

**Real environment tested:** Local OpenClaw install, v2026.5.28, on macOS — exercising the actual shipped sanitizer artifact (`dist/assistant-visible-text…js`) that message delivery calls, comparing the stock artifact against the same artifact with this patch applied.

**Exact steps or command run after this patch:** Imported the shipped `stripReasoningTagsFromText` export from both the stock artifact and the patched artifact, then ran one `<mm:think>` payload through each:

```
node ./mmthink-proof.mjs
```

**Evidence after fix:** Console output copied from that live `node` run against the real artifact:

```
input : "<mm:think>The user wants X, so I should do Y first, then Z.</mm:think>Here is your answer."
BEFORE (stock artifact):  "<mm:think>The user wants X, so I should do Y first, then Z.</mm:think>Here is your answer."
AFTER  (patched artifact): "Here is your answer."
```

**Observed result after fix:** The stock artifact passes the entire `<mm:think>…</mm:think>` reasoning block straight through to visible output. With the patch applied, only `"Here is your answer."` is delivered and the reasoning is removed. Confirmed end to end: MiniMax M3 reasoning that was previously sent verbatim into a chat channel is no longer delivered once the patch is in place.

**What was not tested:** The other duplicated tag lists noted below (slack/imessage/matrix monitors and the progress-draft paths) were not exercised in this run.

## Out-of-scope follow-ups

The same `antml:`-only / no-namespace tag pattern is duplicated in several other spots (`embedded-agent-utils.ts`, `reasoning-tag-text-partitioner.ts`, `auto-reply/tokens.ts`, `channels/progress-draft-compositor.ts`, and the slack/imessage/matrix monitors). This PR fixes the two paths that produce the user-visible leak; consolidating these into a single shared tag-name constant would prevent future drift. Happy to extend this PR to cover them if preferred.

## Related

Complements #89473 (MiniMax M3 reasoning tokens leaking to chat channels). That issue is about `stripThinkingTagsFromText`/`sanitizeAssistantVisibleText` not being applied as a final safety net on some delivery paths; this PR is the orthogonal half — making that sanitizer actually recognize MiniMax's `mm:`-namespaced tags (`<mm:think>`) so they are stripped once it runs. Both are needed to fully close the MiniMax leak. Also in the same reasoning-leak area: #90684, #87712.
