### PR TITLE
fix(cron): preserve startup overflow catch-up deferrals in start() maintenance pass

### DIFF
--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import { start } from "./service/ops.js";
+import { createCronServiceState } from "./service/state.js";
+import { saveCronStore } from "./store.js";
+import type { CronJob } from "./types.js";
+
+const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-overflow-",
+  baseTimeIso: "2025-12-13T17:00:00.000Z",
+});
+
+describe("CronService startup catch-up repair scoping", () => {
+  function createHourlyCronJob(id: string, nextRunAtMs: number): CronJob {
+    return {
+      id,
+      name: `job-${id}`,
+      enabled: true,
+      createdAtMs: nextRunAtMs - 60_000,
+      updatedAtMs: nextRunAtMs - 60_000,
+      schedule: { kind: "cron", expr: "0 * * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: `tick-${id}` },
+      state: { nextRunAtMs },
+    };
+  }
+
+  function createDailyCronJob(id: string, nextRunAtMs: number): CronJob {
+    return {
+      id,
+      name: `job-${id}`,
+      enabled: true,
+      createdAtMs: nextRunAtMs - 60_000,
+      updatedAtMs: nextRunAtMs - 60_000,
+      schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: `tick-${id}` },
+      state: { nextRunAtMs },
+    };
+  }
+
+  it("keeps the overflow daily-cron catch-up deferral after start()'s maintenance pass", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const tomorrowNaturalSlot = Date.parse("2025-12-14T09:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    const deferred = state.store?.jobs.find((job) => job.id === "daily-overflow");
+
+    expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
+    expect(deferred?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("still repairs a stale future cron slot on start() when no jobs were deferred", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const staleFutureSlot = Date.parse("2025-12-13T18:00:00.000Z");
+    const naturalSlot = Date.parse("2025-12-14T09:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [createDailyCronJob("daily-stale-future", staleFutureSlot)],
+    });
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    const repaired = state.store?.jobs.find((job) => job.id === "daily-stale-future");
+
+    expect(repaired?.state.nextRunAtMs).toBe(naturalSlot);
+    expect(repaired?.state.nextRunAtMs).not.toBe(staleFutureSlot);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -669,10 +669,16 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
  */
 export function recomputeNextRunsForMaintenance(
   state: CronServiceState,
-  opts?: { recomputeExpired?: boolean; nowMs?: number; repairFutureCronNextRunAtMs?: boolean },
+  opts?: {
+    recomputeExpired?: boolean;
+    nowMs?: number;
+    repairFutureCronNextRunAtMs?: boolean;
+    skipFutureRepairJobIds?: ReadonlySet<string>;
+  },
 ): boolean {
   const recomputeExpired = opts?.recomputeExpired ?? false;
   const repairFutureCronNextRunAtMs = opts?.repairFutureCronNextRunAtMs ?? true;
+  const skipFutureRepairJobIds = opts?.skipFutureRepairJobIds;
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {
@@ -683,6 +689,7 @@ export function recomputeNextRunsForMaintenance(
         }
       } else if (
         repairFutureCronNextRunAtMs &&
+        !skipFutureRepairJobIds?.has(job.id) &&
         shouldRepairFutureCronNextRunAtMs({ state, job, nowMs: now })
       ) {
         if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -253,7 +253,7 @@ export async function start(state: CronServiceState) {
   if (state.stopped) {
     return;
   }
-  await runMissedJobs(state, {
+  const deferredCatchupJobIds = await runMissedJobs(state, {
     skipJobIds: interruptedJobIds.size > 0 ? interruptedJobIds : undefined,
     deferAgentTurnJobs: true,
   });
@@ -266,7 +266,10 @@ export async function start(state: CronServiceState) {
     if (state.stopped) {
       return;
     }
-    const changed = recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+    const changed = recomputeNextRunsForMaintenance(state, {
+      recomputeExpired: true,
+      skipFutureRepairJobIds: deferredCatchupJobIds,
+    });
     if (changed) {
       await persist(state);
     }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1597,13 +1597,13 @@ function deferPendingBackoffMissedCronSlots(
 export async function runMissedJobs(
   state: CronServiceState,
   opts?: { skipJobIds?: ReadonlySet<string>; deferAgentTurnJobs?: boolean },
-) {
+): Promise<ReadonlySet<string>> {
   if (state.stopped) {
-    return;
+    return new Set();
   }
   const plan = await planStartupCatchup(state, opts);
   if (plan.candidates.length === 0 && plan.deferredJobs.length === 0) {
-    return;
+    return new Set();
   }
 
   const outcomes = await executeStartupCatchupPlan(state, plan);
@@ -1611,6 +1611,7 @@ export async function runMissedJobs(
   for (const outcome of finalizedOutcomes) {
     maybeNotifyIsolatedAgentSetupTimeout(state, outcome);
   }
+  return new Set(plan.deferredJobs.map((deferred) => deferred.jobId));
 }
 
 async function planStartupCatchup(


### PR DESCRIPTION
## Summary
After the gateway is down across one or more cron slots and restarts with more overdue cron-expression jobs than `maxMissedJobsPerRestart` (default 5), the overflow jobs have their startup catch-up run silently dropped for a full schedule period. A daily `0 9 * * *` job whose catch-up was staggered to `now + 5s` is pushed back to the next natural `09:00`, roughly 16 hours later, so the missed run never happens.

## Root cause
`runMissedJobs` defers overflow jobs to a near-future staggered slot and deliberately protects those deferrals so a later maintenance pass does not advance them. The protective pass in `src/cron/service/timer.ts:1856` disables future-slot repair:

```ts
// timer.ts, the sibling protective pass during catch-up
recomputeNextRunsForMaintenance(state, { repairFutureCronNextRunAtMs: false });
```

But `start()`'s own second maintenance pass in `src/cron/service/ops.ts:269` omitted any protection:

```ts
// before (ops.ts:269)
const changed = recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
```

`repairFutureCronNextRunAtMs` defaults to `true` (`src/cron/service/jobs.ts:675`), so `shouldRepairFutureCronNextRunAtMs` (`src/cron/service/jobs.ts:197`) sees each overflow cron deferral as a stale future slot (`now < nextRunAtMs < naturalNext`, `kind: "cron"`, non-`agentTurn`) and recomputes it to its natural schedule slot, clobbering the catch-up.

## Fix
The right fix is not to disable all future-slot repair in `start()`'s pass (that pass legitimately repairs genuinely stale future cron slots on startup). It is to exempt only the jobs that `runMissedJobs` just deferred, while leaving repair on for everything else.

- `runMissedJobs` now returns the set of job ids it deferred this startup (`src/cron/service/timer.ts`).
- `recomputeNextRunsForMaintenance` gains a `skipFutureRepairJobIds` option that skips future-slot repair for exactly those ids while still running every other repair/expiry branch (`src/cron/service/jobs.ts`).
- `start()` threads the deferred ids into its second pass (`src/cron/service/ops.ts:269`):

```ts
// after
const deferredCatchupJobIds = await runMissedJobs(state, { ... });
...
const changed = recomputeNextRunsForMaintenance(state, {
  recomputeExpired: true,
  skipFutureRepairJobIds: deferredCatchupJobIds,
});
```

An earlier revision of this PR used a blanket `repairFutureCronNextRunAtMs: false` here; that over-corrected by disabling ordinary stale-future repair for every job in the pass. The scoped exemption fixes the dropped catch-up without weakening the repair feature.

## Why this is the right boundary
The catch-up deferral and its protection are owned by the startup path. `runMissedJobs` creates the deferrals, so it is the natural owner of "which ids are exempt this startup," and `start()`'s follow-up pass is the only consumer. The exemption is keyed on those ids, so:
- overflow catch-up deferrals survive until their staggered tick, and
- any other stale future cron slot present at startup is still repaired by the same pass.

No sibling surfaces share the defect: `runMissedJobs` (timer.ts) already disables repair in its own pass, and regular timer-tick maintenance uses `recomputeNextRuns`/read paths outside the startup overflow window. Existing behavior for missing, expired, and already-executed slots is preserved.

## Verification
New colocated regression tests `src/cron/service.startup-overflow-clobber.test.ts` drive the real `ops.start()`:
- `keeps the overflow daily-cron catch-up deferral after start()'s maintenance pass` (6 overdue cron jobs at production defaults: `maxMissedJobsPerRestart` 5, stagger 5000ms). Fails on pristine `main`, passes with this patch.
- `still repairs a stale future cron slot on start() when no jobs were deferred`. Passes with this patch; fails if the exemption is widened back to a blanket `repairFutureCronNextRunAtMs: false`, guarding the scoping.

```
node scripts/run-vitest.mjs src/cron/service.startup-overflow-clobber.test.ts
  -> Tests 2 passed (2)
node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts \
  src/cron/service/ops.test.ts src/cron/service/ops.regression.test.ts \
  src/cron/service/timer.regression.test.ts src/cron/service/timer.test.ts
  -> Test Files 6 passed (6), Tests 114 passed (114)
node scripts/run-vitest.mjs src/cron/service.jobs.test.ts src/cron/stagger.test.ts (+3 jobs suites)
  -> Test Files 5 passed (5), Tests 97 passed (97)
oxlint --type-aware <changed files>  -> exit 0
oxfmt --check <changed files>        -> All matched files use the correct format
run-tsgo -p tsconfig.core.json                      -> exit 0
run-tsgo -p test/tsconfig/tsconfig.core.test.json   -> exit 0
```

Proof matrix across all three variants of the same two tests:

| variant | overflow deferral test | stale-future repair test |
| --- | --- | --- |
| pristine `main` | FAIL (clobbered) | PASS |
| blanket `repairFutureCronNextRunAtMs: false` | PASS | FAIL (ordinary repair lost) |
| this PR (scoped exemption) | PASS | PASS |

## Real behavior proof
Behavior addressed: overflow cron catch-up deferral survives `start()`'s maintenance pass while ordinary stale-future repair still runs.
Real environment tested: the real `ops.start()` startup path (recover, `runMissedJobs`, second maintenance pass, arm timer) over temp cron stores, on pristine `main` and on the patched tree with identical inputs. Output below is captured from the cron service's own structured logger plus the resulting `nextRunAtMs`.
Exact steps or command run after this patch: drive `ops.start()` with a capturing logger over two stores (6 overdue cron jobs; one stale-future cron slot).
Evidence after fix:
```
# BEFORE (pristine main f94a2506d2) - Scenario A: 6 overdue cron jobs, production defaults
[info] cron: staggering missed jobs to prevent gateway overload {"immediateCount":5,"deferredCount":1,"totalMissed":6}
[info] cron: running missed jobs after restart {"count":5,"jobIds":["hourly-0",...,"hourly-4"]}
daily-overflow nextRunAtMs = 1765702800000 (2025-12-14T09:00:00.000Z)   <- catch-up dropped, next run ~16h away

# AFTER (this patch) - Scenario A: identical inputs
[info] cron: staggering missed jobs to prevent gateway overload {"immediateCount":5,"deferredCount":1,"totalMissed":6}
[info] cron: running missed jobs after restart {"count":5,"jobIds":["hourly-0",...,"hourly-4"]}
[info] cron: started {"enabled":true,"jobs":6,"nextWakeAtMs":1765645205000}
daily-overflow nextRunAtMs = 1765645205000 (2025-12-13T17:00:05.000Z)    <- catch-up preserved, gateway wakes in 5s

# AFTER (this patch) - Scenario B: 1 stale future cron slot, no overflow deferrals
[info] cron: started {"enabled":true,"jobs":1,"nextWakeAtMs":1765702800000}
daily-stale-future nextRunAtMs = 1765702800000 (2025-12-14T09:00:00.000Z) <- stale slot still repaired to natural slot
```
Observed result after fix: the overflow daily job keeps its `now + 5s` catch-up (timer arms to wake in 5s), and a non-deferred stale future slot is still repaired to its natural `09:00`.
What was not tested: end-to-end gateway restart against a live on-disk store with the OS timer actually firing the deferred run; the proof drives the startup function directly under a fixed clock.

## Relation to existing work
PR #78272 (merged) added the future-slot repair feature and the protective pass in `timer.ts`, but did not touch `ops.ts`, leaving its second pass unprotected. PR #81731 (open) fixes a separate exact-second slot misclassification in `jobs.ts` and does not change `ops.ts:269`; the two changes do not overlap.
