### PR TITLE
fix(whatsapp): keep opening text chunk when first media fails on multi-chunk reply

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -624,6 +624,32 @@ describe("deliverWebReply", () => {
     expect(warnContext.mediaUrl).toBe("http://example.com/img.jpg");
   });
 
+  it("delivers the opening text chunk when the first media fails on a multi-chunk reply", async () => {
+    const msg = makeMsg();
+    mockLoadedImageMedia();
+    mockFirstSendMediaFailure(msg, "boom");
+
+    await deliverWebReply({
+      replyResult: { text: "ALPHALINEBRAVOLINE", mediaUrl: "http://example.com/img.jpg" },
+      msg,
+      maxMediaBytes: 1024 * 1024,
+      textLimit: 9,
+      replyLogger,
+      skipLog: true,
+    });
+
+    expect(replyText(msg, 0)).toContain("ALPHALINE");
+    expect(replyText(msg, 0)).toContain("⚠️ Media failed");
+    const allReplies = (
+      msg.platform.reply as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(allReplies).toContain("ALPHALINE");
+    expect(allReplies).toContain("BRAVOLINE");
+    expect(allReplies).not.toContain("boom");
+  });
+
   it("still attempts later media after the first media fails", async () => {
     vi.clearAllMocks();
     const msg = makeMsg();

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -340,7 +340,7 @@ export async function deliverWebReply(params: {
         return;
       }
       const warning = "⚠️ Media failed.";
-      const fallbackTextParts = [remainingText.shift() ?? caption ?? "", warning].filter(Boolean);
+      const fallbackTextParts = [caption ?? "", warning].filter(Boolean);
       const fallbackText = fallbackTextParts.join("\n");
       if (!fallbackText) {
         return;


### PR DESCRIPTION
## Summary

When a WhatsApp auto-reply is longer than the chunk limit (default 4000, so two or more chunks) and is sent with an image whose fetch or send fails (404, timeout, oversize), the opening chunk of the agent's answer is silently dropped. The user receives the second chunk, the "Media failed" warning, then the rest, but never the first chunk. The adapter still logs the reply as delivered, so the loss is invisible.

Single-chunk captions are unaffected, which is why this was not caught earlier: every existing test uses a one-chunk caption.

## Root cause

`extensions/whatsapp/src/auto-reply/deliver-reply.ts`. The leading text chunk is popped off `remainingText` and attached to the first media item as its caption:

```ts
const remainingText = [...textChunks];
const leadingCaption = remainingText.shift() || "";
await sendMediaWithLeadingCaption({
  mediaUrls: mediaList,
  caption: leadingCaption,
  ...
```

When the first media send fails, `onError` is called with `caption` set to that first chunk so it can be resurfaced as text. The fallback line was:

```ts
// before
const fallbackTextParts = [remainingText.shift() ?? caption ?? "", warning].filter(Boolean);
```

`remainingText.shift()` is evaluated first. On a multi-chunk reply it returns the second chunk, which is truthy, so `?? caption` is never reached and the first chunk (the caption) is discarded. It also consumes the second chunk from `remainingText`, but the trailing loop below re-sends the rest, so only the first chunk is lost. On a single-chunk reply `remainingText` is empty, `shift()` is `undefined`, and `?? caption` resurfaces the only chunk, which is why the existing behavior looked correct.

## Fix

```ts
// after
const fallbackTextParts = [caption ?? "", warning].filter(Boolean);
```

`caption` already holds the first chunk that was attached to the failed media item, so resurfacing it is exactly what the fallback intends. The trailing loop (`for (const chunk of remainingText)`) already sends every remaining chunk, so dropping the stray `shift()` here both restores the opening chunk and keeps the rest intact.

## Why this is the right boundary

The defect is entirely in the first-media `onError` text fallback. The trailing-media branch (`isFirst === false`) was added by PR #93334 and is untouched and unaffected: it sends a fixed "Media unavailable." notice and never handled caption text. The trailing-text loop that emits the remaining chunks is unchanged. No other channel reuses this WhatsApp-local fallback. Single-chunk behavior is preserved (`caption` resurfaces the only chunk exactly as before).

## Verification

- New regression test `delivers the opening text chunk when the first media fails on a multi-chunk reply` fails on pristine main and passes with the patch.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/deliver-reply.test.ts`
  - pristine main: `Tests 1 failed | 29 passed (30)`, failure `expected 'BRAVOLINE\n⚠️ Media failed.' to contain 'ALPHALINE'`
  - with patch: `Tests 30 passed (30)`
- `node scripts/run-oxlint.mjs <changed files>`: clean
- `oxfmt --check <changed files>`: new code conforms (oxfmt 0.52.0)
- `node scripts/run-tsgo.mjs -p extensions/whatsapp/tsconfig.json`: exit 0
- Separately captured the real outbound envelope sequence at the Baileys `sock.sendMessage` boundary (below) to confirm the user-visible delivery, not just the unit assertion.

## Real behavior proof

Behavior addressed: On a multi-chunk WhatsApp reply whose first image upload fails, the opening text chunk is now delivered to the wire instead of dropped.
Real environment tested: The real WhatsApp/Baileys outbound path was exercised end to end: production `deliverWebReply` -> the `inbound/monitor.ts` `reply`/`sendMedia` send closures (real `addWhatsAppImagePreviewFields` image-envelope build plus outbound mentions) -> the real `createWhatsAppSocketOperationTimeoutAdapter` -> Baileys `sock.sendMessage`. Only the WebSocket socket itself was substituted, recording every outgoing envelope and rejecting the first image upload the way a real HTTP 404 does. Identical inputs were run against the pristine tree (fix reverted) and the patched tree.
Exact steps or command run after this patch: Drove `deliverWebReply` with a 4139-character reply (two chunks at the production default 4000 limit; opening chunk begins `ALPHA-OPENING`, second begins `BRAVO-SECOND`) plus one image whose first upload is rejected, then serialized the captured `sock.sendMessage` envelope sequence to a file for the pristine and patched trees.
Evidence after fix:
```
# BEFORE (fix reverted) - real Baileys sock.sendMessage envelope sequence
reply text length: 4139 chars
  sock.sendMessage #1 -> imageMessage  [TRANSPORT REJECTED upload (simulated HTTP 404)]
  sock.sendMessage #2 -> textMessage "BRAVO-SECOND-CHUNK more more more "
opening chunk ("ALPHA-OPENING") delivered to wire: NO -- LOST

# AFTER (this patch, identical inputs) - real Baileys sock.sendMessage envelope sequence
reply text length: 4139 chars
  sock.sendMessage #1 -> imageMessage  [TRANSPORT REJECTED upload (simulated HTTP 404)]
  sock.sendMessage #2 -> textMessage "ALPHA-OPENING-CHUNK word word word"
  sock.sendMessage #3 -> textMessage "BRAVO-SECOND-CHUNK more more more "
opening chunk ("ALPHA-OPENING") delivered to wire: YES
```
Observed result after fix: Before the patch the first image upload is rejected and only the second chunk (`BRAVO-SECOND-CHUNK`) reaches `sock.sendMessage`, so the opening chunk is permanently lost. After the patch the same rejected upload is followed by the opening chunk (`ALPHA-OPENING-CHUNK`, carrying the "Media failed" warning) and then the second chunk, both reaching the Baileys transport in order; no chunk is lost.
What was not tested: No round-trip against a live paired WhatsApp account. The WhatsApp WebSocket socket was substituted at the `sock.sendMessage` boundary (the only seam below it is the network socket), so the envelope payloads are built and ordered by real production code but the WhatsApp server's own media-upload response is not contacted.

### How the proof was driven

The capture used a small local driver (not committed) that imports the production `deliverWebReply` and rebuilds the exact `reply`/`sendMedia` closures from `extensions/whatsapp/src/inbound/monitor.ts:1103-1123` over the real `createWhatsAppSocketOperationTimeoutAdapter`, backed by a recording socket whose first image `sendMessage` throws. It was run once on the patched tree and once with the one-line fix reverted, under `node scripts/run-vitest.mjs`, writing the envelope sequence above for each tree.
