### PR TITLE
fix(gateway): hot-reload browser profile config

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -107,7 +107,10 @@ function registerBrowserAutoEnableProbe(): BrowserAutoEnableProbe {
 
 describe("browser plugin", () => {
   it("exposes static browser metadata on the plugin definition", () => {
-    expect(browserPluginReload).toEqual({ restartPrefixes: ["browser"] });
+    expect(browserPluginReload).toEqual({
+      restartPrefixes: ["browser"],
+      hotPrefixes: ["browser.profiles"],
+    });
     expect(browserPluginNodeHostCommands).toHaveLength(1);
     expect(browserPluginNodeHostCommands[0]?.command).toBe("browser.proxy");
     expect(browserPluginNodeHostCommands[0]?.cap).toBe("browser");

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -141,7 +141,10 @@ function createBrowserToolOptions(ctx: OpenClawPluginToolContext): {
 }
 
 /** Browser plugin reload policy. */
-export const browserPluginReload = { restartPrefixes: ["browser"] };
+export const browserPluginReload = {
+  restartPrefixes: ["browser"],
+  hotPrefixes: ["browser.profiles"],
+};
 
 /** Node-host command descriptors exposed by the Browser plugin. */
 export const browserPluginNodeHostCommands: OpenClawPluginNodeHostCommand[] = [

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -3,8 +3,8 @@
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import {
   getActivePluginChannelRegistryVersion,
-  getActivePluginRegistry,
-  getActivePluginRegistryVersion,
+  getActivePluginHttpRouteRegistry,
+  getActivePluginHttpRouteRegistryVersion,
 } from "../plugins/runtime.js";
 import { isPlainObject } from "../utils.js";
 
@@ -146,24 +146,26 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
 ];
 
 let cachedReloadRules: ReloadRule[] | null = null;
-let cachedRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
-let cachedActiveRegistryVersion = -1;
+let cachedRegistry: ReturnType<typeof getActivePluginHttpRouteRegistry> | null = null;
+let cachedGatewayRegistryVersion = -1;
 let cachedChannelRegistryVersion = -1;
 
 function listReloadRules(): ReloadRule[] {
-  const registry = getActivePluginRegistry();
-  const activeRegistryVersion = getActivePluginRegistryVersion();
+  // Reload metadata is Gateway policy. Agent-scoped registry activation must
+  // not replace the pinned Gateway surface and silently change restart rules.
+  const registry = getActivePluginHttpRouteRegistry();
+  const gatewayRegistryVersion = getActivePluginHttpRouteRegistryVersion();
   const channelRegistryVersion = getActivePluginChannelRegistryVersion();
   // Plugin/channel reload rules are process-stable until the active registry
   // version changes; cache them to keep every config diff cheap.
   if (
     registry !== cachedRegistry ||
-    activeRegistryVersion !== cachedActiveRegistryVersion ||
+    gatewayRegistryVersion !== cachedGatewayRegistryVersion ||
     channelRegistryVersion !== cachedChannelRegistryVersion
   ) {
     cachedReloadRules = null;
     cachedRegistry = registry;
-    cachedActiveRegistryVersion = activeRegistryVersion;
+    cachedGatewayRegistryVersion = gatewayRegistryVersion;
     cachedChannelRegistryVersion = channelRegistryVersion;
   }
   if (cachedReloadRules) {

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -234,12 +234,15 @@ function listReloadRules(): ReloadRule[] {
 }
 
 function matchRule(path: string): ReloadRule | null {
+  let bestRule: ReloadRule | null = null;
   for (const rule of listReloadRules()) {
     if (path === rule.prefix || path.startsWith(`${rule.prefix}.`)) {
-      return rule;
+      if (!bestRule || rule.prefix.length > bestRule.prefix.length) {
+        bestRule = rule;
+      }
     }
   }
-  return null;
+  return bestRule;
 }
 
 export function resolveConfigReloadMetadata(path: string): ConfigReloadMetadata {

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -229,20 +229,20 @@ function listReloadRules(): ReloadRule[] {
     ...channelPluginStateRules,
     ...BASE_RELOAD_RULES_TAIL,
   ];
+  // Narrow config contracts must override broad owner fallbacks. Sort once per
+  // registry snapshot so the hot path can retain first-match semantics.
+  rules.sort((a, b) => b.prefix.length - a.prefix.length);
   cachedReloadRules = rules;
   return rules;
 }
 
 function matchRule(path: string): ReloadRule | null {
-  let bestRule: ReloadRule | null = null;
   for (const rule of listReloadRules()) {
     if (path === rule.prefix || path.startsWith(`${rule.prefix}.`)) {
-      if (!bestRule || rule.prefix.length > bestRule.prefix.length) {
-        bestRule = rule;
-      }
+      return rule;
     }
   }
-  return bestRule;
+  return null;
 }
 
 export function resolveConfigReloadMetadata(path: string): ConfigReloadMetadata {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -12,6 +12,7 @@ import type {
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   pinActivePluginChannelRegistry,
+  pinActivePluginHttpRouteRegistry,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
@@ -223,6 +224,17 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.hotReasons).toEqual([path]);
     expect(plan.noopPaths).toStrictEqual([]);
     expect(resolveConfigReloadMetadata(path).kind).toBe("hot");
+  });
+
+  it("keeps Gateway reload policy when an agent activates a scoped registry", () => {
+    pinActivePluginHttpRouteRegistry(registry);
+    setActivePluginRegistry(emptyRegistry);
+
+    const path = "browser.profiles.sandbox.cdpUrl";
+    expect(buildGatewayReloadPlan([path])).toMatchObject({
+      restartGateway: false,
+      hotReasons: [path],
+    });
   });
 
   it("restarts the Gmail watcher for hooks.gmail changes", () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -172,7 +172,7 @@ describe("buildGatewayReloadPlan", () => {
     {
       pluginId: "browser",
       pluginName: "Browser",
-      registration: { restartPrefixes: ["browser"] },
+      registration: { restartPrefixes: ["browser"], hotPrefixes: ["browser.profiles"] },
       source: "test",
     },
     {
@@ -212,6 +212,17 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartGateway).toBe(true);
     expect(plan.restartReasons).toContain("browser.enabled");
     expect(plan.hotReasons).toStrictEqual([]);
+  });
+
+  it("hot-reloads browser profile config under the broad browser restart rule", () => {
+    const path = "browser.profiles.sandbox.cdpUrl";
+    const plan = buildGatewayReloadPlan([path]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartReasons).toStrictEqual([]);
+    expect(plan.hotReasons).toEqual([path]);
+    expect(plan.noopPaths).toStrictEqual([]);
+    expect(resolveConfigReloadMetadata(path).kind).toBe("hot");
   });
 
   it("restarts the Gmail watcher for hooks.gmail changes", () => {
@@ -512,6 +523,16 @@ describe("buildGatewayReloadPlan", () => {
       path: "browser.enabled",
       expectRestartGateway: true,
       expectRestartReason: "browser.enabled",
+    },
+    {
+      path: "browser.defaultProfile",
+      expectRestartGateway: true,
+      expectRestartReason: "browser.defaultProfile",
+    },
+    {
+      path: "browser.profiles.sandbox.cdpUrl",
+      expectRestartGateway: false,
+      expectHotPath: "browser.profiles.sandbox.cdpUrl",
     },
     {
       path: "gateway.channelHealthCheckMinutes",

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -4,6 +4,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import {
   createConfigHandlerHarness,
   createConfigWriteSnapshot,
@@ -141,6 +143,19 @@ function hotReloadConfig(): OpenClawConfig {
   };
 }
 
+function installBrowserReloadRegistry(): void {
+  const registry = createTestRegistry([]);
+  registry.reloads = [
+    {
+      pluginId: "browser",
+      pluginName: "Browser",
+      registration: { restartPrefixes: ["browser"], hotPrefixes: ["browser.profiles"] },
+      source: "test",
+    },
+  ];
+  setActivePluginRegistry(registry);
+}
+
 function mockPreviousConfig(config: OpenClawConfig): void {
   readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(config));
 }
@@ -171,6 +186,7 @@ function expectNoDirectRestart(): void {
 
 afterEach(() => {
   vi.clearAllMocks();
+  resetPluginRuntimeStateForTest();
 });
 
 beforeEach(() => {
@@ -380,6 +396,34 @@ describe("config shared auth disconnects", () => {
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
     const payload = restartSentinelMocks.writeRestartSentinel.mock.calls.at(-1)?.[0];
     expect(payload?.stats?.requiresRestart).toBe(false);
+  });
+
+  it("does not schedule a direct restart for hot-mode browser profile config.patch writes", async () => {
+    installBrowserReloadRegistry();
+    mockPreviousConfig({
+      ...hotReloadConfig(),
+      browser: {
+        profiles: {
+          sandbox: {
+            cdpUrl: "http://127.0.0.1:9222",
+            color: "#0066CC",
+          },
+        },
+      },
+    });
+
+    await runConfigPatch({
+      browser: {
+        profiles: {
+          sandbox: {
+            cdpUrl: "http://127.0.0.1:9223",
+            color: "#0066CC",
+          },
+        },
+      },
+    });
+
+    expectNoDirectRestart();
   });
 
   it("does not add an agent continuation from generic control-plane sessionKey params", async () => {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes browser profile config reload classification so `browser.profiles.*` changes can hot-reload instead of forcing a gateway restart.
- Keeps broader browser config changes, such as `browser.enabled` and `browser.defaultProfile`, restart-scoped.

Why does this matter now?

- Issue #43803 reports browser profile edits causing avoidable gateway restart behavior. Browser profile connection details should be adjustable without disrupting the whole gateway.

What is the intended outcome?

- Browser profile fields resolve as hot-reloadable config paths.
- Broader browser settings still require restart where appropriate.
- Config reload rules prefer the most specific matching prefix, so narrow hot rules can override broad restart rules.

What is intentionally out of scope?

- No changes to browser runtime connection behavior beyond reload classification.
- No changes to auth, pairing, plugin loading, or browser profile schema fields.

What does success look like?

- `browser.profiles.sandbox.cdpUrl` resolves to `hot`.
- `browser.enabled` and `browser.defaultProfile` continue resolving to `restart`.
- Focused gateway/browser tests and the full build pass.

What should reviewers focus on?

- Whether longest-prefix reload rule matching is the right project-native behavior.
- Whether `browser.profiles` is the correct narrow hot-reload boundary.
- Whether the regression coverage protects both direct reload planning and authenticated `config.patch` behavior.

## Linked context

Which issue does this close?

Closes #43803

Which issues, PRs, or discussions are related?

Related #64204

Was this requested by a maintainer or owner?

- This follows the contributor queue metadata on #43803: `queueable-fix`, `fix-shape-clear`, and `source-repro`.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: browser profile config paths were classified under the broad `browser` restart rule, so profile-only changes could schedule a gateway restart instead of hot reload.
- Real environment tested: local OpenClaw checkout using Node v24, built gateway artifacts, temporary config/state directories, loopback gateway, browser plugin enabled, and `gateway.reload.mode: "hot"`.
- Exact steps or command run after this patch:
  - Built the project with `node scripts/build-all.mjs`.
  - Started the built gateway with a temporary config containing `browser.profiles.sandbox`.
  - Queried live schema metadata through the gateway for `browser.profiles.sandbox.cdpUrl` and `browser.enabled`.
  - Queried gateway health after startup.
- Evidence after fix: copied live output from the running gateway: `config.schema.lookup browser.profiles.sandbox.cdpUrl -> {"path":"browser.profiles.sandbox.cdpUrl","reloadKind":"hot"}`; `config.schema.lookup browser.enabled -> {"path":"browser.enabled","reloadKind":"restart"}`; `health -> {"ok":true,"loadedPlugins":["browser"]}`.
- Observed result after fix: the live gateway exposes browser profile connection fields as hot-reloadable while preserving restart classification for broader browser settings.
- What was not tested: a live write-scoped `config.patch` through a fully paired external client was not completed.
- Proof limitations or environment constraints: the local CLI client could read schema/health successfully, but write-scoped `config.patch` was blocked by the gateway pairing/scope-upgrade flow. The patch path is covered by the authenticated server-method regression test.
- Before evidence: `browser.profiles.sandbox.cdpUrl` reproduced as restart-scoped in the focused reload-plan regression before this patch. The authenticated `config.patch` regression also reproduced a scheduled gateway restart for the same profile-only path before this patch.

## Tests and validation

Which commands did you run?

- `node scripts/test-projects.mjs src/gateway/config-reload.test.ts -- --testNamePattern "browser profile" --reporter=verbose`
- `node scripts/test-projects.mjs src/gateway/server-methods/config.shared-auth.test.ts -- --testNamePattern "browser profile" --reporter=verbose`
- `node scripts/test-projects.mjs extensions/browser/index.test.ts -- --testNamePattern "static browser metadata" --reporter=verbose`
- `node scripts/test-projects.mjs src/gateway/config-reload.test.ts extensions/browser/index.test.ts src/gateway/server-methods/config.shared-auth.test.ts`
- `node_modules/.bin/oxfmt --check src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts src/gateway/server-methods/config.shared-auth.test.ts extensions/browser/plugin-registration.ts extensions/browser/index.test.ts`
- `node_modules/.bin/oxlint src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts src/gateway/server-methods/config.shared-auth.test.ts extensions/browser/plugin-registration.ts extensions/browser/index.test.ts`
- `git diff --check`
- `node scripts/build-all.mjs`

What regression coverage was added or updated?

- Added coverage that `browser.profiles.sandbox.cdpUrl` plans as hot reload even when a broader `browser` restart rule exists.
- Updated browser plugin metadata coverage to assert `hotPrefixes: ["browser.profiles"]`.
- Added authenticated `config.patch` coverage proving a browser profile-only change does not schedule a gateway SIGUSR1 restart in hot mode.

What failed before this fix, if known?

- The focused reload-plan test failed because `browser.profiles.sandbox.cdpUrl` still produced `restartGateway: true`.
- The authenticated server-method regression failed because `scheduleGatewaySigusr1Restart` was called for a browser profile-only patch.

If no test was added, why not?

- Tests were added and updated.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes

Did config, environment, or migration behavior change? (`Yes/No`)

Yes

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No

What is the highest-risk area?

- Reload classification precedence now uses the longest matching prefix instead of the first matching rule.

How is that risk mitigated?

- The behavior is covered by focused reload-plan tests, browser metadata tests, and authenticated config patch tests.
- Existing broader browser config paths are explicitly checked to remain restart-scoped.

## Current review state

What is the next action?

- Ready for maintainer review after the refreshed CI run completes.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on refreshed CI and maintainer review.
- External write-scoped runtime proof through a paired client was not completed locally; the server-method regression covers the same restart scheduling behavior.

Which bot or reviewer comments were addressed?

- Addressed Barnacle's real-behavior-proof parsing requirement by making the after-fix evidence explicit as copied live output from the running gateway.
