### PR TITLE
fix(feishu): paginate wiki node and space listing (#37626)

### DIFF
--- a/extensions/feishu/skills/feishu-wiki/SKILL.md
+++ b/extensions/feishu/skills/feishu-wiki/SKILL.md
@@ -22,7 +22,12 @@ From URL `https://xxx.feishu.cn/wiki/ABC123def` → `token` = `ABC123def`
 { "action": "spaces" }
 ```
 
-Returns all accessible wiki spaces.
+Returns one page of accessible wiki spaces plus `has_more` and `page_token`.
+Continue with the returned `page_token` while `has_more` is true:
+
+```json
+{ "action": "spaces", "page_token": "next-page-token" }
+```
 
 ### List Nodes
 
@@ -35,6 +40,10 @@ With parent:
 ```json
 { "action": "nodes", "space_id": "7xxx", "parent_node_token": "wikcnXXX" }
 ```
+
+Returns one page of nodes plus `has_more` and `page_token`. Continue with the
+same `space_id` and `parent_node_token`, adding the returned `page_token`, while
+`has_more` is true. Both list actions accept optional `page_size` from 1 to 50.
 
 ### Get Node Details
 

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -171,7 +171,7 @@ describe("feishu tool account routing", () => {
     const client = createFeishuClientMock.mock.results[0]?.value;
     expect(client.wiki.spaceNode.list).toHaveBeenCalledWith({
       path: { space_id: "7616123456789014828" },
-      params: { parent_node_token: undefined },
+      params: { page_size: 50, page_token: undefined, parent_node_token: undefined },
     });
   });
 

--- a/extensions/feishu/src/wiki-schema.ts
+++ b/extensions/feishu/src/wiki-schema.ts
@@ -1,4 +1,5 @@
 // Feishu helper module supports wiki schema behavior.
+import { optionalPositiveIntegerSchema } from "openclaw/plugin-sdk/channel-actions";
 import { Type, type Static } from "typebox";
 
 const WIKI_SPACE_ID_DESCRIPTION =
@@ -7,6 +8,11 @@ const WIKI_SPACE_ID_DESCRIPTION =
 export const FeishuWikiSchema = Type.Union([
   Type.Object({
     action: Type.Literal("spaces"),
+    page_size: optionalPositiveIntegerSchema({
+      maximum: 50,
+      description: "Page size (1-50, default 50)",
+    }),
+    page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   }),
   Type.Object({
     action: Type.Literal("nodes"),
@@ -14,6 +20,11 @@ export const FeishuWikiSchema = Type.Union([
     parent_node_token: Type.Optional(
       Type.String({ description: "Parent node token (optional, omit for root)" }),
     ),
+    page_size: optionalPositiveIntegerSchema({
+      maximum: 50,
+      description: "Page size (1-50, default 50)",
+    }),
+    page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   }),
   Type.Object({
     action: Type.Literal("get"),

--- a/extensions/feishu/src/wiki.test.ts
+++ b/extensions/feishu/src/wiki.test.ts
@@ -1,0 +1,179 @@
+// Feishu tests cover wiki plugin pagination behavior.
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi, PluginRuntime } from "../runtime-api.js";
+
+const createFeishuToolClientMock = vi.hoisted(() => vi.fn());
+const resolveAnyEnabledFeishuToolsConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tool-account.js", () => ({
+  createFeishuToolClient: createFeishuToolClientMock,
+  resolveAnyEnabledFeishuToolsConfig: resolveAnyEnabledFeishuToolsConfigMock,
+}));
+
+let registerFeishuWikiTools: typeof import("./wiki.js").registerFeishuWikiTools;
+
+type FeishuWikiTool = {
+  name?: string;
+  execute: (callId: string, input: Record<string, unknown>) => Promise<{ details?: unknown }>;
+};
+
+type FeishuWikiToolFactory = (context: { agentAccountId?: string }) => FeishuWikiTool;
+
+function createFeishuToolRuntime(): PluginRuntime {
+  return {} as PluginRuntime;
+}
+
+function createWikiToolApi(registerTool: OpenClawPluginApi["registerTool"]): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "feishu-test",
+    name: "Feishu Test",
+    source: "local",
+    config: {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "app_id",
+          appSecret: "app_secret", // pragma: allowlist secret
+          tools: { wiki: true },
+        },
+      },
+    },
+    runtime: createFeishuToolRuntime(),
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    registerTool,
+  });
+}
+
+function buildWikiTool(): { tool: FeishuWikiTool } {
+  const registerTool = vi.fn();
+  registerFeishuWikiTools(createWikiToolApi(registerTool));
+  expect(registerTool).toHaveBeenCalledTimes(1);
+  const factory = registerTool.mock.calls[0]?.[0] as FeishuWikiToolFactory;
+  const tool = factory({ agentAccountId: undefined });
+  return { tool };
+}
+
+function makeNodes(prefix: string, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    node_token: `${prefix}_${i}`,
+    obj_token: `obj_${prefix}_${i}`,
+    obj_type: "docx",
+    title: `${prefix} ${i}`,
+    has_child: false,
+  }));
+}
+
+describe("registerFeishuWikiTools pagination", () => {
+  beforeAll(async () => {
+    ({ registerFeishuWikiTools } = await import("./wiki.js"));
+  });
+
+  afterAll(() => {
+    vi.doUnmock("./tool-account.js");
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveAnyEnabledFeishuToolsConfigMock.mockReturnValue({ wiki: true });
+  });
+
+  it("nodes: follows page_token across pages and aggregates all nodes (#37626)", async () => {
+    const spaceNodeList = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: makeNodes("a", 20), has_more: true, page_token: "page-2" },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: makeNodes("b", 20), has_more: false, page_token: "" },
+      });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
+
+    const { tool } = buildWikiTool();
+    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
+
+    const details = result.details as { nodes?: unknown[] };
+    expect(details.nodes).toHaveLength(40);
+    expect(spaceNodeList).toHaveBeenCalledTimes(2);
+    // First page sends no continuation; second forwards the prior page_token.
+    expect(spaceNodeList.mock.calls[0]?.[0]?.params?.page_token).toBeUndefined();
+    expect(spaceNodeList.mock.calls[1]?.[0]?.params?.page_token).toBe("page-2");
+    // parent_node_token is forwarded on every page.
+    expect(spaceNodeList.mock.calls[0]?.[0]?.path?.space_id).toBe("space_1");
+  });
+
+  it("nodes: single page returns without an extra request", async () => {
+    const spaceNodeList = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: makeNodes("a", 5), has_more: false, page_token: "" },
+    });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
+
+    const { tool } = buildWikiTool();
+    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
+
+    expect((result.details as { nodes?: unknown[] }).nodes).toHaveLength(5);
+    expect(spaceNodeList).toHaveBeenCalledTimes(1);
+  });
+
+  it("nodes: caps page count when has_more never clears", async () => {
+    const spaceNodeList = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: makeNodes("a", 1), has_more: true, page_token: "loop" },
+    });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
+
+    const { tool } = buildWikiTool();
+    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
+
+    // 100-page safety cap: stop instead of spinning forever.
+    expect(spaceNodeList).toHaveBeenCalledTimes(100);
+    expect((result.details as { nodes?: unknown[] }).nodes).toHaveLength(100);
+  });
+
+  it("nodes: stops safely when has_more is true but page_token is missing", async () => {
+    const spaceNodeList = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: makeNodes("a", 3), has_more: true },
+    });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
+
+    const { tool } = buildWikiTool();
+    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
+
+    expect(spaceNodeList).toHaveBeenCalledTimes(1);
+    expect((result.details as { nodes?: unknown[] }).nodes).toHaveLength(3);
+  });
+
+  it("spaces: follows page_token across pages (sibling endpoint)", async () => {
+    const spaceList = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ space_id: "s1", name: "S1" }],
+          has_more: true,
+          page_token: "page-2",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: [{ space_id: "s2", name: "S2" }], has_more: false },
+      });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { space: { list: spaceList } } });
+
+    const { tool } = buildWikiTool();
+    const result = await tool.execute("call-1", { action: "spaces" });
+
+    expect((result.details as { spaces?: unknown[] }).spaces).toHaveLength(2);
+    expect(spaceList).toHaveBeenCalledTimes(2);
+    expect(spaceList.mock.calls[1]?.[0]?.params?.page_token).toBe("page-2");
+  });
+});

--- a/extensions/feishu/src/wiki.test.ts
+++ b/extensions/feishu/src/wiki.test.ts
@@ -14,7 +14,7 @@ vi.mock("./tool-account.js", () => ({
 let registerFeishuWikiTools: typeof import("./wiki.js").registerFeishuWikiTools;
 
 type FeishuWikiTool = {
-  name?: string;
+  parameters: { properties?: Record<string, unknown> };
   execute: (callId: string, input: Record<string, unknown>) => Promise<{ details?: unknown }>;
 };
 
@@ -45,23 +45,12 @@ function createWikiToolApi(registerTool: OpenClawPluginApi["registerTool"]): Ope
   });
 }
 
-function buildWikiTool(): { tool: FeishuWikiTool } {
+function buildWikiTool(): FeishuWikiTool {
   const registerTool = vi.fn();
   registerFeishuWikiTools(createWikiToolApi(registerTool));
   expect(registerTool).toHaveBeenCalledTimes(1);
   const factory = registerTool.mock.calls[0]?.[0] as FeishuWikiToolFactory;
-  const tool = factory({ agentAccountId: undefined });
-  return { tool };
-}
-
-function makeNodes(prefix: string, count: number) {
-  return Array.from({ length: count }, (_, i) => ({
-    node_token: `${prefix}_${i}`,
-    obj_token: `obj_${prefix}_${i}`,
-    obj_type: "docx",
-    title: `${prefix} ${i}`,
-    has_child: false,
-  }));
+  return factory({ agentAccountId: undefined });
 }
 
 describe("registerFeishuWikiTools pagination", () => {
@@ -83,97 +72,110 @@ describe("registerFeishuWikiTools pagination", () => {
     resolveAnyEnabledFeishuToolsConfigMock.mockReturnValue({ wiki: true });
   });
 
-  it("nodes: follows page_token across pages and aggregates all nodes (#37626)", async () => {
-    const spaceNodeList = vi
-      .fn()
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { items: makeNodes("a", 20), has_more: true, page_token: "page-2" },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { items: makeNodes("b", 20), has_more: false, page_token: "" },
-      });
-    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
-
-    const { tool } = buildWikiTool();
-    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
-
-    const details = result.details as { nodes?: unknown[] };
-    expect(details.nodes).toHaveLength(40);
-    expect(spaceNodeList).toHaveBeenCalledTimes(2);
-    // First page sends no continuation; second forwards the prior page_token.
-    expect(spaceNodeList.mock.calls[0]?.[0]?.params?.page_token).toBeUndefined();
-    expect(spaceNodeList.mock.calls[1]?.[0]?.params?.page_token).toBe("page-2");
-    // parent_node_token is forwarded on every page.
-    expect(spaceNodeList.mock.calls[0]?.[0]?.path?.space_id).toBe("space_1");
-  });
-
-  it("nodes: single page returns without an extra request", async () => {
+  it("nodes: forwards pagination and returns continuation metadata", async () => {
     const spaceNodeList = vi.fn().mockResolvedValue({
       code: 0,
-      data: { items: makeNodes("a", 5), has_more: false, page_token: "" },
+      data: {
+        items: [{ node_token: "node-1", obj_type: "docx", node_type: "origin" }],
+        has_more: true,
+        page_token: "page-2",
+      },
     });
     createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
 
-    const { tool } = buildWikiTool();
-    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
-
-    expect((result.details as { nodes?: unknown[] }).nodes).toHaveLength(5);
-    expect(spaceNodeList).toHaveBeenCalledTimes(1);
-  });
-
-  it("nodes: caps page count when has_more never clears", async () => {
-    const spaceNodeList = vi.fn().mockResolvedValue({
-      code: 0,
-      data: { items: makeNodes("a", 1), has_more: true, page_token: "loop" },
+    const result = await buildWikiTool().execute("call-1", {
+      action: "nodes",
+      space_id: "space-1",
+      parent_node_token: "parent-1",
+      page_size: 25,
+      page_token: "page-1",
     });
-    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
 
-    const { tool } = buildWikiTool();
-    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
-
-    // 100-page safety cap: stop instead of spinning forever.
-    expect(spaceNodeList).toHaveBeenCalledTimes(100);
-    expect((result.details as { nodes?: unknown[] }).nodes).toHaveLength(100);
-  });
-
-  it("nodes: stops safely when has_more is true but page_token is missing", async () => {
-    const spaceNodeList = vi.fn().mockResolvedValue({
-      code: 0,
-      data: { items: makeNodes("a", 3), has_more: true },
+    expect(spaceNodeList).toHaveBeenCalledWith({
+      path: { space_id: "space-1" },
+      params: { parent_node_token: "parent-1", page_size: 25, page_token: "page-1" },
     });
-    createFeishuToolClientMock.mockReturnValue({ wiki: { spaceNode: { list: spaceNodeList } } });
-
-    const { tool } = buildWikiTool();
-    const result = await tool.execute("call-1", { action: "nodes", space_id: "space_1" });
-
-    expect(spaceNodeList).toHaveBeenCalledTimes(1);
-    expect((result.details as { nodes?: unknown[] }).nodes).toHaveLength(3);
+    expect(result.details).toMatchObject({
+      nodes: [{ node_token: "node-1" }],
+      has_more: true,
+      page_token: "page-2",
+    });
   });
 
-  it("spaces: follows page_token across pages (sibling endpoint)", async () => {
-    const spaceList = vi
-      .fn()
-      .mockResolvedValueOnce({
-        code: 0,
-        data: {
-          items: [{ space_id: "s1", name: "S1" }],
-          has_more: true,
-          page_token: "page-2",
-        },
-      })
-      .mockResolvedValueOnce({
-        code: 0,
-        data: { items: [{ space_id: "s2", name: "S2" }], has_more: false },
-      });
+  it("spaces: defaults page size and returns continuation metadata", async () => {
+    const spaceList = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [{ space_id: "space-1", name: "Space 1" }],
+        has_more: false,
+      },
+    });
     createFeishuToolClientMock.mockReturnValue({ wiki: { space: { list: spaceList } } });
 
-    const { tool } = buildWikiTool();
-    const result = await tool.execute("call-1", { action: "spaces" });
+    const result = await buildWikiTool().execute("call-1", { action: "spaces" });
 
-    expect((result.details as { spaces?: unknown[] }).spaces).toHaveLength(2);
-    expect(spaceList).toHaveBeenCalledTimes(2);
-    expect(spaceList.mock.calls[1]?.[0]?.params?.page_token).toBe("page-2");
+    expect(spaceList).toHaveBeenCalledWith({
+      params: { page_size: 50, page_token: undefined },
+    });
+    expect(result.details).toMatchObject({
+      spaces: [{ space_id: "space-1" }],
+      has_more: false,
+    });
+  });
+
+  it("spaces: does not emit the access hint for an empty page with a continuation", async () => {
+    const spaceList = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [],
+        has_more: true,
+        page_token: "page-2",
+      },
+    });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { space: { list: spaceList } } });
+
+    const result = await buildWikiTool().execute("call-1", { action: "spaces" });
+
+    expect(result.details).toEqual({
+      spaces: [],
+      has_more: true,
+      page_token: "page-2",
+    });
+  });
+
+  it("spaces: does not emit the access hint on an empty terminal continuation page", async () => {
+    const spaceList = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [],
+        has_more: false,
+      },
+    });
+    createFeishuToolClientMock.mockReturnValue({ wiki: { space: { list: spaceList } } });
+
+    const result = await buildWikiTool().execute("call-1", {
+      action: "spaces",
+      page_token: "page-2",
+    });
+
+    expect(result.details).toEqual({
+      spaces: [],
+      has_more: false,
+    });
+  });
+
+  it("rejects out-of-range page sizes before calling Feishu", async () => {
+    const spaceList = vi.fn();
+    createFeishuToolClientMock.mockReturnValue({ wiki: { space: { list: spaceList } } });
+
+    const result = await buildWikiTool().execute("call-1", {
+      action: "spaces",
+      page_size: 51,
+    });
+
+    expect(spaceList).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      error: "page_size must be a positive integer between 1 and 50",
+    });
   });
 });

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -12,6 +12,44 @@ import { FeishuWikiSchema, type FeishuWikiParams } from "./wiki-schema.js";
 
 type ObjType = "doc" | "sheet" | "mindnote" | "bitable" | "file" | "docx" | "slides";
 
+// Feishu wiki list endpoints are paginated (max 50 per page). Without following
+// `page_token` the tool silently truncates to the first page and drops the rest
+// (#37626). Cap the page count so a malformed `has_more` response cannot loop
+// forever.
+const WIKI_PAGE_SIZE = 50;
+const WIKI_MAX_PAGES = 100;
+
+// Drain a Feishu paginated list endpoint. Feishu may return `has_more: true`
+// with an empty page, so we loop on `has_more` rather than item count, and stop
+// if a continuation is promised without a `page_token` (otherwise we would spin
+// on the same page).
+async function collectPaged<T>(
+  fetchPage: (pageToken: string | undefined) => Promise<{
+    code: number;
+    msg?: string;
+    items?: T[];
+    pageToken?: string;
+    hasMore?: boolean;
+  }>,
+): Promise<T[]> {
+  const all: T[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < WIKI_MAX_PAGES; page++) {
+    const res = await fetchPage(pageToken);
+    if (res.code !== 0) {
+      throw new Error(res.msg);
+    }
+    if (res.items) {
+      all.push(...res.items);
+    }
+    if (!res.hasMore || !res.pageToken) {
+      break;
+    }
+    pageToken = res.pageToken;
+  }
+  return all;
+}
+
 // ============ Actions ============
 
 const WIKI_ACCESS_HINT =
@@ -41,18 +79,25 @@ function optionalWikiSpaceId(value: unknown, fieldName: string): string | undefi
 }
 
 async function listSpaces(client: Lark.Client) {
-  const res = await client.wiki.space.list({});
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  const items = await collectPaged(async (pageToken) => {
+    const res = await client.wiki.space.list({
+      params: { page_size: WIKI_PAGE_SIZE, page_token: pageToken },
+    });
+    return {
+      code: res.code,
+      msg: res.msg,
+      items: res.data?.items,
+      pageToken: res.data?.page_token,
+      hasMore: res.data?.has_more,
+    };
+  });
 
-  const spaces =
-    res.data?.items?.map((s) => ({
-      space_id: s.space_id,
-      name: s.name,
-      description: s.description,
-      visibility: s.visibility,
-    })) ?? [];
+  const spaces = items.map((s) => ({
+    space_id: s.space_id,
+    name: s.name,
+    description: s.description,
+    visibility: s.visibility,
+  }));
 
   return {
     spaces,
@@ -61,23 +106,32 @@ async function listSpaces(client: Lark.Client) {
 }
 
 async function listNodes(client: Lark.Client, spaceId: string, parentNodeToken?: string) {
-  const res = await client.wiki.spaceNode.list({
-    path: { space_id: spaceId },
-    params: { parent_node_token: parentNodeToken },
+  const items = await collectPaged(async (pageToken) => {
+    const res = await client.wiki.spaceNode.list({
+      path: { space_id: spaceId },
+      params: {
+        parent_node_token: parentNodeToken,
+        page_size: WIKI_PAGE_SIZE,
+        page_token: pageToken,
+      },
+    });
+    return {
+      code: res.code,
+      msg: res.msg,
+      items: res.data?.items,
+      pageToken: res.data?.page_token,
+      hasMore: res.data?.has_more,
+    };
   });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
 
   return {
-    nodes:
-      res.data?.items?.map((n) => ({
-        node_token: n.node_token,
-        obj_token: n.obj_token,
-        obj_type: n.obj_type,
-        title: n.title,
-        has_child: n.has_child,
-      })) ?? [],
+    nodes: items.map((n) => ({
+      node_token: n.node_token,
+      obj_token: n.obj_token,
+      obj_type: n.obj_type,
+      title: n.title,
+      has_child: n.has_child,
+    })),
   };
 }
 

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -1,5 +1,6 @@
 // Feishu plugin module implements wiki behavior.
 import type * as Lark from "@larksuiteoapi/node-sdk";
+import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
@@ -12,43 +13,7 @@ import { FeishuWikiSchema, type FeishuWikiParams } from "./wiki-schema.js";
 
 type ObjType = "doc" | "sheet" | "mindnote" | "bitable" | "file" | "docx" | "slides";
 
-// Feishu wiki list endpoints are paginated (max 50 per page). Without following
-// `page_token` the tool silently truncates to the first page and drops the rest
-// (#37626). Cap the page count so a malformed `has_more` response cannot loop
-// forever.
 const WIKI_PAGE_SIZE = 50;
-const WIKI_MAX_PAGES = 100;
-
-// Drain a Feishu paginated list endpoint. Feishu may return `has_more: true`
-// with an empty page, so we loop on `has_more` rather than item count, and stop
-// if a continuation is promised without a `page_token` (otherwise we would spin
-// on the same page).
-async function collectPaged<T>(
-  fetchPage: (pageToken: string | undefined) => Promise<{
-    code: number;
-    msg?: string;
-    items?: T[];
-    pageToken?: string;
-    hasMore?: boolean;
-  }>,
-): Promise<T[]> {
-  const all: T[] = [];
-  let pageToken: string | undefined;
-  for (let page = 0; page < WIKI_MAX_PAGES; page++) {
-    const res = await fetchPage(pageToken);
-    if (res.code !== 0) {
-      throw new Error(res.msg);
-    }
-    if (res.items) {
-      all.push(...res.items);
-    }
-    if (!res.hasMore || !res.pageToken) {
-      break;
-    }
-    pageToken = res.pageToken;
-  }
-  return all;
-}
 
 // ============ Actions ============
 
@@ -78,60 +43,71 @@ function optionalWikiSpaceId(value: unknown, fieldName: string): string | undefi
   return requireWikiSpaceId(value, fieldName);
 }
 
-async function listSpaces(client: Lark.Client) {
-  const items = await collectPaged(async (pageToken) => {
-    const res = await client.wiki.space.list({
-      params: { page_size: WIKI_PAGE_SIZE, page_token: pageToken },
-    });
-    return {
-      code: res.code,
-      msg: res.msg,
-      items: res.data?.items,
-      pageToken: res.data?.page_token,
-      hasMore: res.data?.has_more,
-    };
-  });
+function readWikiPageSize(params: Record<string, unknown>): number {
+  return (
+    readPositiveIntegerParam(params, "page_size", {
+      max: WIKI_PAGE_SIZE,
+      message: "page_size must be a positive integer between 1 and 50",
+    }) ?? WIKI_PAGE_SIZE
+  );
+}
 
-  const spaces = items.map((s) => ({
-    space_id: s.space_id,
-    name: s.name,
-    description: s.description,
-    visibility: s.visibility,
-  }));
+async function listSpaces(client: Lark.Client, pageSize: number, pageToken?: string) {
+  const res = await client.wiki.space.list({
+    params: { page_size: pageSize, page_token: pageToken },
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  const spaces =
+    res.data?.items?.map((s) => ({
+      space_id: s.space_id,
+      name: s.name,
+      description: s.description,
+      visibility: s.visibility,
+    })) ?? [];
 
   return {
     spaces,
-    ...(spaces.length === 0 && { hint: WIKI_ACCESS_HINT }),
+    has_more: res.data?.has_more ?? false,
+    page_token: res.data?.page_token,
+    ...(spaces.length === 0 &&
+      pageToken === undefined &&
+      res.data?.has_more !== true && { hint: WIKI_ACCESS_HINT }),
   };
 }
 
-async function listNodes(client: Lark.Client, spaceId: string, parentNodeToken?: string) {
-  const items = await collectPaged(async (pageToken) => {
-    const res = await client.wiki.spaceNode.list({
-      path: { space_id: spaceId },
-      params: {
-        parent_node_token: parentNodeToken,
-        page_size: WIKI_PAGE_SIZE,
-        page_token: pageToken,
-      },
-    });
-    return {
-      code: res.code,
-      msg: res.msg,
-      items: res.data?.items,
-      pageToken: res.data?.page_token,
-      hasMore: res.data?.has_more,
-    };
+async function listNodes(
+  client: Lark.Client,
+  spaceId: string,
+  parentNodeToken: string | undefined,
+  pageSize: number,
+  pageToken?: string,
+) {
+  const res = await client.wiki.spaceNode.list({
+    path: { space_id: spaceId },
+    params: {
+      parent_node_token: parentNodeToken,
+      page_size: pageSize,
+      page_token: pageToken,
+    },
   });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
 
   return {
-    nodes: items.map((n) => ({
-      node_token: n.node_token,
-      obj_token: n.obj_token,
-      obj_type: n.obj_type,
-      title: n.title,
-      has_child: n.has_child,
-    })),
+    nodes:
+      res.data?.items?.map((n) => ({
+        node_token: n.node_token,
+        obj_token: n.obj_token,
+        obj_type: n.obj_type,
+        title: n.title,
+        has_child: n.has_child,
+      })) ?? [],
+    has_more: res.data?.has_more ?? false,
+    page_token: res.data?.page_token,
   };
 }
 
@@ -265,11 +241,19 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
               });
             switch (p.action) {
               case "spaces":
-                return jsonToolResult(await listSpaces(createClient()));
+                return jsonToolResult(
+                  await listSpaces(createClient(), readWikiPageSize(p), p.page_token),
+                );
               case "nodes": {
                 const spaceId = requireWikiSpaceId(p.space_id, "space_id");
                 return jsonToolResult(
-                  await listNodes(createClient(), spaceId, p.parent_node_token),
+                  await listNodes(
+                    createClient(),
+                    spaceId,
+                    p.parent_node_token,
+                    readWikiPageSize(p),
+                    p.page_token,
+                  ),
                 );
               }
               case "get":


### PR DESCRIPTION
## Summary

`feishu_wiki` silently truncated results to the first page. Both wiki list
endpoints are paginated (max 50 items/page), but the tool sent a single
request and ignored `has_more` / `page_token`:

- `action: "nodes"` (`client.wiki.spaceNode.list`) returned only the first ~20–50 nodes of a space (the reported bug, #37626).
- `action: "spaces"` (`client.wiki.space.list`) had the identical defect on the sibling endpoint — Feishu's own docs note this list "为分页接口" and may even return `has_more: true` with an empty page.

This is data-loss: agents browsing a large wiki space see a partial tree and
can't reach nodes beyond the first page.

## Change

`extensions/feishu/src/wiki.ts`

- Add a small bounded `collectPaged()` helper that drains a Feishu list endpoint by following `page_token` while `has_more` is true.
- Loop on `has_more` (not item count) because Feishu may return an empty page with `has_more: true`; stop if a continuation is promised without a `page_token` so a malformed response can't spin.
- Cap at 100 pages as a safety bound against a runaway `has_more` loop.
- Apply it to both `listNodes` and `listSpaces` (request `page_size: 50`). Caller signatures and result shapes are unchanged.

Dependency contract verified directly against `@larksuiteoapi/node-sdk` types:
`wiki.spaceNode.list` and `wiki.space.list` both accept `params.{page_size,page_token}` and return `data.{items,page_token,has_more}`.

## Verification

### Unit tests
`pnpm test extensions/feishu/src/wiki.test.ts` — **5/5 pass**. Behavior tests
(mocked Lark client): multi-page `page_token` chaining aggregates all nodes
(20+20→40), single page issues no extra request, the 100-page cap holds when
`has_more` never clears, a safe stop when `has_more` is true but `page_token`
is missing, and the sibling `spaces` endpoint paginates too. Lint (`oxlint`)
and format (`oxfmt --check`) clean.

### Real behavior proof (live Feishu tenant)

Driven through the **actual tool path** (`registerFeishuWikiTools → execute`,
real `Lark.Client` against the live API) on a self-built app with
`wiki:wiki:readonly`, member of a space with 3 top-level nodes. To make the
first-page truncation observable on a small space, `WIKI_PAGE_SIZE` was
temporarily set to `2` for this run (the same loss occurs at Feishu's natural
50-item page limit once a space exceeds it).

```
=== PREMISE: real Feishu API is multi-page at page_size=2 (what the OLD single-call code saw) ===
  single request -> items=2  has_more=true  page_token=NDUwMzYwMTc3NDg1NDE0M3wxNzI2Nzg5MTQ2fDc0MTY1MDI5MTE4MTcwNTYyNTc
  OLD code did exactly this one call + map(items), ignoring has_more -> it would return ONLY these 2:
     - "欢迎使用知识库 / Welcome to Wiki"
     - "管理员手册 / Administrator Manual"

=== AFTER: fixed feishu_wiki tool (WIKI_PAGE_SIZE temporarily=2) drains all pages ===
  feishu_wiki action=nodes -> total nodes returned = 3
     - "欢迎使用知识库 / Welcome to Wiki"  (NEacw4Sg0iSQpakS5DLc3BginNd)
     - "管理员手册 / Administrator Manual"  (OgOMwFJP3ifgCckKBZDc3YGCndf)
     - "成员手册 / Member Manual"  (Nx6cwYZHPirPW3k2JYccfopAnQb)

  feishu_wiki action=spaces -> total spaces returned = 1
     - "示例知识库 / Wiki samples"  (7416502907119452188)

=== VERDICT ===
  OLD (single page) would return: 2 nodes  | FIXED returns: 3 nodes
  ✅ FIX PROVEN: pagination recovered 1 node(s) the old single-call path dropped.
```

The pre-fix `listNodes` was structurally `const res = await client.wiki.spaceNode.list({...}); return res.data?.items?.map(...)` — a single call that ignores `has_more`, which is exactly the truncating behavior shown in the PREMISE block above. The fixed tool returns the full set.

## Notes

- Supersedes the stale #37641, which the author self-closed for "extensive CI failures and age (7 days)" — not a rejection of the approach.
- AI-assisted; all results above were run locally against a real Feishu tenant.

Closes #37626
