### PR TITLE
fix(ui): scope Skill Workshop proposals to selected agent

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -380,14 +380,13 @@ async function ensureSkillWorkshopRevisionSessionsLoaded(
 async function resolveSkillWorkshopRevisionSessionKey(
   state: AppViewState,
   proposal: { key: string; slug: string; origin?: { agentId?: string; sessionKey?: string } },
+  proposalAgentId: string,
 ): Promise<string | null> {
   if (state.skillWorkshopUseCurrentChatForRevisions) {
     return normalizeOptionalString(state.sessionKey) ?? null;
   }
 
-  const agentId = normalizeAgentId(
-    proposal.origin?.agentId ?? resolveSidebarSelectedAgentId(state),
-  );
+  const agentId = normalizeAgentId(proposal.origin?.agentId ?? proposalAgentId);
   await ensureSkillWorkshopRevisionSessionsLoaded(state, agentId);
 
   const originRow = findSkillWorkshopRevisionSessionRow(state, proposal.origin?.sessionKey);
@@ -412,11 +411,12 @@ async function sendSkillWorkshopRevisionRequest(
   state: AppViewState,
   instructions: string,
   proposal: { key: string; slug: string; origin?: { agentId?: string; sessionKey?: string } },
+  proposalAgentId: string,
 ): Promise<void> {
   if (!state.client || !state.connected) {
     throw new Error("Gateway is not connected.");
   }
-  const sessionKey = await resolveSkillWorkshopRevisionSessionKey(state, proposal);
+  const sessionKey = await resolveSkillWorkshopRevisionSessionKey(state, proposal, proposalAgentId);
   if (!sessionKey) {
     throw new Error(state.sessionsError ?? "Could not prepare a Skill Workshop session.");
   }
@@ -428,12 +428,12 @@ async function sendSkillWorkshopRevisionRequest(
   } else {
     await switchChatSessionAndWait(state, sessionKey);
   }
-  const proposalAgentId = proposal.origin?.agentId?.trim();
+  const scopedProposalAgentId = proposal.origin?.agentId?.trim() || proposalAgentId;
   await state.handleSendChat(instructions, {
     restoreDraft: true,
     skillWorkshopRevision: {
       proposalId: proposal.key,
-      ...(proposalAgentId ? { agentId: proposalAgentId } : {}),
+      agentId: scopedProposalAgentId,
     },
   });
 }
@@ -1406,8 +1406,9 @@ export function renderApp(state: AppViewState) {
   const showToolCalls = state.onboarding ? true : state.settings.chatShowToolCalls;
   const activeAssistantAgentId = resolveSidebarSelectedAgentId(state);
   const localAssistantAvatarOverride =
-    normalizeOptionalString(loadLocalAssistantIdentity({ agentId: activeAssistantAgentId }).avatar) ??
-    null;
+    normalizeOptionalString(
+      loadLocalAssistantIdentity({ agentId: activeAssistantAgentId }).avatar,
+    ) ?? null;
   const assistantAvatarUrl = resolveAssistantAvatarUrl(state);
   const chatAssistantAvatarStatus = localAssistantAvatarOverride
     ? "data"
@@ -3654,8 +3655,8 @@ export function renderApp(state: AppViewState) {
                   state.skillWorkshopRevisionDraft = "";
                 },
                 onRevisionSubmit: (key) =>
-                  void requestSkillWorkshopRevision(state, key, (message, proposal) =>
-                    sendSkillWorkshopRevisionRequest(state, message, proposal),
+                  void requestSkillWorkshopRevision(state, key, (message, proposal, agentId) =>
+                    sendSkillWorkshopRevisionRequest(state, message, proposal, agentId),
                   ),
                 onPreviewFile: (key, path) => {
                   state.skillWorkshopSelectedKey = key;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -108,7 +108,10 @@ import {
   type ExecApprovalRequest,
 } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
-import type { SkillWorkshopState } from "./controllers/skill-workshop.ts";
+import {
+  loadSkillWorkshopProposals,
+  type SkillWorkshopState,
+} from "./controllers/skill-workshop.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillSecurityVerdict,
@@ -636,6 +639,7 @@ export class OpenClawApp extends LitElement {
   @state() skillCardLoadingKey: string | null = null;
   @state() skillCardErrors: Record<string, string> = {};
   @state() skillWorkshopLoading = false;
+  @state() skillWorkshopAgentId: string | null = null;
   @state() skillWorkshopLoaded = false;
   @state() skillWorkshopError: string | null = null;
   @state() skillWorkshopInspectingKey: string | null = null;
@@ -855,6 +859,12 @@ export class OpenClawApp extends LitElement {
     // Some render callbacks assign tab directly while preparing nested panel state.
     if (changed.has("tab") && this.tab !== "chat" && this.chatMobileControlsOpen) {
       this.setChatMobileControlsOpen(false);
+    }
+    if (
+      this.tab === "skillWorkshop" &&
+      (changed.has("sessionKey") || changed.has("assistantAgentId"))
+    ) {
+      void loadSkillWorkshopProposals(this, { force: true });
     }
     if (!changed.has("sessionKey") || this.agentsPanel !== "tools") {
       return;

--- a/ui/src/ui/controllers/skill-workshop.test.ts
+++ b/ui/src/ui/controllers/skill-workshop.test.ts
@@ -4,6 +4,7 @@ import type { SkillWorkshopProposal } from "../views/skill-workshop.ts";
 import {
   loadSkillWorkshopProposalDetail,
   loadSkillWorkshopProposals,
+  requestSkillWorkshopRevision,
   runSkillWorkshopLifecycleAction,
   type SkillWorkshopState,
 } from "./skill-workshop.ts";
@@ -24,6 +25,7 @@ function createState(overrides: Partial<SkillWorkshopState> = {}): {
     agentsList: { defaultId: "main", mainKey: "main" },
     hello: null,
     sessionKey: "global",
+    skillWorkshopAgentId: null,
     skillWorkshopLoading: false,
     skillWorkshopLoaded: false,
     skillWorkshopError: null,
@@ -106,6 +108,17 @@ function proposal(overrides: Partial<SkillWorkshopProposal> = {}): SkillWorkshop
     isNew: false,
     ...overrides,
   };
+}
+
+function createDeferred<T>() {
+  let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  if (!resolve) {
+    throw new Error("Expected deferred promise callback to be initialized");
+  }
+  return { promise, resolve };
 }
 
 function clearNoticeTimer(state: SkillWorkshopState): void {
@@ -198,4 +211,120 @@ describe("Skill Workshop proposal RPCs", () => {
       });
     },
   );
+
+  it("reloads proposals when the selected session changes agent scope", async () => {
+    const { state, request } = createState({
+      sessionKey: "agent:ops:main",
+      skillWorkshopAgentId: "research",
+      skillWorkshopLoaded: true,
+      skillWorkshopProposals: [proposal()],
+    });
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.proposals.list") {
+        return manifest();
+      }
+      if (method === "skills.proposals.inspect") {
+        return inspectResult();
+      }
+      return {};
+    });
+
+    await loadSkillWorkshopProposals(state);
+
+    expect(state.skillWorkshopAgentId).toBe("ops");
+    expect(request).toHaveBeenNthCalledWith(1, "skills.proposals.list", { agentId: "ops" });
+    expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.inspect", {
+      agentId: "ops",
+      proposalId: "proposal-1",
+    });
+  });
+
+  it("clears stale proposals when the agent changes during an in-flight reload", async () => {
+    const researchList = createDeferred<ReturnType<typeof manifest>>();
+    const { state, request } = createState({
+      assistantAgentId: "research",
+      skillWorkshopAgentId: "research",
+      skillWorkshopLoaded: true,
+      skillWorkshopProposals: [proposal()],
+    });
+    request.mockImplementation(async (method: string, payload?: unknown) => {
+      if (method !== "skills.proposals.list") {
+        return inspectResult();
+      }
+      return (payload as { agentId?: string }).agentId === "research"
+        ? researchList.promise
+        : manifest();
+    });
+
+    const researchReload = loadSkillWorkshopProposals(state, { force: true });
+    state.assistantAgentId = "ops";
+    await loadSkillWorkshopProposals(state);
+
+    expect(state.skillWorkshopAgentId).toBe("ops");
+    expect(state.skillWorkshopProposals).toEqual([]);
+
+    researchList.resolve(manifest());
+    await researchReload;
+    await vi.waitFor(() => {
+      expect(state.skillWorkshopLoaded).toBe(true);
+    });
+
+    expect(state.skillWorkshopAgentId).toBe("ops");
+    expect(request).toHaveBeenCalledWith("skills.proposals.list", { agentId: "ops" });
+  });
+
+  it("preserves the loaded proposal agent for originless revisions", async () => {
+    const { state } = createState({
+      assistantAgentId: "main",
+      skillWorkshopAgentId: "research",
+      skillWorkshopProposals: [proposal()],
+      skillWorkshopRevisionDraft: "Tighten the trigger.",
+    });
+    const sendRevisionRequest = vi.fn(async () => {});
+
+    await requestSkillWorkshopRevision(state, "proposal-1", sendRevisionRequest);
+
+    expect(sendRevisionRequest).toHaveBeenCalledWith(
+      "Tighten the trigger.",
+      expect.objectContaining({ key: "proposal-1" }),
+      "research",
+    );
+  });
+
+  it("discards proposal detail that resolves after the agent scope changes", async () => {
+    const detail = createDeferred<ReturnType<typeof inspectResult>>();
+    const { state, request } = createState({
+      skillWorkshopAgentId: "research",
+      skillWorkshopProposals: [proposal({ body: "" })],
+    });
+    request.mockReturnValueOnce(detail.promise);
+
+    const loading = loadSkillWorkshopProposalDetail(state, "proposal-1");
+    state.skillWorkshopAgentId = "ops";
+    state.skillWorkshopProposals = [proposal({ body: "Ops proposal." })];
+    state.skillWorkshopInspectingKey = "proposal-1";
+    detail.resolve(inspectResult());
+    await loading;
+
+    expect(state.skillWorkshopProposals[0]?.body).toBe("Ops proposal.");
+    expect(state.skillWorkshopInspectingKey).toBe("proposal-1");
+  });
+
+  it("does not send an originless revision after the agent scope changes", async () => {
+    const detail = createDeferred<ReturnType<typeof inspectResult>>();
+    const { state, request } = createState({
+      skillWorkshopAgentId: "research",
+      skillWorkshopProposals: [proposal({ body: "" })],
+      skillWorkshopRevisionDraft: "Tighten the trigger.",
+    });
+    request.mockReturnValueOnce(detail.promise);
+    const sendRevisionRequest = vi.fn(async () => {});
+
+    const revision = requestSkillWorkshopRevision(state, "proposal-1", sendRevisionRequest);
+    state.skillWorkshopAgentId = "ops";
+    detail.resolve(inspectResult());
+
+    await expect(revision).resolves.toBe(false);
+    expect(sendRevisionRequest).not.toHaveBeenCalled();
+  });
 });

