### PR TITLE
fix(telegram): emit expandable attribute on rich message blockquote

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -44,7 +44,7 @@ describe("markdownToTelegramHtml", () => {
     const input = [
       "✉️ <b>Morning Email Rollup</b>",
       "",
-      "<blockquote>✅ No important emails in the last 24 hours.</blockquote>",
+      "<blockquote expandable>✅ No important emails in the last 24 hours.</blockquote>",
       "",
       "<pre><code>oauth2: invalid_grant</code></pre>",
     ].join("\n");
@@ -223,28 +223,28 @@ describe("markdownToTelegramHtml", () => {
 
   it("renders blockquotes as native Telegram blockquote tags", () => {
     const res = markdownToTelegramHtml("> Quote");
-    expect(res).toContain("<blockquote>");
+    expect(res).toContain("<blockquote expandable>");
     expect(res).toContain("Quote");
     expect(res).toContain("</blockquote>");
   });
 
   it("renders blockquotes with inline formatting", () => {
     const res = markdownToTelegramHtml("> **bold** quote");
-    expect(res).toContain("<blockquote>");
+    expect(res).toContain("<blockquote expandable>");
     expect(res).toContain("<b>bold</b>");
     expect(res).toContain("</blockquote>");
   });
 
   it("renders multiline blockquotes as a single Telegram blockquote", () => {
     const res = markdownToTelegramHtml("> first\n> second");
-    expect(res).toBe("<blockquote>first\nsecond</blockquote>");
+    expect(res).toBe("<blockquote expandable>first\nsecond</blockquote>");
   });
 
   it("renders separated quoted paragraphs as distinct blockquotes", () => {
     const res = markdownToTelegramHtml("> first\n\n> second");
-    expect(res).toContain("<blockquote>first");
-    expect(res).toContain("<blockquote>second</blockquote>");
-    expect(res.match(/<blockquote>/g)).toHaveLength(2);
+    expect(res).toContain("<blockquote expandable>first");
+    expect(res).toContain("<blockquote expandable>second</blockquote>");
+    expect(res.match(/<blockquote\b/g)).toHaveLength(2);
   });
 
   it("renders fenced code block languages for Telegram native copy buttons", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -81,7 +81,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       code: { open: "<code>", close: "</code>" },
       code_block: { open: buildTelegramCodeBlockOpen, close: "</code></pre>" },
       spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
-      blockquote: { open: "<blockquote>", close: "</blockquote>" },
+      blockquote: { open: "<blockquote expandable>", close: "</blockquote>" },
       heading_1: { open: "<h1>", close: "</h1>" },
       heading_2: { open: "<h2>", close: "</h2>" },
       heading_3: { open: "<h3>", close: "</h3>" },


### PR DESCRIPTION
## Summary

- The Telegram rich message converter (`buildTelegramRichMessage` → `renderTelegramHtml`) always emits plain `<blockquote>` for blockquote elements
- Bot API 10.1 supports `<blockquote expandable>` which renders a tap-to-collapse control on long quotes
- The parser in `markdownToTelegramHtml` (format.ts) already accepts the `expandable` attribute, but the emit template never produces it
- Fix: change the blockquote open template from `<blockquote>` to `<blockquote expandable>`
- Update all test assertions to expect `<blockquote expandable>`

Fixes #93824

## Real behavior proof

**Behavior addressed**: Telegram rich messages now emit `<blockquote expandable>` so multi-line quotes render with Telegram's native tap-to-collapse control instead of always being fully expanded.

**Real setup tested**:
- **Runtime**: node (pnpm test)

**Exact steps or command run after fix**:

```bash
# Run the format test suite to verify all blockquote rendering produces expandable
cd /home/git-product/AI/openclaw
pnpm exec vitest run extensions/telegram/src/format.test.ts
```

**After-fix evidence**:

```
 RUN  v4.1.8 /home/git-product/AI/openclaw

 Test Files  1 passed (1)
      Tests  45 passed (45)
   Start at  09:10:35
   Duration  1.42s (transform 607ms, setup 414ms, import 445ms, tests 291ms, environment 0ms)
```

**Observed result after the fix**: All 45 tests pass. The `renderTelegramHtml` function now emits `<blockquote expandable>` for markdown blockquotes. The parser already handles `expandable` on input (test at format.test.ts:60 `"preserves Telegram expandable blockquote HTML"` passes), so round-tripping is consistent: parser accepts it, emitter produces it.

**What was not tested**: End-to-end Bot API 10.1 sendRichMessage call. The change is in the markdown→HTML converter layer; the actual Telegram API call path is unchanged.

**Proof limitations or environment constraints**: Test environment only — no live Telegram API call was made. The Bot API 10.1 `expandable` attribute behavior is documented in Telegram's Bot API spec; clients that do not support it will silently ignore the unknown attribute.

## Tests and validation

- `pnpm exec vitest run extensions/telegram/src/format.test.ts` — 45/45 passed
- The existing `"preserves Telegram expandable blockquote HTML"` test confirms round-trip: input `<blockquote expandable>` → output `<blockquote expandable>`
- Code change: 1 line in `format.ts` (blockquote open template), 6 lines updated in `format.test.ts` to match new output

## Risk checklist

Did user-visible behavior change? (`Yes`)
- All Telegram blockquote elements now include `expandable` attribute. Clients that support it show a collapsible control; clients that don't (older Telegram Web) silently ignore the attribute with no rendering change.

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- None. This is a pure markup attribute addition in the HTML renderer. The `expandable` attribute is a boolean attribute per HTML spec — adding it to `<blockquote>` is safe even for parsers that don't recognize it.

How is that risk mitigated?
- The parser already accepts the attribute (tested). The existing 45-test suite covers all blockquote rendering paths including multi-line, separated paragraphs, inline formatting, and HTML passthrough.

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- No CI was run (this is a pre-submit action). The full OpenClaw CI pipeline will verify integration on PR creation.

Which bot or reviewer comments were addressed?
- No prior reviewer comments — this is a fresh PR addressing issue #93824.
