### PR TITLE
fix: label successful config.patch notices as restart required (#46797)

### DIFF
--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -152,6 +152,18 @@ describe("restart sentinel", () => {
     expect(result).toContain("Gateway restart");
   });
 
+  it("reports config.patch success as restart required", () => {
+    const payload = {
+      kind: "config-patch" as const,
+      status: "ok" as const,
+      ts: Date.now(),
+      stats: { mode: "config.patch" },
+    };
+
+    expect(summarizeRestartSentinel(payload)).toBe("Gateway restart required (config.patch)");
+    expect(formatRestartSentinelMessage(payload)).toBe("Gateway restart required (config.patch)");
+  });
+
   it("formats summary, distinct reason, and doctor hint together", () => {
     const payload = {
       kind: "config-patch" as const,

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -232,9 +232,12 @@ export function summarizeRestartSentinel(payload: RestartSentinelPayload): strin
   if (payload.kind === "config-auto-recovery") {
     return "Gateway auto-recovery";
   }
+  const mode = payload.stats?.mode ? ` (${payload.stats.mode})` : "";
+  if (payload.kind === "config-patch" && payload.status === "ok") {
+    return `Gateway restart required${mode}`.trim();
+  }
   const kind = payload.kind;
   const status = payload.status;
-  const mode = payload.stats?.mode ? ` (${payload.stats.mode})` : "";
   const kindSegment = kind === "restart" ? "" : ` ${kind}`;
   return `Gateway restart${kindSegment} ${status}${mode}`.trim();
 }


### PR DESCRIPTION
## Summary
- report successful config.patch sentinel summaries as restart required instead of restart complete
- preserve existing wording for config.patch failures and other sentinel kinds
- add regression coverage for the success-path notice

## Testing
- pnpm exec vitest run --config test/vitest/vitest.unit.config.ts src/infra/restart-sentinel.test.ts

Closes #46797