### PR TITLE
List all ClawHub docs in sidebar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1386,7 +1386,11 @@
                   "clawhub/api",
                   "clawhub/http-api",
                   "clawhub/acceptable-usage",
-                  "clawhub/content-rights"
+                  "clawhub/moderation",
+                  "clawhub/security",
+                  "clawhub/security-audits",
+                  "clawhub/content-rights",
+                  "clawhub/plugin-validation-fixes"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary
- adds the missing ClawHub docs pages to the OpenClaw docs sidebar: moderation, security, security audits, and plugin validation fixes
- keeps content rights visible alongside acceptable usage and the API pages

## Companion PR
- ClawHub policy/docs update: https://github.com/openclaw/clawhub/pull/2695

## Validation
- `pnpm docs:list`
- `pnpm format:docs:check`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/.codex/worktrees/277a/clawhub pnpm docs:check-links`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/.codex/worktrees/277a/clawhub pnpm docs:check-mdx`
- `git diff --check`
