### PR TITLE
fix: avoid reminder-guard false positives for plain memory promises (#47586)

### DIFF
--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
-import { appendUnscheduledReminderNote } from "./agent-runner-reminder-guard.js";
+import {
+  appendUnscheduledReminderNote,
+  hasUnbackedReminderCommitment,
+} from "./agent-runner-reminder-guard.js";
+
+describe("hasUnbackedReminderCommitment", () => {
+  it("matches temporal reminder commitments without flagging plain memory statements", () => {
+    expect(hasUnbackedReminderCommitment("I'll remind you tomorrow.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I'll remember to check on that tomorrow.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I'll remember that preference.")).toBe(false);
+    expect(hasUnbackedReminderCommitment("I'll remember the specifics.")).toBe(false);
+  });
+});
 
 describe("appendUnscheduledReminderNote", () => {
   it("preserves transcript ownership metadata when appending the guard note", () => {

--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -11,8 +11,13 @@ describe("hasUnbackedReminderCommitment", () => {
     expect(hasUnbackedReminderCommitment("I'll remember to check on that tomorrow.")).toBe(true);
     expect(hasUnbackedReminderCommitment("I'll remember and remind you tomorrow.")).toBe(true);
     expect(hasUnbackedReminderCommitment("I will remember, then follow up next week.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I'll remember that and remind you tomorrow.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I'll remember this, then follow up next week.")).toBe(
+      true,
+    );
     expect(hasUnbackedReminderCommitment("I'll remember that preference.")).toBe(false);
     expect(hasUnbackedReminderCommitment("I'll remember the specifics.")).toBe(false);
+    expect(hasUnbackedReminderCommitment("I'll remember to use metric units for you.")).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -12,6 +12,9 @@ describe("hasUnbackedReminderCommitment", () => {
     expect(hasUnbackedReminderCommitment("I'll remember and remind you tomorrow.")).toBe(true);
     expect(hasUnbackedReminderCommitment("I will remember, then follow up next week.")).toBe(true);
     expect(hasUnbackedReminderCommitment("I'll remember that and remind you tomorrow.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I'll remember that and will remind you tomorrow.")).toBe(
+      true,
+    );
     expect(hasUnbackedReminderCommitment("I'll remember this, then follow up next week.")).toBe(
       true,
     );

--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -9,6 +9,8 @@ describe("hasUnbackedReminderCommitment", () => {
   it("matches temporal reminder commitments without flagging plain memory statements", () => {
     expect(hasUnbackedReminderCommitment("I'll remind you tomorrow.")).toBe(true);
     expect(hasUnbackedReminderCommitment("I'll remember to check on that tomorrow.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I'll remember and remind you tomorrow.")).toBe(true);
+    expect(hasUnbackedReminderCommitment("I will remember, then follow up next week.")).toBe(true);
     expect(hasUnbackedReminderCommitment("I'll remember that preference.")).toBe(false);
     expect(hasUnbackedReminderCommitment("I'll remember the specifics.")).toBe(false);
   });

--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -21,6 +21,11 @@ describe("hasUnbackedReminderCommitment", () => {
     expect(hasUnbackedReminderCommitment("I'll remember that preference.")).toBe(false);
     expect(hasUnbackedReminderCommitment("I'll remember the specifics.")).toBe(false);
     expect(hasUnbackedReminderCommitment("I'll remember to use metric units for you.")).toBe(false);
+    expect(
+      hasUnbackedReminderCommitment(
+        "I'll remember to use metric units when answering distance questions.",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -8,8 +8,10 @@ const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
 
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember\s+to\b|remind|ping|follow up|follow-up|check back|circle back)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b\s*(?:,\s*(?:and\s+)?then|\s+and(?:\s+then)?)\s+(?:remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\s+(?:(?:remind|ping|follow up|follow-up|check back|circle back)\b|(?:set|create|schedule)\s+(?:a\s+)?reminder\b)/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\b[^.!?]{0,160}\b(?:tomorrow|tonight|later|(?:this|next)\s+(?:morning|afternoon|evening|week|month|year)|in\s+(?:\d+|an?|one|two|three|four|five)\s+(?:minutes?|hours?|days?|weeks?)|at\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?|when|once|after|before)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b[^.!?]{0,160}?(?:\s+and(?:\s+then)?|,\s*(?:(?:and\s+)?then)?)\s+(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back|(?:set|create|schedule)\s+(?:a\s+)?reminder)\b/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
 ];
 

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -11,7 +11,7 @@ const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
   /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back)\b/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\s+(?:(?:remind|ping|follow up|follow-up|check back|circle back)\b|(?:set|create|schedule)\s+(?:a\s+)?reminder\b)/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\b[^.!?]{0,160}\b(?:tomorrow|tonight|later|(?:this|next)\s+(?:morning|afternoon|evening|week|month|year)|in\s+(?:\d+|an?|one|two|three|four|five)\s+(?:minutes?|hours?|days?|weeks?)|at\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?|when|once|after|before)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b[^.!?]{0,160}?(?:\s+and(?:\s+then)?|,\s*(?:(?:and\s+)?then)?)\s+(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back|(?:set|create|schedule)\s+(?:a\s+)?reminder)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b[^.!?]{0,160}?(?:\s+and(?:\s+then)?|,\s*(?:(?:and\s+)?then)?)\s+(?:(?:i\s*['’]?ll|i will|will)\s+)?(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back|(?:set|create|schedule)\s+(?:a\s+)?reminder)\b/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
 ];
 

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -9,6 +9,7 @@ const UNSCHEDULED_REMINDER_NOTE =
 
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
   /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember\s+to\b|remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b\s*(?:,\s*(?:and\s+)?then|\s+and(?:\s+then)?)\s+(?:remind|ping|follow up|follow-up|check back|circle back)\b/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
 ];
 

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -8,7 +8,7 @@ const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
 
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember\s+to\b|remind|ping|follow up|follow-up|check back|circle back)\b/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
 ];
 

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -8,10 +8,9 @@ const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
 
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\s+(?:(?:remind|ping|follow up|follow-up|check back|circle back)\b|(?:set|create|schedule)\s+(?:a\s+)?reminder\b)/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\b[^.!?]{0,160}\b(?:tomorrow|tonight|later|(?:this|next)\s+(?:morning|afternoon|evening|week|month|year)|in\s+(?:\d+|an?|one|two|three|four|five)\s+(?:minutes?|hours?|days?|weeks?)|at\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?|when|once|after|before)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b[^.!?]{0,160}?(?:\s+and(?:\s+then)?|,\s*(?:(?:and\s+)?then)?)\s+(?:(?:i\s*['’]?ll|i will|will)\s+)?(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check back|circle back|(?:set|create|schedule)\s+(?:a\s+)?reminder)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check (?:back|on)|circle back)\b/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\s+to\s+(?:(?:remind|ping|follow up|follow-up|check (?:back|on)|circle back)\b|(?:set|create|schedule)\s+(?:a\s+)?reminder\b)/i,
+  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?remember\b[^.!?]{0,160}?(?:\s+and(?:\s+then)?|,\s*(?:(?:and\s+)?then)?)\s+(?:(?:i\s*['’]?ll|i will|will)\s+)?(?:make sure to\s+)?(?:remind|ping|follow up|follow-up|check (?:back|on)|circle back|(?:set|create|schedule)\s+(?:a\s+)?reminder)\b/i,
   /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
 ];
 

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2659,6 +2659,17 @@ describe("runReplyAgent reminder commitment guard", () => {
     );
   });
 
+  it("does not append a reminder note to a plain memory promise", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll remember that preference." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun();
+    expectReplyText(result, "I'll remember that preference.");
+  });
+
   it("keeps reminder commitment unchanged when cron.add succeeded", async () => {
     runEmbeddedAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "I'll remind you tomorrow morning." }],


### PR DESCRIPTION
## What Problem This Solves

The reminder guard treated every first-person use of `remember` as an unscheduled reminder promise. Replies that only acknowledged stored preferences, such as "I'll remember that preference," therefore received a misleading note saying no automatic reminder had been scheduled.

Closes #47586

## Why This Change Was Made

- Require an explicit reminder action: remind, ping, follow up, check back/on, circle back, or set/create/schedule a reminder.
- Preserve natural coordinated promises, including "I'll remember that and will remind you tomorrow."
- Avoid generic temporal-word inference, so preference statements such as "I'll remember to use metric units when answering distance questions" remain plain memory promises.
- Exercise the actual `runReplyAgent` final-payload path, not only the regex helper.

## User Impact

Plain memory acknowledgements no longer receive an incorrect unscheduled-reminder warning. Explicit reminder and follow-up promises still receive the warning when no cron job was created or already covers the session.

## Evidence

- Focused positive/negative matcher regression coverage.
- Full runner regression coverage for final payload output.
- `oxfmt` check and `git diff --check` pass for all touched files.
- Fresh high-depth autoreview on `aba3ff87652` found no actionable issues (confidence 0.86).
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/28843408053
