### PR TITLE
fix(trajectory): export legacy v1 sessions without entry timestamps

### DIFF
--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -1467,4 +1467,39 @@ describe("exportTrajectoryBundle", () => {
     expect(tools).toContain("$WORKSPACE_DIR/docs");
     expect(`${prompts}\n${artifacts}\n${systemPrompt}\n${tools}`).not.toContain(tmpDir);
   });
+
+  it("exports the transcript for a legacy v1 session without entry timestamps", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const outputDir = path.join(tmpDir, "bundle");
+    const header = {
+      type: "session",
+      version: 1,
+      id: "session-1",
+      cwd: tmpDir,
+    };
+    const userEntry = {
+      type: "message",
+      message: userMessage("hello"),
+    };
+    const assistantEntry = {
+      type: "message",
+      message: assistantMessage([{ type: "text", text: "done" }]),
+    };
+    fs.writeFileSync(
+      sessionFile,
+      `${[header, userEntry, assistantEntry].map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf8",
+    );
+
+    const bundle = await exportTrajectoryBundle({
+      outputDir,
+      sessionFile,
+      sessionId: "session-1",
+      workspaceDir: tmpDir,
+    });
+
+    expect(bundle.manifest.transcriptEventCount).toBe(2);
+    expect(eventTypes(bundle.events)).toEqual(["user.message", "assistant.message"]);
+  });
 });

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -185,9 +185,7 @@ async function readSessionBranch(filePath: string): Promise<{
     (entry): entry is SessionEntry =>
       entry.type !== "session" &&
       isCanonicalSessionTranscriptEntry(entry) &&
-      typeof (entry as { id?: unknown }).id === "string" &&
-      (typeof (entry as { timestamp?: unknown }).timestamp === "string" ||
-        typeof (entry as { timestamp?: unknown }).timestamp === "number"),
+      typeof (entry as { id?: unknown }).id === "string",
   );
   const tree = scanSessionTranscriptTree(fileEntries);
   if (!tree.hasLeafUpdate) {


### PR DESCRIPTION
## Summary

Exporting a trajectory bundle for an old (version 1) session produces an empty transcript. The CLI reports `Trajectory exported!` and writes a bundle whose `manifest.transcriptEventCount` is `0`, silently dropping every message in the session. This hits real users: `openclaw export-trajectory` / `/export-trajectory` run against any session file written before entry timestamps existed.

## Root cause

`readSessionBranch` filters session entries down to canonical transcript entries, but the filter also requires a present `timestamp`:

```ts
// before - src/trajectory/export.ts
const entries = fileEntries.filter(
  (entry): entry is SessionEntry =>
    entry.type !== "session" &&
    isCanonicalSessionTranscriptEntry(entry) &&
    typeof (entry as { id?: unknown }).id === "string" &&
    (typeof (entry as { timestamp?: unknown }).timestamp === "string" ||
      typeof (entry as { timestamp?: unknown }).timestamp === "number"),
);
```

The legacy migration `migrateLegacySessionEntries` synthesizes an `id` and `parentId` for every entry of a `version < 2` session, but it never synthesizes a `timestamp` (those logs predate entry timestamps). The downstream event builder already tolerates a missing timestamp: `buildTranscriptEvents` calls `normalizeTimestamp(entry.timestamp)`, which defaults an absent value to the epoch. That tolerance is dead code, because the filter strips the timestamp-less entries before they ever reach it. Result: every entry of a timestamp-less v1 session is filtered out and the bundle is empty.

## Fix

Drop the timestamp clause from the filter. Entry identity (`id`) plus `isCanonicalSessionTranscriptEntry` is what the branch walk needs; the timestamp is normalized later.

```ts
// after - src/trajectory/export.ts
const entries = fileEntries.filter(
  (entry): entry is SessionEntry =>
    entry.type !== "session" &&
    isCanonicalSessionTranscriptEntry(entry) &&
    typeof (entry as { id?: unknown }).id === "string",
);
```

`normalizeTimestamp` (already in the event path) defaults a missing or non-finite timestamp to `new Date(0).toISOString()`, so v3 sessions with real timestamps are unaffected and v1 sessions now export with epoch-defaulted timestamps instead of vanishing.

## Why this is the right boundary

`readSessionBranch` is the single owner of which persisted entries enter the exported branch. The timestamp requirement contradicted the migration contract (v1 entries legitimately have no entry timestamp) and the normalization contract (the builder already defaults missing timestamps). Removing the clause makes those two contracts reachable instead of adding a second compensating path. No sibling surface re-derives this filter; runtime event ingestion is separate and uses its own `isRuntimeTrajectoryEvent` guard, which is unchanged.

## Verification

- `node scripts/run-vitest.mjs src/trajectory/export.test.ts` - full 24-test export suite green with the fix (23 existing + 1 new regression).
- New test `exports the transcript for a legacy v1 session without entry timestamps` fails on pristine `main` (`transcriptEventCount` is `0`) and passes with the patch.
- `node scripts/run-oxlint.mjs src/trajectory/export.ts src/trajectory/export.test.ts` clean.
- `oxfmt --check` clean on both files.
- `tsgo -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` clean.

## Real behavior proof

Behavior addressed: trajectory export of a legacy v1 session (no entry timestamps) drops the entire transcript and reports `transcriptEventCount: 0`.
Real environment tested: the real `exportTrajectoryBundle` runtime driven end to end over a v1 session JSONL (header `version: 1`, two timestamp-less message entries), on pristine `main` and on the patched tree with identical input.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/trajectory/export.test.ts -t "legacy v1 session"`.
Evidence after fix:
```
# BEFORE (pristine main f94a2506d2)
FAIL  exports the transcript for a legacy v1 session without entry timestamps
expected 0 to be 2 // manifest.transcriptEventCount

# AFTER (this patch, identical input)
PASS  exports the transcript for a legacy v1 session without entry timestamps
manifest.transcriptEventCount === 2; eventTypes === ["user.message","assistant.message"]
```
Observed result after fix: the v1 session exports both messages; the bundle is no longer empty.
What was not tested: did not run the full `pnpm check` / `pnpm build` (no dynamic-import or packaging surface touched); proof is the real `exportTrajectoryBundle` runtime over a synthesized v1 session file rather than a CLI invocation against an on-disk historical session.
