### PR TITLE
fix(google): keep parallel Gemini tool responses in the turn after the model

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -284,6 +284,35 @@ function toolResultTurn(toolCallId = "call_1", timestamp = 1): Record<string, un
   };
 }
 
+function parallelGoogleToolCallAssistantTurn(): Record<string, unknown> {
+  return {
+    role: "assistant",
+    provider: "google",
+    api: "google-generative-ai",
+    model: "gemini-2.5-flash",
+    stopReason: "toolUse",
+    timestamp: 0,
+    content: [
+      { type: "toolCall", id: "call_1", name: "screenshot", arguments: {} },
+      { type: "toolCall", id: "call_2", name: "weather", arguments: {} },
+    ],
+  };
+}
+
+function googleToolResultMessage(name: "screenshot" | "weather"): Record<string, unknown> {
+  return {
+    role: "toolResult",
+    toolCallId: name === "screenshot" ? "call_1" : "call_2",
+    toolName: name,
+    content:
+      name === "screenshot"
+        ? [{ type: "image", mimeType: "image/png", data: "png-bytes" }]
+        : [{ type: "text", text: "Sunny, 21C" }],
+    isError: false,
+    timestamp: 1,
+  };
+}
+
 describe("google transport stream", () => {
   beforeAll(async () => {
     ({
@@ -2041,6 +2070,49 @@ describe("google transport stream", () => {
 
     expect(params.contents).toEqual([{ role: "user", parts: [{ text: " " }] }]);
   });
+
+  it.each([
+    ["image first", ["screenshot", "weather"]],
+    ["image last", ["weather", "screenshot"]],
+  ] as const)(
+    "keeps parallel function responses immediate and retains the deferred %s result",
+    (_label, resultOrder) => {
+      const params = buildGoogleGenerativeAiParams(
+        buildGeminiModel({ id: "gemini-2.5-flash", input: ["text", "image"] }),
+        {
+          messages: [
+            { role: "user", content: "Screenshot the page and check the weather.", timestamp: 0 },
+            parallelGoogleToolCallAssistantTurn(),
+            ...resultOrder.map(googleToolResultMessage),
+          ],
+        } as never,
+      );
+
+      expect(params.contents.map((content) => content.role)).toEqual([
+        "user",
+        "model",
+        "user",
+        "user",
+      ]);
+      expect(params.contents[2]).toEqual({
+        role: "user",
+        parts: resultOrder.map((name) => ({
+          functionResponse: {
+            name,
+            response:
+              name === "screenshot" ? { output: "(see attached image)" } : { output: "Sunny, 21C" },
+          },
+        })),
+      });
+      expect(params.contents[3]).toEqual({
+        role: "user",
+        parts: [
+          { text: "Tool result image:" },
+          { inlineData: { mimeType: "image/png", data: "png-bytes" } },
+        ],
+      });
+    },
+  );
 
   it.each([
     ["gemini-2.5-flash-lite", "minimal", 512],

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -526,7 +526,20 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
       preserveCrossModelToolCallThoughtSignature: requiresToolCallThoughtSignature(model.id),
     },
   );
+  // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot
+  // live inside functionResponse, so hold them until the consecutive result run ends.
+  const pendingToolResultImageTurns: Array<Record<string, unknown>> = [];
+  let activeToolResultParts: Array<Record<string, unknown>> | undefined;
+  const flushToolResultRun = (): void => {
+    contents.push(...pendingToolResultImageTurns);
+    pendingToolResultImageTurns.length = 0;
+    activeToolResultParts = undefined;
+  };
+
   for (const msg of transformedMessages) {
+    if (msg.role !== "toolResult") {
+      flushToolResultRun();
+    }
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         contents.push({
@@ -658,31 +671,32 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           data: imageBlock.data,
         },
       }));
+      const modelSupportsMultimodalFunctionResponse = supportsMultimodalFunctionResponse(model.id);
       const functionResponse = {
         functionResponse: {
           name: msg.toolName,
           response: msg.isError ? { error: responseValue } : { output: responseValue },
-          ...(supportsMultimodalFunctionResponse(model.id) && imageParts.length > 0
+          ...(modelSupportsMultimodalFunctionResponse && imageParts.length > 0
             ? { parts: imageParts }
             : {}),
           ...(requiresToolCallId(model.id) ? { id: msg.toolCallId } : {}),
         },
       };
-      const last = contents[contents.length - 1];
-      if (
-        last?.role === "user" &&
-        Array.isArray(last.parts) &&
-        last.parts.some((part) => "functionResponse" in part)
-      ) {
-        (last.parts as Array<Record<string, unknown>>).push(functionResponse);
+      if (activeToolResultParts) {
+        activeToolResultParts.push(functionResponse);
       } else {
-        contents.push({ role: "user", parts: [functionResponse] });
+        activeToolResultParts = [functionResponse];
+        contents.push({ role: "user", parts: activeToolResultParts });
       }
-      if (imageParts.length > 0 && !supportsMultimodalFunctionResponse(model.id)) {
-        contents.push({ role: "user", parts: [{ text: "Tool result image:" }, ...imageParts] });
+      if (imageParts.length > 0 && !modelSupportsMultimodalFunctionResponse) {
+        pendingToolResultImageTurns.push({
+          role: "user",
+          parts: [{ text: "Tool result image:" }, ...imageParts],
+        });
       }
     }
   }
+  flushToolResultRun();
   if (contents.length === 0) {
     contents.push({ role: "user", parts: [{ text: " " }] });
   }

--- a/src/llm/providers/google-shared.parallel-image-repro.test.ts
+++ b/src/llm/providers/google-shared.parallel-image-repro.test.ts
@@ -1,0 +1,78 @@
+import type { Part } from "@google/genai";
+import { describe, expect, it } from "vitest";
+import type { Context, Model } from "../types.js";
+import { convertMessages } from "./google-shared.js";
+import { makeGoogleAssistantMessage } from "./google-shared.test-helpers.js";
+
+const convertMessagesForTest = convertMessages as unknown as (
+  model: Model<"google-generative-ai">,
+  context: Context,
+) => ReturnType<typeof convertMessages>;
+
+const makeVisionModel = (id: string): Model<"google-generative-ai"> =>
+  ({
+    id,
+    name: id,
+    api: "google-generative-ai",
+    provider: "google",
+    baseUrl: "https://example.invalid",
+    reasoning: false,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1,
+    maxTokens: 1,
+  }) as Model<"google-generative-ai">;
+
+function countFunctionResponses(parts: readonly Part[] | undefined): number {
+  return (parts ?? []).filter((p) => p.functionResponse != null).length;
+}
+
+function countFunctionCalls(parts: readonly Part[] | undefined): number {
+  return (parts ?? []).filter((p) => p.functionCall != null).length;
+}
+
+describe("google-shared convertMessages — parallel tool results with an image (Gemini < 3)", () => {
+  it("keeps both parallel function responses in the user turn immediately after the model turn", () => {
+    const model = makeVisionModel("gemini-2.5-flash");
+    const context = {
+      messages: [
+        { role: "user", content: "Screenshot the page and check the weather." },
+        makeGoogleAssistantMessage(model.id, [
+          { type: "toolCall", id: "call_1", name: "screenshot", arguments: {} },
+          { type: "toolCall", id: "call_2", name: "weather", arguments: {} },
+        ]),
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "screenshot",
+          content: [{ type: "image", mimeType: "image/png", data: "AAAA" }],
+          isError: false,
+          timestamp: 0,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_2",
+          toolName: "weather",
+          content: [{ type: "text", text: "Sunny, 21C" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessagesForTest(model, context);
+
+    const modelTurn = contents[1];
+    expect(modelTurn.role).toBe("model");
+    expect(countFunctionCalls(modelTurn.parts)).toBe(2);
+
+    const immediateUserTurn = contents[2];
+    expect(immediateUserTurn.role).toBe("user");
+    expect(countFunctionResponses(immediateUserTurn.parts)).toBe(2);
+
+    const strandedAfterIndex2 = contents
+      .slice(3)
+      .some((c) => countFunctionResponses(c.parts) > 0);
+    expect(strandedAfterIndex2).toBe(false);
+  });
+});

--- a/src/llm/providers/google-shared.parallel-image-repro.test.ts
+++ b/src/llm/providers/google-shared.parallel-image-repro.test.ts
@@ -27,21 +27,22 @@ function countFunctionResponses(parts: readonly Part[] | undefined): number {
   return (parts ?? []).filter((p) => p.functionResponse != null).length;
 }
 
-function countFunctionCalls(parts: readonly Part[] | undefined): number {
-  return (parts ?? []).filter((p) => p.functionCall != null).length;
+function functionResponseNames(parts: readonly Part[] | undefined): string[] {
+  return (parts ?? []).flatMap((part) =>
+    part.functionResponse?.name ? [part.functionResponse.name] : [],
+  );
 }
 
 describe("google-shared convertMessages — parallel tool results with an image (Gemini < 3)", () => {
-  it("keeps both parallel function responses in the user turn immediately after the model turn", () => {
-    const model = makeVisionModel("gemini-2.5-flash");
-    const context = {
-      messages: [
-        { role: "user", content: "Screenshot the page and check the weather." },
-        makeGoogleAssistantMessage(model.id, [
-          { type: "toolCall", id: "call_1", name: "screenshot", arguments: {} },
-          { type: "toolCall", id: "call_2", name: "weather", arguments: {} },
-        ]),
-        {
+  it.each([
+    ["image first", ["screenshot", "weather"]],
+    ["image last", ["weather", "screenshot"]],
+  ] as const)(
+    "keeps the response run immediate and retains a deferred %s result",
+    (_label, resultOrder) => {
+      const model = makeVisionModel("gemini-2.5-flash");
+      const toolResults = {
+        screenshot: {
           role: "toolResult",
           toolCallId: "call_1",
           toolName: "screenshot",
@@ -49,7 +50,7 @@ describe("google-shared convertMessages — parallel tool results with an image 
           isError: false,
           timestamp: 0,
         },
-        {
+        weather: {
           role: "toolResult",
           toolCallId: "call_2",
           toolName: "weather",
@@ -57,22 +58,30 @@ describe("google-shared convertMessages — parallel tool results with an image 
           isError: false,
           timestamp: 0,
         },
-      ],
-    } as unknown as Context;
+      } as const;
+      const context = {
+        messages: [
+          { role: "user", content: "Screenshot the page and check the weather." },
+          makeGoogleAssistantMessage(model.id, [
+            { type: "toolCall", id: "call_1", name: "screenshot", arguments: {} },
+            { type: "toolCall", id: "call_2", name: "weather", arguments: {} },
+          ]),
+          ...resultOrder.map((name) => toolResults[name]),
+        ],
+      } as unknown as Context;
 
-    const contents = convertMessagesForTest(model, context);
+      const contents = convertMessagesForTest(model, context);
 
-    const modelTurn = contents[1];
-    expect(modelTurn.role).toBe("model");
-    expect(countFunctionCalls(modelTurn.parts)).toBe(2);
-
-    const immediateUserTurn = contents[2];
-    expect(immediateUserTurn.role).toBe("user");
-    expect(countFunctionResponses(immediateUserTurn.parts)).toBe(2);
-
-    const strandedAfterIndex2 = contents
-      .slice(3)
-      .some((c) => countFunctionResponses(c.parts) > 0);
-    expect(strandedAfterIndex2).toBe(false);
-  });
+      expect(contents.map((content) => content.role)).toEqual(["user", "model", "user", "user"]);
+      expect(functionResponseNames(contents[2].parts)).toEqual(resultOrder);
+      expect(contents[3]).toEqual({
+        role: "user",
+        parts: [
+          { text: "Tool result image:" },
+          { inlineData: { mimeType: "image/png", data: "AAAA" } },
+        ],
+      });
+      expect(contents.slice(3).some((c) => countFunctionResponses(c.parts) > 0)).toBe(false);
+    },
+  );
 });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -170,7 +170,20 @@ export function convertMessages<T extends GoogleApiType>(
 
   const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
 
+  const pendingToolResultImageTurns: Content[] = [];
+  let activeToolResultParts: Part[] | undefined;
+  const flushToolResultRun = (): void => {
+    for (const imageTurn of pendingToolResultImageTurns) {
+      contents.push(imageTurn);
+    }
+    pendingToolResultImageTurns.length = 0;
+    activeToolResultParts = undefined;
+  };
+
   for (const msg of transformedMessages) {
+    if (msg.role !== "toolResult") {
+      flushToolResultRun();
+    }
     if (msg.role === "user") {
       if (typeof msg.content === "string") {
         contents.push({
@@ -303,20 +316,19 @@ export function convertMessages<T extends GoogleApiType>(
       };
 
       // Cloud Code Assist API requires all function responses to be in a single user turn.
-      // Check if the last content is already a user turn with function responses and merge.
-      const lastContent = contents[contents.length - 1];
-      if (lastContent?.role === "user" && lastContent.parts?.some((p) => p.functionResponse)) {
-        lastContent.parts.push(functionResponsePart);
+      if (activeToolResultParts) {
+        activeToolResultParts.push(functionResponsePart);
       } else {
+        activeToolResultParts = [functionResponsePart];
         contents.push({
           role: "user",
-          parts: [functionResponsePart],
+          parts: activeToolResultParts,
         });
       }
 
       // For Gemini < 3, add images in a separate user message
       if (hasImages && !modelSupportsMultimodalFunctionResponse) {
-        contents.push({
+        pendingToolResultImageTurns.push({
           role: "user",
           parts: [{ text: "Tool result image:" }, ...imageParts],
         });
@@ -324,6 +336,7 @@ export function convertMessages<T extends GoogleApiType>(
     }
   }
 
+  flushToolResultRun();
   return contents;
 }
 

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -170,12 +170,12 @@ export function convertMessages<T extends GoogleApiType>(
 
   const transformedMessages = transformMessages(context.messages, model, normalizeToolCallId);
 
+  // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot
+  // live inside functionResponse, so hold them until the consecutive result run ends.
   const pendingToolResultImageTurns: Content[] = [];
   let activeToolResultParts: Part[] | undefined;
   const flushToolResultRun = (): void => {
-    for (const imageTurn of pendingToolResultImageTurns) {
-      contents.push(imageTurn);
-    }
+    contents.push(...pendingToolResultImageTurns);
     pendingToolResultImageTurns.length = 0;
     activeToolResultParts = undefined;
   };


### PR DESCRIPTION
## Summary

On Gemini < 3 vision models (gemini-2.5-*), a single assistant turn with parallel tool calls where a non-last result returns an image serializes a request whose user turn immediately after the model carries fewer functionResponse parts than the model issued functionCall parts. On the Gemini surfaces that enforce the parallel function-call contract (the Cloud Code Assist OAuth path and Vertex), that turn shape is rejected with 400 INVALID_ARGUMENT ("the number of function response parts is equal to the number of function call parts of the function call turn"). Because the malformed turn is persisted in session history, every subsequent turn re-serializes it and re-fails, so the session is stuck until the user compacts or starts over. This is the same parallel-function-call contract repeatedly reported against gemini-cli (google-gemini/gemini-cli #6315, #1535, #16135, #16415).

Scope: the AI Studio generativelanguage endpoint (plain API key) does not currently enforce this contract and accepts the malformed turn (live-verified below, including a payload with a response missing entirely), so API-key users are not affected. The failure is on the contract-enforcing surfaces (Cloud Code Assist / Vertex). The fix conforms the serialized history on all surfaces, which is correct and harmless regardless of which endpoint receives it.

## Root cause

`convertMessages` in `src/llm/providers/google-shared.ts`. For Gemini < 3 (no multimodal functionResponse) an image-bearing tool result emits a separate "Tool result image:" user turn. The old merge heuristic only inspected `contents[contents.length - 1]`: when that separate image turn lands between two parallel function responses, the heuristic sees the image turn (not a functionResponse turn) and starts a fresh user turn for the second response. The turn right after the model then holds only 1 of 2 responses, so the count mismatches. It is order-dependent: if the image-bearing result is last it merges fine, which is why it slipped through.

Produced `contents` before the fix: `[user, model(fc1,fc2), user(fr1), user(image), user(fr2)]`, with fr2 stranded behind the image turn.

## Fix

Replace the fragile `contents[last]` heuristic with a run-scoped accumulator. All function responses for one model turn merge into the single user turn right after it; Gemini < 3 image turns are deferred and flushed at the end of the tool-result run so they trail the merged response turn. After the fix: `[user, model(fc1,fc2), user(fr1,fr2), user(image)]`, both responses in the immediately following turn. This is the turn shape the Cloud Code Assist / Vertex contract requires, and it matches the direction gemini-cli took for the same parallel-call defect.

Both Gemini surfaces, `google.ts` (Gemini API) and `google-vertex.ts` (Cloud Code Assist / Vertex), route through this single `convertMessages`, so the one change covers both. This is a latent bug in the Gemini-<3 separate-image-turn path (landed around 2026-05-31), not a fresh regression.

## Real behavior proof

**Behavior or issue addressed:** On gemini-2.5-* a parallel tool-call turn whose non-last result returns an image makes the provider serialize a request whose user turn right after the model carries fewer functionResponse parts than the model issued functionCall parts. The surfaces that enforce the parallel function-call contract (Cloud Code Assist / Vertex) reject that with 400 INVALID_ARGUMENT, and because the malformed turn is persisted every later turn re-sends it and re-fails (stuck session).

**Real environment tested:** Local OpenClaw checkout at this PR head. Two real things were exercised. (1) Drove the real Google provider request-assembly path: imported `convertMessages` from both the origin/main file and the patched file in one `node --import tsx` process for model `gemini-2.5-flash`, and captured the exact `contents[]` each version POSTs. (2) Sent both serialized payloads over HTTP to the live Gemini 2.5 generateContent API (`generativelanguage.googleapis.com`).

**Exact steps or command run after this patch:** `node --import tsx gemini-live-proof.ts` — builds the parallel screenshot + weather turn where the non-last result is an image, prints each serialized `contents[]`, and performs a live HTTP POST of each to the generateContent endpoint.

**Evidence after fix:** live console output from the real provider code:

```
========== BEFORE (pristine main convertMessages) ==========
  [0] role=user: text("Screenshot the page and...")
  [1] role=model: functionCall(screenshot), functionCall(weather)
  [2] role=user: functionResponse(screenshot)
  [3] role=user: text("Tool result image:"), inlineData(image)
  [4] role=user: functionResponse(weather)
model issued 2 functionCall(s); turn after model carries 1 functionResponse(s)

========== AFTER (this patch convertMessages) ==========
  [0] role=user: text("Screenshot the page and...")
  [1] role=model: functionCall(screenshot), functionCall(weather)
  [2] role=user: functionResponse(screenshot), functionResponse(weather)
  [3] role=user: text("Tool result image:"), inlineData(image)
model issued 2 functionCall(s); turn after model carries 2 functionResponse(s)
```

Live HTTP round-trip of both payloads to the AI Studio endpoint (`generativelanguage.googleapis.com`, gemini-2.5-flash):

```
HTTP 200  BEFORE (split, fr2 stranded behind image)  -> ACCEPTED
HTTP 200  AFTER  (grouped)                            -> ACCEPTED
HTTP 200  probe: one functionResponse missing entirely -> ACCEPTED
```

This endpoint does not enforce the parallel function-call-count contract, so it is not the surface that fails. The 400 INVALID_ARGUMENT this patch prevents is the contract enforced on Cloud Code Assist and Vertex, documented in-repo (`src/llm/providers/google-shared.ts`: "Cloud Code Assist API requires all function responses to be in a single user turn") and repeatedly reported against gemini-cli, which uses the Code Assist path (#6315, #1535, #16135, #16415).

**Observed result after fix:** Before the patch, the real `convertMessages` strands the second functionResponse behind the image turn (turn after model carries 1 of 2). After the patch it carries both (2 of 2) with the image trailing. On the surfaces that enforce the contract, that is the difference between a rejected request (stuck session) and an accepted one; on the AI Studio endpoint both shapes are accepted.

**What was not tested:** No live Cloud Code Assist or Vertex HTTP round-trip from this machine (no OAuth credentials here), and that is the surface that returns the 400. The live HTTP evidence above is against the AI Studio endpoint, which tolerates both shapes. The cross-surface 400 contract is corroborated by the in-repo comment and the gemini-cli issue reports cited. A maintainer with Code Assist or Vertex access can confirm the before-shape 400 directly with the same two payloads.

## Verification

Regression test `src/llm/providers/google-shared.parallel-image-repro.test.ts` asserts the user turn after the model carries both responses and nothing is stranded. It is red on origin/main (`expected 1 to be 2`) and green with the fix. The existing google-shared convert and conversion suites stay green (14 cases), and the changed files pass tsgo (`tsgo:core:test`) and oxlint.
