### PR TITLE
Suppress internal source-reply final statuses

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7307,6 +7307,81 @@ describe("dispatchReplyFromConfig", () => {
     expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
   });
 
+  it("suppresses short internal final status text after a group source reply was delivered", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const hasRepliedRef = { value: true };
+    const ctx = buildTestCtx({ Provider: "slack", Surface: "slack", ChatType: "group" });
+    const replyResolver = async () => ({ text: "Sent." }) satisfies ReplyPayload;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { hasRepliedRef },
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses done-posted internal final status text after a group source reply was delivered", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const hasRepliedRef = { value: true };
+    const ctx = buildTestCtx({ Provider: "slack", Surface: "slack", ChatType: "group" });
+    const replyResolver = async () =>
+      ({ text: "Done - posted to #research-tasks." }) satisfies ReplyPayload;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { hasRepliedRef },
+    });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps substantive group final text even when a source reply was delivered", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const hasRepliedRef = { value: true };
+    const ctx = buildTestCtx({ Provider: "slack", Surface: "slack", ChatType: "group" });
+    const reply = { text: "Here is the actual answer." } satisfies ReplyPayload;
+    const replyResolver = async () => reply;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { hasRepliedRef },
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(reply);
+  });
+
+  it("keeps direct-chat final status text after source reply delivery", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const hasRepliedRef = { value: true };
+    const ctx = buildTestCtx({ Provider: "slack", Surface: "slack", ChatType: "direct" });
+    const reply = { text: "Sent." } satisfies ReplyPayload;
+    const replyResolver = async () => reply;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { hasRepliedRef },
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(reply);
+  });
+
   it("suppresses isReasoning payloads from block replies (generic dispatch path)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -362,6 +362,30 @@ async function maybeApplyTtsToReplyPayload(
     : copyReplyPayloadMetadata(params.payload, ttsPayload);
 }
 
+function isLikelyInternalSourceReplyFinal(params: {
+  reply: ReplyPayload;
+  chatType: string | undefined;
+  hasRepliedRef?: { value: boolean };
+}): boolean {
+  if (params.chatType !== "group" && params.chatType !== "channel") {
+    return false;
+  }
+  if (params.hasRepliedRef?.value !== true) {
+    return false;
+  }
+  const parts = resolveSendableOutboundReplyParts(params.reply);
+  if (!parts.hasText || parts.hasMedia) {
+    return false;
+  }
+  const text = parts.trimmedText.replace(/\s+/g, " ");
+  if (text.length > 500) {
+    return false;
+  }
+  return /^(?:sent\.?|sent[,:; -]|replied(?:\s+in|\s+to)?\b|message sent\b|delivered\b|posted\b|done\b.*\b(?:posted|sent|replied|responded|delivered|confirmed|flagged)\b|confirmed\b.*\b(?:replied|responded|sent|flagged)\b|i (?:replied|responded|sent|flagged)\b)/i.test(
+    text,
+  );
+}
+
 const resolveRoutedPolicyConversationType = (
   ctx: FinalizedMsgContext,
 ): "direct" | "group" | undefined => {
@@ -3277,6 +3301,28 @@ export async function dispatchReplyFromConfig(
       // Suppress reasoning payloads from channel delivery — channels using this
       // generic dispatch path do not have a dedicated reasoning lane.
       if (reply.isReasoning === true) {
+        continue;
+      }
+      if (
+        isLikelyInternalSourceReplyFinal({
+          reply,
+          chatType,
+          hasRepliedRef: params.replyOptions?.hasRepliedRef,
+        }) &&
+        !shouldDeliverDespiteSourceReplySuppression(reply)
+      ) {
+        logVerbose(
+          [
+            "dispatch-from-config: final reply suppressed because a source reply was already delivered",
+            `(session=${acpDispatchSessionKey ?? sessionKey ?? "unknown"}`,
+            `provider=${ctx.Provider ?? "unknown"}`,
+            `surface=${ctx.Surface ?? "unknown"}`,
+            `chatType=${chatType ?? "unknown"}`,
+            `inboundEventKind=${ctx.InboundEventKind ?? "unknown"}`,
+            `message=${ctx.MessageSidFull ?? ctx.MessageSid ?? "unknown"}`,
+            `${formatSuppressedReplyPayloadForLog(reply)})`,
+          ].join(" "),
+        );
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {


### PR DESCRIPTION
## Summary
- suppress short internal final status text, such as `Sent.` and `Done - posted to #research-tasks.`, after a group/channel source reply has already been delivered
- keep substantive group/channel final replies visible
- keep direct-chat final status text unchanged

## Test
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts`
- Result: `214 passed`