### PR TITLE
docs: add ClawHub trust pages to sidebar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1385,6 +1385,10 @@
                 "pages": [
                   "clawhub/api",
                   "clawhub/http-api",
+                  "clawhub/security",
+                  "clawhub/security-audits",
+                  "clawhub/moderation",
+                  "clawhub/plugin-validation-fixes",
                   "clawhub/acceptable-usage",
                   "clawhub/content-rights"
                 ]


### PR DESCRIPTION
## Summary

Adds the remaining public ClawHub trust and remediation pages to the ClawHub sidebar navigation:

- `clawhub/security`
- `clawhub/security-audits`
- `clawhub/moderation`
- `clawhub/plugin-validation-fixes`

These pages already exist in the ClawHub docs source; this change makes them discoverable from the docs sidebar.

## Verification

- Parsed `docs/docs.json` with Node JSON parsing.
- Compared the ClawHub sidebar entries against the public Markdown pages in `openclaw/clawhub/docs`.
- Ran `git diff --check HEAD~1..HEAD`.
- Confirmed the PR diff is limited to `docs/docs.json`.
