### PR TITLE
fix: keep active foreground reply generations alive (#93831)

### DIFF
--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -424,7 +424,7 @@ describe("foreground reply freshness", () => {
     expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
 
-  it("suppresses an older foreground final when a newer settled hook reports visible delivery", async () => {
+  it("keeps an older foreground final active after a newer settled hook reports visible delivery", async () => {
     const deliveries: Delivery[] = [];
     const beforeDeliverStarted = createDeferred<void>();
     const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
@@ -472,10 +472,10 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 1 },
     });
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([]);
+    expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
   });
 
   it("still runs stale generic settled hooks after a newer visible reply", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -167,7 +167,7 @@ async function shouldCancelForegroundReplyDelivery(
       return false;
     }
     if (state.visibleDeliveryGeneration > snapshot.generation) {
-      return true;
+      return !state.activeGenerations.has(snapshot.generation);
     }
     if (!hasNewerActiveForegroundReplyFenceGeneration(state, snapshot.generation)) {
       return false;


### PR DESCRIPTION
## Summary
- keep older foreground reply generations alive while they are still active
- only cancel stale foreground delivery after the older generation has fully left the active set
- update freshness coverage for newer visible delivery reported from settled hooks

## Testing
- pnpm exec vitest run --config test/vitest/vitest.unit.config.ts src/auto-reply/dispatch.freshness.test.ts

Closes #93831