### PR TITLE
Strip UTF-8 BOM when reading SKILL.md in quick_validate

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -73,7 +73,7 @@ def validate_skill(skill_path):
         return False, "SKILL.md not found"
 
     try:
-        content = skill_md.read_text(encoding="utf-8")
+        content = skill_md.read_text(encoding="utf-8-sig")
     except OSError as e:
         return False, f"Could not read SKILL.md: {e}"
 


### PR DESCRIPTION
strip UTF-8 BOM when reading SKILL.md in quick_validate

The previous `read_text(encoding="utf-8")` call left the UTF-8 byte
order mark (EF BB BF, three bytes) in the content string if the file
was saved by a tool that emits a BOM. The first line check
(`lines[0].strip() != "---"`) then saw "\ufeff---" and rejected the
file as "Invalid frontmatter format", even though the document was
otherwise valid frontmatter.