### PR TITLE
fix(status): show 0/1.0m instead of ?/1.0m on fresh session

### DIFF
--- a/src/auto-reply/usage-bar/contract.test.ts
+++ b/src/auto-reply/usage-bar/contract.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { buildUsageContract } from "./contract.js";
+import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
+
+describe("buildUsageContract", () => {
+  const baseState: PluginHookReplyUsageState = {
+    model: "test-model",
+    provider: "test",
+    usage: {},
+  } as unknown as PluginHookReplyUsageState;
+
+  function getContext(result: Record<string, unknown>): { used_tokens?: number; pct_used?: number } {
+    return result.context as { used_tokens?: number; pct_used?: number };
+  }
+
+  it("returns 0 used_tokens on a fresh session with no usage", () => {
+    const result = buildUsageContract(baseState);
+    expect(getContext(result).used_tokens).toBe(0);
+  });
+
+  it("returns 0 used_tokens when contextUsedTokens is undefined and promptTotal is 0", () => {
+    const state = {
+      ...baseState,
+      contextUsedTokens: undefined,
+      usage: { input: 0, cacheRead: 0, cacheWrite: 0 },
+    } as unknown as PluginHookReplyUsageState;
+    const result = buildUsageContract(state);
+    expect(getContext(result).used_tokens).toBe(0);
+  });
+
+  it("accepts contextUsedTokens of 0 as valid", () => {
+    const state = {
+      ...baseState,
+      contextUsedTokens: 0,
+      contextTokenBudget: 1000000,
+    } as unknown as PluginHookReplyUsageState;
+    const result = buildUsageContract(state);
+    expect(getContext(result).used_tokens).toBe(0);
+    expect(getContext(result).pct_used).toBe(0);
+  });
+
+  it("uses contextUsedTokens when positive", () => {
+    const state = {
+      ...baseState,
+      contextUsedTokens: 50000,
+      contextTokenBudget: 1000000,
+    } as unknown as PluginHookReplyUsageState;
+    const result = buildUsageContract(state);
+    expect(getContext(result).used_tokens).toBe(50000);
+    expect(getContext(result).pct_used).toBe(5);
+  });
+
+  it("falls back to promptTotal when contextUsedTokens is undefined and promptTotal > 0", () => {
+    const state = {
+      ...baseState,
+      contextUsedTokens: undefined,
+      usage: { input: 1000, cacheRead: 500, cacheWrite: 200 },
+    } as unknown as PluginHookReplyUsageState;
+    const result = buildUsageContract(state);
+    // promptTotal = cacheRead + cacheWrite + input = 500 + 200 + 1000 = 1700
+    expect(getContext(result).used_tokens).toBe(1700);
+  });
+});

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -33,9 +33,7 @@ export function buildUsageContract(
   const usedTokens =
     typeof state.contextUsedTokens === "number" && state.contextUsedTokens >= 0
       ? state.contextUsedTokens
-      : promptTotal > 0
-        ? promptTotal
-        : 0;
+      : Math.max(promptTotal, 0);
   const pctUsed =
     maxTokens && usedTokens !== undefined ? Math.round((usedTokens / maxTokens) * 100) : undefined;
 

--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -31,11 +31,11 @@ export function buildUsageContract(
 
   const maxTokens = state.contextTokenBudget;
   const usedTokens =
-    typeof state.contextUsedTokens === "number" && state.contextUsedTokens > 0
+    typeof state.contextUsedTokens === "number" && state.contextUsedTokens >= 0
       ? state.contextUsedTokens
       : promptTotal > 0
         ? promptTotal
-        : undefined;
+        : 0;
   const pctUsed =
     maxTokens && usedTokens !== undefined ? Math.round((usedTokens / maxTokens) * 100) : undefined;
 


### PR DESCRIPTION
## What

Fix `/status` showing `?/1.0m` instead of `0/1.0m` on a fresh session with no prior usage.

## Why

On a fresh session, `state.contextUsedTokens` is `undefined` and `promptTotal` is `0`. The `> 0` guard in `buildUsageContract()` treated zero as invalid and fell through to `undefined`, which the status template renders as `?`.

Fixes #93771

## How

Two changes in `src/auto-reply/usage-bar/contract.ts`:
1. Changed `> 0` to `>= 0` so that `contextUsedTokens: 0` is accepted as valid
2. Changed the final fallback from `undefined` to `0` so fresh sessions show `0` instead of `?`

## Testing

Added `src/auto-reply/usage-bar/contract.test.ts` with 5 cases:
- Fresh session with no usage → returns 0
- `contextUsedTokens` undefined + promptTotal 0 → returns 0
- `contextUsedTokens` explicitly 0 → returns 0, pct_used 0
- `contextUsedTokens` positive → correct value and percentage
- Fallback to promptTotal when contextUsedTokens is undefined

```bash
pnpm test -- src/auto-reply/usage-bar/contract.test.ts
```

## Breaking changes

None. The only change is `undefined` → `0` for the `used_tokens` field, which makes the template render `0` instead of `?`.