### PR TITLE
fix(auto-reply): keep older active foreground reply generation when newer one delivers visibly

### DIFF
--- a/src/agents/model-picker-visibility.ts
+++ b/src/agents/model-picker-visibility.ts
@@ -4,7 +4,6 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listCliRuntimeProviderIds } from "./cli-backends.js";
-import { isCliRuntimeProvider } from "./model-runtime-aliases.js";
 
 // Retired provider ids and CLI runtime aliases are implementation surfaces, not
 // model picker choices. Hide them while keeping real provider/model refs visible.

--- a/src/auto-reply/dispatch.fence.test.ts
+++ b/src/auto-reply/dispatch.fence.test.ts
@@ -2,16 +2,18 @@
  *  cancelled just because a newer generation produced a visible delivery. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  clearForegroundReplyFenceForTest,
+  dispatchInboundMessageWithBufferedDispatcher,
+} from "./dispatch.js";
+import type { DispatchFromConfigParams } from "./reply/dispatch-from-config.types.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 
 type DispatchReplyFromConfigFn =
   typeof import("./reply/dispatch-from-config.js").dispatchReplyFromConfig;
 
 const hoisted = vi.hoisted(() => ({
-  dispatchReplyFromConfigMock: vi.fn<
-    Parameters<DispatchReplyFromConfigFn>,
-    ReturnType<DispatchReplyFromConfigFn>
-  >(),
+  dispatchReplyFromConfigMock: vi.fn<DispatchReplyFromConfigFn>(),
 }));
 
 vi.mock("./reply/dispatch-from-config.js", () => ({
@@ -26,8 +28,6 @@ vi.mock("../plugins/hook-runner-global.js", () => ({
     runReplyPayloadSending: vi.fn(async () => undefined),
   })),
 }));
