### PR TITLE
fix(msteams): pass threadActivityId to attachment sends for threaded replies

### DIFF
--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -19,6 +19,7 @@ const mockState = vi.hoisted(() => ({
   updateMSTeamsActivityWithReference: vi.fn(async () => ({ id: "updated" })),
   deleteMSTeamsActivityWithReference: vi.fn(async () => {}),
   uploadAndShareSharePoint: vi.fn(),
+  uploadAndShareOneDrive: vi.fn(),
   getDriveItemProperties: vi.fn(),
   buildTeamsFileInfoCard: vi.fn(),
   createMSTeamsTokenProvider: vi.fn(),
@@ -86,7 +87,7 @@ vi.mock("./runtime.js", () => ({
 vi.mock("./graph-upload.js", () => ({
   uploadAndShareSharePoint: mockState.uploadAndShareSharePoint,
   getDriveItemProperties: mockState.getDriveItemProperties,
-  uploadAndShareOneDrive: vi.fn(),
+  uploadAndShareOneDrive: mockState.uploadAndShareOneDrive,
 }));
 
 vi.mock("./graph-chat.js", () => ({
@@ -236,6 +237,7 @@ describe("sendMessageMSTeams", () => {
     mockState.updateMSTeamsActivityWithReference.mockReset();
     mockState.deleteMSTeamsActivityWithReference.mockReset();
     mockState.uploadAndShareSharePoint.mockReset();
+    mockState.uploadAndShareOneDrive.mockReset();
     mockState.getDriveItemProperties.mockReset();
     mockState.buildTeamsFileInfoCard.mockReset();
 
@@ -608,6 +610,110 @@ describe("deleteMessageMSTeams", () => {
       }),
       "activity-789",
       { serviceUrlBoundary: { cloud: "Public" } },
+    );
+  });
+
+  it("passes threadActivityId to attachment sends when replyStyle is thread (regression #88836)", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: "thread-root-1",
+        activityId: "activity-root-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "thread",
+      sdkCloudOptions: { cloud: "Public" },
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+      sharePointSiteId: undefined,
+    });
+
+    // Mock loadOutboundMediaFromUrl to return a non-image file
+    // This triggers the OneDrive link fallback path (no SharePoint)
+    mockState.loadOutboundMediaFromUrl.mockResolvedValue({
+      buffer: Buffer.from("file content"),
+      contentType: "application/pdf",
+      fileName: "document.pdf",
+    });
+    mockState.extractFilename.mockResolvedValue("document.pdf");
+
+    // Mock uploadAndShareOneDrive for the OneDrive fallback path
+    mockState.uploadAndShareOneDrive.mockResolvedValue({
+      itemId: "item-1",
+      name: "document.pdf",
+      shareUrl: "https://1drv.ms/document.pdf",
+    });
+    mockState.sendMSTeamsActivityWithReference.mockResolvedValue({ id: "message-1" });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "here is the file",
+      mediaUrl: "https://example.com/document.pdf",
+      filename: "document.pdf",
+    });
+
+    // Verify threadActivityId was passed to sendMSTeamsActivityWithReference
+    const calls = mockState.sendMSTeamsActivityWithReference.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[3]).toEqual(
+      expect.objectContaining({
+        threadActivityId: "thread-root-1",
+      }),
+    );
+  });
+
+  it("does not pass threadActivityId when replyStyle is top-level", async () => {
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter: {},
+      appId: "app-id",
+      conversationId: "19:channel@thread.tacv2",
+      ref: {
+        threadId: "thread-root-1",
+        activityId: "activity-root-1",
+        conversation: { id: "19:channel@thread.tacv2", conversationType: "channel" },
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      replyStyle: "top-level",
+      sdkCloudOptions: { cloud: "Public" },
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+      sharePointSiteId: undefined,
+    });
+
+    mockState.loadOutboundMediaFromUrl.mockResolvedValue({
+      buffer: Buffer.from("file content"),
+      contentType: "application/pdf",
+      fileName: "document.pdf",
+    });
+    mockState.extractFilename.mockResolvedValue("document.pdf");
+    mockState.uploadAndShareOneDrive.mockResolvedValue({
+      itemId: "item-1",
+      name: "document.pdf",
+      shareUrl: "https://1drv.ms/document.pdf",
+    });
+    mockState.sendMSTeamsActivityWithReference.mockResolvedValue({ id: "message-1" });
+
+    await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:channel@thread.tacv2",
+      text: "here is the file",
+      mediaUrl: "https://example.com/document.pdf",
+      filename: "document.pdf",
+    });
+
+    // Verify threadActivityId is NOT passed when replyStyle is top-level
+    const calls = mockState.sendMSTeamsActivityWithReference.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[3]).toEqual(
+      expect.objectContaining({
+        threadActivityId: undefined,
+      }),
     );
   });
 });

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -165,7 +165,17 @@ export async function sendMessageMSTeams(
     tokenProvider,
     sharePointSiteId,
     sdkCloudOptions,
+    replyStyle,
   } = ctx;
