### PR TITLE
fix(imessage): recognize MiniMax mm: reasoning tags in reflection guard (completes #93767)

### DIFF
--- a/extensions/imessage/src/monitor/reflection-guard.test.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.test.ts
@@ -37,14 +37,11 @@ describe("detectReflectedContent", () => {
     expect(result.matchedLabels).toContain("thinking-tag");
   });
 
-  it("detects Anthropic namespaced <think> tags", () => {
-    const result = detectReflectedContent("<antml:think>secret</antml:think>visible");
-    expect(result.isReflection).toBe(true);
-    expect(result.matchedLabels).toContain("thinking-tag");
-  });
-
-  it("detects MiniMax namespaced <mm:think> tags", () => {
-    const result = detectReflectedContent("<mm:think>secret</mm:think>visible");
+  it.each([
+    { provider: "Anthropic", tag: "antml:think" },
+    { provider: "MiniMax", tag: "mm:think" },
+  ])("detects $provider namespaced reasoning tags", ({ tag }) => {
+    const result = detectReflectedContent(`<${tag}>secret</${tag}>visible`);
     expect(result.isReflection).toBe(true);
     expect(result.matchedLabels).toContain("thinking-tag");
   });

--- a/extensions/imessage/src/monitor/reflection-guard.test.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.test.ts
@@ -37,6 +37,18 @@ describe("detectReflectedContent", () => {
     expect(result.matchedLabels).toContain("thinking-tag");
   });
 
+  it("detects Anthropic namespaced <think> tags", () => {
+    const result = detectReflectedContent("<antml:think>secret</antml:think>visible");
+    expect(result.isReflection).toBe(true);
+    expect(result.matchedLabels).toContain("thinking-tag");
+  });
+
+  it("detects MiniMax namespaced <mm:think> tags", () => {
+    const result = detectReflectedContent("<mm:think>secret</mm:think>visible");
+    expect(result.isReflection).toBe(true);
+    expect(result.matchedLabels).toContain("thinking-tag");
+  });
+
   it("detects <relevant_memories> tags", () => {
     const result = detectReflectedContent("<relevant_memories>data</relevant_memories>");
     expect(result.isReflection).toBe(true);

--- a/extensions/imessage/src/monitor/reflection-guard.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.ts
@@ -4,7 +4,13 @@ import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/i;
 // Require closing `>` to avoid false-positives on phrases like "<thought experiment>".
-const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/i;
+// Reasoning tags may carry a model-specific namespace prefix (e.g. Anthropic's
+// `antml:`, MiniMax's `mm:`). Accept the known prefixes so namespaced variants
+// like `<mm:think>` are still detected as reflected assistant content instead of
+// being treated as normal inbound text (matches the shared reasoning-tag contract
+// in src/shared/text/reasoning-tags.ts).
+const THINKING_TAG_RE =
+  /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
 const RELEVANT_MEMORIES_TAG_RE = /<\s*\/?\s*relevant[-_]memories\b[^<>]*>/i;
 // Require closing `>` to avoid false-positives on phrases like "<final answer>".
 const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/i;

--- a/extensions/imessage/src/monitor/reflection-guard.ts
+++ b/extensions/imessage/src/monitor/reflection-guard.ts
@@ -4,11 +4,8 @@ import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/i;
 // Require closing `>` to avoid false-positives on phrases like "<thought experiment>".
-// Reasoning tags may carry a model-specific namespace prefix (e.g. Anthropic's
-// `antml:`, MiniMax's `mm:`). Accept the known prefixes so namespaced variants
-// like `<mm:think>` are still detected as reflected assistant content instead of
-// being treated as normal inbound text (matches the shared reasoning-tag contract
-// in src/shared/text/reasoning-tags.ts).
+// Keep known provider namespaces aligned with the public reasoning-tag contract
+// so reflected hidden reasoning cannot re-enter the agent loop.
 const THINKING_TAG_RE =
   /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/i;
 const RELEVANT_MEMORIES_TAG_RE = /<\s*\/?\s*relevant[-_]memories\b[^<>]*>/i;


### PR DESCRIPTION
## What Problem This Solves

The iMessage **reflection guard** (`extensions/imessage/src/monitor/reflection-guard.ts`) failed to recognize MiniMax `mm:`-namespaced reasoning tags (`<mm:think>`, `<mm:thinking>`, `<mm:thought>`). Its `THINKING_TAG_RE` only matched bare/`antthinking` reasoning tags, so a MiniMax reply carrying `<mm:think>…</mm:think>` was **not** treated as reflected assistant reasoning. Because `detectReflectedContent` feeds the inbound drop decision (`inbound-processing.ts:718`), any user on a MiniMax-backed agent would have the model's internal reasoning leak through to the iMessage thread (and risk echo-amplification) instead of being suppressed. This continues the cleanup flagged by #93767, which added `mm:` support to the central reasoning-tag handling and noted the same pattern was duplicated in other monitor paths — this guard was one of them (it was missing even the `antml:` prefix).

## Evidence

Driven against the **real exported `detectReflectedContent`** (no mocks — it is a deterministic function and importing it exercises the exact code path `inbound-processing.ts:718` uses), local, Node v22.22.0, `node --import tsx`:

- **After fix:** `"<mm:think>secret reasoning</mm:think>visible"` → `isReflection=true`, `labels=["thinking-tag"]`, content suppressed before reaching the downstream inbound pipeline. `<mm:thinking>`/`<mm:thought>` variants all flagged too.
- **No regression:** bare `<think>`/`<thinking>` tags still `isReflection=true`; `mm:think` inside inline code still `isReflection=false` (code-fence exemption preserved); the phrase `"thinking about your minimax question"` still `isReflection=false` (no misclassification).
- **Negative control:** reverting only the source regex to its pre-fix form and re-running the same proof flips the MiniMax case to `isReflection=false` — the reasoning is **delivered downstream (leaks past the guard)**; restoring the fix returns it to suppressed. This pins the behavior change to exactly this patch.
- **Tests:** `reflection-guard.test.ts` → **20 pass**, including the 2 new namespaced cases (Anthropic `<think>` and MiniMax `<mm:think>`). `oxlint` + `oxfmt --check` clean.

## Summary

#93767 added MiniMax `mm:` namespace support to reasoning-tag handling, and its own follow-up note flagged that the same tag pattern is duplicated in several other monitor paths. The iMessage **reflection guard** is one of them: `THINKING_TAG_RE` in `extensions/imessage/src/monitor/reflection-guard.ts:7` only matched bare/`antthinking` reasoning tags, so a MiniMax `<mm:think>…</mm:think>` reply was **not** recognized as reflected reasoning. `detectReflectedContent` feeds the inbound drop decision (`inbound-processing.ts:718`), so unrecognized MiniMax reasoning slips through reflection detection and can be echo-amplified.

## Changes

- `extensions/imessage/src/monitor/reflection-guard.ts`: `(?:think(?:ing)?|thought|antthinking)` → `(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)`, matching #93767's exact pattern (this guard had been missing even `antml:` — aligned to the shared reasoning-tag contract #93767 established). +8/-1 + 2 regression tests.

## Real behavior proof

**Behavior addressed**: the iMessage reflection guard recognizes MiniMax `mm:`-namespaced reasoning tags (`<mm:think>`, `<mm:thinking>`, `<mm:thought>`) the same as bare ones, so MiniMax reasoning is suppressed by the inbound reflection guard instead of being forwarded downstream.

**Real environment tested**: local, Node v22.22.0, `node --import tsx`, driving the **real exported `detectReflectedContent`** from the changed file (which uses the real `openclaw/plugin-sdk/text-chunking` code-region logic). No mocks — this is a deterministic reflection-detection function, so importing it exercises the exact production code path `inbound-processing.ts:718` relies on. A downstream-delivery wrapper models the readback boundary ("what actually reaches the downstream inbound pipeline": a flagged reflection is suppressed; an unflagged one is delivered/leaks).

**Exact steps or command run after this patch**:
```
git worktree add -f /tmp/pwt fork/fix/minimax-mm-channel-monitor-guards
cd /tmp/pwt && node --import tsx proof.mts            # drives real detectReflectedContent
node scripts/run-vitest.mjs extensions/imessage/src/monitor/reflection-guard.test.ts --run
```

**Evidence after fix** (real function output):
```
[PASS] MiniMax mm: namespaced reasoning tag
       input="<mm:think>secret reasoning</mm:think>visible"
       isReflection=true  labels=["thinking-tag"]
       downstream delivered=<suppressed by guard>
[PASS] bare <think>/<thinking> tags         -> isReflection=true  (no regression)
[PASS] mm:think inside inline code           -> isReflection=false (code-fence exemption preserved)
[PASS] "thinking about your minimax question"-> isReflection=false (no misclassification)
<mm:thinking>/<mm:thought> variants          -> isReflection=true  (all mm: forms covered)
```

**Observed result after fix**: MiniMax `<mm:think>…</mm:think>` content is now flagged as a reflection (`isReflection=true`, label `thinking-tag`) and **suppressed** before reaching the downstream inbound pipeline; bare-tag and code-fence-exemption behavior is unchanged. `reflection-guard.test.ts`: **20 pass** (incl. 2 new namespaced cases). `oxlint` + `oxfmt --check` clean.

**Negative control**: reverting only the source regex to its pre-fix form (`git show <parent>:reflection-guard.ts`) and re-running the **same** proof flips the MiniMax case to `isReflection=false` — `"<mm:think>secret reasoning</mm:think>visible"` is **delivered downstream (leaks past the guard)** instead of being suppressed; restoring the fix returns it to suppressed. This pins the behavior change to exactly this patch.

**What was not tested**: no live iMessage round-trip; the change is in the deterministic reflection-detection regex, driven via the real exported function.

<!-- codex-rescue-machine-readable-real-behavior-proof -->
## Real behavior proof

Behavior addressed: The iMessage reflection guard did not recognize MiniMax mm: namespaced reasoning tags such as <mm:think>, <mm:thinking>, and <mm:thought>. This patch makes the guard flag those tags as reflected reasoning so they are suppressed instead of being forwarded downstream.

Real environment tested: Local Linux runtime with Node v22.22.0 and node --import tsx, driving the real exported detectReflectedContent from extensions/imessage/src/monitor/reflection-guard.ts. The function imports and uses the real openclaw/plugin-sdk text-chunking code-region logic. A small downstream-delivery wrapper read back whether flagged content would be suppressed or delivered.

Exact steps or command run after this patch: In PR head fork/fix/minimax-mm-channel-monitor-guards, ran node --import tsx proof.mts to drive real detectReflectedContent, then ran node scripts/run-vitest.mjs extensions/imessage/src/monitor/reflection-guard.test.ts --run.

Evidence after fix: Live terminal output from the proof script:
```text
[PASS] MiniMax mm: namespaced reasoning tag
       input="<mm:think>secret reasoning</mm:think>visible"
       isReflection=true  labels=["thinking-tag"]
       downstream delivered=<suppressed by guard>
[PASS] bare <think>/<thinking> tags         -> isReflection=true  (no regression)
[PASS] mm:think inside inline code           -> isReflection=false (code-fence exemption preserved)
[PASS] "thinking about your minimax question"-> isReflection=false (no misclassification)
<mm:thinking>/<mm:thought> variants          -> isReflection=true  (all mm: forms covered)
```
Negative control reverting only the source regex to the pre-fix form flipped the MiniMax case to isReflection=false and delivered the <mm:think> content downstream; restoring the fix suppressed it again.

Observed result after fix: MiniMax <mm:think>...</mm:think> content is now flagged as a reflection with label thinking-tag and suppressed before reaching the downstream inbound pipeline. Bare-tag behavior and code-fence exemption behavior remain unchanged. reflection-guard.test.ts passed 20 tests, with oxlint and oxfmt --check clean.

What was not tested: No live iMessage round trip was run. The changed behavior is a deterministic reflection-detection regex and was driven through the real exported function rather than a phone/device integration.
