### PR TITLE
fix(agents): remove stale model picker import

### DIFF
--- a/src/agents/model-picker-visibility.ts
+++ b/src/agents/model-picker-visibility.ts
@@ -4,7 +4,6 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listCliRuntimeProviderIds } from "./cli-backends.js";
-import { isCliRuntimeProvider } from "./model-runtime-aliases.js";
 
 // Retired provider ids and CLI runtime aliases are implementation surfaces, not
 // model picker choices. Hide them while keeping real provider/model refs visible.


### PR DESCRIPTION
## Summary

- remove the unused `isCliRuntimeProvider` import left behind by `2ee4b523b4`
- restore the all-project typecheck on `main` without changing runtime behavior

## Linked context

Regression from `2ee4b523b4` (`refactor(agents): trim unused model helper exports`). Requested by a maintainer/owner while landing https://github.com/openclaw/openclaw/pull/93832.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `pnpm check:changed` fails typecheck on current `main`.
- Exact evidence before fix: `src/agents/model-picker-visibility.ts(7,10): error TS6133: isCliRuntimeProvider is declared but its value is never read.`
- Observed result after fix: focused format and lint pass; remote changed-gate pending.
- What was not tested: runtime behavior, because this only removes an unused import.

## Tests and validation

- `node_modules/.bin/oxfmt --check src/agents/model-picker-visibility.ts`
- `node_modules/.bin/oxlint src/agents/model-picker-visibility.ts`
- `git diff --check`

## Risk checklist

Did user-visible behavior change? `No`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest risk: none beyond merge ordering; this is a one-line removal of an unused import.

## Current review state

Next action: run the remote changed-gate, then merge before rebasing PR #93832.