--- a/ui/src/ui/controllers/skill-workshop.test.ts
+++ b/ui/src/ui/controllers/skill-workshop.test.ts
@@ -1,0 +1,201 @@
+// Control UI tests cover skill workshop controller behavior.
+import { describe, expect, it, vi } from "vitest";
+import type { SkillWorkshopProposal } from "../views/skill-workshop.ts";
+import {
+  loadSkillWorkshopProposalDetail,
+  loadSkillWorkshopProposals,
+  runSkillWorkshopLifecycleAction,
+  type SkillWorkshopState,
+} from "./skill-workshop.ts";
+
+type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
+
+const ISO_NOW = "2026-06-16T12:00:00.000Z";
+
+function createState(overrides: Partial<SkillWorkshopState> = {}): {
+  state: SkillWorkshopState;
+  request: ReturnType<typeof vi.fn<TestRequest>>;
+} {
+  const request = vi.fn<TestRequest>();
+  const state: SkillWorkshopState = {
+    client: { request } as unknown as SkillWorkshopState["client"],
+    connected: true,
+    assistantAgentId: "research",
+    agentsList: { defaultId: "main", mainKey: "main" },
+    hello: null,
+    sessionKey: "global",
+    skillWorkshopLoading: false,
+    skillWorkshopLoaded: false,
+    skillWorkshopError: null,
+    skillWorkshopInspectingKey: null,
+    skillWorkshopProposals: [],
+    skillWorkshopSelectedKey: null,
+    skillWorkshopActionBusy: null,
+    skillWorkshopActionNotice: null,
+    skillWorkshopActionNoticeTimer: null,
+    skillWorkshopRevisionKey: null,
+    skillWorkshopRevisionDraft: "",
+    skillWorkshopStatusFilter: "pending",
+    skillWorkshopQuery: "",
+    skillWorkshopFilePreviewKey: null,
+    skillWorkshopFilePreviewQuery: "",
+    skillWorkshopQueueWidth: 360,
+    skillWorkshopMode: "today",
+    skillWorkshopUseCurrentChatForRevisions: false,
+    ...overrides,
+  };
+  return { state, request };
+}
+
+function manifest(status: SkillWorkshopProposal["status"] = "pending") {
+  return {
+    schema: "openclaw.skill-workshop.proposals-manifest.v1",
+    updatedAt: ISO_NOW,
+    proposals: [
+      {
+        id: "proposal-1",
+        kind: "create",
+        status,
+        title: "Inbox Cleaner",
+        description: "Clean inbox triage",
+        skillName: "Inbox Cleaner",
+        skillKey: "inbox-cleaner",
+        createdAt: ISO_NOW,
+        updatedAt: ISO_NOW,
+        scanState: "clean",
+      },
+    ],
+  };
+}
+
+function inspectResult(status: SkillWorkshopProposal["status"] = "pending") {
+  return {
+    record: {
+      id: "proposal-1",
+      kind: "create",
+      status,
+      title: "Inbox Cleaner",
+      description: "Clean inbox triage",
+      createdAt: ISO_NOW,
+      updatedAt: ISO_NOW,
+      proposedVersion: "v1",
+      target: {
+        skillName: "Inbox Cleaner",
+        skillKey: "inbox-cleaner",
+      },
+    },
+    content: "Review unread mail and archive low-priority threads.",
+    supportFiles: [],
+  };
+}
+
+function proposal(overrides: Partial<SkillWorkshopProposal> = {}): SkillWorkshopProposal {
+  return {
+    key: "proposal-1",
+    slug: "inbox-cleaner",
+    name: "Inbox Cleaner",
+    oneLine: "Clean inbox triage",
+    body: "Review unread mail.",
+    status: "pending",
+    version: 1,
+    createdAt: Date.parse(ISO_NOW),
+    updatedAt: Date.parse(ISO_NOW),
+    recencyGroup: "today",
+    ageLabel: "now",
+    supportFiles: [],
+    isNew: false,
+    ...overrides,
+  };
+}
+
+function clearNoticeTimer(state: SkillWorkshopState): void {
+  if (state.skillWorkshopActionNoticeTimer) {
+    globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
+    state.skillWorkshopActionNoticeTimer = null;
+  }
+}
+
+describe("Skill Workshop proposal RPCs", () => {
+  it("lists proposals with the selected agent id and carries it into the initial inspect", async () => {
+    const { state, request } = createState({ assistantAgentId: "research" });
+    request.mockImplementation(async (method: string) => {
+      if (method === "skills.proposals.list") {
+        return manifest();
+      }
+      if (method === "skills.proposals.inspect") {
+        return inspectResult();
+      }
+      return {};
+    });
+
+    await loadSkillWorkshopProposals(state);
+
+    expect(request).toHaveBeenNthCalledWith(1, "skills.proposals.list", {
+      agentId: "research",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.inspect", {
+      agentId: "research",
+      proposalId: "proposal-1",
+    });
+  });
+
+  it("inspects proposals with the current agent from the selected session", async () => {
+    const { state, request } = createState({
+      assistantAgentId: "research",
+      sessionKey: "agent:ops-team:main",
+      skillWorkshopProposals: [proposal({ body: "" })],
+    });
+    request.mockResolvedValue(inspectResult());
+
+    await loadSkillWorkshopProposalDetail(state, "proposal-1");
+
+    expect(request).toHaveBeenCalledWith("skills.proposals.inspect", {
+      agentId: "ops-team",
+      proposalId: "proposal-1",
+    });
+  });
+
+  it.each([
+    ["apply", "skills.proposals.apply", "applied"],
+    ["reject", "skills.proposals.reject", "rejected"],
+  ] as const)(
+    "%s sends the selected agent id and refreshes that agent scope",
+    async (action, method, status) => {
+      const { state, request } = createState({
+        assistantAgentId: "reviewer",
+        skillWorkshopProposals: [proposal()],
+        skillWorkshopSelectedKey: "proposal-1",
+      });
+      request.mockImplementation(async (calledMethod: string) => {
+        if (calledMethod === method) {
+          return {};
+        }
+        if (calledMethod === "skills.proposals.list") {
+          return manifest(status);
+        }
+        if (calledMethod === "skills.proposals.inspect") {
+          return inspectResult(status);
+        }
+        return {};
+      });
+
+      try {
+        await runSkillWorkshopLifecycleAction(state, action, "proposal-1");
+      } finally {
+        clearNoticeTimer(state);
+      }
+
+      expect(request).toHaveBeenNthCalledWith(1, method, {
+        agentId: "reviewer",
+        proposalId: "proposal-1",
+      });
+      expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.list", {
+        agentId: "reviewer",
+      });
+      expect(request).toHaveBeenNthCalledWith(3, "skills.proposals.inspect", {
+        agentId: "reviewer",
+        proposalId: "proposal-1",
+      });
+    },
+  );
+});

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -1,5 +1,10 @@
 // Control UI controller manages skill workshop gateway state.
 import type { GatewayBrowserClient } from "../gateway.ts";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveUiSelectedGlobalAgentId,
+} from "../session-key.ts";
 import type {
   SkillWorkshopAction,
   SkillWorkshopActionNotice,
@@ -76,6 +81,10 @@ type SkillProposalInspectResult = {
 export type SkillWorkshopState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
+  assistantAgentId?: string | null;
+  agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
+  hello?: { snapshot?: unknown } | null;
+  sessionKey?: string | null;
   skillWorkshopLoading: boolean;
   skillWorkshopLoaded: boolean;
   skillWorkshopError: string | null;
@@ -98,6 +107,15 @@ export type SkillWorkshopState = {
 
 function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function skillWorkshopAgentParams(state: SkillWorkshopState): { agentId: string } {
+  const sessionAgentId = parseAgentSessionKey(state.sessionKey)?.agentId;
+  return {
+    agentId: sessionAgentId
+      ? normalizeAgentId(sessionAgentId)
+      : resolveUiSelectedGlobalAgentId(state),
+  };
 }
 
 function parseDateMs(value: string | undefined): number {
@@ -297,7 +315,10 @@ export async function loadSkillWorkshopProposals(
   state.skillWorkshopLoading = true;
   state.skillWorkshopError = null;
   try {
-    const result = await state.client.request<SkillProposalManifest>("skills.proposals.list", {});
+    const result = await state.client.request<SkillProposalManifest>(
+      "skills.proposals.list",
+      skillWorkshopAgentParams(state),
+    );
     const previousByKey = new Map(
       state.skillWorkshopProposals.map((proposal) => [proposal.key, proposal]),
     );
@@ -334,11 +355,10 @@ export async function loadSkillWorkshopProposalDetail(
   state.skillWorkshopInspectingKey = proposalId;
   state.skillWorkshopError = null;
   try {
+    const requestParams = { ...skillWorkshopAgentParams(state), proposalId };
     const result = await state.client.request<SkillProposalInspectResult>(
       "skills.proposals.inspect",
-      {
-        proposalId,
-      },
+      requestParams,
     );
     mergeProposal(state, proposalFromInspect(result, existing));
   } catch (err) {
@@ -375,7 +395,8 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopError = null;
   try {
     const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
-    await state.client.request(method, { proposalId });
+    const requestParams = { ...skillWorkshopAgentParams(state), proposalId };
+    await state.client.request(method, requestParams);
     await refreshAfterMutation(state, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
     showActionNotice(state, updated ?? previous, action === "apply" ? "Applied" : "Rejected");

--- a/ui/src/ui/controllers/skill-workshop.ts
+++ b/ui/src/ui/controllers/skill-workshop.ts
@@ -85,6 +85,7 @@ export type SkillWorkshopState = {
   agentsList?: { defaultId?: string | null; mainKey?: string | null } | null;
   hello?: { snapshot?: unknown } | null;
   sessionKey?: string | null;
+  skillWorkshopAgentId: string | null;
   skillWorkshopLoading: boolean;
   skillWorkshopLoaded: boolean;
   skillWorkshopError: string | null;
@@ -116,6 +117,22 @@ function skillWorkshopAgentParams(state: SkillWorkshopState): { agentId: string 
       ? normalizeAgentId(sessionAgentId)
       : resolveUiSelectedGlobalAgentId(state),
   };
+}
+
+function loadedSkillWorkshopAgentParams(state: SkillWorkshopState): { agentId: string } {
+  return { agentId: state.skillWorkshopAgentId ?? skillWorkshopAgentParams(state).agentId };
+}
+
+function resetSkillWorkshopAgentScope(state: SkillWorkshopState, agentId: string): void {
+  state.skillWorkshopAgentId = agentId;
+  state.skillWorkshopLoaded = false;
+  state.skillWorkshopProposals = [];
+  state.skillWorkshopSelectedKey = null;
+  state.skillWorkshopInspectingKey = null;
+  state.skillWorkshopRevisionKey = null;
+  state.skillWorkshopRevisionDraft = "";
+  state.skillWorkshopFilePreviewKey = null;
+  state.skillWorkshopFilePreviewQuery = "";
 }
 
 function parseDateMs(value: string | undefined): number {
@@ -306,7 +323,14 @@ export async function loadSkillWorkshopProposals(
   state: SkillWorkshopState,
   options?: { force?: boolean },
 ): Promise<void> {
-  if (!state.client || !state.connected || state.skillWorkshopLoading) {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const requestAgentId = skillWorkshopAgentParams(state).agentId;
+  if (state.skillWorkshopAgentId !== requestAgentId) {
+    resetSkillWorkshopAgentScope(state, requestAgentId);
+  }
+  if (state.skillWorkshopLoading) {
     return;
   }
   if (state.skillWorkshopLoaded && !options?.force) {
@@ -315,10 +339,12 @@ export async function loadSkillWorkshopProposals(
   state.skillWorkshopLoading = true;
   state.skillWorkshopError = null;
   try {
-    const result = await state.client.request<SkillProposalManifest>(
-      "skills.proposals.list",
-      skillWorkshopAgentParams(state),
-    );
+    const result = await state.client.request<SkillProposalManifest>("skills.proposals.list", {
+      agentId: requestAgentId,
+    });
+    if (skillWorkshopAgentParams(state).agentId !== requestAgentId) {
+      return;
+    }
     const previousByKey = new Map(
       state.skillWorkshopProposals.map((proposal) => [proposal.key, proposal]),
     );
@@ -337,6 +363,9 @@ export async function loadSkillWorkshopProposals(
     state.skillWorkshopError = getErrorMessage(err);
   } finally {
     state.skillWorkshopLoading = false;
+    if (skillWorkshopAgentParams(state).agentId !== requestAgentId) {
+      void loadSkillWorkshopProposals(state, { force: true });
+    }
   }
 }
 
@@ -352,19 +381,31 @@ export async function loadSkillWorkshopProposalDetail(
   if (existing?.body && !options?.force) {
     return;
   }
+  const requestAgentId = loadedSkillWorkshopAgentParams(state).agentId;
+  if (state.skillWorkshopAgentId === null) {
+    state.skillWorkshopAgentId = requestAgentId;
+  }
   state.skillWorkshopInspectingKey = proposalId;
   state.skillWorkshopError = null;
   try {
-    const requestParams = { ...skillWorkshopAgentParams(state), proposalId };
+    const requestParams = { agentId: requestAgentId, proposalId };
     const result = await state.client.request<SkillProposalInspectResult>(
       "skills.proposals.inspect",
       requestParams,
     );
+    if (state.skillWorkshopAgentId !== requestAgentId) {
+      return;
+    }
     mergeProposal(state, proposalFromInspect(result, existing));
   } catch (err) {
-    state.skillWorkshopError = getErrorMessage(err);
+    if (state.skillWorkshopAgentId === requestAgentId) {
+      state.skillWorkshopError = getErrorMessage(err);
+    }
   } finally {
-    if (state.skillWorkshopInspectingKey === proposalId) {
+    if (
+      state.skillWorkshopAgentId === requestAgentId &&
+      state.skillWorkshopInspectingKey === proposalId
+    ) {
       state.skillWorkshopInspectingKey = null;
     }
   }
@@ -395,7 +436,7 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopError = null;
   try {
     const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
-    const requestParams = { ...skillWorkshopAgentParams(state), proposalId };
+    const requestParams = { ...loadedSkillWorkshopAgentParams(state), proposalId };
     await state.client.request(method, requestParams);
     await refreshAfterMutation(state, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
@@ -415,7 +456,11 @@ export async function runSkillWorkshopLifecycleAction(
 export async function requestSkillWorkshopRevision(
   state: SkillWorkshopState,
   proposalId: string,
-  sendRevisionRequest: (instructions: string, proposal: SkillWorkshopProposal) => Promise<void>,
+  sendRevisionRequest: (
+    instructions: string,
+    proposal: SkillWorkshopProposal,
+    agentId: string,
+  ) => Promise<void>,
 ): Promise<boolean> {
   if (state.skillWorkshopActionBusy) {
     return false;
@@ -425,14 +470,21 @@ export async function requestSkillWorkshopRevision(
   if (!proposal || !instructions) {
     return false;
   }
+  const proposalAgentId = loadedSkillWorkshopAgentParams(state).agentId;
+  if (state.skillWorkshopAgentId === null) {
+    state.skillWorkshopAgentId = proposalAgentId;
+  }
   state.skillWorkshopActionBusy = { key: proposalId, action: "revise" };
   state.skillWorkshopActionNotice = null;
   state.skillWorkshopError = null;
   try {
     await loadSkillWorkshopProposalDetail(state, proposalId);
+    if (state.skillWorkshopAgentId !== proposalAgentId) {
+      return false;
+    }
     const currentProposal =
       state.skillWorkshopProposals.find((item) => item.key === proposalId) ?? proposal;
-    await sendRevisionRequest(instructions, currentProposal);
+    await sendRevisionRequest(instructions, currentProposal, proposalAgentId);
     state.skillWorkshopRevisionKey = null;
     state.skillWorkshopRevisionDraft = "";
     showActionNotice(state, proposal, "Revision requested");


### PR DESCRIPTION
Closes #93760.

Passes the selected Control UI agent scope through Skill Workshop proposal list, inspect, apply, and reject RPCs so the workshop operates on the active workspace instead of the gateway default.

## Real behavior proof

- Behavior or issue addressed: Control UI Skill Workshop proposal reads and lifecycle actions now use the selected agent workspace instead of falling back to the gateway default.
- Real environment tested: Local OpenClaw checkout on macOS 27.0 with Node v24.15.0, current PR head `0a55ce0c60`.
- Exact steps or command run after this patch: Loaded `ui/src/ui/controllers/skill-workshop.ts` through the repo Node/tsx runtime, selected agent `research`, then ran the proposal list and apply flow so the controller emitted its gateway RPC payloads.
- Evidence after fix:

```text
Skill Workshop selected-agent RPC trace
skills.proposals.list {"agentId":"research"}
skills.proposals.inspect {"agentId":"research","proposalId":"proposal-1"}
skills.proposals.apply {"agentId":"research","proposalId":"proposal-1"}
skills.proposals.list {"agentId":"research"}
skills.proposals.inspect {"agentId":"research","proposalId":"proposal-1"}
allRpcPayloadsUseSelectedAgent=true
finalProposalStatus=applied
```

- Observed result after fix: Every Skill Workshop list, inspect, apply, and post-apply refresh RPC carried `agentId: "research"`, and the proposal finished in the applied state for that selected agent scope.
- What was not tested: Full browser rendering; this proof targets the Control UI to gateway RPC routing path changed by this PR.
