### PR TITLE
fix(status): display 0 instead of ? for context usage on fresh sessions

### DIFF
--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -31,11 +31,11 @@ export function buildUsageContract(
 
   const maxTokens = state.contextTokenBudget;
   const usedTokens =
-    typeof state.contextUsedTokens === "number" && state.contextUsedTokens > 0
+    typeof state.contextUsedTokens === "number" && state.contextUsedTokens >= 0
       ? state.contextUsedTokens
       : promptTotal > 0
         ? promptTotal
-        : undefined;
+        : 0;
   const pctUsed =
     maxTokens && usedTokens !== undefined ? Math.round((usedTokens / maxTokens) * 100) : undefined;
 

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -210,7 +210,7 @@ const formatTokens = (total: number | null | undefined, contextTokens: number | 
   const ctx = contextTokens ?? null;
   if (total == null) {
     const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
-    return `?/${ctxLabel}`;
+    return `0/${ctxLabel}`;
   }
   const pct = ctx ? Math.min(999, Math.round((total / ctx) * 100)) : null;
   const totalLabel = formatTokenCount(total);


### PR DESCRIPTION
## Summary

- Fixes /status displaying "Context: ?/1.0m" instead of "0/1.0m" for fresh sessions
- Changes formatTokens() to return "0/<budget>" when no tokens are used yet
- Changes buildUsageContract() to accept 0 as valid contextUsedTokens (changed from > 0 to >= 0)
- Fallback to 0 instead of undefined when no usage data exists

Closes #93771

## Linked context

Closes #93771

## Real behavior proof

- Behavior or issue addressed: On fresh sessions (immediately after /new with no prior runs), /status displays "Context: ?/1.0m" instead of "0/1.0m". The ? appears because total token usage is null/undefined.
- Real environment tested: OpenClaw CLI with local code inspection
- Root cause / premise evidence: formatTokens() function in src/status/status-message.ts returns "?/<ctxLabel>" when total == null; buildUsageContract() in src/auto-reply/usage-bar/contract.ts has condition > 0 instead of >= 0 and fallback to undefined instead of 0
- Before evidence (bug reproduced on main): Code inspection shows line 212 returns `?/${ctxLabel}` when total is null
- Exact steps or command run after this patch: 
  ```
  node scripts/run-vitest.mjs src/status/status-message.test.ts
  node scripts/run-vitest.mjs src/auto-reply/usage-bar/translator.test.ts
  ```
- Evidence after fix: Tests pass; code now returns 0 instead of ?
- Observed result after fix: Status display will show "Context: 0/1.0m" instead of "Context: ?/1.0m"
- What was not tested: Interactive /status command in live CLI session
- Proof limitations or environment constraints: Code-level verification only; live agent session would require interactive setup

## Tests and validation

- `pnpm oxfmt --check src/status/status-message.ts src/auto-reply/usage-bar/contract.ts` ✓
- `node scripts/run-vitest.mjs src/status/status-message.test.ts` ✓ (2 tests)
- `node scripts/run-vitest.mjs src/auto-reply/usage-bar/translator.test.ts` ✓ (13 tests)

## Risk checklist

Did user-visible behavior change? Yes - corrected display of 0 instead of ?

Did config, environment, or migration behavior change? No

Did security, auth, secrets, network, or tool execution behavior change? No

Highest-risk area: Status message formatting for context usage

How is that risk mitigated? Changes are minimal (3 lines in 2 files), localized to token display formatting. Existing unit tests pass. Behavior change is a correct display of actual value (0) instead of unknown (?) for fresh sessions.

Current review state: Ready for maintainer review and CI.

AI-assisted (Claude Haiku 4.5). Proof verified via code inspection and unit tests.
