### PR TITLE
fix(reasoning-tags): strip MiniMax mm: tags on silent-reply and streaming paths missed by #93767

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -213,7 +213,7 @@ function resolveAssistantTextChunk(params: {
   return "";
 }
 
-const REASONING_TAG_RE = /<\s*\/?\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b/i;
+const REASONING_TAG_RE = /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b/i;
 
 function resolveStreamVisibleText(params: {
   previousRawText: string;

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -966,6 +966,20 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(payloads[0]?.delta).toBe("Visible answer");
   });
 
+  it("replaces leaked MiniMax reasoning when its orphan close arrives in a later delta", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "private chain");
+    emitAssistantTextDelta(emit, "</mm:think>Visible answer");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toMatchObject([
+      { text: "private chain", delta: "private chain" },
+      { text: "Visible answer", delta: "", replace: true },
+    ]);
+  });
+
   it("replaces malformed streamed reasoning when orphan close tags split across deltas", () => {
     const { emit, onAgentEvent } = createAgentEventHarness();
 

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -128,6 +128,13 @@ describe("isSilentReplyPayloadText", () => {
     expect(isSilentReplyPayloadText("<think>I will stay quiet here.NO_REPLY")).toBe(true);
   });
 
+  it.each([
+    ["closed", "<mm:think>internal reasoning</mm:think>\nNO_REPLY"],
+    ["open", "<mm:think>internal reasoning\nNO_REPLY"],
+  ])("returns true for %s MiniMax reasoning followed by NO_REPLY", (_kind, text) => {
+    expect(isSilentReplyPayloadText(text)).toBe(true);
+  });
+
   it("keeps substantive replies that also contain a trailing NO_REPLY token", () => {
     expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
     expect(

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -86,9 +86,9 @@ function isSilentReplyEnvelopeText(
 }
 
 const taggedReasoningPrefixRe =
-  /^\s*<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\s*>\s*/i;
+  /^\s*<\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\s*>\s*/i;
 const openReasoningPrefixRe =
-  /^\s*<\s*(?:(?:antml:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
+  /^\s*<\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
 const plainReasoningPrefixRe = /^\s*(?:think(?:ing)?|thought|analysis|reasoning)\s*:?\s*\r?\n/i;
 
 function stripLeadingReasoningBlocks(text: string): string {


### PR DESCRIPTION
## Summary

#93767 added MiniMax `mm:` namespace support to reasoning-tag handling across 9 files (so `<mm:think>` etc. are treated like the existing `antml:`/bare reasoning tags). Two production-path reasoning-tag regexes were missed and still only match `antml:`/bare tags:

- `src/auto-reply/tokens.ts:88-91` — `taggedReasoningPrefixRe` / `openReasoningPrefixRe`, which feed `stripLeadingReasoningBlocks` and `isReasoningPrefixedSilentReplyText` → the exported `isSilentReplyPayloadText` (used at 14+ production call sites: normalize-reply, reply-directives, pending-final-delivery, replay-history, subagent-announce-delivery, qqbot, …).
- `src/agents/embedded-agent-subscribe.handlers.messages.ts:216` — `REASONING_TAG_RE`, the gate at line 737 that decides whether a streaming chunk is recomputed to strip thinking.

Result: a MiniMax model's `<mm:think>…</mm:think>` reasoning leaks past silent-reply detection and into the visible stream, the exact thing #93767 set out to prevent.

## Changes

- Both regexes: `(?:antml:)?` → `(?:antml:|mm:)?`, **character-for-character matching #93767's pattern** (`commit 4f860bfab0`). +3/-3 across 2 files; pure recognition addition, no other regex/logic change.

## Real behavior proof

**Behavior addressed**: MiniMax `mm:`-namespaced reasoning tags are now stripped/detected on both the silent-reply path and the streaming-recompute path, matching `antml:` behavior.

**Real environment**: local, Node v22, `node --import tsx`, driving the **real exported** `isSilentReplyPayloadText` and `handleMessageUpdate` (+ the real mm-aware stream sanitizer) — no mocks.

**Evidence (real functions)**:
```
[silent]  isSilentReplyPayloadText("<mm:think>silent</mm:think>NO_REPLY")  -> silent (after)
          <think>/bare reasoning unchanged; "<mm:think>x</mm:think>Here is the answer: 42." NOT misclassified silent
[stream]  handleMessageUpdate(text_delta "<mm:think>secret</mm:think>Visible answer.") -> emits "Visible answer." (no "secret")
```
**Negative controls** (pre-#93767 antml-only regex, real): `<mm:think>` block survives `.replace` (leaks); stream gate `.test("<mm:think>…") === false` (not stripped → leaks).

**What was not tested**: no live MiniMax provider call; the change is in the deterministic reasoning-tag recognition path, driven via the real exported functions.

## Tests and validation

- `tokens.test.ts` + `reasoning-tags.test.ts` + `reasoning-tag-text-partitioner.test.ts` + `embedded-agent-subscribe.handlers.messages.test.ts`: **199 pass**.
- Negative control reproduces the leak without the fix.
- `oxlint` + `oxfmt --check` clean on both files.
