### PR TITLE
fix(azure): responses model aliases route correctly

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore

--- a/src/agents/embedded-agent-runner/model.compat.ts
+++ b/src/agents/embedded-agent-runner/model.compat.ts
@@ -1,0 +1,95 @@
+import type { ModelCompatConfig, ModelMediaInputConfig } from "../../config/types.models.js";
+import { normalizeProviderId } from "../model-selection.js";
+
+export function mergeModelMediaInput(
+  base: ModelMediaInputConfig | undefined,
+  override: ModelMediaInputConfig | undefined,
+): ModelMediaInputConfig | undefined {
+  if (!base) {
+    return override;
+  }
+  if (!override) {
+    return base;
+  }
+  return {
+    ...base,
+    ...override,
+    image:
+      base.image || override.image
+        ? {
+            ...base.image,
+            ...override.image,
+          }
+        : undefined,
+  };
+}
+
+export function resolveConfiguredFallbackReasoning(params: {
+  provider: string;
+  compat?: unknown;
+  reasoning?: boolean;
+}): boolean {
+  return resolveConfiguredModelReasoning(params) ?? false;
+}
+
+export function resolveConfiguredModelReasoning(params: {
+  provider: string;
+  compat?: unknown;
+  reasoning?: boolean;
+}): boolean | undefined {
+  if (params.reasoning !== undefined) {
+    return params.reasoning;
+  }
+  return isVllmQwenThinkingCompat(params) ? true : undefined;
+}
+
+export function resolveMergedConfiguredModelReasoning(params: {
+  provider: string;
+  configuredCompat?: unknown;
+  resolvedCompat?: unknown;
+  configuredReasoning?: boolean;
+  discoveredReasoning?: boolean;
+}): boolean {
+  if (params.configuredReasoning !== undefined) {
+    return params.configuredReasoning;
+  }
+  if (isVllmQwenThinkingCompat({ provider: params.provider, compat: params.configuredCompat })) {
+    return true;
+  }
+  return (
+    resolveConfiguredModelReasoning({
+      provider: params.provider,
+      compat: params.resolvedCompat,
+      reasoning: params.discoveredReasoning,
+    }) ?? false
+  );
+}
+
+function isVllmQwenThinkingCompat(params: { provider: string; compat?: unknown }): boolean {
+  const thinkingFormat = readCompatThinkingFormat(params.compat);
+  return (
+    normalizeProviderId(params.provider) === "vllm" &&
+    (thinkingFormat === "qwen" || thinkingFormat === "qwen-chat-template")
+  );
+}
+
+function readCompatThinkingFormat(compat: unknown): string | undefined {
+  if (!compat || typeof compat !== "object" || Array.isArray(compat)) {
+    return undefined;
+  }
+  const thinkingFormat = (compat as { thinkingFormat?: unknown }).thinkingFormat;
+  return typeof thinkingFormat === "string" ? thinkingFormat : undefined;
+}
+
+export function mergeModelCompat(
+  base: ModelCompatConfig | undefined,
+  override: ModelCompatConfig | undefined,
+): ModelCompatConfig | undefined {
+  if (!base) {
+    return override;
+  }
+  if (!override) {
+    return base;
+  }
+  return { ...base, ...override };
+}

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -478,6 +478,59 @@ describe("resolveModel forward-compat errors and overrides", () => {
     );
   });
 
+  it("keeps provider-level azure deployment names on the azure owner", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            api: "azure-openai-responses",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "azure-openai-responses",
+      "customer-gpt-deployment",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "azure-openai-responses",
+      id: "customer-gpt-deployment",
+      api: "azure-openai-responses",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    });
+  });
+
+  it("rejects provider-level azure codex-only aliases through the openai owner", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            api: "azure-openai-responses",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "azure-openai-responses",
+      "gpt-5.3-codex-spark",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe(
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
+    );
+  });
+
   it("uses codex fallback even when openai provider is configured", () => {
     const cfg: OpenClawConfig = {
       models: {

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -507,6 +507,34 @@ describe("resolveModel forward-compat errors and overrides", () => {
     });
   });
 
+  it("uses retained azure alias transport defaults for provider-level deployment names", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "azure-openai-responses",
+      "customer-gpt-deployment",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "azure-openai-responses",
+      id: "customer-gpt-deployment",
+      api: "azure-openai-responses",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    });
+  });
+
   it("rejects provider-level azure codex-only aliases through the openai owner", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -478,6 +478,32 @@ describe("resolveModel forward-compat errors and overrides", () => {
     );
   });
 