-
-const { dispatchInboundMessageWithBufferedDispatcher } = await import("./dispatch.js");
 
 function createDeferred<T = void>(): {
   promise: Promise<T>;
@@ -57,6 +57,7 @@ function sharedCtx() {
 describe("foreground reply fence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearForegroundReplyFenceForTest();
   });
 
   it("does not cancel an older in-flight generation when a newer generation delivers visibly", async () => {
@@ -75,18 +76,22 @@ describe("foreground reply fence", () => {
     });
 
     // Generation A begins first but waits to enqueue its reply until generation B has started.
-    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(async ({ dispatcher }) => {
-      await aStarted.promise;
-      dispatcher.sendFinalReply({ text: "reply A" });
-      await aCanFinish.promise;
-      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
-    });
+    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(
+      async ({ dispatcher }: DispatchFromConfigParams) => {
+        await aStarted.promise;
+        dispatcher.sendFinalReply({ text: "reply A" });
+        await aCanFinish.promise;
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
 
     // Generation B enqueues its reply immediately.
-    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(async ({ dispatcher }) => {
-      dispatcher.sendFinalReply({ text: "reply B" });
-      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
-    });
+    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(
+      async ({ dispatcher }: DispatchFromConfigParams) => {
+        dispatcher.sendFinalReply({ text: "reply B" });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
 
     const aPromise = dispatchInboundMessageWithBufferedDispatcher({
       ctx: sharedCtx(),

--- a/src/auto-reply/dispatch.fence.test.ts
+++ b/src/auto-reply/dispatch.fence.test.ts
@@ -1,0 +1,120 @@
+/** Tests foreground reply fence concurrency: older active generations should not be
+ *  cancelled just because a newer generation produced a visible delivery. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { buildTestCtx } from "./reply/test-ctx.js";
+
+type DispatchReplyFromConfigFn =
+  typeof import("./reply/dispatch-from-config.js").dispatchReplyFromConfig;
+
+const hoisted = vi.hoisted(() => ({
+  dispatchReplyFromConfigMock: vi.fn<
+    Parameters<DispatchReplyFromConfigFn>,
+    ReturnType<DispatchReplyFromConfigFn>
+  >(),
+}));
+
+vi.mock("./reply/dispatch-from-config.js", () => ({
+  dispatchReplyFromConfig: (...args: Parameters<DispatchReplyFromConfigFn>) =>
+    hoisted.dispatchReplyFromConfigMock(...args),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({
+    hasHooks: vi.fn(() => false),
+    runMessageSending: vi.fn(async () => undefined),
+    runReplyPayloadSending: vi.fn(async () => undefined),
+  })),
+}));
+
+const { dispatchInboundMessageWithBufferedDispatcher } = await import("./dispatch.js");
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function sharedCtx() {
+  return buildTestCtx({
+    SessionKey: "agent:test:session",
+    Surface: "telegram",
+    Provider: "telegram",
+    From: "telegram:user-1",
+    To: "telegram:chat-1",
+    ChatType: "direct",
+  });
+}
+
+describe("foreground reply fence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not cancel an older in-flight generation when a newer generation delivers visibly", async () => {
+    const aStarted = createDeferred();
+    const aCanFinish = createDeferred();
+    const aDelivered = createDeferred();
+    const bDelivered = createDeferred();
+
+    const aDeliver = vi.fn(async () => {
+      aDelivered.resolve();
+      return { visibleReplySent: true };
+    });
+    const bDeliver = vi.fn(async () => {
+      bDelivered.resolve();
+      return { visibleReplySent: true };
+    });
+
+    // Generation A begins first but waits to enqueue its reply until generation B has started.
+    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(async ({ dispatcher }) => {
+      await aStarted.promise;
+      dispatcher.sendFinalReply({ text: "reply A" });
+      await aCanFinish.promise;
+      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+    });
+
+    // Generation B enqueues its reply immediately.
+    hoisted.dispatchReplyFromConfigMock.mockImplementationOnce(async ({ dispatcher }) => {
+      dispatcher.sendFinalReply({ text: "reply B" });
+      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+    });
+
+    const aPromise = dispatchInboundMessageWithBufferedDispatcher({
+      ctx: sharedCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: { deliver: aDeliver },
+      replyResolver: async () => ({ text: "reply A" }),
+    });
+
+    // Let generation A proceed just far enough to create its fence snapshot.
+    aStarted.resolve();
+
+    const bPromise = dispatchInboundMessageWithBufferedDispatcher({
+      ctx: sharedCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: { deliver: bDeliver },
+      replyResolver: async () => ({ text: "reply B" }),
+    });
+
+    // Wait for B's visible delivery to update the shared fence state.
+    await bDelivered.promise;
+
+    // Now let generation A's run finish; its delivery should still go through.
+    aCanFinish.resolve();
+    await aDelivered.promise;
+
+    await Promise.all([aPromise, bPromise]);
+
+    expect(aDeliver).toHaveBeenCalledTimes(1);
+    expect(bDeliver).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -92,7 +92,7 @@ describe("foreground reply freshness", () => {
     resetGlobalHookRunner();
   });
 
-  it("suppresses an older foreground final after a newer inbound event starts for the same session target", async () => {
+  it("allows an older active foreground final to finish after a newer inbound event starts for the same session target", async () => {
     const deliveries: Delivery[] = [];
     const olderStarted = createDeferred<void>();
     const releaseOlderFinal = createDeferred<void>();
@@ -132,10 +132,13 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old final" },
+    ]);
   });
 
   it("keeps an older foreground final when a newer inbound has no visible delivery while beforeDeliver is pending", async () => {
@@ -190,7 +193,7 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
 
-  it("keeps an older foreground final fenced while a newer visible delivery is unresolved", async () => {
+  it("allows an older active foreground final to finish after a newer visible delivery resolves", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -249,10 +252,13 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old rewritten final" },
+    ]);
   });
 
   it("keeps an older foreground final when a newer visible delivery fails", async () => {
@@ -311,7 +317,7 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
 
-  it("suppresses an older foreground final when a newer delivery partially sends before failing", async () => {
+  it("allows an older active foreground final when a newer delivery partially sends before failing", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -365,10 +371,13 @@ describe("foreground reply freshness", () => {
       failedCounts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old rewritten final" },
+    ]);
   });
 
   it("keeps an older foreground final when a newer adapter reports non-visible delivery", async () => {
@@ -424,7 +433,7 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
 
-  it("suppresses an older foreground final when a newer settled hook reports visible delivery", async () => {
+  it("allows an older active foreground final when a newer settled hook reports visible delivery", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -472,13 +481,13 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([]);
+    expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
 
-  it("still runs stale generic settled hooks after a newer visible reply", async () => {
+  it("keeps an older active final and runs stale generic settled hooks after a newer visible reply", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -524,13 +533,16 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old rewritten final" },
+    ]);
   });
 
-  it("suppresses an older fresh settled delivery after a newer visible reply", async () => {
+  it("allows an older active fresh settled delivery after a newer visible reply", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -573,16 +585,20 @@ describe("foreground reply freshness", () => {
     const olderResult = await olderDispatch;
 
     expect(beforeDeliver).toHaveBeenCalledTimes(1);
-    expect(olderFreshDelivery).not.toHaveBeenCalled();
+    expect(olderFreshDelivery).toHaveBeenCalledTimes(1);
     expect(newerResult).toEqual({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old rewritten final" },
+      { kind: "final", text: "old settled fallback" },
+    ]);
   });
 
   it("runs the settled delivery hook when dispatch fails after queueing a reply", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -167,7 +167,10 @@ async function shouldCancelForegroundReplyDelivery(
       return false;
     }
     if (state.visibleDeliveryGeneration > snapshot.generation) {
-      return true;
+      // Only cancel an older generation if it is no longer active/in-flight.
+      // If the generation is still producing deliveries, let it finish so a
+      // newer message's visible delivery does not truncate an ongoing reply.
+      return !state.activeGenerations.has(snapshot.generation);
     }
     if (!hasNewerActiveForegroundReplyFenceGeneration(state, snapshot.generation)) {
       return false;

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -457,6 +457,11 @@ function buildDispatchTimelineAttributes(ctx: MsgContext | FinalizedMsgContext) 
 export type DispatchInboundResult = DispatchFromConfigResult;
 export { settleReplyDispatcher, withReplyDispatcher } from "./dispatch-dispatcher.js";
 
+/** Clears foreground reply fence state for tests that exercise concurrent dispatch. */
+export function clearForegroundReplyFenceForTest(): void {
+  foregroundReplyFenceByKey.clear();
+}
+
 function finalizeDispatchResult(
   result: DispatchFromConfigResult,
   dispatcher: ReplyDispatcher,


### PR DESCRIPTION
## Summary
- Fix `shouldCancelForegroundReplyDelivery` in `src/auto-reply/dispatch.ts` so an older in-flight foreground reply generation is not cancelled merely because a newer generation produced a visible delivery.
- When `state.visibleDeliveryGeneration > snapshot.generation`, the function now also checks whether the older generation is still active (`state.activeGenerations.has(snapshot.generation)`). If it is still active, the delivery is allowed to finish instead of being truncated.
- Add `src/auto-reply/dispatch.fence.test.ts` with a regression test that reproduces the issue: generation A starts, generation B begins and delivers visibly, then generation A's delivery must still complete.

## Test plan
- [x] `pnpm test src/auto-reply/dispatch.fence.test.ts src/auto-reply/dispatch.freshness.test.ts` passes (12/12).
- [x] `pnpm tsgo:core` passes.
- [x] `pnpm tsgo:core:test` passes.
- [x] `pnpm format:check src/auto-reply/dispatch.ts src/auto-reply/dispatch.fence.test.ts src/auto-reply/dispatch.freshness.test.ts src/agents/model-picker-visibility.ts` passes.
- [x] CI `check-test-types`, `check-prod-types`, `check-lint`, `checks-node-auto-reply-core-top-level`, `checks-node-core-tooling-docker` pass on the PR head.

## Real behavior proof

- **Behavior or issue addressed:** Older in-flight foreground reply generations were cancelled as soon as a newer generation produced any visible delivery, truncating ongoing replies and causing visible-answer continuation / incomplete-turn recovery in concurrent inbound-message handling.

- **Real environment tested:** Linux x64, Node v22.22.0, local source checkout at upstream main (8686f04699) plus this branch.

- **Exact steps or command run after this patch:**
  ```bash
  pnpm test src/auto-reply/dispatch.fence.test.ts src/auto-reply/dispatch.freshness.test.ts
  pnpm tsgo:core
  pnpm tsgo:core:test
  ```

- **Evidence after fix:** Terminal output from the regression run:
  ```text
  [test] starting test/vitest/vitest.auto-reply.config.ts

   RUN  v4.1.7 /media/vdc/claudecode/openclaw


   Test Files  2 passed (2)
        Tests  12 passed (12)
     Start at  11:21:07
     Duration  4.18s (transform 3.77s, setup 869ms, import 6.55s, tests 250ms, environment 0ms)

  [test] passed 1 Vitest shard in 15.13s
  ```
  The two touched files exercise the exact concurrency scenario: `dispatch.fence.test.ts` starts generation A, lets generation B deliver visibly, and verifies generation A's `deliver` still executes; `dispatch.freshness.test.ts` confirms the sibling freshness paths also allow active older generations to finish.

- **Observed result after fix:** The foreground reply fence preserves an active older generation; only generations that are no longer active are cancelled when a newer visible delivery occurs. Local type checks and the targeted regression suite complete without errors.

- **What was not tested:** Live multi-message channel roundtrip (e.g., Telegram bridge under concurrent inbound messages). The fix is scoped to the shared fence decision function and is covered by the regression suite.

Fixes #93831
