### PR TITLE
fix(codex): keep message registered for internal turns

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1315,6 +1315,8 @@ describe("Codex app-server dynamic tool build", () => {
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
     params.disableMessageTool = true;
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    params.toolsAllow = [];
     params.runtimePlan = createCodexRuntimePlanFixture();
     setOpenClawCodingToolsFactoryForTests((options) =>
       options?.disableMessageTool ? [] : [createRuntimeDynamicTool("message")],

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1310,6 +1310,26 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldForceMessageTool(params)).toBe(false);
   });
 
+  it("can retain message in the registered schema when disabled for the current turn", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.disableMessageTool = true;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    setOpenClawCodingToolsFactoryForTests((options) =>
+      options?.disableMessageTool ? [] : [createRuntimeDynamicTool("message")],
+    );
+
+    const availableTools = await buildDynamicToolsForTest(params, workspaceDir);
+    const registeredTools = await buildDynamicToolsForTest(params, workspaceDir, {
+      ignoreDisableMessageTool: true,
+      ignoreRuntimePlan: true,
+    });
+
+    expect(availableTools.map((tool) => tool.name)).not.toContain("message");
+    expect(registeredTools.map((tool) => tool.name)).toContain("message");
+  });
+
   it("passes the live run session key to Codex dynamic tools when sandbox policy uses another key", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -204,6 +204,9 @@ export function formatCodexDynamicToolBuildStageSummary(
 /** Builds, filters, and normalizes Codex-compatible runtime tools for a single turn. */
 export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const { params } = input;
+  const messagePolicyParams = input.ignoreDisableMessageTool
+    ? { ...params, disableMessageTool: false }
+    : params;
   if (params.disableTools) {
     input.onWebSearchPolicyResolved?.(false);
     return [];
@@ -297,7 +300,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
       params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     disableMessageTool: input.ignoreDisableMessageTool ? false : params.disableMessageTool,
-    forceMessageTool: shouldForceMessageTool(params),
+    forceMessageTool: shouldForceMessageTool(messagePolicyParams),
     enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     onYield: (message) => {
@@ -376,7 +379,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         transientWebSearchRestriction &&
         webSearchPolicy.persistentAllowed),
   );
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, messagePolicyParams);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   toolBuildStages.mark("allowlist-filter");
   const normalizedTools = normalizeAgentRuntimeTools({

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -76,6 +76,7 @@ export type DynamicToolBuildParams = {
   pluginConfig: CodexPluginConfig;
   profilerEnabled?: boolean;
   forceHeartbeatTool?: boolean;
+  ignoreDisableMessageTool?: boolean;
   ignoreRuntimePlan?: boolean;
   onYieldDetected: () => void;
   onCodexAppServerEvent?: (event: CodexDynamicToolBuildEvent) => void;
@@ -295,7 +296,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     requireExplicitMessageTarget:
       params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    disableMessageTool: params.disableMessageTool,
+    disableMessageTool: input.ignoreDisableMessageTool ? false : params.disableMessageTool,
     forceMessageTool: shouldForceMessageTool(params),
     enableHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,
     forceHeartbeatTool: params.trigger === "heartbeat" || input.forceHeartbeatTool === true,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1663,6 +1663,7 @@ describe("runCodexAppServerAttempt", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
     params.disableMessageTool = true;
+    params.sourceReplyDeliveryMode = "message_tool_only";
     params.runtimePlan = createCodexRuntimePlanFixture();
 
     const availableTools = await buildDynamicToolsForTest(params, workspaceDir);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -69,7 +69,11 @@ import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
 import { readCodexAppServerBinding, writeCodexAppServerBinding } from "./session-binding.js";
 import * as sharedClientModule from "./shared-client.js";
 import { createCodexTestModel } from "./test-support.js";
-import { buildTurnStartParams, startOrResumeThread } from "./thread-lifecycle.js";
+import {
+  buildTurnStartParams,
+  codexDynamicToolsFingerprint,
+  startOrResumeThread,
+} from "./thread-lifecycle.js";
 
 function flushDiagnosticEvents() {
   return waitForDiagnosticEventsDrained();
@@ -296,7 +300,7 @@ function createCodexToolBridgeForTest(
     tools,
     registeredTools,
     signal,
-    directToolNames: testing.shouldForceMessageTool(params) ? ["message"] : [],
+    directToolNames: testing.resolveCodexDynamicToolDirectNames(params),
   });
 }
 
@@ -1667,9 +1671,26 @@ describe("runCodexAppServerAttempt", () => {
       ignoreRuntimePlan: true,
     });
     const bridge = createCodexToolBridgeForTest(params, availableTools, registeredTools);
+    const normalParams = createParams(sessionFile, workspaceDir);
+    normalParams.disableTools = false;
+    normalParams.sourceReplyDeliveryMode = "message_tool_only";
+    normalParams.runtimePlan = createCodexRuntimePlanFixture();
+    const normalTools = await buildDynamicToolsForTest(normalParams, workspaceDir);
+    const normalRegisteredTools = await buildDynamicToolsForTest(normalParams, workspaceDir, {
+      ignoreDisableMessageTool: true,
+      ignoreRuntimePlan: true,
+    });
+    const normalBridge = createCodexToolBridgeForTest(
+      normalParams,
+      normalTools,
+      normalRegisteredTools,
+    );
 
     expect(bridge.availableSpecs.map((tool) => tool.name)).not.toContain("message");
     expect(bridge.specs.map((tool) => tool.name)).toContain("message");
+    expect(codexDynamicToolsFingerprint(bridge.specs)).toBe(
+      codexDynamicToolsFingerprint(normalBridge.specs),
+    );
     await expect(
       bridge.handleToolCall({
         threadId: "thread-1",

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -198,7 +198,7 @@ async function buildDynamicToolsForTest(
   options: Partial<
     Pick<
       Parameters<typeof testing.buildDynamicTools>[0],
-      "forceHeartbeatTool" | "ignoreRuntimePlan"
+      "forceHeartbeatTool" | "ignoreDisableMessageTool" | "ignoreRuntimePlan"
     >
   > = {},
 ) {
@@ -1648,6 +1648,46 @@ describe("runCodexAppServerAttempt", () => {
 
     expect(heartbeatBridge.specs.map((tool) => tool.name)).toEqual(registeredToolNames);
     expect(nextNormalBridge.specs.map((tool) => tool.name)).toEqual(registeredToolNames);
+  });
+
+  it("keeps message in the registered schema when disabled for an internal turn", async () => {
+    testing.setOpenClawCodingToolsFactoryForTests((options) =>
+      options?.disableMessageTool ? [] : [createRuntimeDynamicTool("message")],
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.disableMessageTool = true;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    const availableTools = await buildDynamicToolsForTest(params, workspaceDir);
+    const registeredTools = await buildDynamicToolsForTest(params, workspaceDir, {
+      ignoreDisableMessageTool: true,
+      ignoreRuntimePlan: true,
+    });
+    const bridge = createCodexToolBridgeForTest(params, availableTools, registeredTools);
+
+    expect(bridge.availableSpecs.map((tool) => tool.name)).not.toContain("message");
+    expect(bridge.specs.map((tool) => tool.name)).toContain("message");
+    await expect(
+      bridge.handleToolCall({
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: {},
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: "OpenClaw tool is not available for this turn: message",
+        },
+      ],
+    });
   });
 
   it("keeps the persistent dynamic schema stable across heartbeat-only turns", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -789,7 +789,7 @@ export async function runCodexAppServerAttempt(
     registeredTools,
     signal: runAbortController.signal,
     loading: resolveCodexDynamicToolsLoadingForModel(pluginConfig, params.modelId),
-    directToolNames: shouldForceMessageTool(params) ? ["message"] : [],
+    directToolNames: resolveCodexDynamicToolDirectNames(params),
     hookContext: {
       agentId: sessionAgentId,
       config: params.config,
@@ -3184,6 +3184,13 @@ function handleApprovalRequest(params: {
   });
 }
 
+function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): string[] {
+  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
+    return [];
+  }
+  return ["message"];
+}
+
 export const testing = {
   buildCodexNativeHookRelayId,
   buildDeveloperInstructions,
@@ -3197,6 +3204,7 @@ export const testing = {
   resolveOpenClawCodingToolsSessionKeys,
   shouldEnableCodexAppServerNativeToolSurface,
   shouldForceMessageTool,
+  resolveCodexDynamicToolDirectNames,
   hasPendingDynamicToolTerminalDiagnostic,
   toTranscriptToolResultForTests: toTranscriptToolResult,
   withCodexStartupTimeout,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -777,6 +777,7 @@ export async function runCodexAppServerAttempt(
     pluginConfig,
     profilerEnabled,
     forceHeartbeatTool: true,
+    ignoreDisableMessageTool: true,
     ignoreRuntimePlan: true,
     onYieldDetected: () => {
       yieldDetected = true;


### PR DESCRIPTION
## Summary

- Keeps the native Codex registered dynamic-tool catalog stable when an internal subagent announcement disables `message` for the current turn.
- Separates the persistent registered schema from the per-turn available tool map, so `message` can remain registered while still being rejected when disabled for that turn.
- Preserves the direct `message` schema shape for `message_tool_only` sessions, including restrictive `toolsAllow` cases.
- Out of scope: broader context-engine bootstrap behavior and unrelated thread-rotation causes.

## Linked context

Closes #93750

Related #84681

Was this requested by a maintainer or owner?

Yes, requested by @jalehman.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: #93750, where native Codex threads churned across `normal Telegram turn -> internal subagent_announce turn with disableMessageTool -> normal Telegram turn` because the registered dynamic-tool catalog changed.
- Real environment tested: Live local OpenClaw gateway from `/Users/phaedrus/Projects/clawdbot`, rebuilt and restarted with a temporary `codex-proof` agent using `agentRuntime.id = "codex"` and model `codex/gpt-5.5`; local final PR branch worktree for regression tests/build.
- Exact steps or command run after this patch: Rebuilt the gateway, restarted it, ran three Gateway `agent` requests against the same Telegram-scoped session key: a normal `message_tool_only` turn, an internal `subagent_announce` turn with `disableMessageTool: true`, then another normal `message_tool_only` turn. Then verified the final branch with `pnpm build`, `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts -t "can retain message in the registered schema when disabled for the current turn"`, `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "keeps message in the registered schema when disabled for an internal turn"`, and `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main --no-web-search`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Live proof session key `agent:codex-proof:telegram:proof-codex-message-schema-1781646513475`; native Codex thread stayed `019ed268-77b2-73e0-9710-7b718cf99277` for the normal turn, internal disabled-message turn, and following normal turn; `dynamicToolsFingerprintCount: 1`; `fingerprintLength: 46898`; `dynamicToolsFingerprintIncludesDirectMessage: true`. Final focused tests after the last rebase both passed: dynamic-tool builder `1 passed | 42 skipped`; app-server bridge `1 passed | 104 skipped`. Final `pnpm build` passed.
- Observed result after fix: The internal `disableMessageTool` announcement no longer changes the registered Codex dynamic-tool fingerprint, and calls to `message` during that disabled turn are still rejected as unavailable for the turn.
- What was not tested: Full repository test suite; live gateway proof did not separately exercise a restrictive `toolsAllow: []` run, which is covered by the focused dynamic-tool builder regression test.
- Proof limitations or environment constraints: The live gateway proof used a temporary local `codex-proof` agent/config that was restored afterward. A redacted agent transcript was not added because that requires explicit approval before inclusion.
- Before evidence (optional but encouraged): The issue repro on OpenClaw `2026.6.8` showed three different native Codex threads for the same session: normal parent turn `019ed1bf-33e7...`, internal `subagent_announce` turn `019ed1bf-6fe5...`, and normal follow-up `019ed1bf-df6d...`.

## Tests and validation

Which commands did you run?

- `git fetch origin main && git rebase origin/main`
- `git diff --check origin/main...HEAD`
- `pnpm build`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts -t "can retain message in the registered schema when disabled for the current turn"`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "keeps message in the registered schema when disabled for an internal turn"`
- `/Users/phaedrus/Projects/prompts/skills/autoreview/scripts/autoreview --mode branch --base origin/main --no-web-search`

What regression coverage was added or updated?

Added focused coverage that:

- registered tools keep `message` even when current-turn available tools remove it;
- registered-only `message` calls fail as unavailable for the disabled turn;
- direct `message` schema fingerprints remain stable across disabled internal and normal turns;
- restrictive allowlists still retain forced `message` in the registered schema.

What failed before this fix, if known?

The live issue path rotated native Codex threads because `message` disappeared from the registered dynamic-tool schema for the internal announcement turn, then reappeared on the following normal turn.

If no test was added, why not?

N/A.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes, native Codex sessions should keep thread continuity through internal subagent announcement turns.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. Current-turn tool availability is still enforced before execution.

What is the highest-risk area?

Codex direct/deferred dynamic-tool schema stability.

How is that risk mitigated?

The change keeps the registered schema and available tool map separate, preserves direct `message` registration for `message_tool_only`, rejects disabled-turn `message` calls, and covers the normal, disabled, and restrictive-allowlist cases with focused tests plus live gateway proof for the reported issue path.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

CI has not run yet on the PR.

Which bot or reviewer comments were addressed?

Local autoreview found and I addressed two issues before opening the PR: a test that compared deferred vs direct `message` fingerprints, and a restrictive-allowlist case where registered schema construction did not apply the same forced-message policy.
