### PR TITLE
fix(reasoning-tags): strip MiniMax `mm:` namespaced reasoning tags

### DIFF
--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -16,8 +16,14 @@ const REASONING_TAG_PREFIXES = [
   "</thinking",
   "</thought",
   "</antthinking",
+  "<mm:think",
+  "<mm:thinking",
+  "<mm:thought",
+  "</mm:think",
+  "</mm:thinking",
+  "</mm:thought",
 ];
-const THINKING_TAG_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+const THINKING_TAG_RE = /<\s*(\/?)\s*(?:(?:(?:antml|mm):)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 
 function extractThinkingFromTaggedStreamOutsideCode(text: string): string {
   if (!text) {

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -322,6 +322,39 @@ describe("stripReasoningTagsFromText", () => {
     });
   });
 
+  describe("mm: namespace (MiniMax reasoning tags)", () => {
+    it.each([
+      {
+        name: "strips mm:think tags",
+        input: "<mm:think>reasoning</mm:think>Answer",
+        expected: "Answer",
+      },
+      {
+        name: "strips mm:thinking tags",
+        input: "<mm:thinking>reasoning</mm:thinking>Answer",
+        expected: "Answer",
+      },
+      {
+        name: "strips mm:thought tags",
+        input: "<mm:thought>reasoning</mm:thought>Answer",
+        expected: "Answer",
+      },
+      {
+        name: "strips truncated unclosed mm:think tag",
+        input: "<mm:think>reasoning without close tag",
+        expected: "reasoning without close tag",
+        opts: { mode: "strict" as const },
+      },
+      {
+        name: "handles orphan mm:think close tag after text",
+        input: "Internal reasoning </mm:think>Answer",
+        expected: "Answer",
+      },
+    ] as const)("$name", (testCase) => {
+      expectStrippedCase(testCase);
+    });
+  });
+
   it.each([
     { input: "A <final>1</final> B", expected: "A 1 B" },
     { input: "C <final>2</final> D", expected: "C 2 D" },

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -4,9 +4,9 @@ import { findFinalTagMatches } from "./final-tags.js";
 export type ReasoningTagMode = "strict" | "preserve";
 export type ReasoningTagTrim = "none" | "start" | "both";
 
-const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
+const QUICK_TAG_RE = /<\s*\/?\s*(?:(?:(?:antml|mm):)?(?:think(?:ing)?|thought)|antthinking|final)\b/i;
 const THINKING_TAG_RE =
-  /<\s*(\/?)\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
+  /<\s*(\/?)\s*(?:(?:(?:antml|mm):)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 
 function applyTrim(value: string, mode: ReasoningTagTrim): string {
   if (mode === "none") {


### PR DESCRIPTION
## What

Strip MiniMax M3 reasoning tags (`<mm:think>`, `<mm:thinking>`, `<mm:thought>`) from visible chat output.

## Why

MiniMax M3 (served via Fireworks/OpenRouter) emits chain-of-thought inline wrapped in `<mm:think>…</mm:think>` — MiniMax's own namespaced tag. The reasoning-tag stripper only recognized the `antml:` namespace, so `<mm:think>` content leaked verbatim into visible chat replies.

Plain `<think>` from other models strips fine — only the namespaced MiniMax variant slipped through because `QUICK_TAG_RE` failed the early-return guard.

Fixes #93767

## How

Accept `mm:` as an alternative namespace prefix alongside `antml:` in all reasoning-tag regex patterns:

- `src/shared/text/reasoning-tags.ts` — `QUICK_TAG_RE` and `THINKING_TAG_RE` now match `(?:(?:antml|mm):)?`
- `extensions/telegram/src/reasoning-lane-coordinator.ts` — Added `mm:` prefixes to `REASONING_TAG_PREFIXES` array and updated local `THINKING_TAG_RE`

## Testing

Added 5 test cases to `src/shared/text/reasoning-tags.test.ts`:
- `<mm:think>reasoning</mm:think>Answer` → `"Answer"`
- `<mm:thinking>reasoning</mm:thinking>Answer` → `"Answer"`
- `<mm:thought>reasoning</mm:thought>Answer` → `"Answer"`
- Truncated unclosed `<mm:think>` tag
- Orphan `</mm:think>` close tag recovery

```bash
pnpm test -- src/shared/text/reasoning-tags.test.ts
```

## Breaking changes

None. Only adds recognition of a new tag prefix — existing behavior for `antml:` and bare tags is unchanged.