### PR TITLE
fix(matrix): deliver reasoning blocks as m.notice when /reasoning on [AI-assisted]

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -2959,6 +2959,7 @@ describe("matrix monitor handler draft streaming", () => {
       spokenText?: string;
       ttsSupplement?: { spokenText: string; visibleTextAlreadyDelivered?: boolean };
       isCompactionNotice?: boolean;
+      isReasoning?: boolean;
       replyToId?: string;
     },
     info: { kind: string },
@@ -3132,6 +3133,37 @@ describe("matrix monitor handler draft streaming", () => {
     expectFinalizedPreviewEdit("$draft1", "Single block");
     expect(deliverMatrixRepliesMock).not.toHaveBeenCalled();
     expect(redactEventMock).not.toHaveBeenCalled();
+    await finish();
+  });
+
+  it("delivers a reasoning block as a separate notice instead of editing the live answer draft", async () => {
+    const { dispatch, redactEventMock } = createStreamingHarness({ blockStreamingEnabled: true });
+    const { deliver, opts, finish } = await dispatch();
+
+    // Establish the live answer draft so a draftEventId exists.
+    opts.onPartialReply?.({ text: "Working answer" });
+    await vi.waitFor(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+
+    deliverMatrixRepliesMock.mockClear();
+    editMessageMatrixMock.mockClear();
+    sendSingleTextMessageMatrixMock.mockClear();
+
+    // A reasoning block arrives mid-stream: it must be delivered as its own
+    // notice (deliverMatrixReplies) and must NOT be edited into the answer
+    // draft, which the next answer block would overwrite.
+    await deliver({ text: "Reasoning: weighing options", isReasoning: true }, { kind: "block" });
+
+    expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
+    const delivered = lastCallArg(deliverMatrixRepliesMock, 0, "deliver replies payload") as {
+      replies?: { isReasoning?: boolean }[];
+    };
+    expect(delivered.replies?.[0]?.isReasoning).toBe(true);
+    expect(editMessageMatrixMock).not.toHaveBeenCalled();
+    expect(sendSingleTextMessageMatrixMock).not.toHaveBeenCalled();
+    expect(redactEventMock).not.toHaveBeenCalled();
+
     await finish();
   });
 

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -2092,7 +2092,15 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ...prefixOptions,
           humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, _route.agentId),
           deliver: async (payload: ReplyPayload, info: { kind: string }) => {
-            if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
+            if (
+              draftStream &&
+              info.kind !== "tool" &&
+              !payload.isCompactionNotice &&
+              // Reasoning is its own quiet m.notice lane; it must not be edited
+              // into the live answer preview (which the next answer block would
+              // overwrite). Route it straight to deliverMatrixReplies below.
+              payload.isReasoning !== true
+            ) {
               const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
               const ttsSupplement = getReplyPayloadTtsSupplement(payload);
               const fallbackPayload =
@@ -2512,7 +2520,12 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                           : undefined,
                         onBlockReplyQueued: draftStream
                           ? (payload, context) => {
-                              if (payload.isCompactionNotice === true) {
+                              // Reasoning and compaction notices are not answer
+                              // blocks, so they must not advance draft boundaries.
+                              if (
+                                payload.isCompactionNotice === true ||
+                                payload.isReasoning === true
+                              ) {
                                 return;
                               }
                               queueDraftBlockBoundary(payload, context);
@@ -2529,6 +2542,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                           : undefined,
                         ...buildPreviewToolProgressReplyOptions(),
                         onModelSelected,
+                        // Matrix renders reasoning as a quiet m.notice, so generic
+                        // dispatch must forward explicit isReasoning payloads to it.
+                        supportsReasoningBlocks: true,
                       },
                     });
                   } finally {

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginRuntime, RuntimeEnv } from "../../../runtime-api.js";
 import type { MatrixClient } from "../sdk.js";
+import { MsgType } from "../send/types.js";
 
 const sendMessageMatrixMock = vi.hoisted(() => vi.fn().mockResolvedValue({ messageId: "mx-1" }));
 const chunkMatrixTextMock = vi.hoisted(() =>
@@ -196,6 +197,48 @@ describe("deliverMatrixReplies", () => {
     expect(sendCall(0)[0]).toBe("room:5");
     expect(sendCall(0)[1]).toBe("Visible answer");
     expect(sendOptions(0).cfg).toBe(cfg);
+  });
+
+  it("delivers an explicit isReasoning payload as an m.notice event", async () => {
+    // Explicit reasoning payloads (the runner emits these when /reasoning is on)
+    // must reach Matrix as a quiet notice, not be dropped. Raw reasoning-looking
+    // text that is NOT an explicit payload stays suppressed (covered above).
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        { text: "Reasoning: weighing options before answering", isReasoning: true },
+        { text: "The answer is 42" },
+      ],
+      roomId: "room:6",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
+    expect(sendCall(0)[0]).toBe("room:6");
+    expect(sendCall(0)[1]).toBe("Reasoning: weighing options before answering");
+    expect(sendOptions(0).msgtype).toBe(MsgType.Notice);
+    expect(sendCall(1)[1]).toBe("The answer is 42");
+    expect(sendOptions(1).msgtype).toBeUndefined();
+  });
+
+  it("still suppresses a raw reasoning-looking text payload that is not flagged isReasoning", async () => {
+    // A plain reply whose text merely looks like reasoning (no isReasoning flag)
+    // stays suppressed so channels cannot leak unflagged thinking text.
+    await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "Reasoning:\n_internal deliberation" }, { text: "The answer is 42" }],
+      roomId: "room:7",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[1]).toBe("The answer is 42");
   });
 
   it("uses supplied cfg for chunking and send delivery without reloading runtime config", async () => {

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
+import { MsgType } from "../send/types.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
 const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
@@ -60,7 +61,14 @@ export async function deliverMatrixReplies(params: {
   let hasReplied = false;
   let deliveredAny = false;
   for (const reply of params.replies) {
-    if (reply.isReasoning === true || shouldSuppressReasoningReplyText(reply.text)) {
+    // Explicit reasoning payloads are delivered as a quiet m.notice so the
+    // operator can follow the model's thinking (mirrors Telegram/Slack). Raw
+    // text that merely looks like reasoning — but is not an explicit payload —
+    // stays suppressed so unflagged thinking text never leaks to the channel.
+    const isReasoning = reply.isReasoning === true;
+    if (isReasoning) {
+      logVerbose("matrix reasoning delivered as notice");
+    } else if (shouldSuppressReasoningReplyText(reply.text)) {
       logVerbose("matrix reply suppressed as reasoning-only");
       continue;
     }
@@ -108,6 +116,7 @@ export async function deliverMatrixReplies(params: {
           replyToId: replyToIdForReply,
           threadId: params.threadId,
           accountId: params.accountId,
+          ...(isReasoning ? { msgtype: MsgType.Notice } : {}),
         });
         deliveredAny = true;
         sentTextChunk = true;

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -356,7 +356,9 @@ export async function sendMessageMatrix(
           if (!text) {
             continue;
           }
-          const content = buildTextContent(text, relation);
+          const content = buildTextContent(text, relation, {
+            msgtype: opts.msgtype ?? MsgType.Text,
+          });
           await enrichMatrixFormattedContent({
             client,
             content,

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -102,6 +102,8 @@ export type MatrixSendOpts = {
   extraContent?: MatrixExtraContentFields;
   /** Send audio as voice message instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Override the text msgtype. Use `MsgType.Notice` for reasoning deliveries. */
+  msgtype?: MatrixTextMsgType;
 };
 
 export type MatrixMediaMsgType =

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -237,4 +237,12 @@ export type GetReplyOptions = {
   hasRepliedRef?: { value: boolean };
   /** Override agent timeout in seconds (0 = no timeout). Threads through to resolveAgentTimeoutMs. */
   timeoutOverrideSeconds?: number;
+  /**
+   * Channel owns a dedicated reasoning lane, so generic dispatch must forward
+   * explicit `isReasoning` payloads instead of suppressing them. Generic-dispatch
+   * channels without a reasoning lane (WhatsApp, web, etc.) keep reasoning
+   * suppressed; channels that render reasoning themselves (e.g. Matrix as an
+   * m.notice) opt in here.
+   */
+  supportsReasoningBlocks?: boolean;
 };

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7339,6 +7339,63 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 
+  it("forwards isReasoning final replies when the channel opts in via supportsReasoningBlocks", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix" });
+    const replyResolver = async () =>
+      [
+        { text: "thinking...", isReasoning: true },
+        { text: "The answer is 42" },
+      ] satisfies ReplyPayload[];
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { supportsReasoningBlocks: true },
+    });
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    // Both the reasoning payload and the answer reach the channel unchanged.
+    expect(finalCalls).toHaveLength(2);
+    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("thinking...");
+    expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.isReasoning).toBe(true);
+    expect((finalCalls[1]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
+  });
+
+  it("forwards isReasoning block replies when the channel opts in via supportsReasoningBlocks", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix" });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "thinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return { text: "The answer is 42" };
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { supportsReasoningBlocks: true },
+    });
+    // The reasoning block is now forwarded instead of suppressed.
+    expect(blockReplySentTexts).toContain("thinking...");
+    expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+
   it("strips split TTS directives from streamed block text before delivery", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7396,6 +7396,83 @@ describe("dispatchReplyFromConfig", () => {
     expect(blockReplySentTexts).toContain("The answer is 42");
   });
 
+  it("does not synthesize TTS for forwarded isReasoning final replies (opted-in channel)", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix" });
+    const replyResolver = async () =>
+      [
+        { text: "thinking...", isReasoning: true },
+        { text: "The answer is 42" },
+      ] satisfies ReplyPayload[];
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { supportsReasoningBlocks: true },
+    });
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    // Both payloads are still delivered (forwarded) — TTS exclusion must not
+    // suppress the reasoning notice.
+    expect(finalCalls).toHaveLength(2);
+    const reasoningFinal = finalCalls[0]?.[0] as ReplyPayload | undefined;
+    const answerFinal = finalCalls[1]?.[0] as ReplyPayload | undefined;
+    expect(reasoningFinal?.text).toBe("thinking...");
+    // The reasoning notice is NOT synthesized into audio.
+    expect(reasoningFinal?.mediaUrl).toBeUndefined();
+    expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalledWith(
+      expect.objectContaining({ payload: expect.objectContaining({ isReasoning: true }) }),
+    );
+    // The answer is still eligible for TTS synthesis.
+    expect(answerFinal?.mediaUrl).toBe("https://example.com/tts-synth.opus");
+  });
+
+  it("excludes isReasoning blocks from accumulated block TTS-only synthesis (opted-in channel)", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "feishu",
+      Surface: "feishu",
+      SessionKey: "agent:main:feishu:ou_user",
+    });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "thinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return undefined;
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { supportsReasoningBlocks: true },
+    });
+    // The reasoning block is forwarded as its own notice (not suppressed).
+    expect(blockReplySentTexts).toContain("thinking...");
+    expect(blockReplySentTexts).toContain("The answer is 42");
+    // The post-stream TTS-only synthetic reply is built from the accumulated
+    // block text. Reasoning text must NOT be synthesized into audio.
+    const ttsOnlyPayload = firstFinalReplyPayload(dispatcher);
+    expect(ttsOnlyPayload?.mediaUrl).toBe("https://example.com/tts-synth.opus");
+    expect(ttsOnlyPayload?.spokenText).toBe("The answer is 42");
+    expect(ttsOnlyPayload?.spokenText).not.toContain("thinking");
+  });
+
   it("strips split TTS directives from streamed block text before delivery", async () => {
     setNoAbort();
     ttsMocks.state.synthesizeFinalAudio = true;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -345,6 +345,15 @@ async function maybeApplyTtsToReplyPayload(
   if (isReplyPayloadStatusNotice(params.payload)) {
     return params.payload;
   }
+  // Reasoning payloads are private thinking text delivered as their own
+  // notice on opted-in channels (e.g. Matrix m.notice). They must never be
+  // synthesised into audio, so skip TTS application for them on every path
+  // (final reply, per-block reply, and the post-stream TTS-only synthetic).
+  // This is a no-op for channels that suppress reasoning before delivery,
+  // since such payloads never reach TTS today.
+  if (params.payload.isReasoning === true) {
+    return params.payload;
+  }
   if (
     !shouldAttemptTtsPayload({
       cfg: params.cfg,
@@ -3180,9 +3189,14 @@ export async function dispatchReplyFromConfig(
                 }
                 // Accumulate block text for TTS generation after streaming.
                 // Exclude status notices — they are informational UI signals
-                // and must not be synthesised into the spoken reply.
+                // and must not be synthesised into the spoken reply. Exclude
+                // explicit reasoning payloads too: opted-in channels deliver
+                // them as their own notice (e.g. Matrix m.notice), so reasoning
+                // text must never be accumulated into the post-stream TTS-only
+                // synthetic reply or counted toward the TTS block gate.
                 const isStatusNotice = isReplyPayloadStatusNotice(payload);
-                if (payload.text && !isStatusNotice) {
+                const isReasoningBlock = payload.isReasoning === true;
+                if (payload.text && !isStatusNotice && !isReasoningBlock) {
                   const joinsBufferedTtsDirective =
                     cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
                   if (accumulatedBlockText.length > 0) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3174,7 +3174,8 @@ export async function dispatchReplyFromConfig(
                 // Suppress reasoning payloads — channels using this generic dispatch
                 // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
                 // Telegram has its own dispatch path that handles reasoning splitting.
-                if (payload.isReasoning === true) {
+                // Channels that own a reasoning lane opt in via supportsReasoningBlocks.
+                if (payload.isReasoning === true && !params.replyOptions?.supportsReasoningBlocks) {
                   return;
                 }
                 // Accumulate block text for TTS generation after streaming.
@@ -3345,8 +3346,9 @@ export async function dispatchReplyFromConfig(
     for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
       // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (reply.isReasoning === true) {
+      // generic dispatch path do not have a dedicated reasoning lane. Channels
+      // that own a reasoning lane opt in via supportsReasoningBlocks.
+      if (reply.isReasoning === true && !params.replyOptions?.supportsReasoningBlocks) {
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## Summary

- **Problem:** On the Matrix channel, `/reasoning on` has no effect. Reasoning/thinking blocks are generated and stored (the web dashboard shows them), but they are never delivered to Matrix. The operator sees the assistant reply with no reasoning, even after explicitly enabling it.
- **Why it matters:** Operators on reasoning-capable models (e.g. `zai/glm-5.1` with thinking) cannot follow the model's reasoning over Matrix, while Telegram and Slack already surface it. This is a regression from the documented `/reasoning on` contract.
- **What changed:** Generic reply dispatch suppresses explicit `isReasoning` payloads by default (WhatsApp/web/etc. have no reasoning lane). Matrix *does* own a reasoning lane, so this adds a narrow `supportsReasoningBlocks` channel capability opt-in: Matrix opts in, generic dispatch forwards the explicit `isReasoning` payload, and Matrix renders it as a quiet `m.notice` event (mirroring Telegram/Slack). Reasoning is routed past the live draft-preview edit so it persists as its own notice instead of being overwritten by the next answer block. Explicit `isReasoning` payloads are also excluded from every TTS synthesis path (per-block, final, and the post-stream accumulated-block TTS-only synthetic reply) so private thinking text is never synthesized into audio.
- **What did NOT change:** Raw text that merely *looks* like reasoning (starts with `reasoning:`, or is only `<thinking>` tags) but is **not** an explicit `isReasoning` payload stays suppressed — channels still never leak unflagged thinking text. `/reasoning off` is unaffected (no reasoning notice is emitted). Non-opted-in channels (WhatsApp, web) keep current suppression and current TTS behavior. No public config/env surface added.
- **Success looks like:** With `/reasoning on`, a Matrix room receives a separate `m.notice` event containing the reasoning text before the assistant reply, and no reasoning audio is synthesized. With `/reasoning off`, no reasoning notice is emitted.
- **Reviewer focus:** The capability gate in `dispatch-from-config.ts` (both the block-reply and final-reply suppression points), the `isReasoning` TTS exclusions in `maybeApplyTtsToReplyPayload` and the block accumulator, and the Matrix draft-stream bypass in `handler.ts` — the bypass is surgical to `isReasoning === true` payloads only, so normal answer delivery and draft streaming are untouched (all 39 existing draft-streaming tests still pass).

## Linked context

Closes #81892

Related: #24411 (earlier inverse problem — Matrix showed reasoning even when off). Two prior attempts at this fix (#82907, #90560) were closed by their authors solely because they could not produce live Matrix/Element behavior proof; this PR provides real-code-path proof (see below).

Requested by a maintainer: the issue was left open by `@bronson` ("Leave it open for a bit longer, maybe a PR will show up") and ClawSweeper confirmed a narrow source-reproducible fix path.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Matrix `/reasoning on` generates explicit reasoning payloads that never reach the channel — generic dispatch and Matrix delivery both dropped them before send. After this patch, an explicit `isReasoning` payload is forwarded by dispatch (Matrix opts in) and rendered as an `m.notice` Matrix event; `/reasoning off` emits no reasoning notice; and reasoning text is excluded from all TTS synthesis.

- Real environment tested: Windows 10 (Node v22.17.1, pnpm 11.2.2), OpenClaw checkout rebased onto upstream `main` `8a5cb85c31` on branch `fix/vuln-81892`. The real Matrix reply builder (`deliverMatrixReplies`) and the real generic dispatcher (`dispatchReplyFromConfig`) were exercised directly; the Matrix network client was an in-memory recording adapter that captures the exact event content and production log lines the real code path produces.

- Exact steps or command run after this patch: drove the real `deliverMatrixReplies` over three reply sets — `/reasoning on` (an explicit `isReasoning` payload + answer), `/reasoning off` (answer only, no reasoning payload), and a raw reasoning-looking text payload (no `isReasoning` flag) + answer — and inspected the captured Matrix send calls and production log lines. Before the patch the `isReasoning` payload was dropped (zero events for it); after the patch it is delivered as `m.notice`, the off case emits no notice, and raw reasoning-looking text stays suppressed.

- Evidence after fix (terminal capture):

```
$ pnpm test proof-capture (drives the real deliverMatrixReplies over on/off/raw reply sets)
PROOF_CAPTURE_JSON:
{
  "on": {
    "logs": ["matrix reasoning delivered as notice"],
    "sends": [
      { "roomId": "!room:example.org", "body": "Reasoning: weighing options before answering", "msgtype": "m.notice" },
      { "roomId": "!room:example.org", "body": "The answer is 42", "msgtype": "m.text (default)" }
    ]
  },
  "off": {
    "logs": [],
    "sends": [
      { "roomId": "!room:example.org", "body": "The answer is 42", "msgtype": "m.text (default)" }
    ]
  },
  "rawSuppressed": {
    "logs": ["matrix reply suppressed as reasoning-only"],
    "sends": [
      { "roomId": "!room:example.org", "body": "The answer is 42", "msgtype": "m.text (default)" }
    ]
  }
}
```

The `/reasoning on` case emits the reasoning block first with `msgtype: "m.notice"` (production log line `matrix reasoning delivered as notice`), then the answer with the default `m.text`. The `/reasoning off` case emits no reasoning notice (no log line, one `m.text` send). The raw reasoning-looking text case (no `isReasoning` flag) is suppressed (production log line `matrix reply suppressed as reasoning-only`), proving the unflagged-thinking-text guard still holds with the opt-in enabled.

TTS exclusion is verified by two regression tests in `dispatch-from-config.test.ts`: the forwarded `isReasoning` final reply is delivered with `mediaUrl` undefined (no audio) while the answer still receives `mediaUrl`, and the post-stream accumulated-block TTS-only synthetic reply has `spokenText` equal to the answer only (does not contain the reasoning text). The TTS skip is a no-op for non-opted-in channels, since such payloads never reach TTS on main today.

- Observed result after fix: The explicit reasoning payload reaches the Matrix send path and is rendered as an `m.notice` event (separate from the answer); `/reasoning off` emits no reasoning notice; raw reasoning-looking text stays suppressed; and reasoning is never synthesized into TTS audio. The dispatch path forwards `isReasoning` only for opted-in channels.

- What was not tested: No live Matrix/Element homeserver end-to-end delivery (no Matrix homeserver credentials in this environment). The Matrix client transport was a recording adapter; the reply-builder branching logic, the msgtype wiring, the generic-dispatch opt-in, and the TTS exclusion guards all ran for real. Not exercised on macOS/Linux locally. The Swift host-env-policy check is skipped on Windows.

- Proof limitations or environment constraints: Local Node is v22.17.1, below the repo's 22.19.0 build gate, so the build's `write-cli-startup-metadata` step fails on the Node version gate (the TypeScript compilation itself — `tsdown` — succeeds). CI runs on Linux Node 24, where this gate does not apply. A live Matrix/Element send-read capture (the strongest proof) would require homeserver credentials I do not have; the real-code-path capture above is provided in its place, and a maintainer can dispatch Mantis to capture the live visible proof.

- Before evidence (optional but encouraged):

```
# dispatch, unpatched — reasoning suppressed even with the opt-in flag absent from main:
expected [ [ { text: 'The answer is 42' } ] ] to have a length of 2 but got 1
expected [ 'The answer is 42' ] to include 'thinking...'
# matrix replies, unpatched — isReasoning payload dropped before send:
expected "vi.fn()" to be called 2 times, but got 1 times   (only the answer was sent)
```

## Tests and validation

Commands run (scoped):

- `pnpm tsgo:core` — pass (0 errors).
- `pnpm lint` (oxlint --type-aware on changed files) — pass (exit 0).
- `oxfmt --check` on changed files — clean.
- `pnpm test extensions/matrix/src/matrix/monitor/replies.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts` — 126/126 pass (8 replies + 118 handler, incl. all 39 draft-streaming tests + the new reasoning bypass test).
- `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts -t isReasoning` — 6/6 pass (2 existing WhatsApp suppression tests + 2 opt-in forwarding tests + 2 new TTS-exclusion tests).
- `pnpm build` — TypeScript compilation (`tsdown`) succeeds; only `write-cli-startup-metadata` fails on the local Node 22.17 < 22.19 gate (environmental; CI is Linux Node 24).

Regression coverage added:

- `dispatch-from-config.test.ts`: forwards `isReasoning` final + block replies when the channel opts in via `supportsReasoningBlocks` (the existing WhatsApp-suppression tests remain and still pass, proving the default is unchanged); plus two new tests asserting `isReasoning` payloads are excluded from final TTS (no `mediaUrl`) and from the accumulated-block TTS-only synthetic reply (`spokenText` excludes reasoning).
- `replies.test.ts`: an explicit `isReasoning` payload is delivered as `MsgType.Notice`; raw reasoning-looking text that is not flagged stays suppressed.
- `handler.test.ts`: a reasoning block arriving mid-stream with draft streaming on is delivered via `deliverMatrixReplies` (as a notice) and is NOT edited into the live answer draft.

Known unrelated local failure: `dispatch-from-config.test.ts > "deduplicates inbound messages by MessageSid and origin"` hangs to a ~6 min timeout on this Windows/Node-22.17 machine. It does not set `supportsReasoningBlocks`, so the changed condition evaluates identically to before (`!undefined === true`); a boolean read cannot cause the hang, so it is pre-existing/environmental and not affected by this change. CI (Linux Node 24) is the source of truth.

If no test was added, why not: N/A — five regression tests were added (three originally + two TTS-exclusion tests).

## Risk checklist

Did user-visible behavior change? (`Yes/No`) **Yes** — Matrix now surfaces reasoning as `m.notice` when `/reasoning on` (the intended, previously-broken behavior), and reasoning is excluded from TTS audio.

Did config, environment, or migration behavior change? (`Yes/No`) **No** — no new config/env keys. The opt-in is an internal reply-options capability flag set by the Matrix channel itself, not operator-facing. The TTS exclusion is a no-op for channels that suppress reasoning before delivery.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) **No**.

What is the highest-risk area? The Matrix draft-stream bypass in `handler.ts` (reasoning payloads skip the live-preview edit path) and the relaxed dispatch suppression guards that let `isReasoning` reach the TTS paths for opted-in channels.

How is that risk mitigated? The two draft-stream guards are guarded by `payload.isReasoning === true`, so they only change behavior for explicit reasoning payloads; normal answer delivery and draft streaming are byte-for-byte unchanged (all 39 existing draft-streaming tests pass, plus a new test asserting reasoning is delivered as a notice and the draft is not edited). Reasoning arrives before the answer, so skipping its draft bookkeeping cannot desync the answer draft. The TTS exclusion is guarded by `isReasoning === true` in `maybeApplyTtsToReplyPayload` (covers final + per-block TTS) and in the block accumulator (covers the post-stream TTS-only synthetic reply); two regression tests assert reasoning receives no `mediaUrl` and is absent from the synthetic `spokenText`. Because `isReasoning` payloads never reach TTS on main today (they are suppressed before delivery), the exclusion is a no-op for non-opted-in channels.

## Current review state

What is the next action? Maintainer review (and, if available, live Matrix/Element confirmation via Mantis).

What is still waiting on author, maintainer, CI, or external proof? CI on Linux Node 24 (rebased onto latest `main` `8a5cb85c31` to clear the pre-existing `check-lint`/`check-prod-types` failures from the stale base); ClawSweeper re-review after the TTS-exclusion fix and the expanded off-guard/raw-suppression proof. Optional live Matrix/Element confirmation — the real-code-path proof above is provided in lieu of a homeserver I do not have access to; a maintainer can dispatch Mantis with: `@openclaw-mantis visual task: verify in Matrix/Element that /reasoning on shows a reasoning notice before the final answer and /reasoning off hides reasoning.`

Which bot or reviewer comments were addressed? ClawSweeper's two P2 review findings are addressed: (1) `dispatch-from-config.ts:3107` — `isReasoning` payloads no longer enter `accumulatedBlockTtsText` / `blockCount`; (2) `dispatch-from-config.ts:3279` — `isReasoning` final replies skip TTS via the `maybeApplyTtsToReplyPayload` guard while still being delivered as the Matrix notice. The branch was also rebased onto the latest `main` so the two failing CI checks (`check-lint`, `check-prod-types`) — caused by a stale base carrying the since-fixed `isCliRuntimeProvider` unused import — now inherit the fix from `main`.
