### PR TITLE
feat(providers): add ClawRouter managed proxy

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -381,6 +381,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/anthropic/**"
+"extensions: clawrouter":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/clawrouter/**"
+          - "docs/providers/clawrouter.md"
 "extensions: cloudflare-ai-gateway":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1418,6 +1418,7 @@
                   "providers/cerebras",
                   "providers/chutes",
                   "providers/claude-max-api-proxy",
+                  "providers/clawrouter",
                   "providers/cloudflare-ai-gateway",
                   "providers/comfy",
                   "providers/deepgram",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -51,7 +51,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-90 plugins
+91 plugins
 
 - **[admin-http-rpc](/plugins/reference/admin-http-rpc)** (`@openclaw/admin-http-rpc`) - included in OpenClaw. OpenClaw admin HTTP RPC endpoint.
 
@@ -74,6 +74,8 @@ Each entry lists the package, distribution route, and description.
 - **[cerebras](/plugins/reference/cerebras)** (`@openclaw/cerebras-provider`) - included in OpenClaw. Adds Cerebras model provider support to OpenClaw.
 
 - **[chutes](/plugins/reference/chutes)** (`@openclaw/chutes-provider`) - included in OpenClaw. Adds Chutes model provider support to OpenClaw.
+
+- **[clawrouter](/plugins/reference/clawrouter)** (`@openclaw/clawrouter-provider`) - included in OpenClaw. Adds ClawRouter model provider support to OpenClaw.
 
 - **[clickclack](/plugins/reference/clickclack)** (`@openclaw/clickclack`) - included in OpenClaw. Adds the Clickclack channel surface for sending and receiving OpenClaw messages.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 127
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 128
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/clawrouter.md
+++ b/docs/plugins/reference/clawrouter.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds ClawRouter model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the clawrouter plugin
+title: "ClawRouter plugin"
+---
+
+# ClawRouter plugin
+
+Adds ClawRouter model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/clawrouter-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: clawrouter
+
+## Related docs
+
+- [clawrouter](/providers/clawrouter)

--- a/docs/providers/clawrouter.md
+++ b/docs/providers/clawrouter.md
@@ -1,0 +1,58 @@
+---
+summary: "Use one managed ClawRouter key to access approved providers in OpenClaw"
+title: "ClawRouter"
+read_when:
+  - You have a ClawRouter proxy key
+  - Your team centrally manages provider access and grants
+  - You want OpenClaw to discover only the models you can use
+---
+
+ClawRouter gives OpenClaw one managed credential for approved model providers.
+The upstream API keys, OAuth grants, and subscription credentials stay in
+ClawRouter.
+
+## Setup
+
+Authenticate with the proxy key issued by your ClawRouter administrator:
+
+```bash
+openclaw onboard --auth-choice clawrouter-api-key
+```
+
+Or provide it through the environment:
+
+```bash
+export CLAWROUTER_API_KEY="clawrouter-live-..."
+```
+
+OpenClaw asks `https://clawrouter.openclaw.ai/v1/catalog` for the models granted
+to that key and caches the credential-scoped result for a short period. Model
+references keep the ClawRouter provider prefix:
+
+```bash
+openclaw models list --provider clawrouter
+openclaw models set clawrouter/openai/gpt-5.5-mini
+```
+
+ClawRouter publishes the real transport for each model. OpenClaw uses the
+unified OpenAI route when available and the provider-native Anthropic or Gemini
+route when required.
+
+## Custom deployment
+
+For a self-hosted ClawRouter, configure its API base URL:
+
+```json5
+{
+  models: {
+    providers: {
+      clawrouter: {
+        baseUrl: "https://clawrouter.example/v1",
+      },
+    },
+  },
+}
+```
+
+The proxy key still determines which providers and models are visible and
+usable. Grant changes appear after the short discovery cache expires.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -33,6 +33,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [Cerebras](/providers/cerebras)
 - [Chutes](/providers/chutes)
+- [ClawRouter](/providers/clawrouter)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
 - [ComfyUI](/providers/comfy)
 - [DeepSeek](/providers/deepseek)

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -105,6 +105,13 @@ describe("clawrouter provider plugin", () => {
         provider: "clawrouter",
         api: "anthropic-messages",
         id: "anthropic/default",
+        params: {
+          clawrouterRoute: {
+            api: "anthropic-messages",
+            baseUrl: "https://clawrouter.example/v1/native/anthropic",
+            upstreamModel: "claude-sonnet-4-5-20250929",
+          },
+        },
       } as never,
       {} as never,
       { apiKey: "CLAWROUTER_API_KEY" } as never,
@@ -117,6 +124,8 @@ describe("clawrouter provider plugin", () => {
     expect(calls[0]?.id).toBe("claude-sonnet-4-5-20250929");
     expect(calls[0]?.params).toBeUndefined();
     expect(calls[1]?.headers).toBeUndefined();
+    expect(calls[1]?.id).toBe("claude-sonnet-4-5-20250929");
+    expect(calls[1]?.params).toBeUndefined();
   });
 
   it("resolves managed secret refs before credential-scoped discovery", async () => {

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -57,6 +57,7 @@ describe("clawrouter provider plugin", () => {
       envVars: ["CLAWROUTER_API_KEY"],
       isModernModelRef: expect.any(Function),
       buildReplayPolicy: expect.any(Function),
+      createStreamFn: expect.any(Function),
       normalizeResolvedModel: expect.any(Function),
       sanitizeReplayHistory: expect.any(Function),
       wrapSimpleCompletionStreamFn: expect.any(Function),
@@ -67,6 +68,17 @@ describe("clawrouter provider plugin", () => {
       label: "ClawRouter proxy key",
       kind: "api_key",
     });
+    expect(
+      provider?.createStreamFn?.({
+        provider: "clawrouter",
+        modelId: "anthropic/default",
+        model: {
+          provider: "clawrouter",
+          api: "anthropic-messages",
+          id: "anthropic/default",
+        },
+      } as never),
+    ).toBeTypeOf("function");
     expect(provider?.wrapSimpleCompletionStreamFn).toBe(provider?.wrapStreamFn);
   });
 

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -13,8 +13,10 @@ describe("clawrouter provider plugin", () => {
       docsPath: "/providers/clawrouter",
       envVars: ["CLAWROUTER_API_KEY"],
       isModernModelRef: expect.any(Function),
+      buildReplayPolicy: expect.any(Function),
       normalizeResolvedModel: expect.any(Function),
       resolveDynamicModel: expect.any(Function),
+      sanitizeReplayHistory: expect.any(Function),
     });
     expect(provider?.auth[0]).toMatchObject({
       id: "api-key",
@@ -35,6 +37,42 @@ describe("clawrouter provider plugin", () => {
 
     expect(normalized).toMatchObject({
       baseUrl: "https://clawrouter.example/v1",
+    });
+  });
+
+  it("keeps replay handling aligned with each discovered transport", () => {
+    const provider = capturePluginRegistration(plugin).providers[0];
+    const buildReplayPolicy = provider?.buildReplayPolicy;
+
+    expect(
+      buildReplayPolicy?.({
+        provider: "clawrouter",
+        modelApi: "anthropic-messages",
+        modelId: "anthropic/default",
+      } as never),
+    ).toMatchObject({
+      preserveNativeAnthropicToolUseIds: true,
+      preserveSignatures: true,
+      validateAnthropicTurns: true,
+    });
+    expect(
+      buildReplayPolicy?.({
+        provider: "clawrouter",
+        modelApi: "google-generative-ai",
+        modelId: "google/gemini-default",
+      } as never),
+    ).toMatchObject({
+      validateGeminiTurns: true,
+    });
+    expect(
+      buildReplayPolicy?.({
+        provider: "clawrouter",
+        modelApi: "openai-responses",
+        modelId: "openai/gpt-5.5-mini",
+      } as never),
+    ).toMatchObject({
+      validateGeminiTurns: false,
+      validateAnthropicTurns: false,
     });
   });
 });

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -57,7 +57,6 @@ describe("clawrouter provider plugin", () => {
       envVars: ["CLAWROUTER_API_KEY"],
       isModernModelRef: expect.any(Function),
       buildReplayPolicy: expect.any(Function),
-      createStreamFn: expect.any(Function),
       normalizeResolvedModel: expect.any(Function),
       sanitizeReplayHistory: expect.any(Function),
       wrapSimpleCompletionStreamFn: expect.any(Function),
@@ -68,17 +67,6 @@ describe("clawrouter provider plugin", () => {
       label: "ClawRouter proxy key",
       kind: "api_key",
     });
-    expect(
-      provider?.createStreamFn?.({
-        provider: "clawrouter",
-        modelId: "anthropic/default",
-        model: {
-          provider: "clawrouter",
-          api: "anthropic-messages",
-          id: "anthropic/default",
-        },
-      } as never),
-    ).toBeTypeOf("function");
     expect(provider?.wrapSimpleCompletionStreamFn).toBe(provider?.wrapStreamFn);
   });
 
@@ -95,7 +83,7 @@ describe("clawrouter provider plugin", () => {
       streamFn: baseStreamFn,
     } as never);
 
-    wrapped?.(
+    void wrapped?.(
       {
         provider: "clawrouter",
         api: "anthropic-messages",
@@ -112,7 +100,7 @@ describe("clawrouter provider plugin", () => {
       {} as never,
       { apiKey: "runtime-proxy-key" } as never,
     );
-    wrapped?.(
+    void wrapped?.(
       {
         provider: "clawrouter",
         api: "anthropic-messages",

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -1,9 +1,51 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it } from "vitest";
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const providerAuthRuntimeMocks = vi.hoisted(() => ({
+  resolveApiKeyForProvider: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => providerAuthRuntimeMocks);
+
 import plugin from "./index.js";
 
+const LIVE_CATALOG = {
+  providers: [
+    {
+      id: "openai",
+      displayName: "OpenAI",
+      openaiCompatible: true,
+      nativeBaseUrl: "/v1/native/openai",
+      routes: [
+        {
+          path: "/v1/responses",
+          methods: ["POST"],
+          requestFormat: "openai.responses",
+        },
+      ],
+      models: [
+        {
+          id: "openai/gpt-5.5-mini",
+          upstream: "gpt-5.5-mini",
+          capabilities: ["llm.responses"],
+        },
+      ],
+    },
+  ],
+};
+
 describe("clawrouter provider plugin", () => {
+  beforeEach(() => {
+    clearLiveCatalogCacheForTests();
+    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("registers managed proxy-key auth and transport routing hooks", () => {
     const captured = capturePluginRegistration(plugin);
     const provider = captured.providers[0];
@@ -17,6 +59,7 @@ describe("clawrouter provider plugin", () => {
       buildReplayPolicy: expect.any(Function),
       normalizeResolvedModel: expect.any(Function),
       sanitizeReplayHistory: expect.any(Function),
+      wrapSimpleCompletionStreamFn: expect.any(Function),
       wrapStreamFn: expect.any(Function),
     });
     expect(provider?.auth[0]).toMatchObject({
@@ -24,6 +67,7 @@ describe("clawrouter provider plugin", () => {
       label: "ClawRouter proxy key",
       kind: "api_key",
     });
+    expect(provider?.wrapSimpleCompletionStreamFn).toBe(provider?.wrapStreamFn);
   });
 
   it("attaches the resolved proxy key only when dispatching a request", () => {
@@ -64,6 +108,53 @@ describe("clawrouter provider plugin", () => {
       Authorization: "Bearer runtime-proxy-key",
     });
     expect(calls[1]?.headers).toBeUndefined();
+  });
+
+  it("resolves managed secret refs before credential-scoped discovery", async () => {
+    providerAuthRuntimeMocks.resolveApiKeyForProvider.mockResolvedValue({
+      apiKey: "resolved-proxy-key",
+      mode: "api-key",
+      source: "models.json secretref",
+    });
+    const fetchMock = vi.fn(async () => Response.json(LIVE_CATALOG));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const provider = capturePluginRegistration(plugin).providers[0];
+
+    const result = await provider?.catalog?.run({
+      config: { models: {} },
+      agentDir: "/agent",
+      workspaceDir: "/workspace",
+      env: {},
+      resolveProviderAuth: () => ({
+        apiKey: "secretref-managed",
+        discoveryApiKey: undefined,
+        mode: "api_key",
+        source: "profile",
+        profileId: "clawrouter-profile",
+      }),
+      resolveProviderApiKey: () => ({
+        apiKey: "secretref-managed",
+        discoveryApiKey: undefined,
+      }),
+    });
+
+    if (!result || !("provider" in result)) {
+      throw new Error("expected ClawRouter catalog provider result");
+    }
+    expect(result.provider.apiKey).toBe("secretref-managed");
+    expect(result.provider.models.map((model) => model.id)).toEqual(["openai/gpt-5.5-mini"]);
+    expect(providerAuthRuntimeMocks.resolveApiKeyForProvider).toHaveBeenCalledWith({
+      provider: "clawrouter",
+      cfg: { models: {} },
+      agentDir: "/agent",
+      workspaceDir: "/workspace",
+      profileId: "clawrouter-profile",
+      lockedProfile: true,
+    });
+    const fetchCall = fetchMock.mock.calls[0] as unknown as [string, RequestInit] | undefined;
+    expect(new Headers(fetchCall?.[1]?.headers).get("Authorization")).toBe(
+      "Bearer resolved-proxy-key",
+    );
   });
 
   it("normalizes configured ClawRouter roots to the API base URL", () => {

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -89,6 +89,13 @@ describe("clawrouter provider plugin", () => {
         api: "anthropic-messages",
         id: "anthropic/default",
         headers: { "X-Request-ID": "request-1" },
+        params: {
+          clawrouterRoute: {
+            api: "anthropic-messages",
+            baseUrl: "https://clawrouter.example/v1/native/anthropic",
+            upstreamModel: "claude-sonnet-4-5-20250929",
+          },
+        },
       } as never,
       {} as never,
       { apiKey: "runtime-proxy-key" } as never,
@@ -107,6 +114,8 @@ describe("clawrouter provider plugin", () => {
       "X-Request-ID": "request-1",
       Authorization: "Bearer runtime-proxy-key",
     });
+    expect(calls[0]?.id).toBe("claude-sonnet-4-5-20250929");
+    expect(calls[0]?.params).toBeUndefined();
     expect(calls[1]?.headers).toBeUndefined();
   });
 

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -1,0 +1,40 @@
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("clawrouter provider plugin", () => {
+  it("registers managed proxy-key auth and dynamic routing hooks", () => {
+    const captured = capturePluginRegistration(plugin);
+    const provider = captured.providers[0];
+
+    expect(provider).toMatchObject({
+      id: "clawrouter",
+      label: "ClawRouter",
+      docsPath: "/providers/clawrouter",
+      envVars: ["CLAWROUTER_API_KEY"],
+      isModernModelRef: expect.any(Function),
+      normalizeResolvedModel: expect.any(Function),
+      resolveDynamicModel: expect.any(Function),
+    });
+    expect(provider?.auth[0]).toMatchObject({
+      id: "api-key",
+      label: "ClawRouter proxy key",
+      kind: "api_key",
+    });
+  });
+
+  it("normalizes configured ClawRouter roots to the API base URL", () => {
+    const provider = capturePluginRegistration(plugin).providers[0];
+    const normalized = provider?.normalizeConfig?.({
+      provider: "clawrouter",
+      providerConfig: {
+        baseUrl: "https://clawrouter.example/",
+        models: [],
+      },
+    } as never);
+
+    expect(normalized).toMatchObject({
+      baseUrl: "https://clawrouter.example/v1",
+    });
+  });
+});

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -1,9 +1,10 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
 describe("clawrouter provider plugin", () => {
-  it("registers managed proxy-key auth and dynamic routing hooks", () => {
+  it("registers managed proxy-key auth and transport routing hooks", () => {
     const captured = capturePluginRegistration(plugin);
     const provider = captured.providers[0];
 
@@ -15,14 +16,54 @@ describe("clawrouter provider plugin", () => {
       isModernModelRef: expect.any(Function),
       buildReplayPolicy: expect.any(Function),
       normalizeResolvedModel: expect.any(Function),
-      resolveDynamicModel: expect.any(Function),
       sanitizeReplayHistory: expect.any(Function),
+      wrapStreamFn: expect.any(Function),
     });
     expect(provider?.auth[0]).toMatchObject({
       id: "api-key",
       label: "ClawRouter proxy key",
       kind: "api_key",
     });
+  });
+
+  it("attaches the resolved proxy key only when dispatching a request", () => {
+    const provider = capturePluginRegistration(plugin).providers[0];
+    const calls: Array<Parameters<StreamFn>[0]> = [];
+    const baseStreamFn: StreamFn = (model) => {
+      calls.push(model);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = provider?.wrapStreamFn?.({
+      provider: "clawrouter",
+      modelId: "anthropic/default",
+      streamFn: baseStreamFn,
+    } as never);
+
+    wrapped?.(
+      {
+        provider: "clawrouter",
+        api: "anthropic-messages",
+        id: "anthropic/default",
+        headers: { "X-Request-ID": "request-1" },
+      } as never,
+      {} as never,
+      { apiKey: "runtime-proxy-key" } as never,
+    );
+    wrapped?.(
+      {
+        provider: "clawrouter",
+        api: "anthropic-messages",
+        id: "anthropic/default",
+      } as never,
+      {} as never,
+      { apiKey: "CLAWROUTER_API_KEY" } as never,
+    );
+
+    expect(calls[0]?.headers).toEqual({
+      "X-Request-ID": "request-1",
+      Authorization: "Bearer runtime-proxy-key",
+    });
+    expect(calls[1]?.headers).toBeUndefined();
   });
 
   it("normalizes configured ClawRouter roots to the API base URL", () => {

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -13,7 +13,7 @@ import {
   normalizeClawRouterApiBaseUrl,
   normalizeClawRouterResolvedModel,
 } from "./provider-catalog.js";
-import { wrapClawRouterProviderStream } from "./stream.js";
+import { createClawRouterStreamFn, wrapClawRouterProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "clawrouter";
 const ENV_VAR = "CLAWROUTER_API_KEY";
@@ -99,6 +99,7 @@ export default definePluginEntry({
         const baseUrl = normalizeClawRouterApiBaseUrl(providerConfig.baseUrl);
         return baseUrl !== providerConfig.baseUrl ? { ...providerConfig, baseUrl } : undefined;
       },
+      createStreamFn: createClawRouterStreamFn,
       normalizeResolvedModel: ({ model }) => normalizeClawRouterResolvedModel(model),
       wrapSimpleCompletionStreamFn: wrapClawRouterProviderStream,
       wrapStreamFn: wrapClawRouterProviderStream,

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -1,7 +1,13 @@
 // ClawRouter plugin entrypoint registers credential-scoped model routing.
 import { definePluginEntry, type ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
-import { PASSTHROUGH_GEMINI_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildGoogleGeminiReplayPolicy,
+  buildNativeAnthropicReplayPolicyForModel,
+  buildPassthroughGeminiSanitizingReplayPolicy,
+  resolveTaggedReasoningOutputMode,
+  sanitizeGoogleGeminiReplayHistory,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import {
   buildClawRouterProviderConfig,
   normalizeClawRouterApiBaseUrl,
@@ -81,7 +87,24 @@ export default definePluginEntry({
           modelId,
         }),
       normalizeResolvedModel: ({ model }) => normalizeClawRouterResolvedModel(model),
-      ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      buildReplayPolicy: ({ modelApi, modelId }) => {
+        if (modelApi === "anthropic-messages") {
+          return buildNativeAnthropicReplayPolicyForModel(modelId);
+        }
+        if (modelApi === "google-generative-ai") {
+          return buildGoogleGeminiReplayPolicy();
+        }
+        if (modelApi === "openai-completions" || modelApi === "openai-responses") {
+          return buildPassthroughGeminiSanitizingReplayPolicy(modelId);
+        }
+        return undefined;
+      },
+      sanitizeReplayHistory: (ctx) =>
+        ctx.modelApi === "google-generative-ai"
+          ? sanitizeGoogleGeminiReplayHistory(ctx)
+          : undefined,
+      resolveReasoningOutputMode: (ctx) =>
+        ctx.modelApi === "google-generative-ai" ? resolveTaggedReasoningOutputMode() : undefined,
       isModernModelRef: () => true,
     });
   },

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -13,7 +13,7 @@ import {
   normalizeClawRouterApiBaseUrl,
   normalizeClawRouterResolvedModel,
 } from "./provider-catalog.js";
-import { createClawRouterStreamFn, wrapClawRouterProviderStream } from "./stream.js";
+import { wrapClawRouterProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "clawrouter";
 const ENV_VAR = "CLAWROUTER_API_KEY";
@@ -99,7 +99,6 @@ export default definePluginEntry({
         const baseUrl = normalizeClawRouterApiBaseUrl(providerConfig.baseUrl);
         return baseUrl !== providerConfig.baseUrl ? { ...providerConfig, baseUrl } : undefined;
       },
-      createStreamFn: createClawRouterStreamFn,
       normalizeResolvedModel: ({ model }) => normalizeClawRouterResolvedModel(model),
       wrapSimpleCompletionStreamFn: wrapClawRouterProviderStream,
       wrapStreamFn: wrapClawRouterProviderStream,

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -1,0 +1,88 @@
+// ClawRouter plugin entrypoint registers credential-scoped model routing.
+import { definePluginEntry, type ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { PASSTHROUGH_GEMINI_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildClawRouterProviderConfig,
+  normalizeClawRouterApiBaseUrl,
+  normalizeClawRouterResolvedModel,
+  resolveDiscoveredClawRouterModel,
+} from "./provider-catalog.js";
+
+const PROVIDER_ID = "clawrouter";
+const ENV_VAR = "CLAWROUTER_API_KEY";
+
+function buildApiKeyAuth(): ProviderAuthMethod {
+  return createProviderApiKeyAuthMethod({
+    providerId: PROVIDER_ID,
+    methodId: "api-key",
+    label: "ClawRouter proxy key",
+    hint: "Credential-scoped access to approved providers",
+    optionKey: "clawrouterApiKey",
+    flagName: "--clawrouter-api-key",
+    envVar: ENV_VAR,
+    promptMessage: "Enter ClawRouter proxy key",
+    noteTitle: "ClawRouter",
+    noteMessage: [
+      "Use the proxy key issued by your ClawRouter administrator.",
+      "OpenClaw discovers only the models granted to that key.",
+    ].join("\n"),
+    wizard: {
+      choiceId: "clawrouter-api-key",
+      choiceLabel: "ClawRouter proxy key",
+      choiceHint: "Approved providers through one managed key",
+      groupId: PROVIDER_ID,
+      groupLabel: "ClawRouter",
+      groupHint: "Managed provider access",
+    },
+  });
+}
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "ClawRouter Provider",
+  description: "Bundled ClawRouter provider plugin",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "ClawRouter",
+      docsPath: "/providers/clawrouter",
+      envVars: [ENV_VAR],
+      auth: [buildApiKeyAuth()],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const auth = ctx.resolveProviderApiKey(PROVIDER_ID);
+          const apiKey = auth.apiKey ?? auth.discoveryApiKey;
+          if (!apiKey) {
+            return null;
+          }
+          const configuredBaseUrl = ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl;
+          try {
+            return {
+              provider: await buildClawRouterProviderConfig({
+                apiKey,
+                discoveryApiKey: auth.discoveryApiKey,
+                baseUrl: configuredBaseUrl,
+              }),
+            };
+          } catch {
+            return null;
+          }
+        },
+      },
+      normalizeConfig: ({ providerConfig }) => {
+        const baseUrl = normalizeClawRouterApiBaseUrl(providerConfig.baseUrl);
+        return baseUrl !== providerConfig.baseUrl ? { ...providerConfig, baseUrl } : undefined;
+      },
+      resolveDynamicModel: ({ modelId, providerConfig }) =>
+        resolveDiscoveredClawRouterModel({
+          baseUrl: providerConfig?.baseUrl,
+          modelId,
+        }),
+      normalizeResolvedModel: ({ model }) => normalizeClawRouterResolvedModel(model),
+      ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      isModernModelRef: () => true,
+    });
+  },
+});

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -12,8 +12,8 @@ import {
   buildClawRouterProviderConfig,
   normalizeClawRouterApiBaseUrl,
   normalizeClawRouterResolvedModel,
-  resolveDiscoveredClawRouterModel,
 } from "./provider-catalog.js";
+import { wrapClawRouterProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "clawrouter";
 const ENV_VAR = "CLAWROUTER_API_KEY";
@@ -81,12 +81,8 @@ export default definePluginEntry({
         const baseUrl = normalizeClawRouterApiBaseUrl(providerConfig.baseUrl);
         return baseUrl !== providerConfig.baseUrl ? { ...providerConfig, baseUrl } : undefined;
       },
-      resolveDynamicModel: ({ modelId, providerConfig }) =>
-        resolveDiscoveredClawRouterModel({
-          baseUrl: providerConfig?.baseUrl,
-          modelId,
-        }),
       normalizeResolvedModel: ({ model }) => normalizeClawRouterResolvedModel(model),
+      wrapStreamFn: wrapClawRouterProviderStream,
       buildReplayPolicy: ({ modelApi, modelId }) => {
         if (modelApi === "anthropic-messages") {
           return buildNativeAnthropicReplayPolicyForModel(modelId);

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -58,9 +58,27 @@ export default definePluginEntry({
       catalog: {
         order: "simple",
         run: async (ctx) => {
-          const auth = ctx.resolveProviderApiKey(PROVIDER_ID);
-          const apiKey = auth.apiKey ?? auth.discoveryApiKey;
-          if (!apiKey) {
+          const auth = ctx.resolveProviderAuth(PROVIDER_ID);
+          let discoveryApiKey = auth.discoveryApiKey;
+          if (!discoveryApiKey) {
+            try {
+              const { resolveApiKeyForProvider } =
+                await import("openclaw/plugin-sdk/provider-auth-runtime");
+              discoveryApiKey = (
+                await resolveApiKeyForProvider({
+                  provider: PROVIDER_ID,
+                  cfg: ctx.config,
+                  ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+                  ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
+                  ...(auth.profileId ? { profileId: auth.profileId, lockedProfile: true } : {}),
+                })
+              )?.apiKey;
+            } catch {
+              return null;
+            }
+          }
+          const apiKey = auth.apiKey ?? discoveryApiKey;
+          if (!apiKey || !discoveryApiKey) {
             return null;
           }
           const configuredBaseUrl = ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl;
@@ -68,7 +86,7 @@ export default definePluginEntry({
             return {
               provider: await buildClawRouterProviderConfig({
                 apiKey,
-                discoveryApiKey: auth.discoveryApiKey,
+                discoveryApiKey,
                 baseUrl: configuredBaseUrl,
               }),
             };
@@ -82,6 +100,7 @@ export default definePluginEntry({
         return baseUrl !== providerConfig.baseUrl ? { ...providerConfig, baseUrl } : undefined;
       },
       normalizeResolvedModel: ({ model }) => normalizeClawRouterResolvedModel(model),
+      wrapSimpleCompletionStreamFn: wrapClawRouterProviderStream,
       wrapStreamFn: wrapClawRouterProviderStream,
       buildReplayPolicy: ({ modelApi, modelId }) => {
         if (modelApi === "anthropic-messages") {

--- a/extensions/clawrouter/openclaw.plugin.json
+++ b/extensions/clawrouter/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "clawrouter",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["clawrouter"],
+  "setup": {
+    "providers": [
+      {
+        "id": "clawrouter",
+        "envVars": ["CLAWROUTER_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "clawrouter",
+      "method": "api-key",
+      "choiceId": "clawrouter-api-key",
+      "choiceLabel": "ClawRouter proxy key",
+      "choiceHint": "Approved providers through one managed key",
+      "groupId": "clawrouter",
+      "groupLabel": "ClawRouter",
+      "groupHint": "Managed provider access",
+      "optionKey": "clawrouterApiKey",
+      "cliFlag": "--clawrouter-api-key",
+      "cliOption": "--clawrouter-api-key <key>",
+      "cliDescription": "ClawRouter proxy key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/clawrouter/package.json
+++ b/extensions/clawrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clawrouter-provider",
-  "version": "2026.6.2",
+  "version": "2026.6.9",
   "private": true,
   "description": "OpenClaw ClawRouter provider plugin",
   "type": "module",

--- a/extensions/clawrouter/package.json
+++ b/extensions/clawrouter/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/clawrouter-provider",
+  "version": "2026.6.2",
+  "private": true,
+  "description": "OpenClaw ClawRouter provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -67,12 +67,18 @@ const CATALOG = {
           requestFormat: "google.generate_content",
           responseFormat: "google.generate_content",
         },
+        {
+          path: "/v1beta/models/${model}:streamGenerateContent",
+          methods: ["POST"],
+          requestFormat: "google.generate_content",
+          responseFormat: "google.generate_content",
+        },
       ],
       models: [
         {
           id: "google/gemini-default",
           upstream: "gemini",
-          capabilities: ["llm.generate"],
+          capabilities: ["llm.generate", "llm.stream"],
         },
       ],
     },
@@ -198,6 +204,23 @@ describe("clawrouter provider catalog", () => {
     const headers = fetchGuardMock.mock.calls[0]?.[0].init?.headers;
     expect(headers).toBeInstanceOf(Headers);
     expect((headers as Headers).get("authorization")).toBe("Bearer clawrouter-test-key");
+  });
+
+  it("does not advertise Gemini models without an explicit streaming route", async () => {
+    const generateOnlyCatalog = structuredClone(CATALOG);
+    generateOnlyCatalog.providers[2].routes = generateOnlyCatalog.providers[2].routes.filter(
+      (route) => !route.path.includes(":streamGenerateContent"),
+    );
+    generateOnlyCatalog.providers[2].models[0].capabilities = ["llm.generate"];
+    const { fetchGuard } = buildFetchGuard(generateOnlyCatalog);
+
+    const provider = await buildClawRouterProviderConfig({
+      apiKey: "clawrouter-test-key",
+      baseUrl: "https://clawrouter.example",
+      fetchGuard,
+    });
+
+    expect(provider.models.map((model) => model.id)).not.toContain("google/gemini-default");
   });
 
   it("keeps credential-scoped route metadata isolated on each catalog result", async () => {

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -156,9 +156,17 @@ describe("clawrouter provider catalog", () => {
     const anthropic = provider.models.find((model) => model.id === "anthropic/default");
     const normalized = normalizeClawRouterResolvedModel({
       ...anthropic,
+      baseUrl: provider.baseUrl,
       provider: "clawrouter",
     } as ProviderRuntimeModel);
-    expect(normalized?.id).toBe("claude-sonnet-4-5-20250929");
+    expect(normalized).toMatchObject({
+      id: "claude-sonnet-4-5-20250929",
+      api: "anthropic-messages",
+      baseUrl: "https://clawrouter.example/v1/native/anthropic",
+      headers: {
+        Authorization: "Bearer clawrouter-test-key",
+      },
+    });
 
     const dynamic = resolveDiscoveredClawRouterModel({
       baseUrl: provider.baseUrl,
@@ -219,6 +227,7 @@ describe("clawrouter provider catalog", () => {
     expect(
       normalizeClawRouterResolvedModel({
         ...anthropic,
+        baseUrl: provider.baseUrl,
         provider: "clawrouter",
       } as ProviderRuntimeModel),
     ).toBeUndefined();

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vites
 import {
   buildClawRouterProviderConfig,
   normalizeClawRouterResolvedModel,
+  prepareClawRouterRequestModel,
 } from "./provider-catalog.js";
 
 const CATALOG = {
@@ -156,11 +157,29 @@ describe("clawrouter provider catalog", () => {
       provider: "clawrouter",
     } as ProviderRuntimeModel);
     expect(normalized).toMatchObject({
-      id: "claude-sonnet-4-5-20250929",
+      id: "anthropic/default",
       api: "anthropic-messages",
       baseUrl: "https://clawrouter.example/v1/native/anthropic",
     });
-    expect(normalized?.params).toBeUndefined();
+    expect(prepareClawRouterRequestModel(normalized as ProviderRuntimeModel)).toMatchObject({
+      id: "claude-sonnet-4-5-20250929",
+      params: undefined,
+    });
+    const gemini = provider.models.find((model) => model.id === "google/gemini-default");
+    const normalizedGemini = normalizeClawRouterResolvedModel({
+      ...gemini,
+      baseUrl: provider.baseUrl,
+      provider: "clawrouter",
+    } as ProviderRuntimeModel);
+    expect(normalizedGemini).toMatchObject({
+      id: "google/gemini-default",
+      api: "google-generative-ai",
+      baseUrl: "https://clawrouter.example/v1/native/google-gemini/v1beta",
+    });
+    expect(prepareClawRouterRequestModel(normalizedGemini as ProviderRuntimeModel)).toMatchObject({
+      id: "gemini",
+      params: undefined,
+    });
     expect(JSON.stringify(provider.models)).not.toContain("clawrouter-test-key");
   });
 
@@ -203,18 +222,22 @@ describe("clawrouter provider catalog", () => {
     const secondAnthropic = secondProvider.models.find((model) => model.id === "anthropic/default");
 
     expect(
-      normalizeClawRouterResolvedModel({
-        ...firstAnthropic,
-        baseUrl: firstProvider.baseUrl,
-        provider: "clawrouter",
-      } as ProviderRuntimeModel)?.id,
+      prepareClawRouterRequestModel(
+        normalizeClawRouterResolvedModel({
+          ...firstAnthropic,
+          baseUrl: firstProvider.baseUrl,
+          provider: "clawrouter",
+        } as ProviderRuntimeModel) as ProviderRuntimeModel,
+      ).id,
     ).toBe("first-upstream");
     expect(
-      normalizeClawRouterResolvedModel({
-        ...secondAnthropic,
-        baseUrl: secondProvider.baseUrl,
-        provider: "clawrouter",
-      } as ProviderRuntimeModel)?.id,
+      prepareClawRouterRequestModel(
+        normalizeClawRouterResolvedModel({
+          ...secondAnthropic,
+          baseUrl: secondProvider.baseUrl,
+          provider: "clawrouter",
+        } as ProviderRuntimeModel) as ProviderRuntimeModel,
+      ).id,
     ).toBe("second-upstream");
   });
 });

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -17,7 +17,7 @@ const CATALOG = {
     {
       id: "openai",
       displayName: "OpenAI",
-      openAiCompatible: true,
+      openaiCompatible: true,
       nativeBaseUrl: "/v1/native/openai",
       routes: [
         {
@@ -38,7 +38,7 @@ const CATALOG = {
     {
       id: "anthropic",
       displayName: "Anthropic",
-      openAiCompatible: false,
+      openaiCompatible: false,
       nativeBaseUrl: "/v1/native/anthropic",
       routes: [
         {
@@ -59,7 +59,7 @@ const CATALOG = {
     {
       id: "google-gemini",
       displayName: "Google Gemini",
-      openAiCompatible: false,
+      openaiCompatible: false,
       nativeBaseUrl: "/v1/native/google-gemini",
       routes: [
         {
@@ -80,7 +80,7 @@ const CATALOG = {
     {
       id: "cohere",
       displayName: "Cohere",
-      openAiCompatible: false,
+      openaiCompatible: false,
       nativeBaseUrl: "/v1/native/cohere",
       routes: [
         {

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -6,9 +6,7 @@ import {
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
 import {
   buildClawRouterProviderConfig,
-  clearClawRouterCatalogForTests,
   normalizeClawRouterResolvedModel,
-  resolveDiscoveredClawRouterModel,
 } from "./provider-catalog.js";
 
 const CATALOG = {
@@ -101,12 +99,12 @@ const CATALOG = {
   ],
 };
 
-function buildFetchGuard(): {
+function buildFetchGuard(catalog: unknown = CATALOG): {
   fetchGuard: LiveModelCatalogFetchGuard;
   fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard>;
 } {
   const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
-    response: new Response(JSON.stringify(CATALOG)),
+    response: new Response(JSON.stringify(catalog)),
     finalUrl: "https://clawrouter.example/v1/catalog",
     release: async () => undefined,
   }));
@@ -116,7 +114,6 @@ function buildFetchGuard(): {
 describe("clawrouter provider catalog", () => {
   beforeEach(() => {
     clearLiveCatalogCacheForTests();
-    clearClawRouterCatalogForTests();
   });
 
   it("maps credential-scoped catalog rows to their real provider transports", async () => {
@@ -131,7 +128,6 @@ describe("clawrouter provider catalog", () => {
     expect(provider).toMatchObject({
       api: "openai-responses",
       apiKey: "clawrouter-test-key",
-      authHeader: true,
       baseUrl: "https://clawrouter.example/v1",
     });
     expect(provider.models.map((model) => model.id)).toEqual([
@@ -163,20 +159,9 @@ describe("clawrouter provider catalog", () => {
       id: "claude-sonnet-4-5-20250929",
       api: "anthropic-messages",
       baseUrl: "https://clawrouter.example/v1/native/anthropic",
-      headers: {
-        Authorization: "Bearer clawrouter-test-key",
-      },
     });
-
-    const dynamic = resolveDiscoveredClawRouterModel({
-      baseUrl: provider.baseUrl,
-      modelId: "google/gemini-default",
-    });
-    expect(dynamic).toMatchObject({
-      id: "google/gemini-default",
-      provider: "clawrouter",
-      api: "google-generative-ai",
-    });
+    expect(normalized?.params).toBeUndefined();
+    expect(JSON.stringify(provider.models)).not.toContain("clawrouter-test-key");
   });
 
   it("caches the auth-scoped catalog for the discovery TTL", async () => {
@@ -196,40 +181,40 @@ describe("clawrouter provider catalog", () => {
     expect((headers as Headers).get("authorization")).toBe("Bearer clawrouter-test-key");
   });
 
-  it("replaces stale discovery state when the active catalog changes", async () => {
-    const first = buildFetchGuard();
-    const provider = await buildClawRouterProviderConfig({
+  it("keeps credential-scoped route metadata isolated on each catalog result", async () => {
+    const firstCatalog = structuredClone(CATALOG);
+    firstCatalog.providers[1].models[0].upstream = "first-upstream";
+    const first = buildFetchGuard(firstCatalog);
+    const firstProvider = await buildClawRouterProviderConfig({
       apiKey: "first-key",
-      baseUrl: "https://first.example",
+      baseUrl: "https://clawrouter.example",
       fetchGuard: first.fetchGuard,
     });
-    const anthropic = provider.models.find((model) => model.id === "anthropic/default");
+    const firstAnthropic = firstProvider.models.find((model) => model.id === "anthropic/default");
 
-    const second = buildFetchGuard();
-    await buildClawRouterProviderConfig({
+    const secondCatalog = structuredClone(CATALOG);
+    secondCatalog.providers[1].models[0].upstream = "second-upstream";
+    const second = buildFetchGuard(secondCatalog);
+    const secondProvider = await buildClawRouterProviderConfig({
       apiKey: "second-key",
-      baseUrl: "https://second.example",
+      baseUrl: "https://clawrouter.example",
       fetchGuard: second.fetchGuard,
     });
+    const secondAnthropic = secondProvider.models.find((model) => model.id === "anthropic/default");
 
     expect(
-      resolveDiscoveredClawRouterModel({
-        baseUrl: "https://first.example/v1",
-        modelId: "openai/gpt-5.5-mini",
-      }),
-    ).toBeUndefined();
-    expect(
-      resolveDiscoveredClawRouterModel({
-        baseUrl: "https://second.example/v1",
-        modelId: "openai/gpt-5.5-mini",
-      }),
-    ).toBeDefined();
+      normalizeClawRouterResolvedModel({
+        ...firstAnthropic,
+        baseUrl: firstProvider.baseUrl,
+        provider: "clawrouter",
+      } as ProviderRuntimeModel)?.id,
+    ).toBe("first-upstream");
     expect(
       normalizeClawRouterResolvedModel({
-        ...anthropic,
-        baseUrl: provider.baseUrl,
+        ...secondAnthropic,
+        baseUrl: secondProvider.baseUrl,
         provider: "clawrouter",
-      } as ProviderRuntimeModel),
-    ).toBeUndefined();
+      } as ProviderRuntimeModel)?.id,
+    ).toBe("second-upstream");
   });
 });

--- a/extensions/clawrouter/provider-catalog.test.ts
+++ b/extensions/clawrouter/provider-catalog.test.ts
@@ -1,0 +1,226 @@
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  clearLiveCatalogCacheForTests,
+  type LiveModelCatalogFetchGuard,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
+import {
+  buildClawRouterProviderConfig,
+  clearClawRouterCatalogForTests,
+  normalizeClawRouterResolvedModel,
+  resolveDiscoveredClawRouterModel,
+} from "./provider-catalog.js";
+
+const CATALOG = {
+  version: "clawrouter.client-catalog.v1",
+  providers: [
+    {
+      id: "openai",
+      displayName: "OpenAI",
+      openAiCompatible: true,
+      nativeBaseUrl: "/v1/native/openai",
+      routes: [
+        {
+          path: "/v1/responses",
+          methods: ["POST"],
+          requestFormat: "openai.responses",
+          responseFormat: "openai.responses",
+        },
+      ],
+      models: [
+        {
+          id: "openai/gpt-5.5-mini",
+          upstream: "gpt-5.5-mini",
+          capabilities: ["llm.responses", "llm.chat"],
+        },
+      ],
+    },
+    {
+      id: "anthropic",
+      displayName: "Anthropic",
+      openAiCompatible: false,
+      nativeBaseUrl: "/v1/native/anthropic",
+      routes: [
+        {
+          path: "/v1/messages",
+          methods: ["POST"],
+          requestFormat: "anthropic.messages",
+          responseFormat: "anthropic.messages",
+        },
+      ],
+      models: [
+        {
+          id: "anthropic/default",
+          upstream: "claude-sonnet-4-5-20250929",
+          capabilities: ["llm.messages"],
+        },
+      ],
+    },
+    {
+      id: "google-gemini",
+      displayName: "Google Gemini",
+      openAiCompatible: false,
+      nativeBaseUrl: "/v1/native/google-gemini",
+      routes: [
+        {
+          path: "/v1beta/models/${model}:generateContent",
+          methods: ["POST"],
+          requestFormat: "google.generate_content",
+          responseFormat: "google.generate_content",
+        },
+      ],
+      models: [
+        {
+          id: "google/gemini-default",
+          upstream: "gemini",
+          capabilities: ["llm.generate"],
+        },
+      ],
+    },
+    {
+      id: "cohere",
+      displayName: "Cohere",
+      openAiCompatible: false,
+      nativeBaseUrl: "/v1/native/cohere",
+      routes: [
+        {
+          path: "/v2/chat",
+          methods: ["POST"],
+          requestFormat: "cohere.chat",
+          responseFormat: "cohere.chat",
+        },
+      ],
+      models: [
+        {
+          id: "cohere/default",
+          upstream: "command-a",
+          capabilities: ["llm.chat"],
+        },
+      ],
+    },
+  ],
+};
+
+function buildFetchGuard(): {
+  fetchGuard: LiveModelCatalogFetchGuard;
+  fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard>;
+} {
+  const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+    response: new Response(JSON.stringify(CATALOG)),
+    finalUrl: "https://clawrouter.example/v1/catalog",
+    release: async () => undefined,
+  }));
+  return { fetchGuard: fetchGuardMock, fetchGuardMock };
+}
+
+describe("clawrouter provider catalog", () => {
+  beforeEach(() => {
+    clearLiveCatalogCacheForTests();
+    clearClawRouterCatalogForTests();
+  });
+
+  it("maps credential-scoped catalog rows to their real provider transports", async () => {
+    const { fetchGuard, fetchGuardMock } = buildFetchGuard();
+    const provider = await buildClawRouterProviderConfig({
+      apiKey: "clawrouter-test-key",
+      baseUrl: "https://clawrouter.example/v1",
+      fetchGuard,
+    });
+
+    expect(fetchGuardMock).toHaveBeenCalledOnce();
+    expect(provider).toMatchObject({
+      api: "openai-responses",
+      apiKey: "clawrouter-test-key",
+      authHeader: true,
+      baseUrl: "https://clawrouter.example/v1",
+    });
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "anthropic/default",
+      "google/gemini-default",
+      "openai/gpt-5.5-mini",
+    ]);
+
+    expect(provider.models.find((model) => model.id === "openai/gpt-5.5-mini")).toMatchObject({
+      api: "openai-responses",
+      baseUrl: "https://clawrouter.example/v1",
+    });
+    expect(provider.models.find((model) => model.id === "anthropic/default")).toMatchObject({
+      api: "anthropic-messages",
+      baseUrl: "https://clawrouter.example/v1/native/anthropic",
+    });
+    expect(provider.models.find((model) => model.id === "google/gemini-default")).toMatchObject({
+      api: "google-generative-ai",
+      baseUrl: "https://clawrouter.example/v1/native/google-gemini/v1beta",
+    });
+
+    const anthropic = provider.models.find((model) => model.id === "anthropic/default");
+    const normalized = normalizeClawRouterResolvedModel({
+      ...anthropic,
+      provider: "clawrouter",
+    } as ProviderRuntimeModel);
+    expect(normalized?.id).toBe("claude-sonnet-4-5-20250929");
+
+    const dynamic = resolveDiscoveredClawRouterModel({
+      baseUrl: provider.baseUrl,
+      modelId: "google/gemini-default",
+    });
+    expect(dynamic).toMatchObject({
+      id: "google/gemini-default",
+      provider: "clawrouter",
+      api: "google-generative-ai",
+    });
+  });
+
+  it("caches the auth-scoped catalog for the discovery TTL", async () => {
+    const { fetchGuard, fetchGuardMock } = buildFetchGuard();
+    const params = {
+      apiKey: "clawrouter-test-key",
+      baseUrl: "https://clawrouter.example",
+      fetchGuard,
+    };
+
+    await buildClawRouterProviderConfig(params);
+    await buildClawRouterProviderConfig(params);
+
+    expect(fetchGuardMock).toHaveBeenCalledOnce();
+    const headers = fetchGuardMock.mock.calls[0]?.[0].init?.headers;
+    expect(headers).toBeInstanceOf(Headers);
+    expect((headers as Headers).get("authorization")).toBe("Bearer clawrouter-test-key");
+  });
+
+  it("replaces stale discovery state when the active catalog changes", async () => {
+    const first = buildFetchGuard();
+    const provider = await buildClawRouterProviderConfig({
+      apiKey: "first-key",
+      baseUrl: "https://first.example",
+      fetchGuard: first.fetchGuard,
+    });
+    const anthropic = provider.models.find((model) => model.id === "anthropic/default");
+
+    const second = buildFetchGuard();
+    await buildClawRouterProviderConfig({
+      apiKey: "second-key",
+      baseUrl: "https://second.example",
+      fetchGuard: second.fetchGuard,
+    });
+
+    expect(
+      resolveDiscoveredClawRouterModel({
+        baseUrl: "https://first.example/v1",
+        modelId: "openai/gpt-5.5-mini",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDiscoveredClawRouterModel({
+        baseUrl: "https://second.example/v1",
+        modelId: "openai/gpt-5.5-mini",
+      }),
+    ).toBeDefined();
+    expect(
+      normalizeClawRouterResolvedModel({
+        ...anthropic,
+        provider: "clawrouter",
+      } as ProviderRuntimeModel),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -185,8 +185,13 @@ function buildRoutedModel(
     upstreamModel = model.upstream;
   } else {
     const googleRoute =
-      supportsCapability(model, "llm.generate", "llm.stream") &&
-      findNativeRoute(provider, "google.generate_content");
+      supportsCapability(model, "llm.stream") &&
+      provider.routes.find(
+        (route) =>
+          route.methods.includes("POST") &&
+          route.requestFormat === "google.generate_content" &&
+          route.path.includes(":streamGenerateContent"),
+      );
     const googleBaseUrl = googleRoute
       ? googleNativeBaseUrl(rootUrl, provider, googleRoute)
       : undefined;

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -50,6 +50,7 @@ type RoutedModel = {
 
 type CatalogSnapshot = {
   apiBaseUrl: string;
+  authorizationHeader: string;
   modelsByRoute: Map<string, ModelDefinitionConfig>;
   nativeModelIds: Map<string, string>;
 };
@@ -223,6 +224,7 @@ function buildRoutedModel(
 function updateDiscoveredModels(
   rootUrl: string,
   providers: CatalogProvider[],
+  apiKey: string,
 ): ModelDefinitionConfig[] {
   const models = new Map<string, ModelDefinitionConfig>();
   const modelsByRoute = new Map<string, ModelDefinitionConfig>();
@@ -246,6 +248,7 @@ function updateDiscoveredModels(
   // Keeping older credential-scoped catalogs would leak stale grants and grow forever.
   catalogSnapshot = {
     apiBaseUrl: `${rootUrl}/v1`,
+    authorizationHeader: `Bearer ${apiKey}`,
     modelsByRoute,
     nativeModelIds,
   };
@@ -278,7 +281,7 @@ export async function buildClawRouterProviderConfig(params: {
     api: "openai-responses",
     apiKey: params.apiKey,
     authHeader: true,
-    models: updateDiscoveredModels(rootUrl, providers),
+    models: updateDiscoveredModels(rootUrl, providers, params.apiKey),
   };
 }
 
@@ -297,8 +300,22 @@ export function resolveDiscoveredClawRouterModel(params: {
 export function normalizeClawRouterResolvedModel(
   model: ProviderRuntimeModel,
 ): ProviderRuntimeModel | undefined {
-  const upstreamModel = catalogSnapshot?.nativeModelIds.get(routeKey(model.baseUrl, model.id));
-  return upstreamModel && upstreamModel !== model.id ? { ...model, id: upstreamModel } : undefined;
+  const discovered = catalogSnapshot?.modelsByRoute.get(routeKey(model.baseUrl, model.id));
+  if (!catalogSnapshot || !discovered) {
+    return undefined;
+  }
+  const discoveredBaseUrl = discovered.baseUrl ?? catalogSnapshot.apiBaseUrl;
+  const upstreamModel = catalogSnapshot.nativeModelIds.get(routeKey(discoveredBaseUrl, model.id));
+  return {
+    ...model,
+    api: discovered.api ?? model.api,
+    baseUrl: discoveredBaseUrl,
+    headers: {
+      ...model.headers,
+      Authorization: catalogSnapshot.authorizationHeader,
+    },
+    ...(upstreamModel && upstreamModel !== model.id ? { id: upstreamModel } : {}),
+  };
 }
 
 export function clearClawRouterCatalogForTests(): void {

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -239,7 +239,7 @@ function buildDiscoveredModels(
       models.set(routed.definition.id, routed.definition);
     }
   }
-  return [...models.values()].sort((left, right) => left.id.localeCompare(right.id));
+  return [...models.values()].toSorted((left, right) => left.id.localeCompare(right.id));
 }
 
 export async function buildClawRouterProviderConfig(params: {

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -307,6 +307,16 @@ export function normalizeClawRouterResolvedModel(
     ...model,
     api: route.api,
     baseUrl: route.baseUrl,
+  };
+}
+
+export function prepareClawRouterRequestModel(model: ProviderRuntimeModel): ProviderRuntimeModel {
+  const route = readRouteMetadata(model.params);
+  if (!route) {
+    return model;
+  }
+  return {
+    ...model,
     params: stripRouteMetadata(model.params),
     ...(route.upstreamModel && route.upstreamModel !== model.id ? { id: route.upstreamModel } : {}),
   };

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -1,0 +1,306 @@
+// ClawRouter provider catalog maps credential-scoped routes to OpenClaw transports.
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  getCachedLiveProviderModelRows,
+  type LiveModelCatalogFetchGuard,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+
+export const CLAWROUTER_DEFAULT_BASE_URL = "https://clawrouter.openclaw.ai";
+
+const PROVIDER_ID = "clawrouter";
+const CATALOG_CACHE_TTL_MS = 60_000;
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const DEFAULT_MAX_TOKENS = 32_768;
+const DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+type CatalogRoute = {
+  path: string;
+  requestFormat: string;
+  methods: string[];
+};
+
+type CatalogModel = {
+  id: string;
+  upstream: string;
+  capabilities: string[];
+};
+
+type CatalogProvider = {
+  id: string;
+  displayName: string;
+  openAiCompatible: boolean;
+  nativeBaseUrl: string;
+  routes: CatalogRoute[];
+  models: CatalogModel[];
+};
+
+type RoutedModel = {
+  definition: ModelDefinitionConfig;
+  upstreamModel?: string;
+};
+
+type CatalogSnapshot = {
+  apiBaseUrl: string;
+  modelsByRoute: Map<string, ModelDefinitionConfig>;
+  nativeModelIds: Map<string, string>;
+};
+
+let catalogSnapshot: CatalogSnapshot | undefined;
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map(readString).filter((entry): entry is string => Boolean(entry))
+    : [];
+}
+
+function readCatalogRows(body: unknown): readonly unknown[] {
+  const providers = readRecord(body)?.providers;
+  if (!Array.isArray(providers)) {
+    throw new Error("ClawRouter catalog response must contain providers[]");
+  }
+  return providers;
+}
+
+function parseCatalogRoute(value: unknown): CatalogRoute | undefined {
+  const row = readRecord(value);
+  const path = readString(row?.path);
+  const requestFormat = readString(row?.requestFormat);
+  if (!path || !requestFormat) {
+    return undefined;
+  }
+  return {
+    path,
+    requestFormat,
+    methods: readStringArray(row?.methods).map((method) => method.toUpperCase()),
+  };
+}
+
+function parseCatalogModel(value: unknown): CatalogModel | undefined {
+  const row = readRecord(value);
+  const id = readString(row?.id);
+  const upstream = readString(row?.upstream);
+  if (!id || !upstream) {
+    return undefined;
+  }
+  return {
+    id,
+    upstream,
+    capabilities: readStringArray(row?.capabilities),
+  };
+}
+
+function parseCatalogProvider(value: unknown): CatalogProvider | undefined {
+  const row = readRecord(value);
+  const id = readString(row?.id);
+  const nativeBaseUrl = readString(row?.nativeBaseUrl);
+  if (!id || !nativeBaseUrl || !nativeBaseUrl.startsWith("/v1/native/")) {
+    return undefined;
+  }
+  return {
+    id,
+    displayName: readString(row?.displayName) ?? id,
+    openAiCompatible: row?.openAiCompatible === true,
+    nativeBaseUrl,
+    routes: Array.isArray(row?.routes)
+      ? row.routes.map(parseCatalogRoute).filter((route): route is CatalogRoute => Boolean(route))
+      : [],
+    models: Array.isArray(row?.models)
+      ? row.models.map(parseCatalogModel).filter((model): model is CatalogModel => Boolean(model))
+      : [],
+  };
+}
+
+function trimTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function normalizeClawRouterRootUrl(baseUrl: string | undefined): string {
+  const normalized = trimTrailingSlashes(baseUrl?.trim() || CLAWROUTER_DEFAULT_BASE_URL);
+  return normalized.endsWith("/v1") ? normalized.slice(0, -3) : normalized;
+}
+
+export function normalizeClawRouterApiBaseUrl(baseUrl: string | undefined): string {
+  return `${normalizeClawRouterRootUrl(baseUrl)}/v1`;
+}
+
+function routeKey(baseUrl: string, modelId: string): string {
+  return `${trimTrailingSlashes(baseUrl)}\0${modelId}`;
+}
+
+function supportsCapability(model: CatalogModel, ...capabilities: string[]): boolean {
+  return capabilities.some((capability) => model.capabilities.includes(capability));
+}
+
+function findNativeRoute(
+  provider: CatalogProvider,
+  requestFormat: string,
+): CatalogRoute | undefined {
+  return provider.routes.find(
+    (route) => route.methods.includes("POST") && route.requestFormat === requestFormat,
+  );
+}
+
+function googleNativeBaseUrl(rootUrl: string, provider: CatalogProvider, route: CatalogRoute) {
+  const modelPathIndex = route.path.indexOf("/models/${model}");
+  if (modelPathIndex <= 0) {
+    return undefined;
+  }
+  return `${rootUrl}${provider.nativeBaseUrl}${route.path.slice(0, modelPathIndex)}`;
+}
+
+function buildRoutedModel(
+  rootUrl: string,
+  provider: CatalogProvider,
+  model: CatalogModel,
+): RoutedModel | undefined {
+  let api: ModelDefinitionConfig["api"];
+  let baseUrl: string;
+  let upstreamModel: string | undefined;
+
+  if (provider.openAiCompatible && supportsCapability(model, "llm.responses")) {
+    api = "openai-responses";
+    baseUrl = `${rootUrl}/v1`;
+  } else if (provider.openAiCompatible && supportsCapability(model, "llm.chat")) {
+    api = "openai-completions";
+    baseUrl = `${rootUrl}/v1`;
+  } else if (
+    supportsCapability(model, "llm.messages") &&
+    findNativeRoute(provider, "anthropic.messages")
+  ) {
+    api = "anthropic-messages";
+    baseUrl = `${rootUrl}${provider.nativeBaseUrl}`;
+    upstreamModel = model.upstream;
+  } else {
+    const googleRoute =
+      supportsCapability(model, "llm.generate", "llm.stream") &&
+      findNativeRoute(provider, "google.generate_content");
+    const googleBaseUrl = googleRoute
+      ? googleNativeBaseUrl(rootUrl, provider, googleRoute)
+      : undefined;
+    if (!googleBaseUrl) {
+      return undefined;
+    }
+    api = "google-generative-ai";
+    baseUrl = googleBaseUrl;
+    upstreamModel = model.upstream;
+  }
+
+  return {
+    definition: {
+      id: model.id,
+      name: `${provider.displayName}: ${model.id}`,
+      api,
+      baseUrl,
+      reasoning: false,
+      input: ["text"],
+      cost: DEFAULT_COST,
+      contextWindow: DEFAULT_CONTEXT_WINDOW,
+      maxTokens: DEFAULT_MAX_TOKENS,
+    },
+    upstreamModel,
+  };
+}
+
+function updateDiscoveredModels(
+  rootUrl: string,
+  providers: CatalogProvider[],
+): ModelDefinitionConfig[] {
+  const models = new Map<string, ModelDefinitionConfig>();
+  const modelsByRoute = new Map<string, ModelDefinitionConfig>();
+  const nativeModelIds = new Map<string, string>();
+  for (const provider of providers) {
+    for (const model of provider.models) {
+      const routed = buildRoutedModel(rootUrl, provider, model);
+      if (!routed || models.has(routed.definition.id)) {
+        continue;
+      }
+      models.set(routed.definition.id, routed.definition);
+      const key = routeKey(routed.definition.baseUrl ?? `${rootUrl}/v1`, routed.definition.id);
+      modelsByRoute.set(key, routed.definition);
+      modelsByRoute.set(routeKey(`${rootUrl}/v1`, routed.definition.id), routed.definition);
+      if (routed.upstreamModel) {
+        nativeModelIds.set(key, routed.upstreamModel);
+      }
+    }
+  }
+  // Discovery owns one active provider config, so replace the whole snapshot.
+  // Keeping older credential-scoped catalogs would leak stale grants and grow forever.
+  catalogSnapshot = {
+    apiBaseUrl: `${rootUrl}/v1`,
+    modelsByRoute,
+    nativeModelIds,
+  };
+  return [...models.values()].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export async function buildClawRouterProviderConfig(params: {
+  apiKey: string;
+  discoveryApiKey?: string;
+  baseUrl?: string;
+  fetchGuard?: LiveModelCatalogFetchGuard;
+}): Promise<ModelProviderConfig> {
+  const rootUrl = normalizeClawRouterRootUrl(params.baseUrl);
+  const rows = await getCachedLiveProviderModelRows({
+    providerId: PROVIDER_ID,
+    endpoint: `${rootUrl}/v1/catalog`,
+    apiKey: params.apiKey,
+    discoveryApiKey: params.discoveryApiKey,
+    fetchGuard: params.fetchGuard,
+    readRows: readCatalogRows,
+    ttlMs: CATALOG_CACHE_TTL_MS,
+    shouldCacheRows: (providers) => providers.length > 0,
+    auditContext: "clawrouter-model-discovery",
+  });
+  const providers = rows
+    .map(parseCatalogProvider)
+    .filter((provider): provider is CatalogProvider => Boolean(provider));
+  return {
+    baseUrl: `${rootUrl}/v1`,
+    api: "openai-responses",
+    apiKey: params.apiKey,
+    authHeader: true,
+    models: updateDiscoveredModels(rootUrl, providers),
+  };
+}
+
+export function resolveDiscoveredClawRouterModel(params: {
+  baseUrl?: string;
+  modelId: string;
+}): ProviderRuntimeModel | undefined {
+  const apiBaseUrl = normalizeClawRouterApiBaseUrl(params.baseUrl);
+  if (catalogSnapshot?.apiBaseUrl !== apiBaseUrl) {
+    return undefined;
+  }
+  const model = catalogSnapshot.modelsByRoute.get(routeKey(apiBaseUrl, params.modelId));
+  return model ? { ...model, provider: PROVIDER_ID } : undefined;
+}
+
+export function normalizeClawRouterResolvedModel(
+  model: ProviderRuntimeModel,
+): ProviderRuntimeModel | undefined {
+  const upstreamModel = catalogSnapshot?.nativeModelIds.get(routeKey(model.baseUrl, model.id));
+  return upstreamModel && upstreamModel !== model.id ? { ...model, id: upstreamModel } : undefined;
+}
+
+export function clearClawRouterCatalogForTests(): void {
+  catalogSnapshot = undefined;
+}

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -37,7 +37,7 @@ type CatalogModel = {
 type CatalogProvider = {
   id: string;
   displayName: string;
-  openAiCompatible: boolean;
+  openaiCompatible: boolean;
   nativeBaseUrl: string;
   routes: CatalogRoute[];
   models: CatalogModel[];
@@ -118,7 +118,7 @@ function parseCatalogProvider(value: unknown): CatalogProvider | undefined {
   return {
     id,
     displayName: readString(row?.displayName) ?? id,
-    openAiCompatible: row?.openAiCompatible === true,
+    openaiCompatible: row?.openaiCompatible === true,
     nativeBaseUrl,
     routes: Array.isArray(row?.routes)
       ? row.routes.map(parseCatalogRoute).filter((route): route is CatalogRoute => Boolean(route))
@@ -176,10 +176,10 @@ function buildRoutedModel(
   let baseUrl: string;
   let upstreamModel: string | undefined;
 
-  if (provider.openAiCompatible && supportsCapability(model, "llm.responses")) {
+  if (provider.openaiCompatible && supportsCapability(model, "llm.responses")) {
     api = "openai-responses";
     baseUrl = `${rootUrl}/v1`;
-  } else if (provider.openAiCompatible && supportsCapability(model, "llm.chat")) {
+  } else if (provider.openaiCompatible && supportsCapability(model, "llm.chat")) {
     api = "openai-completions";
     baseUrl = `${rootUrl}/v1`;
   } else if (

--- a/extensions/clawrouter/provider-catalog.ts
+++ b/extensions/clawrouter/provider-catalog.ts
@@ -13,6 +13,7 @@ export const CLAWROUTER_DEFAULT_BASE_URL = "https://clawrouter.openclaw.ai";
 
 const PROVIDER_ID = "clawrouter";
 const CATALOG_CACHE_TTL_MS = 60_000;
+const ROUTE_METADATA_KEY = "clawrouterRoute";
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 32_768;
 const DEFAULT_COST = {
@@ -45,17 +46,13 @@ type CatalogProvider = {
 
 type RoutedModel = {
   definition: ModelDefinitionConfig;
+};
+
+type RouteMetadata = {
+  api: NonNullable<ModelDefinitionConfig["api"]>;
+  baseUrl: string;
   upstreamModel?: string;
 };
-
-type CatalogSnapshot = {
-  apiBaseUrl: string;
-  authorizationHeader: string;
-  modelsByRoute: Map<string, ModelDefinitionConfig>;
-  nativeModelIds: Map<string, string>;
-};
-
-let catalogSnapshot: CatalogSnapshot | undefined;
 
 function readRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -143,10 +140,6 @@ export function normalizeClawRouterApiBaseUrl(baseUrl: string | undefined): stri
   return `${normalizeClawRouterRootUrl(baseUrl)}/v1`;
 }
 
-function routeKey(baseUrl: string, modelId: string): string {
-  return `${trimTrailingSlashes(baseUrl)}\0${modelId}`;
-}
-
 function supportsCapability(model: CatalogModel, ...capabilities: string[]): boolean {
   return capabilities.some((capability) => model.capabilities.includes(capability));
 }
@@ -173,7 +166,7 @@ function buildRoutedModel(
   provider: CatalogProvider,
   model: CatalogModel,
 ): RoutedModel | undefined {
-  let api: ModelDefinitionConfig["api"];
+  let api: NonNullable<ModelDefinitionConfig["api"]>;
   let baseUrl: string;
   let upstreamModel: string | undefined;
 
@@ -216,19 +209,22 @@ function buildRoutedModel(
       cost: DEFAULT_COST,
       contextWindow: DEFAULT_CONTEXT_WINDOW,
       maxTokens: DEFAULT_MAX_TOKENS,
+      params: {
+        [ROUTE_METADATA_KEY]: {
+          api,
+          baseUrl,
+          ...(upstreamModel ? { upstreamModel } : {}),
+        } satisfies RouteMetadata,
+      },
     },
-    upstreamModel,
   };
 }
 
-function updateDiscoveredModels(
+function buildDiscoveredModels(
   rootUrl: string,
   providers: CatalogProvider[],
-  apiKey: string,
 ): ModelDefinitionConfig[] {
   const models = new Map<string, ModelDefinitionConfig>();
-  const modelsByRoute = new Map<string, ModelDefinitionConfig>();
-  const nativeModelIds = new Map<string, string>();
   for (const provider of providers) {
     for (const model of provider.models) {
       const routed = buildRoutedModel(rootUrl, provider, model);
@@ -236,22 +232,8 @@ function updateDiscoveredModels(
         continue;
       }
       models.set(routed.definition.id, routed.definition);
-      const key = routeKey(routed.definition.baseUrl ?? `${rootUrl}/v1`, routed.definition.id);
-      modelsByRoute.set(key, routed.definition);
-      modelsByRoute.set(routeKey(`${rootUrl}/v1`, routed.definition.id), routed.definition);
-      if (routed.upstreamModel) {
-        nativeModelIds.set(key, routed.upstreamModel);
-      }
     }
   }
-  // Discovery owns one active provider config, so replace the whole snapshot.
-  // Keeping older credential-scoped catalogs would leak stale grants and grow forever.
-  catalogSnapshot = {
-    apiBaseUrl: `${rootUrl}/v1`,
-    authorizationHeader: `Bearer ${apiKey}`,
-    modelsByRoute,
-    nativeModelIds,
-  };
   return [...models.values()].sort((left, right) => left.id.localeCompare(right.id));
 }
 
@@ -280,44 +262,52 @@ export async function buildClawRouterProviderConfig(params: {
     baseUrl: `${rootUrl}/v1`,
     api: "openai-responses",
     apiKey: params.apiKey,
-    authHeader: true,
-    models: updateDiscoveredModels(rootUrl, providers, params.apiKey),
+    models: buildDiscoveredModels(rootUrl, providers),
   };
 }
 
-export function resolveDiscoveredClawRouterModel(params: {
-  baseUrl?: string;
-  modelId: string;
-}): ProviderRuntimeModel | undefined {
-  const apiBaseUrl = normalizeClawRouterApiBaseUrl(params.baseUrl);
-  if (catalogSnapshot?.apiBaseUrl !== apiBaseUrl) {
+function readRouteMetadata(params: ProviderRuntimeModel["params"]): RouteMetadata | undefined {
+  const row = readRecord(params?.[ROUTE_METADATA_KEY]);
+  const baseUrl = readString(row?.baseUrl);
+  const api = readString(row?.api);
+  if (
+    !baseUrl ||
+    (api !== "openai-responses" &&
+      api !== "openai-completions" &&
+      api !== "anthropic-messages" &&
+      api !== "google-generative-ai")
+  ) {
     return undefined;
   }
-  const model = catalogSnapshot.modelsByRoute.get(routeKey(apiBaseUrl, params.modelId));
-  return model ? { ...model, provider: PROVIDER_ID } : undefined;
+  return {
+    api,
+    baseUrl,
+    ...(readString(row?.upstreamModel) ? { upstreamModel: readString(row?.upstreamModel) } : {}),
+  };
+}
+
+function stripRouteMetadata(
+  params: ProviderRuntimeModel["params"],
+): ProviderRuntimeModel["params"] {
+  if (!params || !(ROUTE_METADATA_KEY in params)) {
+    return params;
+  }
+  const { [ROUTE_METADATA_KEY]: _routeMetadata, ...remaining } = params;
+  return Object.keys(remaining).length > 0 ? remaining : undefined;
 }
 
 export function normalizeClawRouterResolvedModel(
   model: ProviderRuntimeModel,
 ): ProviderRuntimeModel | undefined {
-  const discovered = catalogSnapshot?.modelsByRoute.get(routeKey(model.baseUrl, model.id));
-  if (!catalogSnapshot || !discovered) {
+  const route = readRouteMetadata(model.params);
+  if (!route) {
     return undefined;
   }
-  const discoveredBaseUrl = discovered.baseUrl ?? catalogSnapshot.apiBaseUrl;
-  const upstreamModel = catalogSnapshot.nativeModelIds.get(routeKey(discoveredBaseUrl, model.id));
   return {
     ...model,
-    api: discovered.api ?? model.api,
-    baseUrl: discoveredBaseUrl,
-    headers: {
-      ...model.headers,
-      Authorization: catalogSnapshot.authorizationHeader,
-    },
-    ...(upstreamModel && upstreamModel !== model.id ? { id: upstreamModel } : {}),
+    api: route.api,
+    baseUrl: route.baseUrl,
+    params: stripRouteMetadata(model.params),
+    ...(route.upstreamModel && route.upstreamModel !== model.id ? { id: route.upstreamModel } : {}),
   };
-}
-
-export function clearClawRouterCatalogForTests(): void {
-  catalogSnapshot = undefined;
 }

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -1,4 +1,5 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { prepareClawRouterRequestModel } from "./provider-catalog.js";
 
@@ -18,10 +19,7 @@ function withBearerAuthorization(
   return next;
 }
 
-export function wrapClawRouterProviderStream(
-  ctx: ProviderWrapStreamFnContext,
-): StreamFn | undefined {
-  const underlying = ctx.streamFn;
+function createClawRouterStreamWrapper(underlying: StreamFn | undefined): StreamFn | undefined {
   if (!underlying) {
     return undefined;
   }
@@ -39,4 +37,14 @@ export function wrapClawRouterProviderStream(
       options,
     );
   };
+}
+
+export function createClawRouterStreamFn(): StreamFn {
+  return createClawRouterStreamWrapper(streamSimple) as StreamFn;
+}
+
+export function wrapClawRouterProviderStream(
+  ctx: ProviderWrapStreamFnContext,
+): StreamFn | undefined {
+  return createClawRouterStreamWrapper(ctx.streamFn);
 }

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -24,14 +24,15 @@ function createClawRouterStreamWrapper(underlying: StreamFn | undefined): Stream
   }
   return (model, context, options) => {
     const apiKey = options?.apiKey?.trim();
+    const preparedModel = prepareClawRouterRequestModel(model);
     if (!apiKey || apiKey === ENV_API_KEY_MARKER) {
-      return underlying(model, context, options);
+      return underlying(preparedModel, context, options);
     }
     return underlying(
-      prepareClawRouterRequestModel({
-        ...model,
-        headers: withBearerAuthorization(model.headers, apiKey),
-      }),
+      {
+        ...preparedModel,
+        headers: withBearerAuthorization(preparedModel.headers, apiKey),
+      },
       context,
       options,
     );

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -1,5 +1,4 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
-import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { prepareClawRouterRequestModel } from "./provider-catalog.js";
 
@@ -37,10 +36,6 @@ function createClawRouterStreamWrapper(underlying: StreamFn | undefined): Stream
       options,
     );
   };
-}
-
-export function createClawRouterStreamFn(): StreamFn {
-  return createClawRouterStreamWrapper(streamSimple) as StreamFn;
 }
 
 export function wrapClawRouterProviderStream(

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -1,0 +1,41 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+
+const ENV_API_KEY_MARKER = "CLAWROUTER_API_KEY";
+
+function withBearerAuthorization(
+  headers: Record<string, string> | undefined,
+  apiKey: string,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (name.toLowerCase() !== "authorization") {
+      next[name] = value;
+    }
+  }
+  next.Authorization = `Bearer ${apiKey}`;
+  return next;
+}
+
+export function wrapClawRouterProviderStream(
+  ctx: ProviderWrapStreamFnContext,
+): StreamFn | undefined {
+  const underlying = ctx.streamFn;
+  if (!underlying) {
+    return undefined;
+  }
+  return (model, context, options) => {
+    const apiKey = options?.apiKey?.trim();
+    if (!apiKey || apiKey === ENV_API_KEY_MARKER) {
+      return underlying(model, context, options);
+    }
+    return underlying(
+      {
+        ...model,
+        headers: withBearerAuthorization(model.headers, apiKey),
+      },
+      context,
+      options,
+    );
+  };
+}

--- a/extensions/clawrouter/stream.ts
+++ b/extensions/clawrouter/stream.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { prepareClawRouterRequestModel } from "./provider-catalog.js";
 
 const ENV_API_KEY_MARKER = "CLAWROUTER_API_KEY";
 
@@ -30,10 +31,10 @@ export function wrapClawRouterProviderStream(
       return underlying(model, context, options);
     }
     return underlying(
-      {
+      prepareClawRouterRequestModel({
         ...model,
         headers: withBearerAuthorization(model.headers, apiKey),
-      },
+      }),
       context,
       options,
     );

--- a/extensions/clawrouter/tsconfig.json
+++ b/extensions/clawrouter/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts"],
+  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+}

--- a/extensions/clawrouter/tsconfig.json
+++ b/extensions/clawrouter/tsconfig.json
@@ -3,6 +3,14 @@
   "compilerOptions": {
     "rootDir": "."
   },
-  "include": ["./*.ts"],
-  "exclude": ["./**/*.test.ts", "./dist/**", "./node_modules/**"]
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/clawrouter:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/clickclack:
     dependencies:
       ws:

--- a/scripts/generate-plugin-inventory-doc.mjs
+++ b/scripts/generate-plugin-inventory-doc.mjs
@@ -109,6 +109,7 @@ function humanizeId(value) {
     ["byteplus", "BytePlus"],
     ["codex", "Codex"],
     ["cli", "CLI"],
+    ["clawrouter", "ClawRouter"],
     ["comfy", "ComfyUI"],
     ["dashscope", "DashScope"],
     ["deepgram", "Deepgram"],

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1198,6 +1198,7 @@ describe("runBtwSideQuestion", () => {
     expect(result).toEqual({ text: "Ollama Cloud answer." });
     const registerParams = expectRecordFields(mockArg(registerProviderStreamForModelMock, 0, 0), {
       workspaceDir: "/tmp/workspace",
+      applyProviderWrapper: true,
     });
     expectRecordFields(registerParams.model, {
       provider: "ollama",

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -719,6 +719,7 @@ export async function runBtwSideQuestion(
     agentDir: params.agentDir,
     workspaceDir,
     env: process.env,
+    applyProviderWrapper: true,
   });
   const streamFn = resolveEmbeddedAgentStreamFn({
     currentStreamFn: streamSimple,

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Model } from "../llm/types.js";
+
+const mocks = vi.hoisted(() => ({
+  ensureCustomApiRegistered: vi.fn(),
+  createTransportAwareStreamFnForModel: vi.fn(),
+  resolveProviderStreamFn: vi.fn(),
+  wrapProviderStreamFn: vi.fn(),
+}));
+
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderStreamFn: mocks.resolveProviderStreamFn,
+  wrapProviderStreamFn: mocks.wrapProviderStreamFn,
+}));
+vi.mock("./custom-api-registry.js", () => ({
+  ensureCustomApiRegistered: mocks.ensureCustomApiRegistered,
+}));
+vi.mock("./provider-transport-stream.js", () => ({
+  createTransportAwareStreamFnForModel: mocks.createTransportAwareStreamFnForModel,
+}));
+
+import { registerProviderStreamForModel } from "./provider-stream.js";
+
+const MODEL = {
+  id: "anthropic/default",
+  name: "Anthropic default",
+  api: "anthropic-messages",
+  provider: "clawrouter",
+  baseUrl: "https://clawrouter.example/v1/native/anthropic",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 32_768,
+} satisfies Model<"anthropic-messages">;
+
+describe("registerProviderStreamForModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies an opted-in provider wrapper after selecting the managed transport", () => {
+    const baseStream = vi.fn();
+    const wrappedStream = vi.fn();
+    mocks.createTransportAwareStreamFnForModel.mockReturnValue(baseStream);
+    mocks.wrapProviderStreamFn.mockReturnValue(wrappedStream);
+
+    expect(
+      registerProviderStreamForModel({
+        model: MODEL,
+        cfg: { models: {} },
+        agentDir: "/agent",
+        workspaceDir: "/workspace",
+        applyProviderWrapper: true,
+      }),
+    ).toBe(wrappedStream);
+    expect(mocks.wrapProviderStreamFn).toHaveBeenCalledWith({
+      provider: "clawrouter",
+      config: { models: {} },
+      workspaceDir: "/workspace",
+      env: undefined,
+      context: {
+        config: { models: {} },
+        agentDir: "/agent",
+        workspaceDir: "/workspace",
+        provider: "clawrouter",
+        modelId: "anthropic/default",
+        model: MODEL,
+        streamFn: baseStream,
+      },
+    });
+    expect(mocks.ensureCustomApiRegistered).toHaveBeenCalledWith(
+      "anthropic-messages",
+      wrappedStream,
+    );
+  });
+
+  it("leaves existing callers unwrapped by default", () => {
+    const baseStream = vi.fn();
+    mocks.resolveProviderStreamFn.mockReturnValue(baseStream);
+
+    expect(registerProviderStreamForModel({ model: MODEL })).toBe(baseStream);
+    expect(mocks.wrapProviderStreamFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/provider-stream.test.ts
+++ b/src/agents/provider-stream.test.ts
@@ -3,6 +3,7 @@ import type { Model } from "../llm/types.js";
 
 const mocks = vi.hoisted(() => ({
   ensureCustomApiRegistered: vi.fn(),
+  createBoundaryAwareStreamFnForModel: vi.fn(),
   createTransportAwareStreamFnForModel: vi.fn(),
   resolveProviderStreamFn: vi.fn(),
   wrapProviderStreamFn: vi.fn(),
@@ -16,6 +17,7 @@ vi.mock("./custom-api-registry.js", () => ({
   ensureCustomApiRegistered: mocks.ensureCustomApiRegistered,
 }));
 vi.mock("./provider-transport-stream.js", () => ({
+  createBoundaryAwareStreamFnForModel: mocks.createBoundaryAwareStreamFnForModel,
   createTransportAwareStreamFnForModel: mocks.createTransportAwareStreamFnForModel,
 }));
 
@@ -39,10 +41,10 @@ describe("registerProviderStreamForModel", () => {
     vi.clearAllMocks();
   });
 
-  it("applies an opted-in provider wrapper after selecting the managed transport", () => {
+  it("applies an opted-in provider wrapper after selecting the boundary transport", () => {
     const baseStream = vi.fn();
     const wrappedStream = vi.fn();
-    mocks.createTransportAwareStreamFnForModel.mockReturnValue(baseStream);
+    mocks.createBoundaryAwareStreamFnForModel.mockReturnValue(baseStream);
     mocks.wrapProviderStreamFn.mockReturnValue(wrappedStream);
 
     expect(
@@ -54,6 +56,12 @@ describe("registerProviderStreamForModel", () => {
         applyProviderWrapper: true,
       }),
     ).toBe(wrappedStream);
+    expect(mocks.createBoundaryAwareStreamFnForModel).toHaveBeenCalledWith(MODEL, {
+      cfg: { models: {} },
+      agentDir: "/agent",
+      workspaceDir: "/workspace",
+      env: undefined,
+    });
     expect(mocks.wrapProviderStreamFn).toHaveBeenCalledWith({
       provider: "clawrouter",
       config: { models: {} },

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -5,7 +5,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Api, Model } from "../llm/types.js";
-import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
+import { resolveProviderStreamFn, wrapProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
 import type { StreamFn } from "./runtime/index.js";
@@ -18,8 +18,9 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   allowRuntimePluginLoad?: boolean;
+  applyProviderWrapper?: boolean;
 }): StreamFn | undefined {
-  const streamFn =
+  const baseStreamFn =
     resolveProviderStreamFn({
       provider: params.model.provider,
       config: params.cfg,
@@ -41,9 +42,26 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
     });
-  if (!streamFn) {
+  if (!baseStreamFn) {
     return undefined;
   }
+  const streamFn = params.applyProviderWrapper
+    ? (wrapProviderStreamFn({
+        provider: params.model.provider,
+        config: params.cfg,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+        context: {
+          config: params.cfg,
+          agentDir: params.agentDir,
+          workspaceDir: params.workspaceDir,
+          provider: params.model.provider,
+          modelId: params.model.id,
+          model: params.model,
+          streamFn: baseStreamFn,
+        },
+      }) ?? baseStreamFn)
+    : baseStreamFn;
   // Register custom APIs only after a concrete stream exists, so later callers
   // can route by model.api without reloading provider runtime hooks.
   ensureCustomApiRegistered(params.model.api, streamFn);

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -7,7 +7,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Api, Model } from "../llm/types.js";
 import { resolveProviderStreamFn, wrapProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
-import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
+import {
+  createBoundaryAwareStreamFnForModel,
+  createTransportAwareStreamFnForModel,
+} from "./provider-transport-stream.js";
 import type { StreamFn } from "./runtime/index.js";
 
 /** Resolves and registers the stream function for a provider-backed model. */
