### PR TITLE
fix(acp): preserve background terminal summaries

### DIFF
--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -14,7 +14,7 @@ import type { AcpSessionManagerDeps } from "./manager.types.js";
 import { normalizeText } from "./runtime-options.js";
 
 const ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH = 160;
-const ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH = 240;
+const ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH = 1_200;
 
 /** Context needed to mirror a child ACP turn into the requester task registry. */
 export type BackgroundTaskContext = {
@@ -90,7 +90,10 @@ export function resolveBackgroundTaskTerminalResult(progressSummary: string): {
       terminalSummary: "Writable session or apply_patch authorization required.",
     };
   }
-  return {};
+  if (normalized === "ANNOUNCE_SKIP") {
+    return {};
+  }
+  return { terminalSummary: normalized };
 }
 
 /** Resolves the requester task context for a spawned child ACP session. */

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -5,6 +5,10 @@ import {
   withAcpManagerTaskStateDir,
 } from "../../../test/helpers/acp-manager-task-state.js";
 import {
+  appendBackgroundTaskProgressSummary,
+  resolveBackgroundTaskTerminalResult,
+} from "./manager.background-task.js";
+import {
   AcpRuntimeError,
   AcpSessionManager,
   baseCfg,
@@ -268,7 +272,9 @@ describe("AcpSessionManager turn results", () => {
           "I'll inspect the repo now. The crash is a missing null check in src/foo.ts.",
       });
       expect(record.terminalOutcome).toBeUndefined();
-      expect(record.terminalSummary).toBeUndefined();
+      expect(record.terminalSummary).toBe(
+        "I'll inspect the repo now. The crash is a missing null check in src/foo.ts.",
+      );
     });
   });
 
@@ -343,7 +349,27 @@ describe("AcpSessionManager turn results", () => {
           "I'll inspect the repo now: the crash is a missing null check in src/foo.ts.",
       });
       expect(record.terminalOutcome).toBeUndefined();
-      expect(record.terminalSummary).toBeUndefined();
+      expect(record.terminalSummary).toBe(
+        "I'll inspect the repo now: the crash is a missing null check in src/foo.ts.",
+      );
+    });
+  });
+
+  it("cleans successful ACP terminal summaries without hiding useful progress", () => {
+    expect(resolveBackgroundTaskTerminalResult("ANNOUNCE_SKIP")).toEqual({});
+    expect(resolveBackgroundTaskTerminalResult("Set the reply to ANNOUNCE_SKIP")).toEqual({
+      terminalSummary: "Set the reply to ANNOUNCE_SKIP",
+    });
+    expect(resolveBackgroundTaskTerminalResult("Updated SHOULD_ANNOUNCE_SKIP")).toEqual({
+      terminalSummary: "Updated SHOULD_ANNOUNCE_SKIP",
+    });
+
+    const longChunk = "Completed a detailed background task summary. ".repeat(12);
+    const summary = appendBackgroundTaskProgressSummary("", longChunk);
+    expect(summary.length).toBeGreaterThan(240);
+    expect(summary.length).toBeLessThan(1_200);
+    expect(resolveBackgroundTaskTerminalResult(summary)).toEqual({
+      terminalSummary: summary.trim(),
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes #74070.
- Preserve successful ACP background-task progress as `terminalSummary` so completion delivery includes the useful result instead of only `Background task done` / `ready for review` boilerplate.
- Raise the bounded ACP progress summary cap from 240 to 1,200 characters while keeping blocked/required-completion detection ahead of the success fallback.
- Keep exact `ANNOUNCE_SKIP` as non-deliverable control text, but do not truncate substantive summaries that merely contain or end with that literal token.

## Real behavior proof

Behavior addressed: successful ACP background-task completions with useful progress text now persist that text as `terminalSummary`; long one-line progress summaries are retained up to 1,200 chars; exact `ANNOUNCE_SKIP` remains hidden.

Real environment tested: local OpenClaw source runtime smoke on macOS using production ACP background-task helpers and production task delivery formatter, plus focused Vitest through the repo `scripts/run-vitest.mjs` wrapper after `pnpm install --frozen-lockfile` hydrated the new worktree.

Exact steps or command run after this patch: `node --import tsx --input-type=module` source-runtime smoke that imports `src/acp/control-plane/manager.background-task.ts` and `src/tasks/task-executor-policy.ts`; `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts src/acp/control-plane/manager.test.ts src/tasks/task-executor-policy.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `git diff --check`.

Evidence after fix: copied output from the source-runtime smoke:

```text
progressSummary=Implemented the ACP fallback. Verified that successful background tasks now carry terminal summaries to the requester.
terminalSummary=Implemented the ACP fallback. Verified that successful background tasks now carry terminal summaries to the requester.
delivered=Background task done: ACP proof task (run run-proo). Implemented the ACP fallback. Verified that successful background tasks now carry terminal summaries to the requester.
announceSkipTerminal={}
literalAnnounceSkipTerminal={"terminalSummary":"Set the reply to ANNOUNCE_SKIP"}
```

Focused Vitest also passed 3 shards: `manager.turn-results.test.ts` 16 tests, `manager.test.ts` 29 tests, and `task-executor-policy.test.ts` 5 tests. Autoreview returned clean: `no accepted/actionable findings reported`. `git diff --check` passed.

Observed result after fix: production formatting now emits `Background task done: ... <terminal summary>` for successful ACP background-task completion output; exact `ANNOUNCE_SKIP` is still suppressed; substantive `Set the reply to ANNOUNCE_SKIP` and `Updated SHOULD_ANNOUNCE_SKIP` remain visible; and a >240-char summary remains available for terminal delivery.

What was not tested: live ACP provider session and remote Crabbox/Testbox changed gate. The local Crabbox/Testbox dispatch was blocked because no usable `crabbox` or `blacksmith` binary is available in this environment (`node scripts/crabbox-wrapper.mjs ... check:changed` failed at local binary sanity check before remote allocation).

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --write --threads=1 src/acp/control-plane/manager.background-task.ts src/acp/control-plane/manager.turn-results.test.ts`
- `node --import tsx --input-type=module` source-runtime smoke described above
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts src/acp/control-plane/manager.test.ts src/tasks/task-executor-policy.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `git diff --check`
