### PR TITLE
fix: remove unused model picker import

### DIFF
--- a/src/agents/model-picker-visibility.ts
+++ b/src/agents/model-picker-visibility.ts
@@ -4,7 +4,6 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listCliRuntimeProviderIds } from "./cli-backends.js";
-import { isCliRuntimeProvider } from "./model-runtime-aliases.js";
 
 // Retired provider ids and CLI runtime aliases are implementation surfaces, not
 // model picker choices. Hide them while keeping real provider/model refs visible.


### PR DESCRIPTION
## Summary
- remove an unused `isCliRuntimeProvider` import from `src/agents/model-picker-visibility.ts`
- restores the current main lint/prod-types baseline hit by unrelated PRs

## Real behavior proof
- **Behavior or issue addressed:** Main CI lint/prod-types baseline was failing on an unused `isCliRuntimeProvider` import in `src/agents/model-picker-visibility.ts`; after this patch the model picker source no longer imports that unused symbol.
- **Real environment tested:** Local OpenClaw checkout on macOS at `/Users/apple/code/workspaces/openclaw/openclaw`, branch `wolf/main-ci-model-picker-unused-import`, commit `0d349323bb7637f6682213ede092e28346c15408`.
- **Exact steps or command run after this patch:** Ran `node -e`, `node_modules/.bin/oxlint src/agents/model-picker-visibility.ts`, `pnpm lint`, and `pnpm tsgo:prod` in the local OpenClaw checkout after the patch.
- **Evidence after fix:** Terminal output copied from the local checkout:

```text
$ node -e "const fs=require('fs'); const text=fs.readFileSync('src/agents/model-picker-visibility.ts','utf8'); console.log(text.includes('isCliRuntimeProvider')?'still imported':'unused import removed')"
unused import removed

$ node_modules/.bin/oxlint src/agents/model-picker-visibility.ts
# exit 0; no lint output

$ pnpm lint
$ node scripts/run-oxlint-shards.mjs
[oxlint:core] finished
[oxlint:extensions] finished
[oxlint:scripts] finished
# exit 0

$ pnpm tsgo:prod
$ pnpm tsgo:core && pnpm tsgo:extensions
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
# exit 0
```

- **Observed result after fix:** The local terminal check reports `unused import removed`; the targeted lint check, full oxlint shard runner, and prod type check all exit 0.
- **What was not tested:** No browser, device, or live gateway runtime flow was tested because this patch only removes an unused TypeScript import that blocked lint/prod-types on main.

## Verification
- `node_modules/.bin/oxlint src/agents/model-picker-visibility.ts`
- `pnpm lint`
- `pnpm tsgo:prod`
- `git diff --check`
- `gitleaks protect --staged --redact`