+  it("keeps unconditional codex-only suppression on the openai owner when azure config has a matching model row", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            api: "azure-openai-responses",
+            models: [makeModel("gpt-5.3-codex-spark")],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "azure-openai-responses",
+      "gpt-5.3-codex-spark",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe(
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
+    );
+  });
+
   it("keeps provider-level azure deployment names on the azure owner", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -463,7 +463,7 @@ describe("resolveModel forward-compat errors and overrides", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const result = resolveModelForTest(
       "azure-openai-responses",
@@ -485,10 +485,11 @@ describe("resolveModel forward-compat errors and overrides", () => {
           "azure-openai-responses": {
             baseUrl: "https://example.openai.azure.com/openai/v1",
             api: "azure-openai-responses",
+            models: [],
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const result = resolveModelForTest(
       "azure-openai-responses",
@@ -513,10 +514,11 @@ describe("resolveModel forward-compat errors and overrides", () => {
           "azure-openai-responses": {
             baseUrl: "https://example.openai.azure.com/openai/v1",
             api: "azure-openai-responses",
+            models: [],
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const result = resolveModelForTest(
       "azure-openai-responses",

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -452,6 +452,32 @@ describe("resolveModel forward-compat errors and overrides", () => {
     );
   });
 
+  it("rejects azure openai gpt-5.3-codex-spark through the openai owner when azure config has no matching model row", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            api: "azure-openai-responses",
+            models: [makeModel("gpt-5.5")],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "azure-openai-responses",
+      "gpt-5.3-codex-spark",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe(
+      "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
+    );
+  });
+
   it("uses codex fallback even when openai provider is configured", () => {
     const cfg: OpenClawConfig = {
       models: {

--- a/src/agents/embedded-agent-runner/model.manifest-alias.ts
+++ b/src/agents/embedded-agent-runner/model.manifest-alias.ts
@@ -68,7 +68,7 @@ function hasConfiguredModelCatalogProviderEndpointSurface(params: {
   );
 }
 
-function hasManifestModelCatalogSuppression(params: {
+function hasUnconditionalManifestModelCatalogSuppression(params: {
   provider: string;
   modelId?: string;
   plugin: Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">;
@@ -82,7 +82,9 @@ function hasManifestModelCatalogSuppression(params: {
     registry: { plugins: [params.plugin] },
     providerFilter: provider,
     modelFilter: modelId,
-  }).suppressions.some((suppression) => normalizeProviderId(suppression.provider) === provider);
+  }).suppressions.some(
+    (suppression) => !suppression.when && normalizeProviderId(suppression.provider) === provider,
+  );
 }
 
 type ManifestModelCatalogAliasPlugin = Pick<
@@ -171,7 +173,7 @@ function resolveManifestModelCatalogProviderAlias(params: {
       const hasModelId = Boolean(params.modelId?.trim());
       const hasApplicableSuppression =
         hasModelId &&
-        hasManifestModelCatalogSuppression({
+        hasUnconditionalManifestModelCatalogSuppression({
           provider,
           modelId: params.modelId,
           plugin,

--- a/src/agents/embedded-agent-runner/model.manifest-alias.ts
+++ b/src/agents/embedded-agent-runner/model.manifest-alias.ts
@@ -102,6 +102,7 @@ export type ManifestModelCatalogProviderTransport = Readonly<
 >;
 
 export type ManifestModelCatalogProviderAliasMetadata = {
+  readonly ambiguous?: true;
   readonly provider: string;
   readonly transport?: ManifestModelCatalogProviderTransport;
 };
@@ -264,6 +265,7 @@ export function resolveManifestModelCatalogProviderAliasMetadata(params: {
     case "transport":
       return { provider: params.provider, transport: resolved.transport };
     case "conflict":
+      return { provider: params.provider, ambiguous: true };
     case "none":
       return { provider: params.provider };
     default: {

--- a/src/agents/embedded-agent-runner/model.manifest-alias.ts
+++ b/src/agents/embedded-agent-runner/model.manifest-alias.ts
@@ -68,6 +68,23 @@ function hasConfiguredModelCatalogProviderEndpointSurface(params: {
   );
 }
 
+function resolveConfiguredModelCatalogProviderApi(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+}): ModelCatalogAlias["api"] {
+  const provider = normalizeProviderId(params.provider);
+  const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
+  const modelId = params.modelId?.trim();
+  const model =
+    provider && modelId && Array.isArray(config?.models)
+      ? config.models.find((candidate) =>
+          staticModelIdMatches({ candidateId: candidate.id, provider, modelId }),
+        )
+      : undefined;
+  return model?.api ?? config?.api;
+}
+
 function hasUnconditionalManifestModelCatalogSuppression(params: {
   provider: string;
   modelId?: string;
@@ -213,6 +230,11 @@ function resolveManifestModelCatalogProviderAlias(params: {
           cfg: params.cfg,
         });
       const transportApi =
+        resolveConfiguredModelCatalogProviderApi({
+          provider,
+          modelId: params.modelId,
+          cfg: params.cfg,
+        }) ??
         alias.api ??
         resolveManifestAliasTargetApi({
           plugin,

--- a/src/agents/embedded-agent-runner/model.manifest-alias.ts
+++ b/src/agents/embedded-agent-runner/model.manifest-alias.ts
@@ -108,6 +108,7 @@ export type ManifestModelCatalogProviderAliasMetadata = {
 };
 
 type ManifestModelCatalogProviderAliasClaim = {
+  readonly incompleteTransport: boolean;
   readonly targetProvider: string;
   readonly retainsTransportAlias: boolean;
   readonly transport: ManifestModelCatalogProviderTransport;
@@ -116,6 +117,7 @@ type ManifestModelCatalogProviderAliasClaim = {
 type ManifestModelCatalogProviderAliasResolution =
   | { readonly kind: "none" }
   | { readonly kind: "conflict" }
+  | { readonly kind: "incomplete-transport" }
   | { readonly kind: "canonical"; readonly provider: string }
   | {
       readonly kind: "transport";
@@ -143,6 +145,30 @@ function listEligibleManifestModelCatalogAliasPlugins(params: {
       hasExplicitManifestOwnerTrust({ plugin, normalizedConfig })
     );
   });
+}
+
+function resolveManifestAliasTargetApi(params: {
+  plugin: ManifestModelCatalogAliasPlugin;
+  provider: string;
+  modelId?: string;
+}): ModelCatalogAlias["api"] {
+  const providerCatalog = Object.entries(params.plugin.modelCatalog?.providers ?? {}).find(
+    ([provider]) => normalizeProviderId(provider) === params.provider,
+  )?.[1];
+  if (!providerCatalog) {
+    return undefined;
+  }
+  const modelId = params.modelId?.trim();
+  const model = modelId
+    ? providerCatalog.models.find((candidate) =>
+        staticModelIdMatches({
+          candidateId: candidate.id,
+          provider: params.provider,
+          modelId,
+        }),
+      )
+    : undefined;
+  return model?.api ?? providerCatalog.api;
 }
 
 function resolveManifestModelCatalogProviderAlias(params: {
@@ -186,16 +212,29 @@ function resolveManifestModelCatalogProviderAlias(params: {
           modelId: params.modelId,
           cfg: params.cfg,
         });
+      const transportApi =
+        alias.api ??
+        resolveManifestAliasTargetApi({
+          plugin,
+          provider: normalizedTarget,
+          modelId: params.modelId,
+        });
+      const hasTransportOverride = hasModelCatalogAliasTransportOverride(alias);
       const retainsTransportAlias =
-        hasModelCatalogAliasTransportOverride(alias) &&
+        hasTransportOverride &&
         hasEndpointSurface &&
+        Boolean(transportApi) &&
         !hasApplicableSuppression;
       const baseUrl = alias.baseUrl?.trim();
       claims.push({
+        // A retained endpoint needs an explicit wire adapter. Otherwise the generic
+        // model fallback would silently choose OpenAI Responses for another provider.
+        incompleteTransport:
+          hasTransportOverride && hasEndpointSurface && !transportApi && !hasApplicableSuppression,
         targetProvider: normalizedTarget,
         retainsTransportAlias,
         transport: {
-          ...(alias.api ? { api: alias.api } : {}),
+          ...(transportApi ? { api: transportApi } : {}),
           ...(baseUrl ? { baseUrl } : {}),
         },
       });
@@ -210,6 +249,9 @@ function resolveManifestModelCatalogProviderAlias(params: {
   const claim = claims[0];
   if (!claim) {
     return { kind: "none" };
+  }
+  if (claim.incompleteTransport) {
+    return { kind: "incomplete-transport" };
   }
   if (claim.retainsTransportAlias) {
     return {
@@ -265,6 +307,7 @@ export function resolveManifestModelCatalogProviderAliasMetadata(params: {
     case "transport":
       return { provider: params.provider, transport: resolved.transport };
     case "conflict":
+    case "incomplete-transport":
       return { provider: params.provider, ambiguous: true };
     case "none":
       return { provider: params.provider };

--- a/src/agents/embedded-agent-runner/model.manifest-alias.ts
+++ b/src/agents/embedded-agent-runner/model.manifest-alias.ts
@@ -1,0 +1,294 @@
+import type { ModelCatalogAlias } from "@openclaw/model-catalog-core/model-catalog-types";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { ModelProviderConfig } from "../../config/types.models.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { planManifestModelCatalogSuppressions } from "../../model-catalog/manifest-planner.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
+import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+import {
+  hasExplicitManifestOwnerTrust,
+  isActivatedManifestOwner,
+  isBundledManifestOwner,
+} from "../../plugins/manifest-owner-policy.js";
+import {
+  loadPluginManifestRegistry,
+  type PluginManifestRecord,
+} from "../../plugins/manifest-registry.js";
+import { staticModelIdMatches } from "./model.static-id.js";
+
+function hasModelCatalogAliasTransportOverride(alias: ModelCatalogAlias): boolean {
+  return Boolean(alias.api?.trim() || alias.baseUrl?.trim());
+}
+
+function hasModelCatalogAliasEndpointSurface(alias: ModelCatalogAlias): boolean {
+  return Boolean(alias.baseUrl?.trim());
+}
+
+function findConfiguredModelCatalogProviderConfig(params: {
+  provider: string;
+  cfg?: OpenClawConfig;
+}): Partial<ModelProviderConfig> | undefined {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return undefined;
+  }
+  for (const [providerId, providerConfig] of Object.entries(params.cfg?.models?.providers ?? {})) {
+    if (normalizeProviderId(providerId) === provider) {
+      return providerConfig;
+    }
+  }
+  return undefined;
+}
+
+function hasConfiguredModelCatalogProviderEndpointSurface(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return false;
+  }
+  const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
+  if (config?.baseUrl?.trim()) {
+    return true;
+  }
+  const modelId = params.modelId?.trim();
+  if (!modelId || !Array.isArray(config?.models)) {
+    return false;
+  }
+  return config.models.some(
+    (model) =>
+      Boolean(model.baseUrl?.trim()) &&
+      staticModelIdMatches({
+        candidateId: model.id,
+        provider,
+        modelId,
+      }),
+  );
+}
+
+function hasManifestModelCatalogSuppression(params: {
+  provider: string;
+  modelId?: string;
+  plugin: Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  const modelId = params.modelId?.trim();
+  if (!provider || !modelId) {
+    return false;
+  }
+  return planManifestModelCatalogSuppressions({
+    registry: { plugins: [params.plugin] },
+    providerFilter: provider,
+    modelFilter: modelId,
+  }).suppressions.some((suppression) => normalizeProviderId(suppression.provider) === provider);
+}
+
+type ManifestModelCatalogAliasPlugin = Pick<
+  PluginManifestRecord,
+  | "id"
+  | "origin"
+  | "enabledByDefault"
+  | "enabledByDefaultOnPlatforms"
+  | "providers"
+  | "modelCatalog"
+>;
+
+export type ManifestModelCatalogProviderTransport = Readonly<
+  Pick<ModelCatalogAlias, "api" | "baseUrl">
+>;
+
+export type ManifestModelCatalogProviderAliasMetadata = {
+  readonly provider: string;
+  readonly transport?: ManifestModelCatalogProviderTransport;
+};
+
+type ManifestModelCatalogProviderAliasClaim = {
+  readonly targetProvider: string;
+  readonly retainsTransportAlias: boolean;
+  readonly transport: ManifestModelCatalogProviderTransport;
+};
+
+type ManifestModelCatalogProviderAliasResolution =
+  | { readonly kind: "none" }
+  | { readonly kind: "conflict" }
+  | { readonly kind: "canonical"; readonly provider: string }
+  | {
+      readonly kind: "transport";
+      readonly transport: ManifestModelCatalogProviderTransport;
+    };
+
+function listEligibleManifestModelCatalogAliasPlugins(params: {
+  cfg?: OpenClawConfig;
+  plugins: readonly ManifestModelCatalogAliasPlugin[];
+}): readonly ManifestModelCatalogAliasPlugin[] {
+  const normalizedConfig = normalizePluginsConfig(params.cfg?.plugins);
+  return params.plugins.filter((plugin) => {
+    if (
+      !isActivatedManifestOwner({
+        plugin,
+        normalizedConfig,
+        rootConfig: params.cfg,
+      })
+    ) {
+      return false;
+    }
+    return (
+      isBundledManifestOwner(plugin) ||
+      plugin.origin === "config" ||
+      hasExplicitManifestOwnerTrust({ plugin, normalizedConfig })
+    );
+  });
+}
+
+function resolveManifestModelCatalogProviderAlias(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  plugins: readonly ManifestModelCatalogAliasPlugin[];
+}): ManifestModelCatalogProviderAliasResolution {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return { kind: "none" };
+  }
+  const claims: ManifestModelCatalogProviderAliasClaim[] = [];
+  const plugins = listEligibleManifestModelCatalogAliasPlugins({
+    cfg: params.cfg,
+    plugins: params.plugins,
+  });
+  for (const plugin of plugins) {
+    for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
+      const normalizedAlias = normalizeProviderId(rawAlias);
+      const normalizedTarget = normalizeProviderId(alias.provider);
+      if (
+        normalizedAlias !== provider ||
+        !normalizedTarget ||
+        !plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
+      ) {
+        continue;
+      }
+      const hasModelId = Boolean(params.modelId?.trim());
+      const hasApplicableSuppression =
+        hasModelId &&
+        hasManifestModelCatalogSuppression({
+          provider,
+          modelId: params.modelId,
+          plugin,
+        });
+      const hasEndpointSurface =
+        hasModelCatalogAliasEndpointSurface(alias) ||
+        hasConfiguredModelCatalogProviderEndpointSurface({
+          provider,
+          modelId: params.modelId,
+          cfg: params.cfg,
+        });
+      const retainsTransportAlias =
+        hasModelCatalogAliasTransportOverride(alias) &&
+        hasEndpointSurface &&
+        !hasApplicableSuppression;
+      const baseUrl = alias.baseUrl?.trim();
+      claims.push({
+        targetProvider: normalizedTarget,
+        retainsTransportAlias,
+        transport: {
+          ...(alias.api ? { api: alias.api } : {}),
+          ...(baseUrl ? { baseUrl } : {}),
+        },
+      });
+    }
+  }
+  if (claims.length === 0) {
+    return { kind: "none" };
+  }
+  if (claims.length > 1) {
+    return { kind: "conflict" };
+  }
+  const claim = claims[0];
+  if (!claim) {
+    return { kind: "none" };
+  }
+  if (claim.retainsTransportAlias) {
+    return {
+      kind: "transport",
+      transport: claim.transport,
+    };
+  }
+  return {
+    kind: "canonical",
+    provider: claim.targetProvider,
+  };
+}
+
+export function resolveManifestModelCatalogProviderAliasMetadata(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): ManifestModelCatalogProviderAliasMetadata {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return { provider: params.provider };
+  }
+  const env = params.env ?? process.env;
+  // Gateway plugin metadata is process-stable. Reuse its lifecycle-owned snapshot
+  // so every model turn does not rediscover the same manifest alias table.
+  const currentPlugins =
+    env === process.env
+      ? getCurrentPluginMetadataSnapshot({
+          config: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env,
+          ...(params.cfg === undefined ? { requireDefaultDiscoveryContext: true } : {}),
+        })?.plugins
+      : undefined;
+  const plugins =
+    currentPlugins ??
+    loadPluginManifestRegistry({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env,
+    }).plugins;
+  const resolved = resolveManifestModelCatalogProviderAlias({
+    provider,
+    modelId: params.modelId,
+    cfg: params.cfg,
+    plugins,
+  });
+  switch (resolved.kind) {
+    case "canonical":
+      return { provider: resolved.provider };
+    case "transport":
+      return { provider: params.provider, transport: resolved.transport };
+    case "conflict":
+    case "none":
+      return { provider: params.provider };
+    default: {
+      const exhaustive: never = resolved;
+      return exhaustive;
+    }
+  }
+}
+
+/** Resolves a provider alias from plugin model-catalog metadata when the alias is unambiguous. */
+export function canonicalizeManifestModelCatalogProviderAlias(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  return resolveManifestModelCatalogProviderAliasMetadata(params).provider;
+}
+
+/** Resolves transport defaults owned by a retained manifest provider alias. */
+export function resolveManifestModelCatalogProviderTransport(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): ManifestModelCatalogProviderTransport | undefined {
+  return resolveManifestModelCatalogProviderAliasMetadata(params).transport;
+}

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -57,7 +57,7 @@ import {
   loadBundledProviderStaticCatalogContextModels,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
-  resolveManifestModelCatalogProviderTransportApi,
+  resolveManifestModelCatalogProviderTransport,
 } from "./model.static-catalog.js";
 
 function setManifestPlugins(plugins: unknown[]) {
@@ -122,6 +122,37 @@ function createMistralManifestPlugin(overrides?: {
   };
 }
 
+function setConflictingAzureAliasPlugins() {
+  manifestMocks.loadPluginManifestRegistry.mockReturnValue({
+    plugins: [
+      {
+        id: "openai",
+        origin: "bundled",
+        enabledByDefault: true,
+        providers: ["openai"],
+        modelCatalog: {
+          aliases: {
+            "azure-openai-responses": {
+              provider: "openai",
+              api: "azure-openai-responses",
+            },
+          },
+        },
+      },
+      {
+        id: "workspace-override",
+        origin: "workspace",
+        providers: ["github-copilot"],
+        modelCatalog: {
+          aliases: {
+            "azure-openai-responses": { provider: "github-copilot" },
+          },
+        },
+      },
+    ],
+  });
+}
+
 beforeEach(() => {
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReset();
   manifestMocks.listOpenClawPluginManifestMetadata.mockReset();
@@ -151,6 +182,9 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     manifestMocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
+          id: "moonshot",
+          origin: "bundled",
+          enabledByDefault: true,
           providers: ["moonshot"],
           modelCatalog: {
             aliases: {
@@ -170,6 +204,9 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
   it("reuses the current plugin metadata snapshot for repeated alias lookups", () => {
     const plugins = [
       {
+        id: "moonshot",
+        origin: "bundled",
+        enabledByDefault: true,
         providers: ["moonshot"],
         modelCatalog: {
           aliases: {
@@ -218,6 +255,9 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     manifestMocks.loadPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
+          id: "moonshot",
+          origin: "bundled",
+          enabledByDefault: true,
           providers: ["moonshot"],
           modelCatalog: {
             aliases: {
@@ -239,9 +279,11 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     });
   });
 
-  it("canonicalizes Azure aliases without endpoints and exposes retained transport metadata", () => {
+  it("canonicalizes endpoint-less aliases and retains complete transport metadata", () => {
     const plugin = {
       id: "openai",
+      origin: "bundled",
+      enabledByDefault: true,
       providers: ["openai"],
       modelCatalog: {
         providers: {
@@ -255,6 +297,11 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
           "azure-openai-responses": {
             provider: "openai",
             api: "azure-openai-responses",
+          },
+          "azure-openai-fixed-endpoint": {
+            provider: "openai",
+            api: "azure-openai-responses",
+            baseUrl: "https://manifest-alias.example.com/openai/v1",
           },
         },
         discovery: { openai: "runtime" },
@@ -270,7 +317,7 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       }),
     ).toBe("openai");
     expect(
-      resolveManifestModelCatalogProviderTransportApi({
+      resolveManifestModelCatalogProviderTransport({
         provider: "azure-openai-responses",
         modelId: "gpt-5.5",
         cfg: {
@@ -284,7 +331,87 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
           },
         },
       }),
+    ).toEqual({ api: "azure-openai-responses" });
+    expect(
+      canonicalizeManifestModelCatalogProviderAlias({
+        provider: "azure-openai-fixed-endpoint",
+        modelId: "gpt-5.5",
+        cfg: {},
+      }),
+    ).toBe("azure-openai-fixed-endpoint");
+    expect(
+      resolveManifestModelCatalogProviderTransport({
+        provider: "azure-openai-fixed-endpoint",
+        modelId: "gpt-5.5",
+        cfg: {},
+      }),
+    ).toEqual({
+      api: "azure-openai-responses",
+      baseUrl: "https://manifest-alias.example.com/openai/v1",
+    });
+  });
+
+  it("ignores inactive workspace claims that collide with a bundled transport alias", () => {
+    setConflictingAzureAliasPlugins();
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(
+      canonicalizeManifestModelCatalogProviderAlias({
+        provider: "azure-openai-responses",
+        modelId: "gpt-5.4-mini",
+        cfg,
+      }),
     ).toBe("azure-openai-responses");
+    expect(
+      resolveManifestModelCatalogProviderTransport({
+        provider: "azure-openai-responses",
+        modelId: "gpt-5.4-mini",
+        cfg,
+      }),
+    ).toEqual({ api: "azure-openai-responses" });
+  });
+
+  it("fails closed when activated plugins claim the same provider alias", () => {
+    setConflictingAzureAliasPlugins();
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            models: [],
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          "workspace-override": { enabled: true },
+        },
+      },
+    };
+
+    expect(
+      canonicalizeManifestModelCatalogProviderAlias({
+        provider: "azure-openai-responses",
+        modelId: "gpt-5.4-mini",
+        cfg,
+      }),
+    ).toBe("azure-openai-responses");
+    expect(
+      resolveManifestModelCatalogProviderTransport({
+        provider: "azure-openai-responses",
+        modelId: "gpt-5.4-mini",
+        cfg,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -374,12 +374,18 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       {
         provider: "openai-fixed-endpoint",
         modelId: "gpt-5.5",
-        cfg: {},
+        cfg: {
+          models: {
+            providers: {
+              "openai-fixed-endpoint": { api: "anthropic-messages", models: [] },
+            },
+          },
+        },
       },
       {
         provider: "openai-fixed-endpoint",
         transport: {
-          api: "openai-responses",
+          api: "anthropic-messages",
           baseUrl: "https://manifest-alias.example.com/openai/v1",
         },
       },

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -335,9 +335,8 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
             provider: "openai",
             api: "azure-openai-responses",
           },
-          "azure-openai-fixed-endpoint": {
+          "openai-fixed-endpoint": {
             provider: "openai",
-            api: "azure-openai-responses",
             baseUrl: "https://manifest-alias.example.com/openai/v1",
           },
         },
@@ -373,14 +372,14 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     );
     expectManifestAliasResolution(
       {
-        provider: "azure-openai-fixed-endpoint",
+        provider: "openai-fixed-endpoint",
         modelId: "gpt-5.5",
         cfg: {},
       },
       {
-        provider: "azure-openai-fixed-endpoint",
+        provider: "openai-fixed-endpoint",
         transport: {
-          api: "azure-openai-responses",
+          api: "openai-responses",
           baseUrl: "https://manifest-alias.example.com/openai/v1",
         },
       },

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -57,6 +57,7 @@ import {
   loadBundledProviderStaticCatalogContextModels,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
+  resolveManifestModelCatalogProviderTransportApi,
 } from "./model.static-catalog.js";
 
 function setManifestPlugins(plugins: unknown[]) {
@@ -238,7 +239,7 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     });
   });
 
-  it("canonicalizes Azure manifest aliases without configured endpoints back to OpenAI", () => {
+  it("canonicalizes Azure aliases without endpoints and exposes retained transport metadata", () => {
     const plugin = {
       id: "openai",
       providers: ["openai"],
@@ -268,6 +269,22 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
         cfg: {},
       }),
     ).toBe("openai");
+    expect(
+      resolveManifestModelCatalogProviderTransportApi({
+        provider: "azure-openai-responses",
+        modelId: "gpt-5.5",
+        cfg: {
+          models: {
+            providers: {
+              "azure-openai-responses": {
+                baseUrl: "https://example.openai.azure.com/openai/v1",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe("azure-openai-responses");
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -1,4 +1,3 @@
-// Coverage for resolving bundled static manifest model catalog rows.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const manifestMocks = vi.hoisted(() => ({
@@ -88,7 +87,6 @@ function createMistralManifestPlugin(overrides?: {
   discovery?: "static" | "refreshable" | "runtime";
   origin?: string;
 }) {
-  // Mistral fixture represents a bundled plugin with a static modelCatalog row.
   return {
     id: "mistral",
     origin: overrides?.origin ?? "bundled",
@@ -377,7 +375,11 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
         cfg: {
           models: {
             providers: {
-              "openai-fixed-endpoint": { api: "anthropic-messages", models: [] },
+              "openai-fixed-endpoint": {
+                api: "anthropic-messages",
+                baseUrl: "https://configured-alias.example.com/v1",
+                models: [],
+              },
             },
           },
         },

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -346,8 +346,6 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     expectManifestAliasResolution(
       {
         provider: "azure-openai-responses",
-        modelId: "gpt-5.5",
-        cfg: {},
       },
       { provider: "openai", transport: undefined },
     );
@@ -495,7 +493,6 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       {
         provider: "custom-openai-alias",
         modelId: "custom-model",
-        cfg: {},
       },
       {
         provider: "custom-openai-alias",

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -183,6 +183,18 @@ function setConditionalSuppressionAliasPlugin(params?: { unconditional?: boolean
   });
 }
 
+function expectManifestAliasResolution(
+  params: Parameters<typeof canonicalizeManifestModelCatalogProviderAlias>[0],
+  expected: {
+    provider: string;
+    transport: ReturnType<typeof resolveManifestModelCatalogProviderTransport>;
+  },
+  transportParams = params,
+) {
+  expect(canonicalizeManifestModelCatalogProviderAlias(params)).toBe(expected.provider);
+  expect(resolveManifestModelCatalogProviderTransport(transportParams)).toEqual(expected.transport);
+}
+
 beforeEach(() => {
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReset();
   manifestMocks.listOpenClawPluginManifestMetadata.mockReset();
@@ -339,15 +351,14 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     };
     manifestMocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [plugin] });
 
-    expect(
-      canonicalizeManifestModelCatalogProviderAlias({
+    expectManifestAliasResolution(
+      {
         provider: "azure-openai-responses",
         modelId: "gpt-5.5",
         cfg: {},
-      }),
-    ).toBe("openai");
-    expect(
-      resolveManifestModelCatalogProviderTransport({
+      },
+      { provider: "openai", transport: { api: "azure-openai-responses" } },
+      {
         provider: "azure-openai-responses",
         modelId: "gpt-5.5",
         cfg: {
@@ -360,25 +371,22 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
             },
           },
         },
-      }),
-    ).toEqual({ api: "azure-openai-responses" });
-    expect(
-      canonicalizeManifestModelCatalogProviderAlias({
+      },
+    );
+    expectManifestAliasResolution(
+      {
         provider: "azure-openai-fixed-endpoint",
         modelId: "gpt-5.5",
         cfg: {},
-      }),
-    ).toBe("azure-openai-fixed-endpoint");
-    expect(
-      resolveManifestModelCatalogProviderTransport({
+      },
+      {
         provider: "azure-openai-fixed-endpoint",
-        modelId: "gpt-5.5",
-        cfg: {},
-      }),
-    ).toEqual({
-      api: "azure-openai-responses",
-      baseUrl: "https://manifest-alias.example.com/openai/v1",
-    });
+        transport: {
+          api: "azure-openai-responses",
+          baseUrl: "https://manifest-alias.example.com/openai/v1",
+        },
+      },
+    );
   });
 
   it.each([
@@ -400,20 +408,14 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
         },
       };
 
-      expect(
-        canonicalizeManifestModelCatalogProviderAlias({
+      expectManifestAliasResolution(
+        {
           provider: "conditional-alias",
           modelId: "conditional-model",
           cfg,
-        }),
-      ).toBe("conditional-alias");
-      expect(
-        resolveManifestModelCatalogProviderTransport({
-          provider: "conditional-alias",
-          modelId: "conditional-model",
-          cfg,
-        }),
-      ).toEqual({ api: "openai-responses" });
+        },
+        { provider: "conditional-alias", transport: { api: "openai-responses" } },
+      );
     },
   );
 
@@ -431,20 +433,14 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       },
     };
 
-    expect(
-      canonicalizeManifestModelCatalogProviderAlias({
+    expectManifestAliasResolution(
+      {
         provider: "conditional-alias",
         modelId: "conditional-model",
         cfg,
-      }),
-    ).toBe("target-provider");
-    expect(
-      resolveManifestModelCatalogProviderTransport({
-        provider: "conditional-alias",
-        modelId: "conditional-model",
-        cfg,
-      }),
-    ).toBeUndefined();
+      },
+      { provider: "target-provider", transport: undefined },
+    );
   });
 
   it("ignores inactive workspace claims that collide with a bundled transport alias", () => {
@@ -460,20 +456,14 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       },
     };
 
-    expect(
-      canonicalizeManifestModelCatalogProviderAlias({
+    expectManifestAliasResolution(
+      {
         provider: "azure-openai-responses",
         modelId: "gpt-5.4-mini",
         cfg,
-      }),
-    ).toBe("azure-openai-responses");
-    expect(
-      resolveManifestModelCatalogProviderTransport({
-        provider: "azure-openai-responses",
-        modelId: "gpt-5.4-mini",
-        cfg,
-      }),
-    ).toEqual({ api: "azure-openai-responses" });
+      },
+      { provider: "azure-openai-responses", transport: { api: "azure-openai-responses" } },
+    );
   });
 
   it("accepts activated config-load-path alias owners", () => {
@@ -496,23 +486,20 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       ],
     });
 
-    expect(
-      canonicalizeManifestModelCatalogProviderAlias({
+    expectManifestAliasResolution(
+      {
         provider: "custom-openai-alias",
         modelId: "custom-model",
         cfg: {},
-      }),
-    ).toBe("custom-openai-alias");
-    expect(
-      resolveManifestModelCatalogProviderTransport({
+      },
+      {
         provider: "custom-openai-alias",
-        modelId: "custom-model",
-        cfg: {},
-      }),
-    ).toEqual({
-      api: "openai-responses",
-      baseUrl: "https://config-provider.example.com/v1",
-    });
+        transport: {
+          api: "openai-responses",
+          baseUrl: "https://config-provider.example.com/v1",
+        },
+      },
+    );
   });
 
   it("fails closed when activated plugins claim the same provider alias", () => {
@@ -533,20 +520,14 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       },
     };
 
-    expect(
-      canonicalizeManifestModelCatalogProviderAlias({
+    expectManifestAliasResolution(
+      {
         provider: "azure-openai-responses",
         modelId: "gpt-5.4-mini",
         cfg,
-      }),
-    ).toBe("azure-openai-responses");
-    expect(
-      resolveManifestModelCatalogProviderTransport({
-        provider: "azure-openai-responses",
-        modelId: "gpt-5.4-mini",
-        cfg,
-      }),
-    ).toBeUndefined();
+      },
+      { provider: "azure-openai-responses", transport: undefined },
+    );
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -153,6 +153,36 @@ function setConflictingAzureAliasPlugins() {
   });
 }
 
+function setConditionalSuppressionAliasPlugin(params?: { unconditional?: boolean }) {
+  manifestMocks.loadPluginManifestRegistry.mockReturnValue({
+    plugins: [
+      {
+        id: "conditional-provider",
+        origin: "bundled",
+        enabledByDefault: true,
+        providers: ["target-provider"],
+        modelCatalog: {
+          aliases: {
+            "conditional-alias": {
+              provider: "target-provider",
+              api: "openai-responses",
+            },
+          },
+          suppressions: [
+            {
+              provider: "conditional-alias",
+              model: "conditional-model",
+              ...(params?.unconditional
+                ? {}
+                : { when: { baseUrlHosts: ["matching.example.com"] } }),
+            },
+          ],
+        },
+      },
+    ],
+  });
+}
+
 beforeEach(() => {
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReset();
   manifestMocks.listOpenClawPluginManifestMetadata.mockReset();
@@ -349,6 +379,72 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       api: "azure-openai-responses",
       baseUrl: "https://manifest-alias.example.com/openai/v1",
     });
+  });
+
+  it.each([
+    ["matches", "https://matching.example.com/v1"],
+    ["does not match", "https://other.example.com/v1"],
+  ])(
+    "does not use a conditional suppression to rewrite alias ownership when the endpoint %s",
+    (_condition, baseUrl) => {
+      setConditionalSuppressionAliasPlugin();
+      const cfg = {
+        models: {
+          providers: {
+            "conditional-alias": {
+              baseUrl,
+              api: "openai-responses" as const,
+              models: [],
+            },
+          },
+        },
+      };
+
+      expect(
+        canonicalizeManifestModelCatalogProviderAlias({
+          provider: "conditional-alias",
+          modelId: "conditional-model",
+          cfg,
+        }),
+      ).toBe("conditional-alias");
+      expect(
+        resolveManifestModelCatalogProviderTransport({
+          provider: "conditional-alias",
+          modelId: "conditional-model",
+          cfg,
+        }),
+      ).toEqual({ api: "openai-responses" });
+    },
+  );
+
+  it("lets an unconditional suppression canonicalize a transport alias", () => {
+    setConditionalSuppressionAliasPlugin({ unconditional: true });
+    const cfg = {
+      models: {
+        providers: {
+          "conditional-alias": {
+            baseUrl: "https://matching.example.com/v1",
+            api: "openai-responses" as const,
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(
+      canonicalizeManifestModelCatalogProviderAlias({
+        provider: "conditional-alias",
+        modelId: "conditional-model",
+        cfg,
+      }),
+    ).toBe("target-provider");
+    expect(
+      resolveManifestModelCatalogProviderTransport({
+        provider: "conditional-alias",
+        modelId: "conditional-model",
+        cfg,
+      }),
+    ).toBeUndefined();
   });
 
   it("ignores inactive workspace claims that collide with a bundled transport alias", () => {

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -236,6 +236,36 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       env,
       workspaceDir: undefined,
     });
+  it("canonicalizes Azure manifest aliases without configured endpoints back to OpenAI", () => {
+    const plugin = {
+      id: "openai",
+      providers: ["openai"],
+      modelCatalog: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-responses",
+            models: [{ id: "gpt-5.5", name: "gpt-5.5" }],
+          },
+        },
+        aliases: {
+          "azure-openai-responses": {
+            provider: "openai",
+            api: "azure-openai-responses",
+          },
+        },
+        discovery: { openai: "runtime" },
+      },
+    };
+    manifestMocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [plugin] });
+
+    expect(
+      canonicalizeManifestModelCatalogProviderAlias({
+        provider: "azure-openai-responses",
+        modelId: "gpt-5.5",
+        cfg: {},
+      }),
+    ).toBe("openai");
   });
 });
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -380,6 +380,45 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     ).toEqual({ api: "azure-openai-responses" });
   });
 
+  it("accepts activated config-load-path alias owners", () => {
+    manifestMocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "config-provider",
+          origin: "config",
+          providers: ["custom-openai"],
+          modelCatalog: {
+            aliases: {
+              "custom-openai-alias": {
+                provider: "custom-openai",
+                api: "openai-responses",
+                baseUrl: "https://config-provider.example.com/v1",
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(
+      canonicalizeManifestModelCatalogProviderAlias({
+        provider: "custom-openai-alias",
+        modelId: "custom-model",
+        cfg: {},
+      }),
+    ).toBe("custom-openai-alias");
+    expect(
+      resolveManifestModelCatalogProviderTransport({
+        provider: "custom-openai-alias",
+        modelId: "custom-model",
+        cfg: {},
+      }),
+    ).toEqual({
+      api: "openai-responses",
+      baseUrl: "https://config-provider.example.com/v1",
+    });
+  });
+
   it("fails closed when activated plugins claim the same provider alias", () => {
     setConflictingAzureAliasPlugins();
     const cfg = {

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -236,6 +236,8 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
       env,
       workspaceDir: undefined,
     });
+  });
+
   it("canonicalizes Azure manifest aliases without configured endpoints back to OpenAI", () => {
     const plugin = {
       id: "openai",

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -57,6 +57,7 @@ import {
   loadBundledProviderStaticCatalogContextModels,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
+  resolveManifestModelCatalogProviderAliasMetadata,
   resolveManifestModelCatalogProviderTransport,
 } from "./model.static-catalog.js";
 
@@ -186,13 +187,14 @@ function setConditionalSuppressionAliasPlugin(params?: { unconditional?: boolean
 function expectManifestAliasResolution(
   params: Parameters<typeof canonicalizeManifestModelCatalogProviderAlias>[0],
   expected: {
+    ambiguous?: true;
     provider: string;
     transport: ReturnType<typeof resolveManifestModelCatalogProviderTransport>;
   },
-  transportParams = params,
 ) {
+  expect(resolveManifestModelCatalogProviderAliasMetadata(params)).toEqual(expected);
   expect(canonicalizeManifestModelCatalogProviderAlias(params)).toBe(expected.provider);
-  expect(resolveManifestModelCatalogProviderTransport(transportParams)).toEqual(expected.transport);
+  expect(resolveManifestModelCatalogProviderTransport(params)).toEqual(expected.transport);
 }
 
 beforeEach(() => {
@@ -357,7 +359,9 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
         modelId: "gpt-5.5",
         cfg: {},
       },
-      { provider: "openai", transport: { api: "azure-openai-responses" } },
+      { provider: "openai", transport: undefined },
+    );
+    expectManifestAliasResolution(
       {
         provider: "azure-openai-responses",
         modelId: "gpt-5.5",
@@ -372,6 +376,7 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
           },
         },
       },
+      { provider: "azure-openai-responses", transport: { api: "azure-openai-responses" } },
     );
     expectManifestAliasResolution(
       {
@@ -523,10 +528,10 @@ describe("canonicalizeManifestModelCatalogProviderAlias", () => {
     expectManifestAliasResolution(
       {
         provider: "azure-openai-responses",
-        modelId: "gpt-5.4-mini",
+        modelId: "gpt-5.3-codex-spark",
         cfg,
       },
-      { provider: "azure-openai-responses", transport: undefined },
+      { provider: "azure-openai-responses", transport: undefined, ambiguous: true },
     );
   });
 });

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -58,7 +58,6 @@ import {
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
   resolveManifestModelCatalogProviderAliasMetadata,
-  resolveManifestModelCatalogProviderTransport,
 } from "./model.static-catalog.js";
 
 function setManifestPlugins(plugins: unknown[]) {
@@ -185,16 +184,10 @@ function setConditionalSuppressionAliasPlugin(params?: { unconditional?: boolean
 }
 
 function expectManifestAliasResolution(
-  params: Parameters<typeof canonicalizeManifestModelCatalogProviderAlias>[0],
-  expected: {
-    ambiguous?: true;
-    provider: string;
-    transport: ReturnType<typeof resolveManifestModelCatalogProviderTransport>;
-  },
+  params: Parameters<typeof resolveManifestModelCatalogProviderAliasMetadata>[0],
+  expected: ReturnType<typeof resolveManifestModelCatalogProviderAliasMetadata>,
 ) {
   expect(resolveManifestModelCatalogProviderAliasMetadata(params)).toEqual(expected);
-  expect(canonicalizeManifestModelCatalogProviderAlias(params)).toBe(expected.provider);
-  expect(resolveManifestModelCatalogProviderTransport(params)).toEqual(expected.transport);
 }
 
 beforeEach(() => {

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -15,7 +15,12 @@ import {
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { listOpenClawPluginManifestMetadata } from "../../plugins/manifest-metadata-scan.js";
-import { passesManifestOwnerBasePolicy } from "../../plugins/manifest-owner-policy.js";
+import {
+  hasExplicitManifestOwnerTrust,
+  isActivatedManifestOwner,
+  isBundledManifestOwner,
+  passesManifestOwnerBasePolicy,
+} from "../../plugins/manifest-owner-policy.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { loadPluginManifest } from "../../plugins/manifest.js";
@@ -196,7 +201,7 @@ function findConfiguredModelCatalogProviderConfig(params: {
   }
   for (const [providerId, providerConfig] of Object.entries(params.cfg?.models?.providers ?? {})) {
     if (normalizeProviderId(providerId) === provider) {
-      return providerConfig as Partial<ModelProviderConfig>;
+      return providerConfig;
     }
   }
   return undefined;
@@ -290,27 +295,83 @@ function hasManifestModelCatalogSuppression(params: {
   }).suppressions.some((suppression) => normalizeProviderId(suppression.provider) === provider);
 }
 
-type ManifestModelCatalogProviderAliasResolution = {
-  canonicalProvider?: string;
-  transportApi?: ModelCatalogAlias["api"];
+type ManifestModelCatalogAliasPlugin = Pick<
+  PluginManifestRecord,
+  | "id"
+  | "origin"
+  | "enabledByDefault"
+  | "enabledByDefaultOnPlatforms"
+  | "providers"
+  | "modelCatalog"
+>;
+
+export type ManifestModelCatalogProviderTransport = Readonly<
+  Pick<ModelCatalogAlias, "api" | "baseUrl">
+>;
+
+type ManifestModelCatalogProviderAliasClaim = {
+  readonly pluginId: string;
+  readonly targetProvider: string;
+  readonly retainsTransportAlias: boolean;
+  readonly transport: ManifestModelCatalogProviderTransport;
 };
+
+type ManifestModelCatalogProviderAliasResolution =
+  | { readonly kind: "none" }
+  | { readonly kind: "conflict" }
+  | { readonly kind: "canonical"; readonly provider: string }
+  | {
+      readonly kind: "transport";
+      readonly transport: ManifestModelCatalogProviderTransport;
+    };
+
+function listEligibleManifestModelCatalogAliasPlugins(params: {
+  cfg?: OpenClawConfig;
+  plugins: readonly ManifestModelCatalogAliasPlugin[];
+}): readonly ManifestModelCatalogAliasPlugin[] {
+  const normalizedConfig = normalizePluginsConfig(params.cfg?.plugins);
+  return params.plugins.filter((plugin) => {
+    if (
+      !isActivatedManifestOwner({
+        plugin,
+        normalizedConfig,
+        rootConfig: params.cfg,
+      })
+    ) {
+      return false;
+    }
+    return (
+      isBundledManifestOwner(plugin) || hasExplicitManifestOwnerTrust({ plugin, normalizedConfig })
+    );
+  });
+}
 
 function resolveManifestModelCatalogProviderAlias(params: {
   provider: string;
   modelId?: string;
   cfg?: OpenClawConfig;
-  plugins: readonly Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">[];
+  plugins: readonly ManifestModelCatalogAliasPlugin[];
 }): ManifestModelCatalogProviderAliasResolution {
   const provider = normalizeProviderId(params.provider);
   if (!provider) {
-    return {};
+    return { kind: "none" };
   }
-  const targets = new Set<string>();
-  const transportApis = new Set<NonNullable<ModelCatalogAlias["api"]>>();
-  for (const plugin of params.plugins) {
+  const claims: ManifestModelCatalogProviderAliasClaim[] = [];
+  const plugins = listEligibleManifestModelCatalogAliasPlugins({
+    cfg: params.cfg,
+    plugins: params.plugins,
+  });
+  for (const plugin of plugins) {
     for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
       const normalizedAlias = normalizeProviderId(rawAlias);
       const normalizedTarget = normalizeProviderId(alias.provider);
+      if (
+        normalizedAlias !== provider ||
+        !normalizedTarget ||
+        !plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
+      ) {
+        continue;
+      }
       const hasModelId = Boolean(params.modelId?.trim());
       const hasEndpointSurface =
         hasModelCatalogAliasEndpointSurface(alias) ||
@@ -338,26 +399,37 @@ function resolveManifestModelCatalogProviderAlias(params: {
             modelId: params.modelId,
             plugin,
           }));
-      if (
-        normalizedAlias === provider &&
-        normalizedTarget &&
-        plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
-      ) {
-        if (retainsTransportAlias) {
-          if (alias.api) {
-            transportApis.add(alias.api);
-          }
-        } else {
-          targets.add(normalizedTarget);
-        }
-      }
+      const baseUrl = alias.baseUrl?.trim();
+      claims.push({
+        pluginId: plugin.id,
+        targetProvider: normalizedTarget,
+        retainsTransportAlias,
+        transport: {
+          ...(alias.api ? { api: alias.api } : {}),
+          ...(baseUrl ? { baseUrl } : {}),
+        },
+      });
     }
   }
-  const [canonicalProvider] = targets;
-  const [transportApi] = transportApis;
+  if (claims.length === 0) {
+    return { kind: "none" };
+  }
+  if (claims.length > 1) {
+    return { kind: "conflict" };
+  }
+  const claim = claims[0];
+  if (!claim) {
+    return { kind: "none" };
+  }
+  if (claim.retainsTransportAlias) {
+    return {
+      kind: "transport",
+      transport: claim.transport,
+    };
+  }
   return {
-    ...(targets.size === 1 && canonicalProvider ? { canonicalProvider } : {}),
-    ...(transportApis.size === 1 && transportApi ? { transportApi } : {}),
+    kind: "canonical",
+    provider: claim.targetProvider,
   };
 }
 
@@ -367,7 +439,7 @@ function resolveManifestModelCatalogProviderAliasMetadata(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): { provider: string; transportApi?: ModelCatalogAlias["api"] } {
+}): { provider: string; transport?: ManifestModelCatalogProviderTransport } {
   const provider = normalizeProviderId(params.provider);
   if (!provider) {
     return { provider: params.provider };
@@ -397,10 +469,19 @@ function resolveManifestModelCatalogProviderAliasMetadata(params: {
     cfg: params.cfg,
     plugins,
   });
-  return {
-    provider: resolved.canonicalProvider ?? params.provider,
-    ...(resolved.transportApi ? { transportApi: resolved.transportApi } : {}),
-  };
+  switch (resolved.kind) {
+    case "canonical":
+      return { provider: resolved.provider };
+    case "transport":
+      return { provider: params.provider, transport: resolved.transport };
+    case "conflict":
+    case "none":
+      return { provider: params.provider };
+    default: {
+      const exhaustive: never = resolved;
+      return exhaustive;
+    }
+  }
 }
 
 /** Resolves a provider alias from plugin model-catalog metadata when the alias is unambiguous. */
@@ -414,15 +495,15 @@ export function canonicalizeManifestModelCatalogProviderAlias(params: {
   return resolveManifestModelCatalogProviderAliasMetadata(params).provider;
 }
 
-/** Resolves the API owned by a retained manifest provider transport alias. */
-export function resolveManifestModelCatalogProviderTransportApi(params: {
+/** Resolves transport defaults owned by a retained manifest provider alias. */
+export function resolveManifestModelCatalogProviderTransport(params: {
   provider: string;
   modelId?: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): ModelCatalogAlias["api"] | undefined {
-  return resolveManifestModelCatalogProviderAliasMetadata(params).transportApi;
+}): ManifestModelCatalogProviderTransport | undefined {
+  return resolveManifestModelCatalogProviderAliasMetadata(params).transport;
 }
 
 /** Returns whether a bundled static catalog asks runtime discovery to augment its rows. */

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -241,7 +241,7 @@ function hasConfiguredModelCatalogProviderModelRow(params: {
     return false;
   }
   const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
-  return Boolean(
+  return (
     Array.isArray(config?.models) &&
     config.models.some((model) =>
       staticModelIdMatches({
@@ -249,7 +249,7 @@ function hasConfiguredModelCatalogProviderModelRow(params: {
         provider,
         modelId,
       }),
-    ),
+    )
   );
 }
 

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -182,6 +182,10 @@ function hasModelCatalogAliasTransportOverride(alias: ModelCatalogAlias): boolea
   return Boolean(alias.api?.trim() || alias.baseUrl?.trim());
 }
 
+function hasModelCatalogAliasEndpointSurface(alias: ModelCatalogAlias): boolean {
+  return Boolean(alias.baseUrl?.trim());
+}
+
 function findConfiguredModelCatalogProviderConfig(params: {
   provider: string;
   cfg?: OpenClawConfig;
@@ -198,12 +202,32 @@ function findConfiguredModelCatalogProviderConfig(params: {
   return undefined;
 }
 
-function hasConfiguredModelCatalogProviderTransportSurface(params: {
+function hasConfiguredModelCatalogProviderEndpointSurface(params: {
   provider: string;
+  modelId?: string;
   cfg?: OpenClawConfig;
 }): boolean {
-  const config = findConfiguredModelCatalogProviderConfig(params);
-  return Boolean(config?.api || config?.baseUrl?.trim());
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return false;
+  }
+  const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
+  if (config?.baseUrl?.trim()) {
+    return true;
+  }
+  const modelId = params.modelId?.trim();
+  if (!modelId || !Array.isArray(config?.models)) {
+    return false;
+  }
+  return config.models.some(
+    (model) =>
+      Boolean(model.baseUrl?.trim()) &&
+      staticModelIdMatches({
+        candidateId: model.id,
+        provider,
+        modelId,
+      }),
+  );
 }
 
 function hasConfiguredModelCatalogProviderModelRow(params: {
@@ -282,8 +306,16 @@ function resolveManifestModelCatalogProviderAlias(params: {
       const normalizedAlias = normalizeProviderId(rawAlias);
       const normalizedTarget = normalizeProviderId(alias.provider);
       const hasModelId = Boolean(params.modelId?.trim());
+      const hasEndpointSurface =
+        hasModelCatalogAliasEndpointSurface(alias) ||
+        hasConfiguredModelCatalogProviderEndpointSurface({
+          provider,
+          modelId: params.modelId,
+          cfg: params.cfg,
+        });
       const retainsTransportAlias =
         hasModelCatalogAliasTransportOverride(alias) &&
+        hasEndpointSurface &&
         (!hasModelId ||
           hasConfiguredModelCatalogProviderModelRow({
             provider,
@@ -295,12 +327,11 @@ function resolveManifestModelCatalogProviderAlias(params: {
             modelId: params.modelId,
             plugin,
           }) ||
-          (hasConfiguredModelCatalogProviderTransportSurface({ provider, cfg: params.cfg }) &&
-            !hasManifestModelCatalogSuppression({
-              provider,
-              modelId: params.modelId,
-              plugin,
-            })));
+          !hasManifestModelCatalogSuppression({
+            provider,
+            modelId: params.modelId,
+            plugin,
+          }));
       if (
         normalizedAlias === provider &&
         normalizedTarget &&

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -1,28 +1,15 @@
 /**
  * Resolves bundled static catalog rows for embedded-agent model selection.
  */
-import type {
-  ModelCatalogAlias,
-  NormalizedModelCatalogRow,
-} from "@openclaw/model-catalog-core/model-catalog-types";
+import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  planManifestModelCatalogRows,
-  planManifestModelCatalogSuppressions,
-} from "../../model-catalog/manifest-planner.js";
+import { planManifestModelCatalogRows } from "../../model-catalog/manifest-planner.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
-import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { listOpenClawPluginManifestMetadata } from "../../plugins/manifest-metadata-scan.js";
-import {
-  hasExplicitManifestOwnerTrust,
-  isActivatedManifestOwner,
-  isBundledManifestOwner,
-  passesManifestOwnerBasePolicy,
-} from "../../plugins/manifest-owner-policy.js";
+import { passesManifestOwnerBasePolicy } from "../../plugins/manifest-owner-policy.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
-import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { loadPluginManifest } from "../../plugins/manifest.js";
 import {
   normalizePluginDiscoveryResult,
@@ -36,8 +23,18 @@ import {
   resolveOwningPluginIdsForProviderRef,
 } from "../../plugins/providers.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
-import { normalizeStaticProviderModelId } from "../model-ref-shared.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
+import { staticModelIdMatches } from "./model.static-id.js";
+
+export {
+  canonicalizeManifestModelCatalogProviderAlias,
+  resolveManifestModelCatalogProviderAliasMetadata,
+  resolveManifestModelCatalogProviderTransport,
+} from "./model.manifest-alias.js";
+export type {
+  ManifestModelCatalogProviderAliasMetadata,
+  ManifestModelCatalogProviderTransport,
+} from "./model.manifest-alias.js";
 
 /**
  * Resolves bundled plugin static model-catalog rows into runtime model records.
@@ -53,22 +50,6 @@ function rowMatchesModel(params: {
     modelId: params.modelId,
     rowProvider: params.row.provider,
   });
-}
-
-function staticModelIdMatches(params: {
-  candidateId: string;
-  provider: string;
-  modelId: string;
-  rowProvider?: string;
-}): boolean {
-  const normalizedProvider = normalizeProviderId(params.provider);
-  if (params.rowProvider && normalizeProviderId(params.rowProvider) !== normalizedProvider) {
-    return false;
-  }
-  return (
-    normalizeStaticProviderModelId(normalizedProvider, params.candidateId).trim().toLowerCase() ===
-    normalizeStaticProviderModelId(normalizedProvider, params.modelId).trim().toLowerCase()
-  );
 }
 
 function normalizeStaticCatalogInput(
@@ -181,285 +162,6 @@ function listBundledStaticCatalogPlugins(params: {
       },
     ];
   });
-}
-
-function hasModelCatalogAliasTransportOverride(alias: ModelCatalogAlias): boolean {
-  return Boolean(alias.api?.trim() || alias.baseUrl?.trim());
-}
-
-function hasModelCatalogAliasEndpointSurface(alias: ModelCatalogAlias): boolean {
-  return Boolean(alias.baseUrl?.trim());
-}
-
-function findConfiguredModelCatalogProviderConfig(params: {
-  provider: string;
-  cfg?: OpenClawConfig;
-}): Partial<ModelProviderConfig> | undefined {
-  const provider = normalizeProviderId(params.provider);
-  if (!provider) {
-    return undefined;
-  }
-  for (const [providerId, providerConfig] of Object.entries(params.cfg?.models?.providers ?? {})) {
-    if (normalizeProviderId(providerId) === provider) {
-      return providerConfig;
-    }
-  }
-  return undefined;
-}
-
-function hasConfiguredModelCatalogProviderEndpointSurface(params: {
-  provider: string;
-  modelId?: string;
-  cfg?: OpenClawConfig;
-}): boolean {
-  const provider = normalizeProviderId(params.provider);
-  if (!provider) {
-    return false;
-  }
-  const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
-  if (config?.baseUrl?.trim()) {
-    return true;
-  }
-  const modelId = params.modelId?.trim();
-  if (!modelId || !Array.isArray(config?.models)) {
-    return false;
-  }
-  return config.models.some(
-    (model) =>
-      Boolean(model.baseUrl?.trim()) &&
-      staticModelIdMatches({
-        candidateId: model.id,
-        provider,
-        modelId,
-      }),
-  );
-}
-
-function hasManifestModelCatalogSuppression(params: {
-  provider: string;
-  modelId?: string;
-  plugin: Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">;
-}): boolean {
-  const provider = normalizeProviderId(params.provider);
-  const modelId = params.modelId?.trim();
-  if (!provider || !modelId) {
-    return false;
-  }
-  return planManifestModelCatalogSuppressions({
-    registry: { plugins: [params.plugin] },
-    providerFilter: provider,
-    modelFilter: modelId,
-  }).suppressions.some((suppression) => normalizeProviderId(suppression.provider) === provider);
-}
-
-type ManifestModelCatalogAliasPlugin = Pick<
-  PluginManifestRecord,
-  | "id"
-  | "origin"
-  | "enabledByDefault"
-  | "enabledByDefaultOnPlatforms"
-  | "providers"
-  | "modelCatalog"
->;
-
-export type ManifestModelCatalogProviderTransport = Readonly<
-  Pick<ModelCatalogAlias, "api" | "baseUrl">
->;
-
-export type ManifestModelCatalogProviderAliasMetadata = {
-  readonly provider: string;
-  readonly transport?: ManifestModelCatalogProviderTransport;
-};
-
-type ManifestModelCatalogProviderAliasClaim = {
-  readonly pluginId: string;
-  readonly targetProvider: string;
-  readonly retainsTransportAlias: boolean;
-  readonly transport: ManifestModelCatalogProviderTransport;
-};
-
-type ManifestModelCatalogProviderAliasResolution =
-  | { readonly kind: "none" }
-  | { readonly kind: "conflict" }
-  | { readonly kind: "canonical"; readonly provider: string }
-  | {
-      readonly kind: "transport";
-      readonly transport: ManifestModelCatalogProviderTransport;
-    };
-
-function listEligibleManifestModelCatalogAliasPlugins(params: {
-  cfg?: OpenClawConfig;
-  plugins: readonly ManifestModelCatalogAliasPlugin[];
-}): readonly ManifestModelCatalogAliasPlugin[] {
-  const normalizedConfig = normalizePluginsConfig(params.cfg?.plugins);
-  return params.plugins.filter((plugin) => {
-    if (
-      !isActivatedManifestOwner({
-        plugin,
-        normalizedConfig,
-        rootConfig: params.cfg,
-      })
-    ) {
-      return false;
-    }
-    return (
-      isBundledManifestOwner(plugin) ||
-      plugin.origin === "config" ||
-      hasExplicitManifestOwnerTrust({ plugin, normalizedConfig })
-    );
-  });
-}
-
-function resolveManifestModelCatalogProviderAlias(params: {
-  provider: string;
-  modelId?: string;
-  cfg?: OpenClawConfig;
-  plugins: readonly ManifestModelCatalogAliasPlugin[];
-}): ManifestModelCatalogProviderAliasResolution {
-  const provider = normalizeProviderId(params.provider);
-  if (!provider) {
-    return { kind: "none" };
-  }
-  const claims: ManifestModelCatalogProviderAliasClaim[] = [];
-  const plugins = listEligibleManifestModelCatalogAliasPlugins({
-    cfg: params.cfg,
-    plugins: params.plugins,
-  });
-  for (const plugin of plugins) {
-    for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
-      const normalizedAlias = normalizeProviderId(rawAlias);
-      const normalizedTarget = normalizeProviderId(alias.provider);
-      if (
-        normalizedAlias !== provider ||
-        !normalizedTarget ||
-        !plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
-      ) {
-        continue;
-      }
-      const hasModelId = Boolean(params.modelId?.trim());
-      const hasApplicableSuppression =
-        hasModelId &&
-        hasManifestModelCatalogSuppression({
-          provider,
-          modelId: params.modelId,
-          plugin,
-        });
-      const hasEndpointSurface =
-        hasModelCatalogAliasEndpointSurface(alias) ||
-        hasConfiguredModelCatalogProviderEndpointSurface({
-          provider,
-          modelId: params.modelId,
-          cfg: params.cfg,
-        });
-      const retainsTransportAlias =
-        hasModelCatalogAliasTransportOverride(alias) &&
-        hasEndpointSurface &&
-        !hasApplicableSuppression;
-      const baseUrl = alias.baseUrl?.trim();
-      claims.push({
-        pluginId: plugin.id,
-        targetProvider: normalizedTarget,
-        retainsTransportAlias,
-        transport: {
-          ...(alias.api ? { api: alias.api } : {}),
-          ...(baseUrl ? { baseUrl } : {}),
-        },
-      });
-    }
-  }
-  if (claims.length === 0) {
-    return { kind: "none" };
-  }
-  if (claims.length > 1) {
-    return { kind: "conflict" };
-  }
-  const claim = claims[0];
-  if (!claim) {
-    return { kind: "none" };
-  }
-  if (claim.retainsTransportAlias) {
-    return {
-      kind: "transport",
-      transport: claim.transport,
-    };
-  }
-  return {
-    kind: "canonical",
-    provider: claim.targetProvider,
-  };
-}
-
-export function resolveManifestModelCatalogProviderAliasMetadata(params: {
-  provider: string;
-  modelId?: string;
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): ManifestModelCatalogProviderAliasMetadata {
-  const provider = normalizeProviderId(params.provider);
-  if (!provider) {
-    return { provider: params.provider };
-  }
-  const env = params.env ?? process.env;
-  // Gateway plugin metadata is process-stable. Reuse its lifecycle-owned snapshot
-  // so every model turn does not rediscover the same manifest alias table.
-  const currentPlugins =
-    env === process.env
-      ? getCurrentPluginMetadataSnapshot({
-          config: params.cfg,
-          workspaceDir: params.workspaceDir,
-          env,
-          ...(params.cfg === undefined ? { requireDefaultDiscoveryContext: true } : {}),
-        })?.plugins
-      : undefined;
-  const plugins =
-    currentPlugins ??
-    loadPluginManifestRegistry({
-      config: params.cfg,
-      workspaceDir: params.workspaceDir,
-      env,
-    }).plugins;
-  const resolved = resolveManifestModelCatalogProviderAlias({
-    provider,
-    modelId: params.modelId,
-    cfg: params.cfg,
-    plugins,
-  });
-  switch (resolved.kind) {
-    case "canonical":
-      return { provider: resolved.provider };
-    case "transport":
-      return { provider: params.provider, transport: resolved.transport };
-    case "conflict":
-    case "none":
-      return { provider: params.provider };
-    default: {
-      const exhaustive: never = resolved;
-      return exhaustive;
-    }
-  }
-}
-
-/** Resolves a provider alias from plugin model-catalog metadata when the alias is unambiguous. */
-export function canonicalizeManifestModelCatalogProviderAlias(params: {
-  provider: string;
-  modelId?: string;
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): string {
-  return resolveManifestModelCatalogProviderAliasMetadata(params).provider;
-}
-
-/** Resolves transport defaults owned by a retained manifest provider alias. */
-export function resolveManifestModelCatalogProviderTransport(params: {
-  provider: string;
-  modelId?: string;
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): ManifestModelCatalogProviderTransport | undefined {
-  return resolveManifestModelCatalogProviderAliasMetadata(params).transport;
 }
 
 /** Returns whether a bundled static catalog asks runtime discovery to augment its rows. */

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -1,7 +1,10 @@
 /**
  * Resolves bundled static catalog rows for embedded-agent model selection.
  */
-import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
+import type {
+  ModelCatalogAlias,
+  NormalizedModelCatalogRow,
+} from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -172,6 +175,10 @@ function listBundledStaticCatalogPlugins(params: {
   });
 }
 
+function hasModelCatalogAliasTransportOverride(alias: ModelCatalogAlias): boolean {
+  return Boolean(alias.api?.trim() || alias.baseUrl?.trim());
+}
+
 function resolveManifestModelCatalogProviderAlias(params: {
   provider: string;
   plugins: readonly Pick<PluginManifestRecord, "providers" | "modelCatalog">[];
@@ -188,6 +195,7 @@ function resolveManifestModelCatalogProviderAlias(params: {
       if (
         normalizedAlias === provider &&
         normalizedTarget &&
+        !hasModelCatalogAliasTransportOverride(alias) &&
         plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
       ) {
         targets.add(normalizedTarget);

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -290,17 +290,23 @@ function hasManifestModelCatalogSuppression(params: {
   }).suppressions.some((suppression) => normalizeProviderId(suppression.provider) === provider);
 }
 
+type ManifestModelCatalogProviderAliasResolution = {
+  canonicalProvider?: string;
+  transportApi?: ModelCatalogAlias["api"];
+};
+
 function resolveManifestModelCatalogProviderAlias(params: {
   provider: string;
   modelId?: string;
   cfg?: OpenClawConfig;
   plugins: readonly Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">[];
-}): string | undefined {
+}): ManifestModelCatalogProviderAliasResolution {
   const provider = normalizeProviderId(params.provider);
   if (!provider) {
-    return undefined;
+    return {};
   }
   const targets = new Set<string>();
+  const transportApis = new Set<NonNullable<ModelCatalogAlias["api"]>>();
   for (const plugin of params.plugins) {
     for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
       const normalizedAlias = normalizeProviderId(rawAlias);
@@ -335,27 +341,36 @@ function resolveManifestModelCatalogProviderAlias(params: {
       if (
         normalizedAlias === provider &&
         normalizedTarget &&
-        !retainsTransportAlias &&
         plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
       ) {
-        targets.add(normalizedTarget);
+        if (retainsTransportAlias) {
+          if (alias.api) {
+            transportApis.add(alias.api);
+          }
+        } else {
+          targets.add(normalizedTarget);
+        }
       }
     }
   }
-  return targets.size === 1 ? [...targets][0] : undefined;
+  const [canonicalProvider] = targets;
+  const [transportApi] = transportApis;
+  return {
+    ...(targets.size === 1 && canonicalProvider ? { canonicalProvider } : {}),
+    ...(transportApis.size === 1 && transportApi ? { transportApi } : {}),
+  };
 }
 
-/** Resolves a provider alias from plugin model-catalog metadata when the alias is unambiguous. */
-export function canonicalizeManifestModelCatalogProviderAlias(params: {
+function resolveManifestModelCatalogProviderAliasMetadata(params: {
   provider: string;
   modelId?: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): string {
+}): { provider: string; transportApi?: ModelCatalogAlias["api"] } {
   const provider = normalizeProviderId(params.provider);
   if (!provider) {
-    return params.provider;
+    return { provider: params.provider };
   }
   const env = params.env ?? process.env;
   // Gateway plugin metadata is process-stable. Reuse its lifecycle-owned snapshot
@@ -376,14 +391,38 @@ export function canonicalizeManifestModelCatalogProviderAlias(params: {
       workspaceDir: params.workspaceDir,
       env,
     }).plugins;
-  return (
-    resolveManifestModelCatalogProviderAlias({
-      provider,
-      modelId: params.modelId,
-      cfg: params.cfg,
-      plugins,
-    }) ?? params.provider
-  );
+  const resolved = resolveManifestModelCatalogProviderAlias({
+    provider,
+    modelId: params.modelId,
+    cfg: params.cfg,
+    plugins,
+  });
+  return {
+    provider: resolved.canonicalProvider ?? params.provider,
+    ...(resolved.transportApi ? { transportApi: resolved.transportApi } : {}),
+  };
+}
+
+/** Resolves a provider alias from plugin model-catalog metadata when the alias is unambiguous. */
+export function canonicalizeManifestModelCatalogProviderAlias(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  return resolveManifestModelCatalogProviderAliasMetadata(params).provider;
+}
+
+/** Resolves the API owned by a retained manifest provider transport alias. */
+export function resolveManifestModelCatalogProviderTransportApi(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): ModelCatalogAlias["api"] | undefined {
+  return resolveManifestModelCatalogProviderAliasMetadata(params).transportApi;
 }
 
 /** Returns whether a bundled static catalog asks runtime discovery to augment its rows. */

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -235,49 +235,6 @@ function hasConfiguredModelCatalogProviderEndpointSurface(params: {
   );
 }
 
-function hasConfiguredModelCatalogProviderModelRow(params: {
-  provider: string;
-  modelId?: string;
-  cfg?: OpenClawConfig;
-}): boolean {
-  const provider = normalizeProviderId(params.provider);
-  const modelId = params.modelId?.trim();
-  if (!provider || !modelId) {
-    return false;
-  }
-  const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
-  return (
-    Array.isArray(config?.models) &&
-    config.models.some((model) =>
-      staticModelIdMatches({
-        candidateId: model.id,
-        provider,
-        modelId,
-      }),
-    )
-  );
-}
-
-function hasManifestModelCatalogAliasModelRow(params: {
-  provider: string;
-  modelId?: string;
-  plugin: Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">;
-}): boolean {
-  const provider = normalizeProviderId(params.provider);
-  const modelId = params.modelId?.trim();
-  if (!provider || !modelId) {
-    return false;
-  }
-  return planManifestModelCatalogRows({
-    registry: { plugins: [params.plugin] },
-    providerFilter: provider,
-  }).entries.some(
-    (entry) =>
-      normalizeProviderId(entry.provider) === provider &&
-      entry.rows.some((row) => rowMatchesModel({ row, provider, modelId })),
-  );
-}
-
 function hasManifestModelCatalogSuppression(params: {
   provider: string;
   modelId?: string;
@@ -380,6 +337,13 @@ function resolveManifestModelCatalogProviderAlias(params: {
         continue;
       }
       const hasModelId = Boolean(params.modelId?.trim());
+      const hasApplicableSuppression =
+        hasModelId &&
+        hasManifestModelCatalogSuppression({
+          provider,
+          modelId: params.modelId,
+          plugin,
+        });
       const hasEndpointSurface =
         hasModelCatalogAliasEndpointSurface(alias) ||
         hasConfiguredModelCatalogProviderEndpointSurface({
@@ -390,22 +354,7 @@ function resolveManifestModelCatalogProviderAlias(params: {
       const retainsTransportAlias =
         hasModelCatalogAliasTransportOverride(alias) &&
         hasEndpointSurface &&
-        (!hasModelId ||
-          hasConfiguredModelCatalogProviderModelRow({
-            provider,
-            modelId: params.modelId,
-            cfg: params.cfg,
-          }) ||
-          hasManifestModelCatalogAliasModelRow({
-            provider,
-            modelId: params.modelId,
-            plugin,
-          }) ||
-          !hasManifestModelCatalogSuppression({
-            provider,
-            modelId: params.modelId,
-            plugin,
-          }));
+        !hasApplicableSuppression;
       const baseUrl = alias.baseUrl?.trim();
       claims.push({
         pluginId: plugin.id,

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -179,9 +179,63 @@ function hasModelCatalogAliasTransportOverride(alias: ModelCatalogAlias): boolea
   return Boolean(alias.api?.trim() || alias.baseUrl?.trim());
 }
 
+function hasConfiguredModelCatalogProviderSurface(params: {
+  provider: string;
+  modelId?: string;
+  cfg?: OpenClawConfig;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return false;
+  }
+  for (const [providerId, providerConfig] of Object.entries(params.cfg?.models?.providers ?? {})) {
+    if (normalizeProviderId(providerId) !== provider) {
+      continue;
+    }
+    const config = providerConfig as Partial<ModelProviderConfig>;
+    const modelId = params.modelId?.trim();
+    if (!modelId) {
+      return Boolean(config.api || config.baseUrl?.trim());
+    }
+    return Boolean(
+      Array.isArray(config.models) &&
+      config.models.some((model) =>
+        staticModelIdMatches({
+          candidateId: model.id,
+          provider,
+          modelId,
+        }),
+      ),
+    );
+  }
+  return false;
+}
+
+function hasManifestModelCatalogAliasModelRow(params: {
+  provider: string;
+  modelId?: string;
+  plugin: Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  const modelId = params.modelId?.trim();
+  if (!provider || !modelId) {
+    return false;
+  }
+  return planManifestModelCatalogRows({
+    registry: { plugins: [params.plugin] },
+    providerFilter: provider,
+  }).entries.some(
+    (entry) =>
+      normalizeProviderId(entry.provider) === provider &&
+      entry.rows.some((row) => rowMatchesModel({ row, provider, modelId })),
+  );
+}
+
 function resolveManifestModelCatalogProviderAlias(params: {
   provider: string;
-  plugins: readonly Pick<PluginManifestRecord, "providers" | "modelCatalog">[];
+  modelId?: string;
+  cfg?: OpenClawConfig;
+  plugins: readonly Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">[];
 }): string | undefined {
   const provider = normalizeProviderId(params.provider);
   if (!provider) {
@@ -192,10 +246,23 @@ function resolveManifestModelCatalogProviderAlias(params: {
     for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
       const normalizedAlias = normalizeProviderId(rawAlias);
       const normalizedTarget = normalizeProviderId(alias.provider);
+      const retainsTransportAlias =
+        hasModelCatalogAliasTransportOverride(alias) &&
+        (!params.modelId?.trim() ||
+          hasConfiguredModelCatalogProviderSurface({
+            provider,
+            modelId: params.modelId,
+            cfg: params.cfg,
+          }) ||
+          hasManifestModelCatalogAliasModelRow({
+            provider,
+            modelId: params.modelId,
+            plugin,
+          }));
       if (
         normalizedAlias === provider &&
         normalizedTarget &&
-        !hasModelCatalogAliasTransportOverride(alias) &&
+        !retainsTransportAlias &&
         plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedTarget)
       ) {
         targets.add(normalizedTarget);
@@ -208,6 +275,7 @@ function resolveManifestModelCatalogProviderAlias(params: {
 /** Resolves a provider alias from plugin model-catalog metadata when the alias is unambiguous. */
 export function canonicalizeManifestModelCatalogProviderAlias(params: {
   provider: string;
+  modelId?: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -238,6 +306,8 @@ export function canonicalizeManifestModelCatalogProviderAlias(params: {
   return (
     resolveManifestModelCatalogProviderAlias({
       provider,
+      modelId: params.modelId,
+      cfg: params.cfg,
       plugins,
     }) ?? params.provider
   );

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -8,7 +8,10 @@ import type {
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { planManifestModelCatalogRows } from "../../model-catalog/manifest-planner.js";
+import {
+  planManifestModelCatalogRows,
+  planManifestModelCatalogSuppressions,
+} from "../../model-catalog/manifest-planner.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { listOpenClawPluginManifestMetadata } from "../../plugins/manifest-metadata-scan.js";
@@ -179,36 +182,51 @@ function hasModelCatalogAliasTransportOverride(alias: ModelCatalogAlias): boolea
   return Boolean(alias.api?.trim() || alias.baseUrl?.trim());
 }
 
-function hasConfiguredModelCatalogProviderSurface(params: {
+function findConfiguredModelCatalogProviderConfig(params: {
+  provider: string;
+  cfg?: OpenClawConfig;
+}): Partial<ModelProviderConfig> | undefined {
+  const provider = normalizeProviderId(params.provider);
+  if (!provider) {
+    return undefined;
+  }
+  for (const [providerId, providerConfig] of Object.entries(params.cfg?.models?.providers ?? {})) {
+    if (normalizeProviderId(providerId) === provider) {
+      return providerConfig as Partial<ModelProviderConfig>;
+    }
+  }
+  return undefined;
+}
+
+function hasConfiguredModelCatalogProviderTransportSurface(params: {
+  provider: string;
+  cfg?: OpenClawConfig;
+}): boolean {
+  const config = findConfiguredModelCatalogProviderConfig(params);
+  return Boolean(config?.api || config?.baseUrl?.trim());
+}
+
+function hasConfiguredModelCatalogProviderModelRow(params: {
   provider: string;
   modelId?: string;
   cfg?: OpenClawConfig;
 }): boolean {
   const provider = normalizeProviderId(params.provider);
-  if (!provider) {
+  const modelId = params.modelId?.trim();
+  if (!provider || !modelId) {
     return false;
   }
-  for (const [providerId, providerConfig] of Object.entries(params.cfg?.models?.providers ?? {})) {
-    if (normalizeProviderId(providerId) !== provider) {
-      continue;
-    }
-    const config = providerConfig as Partial<ModelProviderConfig>;
-    const modelId = params.modelId?.trim();
-    if (!modelId) {
-      return Boolean(config.api || config.baseUrl?.trim());
-    }
-    return Boolean(
-      Array.isArray(config.models) &&
-      config.models.some((model) =>
-        staticModelIdMatches({
-          candidateId: model.id,
-          provider,
-          modelId,
-        }),
-      ),
-    );
-  }
-  return false;
+  const config = findConfiguredModelCatalogProviderConfig({ provider, cfg: params.cfg });
+  return Boolean(
+    Array.isArray(config?.models) &&
+    config.models.some((model) =>
+      staticModelIdMatches({
+        candidateId: model.id,
+        provider,
+        modelId,
+      }),
+    ),
+  );
 }
 
 function hasManifestModelCatalogAliasModelRow(params: {
@@ -231,6 +249,23 @@ function hasManifestModelCatalogAliasModelRow(params: {
   );
 }
 
+function hasManifestModelCatalogSuppression(params: {
+  provider: string;
+  modelId?: string;
+  plugin: Pick<PluginManifestRecord, "id" | "providers" | "modelCatalog">;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  const modelId = params.modelId?.trim();
+  if (!provider || !modelId) {
+    return false;
+  }
+  return planManifestModelCatalogSuppressions({
+    registry: { plugins: [params.plugin] },
+    providerFilter: provider,
+    modelFilter: modelId,
+  }).suppressions.some((suppression) => normalizeProviderId(suppression.provider) === provider);
+}
+
 function resolveManifestModelCatalogProviderAlias(params: {
   provider: string;
   modelId?: string;
@@ -246,10 +281,11 @@ function resolveManifestModelCatalogProviderAlias(params: {
     for (const [rawAlias, alias] of Object.entries(plugin.modelCatalog?.aliases ?? {})) {
       const normalizedAlias = normalizeProviderId(rawAlias);
       const normalizedTarget = normalizeProviderId(alias.provider);
+      const hasModelId = Boolean(params.modelId?.trim());
       const retainsTransportAlias =
         hasModelCatalogAliasTransportOverride(alias) &&
-        (!params.modelId?.trim() ||
-          hasConfiguredModelCatalogProviderSurface({
+        (!hasModelId ||
+          hasConfiguredModelCatalogProviderModelRow({
             provider,
             modelId: params.modelId,
             cfg: params.cfg,
@@ -258,7 +294,13 @@ function resolveManifestModelCatalogProviderAlias(params: {
             provider,
             modelId: params.modelId,
             plugin,
-          }));
+          }) ||
+          (hasConfiguredModelCatalogProviderTransportSurface({ provider, cfg: params.cfg }) &&
+            !hasManifestModelCatalogSuppression({
+              provider,
+              modelId: params.modelId,
+              plugin,
+            })));
       if (
         normalizedAlias === provider &&
         normalizedTarget &&

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -309,6 +309,11 @@ export type ManifestModelCatalogProviderTransport = Readonly<
   Pick<ModelCatalogAlias, "api" | "baseUrl">
 >;
 
+export type ManifestModelCatalogProviderAliasMetadata = {
+  readonly provider: string;
+  readonly transport?: ManifestModelCatalogProviderTransport;
+};
+
 type ManifestModelCatalogProviderAliasClaim = {
   readonly pluginId: string;
   readonly targetProvider: string;
@@ -341,7 +346,9 @@ function listEligibleManifestModelCatalogAliasPlugins(params: {
       return false;
     }
     return (
-      isBundledManifestOwner(plugin) || hasExplicitManifestOwnerTrust({ plugin, normalizedConfig })
+      isBundledManifestOwner(plugin) ||
+      plugin.origin === "config" ||
+      hasExplicitManifestOwnerTrust({ plugin, normalizedConfig })
     );
   });
 }
@@ -433,13 +440,13 @@ function resolveManifestModelCatalogProviderAlias(params: {
   };
 }
 
-function resolveManifestModelCatalogProviderAliasMetadata(params: {
+export function resolveManifestModelCatalogProviderAliasMetadata(params: {
   provider: string;
   modelId?: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): { provider: string; transport?: ManifestModelCatalogProviderTransport } {
+}): ManifestModelCatalogProviderAliasMetadata {
   const provider = normalizeProviderId(params.provider);
   if (!provider) {
     return { provider: params.provider };

--- a/src/agents/embedded-agent-runner/model.static-id.ts
+++ b/src/agents/embedded-agent-runner/model.static-id.ts
@@ -1,0 +1,18 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeStaticProviderModelId } from "../model-ref-shared.js";
+
+export function staticModelIdMatches(params: {
+  candidateId: string;
+  provider: string;
+  modelId: string;
+  rowProvider?: string;
+}): boolean {
+  const normalizedProvider = normalizeProviderId(params.provider);
+  if (params.rowProvider && normalizeProviderId(params.rowProvider) !== normalizedProvider) {
+    return false;
+  }
+  return (
+    normalizeStaticProviderModelId(normalizedProvider, params.candidateId).trim().toLowerCase() ===
+    normalizeStaticProviderModelId(normalizedProvider, params.modelId).trim().toLowerCase()
+  );
+}

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -25,6 +25,7 @@ const resolveManifestModelCatalogProviderAliasMetadataMock = vi.hoisted(() =>
       provider: string;
       cfg?: { models?: { providers?: Record<string, { baseUrl?: string }> } };
     }) => {
+      ambiguous?: true;
       provider: string;
       transport?: { api?: "azure-openai-responses"; baseUrl?: string };
     }
@@ -3110,6 +3111,35 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect(resolveManifestModelCatalogProviderAliasMetadataMock).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["sync", "async"] as const)(
+    "rejects configured fallbacks for ambiguous manifest aliases in the $path resolver",
+    async (path) => {
+      resolveManifestModelCatalogProviderAliasMetadataMock.mockReturnValue({
+        provider: "azure-openai-responses",
+        ambiguous: true,
+      });
+      const cfg = {
+        models: {
+          providers: {
+            "azure-openai-responses": {
+              baseUrl: "https://example.openai.azure.com/openai/v1",
+              api: "azure-openai-responses" as const,
+              models: [makeModel("gpt-5.5")],
+            },
+          },
+        },
+      };
+
+      const result =
+        path === "sync"
+          ? resolveModelForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg)
+          : await resolveModelAsyncForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg);
+
+      expect(result.model).toBeUndefined();
+      expect(result.error).toBe("Unknown model: azure-openai-responses/gpt-5.5");
+    },
+  );
 
   it("does not treat arbitrary namespaced model ids as provider prefixes", () => {
     const cfg = {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2850,6 +2850,35 @@ describe("resolveModel", () => {
     });
   });
 
+  it("keeps transport-overriding manifest aliases on the requested provider", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            api: "azure-openai-responses",
+            models: [
+              {
+                ...makeModel("gpt-5.5"),
+                api: "azure-openai-responses",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "azure-openai-responses",
+      id: "gpt-5.5",
+      api: "azure-openai-responses",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    });
+  });
+
   it("does not treat arbitrary namespaced model ids as provider prefixes", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -19,12 +19,15 @@ const PLUGIN_MODEL_CATALOG_FILE = "catalog.json";
 
 const resolveBundledStaticCatalogModelMock = vi.hoisted(() => vi.fn());
 const resolveBundledProviderStaticCatalogModelMock = vi.hoisted(() => vi.fn());
-const resolveManifestModelCatalogProviderTransportMock = vi.hoisted(() =>
+const resolveManifestModelCatalogProviderAliasMetadataMock = vi.hoisted(() =>
   vi.fn<
     (params: {
       provider: string;
       cfg?: { models?: { providers?: Record<string, { baseUrl?: string }> } };
-    }) => { api?: "azure-openai-responses"; baseUrl?: string } | undefined
+    }) => {
+      provider: string;
+      transport?: { api?: "azure-openai-responses"; baseUrl?: string };
+    }
   >(),
 );
 const resolveRuntimeSyntheticAuthProviderRefsMock = vi.hoisted(() => vi.fn((): string[] => []));
@@ -149,15 +152,14 @@ vi.mock("../../plugins/synthetic-auth.runtime.js", () => ({
 }));
 
 vi.mock("./model.static-catalog.js", () => ({
-  canonicalizeManifestModelCatalogProviderAlias: ({ provider }: { provider: string }) => {
-    // Static-catalog coverage exercises alias discovery. Model resolution only needs the canonical
-    // result here; rescanning every plugin manifest made each table-like case pay I/O.
-    const normalized = provider.trim().toLowerCase();
-    return normalized === "moonshotai" || normalized === "moonshot-ai" ? "moonshot" : provider;
-  },
+  canonicalizeManifestModelCatalogProviderAlias: (params: { provider: string }) =>
+    resolveManifestModelCatalogProviderAliasMetadataMock(params).provider,
   resolveBundledProviderStaticCatalogModel: resolveBundledProviderStaticCatalogModelMock,
   resolveBundledStaticCatalogModel: resolveBundledStaticCatalogModelMock,
-  resolveManifestModelCatalogProviderTransport: resolveManifestModelCatalogProviderTransportMock,
+  resolveManifestModelCatalogProviderAliasMetadata:
+    resolveManifestModelCatalogProviderAliasMetadataMock,
+  resolveManifestModelCatalogProviderTransport: (params: { provider: string }) =>
+    resolveManifestModelCatalogProviderAliasMetadataMock(params).transport,
 }));
 
 type OpenRouterModelCapabilities = NonNullable<
@@ -208,12 +210,20 @@ beforeEach(() => {
   mockLoadOpenRouterModelCapabilities.mockResolvedValue();
   resolveBundledStaticCatalogModelMock.mockReset();
   resolveBundledProviderStaticCatalogModelMock.mockReset();
-  resolveManifestModelCatalogProviderTransportMock.mockReset();
-  resolveManifestModelCatalogProviderTransportMock.mockImplementation(({ provider, cfg }) =>
-    provider === "azure-openai-responses" && cfg?.models?.providers?.[provider]?.baseUrl
-      ? { api: "azure-openai-responses" }
-      : undefined,
-  );
+  resolveManifestModelCatalogProviderAliasMetadataMock.mockReset();
+  resolveManifestModelCatalogProviderAliasMetadataMock.mockImplementation(({ provider, cfg }) => {
+    const normalized = provider.trim().toLowerCase();
+    const canonicalProvider =
+      normalized === "moonshotai" || normalized === "moonshot-ai" ? "moonshot" : provider;
+    const transport =
+      provider === "azure-openai-responses" && cfg?.models?.providers?.[provider]?.baseUrl
+        ? { api: "azure-openai-responses" as const }
+        : undefined;
+    return {
+      provider: canonicalProvider,
+      ...(transport ? { transport } : {}),
+    };
+  });
 });
 
 function createRuntimeHooks() {
@@ -2963,9 +2973,12 @@ describe("resolveModel", () => {
         },
       },
     };
-    resolveManifestModelCatalogProviderTransportMock.mockReturnValue({
-      api: "azure-openai-responses",
-      baseUrl: "https://manifest-alias.example.com/openai/v1",
+    resolveManifestModelCatalogProviderAliasMetadataMock.mockReturnValue({
+      provider: "azure-openai-responses",
+      transport: {
+        api: "azure-openai-responses",
+        baseUrl: "https://manifest-alias.example.com/openai/v1",
+      },
     });
     const runtimeHooks = {
       ...createRuntimeHooks(),
@@ -3006,6 +3019,96 @@ describe("resolveModel", () => {
       api: "azure-openai-responses",
       baseUrl: "https://manifest-alias.example.com/openai/v1",
     });
+  });
+
+  it("keeps retained manifest alias ownership without provider config", async () => {
+    resolveManifestModelCatalogProviderAliasMetadataMock.mockReturnValue({
+      provider: "azure-openai-responses",
+      transport: {
+        api: "azure-openai-responses",
+        baseUrl: "https://manifest-alias.example.com/openai/v1",
+      },
+    });
+    const runtimeHooks = {
+      ...createRuntimeHooks(),
+      runProviderDynamicModel: vi.fn(({ provider, context }) =>
+        provider === "azure-openai-responses" && context.modelId === "gpt-5.5"
+          ? {
+              provider: "openai",
+              id: "gpt-5.5",
+              name: "gpt-5.5",
+              api: "openai-responses" as const,
+              baseUrl: "https://api.openai.com/v1",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+              contextWindow: 1_000_000,
+              maxTokens: 128_000,
+            }
+          : undefined,
+      ),
+    };
+
+    const result = await resolveModelAsyncForTest(
+      "azure-openai-responses",
+      "gpt-5.5",
+      "/tmp/agent",
+      undefined,
+      {
+        allowBundledStaticCatalogFallback: true,
+        runtimeHooks,
+        skipAgentDiscovery: true,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "azure-openai-responses",
+      id: "gpt-5.5",
+      api: "azure-openai-responses",
+      baseUrl: "https://manifest-alias.example.com/openai/v1",
+    });
+  });
+
+  it("resolves manifest alias metadata once per async model lookup", async () => {
+    resolveManifestModelCatalogProviderAliasMetadataMock.mockReturnValue({
+      provider: "azure-openai-responses",
+      transport: { api: "azure-openai-responses" },
+    });
+    const runtimeHooks = {
+      ...createRuntimeHooks(),
+      runProviderDynamicModel: vi.fn(({ provider, context }) =>
+        provider === "azure-openai-responses" && context.modelId === "gpt-5.5"
+          ? {
+              provider: "openai",
+              id: "gpt-5.5",
+              name: "gpt-5.5",
+              api: "openai-responses" as const,
+              baseUrl: "https://api.openai.com/v1",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+              contextWindow: 1_000_000,
+              maxTokens: 128_000,
+            }
+          : undefined,
+      ),
+    };
+
+    const result = await resolveModelAsyncForTest(
+      "azure-openai-responses",
+      "gpt-5.5",
+      "/tmp/agent",
+      undefined,
+      {
+        allowBundledStaticCatalogFallback: true,
+        runtimeHooks,
+        skipAgentDiscovery: true,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(resolveManifestModelCatalogProviderAliasMetadataMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not treat arbitrary namespaced model ids as provider prefixes", () => {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -19,6 +19,14 @@ const PLUGIN_MODEL_CATALOG_FILE = "catalog.json";
 
 const resolveBundledStaticCatalogModelMock = vi.hoisted(() => vi.fn());
 const resolveBundledProviderStaticCatalogModelMock = vi.hoisted(() => vi.fn());
+const resolveManifestModelCatalogProviderTransportMock = vi.hoisted(() =>
+  vi.fn<
+    (params: {
+      provider: string;
+      cfg?: { models?: { providers?: Record<string, { baseUrl?: string }> } };
+    }) => { api?: "azure-openai-responses"; baseUrl?: string } | undefined
+  >(),
+);
 const resolveRuntimeSyntheticAuthProviderRefsMock = vi.hoisted(() => vi.fn((): string[] => []));
 const resolveRuntimeExternalAuthProviderRefsMock = vi.hoisted(() => vi.fn((): string[] => []));
 
@@ -149,16 +157,7 @@ vi.mock("./model.static-catalog.js", () => ({
   },
   resolveBundledProviderStaticCatalogModel: resolveBundledProviderStaticCatalogModelMock,
   resolveBundledStaticCatalogModel: resolveBundledStaticCatalogModelMock,
-  resolveManifestModelCatalogProviderTransportApi: ({
-    provider,
-    cfg,
-  }: {
-    provider: string;
-    cfg?: { models?: { providers?: Record<string, { baseUrl?: string }> } };
-  }) =>
-    provider === "azure-openai-responses" && cfg?.models?.providers?.[provider]?.baseUrl
-      ? "azure-openai-responses"
-      : undefined,
+  resolveManifestModelCatalogProviderTransport: resolveManifestModelCatalogProviderTransportMock,
 }));
 
 type OpenRouterModelCapabilities = NonNullable<
@@ -209,6 +208,12 @@ beforeEach(() => {
   mockLoadOpenRouterModelCapabilities.mockResolvedValue();
   resolveBundledStaticCatalogModelMock.mockReset();
   resolveBundledProviderStaticCatalogModelMock.mockReset();
+  resolveManifestModelCatalogProviderTransportMock.mockReset();
+  resolveManifestModelCatalogProviderTransportMock.mockImplementation(({ provider, cfg }) =>
+    provider === "azure-openai-responses" && cfg?.models?.providers?.[provider]?.baseUrl
+      ? { api: "azure-openai-responses" }
+      : undefined,
+  );
 });
 
 function createRuntimeHooks() {
@@ -252,14 +257,19 @@ function resolveModelAsyncForTest(
   modelId: string,
   agentDir?: string,
   cfg?: OpenClawConfig,
-  options?: { retryTransientProviderRuntimeMiss?: boolean },
+  options?: {
+    allowBundledStaticCatalogFallback?: boolean;
+    retryTransientProviderRuntimeMiss?: boolean;
+    runtimeHooks?: ReturnType<typeof createRuntimeHooks>;
+    skipAgentDiscovery?: boolean;
+  },
 ) {
   const resolvedAgentDir = agentDir ?? "/tmp/agent";
   return resolveModelAsync(provider, modelId, agentDir, cfg, {
     authStorage: { mocked: true } as never,
     modelRegistry: discoverModels({ mocked: true } as never, resolvedAgentDir),
     ...options,
-    runtimeHooks: createRuntimeHooks(),
+    runtimeHooks: options?.runtimeHooks ?? createRuntimeHooks(),
   });
 }
 
@@ -2876,7 +2886,7 @@ describe("resolveModel", () => {
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    } satisfies OpenClawConfig;
 
     const result = resolveModelForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg);
 
@@ -2895,10 +2905,11 @@ describe("resolveModel", () => {
         providers: {
           "azure-openai-responses": {
             baseUrl: "https://example.openai.azure.com/openai/v1",
+            models: [],
           },
         },
       },
-    } as unknown as OpenClawConfig;
+    };
     const runtimeHooks = {
       ...createRuntimeHooks(),
       runProviderDynamicModel: vi.fn(({ provider, context }) =>
@@ -2919,13 +2930,17 @@ describe("resolveModel", () => {
       ),
     };
 
-    const result = await resolveModelAsync("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg, {
-      authStorage: { mocked: true } as never,
-      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
-      allowBundledStaticCatalogFallback: true,
-      runtimeHooks,
-      skipAgentDiscovery: true,
-    });
+    const result = await resolveModelAsyncForTest(
+      "azure-openai-responses",
+      "gpt-5.5",
+      "/tmp/agent",
+      cfg,
+      {
+        allowBundledStaticCatalogFallback: true,
+        runtimeHooks,
+        skipAgentDiscovery: true,
+      },
+    );
 
     expect(result.error).toBeUndefined();
     expectRecordFields(result.model, {
@@ -2933,6 +2948,63 @@ describe("resolveModel", () => {
       id: "gpt-5.5",
       api: "azure-openai-responses",
       baseUrl: "https://example.openai.azure.com/openai/v1",
+    });
+  });
+
+  it("uses manifest alias base URLs before discovered target endpoints", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "",
+            models: [],
+            params: { temperature: 0.2 },
+          },
+        },
+      },
+    };
+    resolveManifestModelCatalogProviderTransportMock.mockReturnValue({
+      api: "azure-openai-responses",
+      baseUrl: "https://manifest-alias.example.com/openai/v1",
+    });
+    const runtimeHooks = {
+      ...createRuntimeHooks(),
+      runProviderDynamicModel: vi.fn(({ provider, context }) =>
+        provider === "azure-openai-responses" && context.modelId === "gpt-5.5"
+          ? {
+              provider: "openai",
+              id: "gpt-5.5",
+              name: "gpt-5.5",
+              api: "openai-responses" as const,
+              baseUrl: "https://api.openai.com/v1",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+              contextWindow: 1_000_000,
+              maxTokens: 128_000,
+            }
+          : undefined,
+      ),
+    };
+
+    const result = await resolveModelAsyncForTest(
+      "azure-openai-responses",
+      "gpt-5.5",
+      "/tmp/agent",
+      cfg,
+      {
+        allowBundledStaticCatalogFallback: true,
+        runtimeHooks,
+        skipAgentDiscovery: true,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "azure-openai-responses",
+      id: "gpt-5.5",
+      api: "azure-openai-responses",
+      baseUrl: "https://manifest-alias.example.com/openai/v1",
     });
   });
 
@@ -4313,7 +4385,7 @@ describe("resolveModel", () => {
       api: "openai-responses",
       baseUrl: "https://proxy.example.com/v1",
     });
-    expectRecordFields((result.model as unknown as { headers?: Record<string, string> }).headers, {
+    expectRecordFields(result.model?.headers, {
       "X-Proxy-Auth": "token-123",
     });
   });
@@ -4371,19 +4443,32 @@ describe("resolveModel", () => {
 
   it.each([
     { modelId: "claude-sonnet-4.6", expectedApi: "anthropic-messages" },
+    { modelId: "gemini-3.1-pro-preview", expectedApi: "openai-completions" },
     { modelId: "gpt-5.4-mini", expectedApi: "openai-responses" },
   ] as const)(
     "preserves discovered $expectedApi transport for params-only github-copilot $modelId",
     ({ modelId, expectedApi }) => {
+      mockDiscoveredModel(discoverModels, {
+        provider: "github-copilot",
+        modelId,
+        templateModel: {
+          ...makeModel(modelId),
+          provider: "github-copilot",
+          api: expectedApi,
+          baseUrl: "https://api.githubcopilot.com",
+        },
+      });
       const cfg = {
         models: {
           providers: {
             "github-copilot": {
+              baseUrl: "",
+              models: [],
               params: { temperature: 0.2 },
             },
           },
         },
-      } as unknown as OpenClawConfig;
+      };
 
       const result = resolveModelForTest("github-copilot", modelId, "/tmp/agent", cfg);
 

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2879,6 +2879,54 @@ describe("resolveModel", () => {
     });
   });
 
+  it("keeps provider-level Azure transport aliases on the requested provider", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          "azure-openai-responses": {
+            baseUrl: "https://example.openai.azure.com/openai/v1",
+            api: "azure-openai-responses",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeHooks = {
+      ...createRuntimeHooks(),
+      runProviderDynamicModel: vi.fn(({ provider, context }) =>
+        provider === "azure-openai-responses" && context.modelId === "gpt-5.5"
+          ? {
+              provider: "openai",
+              id: "gpt-5.5",
+              name: "gpt-5.5",
+              api: "openai-responses" as const,
+              baseUrl: "https://api.openai.com/v1",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+              contextWindow: 1_000_000,
+              maxTokens: 128_000,
+            }
+          : undefined,
+      ),
+    };
+
+    const result = await resolveModelAsync("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg, {
+      authStorage: { mocked: true } as never,
+      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      allowBundledStaticCatalogFallback: true,
+      runtimeHooks,
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "azure-openai-responses",
+      id: "gpt-5.5",
+      api: "azure-openai-responses",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    });
+  });
+
   it("does not treat arbitrary namespaced model ids as provider prefixes", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -270,6 +270,7 @@ function resolveModelAsyncForTest(
   cfg?: OpenClawConfig,
   options?: {
     allowBundledStaticCatalogFallback?: boolean;
+    preferBundledStaticCatalogTransport?: boolean;
     retryTransientProviderRuntimeMiss?: boolean;
     runtimeHooks?: ReturnType<typeof createRuntimeHooks>;
     skipAgentDiscovery?: boolean;
@@ -2921,25 +2922,18 @@ describe("resolveModel", () => {
         },
       },
     };
-    const runtimeHooks = {
-      ...createRuntimeHooks(),
-      runProviderDynamicModel: vi.fn(({ provider, context }) =>
-        provider === "azure-openai-responses" && context.modelId === "gpt-5.5"
-          ? {
-              provider: "openai",
-              id: "gpt-5.5",
-              name: "gpt-5.5",
-              api: "openai-responses" as const,
-              baseUrl: "https://api.openai.com/v1",
-              reasoning: true,
-              input: ["text", "image"],
-              cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
-              contextWindow: 1_000_000,
-              maxTokens: 128_000,
-            }
-          : undefined,
-      ),
-    };
+    resolveBundledStaticCatalogModelMock.mockReturnValue({
+      provider: "openai",
+      id: "gpt-5.5",
+      name: "gpt-5.5",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    });
 
     const result = await resolveModelAsyncForTest(
       "azure-openai-responses",
@@ -2948,7 +2942,7 @@ describe("resolveModel", () => {
       cfg,
       {
         allowBundledStaticCatalogFallback: true,
-        runtimeHooks,
+        preferBundledStaticCatalogTransport: true,
         skipAgentDiscovery: true,
       },
     );

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -149,6 +149,16 @@ vi.mock("./model.static-catalog.js", () => ({
   },
   resolveBundledProviderStaticCatalogModel: resolveBundledProviderStaticCatalogModelMock,
   resolveBundledStaticCatalogModel: resolveBundledStaticCatalogModelMock,
+  resolveManifestModelCatalogProviderTransportApi: ({
+    provider,
+    cfg,
+  }: {
+    provider: string;
+    cfg?: { models?: { providers?: Record<string, { baseUrl?: string }> } };
+  }) =>
+    provider === "azure-openai-responses" && cfg?.models?.providers?.[provider]?.baseUrl
+      ? "azure-openai-responses"
+      : undefined,
 }));
 
 type OpenRouterModelCapabilities = NonNullable<
@@ -4358,6 +4368,34 @@ describe("resolveModel", () => {
       api: "anthropic-messages",
     });
   });
+
+  it.each([
+    { modelId: "claude-sonnet-4.6", expectedApi: "anthropic-messages" },
+    { modelId: "gpt-5.4-mini", expectedApi: "openai-responses" },
+  ] as const)(
+    "preserves discovered $expectedApi transport for params-only github-copilot $modelId",
+    ({ modelId, expectedApi }) => {
+      const cfg = {
+        models: {
+          providers: {
+            "github-copilot": {
+              params: { temperature: 0.2 },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveModelForTest("github-copilot", modelId, "/tmp/agent", cfg);
+
+      expect(result.error).toBeUndefined();
+      expectRecordFields(result.model, {
+        provider: "github-copilot",
+        id: modelId,
+        api: expectedApi,
+        params: { temperature: 0.2 },
+      });
+    },
+  );
 
   it("builds an openai fallback for gpt-5.5 when the live catalog cache is cold", () => {
     const result = resolveModelForTest("openai", "gpt-5.5", "/tmp/agent");

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2879,13 +2879,12 @@ describe("resolveModel", () => {
     });
   });
 
-  it("keeps provider-level Azure transport aliases on the requested provider", async () => {
+  it("infers provider-level Azure transport aliases from the configured endpoint", async () => {
     const cfg = {
       models: {
         providers: {
           "azure-openai-responses": {
             baseUrl: "https://example.openai.azure.com/openai/v1",
-            api: "azure-openai-responses",
           },
         },
       },

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -3113,8 +3113,8 @@ describe("resolveModel", () => {
   });
 
   it.each(["sync", "async"] as const)(
-    "rejects configured fallbacks for ambiguous manifest aliases in the $path resolver",
-    async (path) => {
+    "rejects configured fallbacks for ambiguous manifest aliases in the $resolver resolver",
+    async (resolver) => {
       resolveManifestModelCatalogProviderAliasMetadataMock.mockReturnValue({
         provider: "azure-openai-responses",
         ambiguous: true,
@@ -3132,7 +3132,7 @@ describe("resolveModel", () => {
       };
 
       const result =
-        path === "sync"
+        resolver === "sync"
           ? resolveModelForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg)
           : await resolveModelAsyncForTest("azure-openai-responses", "gpt-5.5", "/tmp/agent", cfg);
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -756,6 +756,7 @@ function applyConfiguredProviderOverrides(params: {
       providerDefaultApi)
     : (metadataOverrideModel?.api ??
       providerConfig.api ??
+      normalizeResolvedTransportApi(params.provider) ??
       discoveredModel.api ??
       configuredStaticCatalogModel?.api ??
       providerDefaultApi);

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1512,6 +1512,7 @@ function normalizeProviderModelRef(params: {
 }): { provider: string; model: string } {
   const provider = canonicalizeManifestModelCatalogProviderAlias({
     provider: params.provider,
+    modelId: params.modelId,
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
   });

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1507,6 +1507,11 @@ function resolveModelWithPreparedRegistry(
     manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   },
 ): Model | undefined {
+  // Competing activated owners leave credentials and transport authority unresolved.
+  // Refuse the route before configured fallbacks can accidentally select either owner.
+  if (params.manifestAlias.ambiguous) {
+    return undefined;
+  }
   const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
   const explicitModel = resolveExplicitModelWithRegistry(params);
   if (explicitModel?.kind === "suppressed") {
@@ -1678,6 +1683,20 @@ export async function resolveModelAsync(
       ...(workspaceDir ? { workspaceDir } : {}),
     });
   const runtimeHooks = resolveRuntimeHooks(options);
+  if (normalizedRef.manifestAlias.ambiguous) {
+    return {
+      error: buildUnknownModelError({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        cfg,
+        agentDir: resolvedAgentDir,
+        workspaceDir,
+        runtimeHooks,
+      }),
+      authStorage,
+      modelRegistry,
+    };
+  }
   const explicitModel = resolveExplicitModelWithRegistry({
     provider: normalizedRef.provider,
     modelId: normalizedRef.model,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -60,6 +60,7 @@ import {
   canonicalizeManifestModelCatalogProviderAlias,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
+  resolveManifestModelCatalogProviderTransportApi,
 } from "./model.static-catalog.js";
 
 type ProviderRuntimeHooks = {
@@ -756,7 +757,12 @@ function applyConfiguredProviderOverrides(params: {
       providerDefaultApi)
     : (metadataOverrideModel?.api ??
       providerConfig.api ??
-      normalizeResolvedTransportApi(params.provider) ??
+      resolveManifestModelCatalogProviderTransportApi({
+        provider: params.provider,
+        modelId,
+        cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
+      }) ??
       discoveredModel.api ??
       configuredStaticCatalogModel?.api ??
       providerDefaultApi);

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -57,10 +57,10 @@ import {
 } from "./model.inline-provider.js";
 import { normalizeResolvedProviderModel } from "./model.provider-normalization.js";
 import {
-  canonicalizeManifestModelCatalogProviderAlias,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
-  resolveManifestModelCatalogProviderTransport,
+  resolveManifestModelCatalogProviderAliasMetadata,
+  type ManifestModelCatalogProviderAliasMetadata,
 } from "./model.static-catalog.js";
 
 type ProviderRuntimeHooks = {
@@ -621,18 +621,14 @@ function applyConfiguredProviderOverrides(params: {
   providerConfig?: InlineProviderConfig;
   modelId: string;
   cfg?: OpenClawConfig;
+  manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   runtimeHooks?: ProviderRuntimeHooks;
   preferDiscoveredModelMetadata?: boolean;
   preferDiscoveredTransport?: boolean;
   workspaceDir?: string;
 }): ProviderRuntimeModel {
   const { discoveredModel, providerConfig, modelId } = params;
-  const manifestAliasTransport = resolveManifestModelCatalogProviderTransport({
-    provider: params.provider,
-    modelId,
-    cfg: params.cfg,
-    workspaceDir: params.workspaceDir,
-  });
+  const manifestAliasTransport = params.manifestAlias.transport;
   const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
   const defaultModelParams = findConfiguredAgentModelParams({
     cfg: params.cfg,
@@ -671,6 +667,7 @@ function applyConfiguredProviderOverrides(params: {
       ...discoveredModel,
       ...(manifestAliasTransport
         ? {
+            provider: params.provider,
             api: requestConfig.api ?? discoveredModel.api,
             baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
           }
@@ -929,6 +926,7 @@ function resolveExplicitModelWithRegistry(params: {
   modelRegistry: CoreModelRegistry;
   cfg?: OpenClawConfig;
   agentDir?: string;
+  manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
 }): ExplicitModelResolution | undefined {
@@ -982,6 +980,7 @@ function resolveExplicitModelWithRegistry(params: {
           providerConfig,
           modelId,
           cfg,
+          manifestAlias: params.manifestAlias,
           runtimeHooks,
           workspaceDir,
           preferDiscoveredTransport: true,
@@ -1039,6 +1038,7 @@ function resolveExplicitModelWithRegistry(params: {
           providerConfig,
           modelId,
           cfg,
+          manifestAlias: params.manifestAlias,
           runtimeHooks,
           workspaceDir,
         }),
@@ -1168,6 +1168,7 @@ function resolvePluginDynamicModelWithRegistry(params: {
   cfg?: OpenClawConfig;
   agentDir?: string;
   agentRuntimeId?: string;
+  manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   workspaceDir?: string;
   authProfileId?: string;
   authProfileMode?: AuthProfileCredential["type"] | "aws-sdk";
@@ -1226,6 +1227,7 @@ function resolvePluginDynamicModelWithRegistry(params: {
     providerConfig,
     modelId,
     cfg,
+    manifestAlias: params.manifestAlias,
     runtimeHooks,
     workspaceDir,
     preferDiscoveredModelMetadata,
@@ -1247,6 +1249,7 @@ function resolveRuntimePreferredSuppressedModel(params: {
   cfg?: OpenClawConfig;
   agentDir?: string;
   agentRuntimeId?: string;
+  manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   workspaceDir?: string;
   authProfileId?: string;
   authProfileMode?: AuthProfileCredential["type"] | "aws-sdk";
@@ -1286,6 +1289,7 @@ function resolveConfiguredFallbackModel(params: {
   modelId: string;
   cfg?: OpenClawConfig;
   agentDir?: string;
+  manifestAlias: ManifestModelCatalogProviderAliasMetadata;
   workspaceDir?: string;
   runtimeHooks?: ProviderRuntimeHooks;
 }): Model | undefined {
@@ -1330,6 +1334,8 @@ function resolveConfiguredFallbackModel(params: {
   const providerConfiguredApi = normalizeResolvedTransportApi(providerConfig?.api);
   const configuredModelBaseUrl = normalizeTransportBaseUrl(configuredModel?.baseUrl);
   const providerConfiguredBaseUrl = normalizeTransportBaseUrl(providerConfig?.baseUrl);
+  const manifestAliasTransport = params.manifestAlias.transport;
+  const manifestAliasBaseUrl = normalizeTransportBaseUrl(manifestAliasTransport?.baseUrl);
   const staticCatalogBaseUrl = normalizeTransportBaseUrl(staticCatalogModel?.baseUrl);
   const fallbackTransport = resolveProviderTransport({
     provider,
@@ -1337,6 +1343,7 @@ function resolveConfiguredFallbackModel(params: {
     api:
       normalizeResolvedTransportApi(configuredModel?.api) ??
       providerConfiguredApi ??
+      manifestAliasTransport?.api ??
       normalizeResolvedTransportApi(staticCatalogModel?.api) ??
       resolveConfiguredProviderDefaultApi({
         provider,
@@ -1346,7 +1353,11 @@ function resolveConfiguredFallbackModel(params: {
         runtimeHooks,
       }) ??
       "openai-responses",
-    baseUrl: configuredModelBaseUrl ?? providerConfiguredBaseUrl ?? staticCatalogBaseUrl,
+    baseUrl:
+      configuredModelBaseUrl ??
+      providerConfiguredBaseUrl ??
+      manifestAliasBaseUrl ??
+      staticCatalogBaseUrl,
     cfg,
     workspaceDir,
     runtimeHooks,
@@ -1541,20 +1552,28 @@ function normalizeProviderModelRef(params: {
   modelId: string;
   cfg?: OpenClawConfig;
   workspaceDir?: string;
-}): { provider: string; model: string } {
-  const provider = canonicalizeManifestModelCatalogProviderAlias({
+}): {
+  provider: string;
+  model: string;
+  manifestAlias: ManifestModelCatalogProviderAliasMetadata;
+} {
+  const manifestAlias = resolveManifestModelCatalogProviderAliasMetadata({
     provider: params.provider,
     modelId: params.modelId,
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
   });
   return {
-    provider,
-    model: normalizeStaticProviderModelId(normalizeProviderId(provider), params.modelId),
+    provider: manifestAlias.provider,
+    model: normalizeStaticProviderModelId(
+      normalizeProviderId(manifestAlias.provider),
+      params.modelId,
+    ),
+    manifestAlias,
   };
 }
 
-export function resolveModelWithRegistry(params: {
+type ResolveModelWithRegistryParams = {
   provider: string;
   modelId: string;
   modelRegistry: CoreModelRegistry;
@@ -1567,53 +1586,62 @@ export function resolveModelWithRegistry(params: {
   preferredProfile?: string;
   runtimeHooks?: ProviderRuntimeHooks;
   skipConfiguredFallback?: boolean;
-}): Model | undefined {
-  const workspaceDir = params.workspaceDir ?? params.cfg?.agents?.defaults?.workspace;
-  const normalizedRef = normalizeProviderModelRef({ ...params, workspaceDir });
-  const normalizedParams = {
-    ...params,
-    provider: normalizedRef.provider,
-    modelId: normalizedRef.model,
-  };
+};
+
+function resolveModelWithPreparedRegistry(
+  params: ResolveModelWithRegistryParams & {
+    manifestAlias: ManifestModelCatalogProviderAliasMetadata;
+  },
+): Model | undefined {
   const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
-  const scopedParams = {
-    ...normalizedParams,
-    ...(workspaceDir !== undefined ? { workspaceDir } : {}),
-  };
-  const explicitModel = resolveExplicitModelWithRegistry(scopedParams);
+  const explicitModel = resolveExplicitModelWithRegistry(params);
   if (explicitModel?.kind === "suppressed") {
-    return resolveRuntimePreferredSuppressedModel(scopedParams);
+    return resolveRuntimePreferredSuppressedModel(params);
   }
   if (explicitModel?.kind === "resolved") {
     if (
       !shouldCompareProviderRuntimeResolvedModel({
-        provider: scopedParams.provider,
-        modelId: scopedParams.modelId,
-        cfg: scopedParams.cfg,
-        agentDir: scopedParams.agentDir,
-        workspaceDir,
+        provider: params.provider,
+        modelId: params.modelId,
+        cfg: params.cfg,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
         runtimeHooks,
       })
     ) {
       return explicitModel.model;
     }
     return (
-      resolvePluginDynamicModelWithRegistry(scopedParams) ??
+      resolvePluginDynamicModelWithRegistry(params) ??
       (shouldDropRuntimePreferredExplicitMiss({
-        provider: scopedParams.provider,
-        modelId: scopedParams.modelId,
+        provider: params.provider,
+        modelId: params.modelId,
         explicitModel,
       })
         ? undefined
         : explicitModel.model)
     );
   }
-  const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(scopedParams);
+  const pluginDynamicModel = resolvePluginDynamicModelWithRegistry(params);
   if (pluginDynamicModel) {
     return pluginDynamicModel;
   }
 
-  return params.skipConfiguredFallback ? undefined : resolveConfiguredFallbackModel(scopedParams);
+  return params.skipConfiguredFallback ? undefined : resolveConfiguredFallbackModel(params);
+}
+
+export function resolveModelWithRegistry(
+  params: ResolveModelWithRegistryParams,
+): Model | undefined {
+  const workspaceDir = params.workspaceDir ?? params.cfg?.agents?.defaults?.workspace;
+  const normalizedRef = normalizeProviderModelRef({ ...params, workspaceDir });
+  return resolveModelWithPreparedRegistry({
+    ...params,
+    provider: normalizedRef.provider,
+    modelId: normalizedRef.model,
+    manifestAlias: normalizedRef.manifestAlias,
+    ...(workspaceDir !== undefined ? { workspaceDir } : {}),
+  });
 }
 
 export function resolveModel(
@@ -1654,12 +1682,13 @@ export function resolveModel(
       ...(workspaceDir ? { workspaceDir } : {}),
     });
   const runtimeHooks = resolveRuntimeHooks(options);
-  const model = resolveModelWithRegistry({
+  const model = resolveModelWithPreparedRegistry({
     provider: normalizedRef.provider,
     modelId: normalizedRef.model,
     modelRegistry,
     cfg,
     agentDir: resolvedAgentDir,
+    manifestAlias: normalizedRef.manifestAlias,
     workspaceDir,
     authProfileId: options?.authProfileId,
     authProfileMode: options?.authProfileMode,
@@ -1741,6 +1770,7 @@ export async function resolveModelAsync(
     modelRegistry,
     cfg,
     agentDir: resolvedAgentDir,
+    manifestAlias: normalizedRef.manifestAlias,
     workspaceDir,
     runtimeHooks,
   });
@@ -1752,6 +1782,7 @@ export async function resolveModelAsync(
       cfg,
       agentDir: resolvedAgentDir,
       ...(options?.agentRuntimeId ? { agentRuntimeId: options.agentRuntimeId } : {}),
+      manifestAlias: normalizedRef.manifestAlias,
       workspaceDir,
       authProfileId: options?.authProfileId,
       authProfileMode: options?.authProfileMode,
@@ -1819,6 +1850,7 @@ export async function resolveModelAsync(
       providerConfig,
       modelId: normalizedRef.model,
       cfg,
+      manifestAlias: normalizedRef.manifestAlias,
       runtimeHooks,
       workspaceDir,
       preferDiscoveredModelMetadata: true,
@@ -1850,13 +1882,14 @@ export async function resolveModelAsync(
         ...authProfile,
       },
     });
-    return resolveModelWithRegistry({
+    return resolveModelWithPreparedRegistry({
       provider: normalizedRef.provider,
       modelId: normalizedRef.model,
       modelRegistry,
       cfg,
       agentDir: resolvedAgentDir,
       ...(options?.agentRuntimeId ? { agentRuntimeId: options.agentRuntimeId } : {}),
+      manifestAlias: normalizedRef.manifestAlias,
       workspaceDir,
       authProfileId: options?.authProfileId,
       authProfileMode: options?.authProfileMode,
@@ -1893,6 +1926,7 @@ export async function resolveModelAsync(
       modelId: normalizedRef.model,
       cfg,
       agentDir: resolvedAgentDir,
+      manifestAlias: normalizedRef.manifestAlias,
       workspaceDir,
       runtimeHooks,
     });

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -60,7 +60,7 @@ import {
   canonicalizeManifestModelCatalogProviderAlias,
   resolveBundledProviderStaticCatalogModel,
   resolveBundledStaticCatalogModel,
-  resolveManifestModelCatalogProviderTransportApi,
+  resolveManifestModelCatalogProviderTransport,
 } from "./model.static-catalog.js";
 
 type ProviderRuntimeHooks = {
@@ -627,6 +627,12 @@ function applyConfiguredProviderOverrides(params: {
   workspaceDir?: string;
 }): ProviderRuntimeModel {
   const { discoveredModel, providerConfig, modelId } = params;
+  const manifestAliasTransport = resolveManifestModelCatalogProviderTransport({
+    provider: params.provider,
+    modelId,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+  });
   const requestTimeoutMs = resolveProviderRequestTimeoutMs(providerConfig?.timeoutSeconds);
   const defaultModelParams = findConfiguredAgentModelParams({
     cfg: params.cfg,
@@ -641,16 +647,34 @@ function applyConfiguredProviderOverrides(params: {
     const discoveredHeaders = sanitizeModelHeaders(discoveredModel.headers, {
       stripSecretRefMarkers: true,
     });
+    const aliasTransport = manifestAliasTransport
+      ? resolveProviderTransport({
+          provider: params.provider,
+          modelId,
+          api: manifestAliasTransport.api ?? discoveredModel.api,
+          baseUrl:
+            normalizeTransportBaseUrl(manifestAliasTransport.baseUrl) ?? discoveredModel.baseUrl,
+          cfg: params.cfg,
+          workspaceDir: params.workspaceDir,
+          runtimeHooks: params.runtimeHooks,
+        })
+      : undefined;
     const requestConfig = resolveProviderRequestConfig({
       provider: params.provider,
-      api: discoveredModel.api,
-      baseUrl: discoveredModel.baseUrl,
+      api: aliasTransport?.api ?? discoveredModel.api,
+      baseUrl: aliasTransport?.baseUrl ?? discoveredModel.baseUrl,
       discoveredHeaders,
       capability: "llm",
       transport: "stream",
     });
     return {
       ...discoveredModel,
+      ...(manifestAliasTransport
+        ? {
+            api: requestConfig.api ?? discoveredModel.api,
+            baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
+          }
+        : {}),
       ...(resolvedParams ? { params: resolvedParams } : {}),
       // Discovered models originate from models.json and may contain persistence markers.
       headers: requestConfig.headers,
@@ -708,7 +732,8 @@ function applyConfiguredProviderOverrides(params: {
     !providerHeaders &&
     !providerRequest &&
     !providerParams &&
-    !providerConfig.localService
+    !providerConfig.localService &&
+    !manifestAliasTransport
   ) {
     const resolvedParams = mergeModelParams(
       readModelParams(discoveredModel.params),
@@ -749,20 +774,17 @@ function applyConfiguredProviderOverrides(params: {
   const configuredStaticCatalogBaseUrl = normalizeTransportBaseUrl(
     configuredStaticCatalogModel?.baseUrl,
   );
+  const manifestAliasBaseUrl = normalizeTransportBaseUrl(manifestAliasTransport?.baseUrl);
   const resolvedTransportApi = params.preferDiscoveredTransport
     ? (discoveredModel.api ??
       metadataOverrideModel?.api ??
       providerConfig.api ??
+      manifestAliasTransport?.api ??
       configuredStaticCatalogModel?.api ??
       providerDefaultApi)
     : (metadataOverrideModel?.api ??
       providerConfig.api ??
-      resolveManifestModelCatalogProviderTransportApi({
-        provider: params.provider,
-        modelId,
-        cfg: params.cfg,
-        workspaceDir: params.workspaceDir,
-      }) ??
+      manifestAliasTransport?.api ??
       discoveredModel.api ??
       configuredStaticCatalogModel?.api ??
       providerDefaultApi);
@@ -770,9 +792,11 @@ function applyConfiguredProviderOverrides(params: {
     ? (discoveredBaseUrl ??
       metadataOverrideBaseUrl ??
       providerConfiguredBaseUrl ??
+      manifestAliasBaseUrl ??
       configuredStaticCatalogBaseUrl)
     : (metadataOverrideBaseUrl ??
       providerConfiguredBaseUrl ??
+      manifestAliasBaseUrl ??
       discoveredBaseUrl ??
       configuredStaticCatalogBaseUrl);
 

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -821,6 +821,7 @@ function applyConfiguredProviderOverrides(params: {
     attachModelProviderRequestTransport(
       {
         ...discoveredModel,
+        provider: params.provider,
         api: requestConfig.api ?? "openai-responses",
         baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
         reasoning: resolvedReasoning,

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -756,14 +756,13 @@ function applyConfiguredProviderOverrides(params: {
     configuredStaticCatalogModel?.baseUrl,
   );
   const manifestAliasBaseUrl = normalizeTransportBaseUrl(manifestAliasTransport?.baseUrl);
-  // A retained alias owns transport identity. Static discovery may supply model
-  // metadata, but must not replace the alias's wire API or endpoint.
+  // A retained alias owns transport identity and always takes the second branch
+  // below. Discovery-first ordering is therefore alias-free by construction.
   const preferDiscoveredTransport = params.preferDiscoveredTransport && !manifestAliasTransport;
   const resolvedTransportApi = preferDiscoveredTransport
     ? (discoveredModel.api ??
       metadataOverrideModel?.api ??
       providerConfig.api ??
-      manifestAliasTransport?.api ??
       configuredStaticCatalogModel?.api ??
       providerDefaultApi)
     : (metadataOverrideModel?.api ??
@@ -776,7 +775,6 @@ function applyConfiguredProviderOverrides(params: {
     ? (discoveredBaseUrl ??
       metadataOverrideBaseUrl ??
       providerConfiguredBaseUrl ??
-      manifestAliasBaseUrl ??
       configuredStaticCatalogBaseUrl)
     : (metadataOverrideBaseUrl ??
       providerConfiguredBaseUrl ??

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -49,6 +49,13 @@ import {
 } from "../sessions/index.js";
 import { discoverCachedAgentStores } from "./model-discovery-cache.js";
 import {
+  mergeModelCompat,
+  mergeModelMediaInput,
+  resolveConfiguredFallbackReasoning,
+  resolveConfiguredModelReasoning,
+  resolveMergedConfiguredModelReasoning,
+} from "./model.compat.js";
+import {
   buildInlineProviderModels,
   type InlineProviderConfig,
   normalizeResolvedTransportApi,
@@ -390,29 +397,6 @@ function normalizeTransportBaseUrl(baseUrl: unknown): string | undefined {
 
 function resolveProviderRequestTimeoutMs(timeoutSeconds: unknown): number | undefined {
   return finiteSecondsToTimerSafeMilliseconds(timeoutSeconds, { floorSeconds: true });
-}
-
-function mergeModelMediaInput(
-  base: ModelMediaInputConfig | undefined,
-  override: ModelMediaInputConfig | undefined,
-): ModelMediaInputConfig | undefined {
-  if (!base) {
-    return override;
-  }
-  if (!override) {
-    return base;
-  }
-  return {
-    ...base,
-    ...override,
-    image:
-      base.image || override.image
-        ? {
-            ...base.image,
-            ...override.image,
-          }
-        : undefined,
-  };
 }
 
 function matchesProviderScopedModelId(params: {
@@ -1475,76 +1459,6 @@ function shouldCompareProviderRuntimeResolvedModel(params: {
       },
     }) ?? false
   );
-}
-
-function resolveConfiguredFallbackReasoning(params: {
-  provider: string;
-  compat?: unknown;
-  reasoning?: boolean;
-}): boolean {
-  return resolveConfiguredModelReasoning(params) ?? false;
-}
-
-function resolveConfiguredModelReasoning(params: {
-  provider: string;
-  compat?: unknown;
-  reasoning?: boolean;
-}): boolean | undefined {
-  if (params.reasoning !== undefined) {
-    return params.reasoning;
-  }
-  return isVllmQwenThinkingCompat(params) ? true : undefined;
-}
-
-function resolveMergedConfiguredModelReasoning(params: {
-  provider: string;
-  configuredCompat?: unknown;
-  resolvedCompat?: unknown;
-  configuredReasoning?: boolean;
-  discoveredReasoning?: boolean;
-}): boolean {
-  if (params.configuredReasoning !== undefined) {
-    return params.configuredReasoning;
-  }
-  if (isVllmQwenThinkingCompat({ provider: params.provider, compat: params.configuredCompat })) {
-    return true;
-  }
-  return (
-    resolveConfiguredModelReasoning({
-      provider: params.provider,
-      compat: params.resolvedCompat,
-      reasoning: params.discoveredReasoning,
-    }) ?? false
-  );
-}
-
-function isVllmQwenThinkingCompat(params: { provider: string; compat?: unknown }): boolean {
-  const thinkingFormat = readCompatThinkingFormat(params.compat);
-  return (
-    normalizeProviderId(params.provider) === "vllm" &&
-    (thinkingFormat === "qwen" || thinkingFormat === "qwen-chat-template")
-  );
-}
-
-function readCompatThinkingFormat(compat: unknown): string | undefined {
-  if (!compat || typeof compat !== "object" || Array.isArray(compat)) {
-    return undefined;
-  }
-  const thinkingFormat = (compat as { thinkingFormat?: unknown }).thinkingFormat;
-  return typeof thinkingFormat === "string" ? thinkingFormat : undefined;
-}
-
-function mergeModelCompat(
-  base: ModelCompatConfig | undefined,
-  override: ModelCompatConfig | undefined,
-): ModelCompatConfig | undefined {
-  if (!base) {
-    return override;
-  }
-  if (!override) {
-    return base;
-  }
-  return { ...base, ...override };
 }
 
 function normalizeProviderModelRef(params: {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -756,7 +756,10 @@ function applyConfiguredProviderOverrides(params: {
     configuredStaticCatalogModel?.baseUrl,
   );
   const manifestAliasBaseUrl = normalizeTransportBaseUrl(manifestAliasTransport?.baseUrl);
-  const resolvedTransportApi = params.preferDiscoveredTransport
+  // A retained alias owns transport identity. Static discovery may supply model
+  // metadata, but must not replace the alias's wire API or endpoint.
+  const preferDiscoveredTransport = params.preferDiscoveredTransport && !manifestAliasTransport;
+  const resolvedTransportApi = preferDiscoveredTransport
     ? (discoveredModel.api ??
       metadataOverrideModel?.api ??
       providerConfig.api ??
@@ -769,7 +772,7 @@ function applyConfiguredProviderOverrides(params: {
       discoveredModel.api ??
       configuredStaticCatalogModel?.api ??
       providerDefaultApi);
-  const resolvedTransportBaseUrl = params.preferDiscoveredTransport
+  const resolvedTransportBaseUrl = preferDiscoveredTransport
     ? (discoveredBaseUrl ??
       metadataOverrideBaseUrl ??
       providerConfiguredBaseUrl ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring `azure-openai-responses/*` could have model status probes and embedded-agent runs resolve through the OpenAI owner/auth path instead of the configured Azure Responses credentials and base URL.

The inverse boundary also matters: OpenAI-owned, manifest-suppressed models such as `gpt-5.3-codex-spark` must still produce the OpenAI OAuth remediation instead of being misclassified as an Azure deployment.

Closes #93781

## Why This Change Was Made

Alias canonicalization now considers the requested model together with configured Azure endpoint/model surface and manifest suppressions before choosing the provider owner. Configured Azure models and custom deployments keep `azure-openai-responses`; endpoint-less aliases and unconditionally suppressed OpenAI models canonicalize to `openai`.

Conditional suppressions do not rewrite alias ownership at this earlier stage, even when their endpoint condition matches. Their `when.baseUrlHosts` and `when.providerConfigApiIn` policy remains with the existing runtime suppression evaluator, so an alias does not lose its endpoint or credential owner before that policy is evaluated.

Configured overrides also carry the requested provider onto discovered model rows, so Azure API/base URL/auth ownership is preserved after catalog lookup. This does not change public config, schema, migrations, credential storage, or the OpenAI plugin manifest.

When an Azure provider config supplies its endpoint and credential but omits the optional `api` field, the resolver consumes the transport API declared by the retained manifest alias before discovered OpenAI metadata. It does not infer an API from arbitrary provider ids, so params-only GitHub Copilot configurations keep their discovered per-model protocols.

## User Impact

Azure Responses users can probe and run configured `azure-openai-responses` models without OpenClaw silently switching to an OpenAI auth profile. Provider-level Azure deployment names remain Azure-owned, Codex-only models continue to point users to the correct OpenAI OAuth flow, and GitHub Copilot Enterprise params-only configs retain Anthropic/OpenAI transports selected per model.

## Evidence

- Rebuilt the branch on the pinned current-main snapshot `6de8aa6f9b750ebfcdc15048090b62076f19197e` and removed the merge commit `56d6c3b8e662c127315921979d794816bc6ec7b6`. The 14 original contribution commits were replayed linearly with their original authors, leaving zero merge commits in the contribution range.
- Before the follow-up repair below, the history port was byte-for-byte equivalent to the hosted diff (`40b07ded6d508b744a6a039bfa3e2e1494b7cc8e230b62bf8f0b1c4d03aaac1b`) and `git range-diff` matched all 14 original contribution commits. Exact-head review then found that conditional suppression declarations were being consumed as unconditional owner overrides; the candidate adds one bounded production/test repair for that finding.
- Focused resolver regression suite:

  ```text
  Test Files  3 passed (3)
  Tests       197 passed (197)
  ```

  The suite includes discovered and configured-fallback Azure cases with `baseUrl` configured and `api` omitted; a retained manifest alias carrying both `api` and `baseUrl`; a retained alias with no provider config; and params-only GitHub Copilot Claude, Gemini, and GPT cases. Azure resolves to `azure-openai-responses`; Copilot retains `anthropic-messages`, `openai-completions`, and `openai-responses` respectively.

  It also verifies the trust boundary around manifest aliases: inactive workspace claims are ignored, external claims must be explicitly activated/trusted, config-load-path owners retain their operator-granted trust, and multiple eligible owners claiming the same alias fail closed instead of combining one plugin's provider with another plugin's transport metadata. A call-count regression confirms each async model lookup prepares alias owner/transport metadata once rather than rescanning it at three resolver seams.

  The regression matrix also verifies that an explicit Azure model row cannot override unconditional manifest suppression for `gpt-5.3-codex-spark`; the resolver keeps the OpenAI owner and returns the Codex OAuth remediation. Owner-boundary cases prove that conditional suppressions do not canonicalize a transport alias for either matching or non-matching configured endpoints, while an unconditional suppression still canonicalizes it.

- A CI follow-up deduplicated repeated alias-resolution assertions in `model.static-catalog.test.ts` after the repository `max-lines` rule flagged that PR-owned test file. The exact candidate passes the complete file (`28 passed`), changed-file lint including `max-lines`, formatting, and `git diff --check`; production behavior and coverage are unchanged.
- The same remote run also reported an unrelated UI import cycle, stale bundled-channel metadata, deprecated plugin-SDK usage, and additional lint findings in base-owned files outside this PR diff. `openclaw/ci-gate` only aggregates those failed children; this PR does not modify those baseline files.
- Formatting, changed-file lint, `git diff --check`, and the current-main `max-lines` ratchet passed. The ratchet ran on the exact synthetic PR merge preview and accepted the changed production/test surface without adding or expanding a baseline entry.
- No local typecheck claim is made for this candidate. The protected `check:test-types` lane was not started because this host uses cgroup v1 and cannot attest the required `memory.high` envelope; hosted CI remains the full typecheck gate.
- A fresh credential-free production resolver/dispatch driver observed:

  ```json
  {
    "azure": { "provider": "azure-openai-responses", "api": "azure-openai-responses", "baseUrl": "https://example.openai.azure.com/openai/v1", "transport": "openclaw-azure-openai-responses-transport" },
    "azureCustomDeployment": { "provider": "azure-openai-responses", "api": "azure-openai-responses", "baseUrl": "https://example.openai.azure.com/openai/v1", "transport": "openclaw-azure-openai-responses-transport" },
    "copilotClaude": { "provider": "github-copilot", "api": "anthropic-messages", "transport": "openclaw-anthropic-messages-transport" },
    "copilotGemini": { "provider": "github-copilot", "api": "openai-completions", "transport": "openclaw-openai-completions-transport" },
    "copilotGpt": { "provider": "github-copilot", "api": "openai-responses", "transport": "openclaw-openai-responses-transport" }
  }
  ```

- The existing PR proof ran the real `openclaw models status --probe --probe-provider azure-openai-responses` CLI path against a local Responses-compatible endpoint. It observed `azure-openai-responses/gpt-5.5`, the configured Azure-style URL, and `api-key` rather than `Authorization`; ClawSweeper marked that proof sufficient.
- This current-main repair did not repeat the network probe or use live Azure account credentials. The exact candidate is covered by the resolver tests, changed-file lint/checks, max-lines ratchet, and credential-free runtime driver above, while the accepted CLI proof remains scoped to OpenClaw routing rather than an external Azure credential exchange.
