### PR TITLE
fix(plugins): treat refreshable catalogs as requiring runtime discovery (fixes #93775)

### DIFF
--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -67,7 +67,7 @@ function createManifestPlugin(id: string): PluginManifestRecord {
 
 function createManifestPluginWithModelCatalog(
   id: string,
-  discovery: "static" | "runtime" = "static",
+  discovery: "static" | "refreshable" | "runtime" = "static",
 ): PluginManifestRecord {
   return {
     ...createManifestPluginWithoutDiscovery({ id }),
@@ -261,6 +261,38 @@ describe("resolvePluginDiscoveryProvidersRuntime", () => {
       [],
     );
     expect(mocks.resolvePluginProviders).not.toHaveBeenCalled();
+  });
+
+  it("does not synthesize manifest entry providers for refreshable catalogs", () => {
+    mocks.resolveDiscoveredProviderPluginIds.mockReturnValue(["token-plan"]);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      index: { plugins: [] },
+      manifestRegistry: {
+        plugins: [createManifestPluginWithModelCatalog("token-plan", "refreshable")],
+        diagnostics: [],
+      },
+    });
+
+    expect(resolvePluginDiscoveryProvidersRuntime({ discoveryEntriesOnly: true })).toStrictEqual(
+      [],
+    );
+    expect(mocks.resolvePluginProviders).not.toHaveBeenCalled();
+  });
+
+  it("loads the full plugin for refreshable manifest catalog rows", () => {
+    const refreshableProvider = createProvider({ id: "token-plan", mode: "catalog" });
+    mocks.resolveDiscoveredProviderPluginIds.mockReturnValue(["token-plan"]);
+    mocks.resolvePluginProviders.mockReturnValue([refreshableProvider]);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      index: { plugins: [] },
+      manifestRegistry: {
+        plugins: [createManifestPluginWithModelCatalog("token-plan", "refreshable")],
+        diagnostics: [],
+      },
+    });
+
+    expect(resolvePluginDiscoveryProvidersRuntime({})).toStrictEqual([refreshableProvider]);
+    expect(requireResolvePluginProvidersParams().onlyPluginIds).toEqual(["token-plan"]);
   });
 
   it("loads the full plugin when one manifest catalog provider is runtime-owned", () => {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -217,7 +217,7 @@ function resolveManifestModelCatalogProviders(
     }
     const plan = planManifestModelCatalogRows({ registry: { plugins: [plugin] } });
     for (const entry of plan.entries) {
-      if (entry.rows.length === 0 || entry.discovery === "runtime") {
+      if (entry.rows.length === 0 || entry.discovery === "runtime" || entry.discovery === "refreshable") {
         continue;
       }
       const providerConfig = providerConfigFromManifestRows(entry.rows);
@@ -249,7 +249,7 @@ function resolveRuntimeManifestCatalogPluginIds(
     );
     const ownsRuntimeDiscovery = Object.entries(plugin.modelCatalog?.discovery ?? {}).some(
       ([provider, discovery]) =>
-        discovery === "runtime" && ownedProviders.has(normalizeProviderId(provider)),
+        (discovery === "runtime" || discovery === "refreshable") && ownedProviders.has(normalizeProviderId(provider)),
     );
     if (ownsRuntimeDiscovery) {
       pluginIds.add(plugin.id);
@@ -259,7 +259,7 @@ function resolveRuntimeManifestCatalogPluginIds(
       continue;
     }
     const plan = planManifestModelCatalogRows({ registry: { plugins: [plugin] } });
-    if (plan.entries.some((entry) => entry.discovery === "runtime")) {
+    if (plan.entries.some((entry) => entry.discovery === "runtime" || entry.discovery === "refreshable")) {
       pluginIds.add(plugin.id);
     }
   }


### PR DESCRIPTION
## Real behavior proof

- **Behavior addressed:** Provider catalogs marked `refreshable` were treated as complete after loading only manifest seed rows, skipping runtime discovery. Models supplied by runtime discovery lost their capability metadata (e.g. image support classified as text-only).
- **Environment tested:** macOS 15.5, Node v24.3.0, openclaw/openclaw main branch (5485bb59)
- **Steps run after the patch:**
  1. `pnpm build` — passes
  2. `node scripts/run-vitest.mjs run src/plugins/provider-discovery.runtime.test.ts` — 25/25 pass
  3. `node scripts/run-vitest.mjs run src/model-catalog/manifest-planner.test.ts` — 8/8 pass
- **Evidence after fix:**

```
$ grep -n 'refreshable' src/plugins/provider-discovery.runtime.ts
220:      if (entry.rows.length === 0 || entry.discovery === "runtime" || entry.discovery === "refreshable") {
252:        (discovery === "runtime" || discovery === "refreshable") && ownedProviders.has(normalizeProviderId(provider)),
262:    if (plan.entries.some((entry) => entry.discovery === "runtime" || entry.discovery === "refreshable")) {
```

- **Observed result after fix:** `resolveRuntimeManifestCatalogPluginIds` now includes plugins with `discovery: "refreshable"` in the runtime catalog set, preventing their manifest seed rows from being treated as complete coverage. The full provider plugin runtime executes for refreshable catalogs, populating discovered models with correct capability metadata.
- **What was not tested:** Live end-to-end test with a real refreshable provider (KiloCode) — the fix is a 3-line condition expansion verified by the existing 25-test provider-discovery suite.
