### PR TITLE
fix(webchat): skip textarea resize during IME composition to eliminate typing lag

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1839,6 +1839,33 @@ describe("chat composer IME composition", () => {
     expect(onSend).not.toHaveBeenCalled();
     expect(onHistoryKeydown).not.toHaveBeenCalled();
   });
+
+  it("does not force textarea resize during IME composition", () => {
+    const container = renderChatView({});
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    ) as HTMLTextAreaElement;
+
+    // Set a sentinel height to detect unwanted overwrites
+    textarea.style.height = "42px";
+
+    textarea.dispatchEvent(new CompositionEvent("compositionstart", { bubbles: true }));
+    textarea.value = "shi";
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, isComposing: true }));
+    textarea.value = "shichang";
+    textarea.dispatchEvent(new InputEvent("input", { bubbles: true, isComposing: true }));
+
+    // Height must stay untouched — no forced reflow during composition
+    expect(textarea.style.height).toBe("42px");
+
+    textarea.value = "市场";
+    textarea.dispatchEvent(new CompositionEvent("compositionend", { bubbles: true }));
+
+    // After composition ends, adjustTextareaHeight runs via syncComposerValue
+    expect(textarea.style.height).not.toBe("42px");
+  });
 });
 
 describe("chat slash menu accessibility", () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -2422,7 +2422,10 @@ export function renderChat(props: ChatProps) {
   const handleInput = (e: InputEvent) => {
     const target = e.target as HTMLTextAreaElement;
     if (vs.composerComposing || e.isComposing) {
-      adjustTextareaHeight(target);
+      // Skip adjustTextareaHeight during IME composition — each pinyin
+      // keystroke fires `input` and the height read/write forces a
+      // synchronous reflow that blocks the composition thread.
+      // Resize runs once in handleCompositionEnd → syncComposerValue.
       draftMirror.value = target.value;
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #90800.

The webchat composer textarea calls `adjustTextareaHeight()` on every `input` event during IME composition. Each call forces a synchronous layout reflow (`style.height = "auto"` → read `scrollHeight` → write `style.height`), which blocks the IME composition thread and causes severe typing lag for Chinese/Japanese/Korean input methods.

The fix removes the `adjustTextareaHeight()` call from the composing branch of `handleInput`. The resize already runs once in `handleCompositionEnd` → `syncComposerValue` → `adjustTextareaHeight`, so the textarea height is still correctly adjusted when the user commits their composed text.

## Changes

- **`ui/src/ui/views/chat.ts`**: Remove `adjustTextareaHeight(target)` from the `handleInput` composing-input early-return path (line 2382). The draft mirror is still updated during composition for internal state, but no forced reflow occurs.
- **`ui/src/ui/views/chat.test.ts`**: Add test `"does not force textarea resize during IME composition"` that sets a sentinel `style.height`, fires composing input events, and verifies the height is untouched until `compositionend`.

## Real behavior proof

**Behavior or issue addressed**: Chinese IME typing lag in webchat textarea caused by forced layout reflows on every composing keystroke (#90800).

**Real environment tested**: macOS, Control UI webchat, Vitest jsdom unit tests.

**Exact steps or command run after this patch**: `pnpm test -- ui/src/ui/views/chat.test.ts -t "chat composer IME composition"` — all 4 IME composition tests pass (3 existing + 1 new). Full chat view suite: `pnpm test -- ui/src/ui/views/chat.test.ts` — all 108 tests pass.

**Evidence after fix**:
```
 Test Files  1 passed (1)
      Tests  4 passed | 104 skipped (108)
   Start at  13:22:33
   Duration  1.41s
```

Full suite:
```
 Test Files  1 passed (1)
      Tests  108 passed (108)
   Start at  13:22:39
   Duration  18.97s
```

**Observed result after fix**: During IME composition, `adjustTextareaHeight` is no longer called on each pinyin keystroke. The textarea height is adjusted once when composition ends via `handleCompositionEnd` → `syncComposerValue`. All existing IME composition tests continue to pass.

**What was not tested**: Live Chinese/Japanese/Korean IME input in a real browser (fix is a code-path removal verified by unit test behavior; the performance improvement is a direct consequence of eliminating the forced reflow calls).

## Risks and Mitigations

- **Risk**: Textarea might not auto-grow during very long IME compositions.
  - **Mitigation**: IME composition sessions are typically short (one word/phrase). The resize runs immediately on `compositionend`, so users see correct height as soon as they commit text. If needed, a debounced `requestAnimationFrame` resize could be added as a follow-up.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)