### PR TITLE
fix(codex): provision app-server model catalog metadata

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -21,6 +21,7 @@ import {
   resolveCodexAppServerNativeHomeDir,
 } from "./auth-bridge.js";
 import type { CodexAppServerStartOptions } from "./config.js";
+import { CODEX_MODEL_CATALOG_FINGERPRINT_ENV } from "./model-catalog-bridge.js";
 
 const oauthMocks = vi.hoisted(() => ({
   refreshOpenAICodexToken: vi.fn(),
@@ -235,6 +236,58 @@ describe("bridgeCodexAppServerStartOptions", () => {
       await expect(fs.access(codexHome)).resolves.toBeUndefined();
       await expectPathMissing(nativeHome);
       expect(startOptions.env).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("provisions configured custom model metadata in the isolated Codex home", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const startOptions = createStartOptions();
+    try {
+      const codexHome = resolveCodexAppServerHomeDir(agentDir);
+
+      const resolved = await bridgeCodexAppServerStartOptions({
+        startOptions,
+        agentDir,
+        config: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                api: "openai-responses",
+                models: [
+                  {
+                    id: "custom-long-context",
+                    name: "Custom Long Context",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1_000_000,
+                    contextTokens: 950_000,
+                    maxTokens: 128_000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      expect(resolved.env).toMatchObject({
+        CODEX_HOME: codexHome,
+        [CODEX_MODEL_CATALOG_FINGERPRINT_ENV]: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      });
+      const configToml = await fs.readFile(path.join(codexHome, "config.toml"), "utf8");
+      const catalogPath = path.join(codexHome, "openclaw-model-catalog.json");
+      expect(configToml).toBe(`model_catalog_json = ${JSON.stringify(catalogPath)}\n`);
+      const catalog = JSON.parse(await fs.readFile(catalogPath, "utf8")) as {
+        models?: Array<{ slug?: string; context_window?: number; max_context_window?: number }>;
+      };
+      expect(catalog.models?.find((model) => model.slug === "custom-long-context")).toMatchObject({
+        context_window: 950_000,
+        max_context_window: 1_000_000,
+      });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -22,6 +22,7 @@ import {
 import { hasUsableOAuthCredential } from "openclaw/plugin-sdk/provider-auth";
 import type { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
+import { provisionCodexAppServerModelCatalog } from "./model-catalog-bridge.js";
 import type {
   CodexChatgptAuthTokensRefreshResponse,
   CodexGetAccountResponse,
@@ -68,6 +69,7 @@ export async function bridgeCodexAppServerStartOptions(params: {
   const isolatedStartOptions = await withAgentCodexHomeEnvironment(
     params.startOptions,
     params.agentDir,
+    params.config,
   );
   if (params.authProfileId === null) {
     return isolatedStartOptions;
@@ -336,6 +338,7 @@ export function resolveCodexAppServerNativeHomeDir(agentDir: string): string {
 async function withAgentCodexHomeEnvironment(
   startOptions: CodexAppServerStartOptions,
   agentDir: string,
+  config?: AuthProfileOrderConfig,
 ): Promise<CodexAppServerStartOptions> {
   const codexHome = startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim()
     ? startOptions.env[CODEX_HOME_ENV_VAR]
@@ -361,7 +364,11 @@ async function withAgentCodexHomeEnvironment(
   } else {
     delete nextStartOptions.clearEnv;
   }
-  return nextStartOptions;
+  return await provisionCodexAppServerModelCatalog({
+    startOptions: nextStartOptions,
+    codexHome,
+    config,
+  });
 }
 
 function withoutClearedCodexHomeEnv(clearEnv: string[] | undefined): string[] | undefined {

--- a/extensions/codex/src/app-server/model-catalog-bridge.test.ts
+++ b/extensions/codex/src/app-server/model-catalog-bridge.test.ts
@@ -1,0 +1,196 @@
+// Codex tests cover OpenClaw-owned model catalog provisioning for isolated app-server homes.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CodexAppServerStartOptions } from "./config.js";
+import {
+  buildCodexAppServerModelCatalog,
+  CODEX_MODEL_CATALOG_FINGERPRINT_ENV,
+  provisionCodexAppServerModelCatalog,
+  upsertTopLevelTomlStringAssignment,
+} from "./model-catalog-bridge.js";
+
+function createStartOptions(
+  overrides: Partial<CodexAppServerStartOptions> = {},
+): CodexAppServerStartOptions {
+  return {
+    transport: "stdio",
+    command: "codex",
+    args: ["app-server"],
+    headers: {},
+    ...overrides,
+  };
+}
+
+function createModelCatalogConfig() {
+  return {
+    models: {
+      providers: {
+        anthropic: {
+          baseUrl: "https://api.anthropic.com",
+          api: "anthropic-messages",
+          models: [
+            {
+              id: "claude-not-for-codex",
+              name: "Claude",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 200_000,
+              maxTokens: 8_192,
+            },
+          ],
+        },
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-responses",
+          models: [
+            {
+              id: "custom-long-context",
+              name: "Custom Long Context",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 1_000_000,
+              contextTokens: 950_000,
+              maxTokens: 128_000,
+              compat: {
+                supportsTools: true,
+                supportedReasoningEfforts: ["minimal", "low", "medium", "high"],
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+describe("buildCodexAppServerModelCatalog", () => {
+  it("materializes configured OpenAI-compatible model metadata for Codex startup", () => {
+    const catalog = buildCodexAppServerModelCatalog(createModelCatalogConfig());
+
+    expect(catalog?.models.map((model) => model.slug)).toEqual([
+      "custom-long-context",
+      "openai/custom-long-context",
+    ]);
+    expect(catalog?.models[0]).toMatchObject({
+      slug: "custom-long-context",
+      display_name: "Custom Long Context",
+      context_window: 950_000,
+      max_context_window: 1_000_000,
+      effective_context_window_percent: 95,
+      input_modalities: ["text", "image"],
+      supports_image_detail_original: true,
+      supports_parallel_tool_calls: true,
+      supports_reasoning_summaries: true,
+      supported_reasoning_levels: [
+        { effort: "minimal", description: "minimal" },
+        { effort: "low", description: "low" },
+        { effort: "medium", description: "medium" },
+        { effort: "high", description: "high" },
+      ],
+    });
+    expect(catalog?.models.some((model) => model.slug === "claude-not-for-codex")).toBe(false);
+  });
+
+  it("returns undefined when no configured text model can be represented", () => {
+    expect(
+      buildCodexAppServerModelCatalog({
+        models: {
+          providers: {
+            images: {
+              baseUrl: "https://images.example.test",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "image-only",
+                  name: "Image Only",
+                  reasoning: false,
+                  input: ["image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8_000,
+                  maxTokens: 1_000,
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("provisionCodexAppServerModelCatalog", () => {
+  it("writes the catalog, upserts config.toml, and fingerprints startup options", async () => {
+    const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-home-"));
+    const startOptions = createStartOptions({ env: { EXISTING: "1" } });
+    try {
+      await fs.writeFile(path.join(codexHome, "config.toml"), "[features]\nplugins = true\n");
+
+      const resolved = await provisionCodexAppServerModelCatalog({
+        startOptions,
+        codexHome,
+        config: createModelCatalogConfig(),
+      });
+
+      const catalogPath = path.join(codexHome, "openclaw-model-catalog.json");
+      const catalog = JSON.parse(await fs.readFile(catalogPath, "utf8")) as {
+        models?: Array<{ slug?: string; context_window?: number; max_context_window?: number }>;
+      };
+      expect(catalog.models?.find((model) => model.slug === "custom-long-context")).toMatchObject({
+        context_window: 950_000,
+        max_context_window: 1_000_000,
+      });
+      expect(await fs.readFile(path.join(codexHome, "config.toml"), "utf8")).toBe(
+        `model_catalog_json = ${JSON.stringify(catalogPath)}\n[features]\nplugins = true\n`,
+      );
+      expect(resolved.env).toMatchObject({
+        EXISTING: "1",
+        [CODEX_MODEL_CATALOG_FINGERPRINT_ENV]: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      });
+      expect(startOptions.env).toEqual({ EXISTING: "1" });
+    } finally {
+      await fs.rm(codexHome, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps startup options unchanged when there is no catalog to write", async () => {
+    const codexHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-home-"));
+    const startOptions = createStartOptions();
+    try {
+      await expect(
+        provisionCodexAppServerModelCatalog({
+          startOptions,
+          codexHome,
+          config: {},
+        }),
+      ).resolves.toBe(startOptions);
+    } finally {
+      await fs.rm(codexHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("upsertTopLevelTomlStringAssignment", () => {
+  it("replaces existing top-level assignments before TOML tables", () => {
+    expect(
+      upsertTopLevelTomlStringAssignment(
+        'model_catalog_json = "/old/catalog.json"\n[features]\nplugins = true\n',
+        "model_catalog_json",
+        "/new/catalog.json",
+      ),
+    ).toBe('model_catalog_json = "/new/catalog.json"\n[features]\nplugins = true\n');
+  });
+
+  it("inserts top-level assignments ahead of the first TOML table", () => {
+    expect(
+      upsertTopLevelTomlStringAssignment(
+        "[features]\nplugins = true\n",
+        "model_catalog_json",
+        "/catalog.json",
+      ),
+    ).toBe('model_catalog_json = "/catalog.json"\n[features]\nplugins = true\n');
+  });
+});

--- a/extensions/codex/src/app-server/model-catalog-bridge.ts
+++ b/extensions/codex/src/app-server/model-catalog-bridge.ts
@@ -1,0 +1,324 @@
+// Codex app-server model catalog bridge materializes OpenClaw model metadata for isolated homes.
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import type { CodexAppServerStartOptions } from "./config.js";
+
+export const CODEX_MODEL_CATALOG_FINGERPRINT_ENV = "OPENCLAW_CODEX_MODEL_CATALOG_FINGERPRINT";
+
+const CODEX_CONFIG_TOML_FILENAME = "config.toml";
+const CODEX_MODEL_CATALOG_FILENAME = "openclaw-model-catalog.json";
+const CODEX_MODEL_CATALOG_FINGERPRINT_PREFIX = "sha256:";
+const CODEX_MODEL_CATALOG_HASH_DOMAIN = "openclaw:codex-app-server-model-catalog:v1";
+const DEFAULT_CONTEXT_WINDOW = 272_000;
+const EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95;
+const CODEX_COMPATIBLE_MODEL_APIS = new Set([
+  "openai-completions",
+  "openai-responses",
+  "openai-chatgpt-responses",
+  "azure-openai-responses",
+]);
+
+type ModelCatalogConfig = {
+  models?: {
+    providers?: Record<string, ModelProviderConfig | undefined>;
+  };
+};
+
+type CodexReasoningEffortPresetJson = {
+  effort: string;
+  description: string;
+};
+
+type CodexModelCatalogEntryJson = {
+  slug: string;
+  display_name: string;
+  description: string | null;
+  default_reasoning_level?: string;
+  supported_reasoning_levels: CodexReasoningEffortPresetJson[];
+  shell_type: "shell_command";
+  visibility: "list";
+  supported_in_api: boolean;
+  priority: number;
+  additional_speed_tiers: string[];
+  service_tiers: unknown[];
+  default_service_tier: string | null;
+  availability_nux: null;
+  upgrade: null;
+  base_instructions: string;
+  model_messages: null;
+  supports_reasoning_summaries: boolean;
+  default_reasoning_summary: "auto";
+  support_verbosity: boolean;
+  default_verbosity: null;
+  apply_patch_tool_type: null;
+  web_search_tool_type: "text";
+  truncation_policy: { mode: "bytes"; limit: number };
+  supports_parallel_tool_calls: boolean;
+  supports_image_detail_original: boolean;
+  context_window: number;
+  max_context_window: number;
+  auto_compact_token_limit: null;
+  comp_hash: string | null;
+  effective_context_window_percent: number;
+  experimental_supported_tools: string[];
+  input_modalities: Array<"text" | "image">;
+  supports_search_tool: boolean;
+  use_responses_lite: boolean;
+  auto_review_model_override: null;
+};
+
+export type CodexModelCatalogJson = {
+  models: CodexModelCatalogEntryJson[];
+};
+
+export async function provisionCodexAppServerModelCatalog(params: {
+  startOptions: CodexAppServerStartOptions;
+  codexHome: string;
+  config?: unknown;
+}): Promise<CodexAppServerStartOptions> {
+  const catalog = buildCodexAppServerModelCatalog(params.config);
+  if (!catalog) {
+    return params.startOptions;
+  }
+  await fs.mkdir(params.codexHome, { recursive: true });
+  const catalogPath = path.join(params.codexHome, CODEX_MODEL_CATALOG_FILENAME);
+  const catalogJson = `${JSON.stringify(catalog, null, 2)}\n`;
+  await fs.writeFile(catalogPath, catalogJson);
+  await upsertCodexModelCatalogConfig(params.codexHome, catalogPath);
+  const fingerprint = fingerprintCodexModelCatalogJson(catalogJson);
+  return {
+    ...params.startOptions,
+    env: {
+      ...params.startOptions.env,
+      [CODEX_MODEL_CATALOG_FINGERPRINT_ENV]: fingerprint,
+    },
+  };
+}
+
+export function buildCodexAppServerModelCatalog(
+  config: unknown,
+): CodexModelCatalogJson | undefined {
+  const providers = (config as ModelCatalogConfig | undefined)?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const entries: CodexModelCatalogEntryJson[] = [];
+  const seenSlugs = new Set<string>();
+  for (const [providerId, provider] of Object.entries(providers).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (!provider?.models) {
+      continue;
+    }
+    const normalizedProviderId = normalizeCatalogString(providerId);
+    for (const model of provider.models) {
+      if (!isCodexCatalogModel(provider, model)) {
+        continue;
+      }
+      for (const slug of modelCatalogSlugs(normalizedProviderId, model.id)) {
+        if (seenSlugs.has(slug)) {
+          continue;
+        }
+        seenSlugs.add(slug);
+        entries.push(buildCodexModelCatalogEntry(provider, model, slug, entries.length));
+      }
+    }
+  }
+  return entries.length > 0 ? { models: entries } : undefined;
+}
+
+function isCodexCatalogModel(
+  provider: ModelProviderConfig,
+  model: ModelDefinitionConfig | undefined,
+): model is ModelDefinitionConfig {
+  const id = normalizeCatalogString(model?.id);
+  if (!id || !model?.input?.includes("text")) {
+    return false;
+  }
+  const api = model.api ?? provider.api;
+  return api ? CODEX_COMPATIBLE_MODEL_APIS.has(api) : true;
+}
+
+function modelCatalogSlugs(providerId: string, modelId: string): string[] {
+  const id = normalizeCatalogString(modelId);
+  if (!id) {
+    return [];
+  }
+  const providerQualifiedId =
+    providerId && !id.includes("/") ? normalizeCatalogString(`${providerId}/${id}`) : "";
+  return providerQualifiedId && providerQualifiedId !== id ? [id, providerQualifiedId] : [id];
+}
+
+function buildCodexModelCatalogEntry(
+  provider: ModelProviderConfig,
+  model: ModelDefinitionConfig,
+  slug: string,
+  priority: number,
+): CodexModelCatalogEntryJson {
+  const contextWindow = normalizePositiveInteger(model.contextWindow ?? provider.contextWindow);
+  const effectiveContextWindow =
+    normalizePositiveInteger(model.contextTokens ?? provider.contextTokens) ?? contextWindow;
+  const maxContextWindow = contextWindow ?? effectiveContextWindow ?? DEFAULT_CONTEXT_WINDOW;
+  const resolvedContextWindow = Math.min(
+    effectiveContextWindow ?? maxContextWindow,
+    maxContextWindow,
+  );
+  const reasoningEfforts = resolveSupportedReasoningEfforts(model);
+  const defaultReasoningEffort = resolveDefaultReasoningEffort(reasoningEfforts);
+  const supportsSearchTool = model.compat?.nativeWebSearchTool === true;
+  return {
+    slug,
+    display_name: normalizeCatalogString(model.name) || slug,
+    description: null,
+    ...(defaultReasoningEffort ? { default_reasoning_level: defaultReasoningEffort } : {}),
+    supported_reasoning_levels: reasoningEfforts.map((effort) => ({
+      effort,
+      description: effort,
+    })),
+    shell_type: "shell_command",
+    visibility: "list",
+    supported_in_api: true,
+    priority,
+    additional_speed_tiers: [],
+    service_tiers: [],
+    default_service_tier: null,
+    availability_nux: null,
+    upgrade: null,
+    base_instructions: "You are Codex, a coding agent.",
+    model_messages: null,
+    supports_reasoning_summaries: model.reasoning,
+    default_reasoning_summary: "auto",
+    support_verbosity: false,
+    default_verbosity: null,
+    apply_patch_tool_type: null,
+    web_search_tool_type: "text",
+    truncation_policy: { mode: "bytes", limit: 10_000 },
+    supports_parallel_tool_calls: model.compat?.supportsTools !== false,
+    supports_image_detail_original: model.input.includes("image"),
+    context_window: resolvedContextWindow,
+    max_context_window: maxContextWindow,
+    auto_compact_token_limit: null,
+    comp_hash: fingerprintCodexModelSlug(slug, resolvedContextWindow, maxContextWindow),
+    effective_context_window_percent: EFFECTIVE_CONTEXT_WINDOW_PERCENT,
+    experimental_supported_tools: [],
+    input_modalities: model.input.includes("image") ? ["text", "image"] : ["text"],
+    supports_search_tool: supportsSearchTool,
+    use_responses_lite: false,
+    auto_review_model_override: null,
+  };
+}
+
+function resolveSupportedReasoningEfforts(model: ModelDefinitionConfig): string[] {
+  const configured = model.compat?.supportedReasoningEfforts
+    ?.map(normalizeCatalogString)
+    .filter((entry): entry is string => Boolean(entry));
+  const efforts =
+    configured && configured.length > 0
+      ? configured
+      : model.reasoning
+        ? ["low", "medium", "high"]
+        : [];
+  return [...new Set(efforts)];
+}
+
+function resolveDefaultReasoningEffort(efforts: string[]): string | undefined {
+  if (efforts.length === 0) {
+    return undefined;
+  }
+  return efforts.includes("medium") ? "medium" : efforts[0];
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function normalizeCatalogString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function fingerprintCodexModelCatalogJson(catalogJson: string): string {
+  const hash = createHash("sha256");
+  hash.update(CODEX_MODEL_CATALOG_HASH_DOMAIN);
+  hash.update("\0");
+  hash.update(catalogJson);
+  return `${CODEX_MODEL_CATALOG_FINGERPRINT_PREFIX}${hash.digest("hex")}`;
+}
+
+function fingerprintCodexModelSlug(
+  slug: string,
+  contextWindow: number,
+  maxContextWindow: number,
+): string {
+  const hash = createHash("sha256");
+  hash.update("openclaw:codex-app-server-model-info:v1");
+  hash.update("\0");
+  hash.update(slug);
+  hash.update("\0");
+  hash.update(String(contextWindow));
+  hash.update("\0");
+  hash.update(String(maxContextWindow));
+  return `openclaw:${hash.digest("hex")}`;
+}
+
+async function upsertCodexModelCatalogConfig(
+  codexHome: string,
+  catalogPath: string,
+): Promise<void> {
+  const configPath = path.join(codexHome, CODEX_CONFIG_TOML_FILENAME);
+  let content = "";
+  try {
+    content = await fs.readFile(configPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  const nextContent = upsertTopLevelTomlStringAssignment(
+    content,
+    "model_catalog_json",
+    catalogPath,
+  );
+  if (nextContent !== content) {
+    await fs.writeFile(configPath, nextContent);
+  }
+}
+
+export function upsertTopLevelTomlStringAssignment(
+  content: string,
+  key: string,
+  value: string,
+): string {
+  const assignment = `${key} = ${JSON.stringify(value)}`;
+  const tableOffset = firstTomlTableOffset(content);
+  const topLevel = content.slice(0, tableOffset);
+  const rest = content.slice(tableOffset);
+  const keyPattern = tomlKeyPattern(key);
+  const existingTopLevelAssignment = new RegExp(`(^|\\n)\\s*${keyPattern}\\s*=.*(?=\\n|$)`);
+  if (existingTopLevelAssignment.test(topLevel)) {
+    return (
+      topLevel.replace(
+        existingTopLevelAssignment,
+        (_match, prefix: string) => `${prefix}${assignment}`,
+      ) + rest
+    );
+  }
+  const prefix = topLevel.length === 0 || topLevel.endsWith("\n") ? topLevel : `${topLevel}\n`;
+  return `${prefix}${assignment}\n${rest}`;
+}
+
+function firstTomlTableOffset(content: string): number {
+  const match = /^\s*\[/m.exec(content);
+  return match ? match.index : content.length;
+}
+
+function tomlKeyPattern(key: string): string {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return `(?:"${escaped}"|'${escaped}'|${escaped})`;
+}

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -895,6 +895,85 @@ describe("Codex app-server model provider selection", () => {
     expect(request.modelProvider).toBe("openai");
   });
 
+  it("keeps custom catalog metadata out of thread/start config", () => {
+    const params = createAttemptParams({
+      provider: "openai",
+      modelId: "custom-long-context",
+    });
+    params.config = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-responses",
+            models: [
+              {
+                id: "custom-long-context",
+                name: "Custom Long Context",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1_000_000,
+                contextTokens: 950_000,
+                maxTokens: 128_000,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const request = buildThreadStartParams(params, {
+      cwd: "/repo",
+      dynamicTools: [],
+      appServer: createAppServerOptions() as never,
+      developerInstructions: "test instructions",
+    });
+
+    expect(request.model).toBe("custom-long-context");
+    expect(request.modelProvider).toBe("openai");
+    expect(request.config).not.toHaveProperty("model_catalog_json");
+  });
+
+  it("keeps custom catalog metadata out of thread/resume config", () => {
+    const params = createAttemptParams({
+      provider: "openai",
+      modelId: "custom-long-context",
+    });
+    params.config = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-responses",
+            models: [
+              {
+                id: "custom-long-context",
+                name: "Custom Long Context",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1_000_000,
+                contextTokens: 950_000,
+                maxTokens: 128_000,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const request = buildThreadResumeParams(params, {
+      threadId: "thread-1",
+      appServer: createAppServerOptions() as never,
+      developerInstructions: "test instructions",
+    });
+
+    expect(request.model).toBe("custom-long-context");
+    expect(request.modelProvider).toBe("openai");
+    expect(request.config).not.toHaveProperty("model_catalog_json");
+  });
+
   it("splits provider-qualified model refs for app-server thread/start", () => {
     const request = buildThreadStartParams(
       createAttemptParams({ provider: "codex", modelId: "lmstudio/local-model" }),


### PR DESCRIPTION
Closes #93765.

Materializes configured OpenClaw model metadata into each isolated Codex app-server home at startup and keys shared app-server clients on the generated catalog fingerprint, so custom long-context models avoid Codex's unknown-model fallback window.

## Real behavior proof

- Behavior or issue addressed: Isolated Codex app-server homes now receive a generated model catalog and top-level `model_catalog_json` pointer before the app-server process starts.
- Real environment tested: Local OpenClaw checkout on macOS 27.0 with Node v24.15.0, current PR head `4eb9a5d98d`.
- Exact steps or command run after this patch: Called `provisionCodexAppServerModelCatalog` through the repo Node/tsx runtime against a temporary isolated Codex home containing an existing `config.toml` and a custom OpenAI Responses model with 1,000,000 configured context tokens.
- Evidence after fix:

```text
Codex isolated app-server catalog proof
codexHome=/var/folders/sl/5dkd3zq12dv65j6jx57zq1hc0000gn/T/openclaw-codex-proof-sKSzgZ
configToml="model_catalog_json = \"<codexHome>/openclaw-model-catalog.json\"\n[features]\nplugins = true\n"
catalogSlugs=custom-long-context,openai/custom-long-context
customContext=950000/1000000
fingerprint=sha256:82798a12eff41aa2661d4d0d9c74f4508da98aa11562413d6b863048a3c022e8
```

- Observed result after fix: The isolated home had `config.toml` updated to point at `openclaw-model-catalog.json`, the generated catalog exposed both the bare and provider-qualified custom model slugs, Codex-visible context was `950000/1000000`, and startup options included a catalog fingerprint.
- What was not tested: Launching the upstream Codex binary against the generated catalog; this proof covers the OpenClaw-owned startup provisioning path before process launch.
