### PR TITLE
refactor(whatsapp): migrate admission object callers

### DIFF
--- a/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
+++ b/extensions/whatsapp/src/auto-reply.broadcast-groups.combined.test.ts
@@ -241,10 +241,13 @@ describe("broadcast groups", () => {
           reply,
           sendMedia,
         },
-        from: "+1000",
-        conversationId: "+1000",
-        accountId: "default",
-        chatType: "direct",
+        admission: {
+          accountId: "default",
+          conversation: {
+            kind: "direct",
+            id: "+1000",
+          },
+        },
       }),
     );
 

--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -403,10 +403,19 @@ export async function sendWebGroupInboundMessage(params: {
         reply: params.spies.reply,
         sendMedia: params.spies.sendMedia,
       },
-      from: conversationId,
-      conversationId,
-      chatType: "group",
-      accountId,
+      admission: {
+        accountId,
+        conversation: {
+          kind: "group",
+          id: conversationId,
+        },
+        sender: {
+          id: params.senderE164,
+        },
+        senderAccess: {
+          reasonCode: "group_policy_allowed",
+        },
+      },
       group: params.mentionedJids?.length
         ? {
             mentions: {
@@ -431,7 +440,6 @@ export async function sendWebDirectInboundMessage(params: {
   const accountId = params.accountId ?? "default";
   await params.onMessage(
     createTestWebInboundMessage({
-      accountId,
       event: {
         id: params.id,
         timestamp: params.timestamp ?? Date.now(),
@@ -446,9 +454,16 @@ export async function sendWebDirectInboundMessage(params: {
         reply: params.spies.reply,
         sendMedia: params.spies.sendMedia,
       },
-      from: params.from,
-      conversationId: params.from,
-      chatType: "direct",
+      admission: {
+        accountId,
+        conversation: {
+          kind: "direct",
+          id: params.from,
+        },
+        sender: {
+          id: params.from,
+        },
+      },
     }),
   );
 }

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.compresses-common-formats-jpeg-cap.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.compresses-common-formats-jpeg-cap.test.ts
@@ -88,10 +88,16 @@ describe("web auto-reply", () => {
               reply,
               sendMedia,
             },
-            from,
-            conversationId,
-            accountId: overrides?.accountId ?? "default",
-            chatType: "direct",
+            admission: {
+              accountId: overrides?.accountId ?? "default",
+              conversation: {
+                kind: "direct",
+                id: conversationId,
+              },
+              sender: {
+                id: from,
+              },
+            },
           }),
         );
       },

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -1156,10 +1156,13 @@ describe("web auto-reply connection", () => {
           reply: vi.fn(),
           sendMedia: vi.fn(),
         },
-        from: "+1",
-        conversationId: "+1",
-        accountId: "default",
-        chatType: "direct",
+        admission: {
+          accountId: "default",
+          conversation: {
+            kind: "direct",
+            id: "+1",
+          },
+        },
       }),
     );
 
@@ -1213,10 +1216,13 @@ describe("web auto-reply connection", () => {
               reply,
               sendMedia,
             },
-            from: "+1000",
-            conversationId: "+1000",
-            chatType: "direct",
-            accountId: "default",
+            admission: {
+              accountId: "default",
+              conversation: {
+                kind: "direct",
+                id: "+1000",
+              },
+            },
           }),
         );
         return createMockWebListener();

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts
@@ -963,7 +963,7 @@ describe("web auto-reply connection", () => {
 
   it("normalizes legacy flat listener messages and rejects partial nested input", async () => {
     const capture = createWebListenerFactoryCapture();
-    const { reply } = createWebInboundDeliverySpies();
+    const { sendMedia, sendComposing, reply } = createWebInboundDeliverySpies();
 
     await monitorWebChannel(false, capture.listenerFactory as never, false, async () => ({
       text: "ok",
@@ -981,6 +981,26 @@ describe("web auto-reply connection", () => {
     await onMessage(msg);
 
     expect(reply).toHaveBeenCalledWith("ok", undefined);
+    await expect(
+      onMessage({
+        event: { id: "canonical-no-admission" },
+        payload: { body: "canonical" },
+        platform: {
+          chatJid: "+3",
+          recipientJid: "+4",
+          sendComposing,
+          reply,
+          sendMedia,
+        },
+        from: "+3",
+        conversationId: "+3",
+        accountId: "default",
+        chatType: "direct",
+      }),
+    ).rejects.toThrow(/missing admission facts/);
+
+    expect(reply).toHaveBeenCalledWith("ok", undefined);
+    expect(reply).toHaveBeenCalledTimes(1);
     await expect(
       onMessage({
         ...msg,

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.last-route.test.ts
@@ -90,10 +90,16 @@ function buildInboundMessage(params: {
       senderName: params.senderName,
       selfE164: params.selfE164,
     },
-    from: params.from,
-    conversationId: params.conversationId,
-    chatType: params.chatType,
-    accountId: params.accountId ?? "default",
+    admission: {
+      accountId: params.accountId ?? "default",
+      conversation: {
+        kind: params.chatType,
+        id: params.conversationId,
+      },
+      sender: {
+        id: params.senderE164 ?? params.from,
+      },
+    },
   });
 }
 
@@ -196,6 +202,7 @@ describe("web auto-reply last-route", () => {
         conversationId: "123@g.us",
         chatType: "group",
         chatId: "123@g.us",
+        body: "hello +2000",
         timestamp: now,
         accountId: "work",
         senderE164: "+1000",

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -9,7 +9,7 @@ import { sleep } from "openclaw/plugin-sdk/text-utility-runtime";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createAcceptedWhatsAppSendResult } from "../inbound/send-result.test-helper.js";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import { loadWebMedia } from "../media.js";
 import { cacheInboundMessageMeta } from "../quoted-message.js";
 import { WhatsAppSocketOperationTimeoutError } from "../socket-timing.js";
@@ -69,7 +69,7 @@ function unacceptedSendResult(kind: "media" | "text") {
   };
 }
 
-function makeMsg(): WebInboundMessage {
+function makeMsg(): AdmittedWebInboundMessage {
   return createTestWebInboundMessage({
     event: { id: "msg-1" },
     payload: { body: "latest batch body" },
@@ -80,10 +80,19 @@ function makeMsg(): WebInboundMessage {
       reply: vi.fn(async () => createAcceptedWhatsAppSendResult("text", "reply-sent-1")),
       sendMedia: vi.fn(async () => createAcceptedWhatsAppSendResult("media", "media-sent-1")),
     },
-    from: "+10000000000",
-    accountId: "work",
-    chatType: "group",
-    conversationId: "+10000000000",
+    admission: {
+      accountId: "work",
+      conversation: {
+        kind: "group",
+        id: "+10000000000",
+      },
+      sender: {
+        id: "222@s.whatsapp.net",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
   });
 }
 
@@ -97,19 +106,19 @@ function mockLoadedImageMedia() {
   });
 }
 
-function mockFirstSendMediaFailure(msg: WebInboundMessage, message: string) {
+function mockFirstSendMediaFailure(msg: AdmittedWebInboundMessage, message: string) {
   (
     msg.platform.sendMedia as unknown as { mockRejectedValueOnce: (v: unknown) => void }
   ).mockRejectedValueOnce(new Error(message));
 }
 
-function mockFirstReplyFailure(msg: WebInboundMessage, message: string) {
+function mockFirstReplyFailure(msg: AdmittedWebInboundMessage, message: string) {
   (
     msg.platform.reply as unknown as { mockRejectedValueOnce: (v: unknown) => void }
   ).mockRejectedValueOnce(new Error(message));
 }
 
-function mockFirstReplyFailureWithWrappedError(msg: WebInboundMessage, message: string) {
+function mockFirstReplyFailureWithWrappedError(msg: AdmittedWebInboundMessage, message: string) {
   (
     msg.platform.reply as unknown as { mockRejectedValueOnce: (v: unknown) => void }
   ).mockRejectedValueOnce({
@@ -117,7 +126,7 @@ function mockFirstReplyFailureWithWrappedError(msg: WebInboundMessage, message: 
   });
 }
 
-function expectFirstSendMediaPayload(msg: WebInboundMessage) {
+function expectFirstSendMediaPayload(msg: AdmittedWebInboundMessage) {
   const payload = mockCallArg(msg.platform.sendMedia, 0, 0, "sendMedia");
   if (!payload) {
     throw new Error("expected first WhatsApp sendMedia payload");
@@ -144,7 +153,7 @@ function mockCallArg(mock: unknown, callIndex: number, argIndex: number, label: 
   return call[argIndex];
 }
 
-function replyText(msg: WebInboundMessage, callIndex = 0): string {
+function replyText(msg: AdmittedWebInboundMessage, callIndex = 0): string {
   return String(mockCallArg(msg.platform.reply, callIndex, 0, "reply"));
 }
 
@@ -176,7 +185,7 @@ function expectQuotedOptions(
   expect(quoted.message).toEqual({ conversation: expected.body });
 }
 
-function mockSecondReplySuccess(msg: WebInboundMessage) {
+function mockSecondReplySuccess(msg: AdmittedWebInboundMessage) {
   (
     msg.platform.reply as unknown as { mockResolvedValueOnce: (v: unknown) => void }
   ).mockResolvedValueOnce(createAcceptedWhatsAppSendResult("text", "reply-retry-2"));
@@ -677,23 +686,27 @@ describe("deliverWebReply", () => {
     vi.clearAllMocks();
     const msg = makeMsg();
     // Two media items: first load succeeds and sends, second load succeeds but send fails.
-    (loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }).mockResolvedValueOnce({
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
       buffer: Buffer.from("img1"),
       contentType: "image/jpeg",
       kind: "image",
     });
-    (loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }).mockResolvedValueOnce({
+    (
+      loadWebMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce({
       buffer: Buffer.from("img2"),
       contentType: "image/jpeg",
       kind: "image",
     });
     // First sendMedia resolves; second sendMedia rejects.
-    (msg.platform.sendMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }).mockResolvedValueOnce(
-      createAcceptedWhatsAppSendResult("media", "media-first-ok"),
-    );
-    (msg.platform.sendMedia as unknown as { mockRejectedValueOnce: (v: unknown) => void }).mockRejectedValueOnce(
-      new Error("upload failed"),
-    );
+    (
+      msg.platform.sendMedia as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+    ).mockResolvedValueOnce(createAcceptedWhatsAppSendResult("media", "media-first-ok"));
+    (
+      msg.platform.sendMedia as unknown as { mockRejectedValueOnce: (v: unknown) => void }
+    ).mockRejectedValueOnce(new Error("upload failed"));
 
     await deliverWebReply({
       replyResult: {

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -12,9 +12,10 @@ import {
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { requireWhatsAppInboundAdmission } from "../inbound/admission.js";
 import type { WhatsAppSendResult } from "../inbound/send-result.js";
 import { listWhatsAppSendResultMessageIds } from "../inbound/send-result.js";
-import type { WebInboundMessage } from "../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import { loadWebMedia } from "../media.js";
 import {
   type DeliverableWhatsAppOutboundPayload,
@@ -87,7 +88,7 @@ function createWhatsAppReplyDeliveryReceipt(
 export async function deliverWebReply(params: {
   replyResult: ReplyPayload;
   normalizedReplyResult?: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   mediaLocalRoots?: readonly string[];
   maxMediaBytes: number;
   textLimit: number;
@@ -101,6 +102,9 @@ export async function deliverWebReply(params: {
   tableMode?: MarkdownTableMode;
 }): Promise<WhatsAppReplyDeliveryResult> {
   const { replyResult, msg, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } = params;
+  const admission = requireWhatsAppInboundAdmission(msg);
+  const conversationId = admission.conversation.id;
+  const isGroupConversation = admission.conversation.kind === "group";
   const replyStarted = Date.now();
   const sendResults: WhatsAppSendResult[] = [];
   const rememberSendResult = (result: WhatsAppSendResult | undefined) => {
@@ -117,7 +121,7 @@ export async function deliverWebReply(params: {
     };
   };
   if (isReasoningReplyPayload(replyResult)) {
-    whatsappOutboundLog.debug(`Suppressed reasoning payload to ${msg.from}`);
+    whatsappOutboundLog.debug(`Suppressed reasoning payload to ${conversationId}`);
     return finishDelivery();
   }
   const tableMode = params.tableMode ?? "code";
@@ -141,7 +145,7 @@ export async function deliverWebReply(params: {
     // per-message target.  Look up cached metadata for the specific
     // message being quoted — msg.payload.body may be a combined batch body.
     const cached = lookupInboundMessageMeta(
-      msg.accountId,
+      admission.accountId,
       msg.platform.chatJid,
       replyResult.replyToId,
     );
@@ -150,7 +154,7 @@ export async function deliverWebReply(params: {
       remoteJid: msg.platform.chatJid,
       fromMe: cached?.fromMe ?? false,
       participant:
-        cached?.participant ?? (msg.chatType === "group" ? msg.platform.senderJid : undefined),
+        cached?.participant ?? (isGroupConversation ? msg.platform.senderJid : undefined),
       messageText: cached?.body ?? "",
     });
   };
@@ -162,7 +166,7 @@ export async function deliverWebReply(params: {
         maxAttempts,
         onRetry: ({ attempt, maxAttempts: retryMaxAttempts, backoffMs, errorText }) => {
           logVerbose(
-            `Retrying ${label} to ${msg.from} after failure (${attempt}/${retryMaxAttempts - 1}) in ${backoffMs}ms: ${errorText}`,
+            `Retrying ${label} to ${conversationId} after failure (${attempt}/${retryMaxAttempts - 1}) in ${backoffMs}ms: ${errorText}`,
           );
         },
       });
@@ -184,7 +188,7 @@ export async function deliverWebReply(params: {
       if (!skipLog) {
         const durationMs = Date.now() - chunkStarted;
         whatsappOutboundLog.debug(
-          `Sent chunk ${index + 1}/${totalChunks} to ${msg.from} (${durationMs.toFixed(0)}ms)`,
+          `Sent chunk ${index + 1}/${totalChunks} to ${conversationId} (${durationMs.toFixed(0)}ms)`,
         );
       }
     }
@@ -192,7 +196,7 @@ export async function deliverWebReply(params: {
     const logPayload = {
       correlationId: msg.event.id ?? newConnectionId(),
       connectionId: connectionId ?? null,
-      to: msg.from,
+      to: conversationId,
       from: msg.platform.recipientJid,
       text: elide(replyResult.text, 240),
       mediaUrl: null,
@@ -301,13 +305,13 @@ export async function deliverWebReply(params: {
         );
       }
       whatsappOutboundLog.info(
-        `Sent media reply to ${msg.from} (${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB)`,
+        `Sent media reply to ${conversationId} (${(media.buffer.length / (1024 * 1024)).toFixed(2)}MB)`,
       );
       replyLogger.info(
         {
           correlationId: msg.event.id ?? newConnectionId(),
           connectionId: connectionId ?? null,
-          to: msg.from,
+          to: conversationId,
           from: msg.platform.recipientJid,
           text: caption ?? null,
           mediaUrl,
@@ -319,12 +323,14 @@ export async function deliverWebReply(params: {
       );
     },
     onError: async ({ error, mediaUrl, caption, isFirst }) => {
-      whatsappOutboundLog.error(`Failed sending web media to ${msg.from}: ${formatError(error)}`);
+      whatsappOutboundLog.error(
+        `Failed sending web media to ${conversationId}: ${formatError(error)}`,
+      );
       replyLogger.warn({ err: error, mediaUrl }, "failed to send web media reply");
       if (!isFirst) {
         // Non-first media failures were silently dropped before. Notify the user
         // so they know a trailing attachment did not arrive.
-        whatsappOutboundLog.warn(`Trailing media failed; sent warning to ${msg.from}`);
+        whatsappOutboundLog.warn(`Trailing media failed; sent warning to ${conversationId}`);
         rememberSendResult(
           await sendWithRetry(
             () => msg.platform.reply("⚠️ Media unavailable.", getQuote()),
@@ -339,7 +345,7 @@ export async function deliverWebReply(params: {
       if (!fallbackText) {
         return;
       }
-      whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
+      whatsappOutboundLog.warn(`Media skipped; sent text-only to ${conversationId}`);
       rememberSendResult(
         await sendWithRetry(
           () => msg.platform.reply(fallbackText, getQuote()),

--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -11,8 +11,8 @@ import {
   identitiesOverlap,
   type WhatsAppIdentity,
 } from "../identity.js";
-import type { WebInboundMessage } from "../inbound/types.js";
-import { isWhatsAppGroupJid } from "../normalize-target.js";
+import { requireWhatsAppInboundAdmission } from "../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import { isSelfChatMode, normalizeE164 } from "../text-runtime.js";
 
 export type MentionConfig = {
@@ -35,14 +35,17 @@ export function buildMentionConfig(
   return { mentionRegexes, allowFrom: cfg.channels?.whatsapp?.allowFrom };
 }
 
-export function resolveMentionTargets(msg: WebInboundMessage, authDir?: string): MentionTargets {
+export function resolveMentionTargets(
+  msg: AdmittedWebInboundMessage,
+  authDir?: string,
+): MentionTargets {
   const normalizedMentions = getMentionIdentities(msg, authDir);
   const self = getSelfIdentity(msg, authDir);
   return { normalizedMentions, self };
 }
 
 export function isBotMentionedFromTargets(
-  msg: WebInboundMessage,
+  msg: AdmittedWebInboundMessage,
   mentionCfg: MentionConfig,
   targets: MentionTargets,
 ): boolean {
@@ -61,7 +64,8 @@ export function isBotMentionedFromTargets(
   // and let real group @mentions go through the identity-overlap check
   // (#49317). Explicit `mentionCfg.isSelfChat` overrides from the caller
   // are honored as-is so multi-account / precomputed paths keep working.
-  const isGroupConversation = isWhatsAppGroupJid(msg.from);
+  const admission = requireWhatsAppInboundAdmission(msg);
+  const isGroupConversation = admission.conversation.kind === "group";
   const isSelfChat = explicitSelfChatOverride
     ? Boolean(mentionCfg.isSelfChat)
     : isSelfChatMode(targets.self.e164, mentionCfg.allowFrom) && !isGroupConversation;
@@ -103,14 +107,15 @@ export function isBotMentionedFromTargets(
 }
 
 export function debugMention(
-  msg: WebInboundMessage,
+  msg: AdmittedWebInboundMessage,
   mentionCfg: MentionConfig,
   authDir?: string,
 ): { wasMentioned: boolean; details: Record<string, unknown> } {
   const mentionTargets = resolveMentionTargets(msg, authDir);
   const result = isBotMentionedFromTargets(msg, mentionCfg, mentionTargets);
+  const admission = requireWhatsAppInboundAdmission(msg);
   const details = {
-    from: msg.from,
+    from: admission.conversation.id,
     body: msg.payload.body,
     bodyClean: normalizeMentionText(msg.payload.body),
     mentionedJids: msg.group?.mentions?.jids ?? null,

--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.test.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { maybeSendAckReaction } from "./ack-reaction.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -13,16 +13,25 @@ vi.mock("../../send.js", () => ({
   sendReactionWhatsApp: hoisted.sendReactionWhatsApp,
 }));
 
-function createMessage(overrides: Partial<WebInboundMessage> = {}): WebInboundMessage {
+type TestMsgOverrides = NonNullable<Parameters<typeof createTestWebInboundMessage>[0]>;
+
+function createMessage(overrides: TestMsgOverrides = {}): AdmittedWebInboundMessage {
   return createTestWebInboundMessage({
     event: { id: "msg-1" },
     platform: {
       chatJid: "15551234567@s.whatsapp.net",
       recipientJid: "15559876543",
     },
-    from: "15551234567",
-    conversationId: "15551234567",
-    accountId: "default",
+    admission: {
+      accountId: "default",
+      conversation: {
+        kind: "direct",
+        id: "15551234567",
+      },
+      sender: {
+        id: "15551234567",
+      },
+    },
     ...overrides,
   });
 }
@@ -54,9 +63,7 @@ const runAckReaction = (overrides: Partial<AckReactionParams> = {}) =>
     msg: createMessage(),
     agentId: "agent",
     sessionKey: "whatsapp:default:15551234567",
-    conversationId: "15551234567",
     verbose: false,
-    accountId: "default",
     info: vi.fn(),
     warn: vi.fn(),
     ...overrides,
@@ -115,10 +122,11 @@ describe("maybeSendAckReaction", () => {
     const ackReaction = await runAckReaction({
       cfg,
       msg: createMessage({
-        accountId: "work",
+        admission: {
+          accountId: "work",
+        },
       }),
       sessionKey: "whatsapp:work:15551234567",
-      accountId: "work",
     });
 
     expect(ackReaction?.ackReactionValue).toBe("👀");

--- a/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/ack-reaction.ts
@@ -7,7 +7,8 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getSenderIdentity } from "../../identity.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { resolveWhatsAppReactionLevel } from "../../reaction-level.js";
 import { sendReactionWhatsApp } from "../../send.js";
 import { formatError } from "../../session.js";
@@ -16,12 +17,10 @@ import { resolveGroupActivationFor } from "./group-activation.js";
 
 export async function maybeSendAckReaction(params: {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   agentId: string;
   sessionKey: string;
-  conversationId: string;
   verbose: boolean;
-  accountId?: string;
   info: (obj: unknown, msg: string) => void;
   warn: (obj: unknown, msg: string) => void;
 }): Promise<AckReactionHandle | null> {
@@ -29,11 +28,13 @@ export async function maybeSendAckReaction(params: {
     return null;
   }
 
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const accountId = admission.accountId;
   // Keep ackReaction as the emoji/scope control, while letting reactionLevel
   // suppress all automatic reactions when it is explicitly set to "off".
   const reactionLevel = resolveWhatsAppReactionLevel({
     cfg: params.cfg,
-    accountId: params.accountId,
+    accountId,
   });
   if (reactionLevel.level === "off") {
     return null;
@@ -47,23 +48,23 @@ export async function maybeSendAckReaction(params: {
   });
   const directEnabled = ackConfig?.direct ?? true;
   const groupMode = ackConfig?.group ?? "mentions";
-  const conversationIdForCheck = params.msg.conversationId ?? params.msg.from;
+  const isGroup = admission.conversation.kind === "group";
+  const conversationIdForCheck = admission.conversation.id;
 
-  const activation =
-    params.msg.chatType === "group"
-      ? await resolveGroupActivationFor({
-          cfg: params.cfg,
-          accountId: params.accountId,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-          conversationId: conversationIdForCheck,
-        })
-      : null;
+  const activation = isGroup
+    ? await resolveGroupActivationFor({
+        cfg: params.cfg,
+        accountId,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        conversationId: conversationIdForCheck,
+      })
+    : null;
   const shouldSendReaction = () =>
     shouldAckReactionForWhatsApp({
       emoji,
-      isDirect: params.msg.chatType === "direct",
-      isGroup: params.msg.chatType === "group",
+      isDirect: admission.conversation.kind === "direct",
+      isGroup,
       directEnabled,
       groupMode,
       wasMentioned: params.msg.wasMentioned === true,
@@ -83,7 +84,7 @@ export async function maybeSendAckReaction(params: {
     verbose: params.verbose,
     fromMe: false,
     ...(sender.jid ? { participant: sender.jid } : {}),
-    ...(params.accountId ? { accountId: params.accountId } : {}),
+    accountId,
     cfg: params.cfg,
   };
   return createAckReactionHandle({

--- a/extensions/whatsapp/src/auto-reply/monitor/broadcast.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/broadcast.ts
@@ -9,24 +9,26 @@ import {
   normalizeAgentId,
 } from "openclaw/plugin-sdk/routing";
 import { resolveWhatsAppGroupSessionRoute } from "../../group-session-key.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { formatError } from "../../session.js";
 import { whatsappInboundLog } from "../loggers.js";
 import type { GroupHistoryEntry } from "./inbound-context.js";
 
 function buildBroadcastRouteKeys(params: {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   route: ReturnType<typeof resolveAgentRoute>;
   peerId: string;
   agentId: string;
 }) {
+  const admission = requireWhatsAppInboundAdmission(params.msg);
   const sessionKey = buildAgentSessionKey({
     agentId: params.agentId,
     channel: "whatsapp",
     accountId: params.route.accountId,
     peer: {
-      kind: params.msg.chatType === "group" ? "group" : "direct",
+      kind: admission.conversation.kind,
       id: params.peerId,
     },
     dmScope: params.cfg.session?.dmScope,
@@ -49,13 +51,13 @@ function buildBroadcastRouteKeys(params: {
 
 export async function maybeBroadcastMessage(params: {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   peerId: string;
   route: ReturnType<typeof resolveAgentRoute>;
   groupHistoryKey: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
   processMessage: (
-    msg: WebInboundMessage,
+    msg: AdmittedWebInboundMessage,
     route: ReturnType<typeof resolveAgentRoute>,
     groupHistoryKey: string,
     opts?: {
@@ -83,10 +85,11 @@ export async function maybeBroadcastMessage(params: {
 
   const agentIds = params.cfg.agents?.list?.map((agent) => normalizeAgentId(agent.id));
   const hasKnownAgents = (agentIds?.length ?? 0) > 0;
-  const groupHistorySnapshot =
-    params.msg.chatType === "group"
-      ? (params.groupHistories.get(params.groupHistoryKey) ?? [])
-      : undefined;
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const isGroupConversation = admission.conversation.kind === "group";
+  const groupHistorySnapshot = isGroupConversation
+    ? (params.groupHistories.get(params.groupHistoryKey) ?? [])
+    : undefined;
 
   const processForAgent = async (agentId: string): Promise<boolean> => {
     const normalizedAgentId = normalizeAgentId(agentId);
@@ -106,10 +109,9 @@ export async function maybeBroadcastMessage(params: {
       agentId: normalizedAgentId,
       ...routeKeys,
     };
-    const agentRoute =
-      params.msg.chatType === "group"
-        ? resolveWhatsAppGroupSessionRoute(baseAgentRoute)
-        : baseAgentRoute;
+    const agentRoute = isGroupConversation
+      ? resolveWhatsAppGroupSessionRoute(baseAgentRoute)
+      : baseAgentRoute;
 
     try {
       const opts: {
@@ -146,7 +148,7 @@ export async function maybeBroadcastMessage(params: {
     await Promise.allSettled(broadcastAgents.map(processForAgent));
   }
 
-  if (params.msg.chatType === "group") {
+  if (isGroupConversation) {
     params.groupHistories.set(params.groupHistoryKey, []);
   }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.allowlist-warn.test.ts
@@ -6,7 +6,7 @@ vi.mock("./group-activation.js", () => ({
 }));
 
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import type { MentionConfig } from "../mentions.js";
 import {
   resetGroupDropWarningsForTests,
@@ -17,7 +17,7 @@ import {
 function makeUnregisteredGroupMsg(
   conversationId: string,
   accountId = "default",
-): WebInboundMessage {
+): AdmittedWebInboundMessage {
   return createTestWebInboundMessage({
     event: {
       id: `msg-${conversationId}`,
@@ -31,10 +31,19 @@ function makeUnregisteredGroupMsg(
       recipientJid: "+15550000001",
       sender: { e164: "+15550000002", name: "Alice" },
     },
-    from: conversationId,
-    chatType: "group",
-    conversationId,
-    accountId,
+    admission: {
+      accountId,
+      conversation: {
+        kind: "group",
+        id: conversationId,
+      },
+      sender: {
+        id: "+15550000002",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
   });
 }
 
@@ -42,7 +51,7 @@ type WarnLogger = (obj: unknown, msg: string) => void;
 type ApplyGroupGatingParams = Parameters<typeof applyGroupGating>[0];
 
 function makeParams(
-  msg: WebInboundMessage,
+  msg: AdmittedWebInboundMessage,
   warn: WarnLogger,
   cfg: ApplyGroupGatingParams["cfg"] = {
     channels: {
@@ -68,13 +77,16 @@ function makeParams(
     },
   } as never,
 ) {
+  const admission = msg.admission;
+  if (!admission) {
+    throw new Error("Expected admitted WhatsApp test message");
+  }
   return {
     cfg,
     msg,
-    conversationId: msg.conversationId,
-    groupHistoryKey: `whatsapp:group:${msg.conversationId}`,
+    groupHistoryKey: `whatsapp:group:${admission.conversation.id}`,
     agentId: "main",
-    sessionKey: `agent:main:whatsapp:group:${msg.conversationId}`,
+    sessionKey: `agent:main:whatsapp:group:${admission.conversation.id}`,
     baseMentionConfig: { mentionRegexes: [/\bopenclaw\b/i] } satisfies MentionConfig,
     groupHistories: new Map<string, GroupHistoryEntry[]>(),
     groupHistoryLimit: 20,

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.audio-preflight.test.ts
@@ -6,24 +6,36 @@ vi.mock("./group-activation.js", () => ({
 }));
 
 import { createTestWebAudioInboundMessage } from "../../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import type { MentionConfig } from "../mentions.js";
 import { applyGroupGating, type GroupHistoryEntry } from "./group-gating.js";
 
-function makeGroupAudioMsg(): WebInboundMessage {
+function makeGroupAudioMsg(): AdmittedWebInboundMessage {
   return createTestWebAudioInboundMessage({
     platform: {
       chatJid: "1203630@g.us",
       sender: { e164: "+15550000002", name: "Alice" },
     },
-    from: "1203630@g.us",
-    conversationId: "1203630@g.us",
-    chatType: "group",
+    admission: {
+      conversation: {
+        kind: "group",
+        id: "1203630@g.us",
+      },
+      sender: {
+        id: "+15550000002",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
     wasMentioned: false,
   });
 }
 
-function makeParams(msg: WebInboundMessage, groupHistories: Map<string, GroupHistoryEntry[]>) {
+function makeParams(
+  msg: AdmittedWebInboundMessage,
+  groupHistories: Map<string, GroupHistoryEntry[]>,
+) {
   return {
     cfg: {
       channels: {
@@ -38,7 +50,6 @@ function makeParams(msg: WebInboundMessage, groupHistories: Map<string, GroupHis
       },
     } as never,
     msg,
-    conversationId: "1203630@g.us",
     groupHistoryKey: "whatsapp:group:1203630",
     agentId: "main",
     sessionKey: "agent:main:whatsapp:group:1203630",

--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -10,7 +10,8 @@ import {
   identitiesOverlap,
 } from "../../identity.js";
 import { resolveWhatsAppInboundPolicy } from "../../inbound-policy.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import type { MentionConfig } from "../mentions.js";
 import { buildMentionConfig, debugMention, resolveOwnerList } from "../mentions.js";
 import { stripMentionsForCommand } from "./commands.js";
@@ -35,10 +36,9 @@ export type GroupHistoryEntry = {
 
 type ApplyGroupGatingParams = {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   mentionText?: string;
   deferMissingMention?: boolean;
-  conversationId: string;
   groupHistoryKey: string;
   agentId: string;
   sessionKey: string;
@@ -78,7 +78,7 @@ function shouldWarnForGroupDrop(warnKey: string): boolean {
   return true;
 }
 
-function isOwnerSender(baseMentionConfig: MentionConfig, msg: WebInboundMessage) {
+function isOwnerSender(baseMentionConfig: MentionConfig, msg: AdmittedWebInboundMessage) {
   const sender = normalizeE164(getSenderIdentity(msg).e164 ?? "");
   if (!sender) {
     return false;
@@ -88,7 +88,7 @@ function isOwnerSender(baseMentionConfig: MentionConfig, msg: WebInboundMessage)
 }
 
 function recordPendingGroupHistoryEntry(params: {
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   body?: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
   groupHistoryKey: string;
@@ -134,26 +134,26 @@ function skipGroupMessageAndStoreHistory(
 export async function applyGroupGating(params: ApplyGroupGatingParams) {
   const sender = getSenderIdentity(params.msg);
   const self = getSelfIdentity(params.msg, params.authDir);
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const conversationId = admission.conversation.id;
   const inboundPolicy = resolveWhatsAppInboundPolicy({
     cfg: params.cfg,
-    accountId: params.msg.accountId,
+    accountId: admission.accountId,
     selfE164: self.e164 ?? null,
   });
-  const conversationGroupPolicy = inboundPolicy.resolveConversationGroupPolicy(
-    params.conversationId,
-  );
+  const conversationGroupPolicy = inboundPolicy.resolveConversationGroupPolicy(conversationId);
   if (conversationGroupPolicy.allowlistEnabled && !conversationGroupPolicy.allowed) {
     const accountId = inboundPolicy.account.accountId;
-    const warnKey = `${accountId}:${params.conversationId}`;
+    const warnKey = `${accountId}:${conversationId}`;
     if (shouldWarnForGroupDrop(warnKey)) {
       const groupsPath = resolveWhatsAppGroupsConfigPath({ cfg: params.cfg, accountId });
       params.replyLogger.warn(
-        { conversationId: params.conversationId, accountId, groupsPath },
-        `WhatsApp group ${params.conversationId} not in ${groupsPath} — inbound dropped. Add the group JID to ${groupsPath} (or add "*" there to admit all groups). Sender authorization still applies.`,
+        { conversationId, accountId, groupsPath },
+        `WhatsApp group ${conversationId} not in ${groupsPath} — inbound dropped. Add the group JID to ${groupsPath} (or add "*" there to admit all groups). Sender authorization still applies.`,
       );
     }
     params.logVerbose(
-      `Dropping message from unregistered WhatsApp group ${params.conversationId}. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.`,
+      `Dropping message from unregistered WhatsApp group ${conversationId}. Add the group JID to channels.whatsapp.groups, or add "*" there to admit all groups. Sender authorization still applies.`,
     );
     return { shouldProcess: false };
   }
@@ -172,12 +172,12 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
   const mentionConfig = {
     ...buildMentionConfig(params.cfg, params.agentId, {
       provider: "whatsapp",
-      conversationId: params.conversationId,
+      conversationId,
       providerPolicy: params.providerMentionPatterns,
     }),
     allowFrom: inboundPolicy.configuredAllowFrom,
   };
-  const mentionMsg =
+  const mentionMsg: AdmittedWebInboundMessage =
     params.mentionText !== undefined
       ? { ...params.msg, payload: { ...params.msg.payload, body: params.mentionText } }
       : params.msg;
@@ -193,14 +193,14 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
   if (activationCommand.hasCommand && !owner) {
     return skipGroupMessageAndStoreHistory(
       params,
-      `Ignoring /activation from non-owner in group ${params.conversationId}`,
+      `Ignoring /activation from non-owner in group ${conversationId}`,
     );
   }
 
   const mentionDebug = debugMention(mentionMsg, mentionConfig, params.authDir);
   params.replyLogger.debug(
     {
-      conversationId: params.conversationId,
+      conversationId,
       wasMentioned: mentionDebug.wasMentioned,
       ...mentionDebug.details,
     },
@@ -212,7 +212,7 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
     accountId: inboundPolicy.account.accountId,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
-    conversationId: params.conversationId,
+    conversationId,
   });
   const requireMention = activation !== "always";
   const replyContext = getReplyContext(params.msg, params.authDir);
@@ -247,13 +247,13 @@ export async function applyGroupGating(params: ApplyGroupGatingParams) {
   if (!shouldBypassMention && requireMention && mentionDecision.shouldSkip) {
     if (params.deferMissingMention === true) {
       params.logVerbose(
-        `Deferring group mention skip until audio preflight completes in ${params.conversationId}`,
+        `Deferring group mention skip until audio preflight completes in ${conversationId}`,
       );
       return { shouldProcess: false, needsMentionText: true } as const;
     }
     return skipGroupMessageAndStoreHistory(
       params,
-      `Group message stored for context (no mention detected) in ${params.conversationId}: ${mentionMsg.payload.body}`,
+      `Group message stored for context (no mention detected) in ${conversationId}: ${mentionMsg.payload.body}`,
       params.mentionText,
     );
   }

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-context.test.ts
@@ -20,10 +20,19 @@ const makeBlockedQuotedReplyMessage = (id: string): ReplyContextParams["msg"] =>
       senderE164: "+111",
       selfE164: "+999",
     },
-    from: "123@g.us",
-    conversationId: "123@g.us",
-    accountId: "default",
-    chatType: "group",
+    admission: {
+      accountId: "default",
+      conversation: {
+        kind: "group",
+        id: "123@g.us",
+      },
+      sender: {
+        id: "111@s.whatsapp.net",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
     quote: {
       id: "blocked-reply",
       body: "Blocked quoted text",

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-context.ts
@@ -8,7 +8,8 @@ import {
   type WhatsAppIdentity,
   type WhatsAppReplyContext,
 } from "../../identity.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { normalizeE164 } from "../../text-runtime.js";
 
 export type GroupHistoryEntry = {
@@ -72,7 +73,7 @@ export function resolveVisibleWhatsAppGroupHistory(params: {
 }
 
 export function resolveVisibleWhatsAppReplyContext(params: {
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   authDir?: string;
   mode: ContextVisibilityMode;
   groupPolicy: "open" | "allowlist" | "disabled";
@@ -82,8 +83,9 @@ export function resolveVisibleWhatsAppReplyContext(params: {
   if (!replyTo) {
     return null;
   }
+  const admission = requireWhatsAppInboundAdmission(params.msg);
   const senderAllowed =
-    params.msg.chatType !== "group" || params.groupPolicy !== "allowlist"
+    admission.conversation.kind !== "group" || params.groupPolicy !== "allowlist"
       ? true
       : isWhatsAppSupplementalSenderAllowed({
           allowFrom: params.groupAllowFrom,

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -129,7 +129,8 @@ import {
 
 type TestRoute = Parameters<typeof buildWhatsAppInboundContext>[0]["route"];
 type TestMsg = Parameters<typeof buildWhatsAppInboundContext>[0]["msg"];
-type TestMsgOverrides = Parameters<typeof createTestWebInboundMessage>[0];
+type TestMsgOverrides = NonNullable<Parameters<typeof createTestWebInboundMessage>[0]>;
+type TestAdmissionOverride = NonNullable<TestMsgOverrides["admission"]>;
 
 function testReceipt(messageIds: string[]) {
   return {
@@ -158,7 +159,7 @@ function makeRoute(overrides: Partial<TestRoute> = {}): TestRoute {
 }
 
 function makeMsg(overrides: TestMsgOverrides = {}): TestMsg {
-  const { event, payload, platform, ...messageOverrides } = overrides;
+  const { admission, event, payload, platform, ...messageOverrides } = overrides;
   return createTestWebInboundMessage({
     event: {
       id: "msg1",
@@ -173,12 +174,40 @@ function makeMsg(overrides: TestMsgOverrides = {}): TestMsg {
       recipientJid: "+2000",
       ...platform,
     },
-    from: "+1000",
-    conversationId: "+1000",
-    accountId: "default",
-    chatType: "direct",
+    admission: {
+      accountId: "default",
+      conversation: {
+        kind: "direct",
+        id: "+1000",
+      },
+      ...admission,
+    },
     ...messageOverrides,
   });
+}
+
+function directAdmission(conversationId: string): TestAdmissionOverride {
+  return {
+    conversation: {
+      kind: "direct",
+      id: conversationId,
+    },
+    sender: {
+      id: conversationId,
+    },
+  };
+}
+
+function groupAdmission(conversationId: string): TestAdmissionOverride {
+  return {
+    conversation: {
+      kind: "group",
+      id: conversationId,
+    },
+    senderAccess: {
+      reasonCode: "group_policy_allowed",
+    },
+  };
 }
 
 function getCapturedDeliver() {
@@ -285,7 +314,6 @@ async function dispatchBufferedReply(overrides: Partial<BufferedReplyParams> = {
     cfg: { channels: { whatsapp: { blockStreaming: true } } } as never,
     connectionId: "conn",
     context: { Body: "hi" },
-    conversationId: "+1000",
     deliverReply: async () => acceptedDeliveryResult(),
     groupHistories: new Map(),
     groupHistoryKey: "+1000",
@@ -316,12 +344,10 @@ describe("whatsapp inbound dispatch", () => {
   it("builds a finalized inbound context payload", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "Alice: hi",
-      conversationId: "123@g.us",
       groupHistory: [],
       groupMemberRoster: new Map(),
       msg: makeMsg({
-        from: "123@g.us",
-        chatType: "group",
+        admission: groupAdmission("123@g.us"),
         event: { timestamp: 1737158400000 },
         platform: {
           senderName: "Alice",
@@ -359,7 +385,6 @@ describe("whatsapp inbound dispatch", () => {
       bodyForAgent: "spoken transcript",
       combinedBody: "spoken transcript",
       commandBody: "<media:audio>",
-      conversationId: "+1000",
       msg: makeMsg({
         payload: {
           body: "<media:audio>",
@@ -390,7 +415,6 @@ describe("whatsapp inbound dispatch", () => {
   it("preserves remote-only inbound media URLs", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "<image>",
-      conversationId: "+1000",
       msg: makeMsg({
         payload: {
           body: "<image>",
@@ -424,7 +448,6 @@ describe("whatsapp inbound dispatch", () => {
         authorized: true,
         body: "/status",
       },
-      conversationId: "+1000",
       msg: makeMsg({
         payload: { body: "/status" },
       }),
@@ -459,7 +482,6 @@ describe("whatsapp inbound dispatch", () => {
   it("falls back SenderId to SenderE164 when sender id is missing", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "hi",
-      conversationId: "+1000",
       msg: makeMsg({
         platform: {
           senderJid: "",
@@ -480,11 +502,9 @@ describe("whatsapp inbound dispatch", () => {
   it("passes groupSystemPrompt into GroupSystemPrompt for group chats", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "hi",
-      conversationId: "123@g.us",
       groupSystemPrompt: "Specific group prompt",
       msg: makeMsg({
-        from: "123@g.us",
-        chatType: "group",
+        admission: groupAdmission("123@g.us"),
         group: { participants: [] },
       }),
       route: makeRoute({ sessionKey: "agent:main:whatsapp:group:123@g.us" }),
@@ -497,9 +517,8 @@ describe("whatsapp inbound dispatch", () => {
   it("passes groupSystemPrompt into GroupSystemPrompt for direct chats", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "hi",
-      conversationId: "+1555",
       groupSystemPrompt: "Specific direct prompt",
-      msg: makeMsg({ from: "+1555", chatType: "direct" }),
+      msg: makeMsg({ admission: directAdmission("+1555") }),
       route: makeRoute({ sessionKey: "agent:main:whatsapp:direct:+1555" }),
       sender: { e164: "+1555" },
     });
@@ -510,10 +529,8 @@ describe("whatsapp inbound dispatch", () => {
   it("omits GroupSystemPrompt when groupSystemPrompt is not provided", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "hi",
-      conversationId: "123@g.us",
       msg: makeMsg({
-        from: "123@g.us",
-        chatType: "group",
+        admission: groupAdmission("123@g.us"),
         group: { participants: [] },
       }),
       route: makeRoute({ sessionKey: "agent:main:whatsapp:group:123@g.us" }),
@@ -526,7 +543,6 @@ describe("whatsapp inbound dispatch", () => {
   it("preserves reply threading policy in the inbound context", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "hi",
-      conversationId: "+1000",
       msg: makeMsg(),
       route: makeRoute(),
       sender: {
@@ -541,7 +557,6 @@ describe("whatsapp inbound dispatch", () => {
   it("passes WhatsApp structured objects into untrusted structured context", async () => {
     const ctx = await buildWhatsAppInboundContext({
       combinedBody: "<contact>",
-      conversationId: "+1000",
       msg: makeMsg({
         payload: {
           body: "<contact>",
@@ -609,12 +624,10 @@ describe("whatsapp inbound dispatch", () => {
 
     await dispatchBufferedReply({
       context: { Body: "second" },
-      conversationId: "123@g.us",
       groupHistories,
       groupHistoryKey: "whatsapp:default:group:123@g.us",
       msg: makeMsg({
-        from: "123@g.us",
-        chatType: "group",
+        admission: groupAdmission("123@g.us"),
         platform: { senderE164: "+222" },
       }),
       route: makeRoute({ sessionKey: "agent:main:whatsapp:group:123@g.us" }),
@@ -1052,7 +1065,7 @@ describe("whatsapp inbound dispatch", () => {
   it("leaves WhatsApp direct reply mode unset by default", async () => {
     await dispatchBufferedReply({
       context: { Body: "hi", ChatType: "direct" },
-      msg: makeMsg({ from: "+15550001000", chatType: "direct" }),
+      msg: makeMsg({ admission: directAdmission("+15550001000") }),
     });
 
     expect(getCapturedReplyOptions()?.disableBlockStreaming).toBe(false);
@@ -1062,7 +1075,7 @@ describe("whatsapp inbound dispatch", () => {
   it("defaults WhatsApp group replies to message-tool-only and disables source streaming", async () => {
     await dispatchBufferedReply({
       context: { Body: "hi", ChatType: "group" },
-      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group" }),
+      msg: makeMsg({ admission: groupAdmission("120363000000000000@g.us") }),
     });
 
     expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
@@ -1085,8 +1098,7 @@ describe("whatsapp inbound dispatch", () => {
       },
       msg: makeMsg({
         payload: { body: "/status" },
-        from: "120363000000000000@g.us",
-        chatType: "group",
+        admission: groupAdmission("120363000000000000@g.us"),
       }),
     });
 
@@ -1104,7 +1116,7 @@ describe("whatsapp inbound dispatch", () => {
         messages: { groupChat: { visibleReplies: "automatic" } },
       } as never,
       context: { Body: "hi", ChatType: "group" },
-      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group" }),
+      msg: makeMsg({ admission: groupAdmission("120363000000000000@g.us") }),
     });
 
     expectRecordFields(requireRecord(getCapturedReplyOptions(), "reply options"), {
@@ -1117,7 +1129,10 @@ describe("whatsapp inbound dispatch", () => {
   it("suppresses typing for message-tool-only group chat without mention", async () => {
     await dispatchBufferedReply({
       context: { Body: "hi", ChatType: "group" },
-      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group", wasMentioned: false }),
+      msg: makeMsg({
+        admission: groupAdmission("120363000000000000@g.us"),
+        wasMentioned: false,
+      }),
     });
 
     expect(getCapturedReplyOptions()?.suppressTyping).toBe(true);
@@ -1126,7 +1141,10 @@ describe("whatsapp inbound dispatch", () => {
   it("does not suppress typing for group chat when mentioned", async () => {
     await dispatchBufferedReply({
       context: { Body: "@bot hi", ChatType: "group" },
-      msg: makeMsg({ from: "120363000000000000@g.us", chatType: "group", wasMentioned: true }),
+      msg: makeMsg({
+        admission: groupAdmission("120363000000000000@g.us"),
+        wasMentioned: true,
+      }),
     });
 
     expect(getCapturedReplyOptions()?.suppressTyping).toBe(false);
@@ -1135,7 +1153,7 @@ describe("whatsapp inbound dispatch", () => {
   it("does not suppress typing for direct chat", async () => {
     await dispatchBufferedReply({
       context: { Body: "hi", ChatType: "direct" },
-      msg: makeMsg({ from: "+15550001000", chatType: "direct" }),
+      msg: makeMsg({ admission: directAdmission("+15550001000") }),
     });
 
     expect(getCapturedReplyOptions()?.suppressTyping).toBe(false);
@@ -1244,7 +1262,6 @@ describe("whatsapp inbound dispatch", () => {
         cfg: { channels: { whatsapp: { blockStreaming: true } } } as never,
         connectionId: "conn",
         context: { Body: "hi" },
-        conversationId: "+1000",
         deliverReply,
         groupHistories: new Map(),
         groupHistoryKey: "+1000",
@@ -1299,10 +1316,9 @@ describe("whatsapp inbound dispatch", () => {
 
     await dispatchBufferedReply({
       connectionId: "conn-1",
-      conversationId: "+15550001000",
       msg: makeMsg({
+        admission: directAdmission("+15550001000"),
         event: { id: "msg-1" },
-        from: "+15550001000",
         platform: {
           recipientJid: "+15550002000",
           chatJid: "15550001000@s.whatsapp.net",
@@ -1350,10 +1366,9 @@ describe("whatsapp inbound dispatch", () => {
 
     await dispatchBufferedReply({
       connectionId: "conn-boom",
-      conversationId: "+15550020000",
       msg: makeMsg({
+        admission: directAdmission("+15550020000"),
         event: { id: "msg-boom" },
-        from: "+15550020000",
         platform: {
           recipientJid: "+15550021000",
           chatJid: "15550020000@s.whatsapp.net",
@@ -1390,10 +1405,9 @@ describe("whatsapp inbound dispatch", () => {
 
     await dispatchBufferedReply({
       connectionId: "conn-2",
-      conversationId: "+15550003000",
       msg: makeMsg({
+        admission: directAdmission("+15550003000"),
         event: { id: "msg-2" },
-        from: "+15550003000",
         platform: {
           recipientJid: "+15550004000",
           chatJid: "15550003000@s.whatsapp.net",
@@ -1424,10 +1438,9 @@ describe("whatsapp inbound dispatch", () => {
 
     await dispatchBufferedReply({
       connectionId: "conn-3",
-      conversationId: "+15550005000",
       msg: makeMsg({
+        admission: directAdmission("+15550005000"),
         event: { id: "msg-3" },
-        from: "+15550005000",
         platform: {
           recipientJid: "+15550006000",
           chatJid: "15550005000@s.whatsapp.net",
@@ -1533,7 +1546,7 @@ describe("whatsapp inbound dispatch", () => {
   it("resolves DM route targets from the sender first and the chat JID second", async () => {
     expect(
       resolveWhatsAppDmRouteTarget({
-        msg: makeMsg({ from: "15550003333@s.whatsapp.net" }),
+        msg: makeMsg({ admission: directAdmission("15550003333@s.whatsapp.net") }),
         senderE164: "+15550002222",
         normalizeE164: (value) => value,
       }),
@@ -1541,7 +1554,7 @@ describe("whatsapp inbound dispatch", () => {
 
     expect(
       resolveWhatsAppDmRouteTarget({
-        msg: makeMsg({ from: "15550003333@s.whatsapp.net" }),
+        msg: makeMsg({ admission: directAdmission("15550003333@s.whatsapp.net") }),
         normalizeE164: () => null,
       }),
     ).toBe("+15550003333");

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -13,7 +13,8 @@ import { deliverInboundReplyWithMessageSendContext } from "openclaw/plugin-sdk/c
 import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import {
   type DeliverableWhatsAppOutboundPayload,
   normalizeWhatsAppOutboundPayload,
@@ -121,19 +122,19 @@ function logWhatsAppReplyDeliveryError(params: {
   err: unknown;
   info: ReplyDeliveryInfo;
   connectionId: string;
-  conversationId: string;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   replyLogger: ReturnType<typeof getChildLogger>;
 }) {
+  const admission = requireWhatsAppInboundAdmission(params.msg);
   params.replyLogger.error(
     {
       err: normalizeErrForLog(params.err),
       replyKind: params.info.kind,
       correlationId: params.msg.event.id ?? null,
       connectionId: params.connectionId,
-      conversationId: params.conversationId,
+      conversationId: admission.conversation.id,
       chatId: params.msg.platform.chatJid ?? null,
-      to: params.msg.from ?? null,
+      to: admission.conversation.id,
       from: params.msg.platform.recipientJid ?? null,
     },
     "auto-reply delivery failed",
@@ -271,11 +272,10 @@ export async function buildWhatsAppInboundContext(params: {
   commandAuthorized?: boolean;
   commandTurn?: CommandTurnContext;
   commandSource?: "text";
-  conversationId: string;
   groupHistory?: GroupHistoryEntry[];
   groupMemberRoster?: Map<string, string>;
   groupSystemPrompt?: string;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   rawBody?: string;
   route: ReturnType<typeof resolveAgentRoute>;
   sender: SenderContext;
@@ -285,8 +285,11 @@ export async function buildWhatsAppInboundContext(params: {
   visibleReplyTo?: VisibleReplyTarget;
   suppressMessageReceivedHooks?: boolean;
 }): Promise<FinalizedMsgContext> {
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const conversationId = admission.conversation.id;
+  const conversationKind = admission.conversation.kind;
   const inboundHistory =
-    params.msg.chatType === "group"
+    conversationKind === "group"
       ? buildInboundHistoryFromEntries({
           entries: (params.groupHistory ?? []).map((entry) => ({
             sender: entry.sender,
@@ -327,15 +330,15 @@ export async function buildWhatsAppInboundContext(params: {
     media,
     messageId: params.msg.event.id,
     timestamp: params.msg.event.timestamp,
-    from: params.msg.from,
+    from: conversationId,
     sender: {
       id: params.sender.id ?? params.sender.e164,
       name: params.sender.name,
     },
     conversation: {
-      kind: params.msg.chatType,
-      id: params.conversationId,
-      label: params.msg.chatType === "group" ? params.conversationId : params.msg.from,
+      kind: conversationKind,
+      id: conversationId,
+      label: conversationId,
     },
     route: {
       agentId: params.route.agentId,
@@ -344,7 +347,7 @@ export async function buildWhatsAppInboundContext(params: {
     },
     reply: {
       to: params.msg.platform.recipientJid,
-      originatingTo: params.msg.from,
+      originatingTo: conversationId,
     },
     message: {
       body: params.combinedBody,
@@ -357,7 +360,7 @@ export async function buildWhatsAppInboundContext(params: {
       ...(params.msg.wasMentioned !== undefined
         ? {
             mentions: {
-              canDetectMention: params.msg.chatType === "group",
+              canDetectMention: conversationKind === "group",
               wasMentioned: params.msg.wasMentioned,
             },
           }
@@ -426,20 +429,22 @@ function normalizeCommandTurnFromContext(value: unknown): CommandTurnContext | u
 }
 
 export function resolveWhatsAppDmRouteTarget(params: {
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   senderE164?: string;
   normalizeE164: (value: string) => string | null;
 }): string | undefined {
-  if (params.msg.chatType === "group") {
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const conversationId = admission.conversation.id;
+  if (admission.conversation.kind === "group") {
     return undefined;
   }
   if (params.senderE164) {
     return params.normalizeE164(params.senderE164) ?? undefined;
   }
-  if (params.msg.from.includes("@")) {
-    return jidToE164(params.msg.from) ?? undefined;
+  if (conversationId.includes("@")) {
+    return jidToE164(conversationId) ?? undefined;
   }
-  return params.normalizeE164(params.msg.from) ?? undefined;
+  return params.normalizeE164(conversationId) ?? undefined;
 }
 
 export function updateWhatsAppMainLastRoute(params: {
@@ -503,11 +508,10 @@ export async function dispatchWhatsAppBufferedReply(params: {
   cfg: ReturnType<LoadConfigFn>;
   connectionId: string;
   context: Record<string, unknown>;
-  conversationId: string;
   deliverReply: (params: {
     replyResult: ReplyPayload;
     normalizedReplyResult?: DeliverableWhatsAppOutboundPayload<ReplyPayload>;
-    msg: WebInboundMessage;
+    msg: AdmittedWebInboundMessage;
     mediaLocalRoots: readonly string[];
     maxMediaBytes: number;
     textLimit: number;
@@ -521,7 +525,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
   groupHistoryKey: string;
   maxMediaBytes: number;
   maxMediaTextChunkLimit?: number;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   onModelSelected?: ChannelReplyOnModelSelected;
   rememberSentText: (
     text: string | undefined,
@@ -538,6 +542,9 @@ export async function dispatchWhatsAppBufferedReply(params: {
   shouldClearGroupHistory: boolean;
   statusReactionController?: StatusReactionController | null;
 }) {
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const conversationId = admission.conversation.id;
+  const conversationKind = admission.conversation.kind;
   const statusReactionController = params.statusReactionController ?? null;
   const statusReactionTiming = {
     ...DEFAULT_TIMING,
@@ -553,7 +560,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
   });
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(params.cfg, params.route.agentId);
   const sourceReplyChatType =
-    typeof params.context.ChatType === "string" ? params.context.ChatType : params.msg.chatType;
+    typeof params.context.ChatType === "string" ? params.context.ChatType : conversationKind;
   const sourceReplyCommandSource =
     params.context.CommandSource === "native" || params.context.CommandSource === "text"
       ? params.context.CommandSource
@@ -608,9 +615,9 @@ export async function dispatchWhatsAppBufferedReply(params: {
         {
           correlationId: params.msg.event.id ?? null,
           connectionId: params.connectionId,
-          conversationId: params.conversationId,
+          conversationId,
           chatId: params.msg.platform.chatJid,
-          to: params.msg.from,
+          to: conversationId,
           from: params.msg.platform.recipientJid,
           replyKind: info.kind,
         },
@@ -625,8 +632,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
       combinedBodySessionKey: params.route.sessionKey,
       logVerboseMessage: shouldLog,
     });
-    const fromDisplay =
-      params.msg.chatType === "group" ? params.conversationId : (params.msg.from ?? "unknown");
+    const fromDisplay = conversationId;
     if (shouldLogVerbose()) {
       const preview = normalizedDeliveryPayload.text != null ? reply.text : "<media>";
       logVerbose(`Reply body: ${preview}${reply.hasMedia ? " (media)" : ""} -> ${fromDisplay}`);
@@ -684,7 +690,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
               ctxPayload: params.context as FinalizedMsgContext,
               payload: normalizedDeliveryPayload,
               info,
-              to: params.msg.from,
+              to: conversationId,
               formatting: {
                 textLimit,
                 tableMode,
@@ -762,7 +768,6 @@ export async function dispatchWhatsAppBufferedReply(params: {
           err,
           info,
           connectionId: params.connectionId,
-          conversationId: params.conversationId,
           msg: params.msg,
           replyLogger: params.replyLogger,
         });
@@ -772,7 +777,7 @@ export async function dispatchWhatsAppBufferedReply(params: {
       // Message-tool-only unmentioned group turns have no automatic visible reply.
       // Suppress composing there so silent background runs do not leak presence.
       suppressTyping:
-        sourceRepliesAreToolOnly && params.msg.chatType === "group" && !params.msg.wasMentioned,
+        sourceRepliesAreToolOnly && conversationKind === "group" && !params.msg.wasMentioned,
       disableBlockStreaming,
       ...(sourceReplyDeliveryMode ? { sourceReplyDeliveryMode } : {}),
       onModelSelected: params.onModelSelected,

--- a/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/message-line.ts
@@ -6,7 +6,8 @@ import {
   getSenderIdentity,
   type WhatsAppReplyContext,
 } from "../../identity.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import {
   formatInboundEnvelope,
   resolveMessagePrefix,
@@ -22,13 +23,13 @@ function formatReplyTarget(replyTo: WhatsAppReplyContext | null) {
   return `[Replying to ${sender}${idPart}]\n${replyTo.body}\n[/Replying]`;
 }
 
-export function formatReplyContext(msg: WebInboundMessage) {
+export function formatReplyContext(msg: AdmittedWebInboundMessage) {
   return formatReplyTarget(getReplyContext(msg));
 }
 
 export function buildInboundLine(params: {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   agentId: string;
   previousTimestamp?: number;
   envelope?: EnvelopeFormatOptions;
@@ -40,6 +41,9 @@ export function buildInboundLine(params: {
     configured: cfg.channels?.whatsapp?.messagePrefix,
     hasAllowFrom: (cfg.channels?.whatsapp?.allowFrom?.length ?? 0) > 0,
   });
+  const admission = requireWhatsAppInboundAdmission(msg);
+  const conversationId = admission.conversation.id;
+  const conversationKind = admission.conversation.kind;
   const prefixStr = messagePrefix ? `${messagePrefix} ` : "";
   const replyContext =
     params.visibleReplyTo === undefined
@@ -51,10 +55,10 @@ export function buildInboundLine(params: {
   // Wrap with standardized envelope for the agent.
   return formatInboundEnvelope({
     channel: "WhatsApp",
-    from: msg.chatType === "group" ? msg.from : msg.from?.replace(/^whatsapp:/, ""),
+    from: conversationKind === "group" ? conversationId : conversationId.replace(/^whatsapp:/, ""),
     timestamp: msg.event.timestamp,
     body: baseLine,
-    chatType: msg.chatType,
+    chatType: conversationKind,
     sender: {
       name: sender.name ?? undefined,
       e164: sender.e164 ?? undefined,

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.acp-bindings.test.ts
@@ -285,9 +285,16 @@ function createHandler(warn = vi.fn(), cfg: Record<string, unknown> = createCfg(
 
 function createMessage() {
   return createTestWebInboundMessage({
-    accountId: "work",
-    from: "15551234567@s.whatsapp.net",
-    conversationId: "15551234567@s.whatsapp.net",
+    admission: {
+      accountId: "work",
+      conversation: {
+        kind: "direct",
+        id: "15551234567@s.whatsapp.net",
+      },
+      sender: {
+        id: "15551234567@s.whatsapp.net",
+      },
+    },
     platform: {
       chatJid: "15551234567@s.whatsapp.net",
       recipientJid: "15559876543@s.whatsapp.net",
@@ -295,25 +302,45 @@ function createMessage() {
   });
 }
 
-function createGroupMessage() {
+type TestMessageOverrides = NonNullable<Parameters<typeof createTestWebInboundMessage>[0]>;
+
+function createGroupMessage(overrides: TestMessageOverrides = {}) {
+  const { admission, platform, ...message } = overrides;
   return createTestWebInboundMessage({
-    accountId: "work",
-    chatType: "group",
-    from: "120363001234567890@g.us",
-    conversationId: "120363001234567890@g.us",
+    ...message,
+    admission: {
+      ...admission,
+      accountId: "work",
+      conversation: {
+        kind: "group",
+        id: "120363001234567890@g.us",
+        ...admission?.conversation,
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+        ...admission?.senderAccess,
+      },
+    },
     platform: {
       chatJid: "120363001234567890@g.us",
       recipientJid: "15559876543@s.whatsapp.net",
+      ...platform,
     },
   });
 }
 
 function createGroupAudioMessage() {
   return createTestWebInboundMessage({
-    accountId: "work",
-    chatType: "group",
-    from: "120363001234567890@g.us",
-    conversationId: "120363001234567890@g.us",
+    admission: {
+      accountId: "work",
+      conversation: {
+        kind: "group",
+        id: "120363001234567890@g.us",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
     payload: {
       body: "<media:audio>",
       media: {
@@ -467,6 +494,53 @@ describe("createWebOnMessageHandler configured ACP bindings", () => {
     expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
     expect(processMessageMock).not.toHaveBeenCalled();
     expect(groupHistories.get("group-key")).toEqual([pendingEntry]);
+  });
+
+  it("does not record ordinary group routes before group admission", async () => {
+    resolveConfiguredBindingRouteMock.mockImplementationOnce(({ route }) => ({
+      bindingResolution: null,
+      route,
+    }));
+    applyGroupGatingMock.mockResolvedValueOnce({ shouldProcess: false });
+    const { handler } = createHandler(vi.fn(), { channels: { whatsapp: {} } });
+
+    await handler(createGroupMessage());
+
+    expect(applyGroupGatingMock).toHaveBeenCalledTimes(1);
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("does not record group routes when admission blocks dispatch", async () => {
+    const { handler } = createHandler(vi.fn(), { channels: { whatsapp: {} } });
+
+    await handler(
+      createGroupMessage({
+        admission: {
+          ingress: {
+            admission: "drop",
+            decision: "block",
+            reasonCode: "group_policy_not_allowlisted",
+          },
+          senderAccess: {
+            allowed: false,
+            decision: "block",
+            reasonCode: "group_policy_not_allowlisted",
+          },
+          activationAccess: {
+            allowed: false,
+            shouldSkip: true,
+            reasonCode: "group_policy_not_allowlisted",
+          },
+        },
+      }),
+    );
+
+    expect(applyGroupGatingMock).not.toHaveBeenCalled();
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
   });
 
   it("does not record configured ACP group routes when readiness fails", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts
@@ -7,6 +7,7 @@ const maybeSendAckReactionMock = vi.fn();
 const processMessageMock = vi.fn();
 const maybeBroadcastMessageMock = vi.fn();
 const createStatusReactionControllerMock = vi.fn();
+const updateLastRouteInBackgroundMock = vi.fn();
 const statusReactionController = {
   setQueued: vi.fn(async () => {
     events.push("status-queued");
@@ -53,11 +54,12 @@ vi.mock("./group-gating.js", () => ({
 }));
 
 vi.mock("./last-route.js", () => ({
-  updateLastRouteInBackground: () => {},
+  updateLastRouteInBackground: (...args: unknown[]) => updateLastRouteInBackgroundMock(...args),
 }));
 
 vi.mock("./peer.js", () => ({
-  resolvePeerId: (msg: { from: string }) => msg.from,
+  resolvePeerId: (msg: { admission: { conversation: { id: string } } }) =>
+    msg.admission.conversation.id,
 }));
 
 vi.mock("../config.runtime.js", () => ({
@@ -93,7 +95,10 @@ vi.mock("openclaw/plugin-sdk/routing", () => ({
   }),
 }));
 
-import { createTestWebAudioInboundMessage } from "../../inbound/test-message.test-helper.js";
+import {
+  createTestLegacyFlatWebInboundMessage,
+  createTestWebAudioInboundMessage,
+} from "../../inbound/test-message.test-helper.js";
 import type { WebInboundMessage } from "../../inbound/types.js";
 import { createWebOnMessageHandler } from "./on-message.js";
 
@@ -101,13 +106,49 @@ function makeAudioMsg(): WebInboundMessage {
   return createTestWebAudioInboundMessage();
 }
 
+function makeLegacyAudioMsg() {
+  return createTestLegacyFlatWebInboundMessage({
+    body: "<media:audio>",
+    mediaPath: "/tmp/voice.ogg",
+    mediaType: "audio/ogg; codecs=opus",
+  });
+}
+
 function makeGroupAudioMsg(): WebInboundMessage {
   return createTestWebAudioInboundMessage({
     platform: { chatJid: "1203630@g.us" },
-    from: "1203630@g.us",
-    conversationId: "1203630@g.us",
-    chatType: "group",
+    admission: {
+      conversation: {
+        kind: "group",
+        id: "1203630@g.us",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
     wasMentioned: false,
+  });
+}
+
+function makeBlockedDirectAudioMsg(): WebInboundMessage {
+  return createTestWebAudioInboundMessage({
+    admission: {
+      ingress: {
+        admission: "drop",
+        decision: "block",
+        reasonCode: "dm_policy_not_allowlisted",
+      },
+      senderAccess: {
+        allowed: false,
+        decision: "block",
+        reasonCode: "dm_policy_not_allowlisted",
+      },
+      activationAccess: {
+        allowed: false,
+        shouldSkip: true,
+        reasonCode: "dm_policy_not_allowlisted",
+      },
+    },
   });
 }
 
@@ -182,6 +223,8 @@ describe("createWebOnMessageHandler audio preflight", () => {
     createStatusReactionControllerMock.mockReset();
     createStatusReactionControllerMock.mockResolvedValue(statusReactionController);
     Object.values(statusReactionController).forEach((mock) => mock.mockClear());
+    ackReactionHandle.remove.mockClear();
+    updateLastRouteInBackgroundMock.mockReset();
     applyGroupGatingMock.mockReset();
     applyGroupGatingMock.mockResolvedValue({ shouldProcess: true });
   });
@@ -223,10 +266,22 @@ describe("createWebOnMessageHandler audio preflight", () => {
     expect(processParams.ackAlreadySent).toBeUndefined();
   });
 
-  it("skips early DM ack/preflight when access-control was not explicitly passed through", async () => {
+  it("drops blocked DM admission before ack, preflight, or dispatch", async () => {
     const handler = makeHandler();
 
-    await handler({ ...makeAudioMsg(), accessControlPassed: undefined });
+    await handler(makeBlockedDirectAudioMsg());
+
+    expect(events).toStrictEqual([]);
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("skips early DM ack/preflight for legacy audio without explicit access proof", async () => {
+    const handler = makeHandler();
+
+    await handler(makeLegacyAudioMsg());
 
     expect(events).toStrictEqual([]);
     expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
@@ -236,6 +291,34 @@ describe("createWebOnMessageHandler audio preflight", () => {
     expect(processParams).not.toHaveProperty("preflightAudioTranscript");
     expect(processParams).not.toHaveProperty("ackAlreadySent");
     expect(processParams).not.toHaveProperty("ackReaction");
+  });
+
+  it("shares one transcript for legacy direct broadcasts without explicit access proof", async () => {
+    maybeBroadcastMessageMock.mockImplementation(
+      async (params: { preflightAudioTranscript?: string | null }) => {
+        expect(params.preflightAudioTranscript).toBe("transcribed voice note");
+        return true;
+      },
+    );
+    const handler = makeHandler({
+      cfg: {
+        channels: {
+          whatsapp: {
+            ackReaction: { enabled: true },
+          },
+        },
+        broadcast: {
+          "+15551234567": ["main", "backup"],
+        },
+      } as never,
+    });
+
+    await handler(makeLegacyAudioMsg());
+
+    expect(events).toStrictEqual(["stt"]);
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
   });
 
   it("preserves per-agent ack checks for group broadcast voice notes", async () => {
@@ -270,6 +353,40 @@ describe("createWebOnMessageHandler audio preflight", () => {
     expect(processMessageMock).not.toHaveBeenCalled();
   });
 
+  it("clears preflight status reaction before group broadcast voice fan-out", async () => {
+    maybeBroadcastMessageMock.mockImplementation(
+      async (params: { preflightAudioTranscript?: string | null }) => {
+        expect(params.preflightAudioTranscript).toBe("transcribed voice note");
+        expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
+        expect(statusReactionController.clear).toHaveBeenCalledTimes(1);
+        return true;
+      },
+    );
+    const handler = makeHandler({
+      cfg: {
+        messages: { statusReactions: { enabled: true } },
+        broadcast: {
+          "1203630@g.us": ["main", "backup"],
+        },
+        channels: {
+          whatsapp: {
+            ackReaction: { enabled: true },
+          },
+        },
+      } as never,
+    });
+
+    await handler(makeGroupAudioMsg());
+
+    expect(events).toEqual(["status-queued", "stt"]);
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+    expect(statusReactionController.setQueued).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.clear).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.restoreInitial).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+  });
+
   it("uses group voice transcript for mention gating before dispatch", async () => {
     applyGroupGatingMock
       .mockResolvedValueOnce({ shouldProcess: false, needsMentionText: true })
@@ -291,6 +408,50 @@ describe("createWebOnMessageHandler audio preflight", () => {
     expect(processParams.preflightAudioTranscript).toBe("transcribed voice note");
     expect(processParams.ackAlreadySent).toBe(true);
     expect(processParams.ackReaction).toBe(ackReactionHandle);
+  });
+
+  it("removes preflight ack when group voice transcript still misses mention gating", async () => {
+    applyGroupGatingMock
+      .mockResolvedValueOnce({ shouldProcess: false, needsMentionText: true })
+      .mockResolvedValueOnce({ shouldProcess: false });
+    const handler = makeHandler();
+
+    await handler(makeGroupAudioMsg());
+
+    expect(applyGroupGatingMock).toHaveBeenCalledTimes(2);
+    expect(events).toEqual(["ack", "stt"]);
+    expect(ackReactionHandle.remove).toHaveBeenCalledTimes(1);
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("clears preflight status reaction when group voice transcript still misses mention gating", async () => {
+    applyGroupGatingMock
+      .mockResolvedValueOnce({ shouldProcess: false, needsMentionText: true })
+      .mockResolvedValueOnce({ shouldProcess: false });
+    const handler = makeHandler({
+      cfg: {
+        messages: { statusReactions: { enabled: true } },
+        channels: {
+          whatsapp: {
+            ackReaction: { enabled: true },
+          },
+        },
+      } as never,
+    });
+
+    await handler(makeGroupAudioMsg());
+
+    expect(applyGroupGatingMock).toHaveBeenCalledTimes(2);
+    expect(statusReactionController.setQueued).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.clear).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.restoreInitial).not.toHaveBeenCalled();
+    expect(maybeSendAckReactionMock).not.toHaveBeenCalled();
+    expect(updateLastRouteInBackgroundMock).not.toHaveBeenCalled();
+    expect(maybeBroadcastMessageMock).not.toHaveBeenCalled();
+    expect(processMessageMock).not.toHaveBeenCalled();
   });
 
   it("passes routing ctx fields to transcribeFirstAudio so echoTranscript can deliver (#79778)", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -14,11 +14,14 @@ import { resolveWhatsAppAccount } from "../../accounts.js";
 import { resolveWhatsAppGroupSessionRoute } from "../../group-session-key.js";
 import { getPrimaryIdentityId, getSenderIdentity } from "../../identity.js";
 import {
+  requireAdmittedWhatsAppInboundMessage,
+  requireWhatsAppInboundAdmission,
+} from "../../inbound/admission.js";
+import {
   normalizeWebInboundMessage,
   withDeprecatedWebInboundMessageFlatAliases,
 } from "../../inbound/message-aliases.js";
-import type { WebInboundMessageInput } from "../../inbound/types.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import type { AdmittedWebInboundMessage, WebInboundMessageInput } from "../../inbound/types.js";
 import { normalizeE164 } from "../../text-runtime.js";
 import { buildMentionConfig } from "../mentions.js";
 import type { MentionConfig } from "../mentions.js";
@@ -51,9 +54,16 @@ export function createWebOnMessageHandler(params: {
   baseMentionConfig: MentionConfig;
   account: { authDir?: string; accountId?: string; selfChatMode?: boolean };
 }) {
-  const withDirectSenderPeer = (msg: WebInboundMessage, peerId: string): WebInboundMessage => {
+  const hasExplicitlyPassedInboundAccess = (msg: WebInboundMessageInput): boolean =>
+    msg.admission ? msg.admission.ingress.decision === "allow" : msg.accessControlPassed === true;
+
+  const withDirectSenderPeer = (
+    msg: AdmittedWebInboundMessage,
+    peerId: string,
+  ): AdmittedWebInboundMessage => {
+    const admission = requireWhatsAppInboundAdmission(msg);
     if (
-      msg.chatType === "group" ||
+      admission.conversation.kind === "group" ||
       msg.platform.sender?.e164 ||
       msg.platform.senderE164 ||
       !peerId.startsWith("+")
@@ -64,19 +74,21 @@ export function createWebOnMessageHandler(params: {
     if (!normalized) {
       return msg;
     }
-    return withDeprecatedWebInboundMessageFlatAliases({
-      ...msg,
-      platform: {
-        ...msg.platform,
-        sender: { ...msg.platform.sender, e164: normalized },
-        senderE164: normalized,
-      },
-    });
+    return requireAdmittedWhatsAppInboundMessage(
+      withDeprecatedWebInboundMessageFlatAliases({
+        ...msg,
+        platform: {
+          ...msg.platform,
+          sender: { ...msg.platform.sender, e164: normalized },
+          senderE164: normalized,
+        },
+      }),
+    );
   };
 
   const processForRoute = async (
     cfg: OpenClawConfig,
-    msg: WebInboundMessage,
+    msg: AdmittedWebInboundMessage,
     route: ReturnType<typeof resolveAgentRoute>,
     groupHistoryKey: string,
     opts?: {
@@ -128,24 +140,29 @@ export function createWebOnMessageHandler(params: {
   };
 
   return async (rawMsg: WebInboundMessageInput) => {
-    const normalizedMsg = normalizeWebInboundMessage(rawMsg);
+    const canRunDirectEarlyAudioPreflight = hasExplicitlyPassedInboundAccess(rawMsg);
+    const normalizedMsg = requireAdmittedWhatsAppInboundMessage(normalizeWebInboundMessage(rawMsg));
     const cfg = params.loadConfig?.() ?? params.cfg;
     const peerId = resolvePeerId(normalizedMsg);
     const msg = withDirectSenderPeer(normalizedMsg, peerId);
-    const conversationId = msg.conversationId ?? msg.from;
+    const admission = requireWhatsAppInboundAdmission(msg);
+    if (admission.ingress.admission !== "dispatch" && admission.ingress.admission !== "observe") {
+      return;
+    }
+    const conversationId = admission.conversation.id;
+    const conversationKind = admission.conversation.kind;
     const baseRoute = resolveAgentRoute({
       cfg,
       channel: "whatsapp",
-      accountId: msg.accountId,
+      accountId: admission.accountId,
       peer: {
-        kind: msg.chatType === "group" ? "group" : "direct",
+        kind: conversationKind,
         id: peerId,
       },
     });
     const baseConversationRoute =
-      msg.chatType === "group" ? resolveWhatsAppGroupSessionRoute(baseRoute) : baseRoute;
-    const routeAccountId =
-      baseConversationRoute.accountId ?? msg.accountId ?? params.account.accountId ?? "default";
+      conversationKind === "group" ? resolveWhatsAppGroupSessionRoute(baseRoute) : baseRoute;
+    const routeAccountId = baseConversationRoute.accountId ?? admission.accountId;
     const account = resolveWhatsAppAccount({
       cfg,
       accountId: routeAccountId,
@@ -153,8 +170,8 @@ export function createWebOnMessageHandler(params: {
     const baseMentionConfig = buildMentionConfig(cfg);
 
     // Same-phone mode logging retained
-    if (msg.from === msg.platform.recipientJid) {
-      logVerbose(`📱 Same-phone mode detected (from === to: ${msg.from})`);
+    if (conversationId === msg.platform.recipientJid) {
+      logVerbose(`📱 Same-phone mode detected (from === to: ${conversationId})`);
     }
 
     // Skip if this is a message we just sent (echo detection)
@@ -175,7 +192,7 @@ export function createWebOnMessageHandler(params: {
     // Side-effectful ACP readiness still waits until the group turn is admitted.
     const route = configuredRoute.route;
     const groupHistoryKey =
-      msg.chatType === "group"
+      conversationKind === "group"
         ? buildGroupHistoryKey({
             channel: "whatsapp",
             accountId: route.accountId,
@@ -195,7 +212,8 @@ export function createWebOnMessageHandler(params: {
     const hasAudioBody =
       msg.payload.media?.type?.startsWith("audio/") === true &&
       msg.payload.body === "<media:audio>";
-    const canRunEarlyAudioPreflight = msg.chatType === "group" || msg.accessControlPassed === true;
+    const canRunEarlyAudioPreflight =
+      conversationKind === "group" || canRunDirectEarlyAudioPreflight;
     let ackAlreadySent = false;
     let ackReaction: AckReactionHandle | null = null;
     let statusReactionController: StatusReactionController | null = null;
@@ -203,8 +221,10 @@ export function createWebOnMessageHandler(params: {
     const clearPreDispatchReaction = async () => {
       try {
         if (statusReactionController) {
-          statusReactionController.cancelPending();
-          await statusReactionController.clear();
+          const controller = statusReactionController;
+          statusReactionController = null;
+          controller.cancelPending();
+          await controller.clear();
           return;
         }
         if (ackReaction && (await ackReaction.ackReactionPromise)) {
@@ -213,8 +233,36 @@ export function createWebOnMessageHandler(params: {
       } catch (err) {
         params.replyLogger.warn(
           { error: String(err) },
-          "whatsapp: failed to clear pre-dispatch reaction after configured ACP readiness failure",
+          "whatsapp: failed to clear pre-dispatch reaction after pre-dispatch rejection",
         );
+      }
+    };
+    const transcribeAudioOnce = async () => {
+      if (preflightAudioTranscript !== undefined || !hasAudioBody || !msg.payload.media?.path) {
+        return;
+      }
+      try {
+        const { transcribeFirstAudio } = await import("./audio-preflight.runtime.js");
+        // transcribeFirstAudio returns undefined on failure/disabled; store null so
+        // processMessage knows the attempt was already made and does not retry.
+        preflightAudioTranscript =
+          (await transcribeFirstAudio({
+            ctx: {
+              MediaPaths: [msg.payload.media?.path],
+              MediaTypes: msg.payload.media?.type ? [msg.payload.media?.type] : undefined,
+              From: conversationId,
+              To: msg.platform.recipientJid,
+              Provider: "whatsapp",
+              Surface: "whatsapp",
+              OriginatingChannel: "whatsapp",
+              OriginatingTo: conversationId,
+              AccountId: route.accountId,
+            },
+            cfg,
+          })) ?? null;
+      } catch {
+        // Non-fatal: store null so per-agent retries are suppressed.
+        preflightAudioTranscript = null;
       }
     };
     const runAudioPreflightOnce = async () => {
@@ -232,9 +280,7 @@ export function createWebOnMessageHandler(params: {
           msg,
           agentId: route.agentId,
           sessionKey: route.sessionKey,
-          conversationId,
           verbose: params.verbose,
-          accountId: route.accountId,
         });
         if (statusReactionController) {
           await statusReactionController.setQueued();
@@ -245,47 +291,23 @@ export function createWebOnMessageHandler(params: {
           msg,
           agentId: route.agentId,
           sessionKey: route.sessionKey,
-          conversationId,
           verbose: params.verbose,
-          accountId: route.accountId,
           info: params.replyLogger.info.bind(params.replyLogger),
           warn: params.replyLogger.warn.bind(params.replyLogger),
         });
         ackAlreadySent = ackReaction !== null;
       }
-      try {
-        const { transcribeFirstAudio } = await import("./audio-preflight.runtime.js");
-        // transcribeFirstAudio returns undefined on failure/disabled; store null so
-        // processMessage knows the attempt was already made and does not retry.
-        preflightAudioTranscript =
-          (await transcribeFirstAudio({
-            ctx: {
-              MediaPaths: [msg.payload.media?.path],
-              MediaTypes: msg.payload.media?.type ? [msg.payload.media?.type] : undefined,
-              From: msg.from,
-              To: msg.platform.recipientJid,
-              Provider: "whatsapp",
-              Surface: "whatsapp",
-              OriginatingChannel: "whatsapp",
-              OriginatingTo: conversationId,
-              AccountId: route.accountId,
-            },
-            cfg,
-          })) ?? null;
-      } catch {
-        // Non-fatal: store null so per-agent retries are suppressed.
-        preflightAudioTranscript = null;
-      }
+      await transcribeAudioOnce();
     };
 
-    if (msg.chatType === "group") {
+    if (conversationKind === "group") {
       const sender = getSenderIdentity(msg);
       const metaCtx = {
-        From: msg.from,
+        From: conversationId,
         To: msg.platform.recipientJid,
         SessionKey: route.sessionKey,
         AccountId: route.accountId,
-        ChatType: msg.chatType,
+        ChatType: conversationKind,
         ConversationLabel: conversationId,
         GroupSubject: msg.group?.subject,
         SenderName: sender.name ?? undefined,
@@ -308,19 +330,14 @@ export function createWebOnMessageHandler(params: {
           ctx: metaCtx,
           warn: params.replyLogger.warn.bind(params.replyLogger),
         });
-      // Configured ACP group routes are session-owned only after admission and
-      // readiness; ordinary routes keep the existing early group last-route update.
-      if (configuredRoute.bindingResolution) {
-        recordAcceptedConfiguredGroupRoute = recordGroupRoute;
-      } else {
-        recordGroupRoute();
-      }
+      // Last-route state is a dispatch side effect. Group gating must admit the
+      // message first; configured ACP routes also wait for backend readiness.
+      recordAcceptedConfiguredGroupRoute = recordGroupRoute;
 
       let gating = await applyGroupGating({
         cfg,
         msg,
         deferMissingMention: hasAudioBody && Boolean(msg.payload.media?.path),
-        conversationId,
         groupHistoryKey,
         agentId: route.agentId,
         sessionKey: route.sessionKey,
@@ -346,7 +363,6 @@ export function createWebOnMessageHandler(params: {
           ...(typeof preflightAudioTranscript === "string"
             ? { mentionText: preflightAudioTranscript }
             : {}),
-          conversationId,
           groupHistoryKey,
           agentId: route.agentId,
           sessionKey: route.sessionKey,
@@ -362,6 +378,7 @@ export function createWebOnMessageHandler(params: {
         });
       }
       if (!gating.shouldProcess) {
+        await clearPreDispatchReaction();
         return;
       }
     }
@@ -379,9 +396,23 @@ export function createWebOnMessageHandler(params: {
         return;
       }
     }
-    recordAcceptedConfiguredGroupRoute?.();
+    if (recordAcceptedConfiguredGroupRoute && !configuredRoute.bindingResolution) {
+      recordAcceptedConfiguredGroupRoute();
+      recordAcceptedConfiguredGroupRoute = null;
+    }
 
     await runAudioPreflightOnce();
+
+    const hasBroadcastTargets =
+      !configuredRoute.bindingResolution &&
+      Array.isArray(cfg.broadcast?.[peerId]) &&
+      cfg.broadcast[peerId].length > 0;
+    if (hasBroadcastTargets && statusReactionController) {
+      await clearPreDispatchReaction();
+    }
+    if (hasBroadcastTargets && !canRunEarlyAudioPreflight) {
+      await transcribeAudioOnce();
+    }
 
     if (
       !configuredRoute.bindingResolution &&
@@ -396,14 +427,18 @@ export function createWebOnMessageHandler(params: {
         // Group ack eligibility depends on the target agent/session, so a
         // preflight ack attempt on the base route must not suppress downstream
         // per-agent checks during broadcast fan-out.
-        ...(ackAlreadySent && msg.chatType !== "group" ? { ackAlreadySent: true } : {}),
-        ...(ackReaction && msg.chatType !== "group" ? { ackReaction } : {}),
-        ...(statusReactionController && msg.chatType !== "group" ? { ackAlreadySent: true } : {}),
+        ...(ackAlreadySent && conversationKind !== "group" ? { ackAlreadySent: true } : {}),
+        ...(ackReaction && conversationKind !== "group" ? { ackReaction } : {}),
+        ...(statusReactionController && conversationKind !== "group"
+          ? { ackAlreadySent: true }
+          : {}),
         processMessage: (m, r, k, opts) => processForRoute(cfg, m, r, k, opts),
       }))
     ) {
       return;
     }
+
+    recordAcceptedConfiguredGroupRoute?.();
 
     await processForRoute(cfg, msg, route, groupHistoryKey, {
       ...(preflightAudioTranscript !== undefined ? { preflightAudioTranscript } : {}),

--- a/extensions/whatsapp/src/auto-reply/monitor/peer.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/peer.ts
@@ -1,18 +1,21 @@
 // Whatsapp plugin module implements peer behavior.
 import { getSenderIdentity } from "../../identity.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { jidToE164, normalizeE164 } from "../../text-runtime.js";
 
-export function resolvePeerId(msg: WebInboundMessage) {
-  if (msg.chatType === "group") {
-    return msg.conversationId ?? msg.from;
+export function resolvePeerId(msg: AdmittedWebInboundMessage) {
+  const admission = requireWhatsAppInboundAdmission(msg);
+  if (admission.conversation.kind === "group") {
+    return admission.conversation.id;
   }
   const sender = getSenderIdentity(msg);
   if (sender.e164) {
     return normalizeE164(sender.e164) ?? sender.e164;
   }
-  if (msg.from.includes("@")) {
-    return jidToE164(msg.from) ?? msg.from;
+  const conversationId = admission.conversation.id;
+  if (conversationId.includes("@")) {
+    return jidToE164(conversationId) ?? conversationId;
   }
-  return normalizeE164(msg.from) ?? msg.from;
+  return normalizeE164(conversationId) ?? conversationId;
 }

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts
@@ -152,7 +152,7 @@ function makeAudioMsg(overrides: AudioMessageOverrides = {}): WebInboundMsg {
     },
     platform,
     ...messageOverrides,
-  });
+  }) as WebInboundMsg;
 }
 
 function makeRoute(overrides: Partial<TestRoute> = {}): TestRoute {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -1,12 +1,14 @@
 // Whatsapp tests cover process message plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAcceptedWhatsAppSendResult } from "../../inbound/send-result.test-helper.js";
+import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
 
 // Hoisted mocks used across tests so vi.mock factories can reference them.
 const {
   resolvePolicyMock,
   buildContextMock,
   isControlCommandMessageMock,
+  dispatchBufferedReplyMock,
   runMessageReceivedMock,
   shouldComputeCommandAuthorizedMock,
   trackBackgroundTaskMock,
@@ -14,6 +16,10 @@ const {
   resolvePolicyMock: vi.fn(),
   buildContextMock: vi.fn(),
   isControlCommandMessageMock: vi.fn(() => false),
+  dispatchBufferedReplyMock: vi.fn(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
   runMessageReceivedMock: vi.fn(async () => undefined),
   shouldComputeCommandAuthorizedMock: vi.fn(() => false),
   trackBackgroundTaskMock: vi.fn(),
@@ -33,10 +39,7 @@ vi.mock("./inbound-dispatch.js", async (importOriginal) => {
   return {
     ...actual,
     buildWhatsAppInboundContext: buildContextMock,
-    dispatchWhatsAppBufferedReply: async () => ({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
-    }),
+    dispatchWhatsAppBufferedReply: dispatchBufferedReplyMock,
     resolveWhatsAppDmRouteTarget: () => null,
     resolveWhatsAppResponsePrefix: () => undefined,
     updateWhatsAppMainLastRoute: () => {},
@@ -172,7 +175,7 @@ const GROUP_JID = "123@g.us";
 
 function makeBaseMsg(overrides: { body?: string } = {}) {
   const body = overrides.body ?? "hi";
-  return {
+  return createTestWebInboundMessage({
     event: {
       id: "msg1",
       timestamp: 1710000000,
@@ -190,14 +193,23 @@ function makeBaseMsg(overrides: { body?: string } = {}) {
       reply: async () => createAcceptedWhatsAppSendResult("text", "r1"),
       sendMedia: async () => createAcceptedWhatsAppSendResult("media", "m1"),
     },
-    from: GROUP_JID,
-    conversationId: GROUP_JID,
-    accountId: "default",
-    chatType: "group" as const,
+    admission: {
+      accountId: "default",
+      conversation: {
+        kind: "group",
+        id: GROUP_JID,
+      },
+      sender: {
+        id: "+15550002222",
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+      },
+    },
     group: {
       subject: "Test Group",
     },
-  };
+  });
 }
 
 const baseRoute = {
@@ -249,6 +261,7 @@ function mockCallArg(mockFn: ReturnType<typeof vi.fn>, label: string, callIndex 
 describe("processMessage group system prompt wiring", () => {
   beforeEach(() => {
     buildContextMock.mockReset();
+    dispatchBufferedReplyMock.mockClear();
     isControlCommandMessageMock.mockReset();
     isControlCommandMessageMock.mockReturnValue(false);
     resolvePolicyMock.mockReset();
@@ -474,5 +487,45 @@ describe("processMessage group system prompt wiring", () => {
     expect(mockCallArg(trackBackgroundTaskMock, "trackBackgroundTask", 0, 1)).toBeInstanceOf(
       Promise,
     );
+  });
+
+  it("drops blocked admission before session record and reply dispatch", async () => {
+    resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
+    buildContextMock.mockImplementationOnce(() => ({
+      Body: "hi",
+      RawBody: "hi",
+      CommandBody: "hi",
+      SessionKey: baseRoute.sessionKey,
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+    }));
+
+    const result = await callProcessMessage({
+      msg: createTestWebInboundMessage({
+        admission: {
+          ingress: {
+            admission: "drop",
+            decision: "block",
+            reasonCode: "dm_policy_not_allowlisted",
+          },
+          senderAccess: {
+            allowed: false,
+            decision: "block",
+            reasonCode: "dm_policy_not_allowlisted",
+          },
+          activationAccess: {
+            allowed: false,
+            shouldSkip: true,
+            reasonCode: "dm_policy_not_allowlisted",
+          },
+        },
+      }),
+    });
+
+    expect(result).toBe(false);
+    expect(buildContextMock).not.toHaveBeenCalled();
+    expect(trackBackgroundTaskMock).not.toHaveBeenCalled();
+    expect(dispatchBufferedReplyMock).not.toHaveBeenCalled();
+    expect(runMessageReceivedMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -25,7 +25,8 @@ import {
   resolveWhatsAppCommandAuthorized,
   resolveWhatsAppInboundPolicy,
 } from "../../inbound-policy.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { newConnectionId } from "../../reconnect.js";
 import { formatError } from "../../session.js";
 import {
@@ -184,7 +185,7 @@ function resolvePinnedMainDmRecipient(params: {
 
 export async function processMessage(params: {
   cfg: ReturnType<LoadConfigFn>;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   route: ReturnType<typeof resolveAgentRoute>;
   groupHistoryKey: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
@@ -219,11 +220,16 @@ export async function processMessage(params: {
    * - undefined (omitted) → caller did not attempt preflight; run internal STT as normal */
   preflightAudioTranscript?: string | null;
 }) {
-  const conversationId = params.msg.conversationId ?? params.msg.from;
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  if (admission.ingress.admission !== "dispatch" && admission.ingress.admission !== "observe") {
+    return false;
+  }
+  const conversationId = admission.conversation.id;
+  const conversationKind = admission.conversation.kind;
   const self = getSelfIdentity(params.msg);
   const inboundPolicy = resolveWhatsAppInboundPolicy({
     cfg: params.cfg,
-    accountId: params.route.accountId ?? params.msg.accountId,
+    accountId: params.route.accountId ?? admission.accountId,
     selfE164: self.e164 ?? null,
   });
   const account = inboundPolicy.account;
@@ -262,7 +268,7 @@ export async function processMessage(params: {
         ctx: {
           MediaPaths: [params.msg.payload.media?.path],
           MediaTypes: params.msg.payload.media?.type ? [params.msg.payload.media?.type] : undefined,
-          From: params.msg.from,
+          From: conversationId,
           To: params.msg.platform.recipientJid,
           Provider: "whatsapp",
           Surface: "whatsapp",
@@ -285,7 +291,7 @@ export async function processMessage(params: {
   // (used by features such as messages.tts.auto: "inbound") still sees this as an
   // audio message. The transcript and transcribed media index are also stored on
   // context so downstream media understanding does not transcribe it again.
-  const msgForAgent =
+  const msgForAgent: AdmittedWebInboundMessage =
     audioTranscript !== undefined
       ? { ...params.msg, payload: { ...params.msg.payload, body: audioTranscript } }
       : params.msg;
@@ -307,7 +313,7 @@ export async function processMessage(params: {
   });
   let shouldClearGroupHistory = false;
   const visibleGroupHistory =
-    params.msg.chatType === "group"
+    conversationKind === "group"
       ? resolveVisibleWhatsAppGroupHistory({
           history: params.groupHistory ?? params.groupHistories.get(params.groupHistoryKey) ?? [],
           mode: contextVisibilityMode,
@@ -317,7 +323,7 @@ export async function processMessage(params: {
         })
       : undefined;
 
-  if (params.msg.chatType === "group") {
+  if (conversationKind === "group") {
     const history = visibleGroupHistory ?? [];
     if (history.length > 0) {
       const historyEntries: HistoryEntry[] = history.map((m) => ({
@@ -367,9 +373,7 @@ export async function processMessage(params: {
           msg: params.msg,
           agentId: params.route.agentId,
           sessionKey: params.route.sessionKey,
-          conversationId,
           verbose: params.verbose,
-          accountId: account.accountId,
         })
       : null);
 
@@ -388,9 +392,7 @@ export async function processMessage(params: {
       msg: params.msg,
       agentId: params.route.agentId,
       sessionKey: params.route.sessionKey,
-      conversationId,
       verbose: params.verbose,
-      accountId: account.accountId,
       info: params.replyLogger.info.bind(params.replyLogger),
       warn: params.replyLogger.warn.bind(params.replyLogger),
     });
@@ -401,7 +403,7 @@ export async function processMessage(params: {
     {
       connectionId: params.connectionId,
       correlationId,
-      from: params.msg.chatType === "group" ? conversationId : params.msg.from,
+      from: conversationId,
       to: params.msg.platform.recipientJid,
       body: elide(combinedBody, 240),
       mediaType: params.msg.payload.media?.type ?? null,
@@ -410,10 +412,10 @@ export async function processMessage(params: {
     "inbound web message",
   );
 
-  const fromDisplay = params.msg.chatType === "group" ? conversationId : params.msg.from;
+  const fromDisplay = conversationId;
   const kindLabel = params.msg.payload.media?.type ? `, ${params.msg.payload.media?.type}` : "";
   whatsappInboundLog.info(
-    `Inbound message ${fromDisplay} -> ${params.msg.platform.recipientJid} (${params.msg.chatType}${kindLabel}, ${combinedBody.length} chars)`,
+    `Inbound message ${fromDisplay} -> ${params.msg.platform.recipientJid} (${conversationKind}${kindLabel}, ${combinedBody.length} chars)`,
   );
   if (shouldLogVerbose()) {
     whatsappInboundLog.debug(`Inbound body: ${elide(combinedBody, 400)}`);
@@ -459,7 +461,7 @@ export async function processMessage(params: {
   const responsePrefix = resolveWhatsAppResponsePrefix({
     cfg: params.cfg,
     agentId: params.route.agentId,
-    isSelfChat: params.msg.chatType !== "group" && inboundPolicy.isSelfChat,
+    isSelfChat: conversationKind !== "group" && inboundPolicy.isSelfChat,
     pipelineResponsePrefix: replyPipeline.responsePrefix,
   });
   const replyThreading = resolveBatchedReplyThreadingPolicy(
@@ -469,14 +471,14 @@ export async function processMessage(params: {
 
   // Resolve combined conversation system prompt using the group or direct surface.
   const conversationSystemPrompt =
-    params.msg.chatType === "group"
+    conversationKind === "group"
       ? resolveWhatsAppGroupSystemPrompt({
           accountConfig: account,
           groupId: conversationId,
         })
       : resolveWhatsAppDirectSystemPrompt({
           accountConfig: account,
-          peerId: dmRouteTarget ?? params.msg.from,
+          peerId: dmRouteTarget ?? conversationId,
         });
 
   const ctxPayload = await buildWhatsAppInboundContext({
@@ -485,7 +487,6 @@ export async function processMessage(params: {
     commandBody: params.msg.payload.body,
     commandAuthorized,
     commandTurn,
-    conversationId,
     groupHistory: visibleGroupHistory,
     groupMemberRoster: params.groupMemberNames.get(params.groupHistoryKey),
     groupSystemPrompt: conversationSystemPrompt,
@@ -538,6 +539,25 @@ export async function processMessage(params: {
         textForCommands: ctxPayload.CommandBody,
         raw: params.msg,
       }),
+      preflight: () => {
+        const reason = admission.ingress.reasonCode;
+        if (admission.ingress.admission === "dispatch") {
+          return { admission: { kind: "dispatch", reason } };
+        }
+        if (admission.ingress.admission === "observe") {
+          return { admission: { kind: "observeOnly", reason } };
+        }
+        if (admission.ingress.admission === "skip") {
+          return { admission: { kind: "handled", reason } };
+        }
+        return {
+          admission: {
+            kind: "drop",
+            reason,
+            recordHistory: false,
+          },
+        };
+      },
       resolveTurn: () => ({
         channel: "whatsapp",
         accountId: params.route.accountId,
@@ -565,7 +585,6 @@ export async function processMessage(params: {
             cfg: params.cfg,
             connectionId: params.connectionId,
             context: ctxPayload,
-            conversationId,
             deliverReply: deliverWebReply,
             groupHistories: params.groupHistories,
             groupHistoryKey: params.groupHistoryKey,

--- a/extensions/whatsapp/src/auto-reply/monitor/status-reaction.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/status-reaction.test.ts
@@ -2,7 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { createWhatsAppStatusReactionController } from "./status-reaction.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -13,16 +13,25 @@ vi.mock("../../send.js", () => ({
   sendReactionWhatsApp: hoisted.sendReactionWhatsApp,
 }));
 
-function createMessage(overrides: Partial<WebInboundMessage> = {}): WebInboundMessage {
+type TestMsgOverrides = NonNullable<Parameters<typeof createTestWebInboundMessage>[0]>;
+
+function createMessage(overrides: TestMsgOverrides = {}): AdmittedWebInboundMessage {
   return createTestWebInboundMessage({
     event: { id: "msg-1" },
     platform: {
       chatJid: "15551234567@s.whatsapp.net",
       recipientJid: "15559876543",
     },
-    from: "15551234567",
-    conversationId: "15551234567",
-    accountId: "default",
+    admission: {
+      accountId: "default",
+      conversation: {
+        kind: "direct",
+        id: "15551234567",
+      },
+      sender: {
+        id: "15551234567",
+      },
+    },
     ...overrides,
   });
 }
@@ -65,9 +74,7 @@ describe("createWhatsAppStatusReactionController", () => {
       msg: createMessage(),
       agentId: "agent",
       sessionKey: "whatsapp:default:15551234567",
-      conversationId: "15551234567",
       verbose: false,
-      accountId: "default",
     });
 
     void controller?.setQueued();
@@ -80,6 +87,66 @@ describe("createWhatsAppStatusReactionController", () => {
           verbose: false,
           fromMe: false,
           accountId: "default",
+          cfg,
+        },
+      );
+    });
+    await controller?.clear();
+  });
+
+  it("uses the active account reactionLevel override from admission", async () => {
+    const cfg = {
+      messages: {
+        statusReactions: {
+          enabled: true,
+          timing: {
+            debounceMs: 1_000_000,
+            stallSoftMs: 1_000_000,
+            stallHardMs: 1_000_000,
+            doneHoldMs: 0,
+            errorHoldMs: 0,
+          },
+        },
+      },
+      channels: {
+        whatsapp: {
+          reactionLevel: "off",
+          ackReaction: {
+            emoji: "👀",
+            direct: true,
+            group: "mentions",
+          },
+          accounts: {
+            work: {
+              reactionLevel: "ack",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const controller = await createWhatsAppStatusReactionController({
+      cfg,
+      msg: createMessage({
+        admission: {
+          accountId: "work",
+        },
+      }),
+      agentId: "agent",
+      sessionKey: "whatsapp:work:15551234567",
+      verbose: false,
+    });
+
+    void controller?.setQueued();
+    await vi.waitFor(() => {
+      expect(hoisted.sendReactionWhatsApp).toHaveBeenCalledWith(
+        "15551234567@s.whatsapp.net",
+        "msg-1",
+        "👀",
+        {
+          verbose: false,
+          fromMe: false,
+          accountId: "work",
           cfg,
         },
       );

--- a/extensions/whatsapp/src/auto-reply/monitor/status-reaction.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/status-reaction.ts
@@ -7,7 +7,8 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getSenderIdentity } from "../../identity.js";
-import type { WebInboundMessage } from "../../inbound/types.js";
+import { requireWhatsAppInboundAdmission } from "../../inbound/admission.js";
+import type { AdmittedWebInboundMessage } from "../../inbound/types.js";
 import { resolveWhatsAppReactionLevel } from "../../reaction-level.js";
 import { sendReactionWhatsApp } from "../../send.js";
 import { resolveWhatsAppAckEmoji } from "./ack-emoji.js";
@@ -17,12 +18,10 @@ export type { StatusReactionController };
 
 export type WhatsAppStatusReactionParams = {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   agentId: string;
   sessionKey: string;
-  conversationId: string;
   verbose: boolean;
-  accountId?: string;
 };
 
 export async function createWhatsAppStatusReactionController(
@@ -37,9 +36,11 @@ export async function createWhatsAppStatusReactionController(
     return null;
   }
 
+  const admission = requireWhatsAppInboundAdmission(params.msg);
+  const accountId = admission.accountId;
   const reactionLevel = resolveWhatsAppReactionLevel({
     cfg: params.cfg,
-    accountId: params.accountId,
+    accountId,
   });
   if (reactionLevel.level === "off") {
     return null;
@@ -56,23 +57,23 @@ export async function createWhatsAppStatusReactionController(
   }
   const directEnabled = ackConfig?.direct ?? true;
   const groupMode = ackConfig?.group ?? "mentions";
-  const conversationIdForCheck = params.msg.conversationId ?? params.msg.from;
+  const isGroup = admission.conversation.kind === "group";
+  const conversationIdForCheck = admission.conversation.id;
 
-  const activation =
-    params.msg.chatType === "group"
-      ? await resolveGroupActivationFor({
-          cfg: params.cfg,
-          accountId: params.accountId,
-          agentId: params.agentId,
-          sessionKey: params.sessionKey,
-          conversationId: conversationIdForCheck,
-        })
-      : null;
+  const activation = isGroup
+    ? await resolveGroupActivationFor({
+        cfg: params.cfg,
+        accountId,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+        conversationId: conversationIdForCheck,
+      })
+    : null;
 
   const shouldUseStatusReaction = shouldAckReactionForWhatsApp({
     emoji: ackEmoji,
-    isDirect: params.msg.chatType === "direct",
-    isGroup: params.msg.chatType === "group",
+    isDirect: admission.conversation.kind === "direct",
+    isGroup,
     directEnabled,
     groupMode,
     wasMentioned: params.msg.wasMentioned === true,
@@ -88,7 +89,7 @@ export async function createWhatsAppStatusReactionController(
     verbose: params.verbose,
     fromMe: false,
     ...(sender.jid ? { participant: sender.jid } : {}),
-    ...(params.accountId ? { accountId: params.accountId } : {}),
+    accountId,
     cfg: params.cfg,
   };
   const chatId = params.msg.platform.chatJid;

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-monitor.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import { buildMentionConfig } from "./mentions.js";
 import { applyGroupGating, type GroupHistoryEntry } from "./monitor/group-gating.js";
 import { formatWhatsAppInboundListeningLog } from "./monitor/listener-log.js";
@@ -41,14 +41,13 @@ const makeConfig = (overrides: Record<string, unknown>) =>
 
 async function runGroupGating(params: {
   cfg: import("openclaw/plugin-sdk/config-contracts").OpenClawConfig;
-  msg: WebInboundMessage;
-  conversationId?: string;
+  msg: AdmittedWebInboundMessage;
   agentId?: string;
   selfChatMode?: boolean;
   authDir?: string;
 }) {
   const groupHistories = new Map<string, GroupHistoryEntry[]>();
-  const conversationId = params.conversationId ?? "123@g.us";
+  const conversationId = params.msg.admission?.conversation.id ?? "123@g.us";
   const agentId = params.agentId ?? "main";
   const sessionKey = `agent:${agentId}:whatsapp:group:${conversationId}`;
   const baseMentionConfig = buildMentionConfig(params.cfg, undefined);
@@ -56,7 +55,6 @@ async function runGroupGating(params: {
   const result = await applyGroupGating({
     cfg: params.cfg,
     msg: params.msg,
-    conversationId,
     groupHistoryKey: `whatsapp:default:group:${conversationId}`,
     agentId,
     sessionKey,
@@ -73,10 +71,8 @@ async function runGroupGating(params: {
 }
 
 type TestMessageOverrides = {
-  accountId?: string;
+  admission?: NonNullable<Parameters<typeof createTestWebInboundMessage>[0]>["admission"];
   body?: string;
-  conversationId?: string;
-  from?: string;
   id?: string;
   mentionedJids?: string[];
   replyToBody?: string;
@@ -93,7 +89,8 @@ type TestMessageOverrides = {
   to?: string;
 };
 
-function createGroupMessage(overrides: TestMessageOverrides = {}): WebInboundMessage {
+function createGroupMessage(overrides: TestMessageOverrides = {}): AdmittedWebInboundMessage {
+  const conversationId = overrides.admission?.conversation?.id ?? "123@g.us";
   return createTestWebInboundMessage({
     event: {
       id: overrides.id ?? "g1",
@@ -103,7 +100,7 @@ function createGroupMessage(overrides: TestMessageOverrides = {}): WebInboundMes
       body: overrides.body ?? "hello group",
     },
     platform: {
-      chatJid: "123@g.us",
+      chatJid: conversationId,
       recipientJid: overrides.to ?? "+2",
       senderE164: overrides.senderE164 ?? "+111",
       senderJid: overrides.senderJid,
@@ -111,10 +108,23 @@ function createGroupMessage(overrides: TestMessageOverrides = {}): WebInboundMes
       selfE164: overrides.selfE164 ?? "+999",
       selfJid: overrides.selfJid,
     },
-    from: overrides.from ?? "123@g.us",
-    conversationId: overrides.conversationId ?? overrides.from ?? "123@g.us",
-    chatType: "group",
-    accountId: overrides.accountId ?? "default",
+    admission: {
+      ...overrides.admission,
+      accountId: overrides.admission?.accountId ?? "default",
+      conversation: {
+        kind: "group",
+        id: conversationId,
+        ...overrides.admission?.conversation,
+      },
+      sender: {
+        id: overrides.senderJid ?? overrides.senderE164 ?? "+111",
+        ...overrides.admission?.sender,
+      },
+      senderAccess: {
+        reasonCode: "group_policy_allowed",
+        ...overrides.admission?.senderAccess,
+      },
+    },
     quote: overrides.replyToBody
       ? {
           id: overrides.replyToId,
@@ -134,19 +144,50 @@ function createGroupMessage(overrides: TestMessageOverrides = {}): WebInboundMes
   });
 }
 
-function createDirectMessage(overrides: TestMessageOverrides = {}): WebInboundMessage {
-  const msg = createGroupMessage(overrides);
-  return {
-    ...msg,
-    from: overrides.from ?? "+1555",
-    conversationId: overrides.conversationId ?? overrides.from ?? "+1555",
-    chatType: "direct",
-    group: undefined,
-    platform: {
-      ...msg.platform,
-      chatJid: overrides.from ?? "+1555",
+function createDirectMessage(overrides: TestMessageOverrides = {}): AdmittedWebInboundMessage {
+  const conversationId = overrides.admission?.conversation?.id ?? "+1555";
+  return createTestWebInboundMessage({
+    event: {
+      id: overrides.id ?? "d1",
+      timestamp: overrides.timestamp,
     },
-  };
+    payload: {
+      body: overrides.body ?? "hello direct",
+    },
+    platform: {
+      chatJid: conversationId,
+      recipientJid: overrides.to ?? "+2",
+      senderE164: overrides.senderE164 ?? conversationId,
+      senderJid: overrides.senderJid,
+      senderName: overrides.senderName ?? "Alice",
+      selfE164: overrides.selfE164 ?? "+999",
+      selfJid: overrides.selfJid,
+    },
+    admission: {
+      ...overrides.admission,
+      accountId: overrides.admission?.accountId ?? "default",
+      conversation: {
+        kind: "direct",
+        id: conversationId,
+        ...overrides.admission?.conversation,
+      },
+      sender: {
+        id: overrides.senderJid ?? overrides.senderE164 ?? conversationId,
+        ...overrides.admission?.sender,
+      },
+    },
+    quote: overrides.replyToBody
+      ? {
+          id: overrides.replyToId,
+          body: overrides.replyToBody,
+          sender: {
+            displayName: overrides.replyToSender,
+            jid: overrides.replyToSenderJid,
+            e164: overrides.replyToSenderE164,
+          },
+        }
+      : undefined,
+  });
 }
 
 function makeOwnerGroupConfig() {
@@ -224,7 +265,7 @@ describe("applyGroupGating", () => {
       msg: createGroupMessage({
         id: "m1",
         to: "+15550000",
-        accountId: "default",
+        admission: { accountId: "default" },
         body: "following up",
         timestamp: Date.now(),
         selfJid: "15551234567@s.whatsapp.net",
@@ -256,7 +297,7 @@ describe("applyGroupGating", () => {
       msg: createGroupMessage({
         id: "m-self-reply",
         to: "+15550000",
-        accountId: "default",
+        admission: { accountId: "default" },
         body: "following up on my own message",
         timestamp: Date.now(),
         senderE164: "+15551234567",
@@ -290,7 +331,7 @@ describe("applyGroupGating", () => {
       msg: createGroupMessage({
         id: "m-other-reply",
         to: "+15550000",
-        accountId: "default",
+        admission: { accountId: "default" },
         body: "following up on bot reply",
         timestamp: Date.now(),
         senderE164: "+15559999999",
@@ -327,7 +368,7 @@ describe("applyGroupGating", () => {
     });
     const msg = createGroupMessage({
       id: "g-self-lid-mention",
-      accountId: "default",
+      admission: { accountId: "default" },
       body: "@216372600647751 can you see this?",
       mentionedJids: ["216372600647751@lid"],
       senderE164: "+15550001111",
@@ -369,7 +410,7 @@ describe("applyGroupGating", () => {
       msg: createGroupMessage({
         id: "m-account-override",
         to: "+15550000",
-        accountId: "work",
+        admission: { accountId: "work" },
         body: "following up on bot reply",
         timestamp: Date.now(),
         senderE164: "+15551234567",
@@ -406,7 +447,7 @@ describe("applyGroupGating", () => {
       cfg,
       msg: createGroupMessage({
         id: "g-account-policy",
-        accountId: "work",
+        admission: { accountId: "work" },
         body: "following up",
         senderE164: "+111",
         senderJid: "111@s.whatsapp.net",
@@ -447,7 +488,7 @@ describe("applyGroupGating", () => {
       cfg,
       msg: createGroupMessage({
         id: "g-default-inheritance",
-        accountId: "work",
+        admission: { accountId: "work" },
         body: "plain group message",
         senderE164: "+111",
         senderJid: "111@s.whatsapp.net",
@@ -484,7 +525,7 @@ describe("applyGroupGating", () => {
       cfg,
       msg: createGroupMessage({
         id: "g-empty-group-allow-fallback",
-        accountId: "work",
+        admission: { accountId: "work" },
         body: "plain group message",
         senderE164: "+111",
         senderJid: "111@s.whatsapp.net",
@@ -514,7 +555,7 @@ describe("applyGroupGating", () => {
       cfg,
       msg: createGroupMessage({
         id: "g-account-owner",
-        accountId: "work",
+        admission: { accountId: "work" },
         body: "/new",
         senderE164: "+111",
         senderName: "Owner",
@@ -705,7 +746,7 @@ describe("buildInboundLine", () => {
       cfg: makeInboundCfg(""),
       agentId: "main",
       msg: createGroupMessage({
-        accountId: "default",
+        admission: { accountId: "default" },
         body: "ping",
         timestamp: 1700000000000,
         senderJid: "111@s.whatsapp.net",
@@ -723,7 +764,11 @@ describe("buildInboundLine", () => {
       cfg: makeInboundCfg(""),
       agentId: "main",
       msg: createDirectMessage({
-        from: "+1555",
+        admission: {
+          conversation: {
+            id: "+1555",
+          },
+        },
         body: "hello",
         replyToId: "q1",
         replyToBody: "original",
@@ -742,7 +787,11 @@ describe("buildInboundLine", () => {
       cfg: makeInboundCfg("[PFX]"),
       agentId: "main",
       msg: createDirectMessage({
-        from: "+1555",
+        admission: {
+          conversation: {
+            id: "+1555",
+          },
+        },
         body: "ping",
         to: "+2666",
       }),
@@ -757,7 +806,11 @@ describe("buildInboundLine", () => {
       cfg: makeInboundCfg(""),
       agentId: "main",
       msg: createDirectMessage({
-        from: "whatsapp:+15550001111",
+        admission: {
+          conversation: {
+            id: "whatsapp:+15550001111",
+          },
+        },
         body: "ping",
         to: "+2666",
       }),

--- a/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
+++ b/extensions/whatsapp/src/auto-reply/web-auto-reply-utils.test.ts
@@ -7,7 +7,7 @@ import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { createTestWebInboundMessage } from "../inbound/test-message.test-helper.js";
-import type { WebInboundMessage } from "../inbound/types.js";
+import type { AdmittedWebInboundMessage } from "../inbound/types.js";
 import {
   evaluateSessionFreshness,
   loadSessionStore,
@@ -27,32 +27,45 @@ import {
 import { elide, isLikelyWhatsAppCryptoError } from "./util.js";
 
 type TestMessageOverrides = {
+  admission?: NonNullable<Parameters<typeof createTestWebInboundMessage>[0]>["admission"];
   body?: string;
-  chatType?: "direct" | "group";
-  conversationId?: string;
-  from?: string;
   mentionedJids?: string[];
   selfE164?: string;
   selfJid?: string;
   selfLid?: string;
 };
 
-const makeMsg = (overrides: TestMessageOverrides): WebInboundMessage => {
-  const from = overrides.from ?? "120363401234567890@g.us";
+const makeMsg = (overrides: TestMessageOverrides): AdmittedWebInboundMessage => {
+  const conversationId = overrides.admission?.conversation?.id ?? "120363401234567890@g.us";
+  const conversationKind = overrides.admission?.conversation?.kind ?? "group";
   return createTestWebInboundMessage({
     event: { id: "m1" },
     payload: { body: overrides.body ?? "" },
     platform: {
-      chatJid: "120363401234567890@g.us",
+      chatJid: conversationId,
       recipientJid: "15551234567@s.whatsapp.net",
       selfE164: overrides.selfE164,
       selfJid: overrides.selfJid,
       selfLid: overrides.selfLid,
     },
-    from,
-    conversationId: overrides.conversationId ?? from,
-    accountId: "default",
-    chatType: overrides.chatType ?? "group",
+    admission: {
+      ...overrides.admission,
+      accountId: overrides.admission?.accountId ?? "default",
+      conversation: {
+        kind: conversationKind,
+        id: conversationId,
+        ...overrides.admission?.conversation,
+      },
+      sender: {
+        id: conversationId,
+        ...overrides.admission?.sender,
+      },
+      senderAccess: {
+        reasonCode:
+          conversationKind === "direct" ? "dm_policy_allowlisted" : "group_policy_allowed",
+        ...overrides.admission?.senderAccess,
+      },
+    },
     group: {
       mentions: {
         jids: overrides.mentionedJids,
@@ -119,7 +132,7 @@ describe("isBotMentionedFromTargets", () => {
   const mentionCfg = { mentionRegexes: [/\bopenclaw\b/i] };
 
   function expectMentioned(
-    msg: WebInboundMessage,
+    msg: AdmittedWebInboundMessage,
     cfg: { mentionRegexes: RegExp[]; allowFrom?: Array<string | number>; isSelfChat?: boolean },
     expected: boolean,
   ) {
@@ -162,9 +175,12 @@ describe("isBotMentionedFromTargets", () => {
       // Direct chat with self, not a group — the original "ignore mentions
       // in self-chat" suppression still applies here so that mentioning the
       // owner in their own DM does not falsely trigger the bot.
-      from: "999@s.whatsapp.net",
-      conversationId: "999@s.whatsapp.net",
-      chatType: "direct",
+      admission: {
+        conversation: {
+          kind: "direct",
+          id: "999@s.whatsapp.net",
+        },
+      },
       body: "@owner ping",
       mentionedJids: ["999@s.whatsapp.net"],
       selfE164: "+999",
@@ -173,9 +189,12 @@ describe("isBotMentionedFromTargets", () => {
     expectMentioned(msg, cfg, false);
 
     const msgTextMention = makeMsg({
-      from: "999@s.whatsapp.net",
-      conversationId: "999@s.whatsapp.net",
-      chatType: "direct",
+      admission: {
+        conversation: {
+          kind: "direct",
+          id: "999@s.whatsapp.net",
+        },
+      },
       body: "openclaw ping",
       selfE164: "+999",
       selfJid: "999@s.whatsapp.net",
@@ -316,7 +335,11 @@ describe("web auto-reply util", () => {
   describe("mentions diagnostics", () => {
     it("returns normalized debug fields and mention outcome", () => {
       const msg = makeMsg({
-        from: "777@lid",
+        admission: {
+          conversation: {
+            id: "777@lid",
+          },
+        },
         body: "openclaw ping",
         selfE164: "+15551234567",
         selfJid: "15551234567@s.whatsapp.net",

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -15,7 +15,7 @@ import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts
 import { getSelfIdentity, getSenderIdentity } from "./identity.js";
 import { requireWhatsAppInboundAdmission } from "./inbound/admission.js";
 import { resolveWhatsAppGroupConversationId } from "./inbound/group-conversation.js";
-import type { WebInboundMessage } from "./inbound/types.js";
+import type { AdmittedWebInboundMessage } from "./inbound/types.js";
 import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
 import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
 
@@ -171,7 +171,7 @@ export async function resolveWhatsAppIngressAccess(params: {
 
 export async function resolveWhatsAppCommandAuthorized(params: {
   cfg: OpenClawConfig;
-  msg: WebInboundMessage;
+  msg: AdmittedWebInboundMessage;
   policy?: ResolvedWhatsAppInboundPolicy;
 }): Promise<boolean> {
   const useAccessGroups = params.cfg.commands?.useAccessGroups !== false;

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -13,6 +13,7 @@ import type {
 import { resolveDefaultGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
 import { getSelfIdentity, getSenderIdentity } from "./identity.js";
+import { requireWhatsAppInboundAdmission } from "./inbound/admission.js";
 import { resolveWhatsAppGroupConversationId } from "./inbound/group-conversation.js";
 import type { WebInboundMessage } from "./inbound/types.js";
 import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
@@ -179,16 +180,17 @@ export async function resolveWhatsAppCommandAuthorized(params: {
   }
 
   const self = getSelfIdentity(params.msg);
+  const admission = requireWhatsAppInboundAdmission(params.msg);
   const policy =
     params.policy ??
     resolveWhatsAppInboundPolicy({
       cfg: params.cfg,
-      accountId: params.msg.accountId,
+      accountId: admission.accountId,
       selfE164: self.e164 ?? null,
     });
-  const isGroup = params.msg.chatType === "group";
+  const isGroup = admission.conversation.kind === "group";
   const sender = getSenderIdentity(params.msg);
-  const dmSender = sender.e164 ?? params.msg.from ?? "";
+  const dmSender = sender.e164 ?? admission.conversation.id;
   const groupSender = sender.e164 ?? "";
   if (!normalizeE164(isGroup ? groupSender : dmSender)) {
     return false;
@@ -198,7 +200,7 @@ export async function resolveWhatsAppCommandAuthorized(params: {
     cfg: params.cfg,
     policy,
     isGroup,
-    conversationId: params.msg.conversationId ?? params.msg.platform.chatJid ?? params.msg.from,
+    conversationId: admission.conversation.id,
     senderId: isGroup ? groupSender : dmSender,
     dmSenderId: dmSender,
     includeCommand: true,

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -71,10 +71,16 @@ async function checkCommandAuthorizedForDm(params: {
         senderE164: params.senderE164 ?? params.from ?? "+15550001111",
         selfE164: params.selfE164 ?? "+15550009999",
       },
-      accountId: params.accountId ?? "work",
-      chatType: "direct",
-      from: params.from ?? "+15550001111",
-      conversationId: params.from ?? "+15550001111",
+      admission: {
+        accountId: params.accountId ?? "work",
+        conversation: {
+          kind: "direct",
+          id: params.from ?? "+15550001111",
+        },
+        sender: {
+          id: params.senderE164 ?? params.from ?? "+15550001111",
+        },
+      },
     }) as never,
   });
 }
@@ -97,10 +103,19 @@ async function checkCommandAuthorizedForGroup(params: {
         senderE164: params.senderE164 ?? "+15550001111",
         selfE164: params.selfE164 ?? "+15550009999",
       },
-      accountId: params.accountId ?? "work",
-      chatType: "group",
-      from: params.from ?? "120363401234567890@g.us",
-      conversationId: params.from ?? "120363401234567890@g.us",
+      admission: {
+        accountId: params.accountId ?? "work",
+        conversation: {
+          kind: "group",
+          id: params.from ?? "120363401234567890@g.us",
+        },
+        sender: {
+          id: params.senderE164 ?? "+15550001111",
+        },
+        senderAccess: {
+          reasonCode: "group_policy_allowed",
+        },
+      },
     }) as never,
   });
 }

--- a/extensions/whatsapp/src/inbound/admission-types.ts
+++ b/extensions/whatsapp/src/inbound/admission-types.ts
@@ -1,0 +1,75 @@
+import type { ResolvedChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
+
+type WhatsAppInboundIngressDecision = Pick<
+  ResolvedChannelMessageIngress["ingress"],
+  "admission" | "decision" | "decisiveGateId" | "reasonCode"
+>;
+
+type WhatsAppInboundSenderAccess = Pick<
+  ResolvedChannelMessageIngress["senderAccess"],
+  "allowed" | "decision" | "reasonCode" | "providerMissingFallbackApplied"
+>;
+
+type WhatsAppInboundCommandAccess = Pick<
+  ResolvedChannelMessageIngress["commandAccess"],
+  "requested" | "authorized" | "shouldBlockControlCommand" | "reasonCode"
+>;
+
+type WhatsAppInboundActivationAccess = Pick<
+  ResolvedChannelMessageIngress["activationAccess"],
+  "ran" | "allowed" | "shouldSkip" | "reasonCode"
+>;
+
+export type WhatsAppInboundAdmissionAccess = {
+  ingress: WhatsAppInboundIngressDecision;
+  senderAccess: WhatsAppInboundSenderAccess;
+  commandAccess: WhatsAppInboundCommandAccess;
+  activationAccess: WhatsAppInboundActivationAccess;
+};
+
+export type WhatsAppInboundAdmissionPolicy = {
+  account: {
+    accountId: string;
+    name?: string;
+    enabled: boolean;
+    sendReadReceipts: boolean;
+    selfChatMode?: boolean;
+    replyToMode?: ReplyToMode;
+  };
+  isSelfChat: boolean;
+  isSamePhone: (value?: string | null) => boolean;
+};
+
+/**
+ * Public-safe accepted inbound facts resolved by access control.
+ *
+ * Keep this as an admission envelope around canonical channel ingress
+ * projections. Later PRs can migrate consumers to these projections without
+ * publishing raw allowlist material or session-dependent post-admission state.
+ */
+export type WhatsAppInboundAdmission = {
+  accountId: string;
+  isSelfChat: boolean;
+  account: {
+    accountId: string;
+    name?: string;
+    enabled: boolean;
+    sendReadReceipts: boolean;
+    selfChatMode?: boolean;
+    replyToMode?: ReplyToMode;
+  };
+  conversation: {
+    kind: "direct" | "group";
+    id: string;
+    groupSessionId: string;
+  };
+  sender: {
+    id: string;
+    isSamePhone: boolean;
+  };
+  ingress: WhatsAppInboundIngressDecision;
+  senderAccess: WhatsAppInboundSenderAccess;
+  commandAccess: WhatsAppInboundCommandAccess;
+  activationAccess: WhatsAppInboundActivationAccess;
+};

--- a/extensions/whatsapp/src/inbound/admission.ts
+++ b/extensions/whatsapp/src/inbound/admission.ts
@@ -1,72 +1,17 @@
-import type { ResolvedChannelMessageIngress } from "openclaw/plugin-sdk/channel-ingress-runtime";
-import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  WhatsAppInboundAdmission,
+  WhatsAppInboundAdmissionAccess,
+  WhatsAppInboundAdmissionPolicy,
+} from "./admission-types.js";
 import { resolveWhatsAppGroupConversationId } from "./group-conversation.js";
+import type {
+  AdmittedWebInboundMessage,
+  DeprecatedWebInboundAdmissionTopLevelFields,
+  WebInboundCallbackMessage,
+  WebInboundMessage,
+} from "./types.js";
 
-type WhatsAppInboundIngressDecision = Pick<
-  ResolvedChannelMessageIngress["ingress"],
-  "admission" | "decision" | "decisiveGateId" | "reasonCode"
->;
-
-type WhatsAppInboundSenderAccess = Pick<
-  ResolvedChannelMessageIngress["senderAccess"],
-  "allowed" | "decision" | "reasonCode" | "providerMissingFallbackApplied"
->;
-
-type WhatsAppInboundCommandAccess = Pick<
-  ResolvedChannelMessageIngress["commandAccess"],
-  "requested" | "authorized" | "shouldBlockControlCommand" | "reasonCode"
->;
-
-type WhatsAppInboundActivationAccess = Pick<
-  ResolvedChannelMessageIngress["activationAccess"],
-  "ran" | "allowed" | "shouldSkip" | "reasonCode"
->;
-
-type WhatsAppInboundAdmissionPolicy = {
-  account: {
-    accountId: string;
-    name?: string;
-    enabled: boolean;
-    sendReadReceipts: boolean;
-    selfChatMode?: boolean;
-    replyToMode?: ReplyToMode;
-  };
-  isSelfChat: boolean;
-  isSamePhone: (value?: string | null) => boolean;
-};
-
-/**
- * Public-safe accepted inbound facts resolved by access control.
- *
- * Keep this as an admission envelope around canonical channel ingress
- * projections. Later PRs can migrate consumers to these projections without
- * publishing raw allowlist material or session-dependent post-admission state.
- */
-export type WhatsAppInboundAdmission = {
-  accountId: string;
-  isSelfChat: boolean;
-  account: {
-    accountId: string;
-    name?: string;
-    enabled: boolean;
-    sendReadReceipts: boolean;
-    selfChatMode?: boolean;
-    replyToMode?: ReplyToMode;
-  };
-  conversation: {
-    kind: "direct" | "group";
-    id: string;
-    groupSessionId: string;
-  };
-  sender: {
-    id: string;
-    isSamePhone: boolean;
-  };
-  ingress: WhatsAppInboundIngressDecision;
-  senderAccess: WhatsAppInboundSenderAccess;
-  commandAccess: WhatsAppInboundCommandAccess;
-  activationAccess: WhatsAppInboundActivationAccess;
-};
+export type { WhatsAppInboundAdmission } from "./admission-types.js";
 
 function copyAccount(
   account: WhatsAppInboundAdmissionPolicy["account"],
@@ -90,7 +35,7 @@ function copyAccount(
 
 export function buildWhatsAppInboundAdmission(params: {
   policy: WhatsAppInboundAdmissionPolicy;
-  access: ResolvedChannelMessageIngress;
+  access: WhatsAppInboundAdmissionAccess;
   isGroup: boolean;
   conversationId: string;
   senderId: string;
@@ -133,4 +78,95 @@ export function buildWhatsAppInboundAdmission(params: {
       reasonCode: params.access.activationAccess.reasonCode,
     },
   };
+}
+
+export function buildDeprecatedFlatWhatsAppInboundAdmission(
+  msg: Partial<DeprecatedWebInboundAdmissionTopLevelFields> & {
+    platform?: WebInboundCallbackMessage["platform"];
+    senderE164?: string | null;
+    senderJid?: string | null;
+    senderName?: string | null;
+  },
+): WhatsAppInboundAdmission {
+  const conversationId = msg.conversationId || msg.from;
+  if (!conversationId || !msg.accountId || !msg.chatType) {
+    throw new Error(
+      "WhatsApp legacy flat inbound messages must include deprecated top-level admission fields.",
+    );
+  }
+  const accountId = msg.accountId;
+  const admitted = msg.accessControlPassed !== false;
+  const platformSender = msg.platform?.sender;
+  const senderE164 = platformSender?.e164 ?? msg.platform?.senderE164 ?? msg.senderE164;
+  const senderJid = platformSender?.jid ?? msg.platform?.senderJid ?? msg.senderJid;
+  const senderName = platformSender?.name ?? msg.platform?.senderName ?? msg.senderName;
+  const senderId =
+    msg.chatType === "group"
+      ? (senderE164 ?? senderJid ?? senderName ?? conversationId)
+      : (senderE164 ?? conversationId);
+  const reasonCode = admitted
+    ? msg.chatType === "group"
+      ? "group_policy_allowed"
+      : "dm_policy_allowlisted"
+    : "no_policy_match";
+
+  // Compatibility only: deprecated listenerFactory flat inputs predate the
+  // admission envelope, so convert them through the canonical admission builder.
+  // Canonical nested inputs without admission remain malformed for runtime use.
+  return buildWhatsAppInboundAdmission({
+    policy: {
+      account: {
+        accountId,
+        enabled: true,
+        sendReadReceipts: true,
+      },
+      isSelfChat: false,
+      isSamePhone: () => false,
+    },
+    access: {
+      ingress: {
+        admission: admitted ? "dispatch" : "drop",
+        decision: admitted ? "allow" : "block",
+        decisiveGateId: "legacy-flat-compat",
+        reasonCode,
+      },
+      senderAccess: {
+        allowed: admitted,
+        decision: admitted ? "allow" : "block",
+        reasonCode,
+        providerMissingFallbackApplied: false,
+      },
+      commandAccess: {
+        requested: false,
+        authorized: false,
+        shouldBlockControlCommand: false,
+        reasonCode: "command_authorized",
+      },
+      activationAccess: {
+        ran: false,
+        allowed: admitted,
+        shouldSkip: !admitted,
+        reasonCode: admitted ? "activation_allowed" : "activation_skipped",
+      },
+    },
+    isGroup: msg.chatType === "group",
+    conversationId,
+    senderId,
+  });
+}
+
+export function requireWhatsAppInboundAdmission(params: {
+  admission?: WhatsAppInboundAdmission;
+}): WhatsAppInboundAdmission {
+  if (!params.admission) {
+    throw new Error("WhatsApp inbound message is missing admission facts");
+  }
+  return params.admission;
+}
+
+export function requireAdmittedWhatsAppInboundMessage(
+  msg: WebInboundMessage,
+): AdmittedWebInboundMessage {
+  requireWhatsAppInboundAdmission(msg);
+  return msg as AdmittedWebInboundMessage;
 }

--- a/extensions/whatsapp/src/inbound/message-aliases.test.ts
+++ b/extensions/whatsapp/src/inbound/message-aliases.test.ts
@@ -1,11 +1,14 @@
 // WhatsApp tests cover inbound message alias compatibility.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
   normalizeWebInboundMessage,
   withDeprecatedWebInboundMessageFlatAliases,
 } from "./message-aliases.js";
+import type { monitorWebInbox } from "./monitor.js";
 import { createAcceptedWhatsAppSendResult } from "./send-result.test-helper.js";
 import type { LegacyFlatWebInboundMessage, WebInboundCallbackMessage } from "./types.js";
+
+type MonitorWebInboxMessage = Parameters<Parameters<typeof monitorWebInbox>[0]["onMessage"]>[0];
 
 function createAdmission(): NonNullable<WebInboundCallbackMessage["admission"]> {
   return {
@@ -114,6 +117,17 @@ function createCanonicalMessage(overrides: Partial<WebInboundCallbackMessage> = 
 }
 
 describe("WhatsApp inbound flat aliases", () => {
+  it("keeps deprecated admission fields typed on monitor callbacks", () => {
+    expectTypeOf<MonitorWebInboxMessage>().toMatchTypeOf<{
+      admission: NonNullable<WebInboundCallbackMessage["admission"]>;
+      from: string;
+      conversationId: string;
+      accountId: string;
+      accessControlPassed?: boolean;
+      chatType: "direct" | "group";
+    }>();
+  });
+
   it("keeps deprecated flat aliases live against canonical contexts", async () => {
     const msg = createCanonicalMessage();
     const nextReply = vi.fn(async () => createAcceptedWhatsAppSendResult("text", "reply-2"));
@@ -199,6 +213,44 @@ describe("WhatsApp inbound flat aliases", () => {
     expect(msg.accessControlPassed).toBe(true);
   });
 
+  it("normalizes canonical messages without admission without rebuilding admission facts", () => {
+    const normalized = normalizeWebInboundMessage({
+      event: {
+        id: "group-no-admission",
+        timestamp: 1_700_000_456,
+      },
+      payload: {
+        body: "hello group",
+      },
+      platform: {
+        chatJid: "123@g.us",
+        recipientJid: "+15550000001",
+        senderJid: "15550000002@s.whatsapp.net",
+        senderE164: "+15550000002",
+        senderName: "Alice",
+        sendComposing: vi.fn(async () => undefined),
+        reply: vi.fn(async () => createAcceptedWhatsAppSendResult("text", "reply-group")),
+        sendMedia: vi.fn(async () => createAcceptedWhatsAppSendResult("media", "media-group")),
+      },
+      from: "123@g.us",
+      conversationId: "123@g.us",
+      accountId: "work",
+      accessControlPassed: true,
+      chatType: "group",
+    });
+
+    expect(normalized.admission).toBeUndefined();
+    expect(normalized.from).toBe("123@g.us");
+    expect(normalized.conversationId).toBe("123@g.us");
+    expect(normalized.accountId).toBe("work");
+    expect(normalized.chatType).toBe("group");
+
+    normalized.conversationId = "456@g.us";
+    expect(normalized.admission).toBeUndefined();
+    expect(normalized.from).toBe("456@g.us");
+    expect(normalized.conversationId).toBe("456@g.us");
+  });
+
   it("normalizes legacy flat messages into canonical contexts with live aliases", () => {
     const legacyReply = vi.fn(async () => createAcceptedWhatsAppSendResult("text", "reply-legacy"));
     const legacy: LegacyFlatWebInboundMessage = {
@@ -241,6 +293,13 @@ describe("WhatsApp inbound flat aliases", () => {
       chatJid: "15550000002@s.whatsapp.net",
       recipientJid: "+15550000001",
     });
+    expect(normalized.admission?.ingress).toMatchObject({
+      admission: "dispatch",
+      decision: "allow",
+      decisiveGateId: "legacy-flat-compat",
+      reasonCode: "dm_policy_allowlisted",
+    });
+    expect(normalized.accessControlPassed).toBe(true);
     expect(normalized.quote).toMatchObject({
       id: "quote-legacy",
       body: "legacy quoted",
@@ -260,5 +319,37 @@ describe("WhatsApp inbound flat aliases", () => {
     expect(normalized.body).toBe("canonical update");
     normalized.replyToSender = "Updated Sender";
     expect(normalized.quote?.sender?.displayName).toBe("Updated Sender");
+  });
+
+  it("normalizes blocked legacy flat admission fields through the compatibility seam", () => {
+    const normalized = normalizeWebInboundMessage({
+      id: "legacy-blocked",
+      from: "+15550000002",
+      conversationId: "+15550000002",
+      accountId: "default",
+      accessControlPassed: false,
+      chatType: "direct",
+      to: "+15550000001",
+      body: "blocked legacy body",
+      chatId: "15550000002@s.whatsapp.net",
+      sendComposing: vi.fn(async () => undefined),
+      reply: vi.fn(async () => createAcceptedWhatsAppSendResult("text", "reply-blocked")),
+      sendMedia: vi.fn(async () => createAcceptedWhatsAppSendResult("media", "media-blocked")),
+    });
+
+    expect(normalized.admission).toMatchObject({
+      ingress: {
+        admission: "drop",
+        decision: "block",
+        decisiveGateId: "legacy-flat-compat",
+        reasonCode: "no_policy_match",
+      },
+      senderAccess: {
+        allowed: false,
+        decision: "block",
+        reasonCode: "no_policy_match",
+      },
+    });
+    expect(normalized.accessControlPassed).toBe(false);
   });
 });

--- a/extensions/whatsapp/src/inbound/message-aliases.test.ts
+++ b/extensions/whatsapp/src/inbound/message-aliases.test.ts
@@ -6,54 +6,10 @@ import {
 } from "./message-aliases.js";
 import type { monitorWebInbox } from "./monitor.js";
 import { createAcceptedWhatsAppSendResult } from "./send-result.test-helper.js";
+import { createTestWhatsAppInboundAdmission } from "./test-message.test-helper.js";
 import type { LegacyFlatWebInboundMessage, WebInboundCallbackMessage } from "./types.js";
 
 type MonitorWebInboxMessage = Parameters<Parameters<typeof monitorWebInbox>[0]["onMessage"]>[0];
-
-function createAdmission(): NonNullable<WebInboundCallbackMessage["admission"]> {
-  return {
-    accountId: "default",
-    isSelfChat: false,
-    account: {
-      accountId: "default",
-      enabled: true,
-      sendReadReceipts: true,
-    },
-    conversation: {
-      kind: "group",
-      id: "123@g.us",
-      groupSessionId: "123@g.us",
-    },
-    sender: {
-      id: "+15550000002",
-      isSamePhone: false,
-    },
-    ingress: {
-      admission: "dispatch",
-      decision: "allow",
-      decisiveGateId: "activation",
-      reasonCode: "activation_allowed",
-    },
-    senderAccess: {
-      allowed: true,
-      decision: "allow",
-      providerMissingFallbackApplied: false,
-      reasonCode: "group_policy_allowed",
-    },
-    commandAccess: {
-      requested: false,
-      authorized: false,
-      shouldBlockControlCommand: false,
-      reasonCode: "command_authorized",
-    },
-    activationAccess: {
-      ran: true,
-      allowed: true,
-      shouldSkip: false,
-      reasonCode: "activation_allowed",
-    },
-  };
-}
 
 function createCanonicalMessage(overrides: Partial<WebInboundCallbackMessage> = {}) {
   return withDeprecatedWebInboundMessageFlatAliases({
@@ -116,6 +72,26 @@ function createCanonicalMessage(overrides: Partial<WebInboundCallbackMessage> = 
   });
 }
 
+const callbackMessageWithoutAdmissionFacts = {
+  event: {
+    id: "event-missing-admission",
+  },
+  payload: {
+    body: "missing admission",
+  },
+  platform: {
+    chatJid: "123@g.us",
+    recipientJid: "+15550000001",
+    sendComposing: async () => undefined,
+    reply: async () => createAcceptedWhatsAppSendResult("text", "reply-missing-admission"),
+    sendMedia: async () => createAcceptedWhatsAppSendResult("media", "media-missing-admission"),
+  },
+};
+
+// @ts-expect-error Callback messages must provide admission or deprecated admission fields.
+const invalidCallbackMessage: WebInboundCallbackMessage = callbackMessageWithoutAdmissionFacts;
+void invalidCallbackMessage;
+
 describe("WhatsApp inbound flat aliases", () => {
   it("keeps deprecated admission fields typed on monitor callbacks", () => {
     expectTypeOf<MonitorWebInboxMessage>().toMatchTypeOf<{
@@ -169,7 +145,20 @@ describe("WhatsApp inbound flat aliases", () => {
   });
 
   it("keeps deprecated admission top-level fields aligned with admission", () => {
-    const msg = createCanonicalMessage({ admission: createAdmission() });
+    const msg = createCanonicalMessage({
+      admission: createTestWhatsAppInboundAdmission({
+        conversation: {
+          kind: "group",
+          id: "123@g.us",
+        },
+        sender: {
+          id: "+15550000002",
+        },
+        senderAccess: {
+          reasonCode: "group_policy_allowed",
+        },
+      }),
+    });
 
     expect(msg.from).toBe("123@g.us");
     msg.admission!.conversation.id = "456@g.us";

--- a/extensions/whatsapp/src/inbound/message-aliases.ts
+++ b/extensions/whatsapp/src/inbound/message-aliases.ts
@@ -1,3 +1,4 @@
+import { buildDeprecatedFlatWhatsAppInboundAdmission } from "./admission.js";
 import { resolveWhatsAppGroupConversationId } from "./group-conversation.js";
 import type {
   DeprecatedWebInboundAdmissionTopLevelFields,
@@ -373,6 +374,7 @@ function normalizeLegacyFlatWebInboundMessage(msg: LegacyFlatWebInboundMessage):
       : undefined;
   return withDeprecatedWebInboundMessageFlatAliases({
     ...msg,
+    admission: msg.admission ?? buildDeprecatedFlatWhatsAppInboundAdmission(msg),
     event: {
       id: msg.id,
       timestamp: msg.timestamp,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -43,6 +43,10 @@ import {
   type AcceptedInboundAccessControlResult,
 } from "./access-control.js";
 import {
+  requireAdmittedWhatsAppInboundMessage,
+  requireWhatsAppInboundAdmission,
+} from "./admission.js";
+import {
   claimRecentInboundMessageDelivery,
   commitRecentInboundMessage,
   isRecentOutboundMessage,
@@ -84,7 +88,12 @@ import {
 import { DisconnectReason, isJidGroup } from "./runtime-api.js";
 import { createWebSendApi } from "./send-api.js";
 import { normalizeWhatsAppSendResult } from "./send-result.js";
-import type { WebInboundMessageInput, WebInboundMessage, WebListenerCloseReason } from "./types.js";
+import type {
+  AdmittedWebInboundMessage,
+  WebInboundMessage,
+  WebInboundMessageInput,
+  WebListenerCloseReason,
+} from "./types.js";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
 const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress";
@@ -196,6 +205,10 @@ function isNonEmptyString(value: string | undefined): value is string {
   return Boolean(value);
 }
 
+type AdmittedWebInboundCallbackMessage = WebInboundMessage & {
+  admission: AdmittedWebInboundMessage["admission"];
+};
+
 type MonitorWebInboxOptions = {
   cfg: OpenClawConfig;
   loadConfig?: () => OpenClawConfig;
@@ -203,7 +216,7 @@ type MonitorWebInboxOptions = {
   verbose: boolean;
   accountId: string;
   authDir: string;
-  onMessage: (msg: WebInboundMessage) => Promise<void>;
+  onMessage: (msg: AdmittedWebInboundCallbackMessage) => Promise<void>;
   mediaMaxMb?: number;
   /** Keep the global presence unavailable so self-chat sessions do not mute phone pushes. */
   selfChatMode?: boolean;
@@ -212,7 +225,7 @@ type MonitorWebInboxOptions = {
   /** Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable). */
   debounceMs?: number;
   /** Optional debounce gating predicate. */
-  shouldDebounce?: (msg: WebInboundMessage) => boolean;
+  shouldDebounce?: (msg: AdmittedWebInboundCallbackMessage) => boolean;
   /** Optional shared socket reference so reply closures can follow reconnects. */
   socketRef?: { current: WASocket | null };
   /** Whether send retries should wait for a reconnect. */
@@ -323,35 +336,35 @@ export async function attachWebInboxToSocket(
     return successor.getCurrentSock();
   };
   type QueuedInboundMessageMetadata = {
-    admission: NonNullable<WebInboundMessage["admission"]>;
+    admission: AdmittedWebInboundCallbackMessage["admission"];
     dedupeKey?: string;
     debounceKey?: string;
     durableId?: string;
     readReceipt?: WhatsAppReadReceiptTarget;
     receiveOrder?: number;
   };
-  type QueuedInboundMessage = WebInboundMessage & QueuedInboundMessageMetadata;
+  type QueuedInboundMessage = AdmittedWebInboundCallbackMessage & QueuedInboundMessageMetadata;
   const durableInboundJournal = createWhatsAppDurableInboundReceiveJournal(options.accountId);
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingDebounceKeys = new Set<string>();
   const activeInboundFlushes = new Set<Promise<void>>();
-  const buildInboundDebounceKey = (msg: WebInboundMessage): string | null => {
+  const buildInboundDebounceKey = (msg: QueuedInboundMessage): string | null => {
+    const admission = requireWhatsAppInboundAdmission(msg);
     const sender = msg.platform.sender;
     const senderKey =
-      msg.chatType === "group"
+      admission.conversation.kind === "group"
         ? (getPrimaryIdentityId(sender ?? null) ??
           msg.platform.senderJid ??
           msg.platform.senderE164 ??
           msg.platform.senderName ??
-          msg.from)
-        : msg.from;
+          admission.sender.id)
+        : admission.conversation.id;
     if (!senderKey) {
       return null;
     }
-    const conversationKey = msg.chatType === "group" ? msg.platform.chatJid : msg.from;
-    return `${msg.accountId}:${conversationKey}:${senderKey}`;
+    return `${admission.accountId}:${admission.conversation.id}:${senderKey}`;
   };
-  const shouldDebounceInboundMessage = (msg: WebInboundMessage): boolean =>
+  const shouldDebounceInboundMessage = (msg: AdmittedWebInboundCallbackMessage): boolean =>
     options.shouldDebounce?.(msg) ?? true;
   const orderDebouncedInboundEntries = (entries: QueuedInboundMessage[]) =>
     entries.toSorted((a, b) => {
@@ -1197,11 +1210,6 @@ export async function attachWebInboxToSocket(
         reply,
         sendMedia,
       },
-      from: inbound.from,
-      conversationId: inbound.from,
-      accountId: inbound.access.resolvedAccountId,
-      accessControlPassed: true,
-      chatType: inbound.group ? "group" : "direct",
       quote: enriched.replyContext
         ? {
             context: enriched.replyContext,
@@ -1228,14 +1236,17 @@ export async function attachWebInboxToSocket(
       }
     }
     if (inboundMessage.event.id) {
+      const admission = requireWhatsAppInboundAdmission(inboundMessage);
       cacheInboundMessageMeta(
-        inboundMessage.accountId,
+        admission.accountId,
         inboundMessage.platform.chatJid,
         inboundMessage.event.id,
         {
           participant: inboundMessage.platform.senderJid,
           participantE164:
-            inboundMessage.chatType === "direct" ? inboundMessage.platform.senderE164 : undefined,
+            admission.conversation.kind === "direct"
+              ? inboundMessage.platform.senderE164
+              : undefined,
           body: inboundMessage.payload.body,
           fromMe: inboundMessage.platform.fromMe,
         },
@@ -1453,13 +1464,19 @@ export async function monitorWebInbox(options: MonitorWebInboxOptions) {
     throw err;
   }
   const shouldDebounce = options.shouldDebounce;
+  const normalizeAdmittedWebInboundMessage = (
+    msg: WebInboundMessageInput,
+  ): AdmittedWebInboundCallbackMessage =>
+    requireAdmittedWhatsAppInboundMessage(
+      normalizeWebInboundMessage(msg),
+    ) as AdmittedWebInboundCallbackMessage;
   return attachWebInboxToSocket({
     ...options,
     onMessage: async (msg) => {
-      await options.onMessage(normalizeWebInboundMessage(msg));
+      await options.onMessage(normalizeAdmittedWebInboundMessage(msg));
     },
     shouldDebounce: shouldDebounce
-      ? (msg) => shouldDebounce(normalizeWebInboundMessage(msg))
+      ? (msg) => shouldDebounce(normalizeAdmittedWebInboundMessage(msg))
       : undefined,
     socketTiming,
     sock,

--- a/extensions/whatsapp/src/inbound/test-message.test-helper.ts
+++ b/extensions/whatsapp/src/inbound/test-message.test-helper.ts
@@ -4,6 +4,7 @@ import { withDeprecatedWebInboundMessageFlatAliases } from "./message-aliases.js
 import { createAcceptedWhatsAppSendResult } from "./send-result.test-helper.js";
 import type {
   LegacyFlatWebInboundMessage,
+  AdmittedWebInboundMessage,
   WebInboundCallbackMessage,
   WebInboundMessage,
   WhatsAppInboundEvent,
@@ -11,7 +12,7 @@ import type {
   WhatsAppInboundPlatform,
 } from "./types.js";
 
-type TestWhatsAppInboundAdmissionOverrides = Partial<
+export type TestWhatsAppInboundAdmissionOverrides = Partial<
   Omit<
     WhatsAppInboundAdmission,
     | "account"
@@ -52,7 +53,7 @@ type TestInboundMessageOverrides = Partial<
   platform?: Partial<WhatsAppInboundPlatform>;
 };
 
-function createTestWhatsAppInboundAdmission(
+export function createTestWhatsAppInboundAdmission(
   overrides: TestWhatsAppInboundAdmissionOverrides = {},
 ): WhatsAppInboundAdmission {
   const conversationId = overrides.conversation?.id ?? "+15551234567";
@@ -112,7 +113,7 @@ function createTestWhatsAppInboundAdmission(
 
 export function createTestWebInboundMessage(
   overrides: TestInboundMessageOverrides = {},
-): WebInboundMessage {
+): WebInboundMessage & AdmittedWebInboundMessage {
   const { admission: admissionOverrides, event, payload, platform, ...message } = overrides;
   const admission = createTestWhatsAppInboundAdmission(admissionOverrides);
   return withDeprecatedWebInboundMessageFlatAliases({
@@ -134,7 +135,7 @@ export function createTestWebInboundMessage(
     },
     admission,
     ...message,
-  });
+  }) as WebInboundMessage & AdmittedWebInboundMessage;
 }
 
 export function createTestLegacyFlatWebInboundMessage(
@@ -158,7 +159,7 @@ export function createTestLegacyFlatWebInboundMessage(
 
 export function createTestWebAudioInboundMessage(
   overrides: TestInboundMessageOverrides = {},
-): WebInboundMessage {
+): WebInboundMessage & AdmittedWebInboundMessage {
   const { event, payload, platform, ...message } = overrides;
   const media = Object.hasOwn(payload ?? {}, "media")
     ? payload?.media

--- a/extensions/whatsapp/src/inbound/test-message.test-helper.ts
+++ b/extensions/whatsapp/src/inbound/test-message.test-helper.ts
@@ -1,3 +1,5 @@
+import type { WhatsAppInboundAdmission } from "./admission.js";
+import { resolveWhatsAppGroupConversationId } from "./group-conversation.js";
 import { withDeprecatedWebInboundMessageFlatAliases } from "./message-aliases.js";
 import { createAcceptedWhatsAppSendResult } from "./send-result.test-helper.js";
 import type {
@@ -9,18 +11,110 @@ import type {
   WhatsAppInboundPlatform,
 } from "./types.js";
 
-type TestInboundMessageOverrides = Partial<
-  Omit<WebInboundCallbackMessage, "event" | "payload" | "platform">
+type TestWhatsAppInboundAdmissionOverrides = Partial<
+  Omit<
+    WhatsAppInboundAdmission,
+    | "account"
+    | "conversation"
+    | "sender"
+    | "ingress"
+    | "senderAccess"
+    | "commandAccess"
+    | "activationAccess"
+  >
 > & {
+  account?: Partial<WhatsAppInboundAdmission["account"]>;
+  conversation?: Partial<WhatsAppInboundAdmission["conversation"]>;
+  sender?: Partial<WhatsAppInboundAdmission["sender"]>;
+  ingress?: Partial<WhatsAppInboundAdmission["ingress"]>;
+  senderAccess?: Partial<WhatsAppInboundAdmission["senderAccess"]>;
+  commandAccess?: Partial<WhatsAppInboundAdmission["commandAccess"]>;
+  activationAccess?: Partial<WhatsAppInboundAdmission["activationAccess"]>;
+};
+
+type TestInboundMessageOverrides = Partial<
+  Omit<
+    WebInboundCallbackMessage,
+    | "event"
+    | "payload"
+    | "platform"
+    | "admission"
+    | "from"
+    | "conversationId"
+    | "accountId"
+    | "accessControlPassed"
+    | "chatType"
+  >
+> & {
+  admission?: TestWhatsAppInboundAdmissionOverrides;
   event?: Partial<WhatsAppInboundEvent>;
   payload?: Partial<WhatsAppInboundPayload>;
   platform?: Partial<WhatsAppInboundPlatform>;
 };
 
+function createTestWhatsAppInboundAdmission(
+  overrides: TestWhatsAppInboundAdmissionOverrides = {},
+): WhatsAppInboundAdmission {
+  const conversationId = overrides.conversation?.id ?? "+15551234567";
+  const accountId = overrides.accountId ?? overrides.account?.accountId ?? "default";
+  const kind = overrides.conversation?.kind ?? "direct";
+
+  return {
+    accountId,
+    isSelfChat: overrides.isSelfChat ?? false,
+    account: {
+      accountId,
+      enabled: true,
+      sendReadReceipts: true,
+      ...overrides.account,
+    },
+    conversation: {
+      kind,
+      id: conversationId,
+      groupSessionId:
+        overrides.conversation?.groupSessionId ??
+        resolveWhatsAppGroupConversationId(conversationId),
+    },
+    sender: {
+      id: overrides.sender?.id ?? conversationId,
+      isSamePhone: overrides.sender?.isSamePhone ?? false,
+    },
+    ingress: {
+      admission: "dispatch",
+      decision: "allow",
+      decisiveGateId: "activation",
+      reasonCode: "activation_allowed",
+      ...overrides.ingress,
+    },
+    senderAccess: {
+      allowed: true,
+      decision: "allow",
+      reasonCode: "dm_policy_allowlisted",
+      providerMissingFallbackApplied: false,
+      ...overrides.senderAccess,
+    },
+    commandAccess: {
+      requested: false,
+      authorized: false,
+      shouldBlockControlCommand: false,
+      reasonCode: "command_authorized",
+      ...overrides.commandAccess,
+    },
+    activationAccess: {
+      ran: true,
+      allowed: true,
+      shouldSkip: false,
+      reasonCode: "activation_allowed",
+      ...overrides.activationAccess,
+    },
+  };
+}
+
 export function createTestWebInboundMessage(
   overrides: TestInboundMessageOverrides = {},
 ): WebInboundMessage {
-  const { event, payload, platform, ...message } = overrides;
+  const { admission: admissionOverrides, event, payload, platform, ...message } = overrides;
+  const admission = createTestWhatsAppInboundAdmission(admissionOverrides);
   return withDeprecatedWebInboundMessageFlatAliases({
     event: {
       id: "msg-1",
@@ -38,10 +132,7 @@ export function createTestWebInboundMessage(
       sendMedia: async () => createAcceptedWhatsAppSendResult("media", "media-1"),
       ...platform,
     },
-    from: "+15551234567",
-    conversationId: "+15551234567",
-    accountId: "default",
-    chatType: "direct",
+    admission,
     ...message,
   });
 }
@@ -91,11 +182,16 @@ export function createTestWebAudioInboundMessage(
       recipientJid: "+15550000001",
       ...platform,
     },
-    from: "+15550000002",
-    conversationId: "+15550000002",
-    chatType: "direct",
-    accountId: "default",
-    accessControlPassed: true,
+    admission: {
+      accountId: "default",
+      conversation: {
+        kind: "direct",
+        id: "+15550000002",
+      },
+      ingress: {
+        decision: "allow",
+      },
+    },
     ...message,
   });
 }

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -3,7 +3,7 @@ import type { AnyMessageContent, MiscMessageGenerationOptions } from "baileys";
 import type { NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
 import type { PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import type { WhatsAppIdentity, WhatsAppReplyContext, WhatsAppSelfIdentity } from "../identity.js";
-import type { WhatsAppInboundAdmission } from "./admission.js";
+import type { WhatsAppInboundAdmission } from "./admission-types.js";
 import type { WhatsAppSendResult } from "./send-result.js";
 
 export type WebListenerCloseReason = {
@@ -219,23 +219,38 @@ export type DeprecatedWebInboundAdmissionTopLevelFields = {
   chatType: "direct" | "group";
 };
 
-type WebInboundMessageCommon = DeprecatedWebInboundAdmissionTopLevelFields & {
-  admission?: WhatsAppInboundAdmission;
+type WebInboundCallbackMessageCommon = {
   quote?: WhatsAppInboundQuote;
   group?: WhatsAppInboundGroupContext;
   wasMentioned?: boolean;
 };
 
-export type WebInboundCallbackMessage = WebInboundMessageCommon & {
-  event: WhatsAppInboundEvent;
-  payload: WhatsAppInboundPayload;
-  platform: WhatsAppInboundPlatform;
+type WebInboundCallbackAdmissionFields =
+  | ({ admission: WhatsAppInboundAdmission } & Partial<DeprecatedWebInboundAdmissionTopLevelFields>)
+  | ({ admission?: WhatsAppInboundAdmission } & DeprecatedWebInboundAdmissionTopLevelFields);
+
+export type WebInboundCallbackMessage = WebInboundCallbackMessageCommon &
+  WebInboundCallbackAdmissionFields & {
+    event: WhatsAppInboundEvent;
+    payload: WhatsAppInboundPayload;
+    platform: WhatsAppInboundPlatform;
+  };
+
+export type WebInboundMessage = WebInboundCallbackMessage &
+  DeprecatedWebInboundAdmissionTopLevelFields &
+  DeprecatedWebInboundMessageFlatAliases;
+
+export type AdmittedWebInboundMessage = Omit<
+  WebInboundMessage,
+  keyof DeprecatedWebInboundAdmissionTopLevelFields | "admission"
+> & {
+  admission: WhatsAppInboundAdmission;
 };
 
-export type WebInboundMessage = WebInboundCallbackMessage & DeprecatedWebInboundMessageFlatAliases;
-
-export type LegacyFlatWebInboundMessage = WebInboundMessageCommon &
-  DeprecatedWebInboundMessageFlatAliases & {
+export type LegacyFlatWebInboundMessage = DeprecatedWebInboundAdmissionTopLevelFields &
+  Pick<WebInboundCallbackMessageCommon, "wasMentioned"> & {
+    admission?: WhatsAppInboundAdmission;
+  } & DeprecatedWebInboundMessageFlatAliases & {
     event?: never;
     payload?: never;
     platform?: never;

--- a/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test-support.ts
@@ -117,7 +117,11 @@ describe("web monitor inbox", () => {
     // Should call onMessage for authorized senders
     expect(onMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "+999",
+        admission: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "+999",
+          }),
+        }),
         payload: expect.objectContaining({
           body: "authorized message",
         }),
@@ -151,7 +155,11 @@ describe("web monitor inbox", () => {
     // Should allow self-messages even if not in allowFrom
     expect(onMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "+123",
+        admission: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "+123",
+          }),
+        }),
         payload: expect.objectContaining({
           body: "self message",
         }),
@@ -214,7 +222,11 @@ describe("web monitor inbox", () => {
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(onMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "+123",
+        admission: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "+123",
+          }),
+        }),
         payload: expect.objectContaining({
           body: "self ping",
         }),
@@ -303,8 +315,12 @@ describe("web monitor inbox", () => {
 
     expect(onMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatType: "group",
-        from: "120363@g.us",
+        admission: expect.objectContaining({
+          conversation: expect.objectContaining({
+            kind: "group",
+            id: "120363@g.us",
+          }),
+        }),
         payload: expect.objectContaining({
           body: "/status",
         }),

--- a/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test-support.ts
@@ -209,8 +209,14 @@ describe("web monitor inbox", () => {
     expect(onMessage).toHaveBeenCalledTimes(1);
     expect(onMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        from: "+123",
-        accessControlPassed: true,
+        admission: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "+123",
+          }),
+          ingress: expect.objectContaining({
+            decision: "allow",
+          }),
+        }),
         payload: expect.objectContaining({
           body: "self ping",
         }),
@@ -267,7 +273,7 @@ describe("web monitor inbox", () => {
 
     expect(onMessage).toHaveBeenCalledTimes(1);
     const payload = firstInboundPayload(onMessage);
-    expect(payload.chatType).toBe("group");
+    expect(payload.admission?.conversation.kind).toBe("group");
     expect(payload.platform.senderE164).toBe("+999");
 
     await listener.close();
@@ -355,7 +361,7 @@ describe("web monitor inbox", () => {
     // Should call onMessage because sender is in groupAllowFrom
     expect(onMessage).toHaveBeenCalledTimes(1);
     const payload = firstInboundPayload(onMessage);
-    expect(payload.chatType).toBe("group");
+    expect(payload.admission?.conversation.kind).toBe("group");
     expect(payload.platform.senderE164).toBe("+15551234567");
 
     await listener.close();
@@ -389,7 +395,7 @@ describe("web monitor inbox", () => {
     // Should call onMessage because wildcard allows all senders
     expect(onMessage).toHaveBeenCalledTimes(1);
     const payload = firstInboundPayload(onMessage);
-    expect(payload.chatType).toBe("group");
+    expect(payload.admission?.conversation.kind).toBe("group");
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test-support.ts
@@ -222,8 +222,12 @@ describe("web monitor inbox", () => {
     });
 
     expectSingleGroupMessage(onMessage, {
-      chatType: "group",
-      conversationId: "99999@g.us",
+      admission: expect.objectContaining({
+        conversation: expect.objectContaining({
+          kind: "group",
+          id: "99999@g.us",
+        }),
+      }),
       group: expect.objectContaining({
         mentions: expect.objectContaining({
           jids: ["123@s.whatsapp.net"],
@@ -261,8 +265,12 @@ describe("web monitor inbox", () => {
       ],
     });
     expectSingleGroupMessage(onMessage, {
-      chatType: "group",
-      conversationId: "424242@g.us",
+      admission: expect.objectContaining({
+        conversation: expect.objectContaining({
+          kind: "group",
+          id: "424242@g.us",
+        }),
+      }),
       group: expect.objectContaining({
         mentions: expect.objectContaining({
           jids: ["123@s.whatsapp.net"],
@@ -313,8 +321,12 @@ describe("web monitor inbox", () => {
       ],
     });
     expectSingleGroupMessage(onMessage, {
-      chatType: "group",
-      from: "55555@g.us",
+      admission: expect.objectContaining({
+        conversation: expect.objectContaining({
+          kind: "group",
+          id: "55555@g.us",
+        }),
+      }),
       group: expect.objectContaining({
         mentions: expect.objectContaining({
           jids: ["123@s.whatsapp.net"],

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -84,6 +84,14 @@ function inboundMessage(onMessage: ReturnType<typeof vi.fn>, index = 0): WebInbo
   return msg as WebInboundMessage;
 }
 
+function expectDeprecatedAdmissionAliases(inbound: WebInboundMessage) {
+  expect(inbound.from).toBe(inbound.admission?.conversation.id);
+  expect(inbound.conversationId).toBe(inbound.admission?.conversation.id);
+  expect(inbound.accountId).toBe(inbound.admission?.accountId);
+  expect(inbound.chatType).toBe(inbound.admission?.conversation.kind);
+  expect(inbound.accessControlPassed).toBe(inbound.admission?.ingress.decision === "allow");
+}
+
 async function expectSocketOperationTimeout(
   operation: "sendMessage" | "sendPresenceUpdate",
   promise: Promise<unknown>,
@@ -224,7 +232,6 @@ describe("web monitor inbox", () => {
 
     const inbound = inboundMessage(onMessage);
     expect(inbound.payload.body).toBe("ping");
-    expect(inbound.from).toBe("+999");
     expect(inbound.platform.recipientJid).toBe("+123");
     expect(inbound.admission).toMatchObject({
       accountId: DEFAULT_ACCOUNT_ID,
@@ -240,8 +247,7 @@ describe("web monitor inbox", () => {
         decision: "allow",
       },
     });
-    expect(inbound.accountId).toBe(inbound.admission?.accountId);
-    expect(inbound.chatType).toBe(inbound.admission?.conversation.kind);
+    expectDeprecatedAdmissionAliases(inbound);
     expect(sock.readMessages).toHaveBeenCalledWith([
       {
         remoteJid: "999@s.whatsapp.net",
@@ -417,7 +423,7 @@ describe("web monitor inbox", () => {
 
     await waitForMessageCalls(onMessage, 1);
     const inbound = inboundMessage(onMessage);
-    expect(inbound.chatType).toBe("group");
+    expect(inbound.admission?.conversation.kind).toBe("group");
     expect(inbound.group).toBeUndefined();
 
     await listener.close();
@@ -465,10 +471,10 @@ describe("web monitor inbox", () => {
     await waitForMessageCalls(onMessage, 1);
     const inbound = inboundMessage(onMessage);
     expect(inbound.payload.body).toBe("ping");
-    expect(inbound.from).toBe("123@g.us");
+    expect(inbound.admission?.conversation.id).toBe("123@g.us");
     expect(inbound.group?.subject).toBe("Recovered Group");
     expect(inbound.platform.senderE164).toBe("+444");
-    expect(inbound.chatType).toBe("group");
+    expect(inbound.admission?.conversation.kind).toBe("group");
     expect(inbound.group?.participants).toBeUndefined();
 
     await second.listener.close();
@@ -718,7 +724,7 @@ describe("web monitor inbox", () => {
       await waitForMessageCalls(onMessage, 1);
       const inbound = inboundMessage(onMessage);
       expect(inbound.payload.body).toBe("first\nsecond");
-      expect(inbound.chatType).toBe("direct");
+      expect(inbound.admission?.conversation.kind).toBe("direct");
     } finally {
       vi.useRealTimers();
     }
@@ -1339,7 +1345,7 @@ describe("web monitor inbox", () => {
     expect(getPNForLID).toHaveBeenCalledWith("999@lid");
     const inbound = inboundMessage(onMessage);
     expect(inbound.payload.body).toBe("ping");
-    expect(inbound.from).toBe("+999");
+    expect(inbound.admission?.conversation.id).toBe("+999");
     expect(inbound.platform.recipientJid).toBe("+123");
 
     await listener.close();
@@ -1367,7 +1373,7 @@ describe("web monitor inbox", () => {
 
     const inbound = inboundMessage(onMessage);
     expect(inbound.payload.body).toBe("ping");
-    expect(inbound.from).toBe("+1555");
+    expect(inbound.admission?.conversation.id).toBe("+1555");
     expect(inbound.platform.recipientJid).toBe("+123");
     expect(getPNForLID).not.toHaveBeenCalled();
 
@@ -1394,9 +1400,9 @@ describe("web monitor inbox", () => {
     expect(getPNForLID).toHaveBeenCalledWith("444@lid");
     const inbound = inboundMessage(onMessage);
     expect(inbound.payload.body).toBe("ping");
-    expect(inbound.from).toBe("123@g.us");
+    expect(inbound.admission?.conversation.id).toBe("123@g.us");
     expect(inbound.platform.senderE164).toBe("+444");
-    expect(inbound.chatType).toBe("group");
+    expect(inbound.admission?.conversation.kind).toBe("group");
 
     await listener.close();
   });


### PR DESCRIPTION
## Summary

This PR completes the next internal step of the WhatsApp inbound-message migration: runtime code that was still reading deprecated top-level admission fields now reads the canonical `msg.admission` envelope instead.

It builds on the two earlier WhatsApp inbound refactors:

- #88245 introduced the structured inbound message contexts (`event`, `payload`, `quote`, `group`, and `platform`) while keeping the old flat callback fields as deprecated aliases.
- #92578 added the public-safe WhatsApp inbound `admission` envelope and deprecated the old top-level admission fields (`from`, `conversationId`, `accountId`, `accessControlPassed`, and `chatType`). That PR intentionally stopped at the foundation and compatibility layer.

This PR migrates the internal WhatsApp auto-reply, dispatch, delivery, reaction, group-gating, broadcast, and test-support callers that should now use `admission` as the source of truth.

## What Changed

- Moves WhatsApp auto-reply routing, dispatch, group gating, broadcast fanout, ack/status reactions, message-line formatting, peer identity, and reply delivery off deprecated flat admission fields.
- Adds a narrow `AdmittedWebInboundMessage` type and `requireWhatsAppInboundAdmission(...)` guard so runtime consumers express the invariant they already require.
- Keeps canonical nested messages strict: a canonical message without `admission` is malformed for admitted runtime use and is rejected instead of being silently repaired from flat aliases.
- Preserves the shipped/deprecated legacy-flat listener input path during the compatibility window by converting only true legacy flat inputs through an explicit `buildDeprecatedFlatWhatsAppInboundAdmission(...)` adapter.
- Updates WhatsApp fixtures and focused tests so admitted messages carry resolver-built admission facts and deprecated flat aliases remain usable where they are part of the compatibility contract.

## Diff Surface

The branch touches the full WhatsApp post-admission receive path:

- Inbound admission and type contracts: `admission`, `types`, `message-aliases`, access-control tests, and the shared inbound test-message helper.
- Real web inbox handoff: the Baileys monitor continues to attach resolver-built admission facts before callback/auto-reply delivery.
- Auto-reply entrypoint and dispatch: `on-message`, `process-message`, `inbound-dispatch`, and inbound context assembly now require/read admitted message facts.
- Reply and delivery behavior: direct reply delivery, durable final reply context, mention handling, and outbound target/account facts now come from `admission`.
- Group and multi-agent behavior: group gating, group history tests, broadcast fanout, ACP binding readiness, and scoped group route handling are updated to use admitted conversation/account facts.
- Feedback behavior: ack reactions and status reactions now read account/conversation identity from admission.
- Test infrastructure: WhatsApp test harnesses, monitor-inbox support fixtures, and focused auto-reply tests now build admitted messages through canonical fixtures instead of relying on flat top-level admission fields.

## Compatibility

This does not remove the old flat fields. The deprecated callback fields remain available as live aliases while the compatibility window from #88245 and #92578 is still open.

The important boundary is intentional:

- Canonical nested input must provide `admission`.
- Legacy flat input can still be normalized for compatibility.
- Internal runtime paths now require/read `admission` instead of rebuilding decisions from `from`, `conversationId`, `accountId`, `accessControlPassed`, or `chatType`.

## Verification

- `node scripts/run-vitest.mjs extensions/whatsapp/src/inbound/message-aliases.test.ts extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts extensions/whatsapp/src/auto-reply.web-auto-reply.connection-and-logging.e2e.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

The focused Vitest run passed 45 tests across the WhatsApp inbound alias/admission and auto-reply listener paths. Autoreview reported no accepted/actionable findings.

## Review Notes

The master quality gate found no in-scope correctness or owner-seam blockers for this migration. Two broader items are intentionally left out of this PR to keep the scope contained:

- Moving all WhatsApp group route/mention policy fully into core ingress projections is a real architecture follow-up, but that local `applyGroupGating` ownership already existed before this branch. This PR only changes those paths to read admitted identity/account/conversation facts.
- The legacy-flat admission adapter is a temporary compatibility seam for the already-deprecated flat listener input shape. It should be removed or replaced with resolver-backed compatibility when the deprecation window closes.

Before merge, this branch should be refreshed on the latest `main` and the focused proof above should be rerun, because `main` has moved since the last local rebase.
