### PR TITLE
fix(ollama): show all thinking levels in /think menu for dynamically-discovered models

### DIFF
--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -56,5 +56,11 @@ export function resolveThinkingProfile({
 }: {
   reasoning?: boolean;
 }): ProviderThinkingProfile {
-  return reasoning ? OLLAMA_REASONING_THINKING_PROFILE : OLLAMA_NON_REASONING_THINKING_PROFILE;
+  // When reasoning is undefined (e.g. dynamically-discovered model not in catalog),
+  // treat it as reasoning-capable so the /think menu shows all available levels.
+  // Only restrict to off-only when reasoning is explicitly false.
+  if (reasoning === false) {
+    return OLLAMA_NON_REASONING_THINKING_PROFILE;
+  }
+  return OLLAMA_REASONING_THINKING_PROFILE;
 }


### PR DESCRIPTION
## Summary

Fixes #93835

When an Ollama model with thinking capability is dynamically discovered (e.g. via local Ollama endpoint `/api/tags`), it is not in the configured model catalog. The `resolveThinkingProfile` function in `provider-policy-api.ts` was treating `undefined` reasoning as non-reasoning, returning only `["off"]` levels — causing the Telegram `/think` menu to show only "default, off".

## Root Cause

Two issues combined:

1. **`provider-policy-api.ts`**: `resolveThinkingProfile({ reasoning })` used `reasoning ? A : B`, treating `undefined` as falsy and returning the non-reasoning profile (off-only).

2. **Catalog mismatch**: Dynamically-discovered models store their `reasoning` field in `dynamicModelCache`, but the thinking system queries `buildConfiguredModelCatalog` which only includes configured models. So for dynamic models, `reasoning` is `undefined` when resolving the thinking profile.

## Fix

Change `resolveThinkingProfile` to only restrict to off-only when `reasoning` is explicitly `false`. When reasoning is `undefined` (dynamic model, unknown capabilities), return the full reasoning profile so all thinking levels (`off`, `low`, `medium`, `high`, `max`) appear in the `/think` menu.

## Behavior mapping

| Scenario | reasoning value | Before fix | After fix |
|---|---|---|---|
| Reasoning model (configured) | `true` | all levels ✅ | all levels ✅ |
| Non-reasoning model (configured) | `false` | off only ✅ | off only ✅ |
| Dynamic model with thinking | `undefined` | off only ❌ | all levels ✅ |
| Dynamic model without thinking | `undefined` | off only ⚠️ | all levels (consistent with other providers) ✅ |

## Real behavior proof

**Behavior or issue addressed**: Telegram `/think` menu shows only "default, off" for dynamically-discovered Ollama models that have thinking capability and accept `/think medium` etc.

**Real environment tested**: Code path analysis on `openclaw/openclaw` main branch (commit `0c651fd082b`), reviewed against the full call chain:
```
/think menu → resolveCommandArgMenu → resolveCommandArgChoices
→ buildBuiltinChatCommands({ listThinkingLevels })
→ listThinkingLevels(provider, model, catalog)
→ resolveThinkingProfile({ provider, model, catalog })
→ resolveProviderThinkingProfile({ provider: "ollama", context })
→ resolveBundledProviderPolicySurface("ollama")
→ provider-policy-api.ts::resolveThinkingProfile({ reasoning })
```

**Exact steps or command run after this patch**: Code review of the diff and trace verification:

```diff
-  return reasoning ? OLLAMA_REASONING_THINKING_PROFILE : OLLAMA_NON_REASONING_THINKING_PROFILE;
+  if (reasoning === false) {
+    return OLLAMA_NON_REASONING_THINKING_PROFILE;
+  }
+  return OLLAMA_REASONING_THINKING_PROFILE;
```

**Evidence after fix**: The fix changes the conditional from loose falsy check (`reasoning ?`) to strict equality check (`reasoning === false`). This is the complete proof trace:

```typescript
// provider-policy-api.ts — the two thinking profiles:

const OLLAMA_REASONING_THINKING_PROFILE = {
  levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
  defaultLevel: "off",
} satisfies ProviderThinkingProfile;

const OLLAMA_NON_REASONING_THINKING_PROFILE = {
  levels: [{ id: "off" }],
  defaultLevel: "off",
} satisfies ProviderThinkingProfile;

// Before fix — reasoning=undefined → falsy → NON_REASONING → /think menu shows "default, off"
// After fix  — reasoning=undefined → !== false → REASONING → /think menu shows "default, off, low, medium, high, max"
```

Call chain trace:

```
[Scenario: Dynamic Ollama model "glm-5.2:cloud" with thinking capability, not in config catalog]

1. resolveThinkingPolicyContext({ provider:"ollama", model:"glm-5.2:cloud", catalog })
   → catalog.find(...) → undefined (model is dynamic, not configured)
   → returns { normalizedProvider:"ollama", reasoning:undefined, ... }

2. resolveProviderThinkingProfile({ provider:"ollama", context:{ reasoning:undefined } })
   → resolveActiveThinkingProvider("ollama") → undefined (plugin registry format mismatch)
   → resolveBundledProviderPolicySurface("ollama")
     → loads extensions/ollama/provider-policy-api.js
     → calls resolveThinkingProfile({ reasoning: undefined })

3. BEFORE FIX:  undefined ? REASONING : NON_REASONING → NON_REASONING_PROFILE → ["off"]
4. AFTER  FIX:  undefined === false? NO → REASONING_PROFILE → ["off","low","medium","high","max"]

5. listThinkingLevelChoices returns:
   BEFORE: ["default", "off"]                    → Telegram menu: "default, off"
   AFTER:  ["default", "off","low","medium","high","max"] → Telegram menu: full list
```

**Observed result after fix**: For any dynamically-discovered Ollama model, `resolveThinkingProfile` will return the reasoning profile (with all levels: off, low, medium, high, max) instead of the non-reasoning profile (off only). The `/think` Telegram menu will display `"default, off, low, medium, high, max"` as options, matching the actual model capabilities reported by `ollama/api/show`.

**What was not tested**: This fix was not tested against a live Ollama instance + Telegram setup. The fix is based on static code path analysis. The dynamically-discovered models `reasoning` flag is correctly set by `buildOllamaModelDefinition` (which checks `capabilities.includes("thinking")`), but this info lives in `dynamicModelCache` and is not propagated to the thinking systems catalog lookup — that mismatch is what this fix works around at the profile level. A more complete fix would also sync dynamic model metadata into the catalog, but that would require larger refactoring.

Fixes #93835

🤖 Generated with [Claude Code](https://claude.com/claude-code)