### PR TITLE
fix(secrets): pass BWS_SERVER_URL to bws CLI in resolver script (fixes #93851)

### DIFF
--- a/scripts/secrets/openclaw-bws-resolver.mjs
+++ b/scripts/secrets/openclaw-bws-resolver.mjs
@@ -52,6 +52,7 @@ const main = async () => {
     env: {
       BWS_ACCESS_TOKEN: process.env.BWS_ACCESS_TOKEN,
       PATH: process.env.PATH || "",
+      ...(process.env.BWS_SERVER_URL ? { BWS_SERVER_URL: process.env.BWS_SERVER_URL } : {}),
     },
     maxBuffer: 1024 * 1024,
     timeout: 15_000,


### PR DESCRIPTION
## Summary

Self-hosted Bitwarden Secrets Manager requires `BWS_SERVER_URL` to connect to the correct server. The resolver script was only passing `BWS_ACCESS_TOKEN` and `PATH` to the child `bws` process, causing self-hosted instances to fail with 401 errors.

## Fix

Added `BWS_SERVER_URL` forwarding in the resolver script's child process environment when the variable is present.

## Testing

- Self-hosted Bitwarden users with `BWS_SERVER_URL` set in their environment will now have it forwarded to the `bws` CLI
- SaaS Bitwarden users (no `BWS_SERVER_URL` set) are unaffected — the spread only applies when the variable exists

Closes #93851

🤖 Generated with [Claude Code](https://claude.com/claude-code)