### PR TITLE
fix(status): show 0/1.0m instead of ?/1.0m on fresh session

### DIFF
--- a/src/auto-reply/usage-bar/contract.ts
+++ b/src/auto-reply/usage-bar/contract.ts
@@ -31,11 +31,11 @@ export function buildUsageContract(
 
   const maxTokens = state.contextTokenBudget;
   const usedTokens =
-    typeof state.contextUsedTokens === "number" && state.contextUsedTokens > 0
+    typeof state.contextUsedTokens === "number" && state.contextUsedTokens >= 0
       ? state.contextUsedTokens
       : promptTotal > 0
         ? promptTotal
-        : undefined;
+        : 0;
   const pctUsed =
     maxTokens && usedTokens !== undefined ? Math.round((usedTokens / maxTokens) * 100) : undefined;
 

--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -110,6 +110,38 @@ describe("usage-bar segment forms", () => {
   });
 });
 
+describe("buildUsageContract edge cases", () => {
+  it("fresh session with no usage returns 0 for context.used_tokens", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        contextTokenBudget: 1000000,
+        // No contextUsedTokens set — simulates fresh session
+        usage: {},
+      },
+      "discord",
+    );
+    expect(contract.context.used_tokens).toBe(0);
+    expect(contract.context.pct_used).toBe(0);
+  });
+
+  it("contextUsedTokens of 0 is treated as valid", () => {
+    const contract = buildUsageContract(
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        contextTokenBudget: 1000000,
+        contextUsedTokens: 0,
+        usage: {},
+      },
+      "discord",
+    );
+    expect(contract.context.used_tokens).toBe(0);
+    expect(contract.context.pct_used).toBe(0);
+  });
+});
+
 describe("usage-bar end-to-end with buildUsageContract", () => {
   it("renders a full footer from a reply usage snapshot", () => {
     const contract = buildUsageContract(


### PR DESCRIPTION
## Summary

Fixes #93771 — `/status` displays `📚 Context: ?/1.0m` instead of `0/1.0m` on a fresh session.

## Root Cause

In `buildUsageContract()`, the condition for resolving `usedTokens` uses `> 0` which rejects a valid `contextUsedTokens` value of `0`, and falls through to `undefined` when `promptTotal` is also `0` (fresh session). The template then renders `undefined` as `?`.

## Fix

- Changed `> 0` to `>= 0` so that `contextUsedTokens: 0` is accepted as a valid value
- Changed the final fallback from `undefined` to `0` — when no data exists, 0 is the correct display value

## Changes

- `src/auto-reply/usage-bar/contract.ts` — fix the `usedTokens` resolution logic
- `src/auto-reply/usage-bar/translator.test.ts` — add test cases for fresh session and `contextUsedTokens: 0`

## Testing

Added two test cases in the `buildUsageContract edge cases` describe block:
1. Fresh session (no `contextUsedTokens` set) → `context.used_tokens` is `0`
2. Explicit `contextUsedTokens: 0` → treated as valid, returns `0`