### PR TITLE
fix(feishu): recover CJK filenames from JSON file_name field (fixes #81103)

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -899,7 +899,7 @@ describe("downloadMessageResourceFeishu", () => {
     expect(result.fileName).toBe("café-Â©.txt");
   });
 
-  it("recovers CJK filenames from JSON-derived file_name field", async () => {
+  it("keeps JSON-derived file_name metadata unchanged", async () => {
     const fileName = "武汉15座山登山信息汇总.csv";
     const latin1LookingFileName = Buffer.from(fileName, "utf8").toString("latin1");
     messageResourceGetMock.mockResolvedValueOnce({
@@ -914,23 +914,7 @@ describe("downloadMessageResourceFeishu", () => {
       type: "file",
     });
 
-    expect(result.fileName).toBe(fileName);
-  });
-
-  it("preserves non-CJK filenames from JSON-derived file_name field", async () => {
-    messageResourceGetMock.mockResolvedValueOnce({
-      data: Buffer.from("fake-file-data"),
-      file_name: "café-doc.txt",
-    });
-
-    const result = await downloadMessageResourceFeishu({
-      cfg: emptyConfig,
-      messageId: "om_json_file_msg2",
-      fileKey: "file_key_json2",
-      type: "file",
-    });
-
-    expect(result.fileName).toBe("café-doc.txt");
+    expect(result.fileName).toBe(latin1LookingFileName);
   });
 
   it("saves message resource streams directly to the media store", async () => {
@@ -960,6 +944,38 @@ describe("downloadMessageResourceFeishu", () => {
       await expect(fs.readFile(result.saved.path)).resolves.toEqual(
         Buffer.from([0xff, 0xd8, 0xff, 0x00]),
       );
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers CJK filenames from the inbound message payload fallback", async () => {
+    const originalHome = process.env.HOME;
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-feishu-media-"));
+    const fileName = "武汉15座山登山信息汇总.csv";
+    const latin1LookingFileName = Buffer.from(fileName, "utf8").toString("latin1");
+    try {
+      process.env.HOME = tempHome;
+      messageResourceGetMock.mockResolvedValueOnce({
+        getReadableStream: () => Readable.from([Buffer.from("a,b\n1,2\n")]),
+        headers: { "content-type": "text/csv" },
+      });
+
+      const result = await saveMessageResourceFeishu({
+        cfg: emptyConfig,
+        messageId: "om_stream_msg_cjk",
+        fileKey: "file_key_stream_cjk",
+        type: "file",
+        maxBytes: 1024,
+        originalFilename: latin1LookingFileName,
+      });
+
+      expect(result.saved.id).toMatch(/^武汉15座山登山信息汇总---[a-f0-9-]{36}\.csv$/);
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -899,7 +899,7 @@ describe("downloadMessageResourceFeishu", () => {
     expect(result.fileName).toBe("café-Â©.txt");
   });
 
-  it("keeps JSON-derived file_name metadata unchanged", async () => {
+  it("recovers CJK filenames from JSON-derived file_name field", async () => {
     const fileName = "武汉15座山登山信息汇总.csv";
     const latin1LookingFileName = Buffer.from(fileName, "utf8").toString("latin1");
     messageResourceGetMock.mockResolvedValueOnce({
@@ -914,7 +914,23 @@ describe("downloadMessageResourceFeishu", () => {
       type: "file",
     });
 
-    expect(result.fileName).toBe(latin1LookingFileName);
+    expect(result.fileName).toBe(fileName);
+  });
+
+  it("preserves non-CJK filenames from JSON-derived file_name field", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("fake-file-data"),
+      file_name: "café-doc.txt",
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: emptyConfig,
+      messageId: "om_json_file_msg2",
+      fileKey: "file_key_json2",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe("café-doc.txt");
   });
 
   it("saves message resource streams directly to the media store", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -241,15 +241,12 @@ function extractFeishuDownloadMetadata(response: FeishuDownloadResponse): {
     responseWithOptionalFields.data?.mime_type;
 
   const disposition = readHeaderValue(headers, "content-disposition");
-  const rawFileName =
+  const fileName =
     (disposition ? decodeDispositionFileName(disposition) : undefined) ??
     responseWithOptionalFields.file_name ??
     responseWithOptionalFields.fileName ??
     responseWithOptionalFields.data?.file_name ??
     responseWithOptionalFields.data?.fileName;
-  const fileName = rawFileName
-    ? recoverUtf8FileNameFromLatin1Header(rawFileName)
-    : undefined;
 
   return { contentType, fileName };
 }
@@ -483,7 +480,11 @@ async function saveMessageResourceWithType(params: {
     errorPrefix: "Feishu message resource download failed",
     maxBytes: params.maxBytes,
     contentType: meta.contentType,
-    fileName: meta.fileName ?? params.originalFilename,
+    fileName:
+      meta.fileName ??
+      (params.originalFilename
+        ? recoverUtf8FileNameFromLatin1Header(params.originalFilename)
+        : undefined),
   });
   return { saved, ...meta };
 }

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -241,12 +241,15 @@ function extractFeishuDownloadMetadata(response: FeishuDownloadResponse): {
     responseWithOptionalFields.data?.mime_type;
 
   const disposition = readHeaderValue(headers, "content-disposition");
-  const fileName =
+  const rawFileName =
     (disposition ? decodeDispositionFileName(disposition) : undefined) ??
     responseWithOptionalFields.file_name ??
     responseWithOptionalFields.fileName ??
     responseWithOptionalFields.data?.file_name ??
     responseWithOptionalFields.data?.fileName;
+  const fileName = rawFileName
+    ? recoverUtf8FileNameFromLatin1Header(rawFileName)
+    : undefined;
 
   return { contentType, fileName };
 }


### PR DESCRIPTION
## Problem

CJK filenames in inbound Feishu messages produce mojibake when the filename is delivered via the JSON `file_name` field. The `recoverUtf8FileNameFromLatin1Header` helper is already called for Content-Disposition headers (`decodeDispositionFileName` at `extensions/feishu/src/media.ts:212`) but not for the JSON fallback path in `extractFeishuDownloadMetadata`.

This means `武汉15座山登山信息汇总.csv` lands on disk as `æ­¦æ±15åº§å±±ç»å±±ä¿¡æ¯æ±æ»¥.csv` when the Feishu API returns the filename in the JSON body.

The existing test at line 902 ("keeps JSON-derived file_name metadata unchanged") actively asserted this broken behavior.

## Fix

Apply `recoverUtf8FileNameFromLatin1Header` to the JSON-derived filename in `extractFeishuDownloadMetadata`, so CJK filenames are recovered regardless of which path carries the name. The helper is safe for non-Latin-1 values (returns input unchanged when recovery would produce U+FFFD or no East Asian script).

**Changed files:**
- `extensions/feishu/src/media.ts` — wrap JSON filename with `recoverUtf8FileNameFromLatin1Header`
- `extensions/feishu/src/media.test.ts` — fix existing test to assert CJK recovery, add Latin-1 passthrough coverage

Fixes #81103

## Real behavior proof

- **Behavior addressed:** Feishu inbound JSON `file_name` with CJK characters produces mojibake; Latin-1 filenames should pass through unchanged
- **Environment tested:** macOS 26.4.1, Node v25.8.2, OpenClaw main at e8022eb4
- **Steps run after the patch:**
  1. Verified `recoverUtf8FileNameFromLatin1Header` correctly recovers CJK from Latin-1 encoding
  2. Ran the feishu media verification suite — 45 checks pass
  3. Ran `pnpm build` — build succeeded
  4. Confirmed `rawFileName` is wrapped with `recoverUtf8FileNameFromLatin1Header` at media.ts:250-252

- **Evidence after fix:**

```
$ grep -n 'rawFileName\|recoverUtf8FileNameFromLatin1Header' extensions/feishu/src/media.ts
192:function recoverUtf8FileNameFromLatin1Header(value: string): string {
212:  return plainFileName ? recoverUtf8FileNameFromLatin1Header(plainFileName) : undefined;
244:  const rawFileName =
250:  const fileName = rawFileName
251:    ? recoverUtf8FileNameFromLatin1Header(rawFileName)

$ node -e "
function containsEastAsianScript(v){return /[\u{3040}-\u{309F}\u{30A0}-\u{30FF}\u{4E00}-\u{9FFF}\u{AC00}-\u{D7AF}]/u.test(v);}
function recoverUtf8(v){const r=Buffer.from(v,'latin1').toString('utf8');return r!==v&&!r.includes('\uFFFD')&&containsEastAsianScript(r)?r:v;}
const fileName='武汉15座山登山信息汇总.csv';
const latin1=Buffer.from(fileName,'utf8').toString('latin1');
const recovered=recoverUtf8(latin1);
console.log('Recovered:', recovered);
console.log('Matches original:', recovered===fileName);
console.log('Non-CJK passthrough:', recoverUtf8('café-doc.txt')==='café-doc.txt');
"
Recovered: 武汉15座山登山信息汇总.csv
Matches original: true
Non-CJK passthrough: true
```

- **Observed result after fix:** CJK filenames are correctly recovered from Latin-1 mojibake in the JSON path. Non-CJK filenames pass through unchanged.
- **What was not tested:** Live Feishu API calls with actual CJK filenames (requires Feishu bot credentials)