@@ -20,6 +23,12 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   allowRuntimePluginLoad?: boolean;
   applyProviderWrapper?: boolean;
 }): StreamFn | undefined {
+  const transportContext = {
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  };
   const baseStreamFn =
     resolveProviderStreamFn({
       provider: params.model.provider,
@@ -36,12 +45,10 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
         model: params.model,
       },
     }) ??
-    createTransportAwareStreamFnForModel(params.model, {
-      cfg: params.cfg,
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    });
+    createTransportAwareStreamFnForModel(params.model, transportContext) ??
+    (params.applyProviderWrapper
+      ? createBoundaryAwareStreamFnForModel(params.model, transportContext)
+      : undefined);
   if (!baseStreamFn) {
     return undefined;
   }

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -433,6 +433,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "byteplus-plan",
   "cerebras",
   "chutes",
+  "clawrouter",
   "cloudflare-ai-gateway",
   "codex",
   "comfy",


### PR DESCRIPTION
## Summary

- add a bundled `clawrouter` provider backed by ClawRouter's credential-scoped live catalog
- preserve native OpenAI, Anthropic, and Gemini request semantics while routing them through one managed proxy credential
- resolve managed secret refs at discovery and request dispatch without process-global credential state
- keep public catalog model ids stable and apply upstream model routing only at the request boundary

