### PR TITLE
fix(agents): skip A2A announce flow for isolated cron sessions_send

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -191,6 +191,12 @@ function isRequesterParentOfNativeSubagentSession(params: {
   return requester === spawnedBy || requester === parentSessionKey;
 }
 
+/** Detect isolated cron requesters by the `:cron:` marker in the session key. */
+function isRequesterIsolatedCron(requesterSessionKey: string | null | undefined): boolean {
+  const requester = normalizeOptionalString(requesterSessionKey);
+  return Boolean(requester?.includes(":cron:"));
+}
+
 function isTerminalAgentWaitTimeout(result: AgentWaitResult): boolean {
   return result.endedAt !== undefined || Boolean(result.stopReason || result.livenessState);
 }
@@ -635,7 +641,8 @@ export function createSessionsSendTool(opts?: {
           requesterSessionKey: effectiveRequesterKey,
           targetSessionKey: resolvedKey,
         });
-      const skipA2AFlow = skipAcpA2AFlow || skipNativeParentA2AFlow;
+      const skipCronA2AFlow = isRequesterIsolatedCron(effectiveRequesterKey);
+      const skipA2AFlow = skipAcpA2AFlow || skipNativeParentA2AFlow || skipCronA2AFlow;
       // When the A2A flow is skipped, no follow-up announcement will fire and
       // the reply (when present) is returned inline via the `reply` field.
       // Reflect that in the metadata so the parent LLM does not wait for a

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -640,8 +640,7 @@ export function createSessionsSendTool(opts?: {
           requesterSessionKey: effectiveRequesterKey,
           targetSessionKey: resolvedKey,
         });
-      const skipCronA2AFlow = isRequesterIsolatedCron(effectiveRequesterKey);
-      const skipA2AFlow = skipAcpA2AFlow || skipNativeParentA2AFlow || skipCronA2AFlow;
+      const skipA2AFlow = skipAcpA2AFlow || skipNativeParentA2AFlow;
       // When the A2A flow is skipped, no follow-up announcement will fire and
       // the reply (when present) is returned inline via the `reply` field.
       // Reflect that in the metadata so the parent LLM does not wait for a
@@ -649,6 +648,14 @@ export function createSessionsSendTool(opts?: {
       const delivery = skipA2AFlow
         ? ({ status: "skipped", mode: "announce" } as const)
         : ({ status: "pending", mode: "announce" } as const);
+
+      // Isolated cron sessions must still run the target announce path so the
+      // message is delivered, but skip the ping-pong requester feedback loop
+      // to prevent the target's reply context from leaking back into the cron
+      // session (#92257).
+      const cronPingPongTurns = isRequesterIsolatedCron(effectiveRequesterKey)
+        ? 0
+        : maxPingPongTurns;
 
       const startA2AFlow = (
         roundOneReply?: string,
@@ -664,7 +671,7 @@ export function createSessionsSendTool(opts?: {
           displayKey: flowDisplayKey,
           message,
           announceTimeoutMs,
-          maxPingPongTurns,
+          maxPingPongTurns: cronPingPongTurns,
           requesterSessionKey,
           requesterChannel,
           baseline: baselineReply,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -191,10 +191,9 @@ function isRequesterParentOfNativeSubagentSession(params: {
   return requester === spawnedBy || requester === parentSessionKey;
 }
 
-/** Detect isolated cron requesters by the `:cron:` marker in the session key. */
+/** Detect isolated cron requesters using the canonical session-key parser. */
 function isRequesterIsolatedCron(requesterSessionKey: string | null | undefined): boolean {
-  const requester = normalizeOptionalString(requesterSessionKey);
-  return Boolean(requester?.includes(":cron:"));
+  return isCronRunSessionKey(requesterSessionKey);
 }
 
 function isTerminalAgentWaitTimeout(result: AgentWaitResult): boolean {


### PR DESCRIPTION
## Summary

- Isolated cron sessions calling `sessions_send` had the target agent's reply injected back into the cron run via the A2A ping-pong loop (#92257).
- This fix narrows the approach per ClawSweeper review: instead of skipping the entire A2A flow (which also suppressed target announce delivery), it sets `maxPingPongTurns=0` for isolated cron requesters.
- **Target announce delivery is preserved** — the message still reaches the intended recipient.
- **Requester ping-pong is suppressed** — the cron session does not get stepped with the target's reply.

## Changes from previous iteration
- Removed `skipCronA2AFlow` from the `skipA2AFlow` gate
- Added `cronPingPongTurns` variable: 0 for cron requesters, `maxPingPongTurns` for normal callers
- The `startA2AFlow` callback now passes `maxPingPongTurns: cronPingPongTurns`

## Verification

- `node scripts/run-vitest.mjs run src/agents/tools/sessions-send-tool.a2a.test.ts sessions-send-helpers.test.ts` → **27/27 passed**
- Cron detection uses `isCronRunSessionKey` (canonical parsed classifier), correctly rejecting non-canonical `:cron:` keys

## Impact Assessment

- Scope: `src/agents/tools/sessions-send-tool.ts` — modifies `maxPingPongTurns` for cron requesters only
- Target announce: preserved — the delivery status stays `"pending"` and the announce path runs normally
- Requester feedback: suppressed — cron sessions get 0 ping-pong turns
- Non-cron sessions: unaffected — `cronPingPongTurns` falls back to `maxPingPongTurns`

## Real behavior proof

**Behavior addressed:** Narrowed fix that only suppresses the ping-pong requester feedback loop for isolated cron `sessions_send`, while preserving the target announce delivery path.

**Environment tested:** Node 22.x on Linux, vitest test suite.

**Steps run after the patch:** Ran sessions-send A2A and helpers test suites.

```bash
node scripts/run-vitest.mjs run src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/sessions-send-helpers.test.ts
```

**Evidence after fix:**

```text
Test Files  2 passed (2)
     Tests  27 passed (27)
```

**Observed result:** All 27 tests pass. The cron ping-pong suppression is parameterized through `maxPingPongTurns=0` rather than skipping the entire A2A flow.

**Not tested:** Live gateway with a cron job triggering sessions_send was not exercised.

Closes #92257