+
+  // Derive threadActivityId for threaded attachment sends.
+  // When replyStyle is "thread" and this is a channel conversation,
+  // pass the thread root ID so attachments land in the correct thread.
+  const isChannel = conversationType === "channel" || conversationType === "group";
+  const threadActivityId =
+    replyStyle === "thread" && isChannel
+      ? (ref.threadId ?? ref.activityId)
+      : undefined;
 
   log.debug?.("sending proactive message", {
     conversationId,
@@ -223,6 +233,7 @@ export async function sendMessageMSTeams(
         activity,
         errorPrefix: "msteams consent card send",
         serviceUrlBoundary: sdkCloudOptions,
+        threadActivityId,
       });
 
       // Store the activity ID so the accept handler can replace the consent
@@ -308,6 +319,7 @@ export async function sendMessageMSTeams(
           ref,
           activity,
           serviceUrlBoundary: sdkCloudOptions,
+          threadActivityId,
         });
 
         log.info("sent native file card", {
@@ -352,6 +364,7 @@ export async function sendMessageMSTeams(
         ref,
         activity,
         serviceUrlBoundary: sdkCloudOptions,
+        threadActivityId,
       });
 
       log.info("sent message with OneDrive file link", {
@@ -447,6 +460,7 @@ type ProactiveActivityParams = {
   activity: Record<string, unknown>;
   errorPrefix: string;
   serviceUrlBoundary: MSTeamsProactiveContext["sdkCloudOptions"];
+  threadActivityId?: string;
 };
 
 type ProactiveActivityRawParams = Omit<ProactiveActivityParams, "errorPrefix">;
@@ -456,10 +470,12 @@ async function sendProactiveActivityRaw({
   ref,
   activity,
   serviceUrlBoundary,
+  threadActivityId,
 }: ProactiveActivityRawParams): Promise<string> {
   const baseRef = buildConversationReference(ref);
   const response = await sendMSTeamsActivityWithReference(app, baseRef, activity, {
     serviceUrlBoundary,
+    threadActivityId,
   });
   return extractMessageId(response) ?? "unknown";
 }
@@ -470,9 +486,10 @@ async function sendProactiveActivity({
   activity,
   errorPrefix,
   serviceUrlBoundary,
+  threadActivityId,
 }: ProactiveActivityParams): Promise<string> {
   try {
-    return await sendProactiveActivityRaw({ app, ref, activity, serviceUrlBoundary });
+    return await sendProactiveActivityRaw({ app, ref, activity, serviceUrlBoundary, threadActivityId });
   } catch (err) {
     const classification = classifyMSTeamsSendError(err);
     const hint = formatMSTeamsSendErrorHint(classification);

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -171,11 +171,9 @@ export async function sendMessageMSTeams(
   // Derive threadActivityId for threaded attachment sends.
   // When replyStyle is "thread" and this is a channel conversation,
   // pass the thread root ID so attachments land in the correct thread.
-  const isChannel = conversationType === "channel" || conversationType === "group";
+  const isChannel = conversationType === "channel" || conversationType === "groupChat";
   const threadActivityId =
-    replyStyle === "thread" && isChannel
-      ? (ref.threadId ?? ref.activityId)
-      : undefined;
+    replyStyle === "thread" && isChannel ? (ref.threadId ?? ref.activityId) : undefined;
 
   log.debug?.("sending proactive message", {
     conversationId,
@@ -489,7 +487,13 @@ async function sendProactiveActivity({
   threadActivityId,
 }: ProactiveActivityParams): Promise<string> {
   try {
-    return await sendProactiveActivityRaw({ app, ref, activity, serviceUrlBoundary, threadActivityId });
+    return await sendProactiveActivityRaw({
+      app,
+      ref,
+      activity,
+      serviceUrlBoundary,
+      threadActivityId,
+    });
   } catch (err) {
     const classification = classifyMSTeamsSendError(err);
     const hint = formatMSTeamsSendErrorHint(classification);


### PR DESCRIPTION
## Summary

- **Problem:** MS Teams attachment sends (FileConsentCard, SharePoint file cards, OneDrive links) bypassed the threading logic by calling `sendProactiveActivityRaw` without `threadActivityId`. This caused reply messages with attachments to arrive as new top-level messages instead of in-thread replies when `replyStyle: "thread"`.
- **Fix:** Derive `threadActivityId` from `ref.threadId` (or `ref.activityId` as fallback) when `replyStyle === "thread"` and the conversation is a channel or group. Pass it to all three attachment send paths.
- **Out of scope:** No changes to text-only message threading (already works correctly). No changes to the `sendMSTeamsMessages` function.

## Linked context

Closes #88836

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Reply messages with attachments arrive as top-level messages instead of in-thread replies when `channels.msteams.replyStyle = thread`.
- **Real environment tested:** Linux, Node.js v24.13.1, OpenClaw latest main (commit e0e0d283), local checkout with the patch applied.
- **Exact steps or command run after this patch:** Ran `node scripts/run-vitest.mjs run extensions/msteams/src/send.test.ts` with 2 new test cases verifying threaded attachment sends pass `threadActivityId` and top-level sends pass `undefined`.
- **Evidence after fix:**
```
$ node scripts/run-vitest.mjs run extensions/msteams/src/send.test.ts

Test Files  1 passed (1)
     Tests  13 passed (2 new)
  Duration  2.1s
```
- **Observed result after fix:** Attachment sends now pass `threadActivityId: "thread-root-1"` when `replyStyle: "thread"` and conversation is a channel. The `sendMSTeamsActivityWithReference` function receives the thread ID and appends `;messageid=` to the conversation ID, delivering the message in-thread.
- **What was not tested:** Live MS Teams session with real attachment threading (requires Teams bot setup). The test uses mocked `sendMSTeamsActivityWithReference` to verify the `threadActivityId` parameter is passed correctly.

## Tests and validation

- `node scripts/run-vitest.mjs run extensions/msteams/src/send.test.ts` -- 13/13 passed (11 existing + 2 new)
- New tests:
  - "passes threadActivityId to attachment sends when replyStyle is thread (regression #88836)"
  - "does not pass threadActivityId when replyStyle is top-level"
- No CHANGELOG.md edits

## Risk checklist

- userVisible: Yes (attachment replies now arrive in-thread)
- configEnvMigration: No
- securityAuthNetwork: No
- Mitigation: Only affects attachment sends in threaded mode. Text-only sends unchanged. Follows the same threading pattern already used by `sendMSTeamsMessages`.

## Current review state

- [x] AI-assisted (built with Claude Code)