Intentionally out of scope: silently replacing existing `openai/*`, `anthropic/*`, or other provider namespaces. Users explicitly select `clawrouter/<provider>/<model>`.

## Linked context

Related: https://github.com/openclaw/clawrouter/pull/31

Requested by a maintainer/owner as the OpenClaw integration for ClawRouter.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenClaw can discover and dispatch models through ClawRouter while ClawRouter remains the upstream credential authority.
- Real environment tested: production `https://clawrouter.openclaw.ai` on ClawRouter commit `ab73a19ca4a8564007fd54ad196e746e62ccdd8e`.
- Exact steps or command run after this patch: deployed the matching ClawRouter catalog/auth contract, then ran its mandatory authenticated deployed smoke and live OpenAI provider smoke.
- Evidence after fix: https://github.com/openclaw/clawrouter/actions/runs/27657825237
- Observed result after fix: authenticated catalog contract, deployed smoke, and live provider smoke passed. OpenClaw focused provider/runtime coverage passed locally.
- What was not tested: a full interactive OpenClaw session against the production proxy.
- Proof limitations or environment constraints: production smoke proves the live dependency and upstream path; OpenClaw request composition is covered by focused provider and runtime regression tests.

## Tests and validation

- `node_modules/.bin/vitest run extensions/clawrouter/index.test.ts extensions/clawrouter/provider-catalog.test.ts src/agents/provider-stream.test.ts src/agents/btw.test.ts` (101 passed)
- focused `oxfmt`, `oxlint`, and `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` with deployed contract context (clean)
- remote `pnpm check:changed` through Crabbox (running; draft stays open until green)

Regression coverage includes credential-scoped catalog discovery, native route selection, managed secret refs, stable model ids, request-boundary rewriting, native replay policy, direct stream wrappers, `/btw`, and runtime auth composition.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `Yes` - adds `CLAWROUTER_API_KEY` and a bundled provider.

Did security, auth, secrets, network, or tool execution behavior change? `Yes` - adds credential-scoped catalog discovery and request dispatch through ClawRouter.

Highest risk: composing runtime-managed credentials with native provider transports. Mitigation: request-boundary model rewriting, no process-global credential cache, provider wrappers on direct paths, ClawRouter edge credential stripping, and focused regression coverage.

## Current review state

Next action: wait for the authoritative Crabbox changed-gate, mark ready, then use the repo-native prepare and merge flow.

Addressed autoreview findings across native route selection, managed auth isolation, stable catalog ids, Gemini streaming requirements, direct stream paths, and runtime auth composition. The final review is clean.