### PR TITLE
fix(ui): render persisted history text blocks

### DIFF
--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -580,12 +580,16 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
       return undefined;
     }
     const typed = block as { type?: unknown; text?: unknown };
-    if ((typed.type !== "text" && typed.type !== "output_text") || typeof typed.text !== "string") {
+    if (!isAssistantTextContentType(typed.type) || typeof typed.text !== "string") {
       return undefined;
     }
     texts.push(typed.text);
   }
   return texts.length > 0 ? texts.join("\n") : undefined;
+}
+
+function isAssistantTextContentType(type: unknown): boolean {
+  return type === "text" || type === "input_text" || type === "output_text";
 }
 
 function hasAssistantNonTextContent(message: unknown): boolean {
@@ -600,8 +604,7 @@ function hasAssistantNonTextContent(message: unknown): boolean {
     (block) =>
       block &&
       typeof block === "object" &&
-      (block as { type?: unknown }).type !== "text" &&
-      (block as { type?: unknown }).type !== "output_text",
+      !isAssistantTextContentType((block as { type?: unknown }).type),
   );
 }
 
@@ -623,7 +626,11 @@ function hasAssistantMixedToolVisibleText(message: unknown): boolean {
     if (isToolHistoryBlockType(entry.type)) {
       hasToolHistoryBlock = true;
     }
-    if (entry.type === "text" && typeof entry.text === "string" && entry.text.trim()) {
+    if (
+      isAssistantTextContentType(entry.type) &&
+      typeof entry.text === "string" &&
+      entry.text.trim()
+    ) {
       hasText = true;
     }
   }
@@ -1648,7 +1655,7 @@ function projectEmptyAssistantErrorMessages(
         }
         const type = (block as { type?: unknown }).type;
         return (
-          type !== "text" &&
+          !isAssistantTextContentType(type) &&
           type !== "thinking" &&
           type !== "reasoning" &&
           type !== "redacted_thinking"
@@ -1669,7 +1676,7 @@ function projectEmptyAssistantErrorMessages(
           continue;
         }
         const entry = block as { type?: unknown; text?: unknown };
-        if (entry.type === "text" && typeof entry.text === "string") {
+        if (isAssistantTextContentType(entry.type) && typeof entry.text === "string") {
           visibleTexts.push(entry.text);
         }
       }

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -580,7 +580,7 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
       return undefined;
     }
     const typed = block as { type?: unknown; text?: unknown };
-    if (typed.type !== "text" || typeof typed.text !== "string") {
+    if ((typed.type !== "text" && typed.type !== "output_text") || typeof typed.text !== "string") {
       return undefined;
     }
     texts.push(typed.text);
@@ -597,7 +597,11 @@ function hasAssistantNonTextContent(message: unknown): boolean {
     return false;
   }
   return content.some(
-    (block) => block && typeof block === "object" && (block as { type?: unknown }).type !== "text",
+    (block) =>
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type !== "text" &&
+      (block as { type?: unknown }).type !== "output_text",
   );
 }
 

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -44,6 +44,20 @@ describe("stripEnvelopeFromMessage", () => {
     expect(assistant.content?.[0]?.text).toBe("Assistant body");
   });
 
+  test("strips internal metadata from assistant input_text blocks", () => {
+    const assistant = stripEnvelopeFromMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "input_text",
+          text: 'Conversation info (untrusted metadata):\n```json\n{"message_id":"123"}\n```\n\nAssistant body',
+        },
+      ],
+    }) as { content?: Array<{ text?: string }> };
+
+    expect(assistant.content?.[0]?.text).toBe("Assistant body");
+  });
+
   test("does not strip inline message_id text that is part of a line", () => {
     const input = {
       role: "user",

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -25,6 +25,25 @@ describe("stripEnvelopeFromMessage", () => {
     expect(result.content?.[0]?.text).toBe("hi");
   });
 
+  test("strips role-appropriate Responses text blocks", () => {
+    const user = stripEnvelopeFromMessage({
+      role: "user",
+      content: [{ type: "input_text", text: "hello\n[message_id: abc123]" }],
+    }) as { content?: Array<{ text?: string }> };
+    const assistant = stripEnvelopeFromMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: 'Conversation info (untrusted metadata):\n```json\n{"message_id":"123"}\n```\n\nAssistant body',
+        },
+      ],
+    }) as { content?: Array<{ text?: string }> };
+
+    expect(user.content?.[0]?.text).toBe("hello");
+    expect(assistant.content?.[0]?.text).toBe("Assistant body");
+  });
+
   test("does not strip inline message_id text that is part of a line", () => {
     const input = {
       role: "user",

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -47,15 +47,20 @@ function extractMessageSenderLabel(entry: Record<string, unknown>): string | nul
 // inbound envelopes while assistant/tool content may carry internal metadata.
 function stripEnvelopeFromContentWithRole(
   content: unknown[],
-  stripUserEnvelope: boolean,
+  role: string,
 ): { content: unknown[]; changed: boolean } {
+  const stripUserEnvelope = role === "user";
   let changed = false;
   const next = content.map((item) => {
     if (!item || typeof item !== "object") {
       return item;
     }
     const entry = item as Record<string, unknown>;
-    if (entry.type !== "text" || typeof entry.text !== "string") {
+    const isRoleTextBlock =
+      entry.type === "text" ||
+      (role === "user" && entry.type === "input_text") ||
+      (role === "assistant" && entry.type === "output_text");
+    if (!isRoleTextBlock || typeof entry.text !== "string") {
       return item;
     }
     const stripped = stripUserEnvelope
@@ -99,7 +104,7 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       changed = true;
     }
   } else if (Array.isArray(entry.content)) {
-    const updated = stripEnvelopeFromContentWithRole(entry.content, stripUserEnvelope);
+    const updated = stripEnvelopeFromContentWithRole(entry.content, role);
     if (updated.changed) {
       next.content = updated.content;
       changed = true;

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -59,7 +59,7 @@ function stripEnvelopeFromContentWithRole(
     const isRoleTextBlock =
       entry.type === "text" ||
       (role === "user" && entry.type === "input_text") ||
-      (role === "assistant" && entry.type === "output_text");
+      (role === "assistant" && (entry.type === "input_text" || entry.type === "output_text"));
     if (!isRoleTextBlock || typeof entry.text !== "string") {
       return item;
     }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -941,6 +941,43 @@ describe("projectRecentChatDisplayMessages", () => {
     ]);
   });
 
+  it.each([
+    ["output_text", ""],
+    ["output_text", "NO_REPLY"],
+    ["input_text", ""],
+    ["input_text", "NO_REPLY"],
+  ])("projects hidden %s assistant errors %j as a generic safe failure", (type, text) => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [{ type, text }],
+        stopReason: "error",
+        errorMessage: "Connection error.",
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result[0]?.content).toEqual([
+      { type: "text", text: "The agent run failed before producing a reply." },
+    ]);
+  });
+
+  it("preserves visible output_text from a failed assistant turn", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "assistant",
+        content: [{ type: "output_text", text: "A partial reply before the run failed." }],
+        stopReason: "error",
+        errorMessage: "Connection error.",
+        timestamp: 1,
+      },
+    ]);
+
+    expect(result[0]?.content).toEqual([
+      { type: "output_text", text: "A partial reply before the run failed." },
+    ]);
+  });
+
   it("projects thinking-only assistant errors as a generic safe failure", () => {
     const result = projectRecentChatDisplayMessages([
       {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -714,9 +714,22 @@ describe("gateway server chat", () => {
         content: [{ type: "output_text", text: "visible response" }],
         timestamp: 2,
       },
+      {
+        role: "assistant",
+        content: [{ type: "input_text", text: "NO_REPLY" }],
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "input_text", text: "visible assistant input" }],
+        timestamp: 4,
+      },
     ]);
 
-    expect(collectHistoryTextValues(historyMessages)).toEqual(["visible response"]);
+    expect(collectHistoryTextValues(historyMessages)).toEqual([
+      "visible response",
+      "visible assistant input",
+    ]);
   });
 
   test("chat.history mirrors current-session message tool sends before NO_REPLY", async () => {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -702,6 +702,23 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history hides assistant control replies in Responses output blocks", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "assistant",
+        content: [{ type: "output_text", text: "NO_REPLY" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "output_text", text: "visible response" }],
+        timestamp: 2,
+      },
+    ]);
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["visible response"]);
+  });
+
   test("chat.history mirrors current-session message tool sends before NO_REPLY", async () => {
     const replyText = "Here, love. Eva, not Evo.";
     const historyMessages = await loadChatHistoryWithMessages([

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -147,6 +147,15 @@ describe("extractAssistantVisibleText", () => {
     ).toBe("Persisted assistant answer");
   });
 
+  it("extracts persisted Responses assistant input_text blocks", () => {
+    expect(
+      extractAssistantVisibleText({
+        role: "assistant",
+        content: [{ type: "input_text", text: "Persisted assistant input" }],
+      }),
+    ).toBe("Persisted assistant input");
+  });
+
   it("does not mix unphased legacy text into final_answer output", () => {
     expect(
       extractAssistantVisibleText({

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -138,6 +138,15 @@ describe("extractAssistantVisibleText", () => {
     ).toBe("Legacy answer");
   });
 
+  it("extracts persisted Responses output_text blocks as assistant-visible text", () => {
+    expect(
+      extractAssistantVisibleText({
+        role: "assistant",
+        content: [{ type: "output_text", text: "Persisted assistant answer" }],
+      }),
+    ).toBe("Persisted assistant answer");
+  });
+
   it("does not mix unphased legacy text into final_answer output", () => {
     expect(
       extractAssistantVisibleText({

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -23,6 +23,10 @@ export function extractFirstTextBlock(message: unknown): string | undefined {
 
 export type AssistantPhase = "commentary" | "final_answer";
 
+function isAssistantTextContentBlockType(value: unknown): boolean {
+  return value === "text" || value === "output_text";
+}
+
 /** Narrows unknown phase metadata to assistant text phases that affect visibility. */
 export function normalizeAssistantPhase(value: unknown): AssistantPhase | undefined {
   return value === "commentary" || value === "final_answer" ? value : undefined;
@@ -73,7 +77,7 @@ export function resolveAssistantMessagePhase(message: unknown): AssistantPhase |
       continue;
     }
     const record = block as { type?: unknown; textSignature?: unknown };
-    if (record.type !== "text") {
+    if (!isAssistantTextContentBlockType(record.type)) {
       continue;
     }
     const phase = parseAssistantTextSignature(record.textSignature)?.phase;
@@ -156,7 +160,7 @@ export function extractAssistantTextForPhase(
       return false;
     }
     const record = block as { type?: unknown; textSignature?: unknown };
-    if (record.type !== "text") {
+    if (!isAssistantTextContentBlockType(record.type)) {
       return false;
     }
     return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
@@ -173,7 +177,7 @@ export function extractAssistantTextForPhase(
         return null;
       }
       const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
-      if (record.type !== "text" || typeof record.text !== "string") {
+      if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
         return null;
       }
       const signature = parseAssistantTextSignature(record.textSignature);

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -24,7 +24,7 @@ export function extractFirstTextBlock(message: unknown): string | undefined {
 export type AssistantPhase = "commentary" | "final_answer";
 
 function isAssistantTextContentBlockType(value: unknown): boolean {
-  return value === "text" || value === "output_text";
+  return value === "text" || value === "input_text" || value === "output_text";
 }
 
 /** Narrows unknown phase metadata to assistant text phases that affect visibility. */

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -59,6 +59,21 @@ describe("extractTextCached", () => {
     ).toBe("Persisted assistant answer");
   });
 
+  it("ignores persisted Responses text blocks from the wrong role", () => {
+    expect(
+      extractText({
+        role: "user",
+        content: [{ type: "output_text", text: "Assistant-only block" }],
+      }),
+    ).toBeNull();
+    expect(
+      extractText({
+        role: "assistant",
+        content: [{ type: "input_text", text: "User-only block" }],
+      }),
+    ).toBeNull();
+  });
+
   it("prefers final_answer assistant text over commentary text", () => {
     const message = {
       role: "assistant",

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -59,7 +59,7 @@ describe("extractTextCached", () => {
     ).toBe("Persisted assistant answer");
   });
 
-  it("ignores persisted Responses text blocks from the wrong role", () => {
+  it("accepts assistant Responses input blocks but ignores user output blocks", () => {
     expect(
       extractText({
         role: "user",
@@ -71,7 +71,7 @@ describe("extractTextCached", () => {
         role: "assistant",
         content: [{ type: "input_text", text: "User-only block" }],
       }),
-    ).toBeNull();
+    ).toBe("User-only block");
   });
 
   it("prefers final_answer assistant text over commentary text", () => {

--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -44,6 +44,21 @@ describe("extractTextCached", () => {
     expect(extractTextCached(message)).toBe("Final user answer");
   });
 
+  it("extracts text from persisted Responses content blocks", () => {
+    expect(
+      extractText({
+        role: "user",
+        content: [{ type: "input_text", text: "Persisted user question" }],
+      }),
+    ).toBe("Persisted user question");
+    expect(
+      extractText({
+        role: "assistant",
+        content: [{ type: "output_text", text: "Persisted assistant answer" }],
+      }),
+    ).toBe("Persisted assistant answer");
+  });
+
   it("prefers final_answer assistant text over commentary text", () => {
     const message = {
       role: "assistant",

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -13,7 +13,7 @@ function isTextContentBlockType(value: unknown, role: string): boolean {
   return (
     value === "text" ||
     (role === "user" && value === "input_text") ||
-    (role === "assistant" && value === "output_text")
+    (role === "assistant" && (value === "input_text" || value === "output_text"))
   );
 }
 

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -9,8 +9,12 @@ import { stripThinkingTags } from "../strip-thinking-tags.ts";
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
-function isTextContentBlockType(value: unknown): boolean {
-  return value === "text" || value === "input_text" || value === "output_text";
+function isTextContentBlockType(value: unknown, role: string): boolean {
+  return (
+    value === "text" ||
+    (role === "user" && value === "input_text") ||
+    (role === "assistant" && value === "output_text")
+  );
 }
 
 function processMessageText(text: string, role: string): string {
@@ -94,6 +98,7 @@ export function extractThinkingCached(message: unknown): string | null {
 
 export function extractRawText(message: unknown): string | null {
   const m = message as Record<string, unknown>;
+  const role = normalizeLowercaseStringOrEmpty(m.role);
   const content = m.content;
   if (typeof content === "string") {
     return content;
@@ -102,7 +107,7 @@ export function extractRawText(message: unknown): string | null {
     const parts = content
       .map((p) => {
         const item = p as Record<string, unknown>;
-        if (isTextContentBlockType(item.type) && typeof item.text === "string") {
+        if (isTextContentBlockType(item.type, role) && typeof item.text === "string") {
           return item.text;
         }
         return null;

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -9,6 +9,10 @@ import { stripThinkingTags } from "../strip-thinking-tags.ts";
 const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
+function isTextContentBlockType(value: unknown): boolean {
+  return value === "text" || value === "input_text" || value === "output_text";
+}
+
 function processMessageText(text: string, role: string): string {
   const shouldStripInboundMetadata = normalizeLowercaseStringOrEmpty(role) === "user";
   const withoutInternalContext = stripInternalRuntimeContext(text);
@@ -98,7 +102,7 @@ export function extractRawText(message: unknown): string | null {
     const parts = content
       .map((p) => {
         const item = p as Record<string, unknown>;
-        if (item.type === "text" && typeof item.text === "string") {
+        if (isTextContentBlockType(item.type) && typeof item.text === "string") {
           return item.text;
         }
         return null;

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -111,6 +111,20 @@ describe("message-normalizer", () => {
       expect(assistant.content).toEqual([{ type: "text", text: "Persisted assistant answer" }]);
     });
 
+    it("does not reinterpret persisted Responses text blocks from the wrong role", () => {
+      const user = normalizeMessage({
+        role: "user",
+        content: [{ type: "output_text", text: "Assistant-only block" }],
+      });
+      const assistant = normalizeMessage({
+        role: "assistant",
+        content: [{ type: "input_text", text: "User-only block" }],
+      });
+
+      expect(user.content).not.toContainEqual({ type: "text", text: "Assistant-only block" });
+      expect(assistant.content).not.toContainEqual({ type: "text", text: "User-only block" });
+    });
+
     it("normalizes structured base64 audio content blocks as renderable attachments", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -111,7 +111,7 @@ describe("message-normalizer", () => {
       expect(assistant.content).toEqual([{ type: "text", text: "Persisted assistant answer" }]);
     });
 
-    it("does not reinterpret persisted Responses text blocks from the wrong role", () => {
+    it("accepts assistant Responses input blocks but rejects user output blocks", () => {
       const user = normalizeMessage({
         role: "user",
         content: [{ type: "output_text", text: "Assistant-only block" }],
@@ -122,7 +122,7 @@ describe("message-normalizer", () => {
       });
 
       expect(user.content).not.toContainEqual({ type: "text", text: "Assistant-only block" });
-      expect(assistant.content).not.toContainEqual({ type: "text", text: "User-only block" });
+      expect(assistant.content).toContainEqual({ type: "text", text: "User-only block" });
     });
 
     it("normalizes structured base64 audio content blocks as renderable attachments", () => {

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -90,6 +90,27 @@ describe("message-normalizer", () => {
       });
     });
 
+    it("normalizes persisted Responses text blocks as renderable text", () => {
+      const user = normalizeMessage({
+        role: "user",
+        content: [{ type: "input_text", text: "Persisted user question" }],
+      });
+      const assistant = normalizeMessage({
+        role: "assistant",
+        content: [{ type: "output_text", text: "Persisted assistant answer" }],
+      });
+
+      expect(user.content).toEqual([
+        {
+          type: "text",
+          text: "Persisted user question",
+          name: undefined,
+          args: undefined,
+        },
+      ]);
+      expect(assistant.content).toEqual([{ type: "text", text: "Persisted assistant answer" }]);
+    });
+
     it("normalizes structured base64 audio content blocks as renderable attachments", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -23,7 +23,7 @@ function isTextContentBlock(
     typeof item.text === "string" &&
     (item.type === "text" ||
       (role === "user" && item.type === "input_text") ||
-      (role === "assistant" && item.type === "output_text"))
+      (role === "assistant" && (item.type === "input_text" || item.type === "output_text")))
   );
 }
 

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -15,6 +15,15 @@ import { parseInlineDirectives } from "../../../../src/utils/directive-tags.js";
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 export { isToolResultMessage, normalizeRoleForGrouping } from "./role-normalizer.ts";
 
+function isTextContentBlock(item: Record<string, unknown>): item is Record<string, unknown> & {
+  text: string;
+} {
+  return (
+    typeof item.text === "string" &&
+    (item.type === "text" || item.type === "input_text" || item.type === "output_text")
+  );
+}
+
 function coerceCanvasPreview(
   value: unknown,
 ):
@@ -406,15 +415,25 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
           },
         ];
       }
-      if (item.type === "text" && typeof item.text === "string" && isAssistantMessage) {
-        const expanded = expandTextContent(item.text);
-        audioAsVoice = audioAsVoice || expanded.audioAsVoice;
-        if (expanded.replyTarget?.kind === "id") {
-          replyTarget = expanded.replyTarget;
-        } else if (expanded.replyTarget?.kind === "current" && replyTarget === null) {
-          replyTarget = expanded.replyTarget;
+      if (isTextContentBlock(item)) {
+        if (isAssistantMessage) {
+          const expanded = expandTextContent(item.text);
+          audioAsVoice = audioAsVoice || expanded.audioAsVoice;
+          if (expanded.replyTarget?.kind === "id") {
+            replyTarget = expanded.replyTarget;
+          } else if (expanded.replyTarget?.kind === "current" && replyTarget === null) {
+            replyTarget = expanded.replyTarget;
+          }
+          return expanded.content;
         }
-        return expanded.content;
+        return [
+          {
+            type: "text" as const,
+            text: item.text,
+            name: undefined,
+            args: undefined,
+          },
+        ];
       }
       return [
         {

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -15,12 +15,15 @@ import { parseInlineDirectives } from "../../../../src/utils/directive-tags.js";
 import type { NormalizedMessage, MessageContentItem } from "../types/chat-types.ts";
 export { isToolResultMessage, normalizeRoleForGrouping } from "./role-normalizer.ts";
 
-function isTextContentBlock(item: Record<string, unknown>): item is Record<string, unknown> & {
-  text: string;
-} {
+function isTextContentBlock(
+  item: Record<string, unknown>,
+  role: string,
+): item is Record<string, unknown> & { text: string } {
   return (
     typeof item.text === "string" &&
-    (item.type === "text" || item.type === "input_text" || item.type === "output_text")
+    (item.type === "text" ||
+      (role === "user" && item.type === "input_text") ||
+      (role === "assistant" && item.type === "output_text"))
   );
 }
 
@@ -415,7 +418,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
           },
         ];
       }
-      if (isTextContentBlock(item)) {
+      if (isTextContentBlock(item, role)) {
         if (isAssistantMessage) {
           const expanded = expandTextContent(item.text);
           audioAsVoice = audioAsVoice || expanded.audioAsVoice;

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -117,6 +117,25 @@ async function closeOpenBrowserContexts(): Promise<void> {
   await Promise.all([...openBrowserContexts].map((context) => closeBrowserContext(context)));
 }
 
+async function visibleChatBubbleTexts(page: Page): Promise<string[]> {
+  return page.locator(".chat-thread").evaluate((element) => {
+    const thread = element as HTMLElement;
+    const viewport = thread.getBoundingClientRect();
+    return Array.from(thread.querySelectorAll(".chat-bubble"))
+      .filter((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return (
+          rect.height > 0 &&
+          rect.width > 0 &&
+          rect.bottom > viewport.top &&
+          rect.top < viewport.bottom
+        );
+      })
+      .map((candidate) => candidate.textContent?.trim() ?? "")
+      .filter(Boolean);
+  });
+}
+
 async function controlUiEventPayloads(
   page: Page,
   event: string,
@@ -873,6 +892,115 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         .toBeLessThanOrEqual(4);
 
       await gateway.resolveDeferred("chat.send", { runId, status: "started" });
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("shows persisted user messages after opening History and scrolling mixed history", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseTs = Date.now() - 100_000;
+    const currentSessionMessages = [
+      {
+        content: [{ text: "Current session placeholder", type: "text" }],
+        role: "assistant",
+        timestamp: baseTs - 1,
+      },
+    ];
+    const historyMessages = Array.from({ length: 70 }, (_, index) => ({
+      content: [
+        {
+          text: `${index % 2 === 0 ? "User history question" : "Assistant history answer"} ${index}\n${"history detail line\n".repeat(4)}`,
+          type: index % 2 === 0 ? "input_text" : "output_text",
+        },
+      ],
+      role: index % 2 === 0 ? "user" : "assistant",
+      timestamp: baseTs + index,
+    }));
+    const gateway = await installMockGateway(page, {
+      historyMessages: currentSessionMessages,
+      methodResponses: {
+        "chat.history": {
+          cases: [
+            {
+              match: { sessionKey: "agent:main:session-b" },
+              response: {
+                messages: historyMessages,
+                sessionId: "control-ui-e2e-history-session-b",
+                thinkingLevel: null,
+              },
+            },
+            {
+              match: { sessionKey: "agent:main:session-a" },
+              response: {
+                messages: currentSessionMessages,
+                sessionId: "control-ui-e2e-history-session-a",
+                thinkingLevel: null,
+              },
+            },
+          ],
+        },
+        "sessions.list": chatSessionListResponse(),
+      },
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Current session placeholder").waitFor({ timeout: 10_000 });
+
+      await page.getByRole("button", { name: "Chat session" }).click();
+      await page.getByRole("option", { name: /Session B/ }).click();
+      const historyRequest = await gateway.waitForRequest("chat.history");
+      expect(requireRecord(historyRequest.params)).toMatchObject({
+        sessionKey: "agent:main:session-b",
+      });
+      await page.locator(".chat-thread").getByText("User history question 68").waitFor({
+        timeout: 10_000,
+      });
+      await page.locator(".chat-thread").getByText("Assistant history answer 69").waitFor({
+        timeout: 10_000,
+      });
+      await expect
+        .poll(
+          async () => {
+            const texts = await visibleChatBubbleTexts(page);
+            return (
+              texts.some((text) => text.includes("User history question 68")) &&
+              texts.some((text) => text.includes("Assistant history answer 69"))
+            );
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
+
+      await waitForChatScrollIdle(page);
+      await scrollChatThreadToTop(page);
+      await page.locator(".chat-thread").getByText("User history question 10").waitFor({
+        timeout: 10_000,
+      });
+      await scrollChatThreadToTop(page);
+      await page.locator(".chat-thread").getByText("User history question 0").waitFor({
+        timeout: 10_000,
+      });
+      await scrollChatThreadToTop(page);
+      await expect
+        .poll(
+          async () => {
+            const texts = await visibleChatBubbleTexts(page);
+            return (
+              texts.some((text) => text.includes("User history question 0")) &&
+              texts.some((text) => text.includes("Assistant history answer 1"))
+            );
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
     } finally {
       await closeBrowserContext(context);
     }


### PR DESCRIPTION
## Summary

- Problem: Opening a previous Control UI chat from History could show assistant replies while the user's own persisted messages were blank or effectively missing, leaving large empty-looking regions while scrolling through the conversation.
- Solution: Normalize persisted Responses `input_text` / `output_text` content blocks into Control UI renderable text blocks and align the related text extractors with those persisted content shapes.
- What changed: `message-normalizer`, `message-extract`, and shared assistant-visible text extraction now recognize persisted Responses text block names; unit and browser E2E coverage lock the conversion and History behavior.
- Conflict refresh: Rebased the PR onto current `origin/main` and resolved the `ui/src/ui/e2e/chat-flow.e2e.test.ts` conflict by preserving main's `newBrowserContext` / `closeBrowserContext` lifecycle helper pattern while keeping the persisted History regression test.
- What did NOT change: This patch does not change `chat.history` request/response transport, History loading/session selection protocol, CSS layout, unknown content block fallback behavior, or assistant-visible extraction for `input_text` assistant messages; those areas stay unchanged and out of scope.
- Why it matters / User impact: History is used to inspect prior conversations. If persisted user prompts disappear, the transcript loses the question/answer context and the scroll position can look like a large blank gap even though `chat.history` returned the messages.
- Fixes #90241

## Review findings addressed

- **RF-001:** Refreshed the branch against current `origin/main`; GitHub mergeability should be re-evaluated after this push.
- **RF-002:** Preserved the current main E2E browser lifecycle helper shape and updated the added History regression to use `newBrowserContext` and `closeBrowserContext`.
- **RF-003:** Reran focused unit and mocked Gateway browser E2E verification after the conflict refresh; logs are in the evidence files listed below.

## Real behavior proof

- **Behavior or issue addressed:** Opening a previous Control UI chat from History could show assistant replies while persisted user `input_text` messages were not visible, producing the reported missing user messages and empty-looking scroll regions.
- **Real environment tested:** Local repo worktree with project dependencies installed. Browser proof used local Playwright Chromium against the Control UI E2E server with controlled Gateway History responses, exercising the actual Control UI DOM and scroll viewport.
- **Exact steps or command run after this patch:** Ran focused persisted text-block tests, the Control UI text normalization/extraction tests, and the Control UI mocked Gateway browser E2E file after rebasing onto current main.

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/shared/chat-message-content.test.ts
```

```bash
pnpm --dir ui test src/ui/chat/message-normalizer.test.ts src/ui/chat/message-extract.test.ts
```

```bash
node scripts/ensure-playwright-chromium.mjs && node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts
```

- **Evidence after fix:** The local Control UI browser viewport proof showed persisted user `input_text` and assistant `output_text` messages visible after opening History and scrolling through the session.

Focused persisted text-block tests:

```text
Test Files  1 passed (1)
Tests       15 passed (15)
Evidence    /media/vdb/code/ai/aispace/openclaw-pr-93841-evidence/verification-unit-shared.log
```

Control UI normalization/extraction tests:

```text
Test Files  2 passed (2)
Tests       41 passed (41)
Evidence    /media/vdb/code/ai/aispace/openclaw-pr-93841-evidence/verification-ui-unit.log
```

Control UI mocked Gateway E2E after the main refresh:

```text
Test Files  1 passed (1)
Tests       16 passed (16)
Evidence    /media/vdb/code/ai/aispace/openclaw-pr-93841-evidence/verification-ui-e2e.log
```

Browser viewport proof from the local Control UI History session switch:

```json
{
  "bottomVisible": [
    "User history question 66\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "Assistant history answer 67\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "User history question 68\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "Assistant history answer 69\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line"
  ],
  "topVisible": [
    "User history question 0\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "Assistant history answer 1\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "User history question 2\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "Assistant history answer 3\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line",
    "User history question 4\nhistory detail line\nhistory detail line\nhistory detail line\nhistory detail line"
  ]
}
```

- **Observed result after fix:** After opening History and switching to the persisted session, the Control UI browser viewport shows user and assistant chat bubbles at both the bottom and the expanded top of the history. The previously invisible persisted user `input_text` messages render as normal user message text.
- **What was not tested:** No live external provider, account, or channel was used. The issue is a Control UI persisted History rendering bug, and the proof uses the local Control UI E2E server with controlled Gateway responses to exercise the browser-visible behavior without external credentials.

## Regression Test Plan

- **Target test file:** `ui/src/ui/e2e/chat-flow.e2e.test.ts` locks the History session switch and scroll behavior; `ui/src/ui/chat/message-normalizer.test.ts`, `ui/src/ui/chat/message-extract.test.ts`, and `src/shared/chat-message-content.test.ts` lock the text block conversion boundaries.
- **Scenario locked in:** The E2E regression creates 70 mixed persisted history messages, with even items as user `input_text` and odd items as assistant `output_text`, then opens Control UI chat, switches to Session B through the Chat session picker, verifies the `chat.history` request targets `agent:main:session-b`, checks the bottom viewport, scrolls to the top, and checks the top viewport.
- **Why this is the smallest reliable guardrail:** The bug requires the real Control UI grouping/rendering/scroll window to interact with persisted `input_text` and `output_text` blocks. Unit tests lock the conversion boundary, and the local Gateway-history browser test locks the user-visible History behavior without external provider or channel credentials.

## Merge risk

- **Risk labels considered:** `impact:session-state`, `impact:message-loss`, message-delivery, and the issue's `P2` user-visible History regression were considered. No live-channel or provider risk label applies to this Control UI rendering path.
- **Risk explanation:** Low. The change is limited to recognized text content block names and keeps unknown block types on the existing non-text path. Assistant `output_text` follows the existing assistant expansion path, while user `input_text` becomes plain renderable text. This touches message rendering/extraction code but does not change transport, storage, public config, or provider behavior.
- **Why acceptable:** The regression tests cover the conversion boundaries and the real browser-visible History flow, including both the initial bottom render window and scroll expansion to older messages. The conflict refresh preserves current main's E2E browser context cleanup pattern, keeping the test harness aligned with main.

## Root Cause

- **Root cause:** The root cause is a Control UI normalization contract mismatch: the history loader kept the messages, but the Control UI render mapping only treated `type: "text"` blocks as displayable text. Persisted Responses history can store user text as `input_text` and assistant text as `output_text`, so those blocks reached the UI without being normalized into renderable chat text.
- **Why this is root-cause fix:** This changes the normalization/extraction boundary that turns persisted message content into renderable chat items. It fixes the source contract mismatch between persisted Responses text block names and Control UI renderable text items instead of masking the symptom with CSS spacing changes, History loader filtering, or session-specific special cases.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High. The diff is limited to recognized persisted text block names, includes unit coverage at the conversion boundaries, includes a browser-visible History regression for the reported behavior, and has now been refreshed against current main.
- **Patch quality notes:** The E2E uses existing 10s waits already common in this suite for browser-visible UI readiness; they wait for specific session text and viewport conditions, not arbitrary sleep. The public contract boundary remains unchanged because `chat.history` transport/data format is not modified; this patch only normalizes already persisted content block names at the UI boundary.
- **Architecture / source-of-truth check:** The source-of-truth boundary for this bug is the Control UI normalization/extraction layer where persisted message content is converted into renderable chat items. The patch aligns that boundary with persisted Responses `input_text` / `output_text` data before downstream grouping and scroll rendering, and leaves `chat.history` protocol/data format compatibility unchanged.
