### PR TITLE
fix(mattermost): backfill thread history from server when in-memory window is empty

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -642,11 +642,11 @@ describe("fetchMattermostThreadPosts", () => {
     });
     const posts = await fetchMattermostThreadPosts(client, "post1");
     expect(posts).toHaveLength(3);
-    expect(posts[0].id).toBe("post1");
-    expect(posts[1].id).toBe("post2");
-    expect(posts[2].id).toBe("post3");
-    expect(posts[0].message).toBe("hello thread root");
-    expect(calls[0].url).toBe("http://localhost:8065/api/v4/posts/post1/thread");
+    expect(posts[0]?.id).toBe("post1");
+    expect(posts[1]?.id).toBe("post2");
+    expect(posts[2]?.id).toBe("post3");
+    expect(posts[0]?.message).toBe("hello thread root");
+    expect(calls[0]?.url).toBe("http://localhost:8065/api/v4/posts/post1/thread");
   });
 
   it("returns empty array when order is empty", async () => {
@@ -673,7 +673,7 @@ describe("fetchMattermostThreadPosts", () => {
       body: { order: ["post3", "post2", "post1"], posts: mockThreadPosts },
     });
     const posts = await fetchMattermostThreadPosts(client, "post1", { limit: 2 });
-    expect(calls[0].url).toBe(
+    expect(calls[0]?.url).toBe(
       "http://localhost:8065/api/v4/posts/post1/thread?perPage=2&direction=up",
     );
     expect(posts.map((p) => p.id)).toEqual(["post1", "post2", "post3"]);

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -678,4 +678,14 @@ describe("fetchMattermostThreadPosts", () => {
     );
     expect(posts.map((p) => p.id)).toEqual(["post1", "post2", "post3"]);
   });
+
+  it("clamps oversized perPage to Mattermost 200-item max", async () => {
+    const { client, calls } = createTestClient({
+      body: { order: [], posts: mockThreadPosts },
+    });
+    await fetchMattermostThreadPosts(client, "post1", { limit: 250 });
+    expect(calls[0]?.url).toBe(
+      "http://localhost:8065/api/v4/posts/post1/thread?perPage=200&direction=up",
+    );
+  });
 });

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -16,11 +16,11 @@ import {
   createMattermostClient,
   createMattermostDirectChannelWithRetry,
   createMattermostPost,
-  fetchMattermostThreadPosts,
   normalizeMattermostBaseUrl,
   readMattermostError,
   updateMattermostPost,
 } from "./client.js";
+import { fetchMattermostThreadPosts } from "./thread-posts.js";
 
 // ── Helper: mock fetch that captures requests ────────────────────────
 

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -16,6 +16,7 @@ import {
   createMattermostClient,
   createMattermostDirectChannelWithRetry,
   createMattermostPost,
+  fetchMattermostThreadPosts,
   normalizeMattermostBaseUrl,
   readMattermostError,
   updateMattermostPost,
@@ -605,5 +606,63 @@ describe("createMattermostDirectChannelWithRetry delay cap", () => {
       vi.clearAllTimers();
       vi.useRealTimers();
     }
+  });
+});
+
+describe("fetchMattermostThreadPosts", () => {
+  const mockThreadPosts: Record<string, unknown> = {
+    post1: {
+      id: "post1",
+      user_id: "user1",
+      message: "hello thread root",
+      create_at: 1718000000000,
+      channel_id: "chan1",
+    },
+    post2: {
+      id: "post2",
+      user_id: "user2",
+      message: "thread reply one",
+      create_at: 1718000001000,
+      channel_id: "chan1",
+      root_id: "post1",
+    },
+    post3: {
+      id: "post3",
+      user_id: "user1",
+      message: "thread reply two",
+      create_at: 1718000002000,
+      channel_id: "chan1",
+      root_id: "post1",
+    },
+  };
+
+  it("returns posts in order from thread endpoint", async () => {
+    const { client, calls } = createTestClient({
+      body: { order: ["post1", "post2", "post3"], posts: mockThreadPosts },
+    });
+    const posts = await fetchMattermostThreadPosts(client, "post1");
+    expect(posts).toHaveLength(3);
+    expect(posts[0].id).toBe("post1");
+    expect(posts[1].id).toBe("post2");
+    expect(posts[2].id).toBe("post3");
+    expect(posts[0].message).toBe("hello thread root");
+    expect(calls[0].url).toBe("http://localhost:8065/api/v4/posts/post1/thread");
+  });
+
+  it("returns empty array when order is empty", async () => {
+    const { client } = createTestClient({
+      body: { order: [], posts: mockThreadPosts },
+    });
+    const posts = await fetchMattermostThreadPosts(client, "post1");
+    expect(posts).toHaveLength(0);
+  });
+
+  it("filters out posts not present in the posts map", async () => {
+    const { client } = createTestClient({
+      body: { order: ["post1", "post99", "post2"], posts: mockThreadPosts },
+    });
+    const posts = await fetchMattermostThreadPosts(client, "post1");
+    expect(posts).toHaveLength(2);
+    expect(posts.map((p) => p.id)).toEqual(["post1", "post2"]);
   });
 });

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -665,4 +665,17 @@ describe("fetchMattermostThreadPosts", () => {
     expect(posts).toHaveLength(2);
     expect(posts.map((p) => p.id)).toEqual(["post1", "post2"]);
   });
+
+  it("bounds the request and restores chronological order when a limit is given", async () => {
+    const { client, calls } = createTestClient({
+      // direction=up returns the newest posts newest-first; the helper must
+      // re-sort ascending so callers build history oldest-first.
+      body: { order: ["post3", "post2", "post1"], posts: mockThreadPosts },
+    });
+    const posts = await fetchMattermostThreadPosts(client, "post1", { limit: 2 });
+    expect(calls[0].url).toBe(
+      "http://localhost:8065/api/v4/posts/post1/thread?perPage=2&direction=up",
+    );
+    expect(posts.map((p) => p.id)).toEqual(["post1", "post2", "post3"]);
+  });
 });

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -697,13 +697,22 @@ export async function deleteMattermostPost(
 export async function fetchMattermostThreadPosts(
   client: MattermostClient,
   postId: string,
-  signal?: AbortSignal,
+  options: { limit?: number; signal?: AbortSignal } = {},
 ): Promise<MattermostPost[]> {
+  const { limit, signal } = options;
+  // GET /posts/{id}/thread returns the ENTIRE thread at the Mattermost default
+  // perPage=0, so a long thread would allocate and parse unboundedly on the
+  // inbound path. The endpoint reads camelCase perPage (not per_page); bound the
+  // response to the newest posts the caller needs: direction=up returns the most
+  // recent perPage posts (server orders CreateAt DESC), so we restore ascending
+  // chronological order below for callers that build history oldest-first.
+  const query = typeof limit === "number" && limit > 0 ? `?perPage=${limit}&direction=up` : "";
   const data = await client.request<{
     order: string[];
     posts: Record<string, MattermostPost>;
-  }>(`/posts/${postId}/thread`, signal ? { signal } : undefined);
-  return (data.order ?? []).map((pid) => data.posts?.[pid]).filter(Boolean);
+  }>(`/posts/${postId}/thread${query}`, signal ? { signal } : undefined);
+  const posts = (data.order ?? []).map((pid) => data.posts?.[pid]).filter(Boolean);
+  return posts.toSorted((a, b) => (a.create_at ?? 0) - (b.create_at ?? 0));
 }
 
 export async function uploadMattermostFile(

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -694,29 +694,6 @@ export async function deleteMattermostPost(
   });
 }
 
-export async function fetchMattermostThreadPosts(
-  client: MattermostClient,
-  postId: string,
-  options: { limit?: number; signal?: AbortSignal } = {},
-): Promise<MattermostPost[]> {
-  const { limit, signal } = options;
-  // GET /posts/{id}/thread returns the ENTIRE thread at the Mattermost default
-  // perPage=0, so a long thread would allocate and parse unboundedly on the
-  // inbound path. The endpoint reads camelCase perPage (not per_page); bound the
-  // response to the newest posts the caller needs: direction=up returns the most
-  // recent perPage posts (server orders CreateAt DESC), so we restore ascending
-  // chronological order below for callers that build history oldest-first.
-  const query = typeof limit === "number" && limit > 0 ? `?perPage=${limit}&direction=up` : "";
-  const data = await client.request<{
-    order: string[];
-    posts: Record<string, MattermostPost>;
-  }>(`/posts/${postId}/thread${query}`, signal ? { signal } : undefined);
-  const posts: MattermostPost[] = (data.order ?? [])
-    .map((pid) => data.posts?.[pid])
-    .filter((p): p is MattermostPost => p != null);
-  return posts.toSorted((a, b) => (a.create_at ?? 0) - (b.create_at ?? 0));
-}
-
 export async function uploadMattermostFile(
   client: MattermostClient,
   params: {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -694,6 +694,18 @@ export async function deleteMattermostPost(
   });
 }
 
+export async function fetchMattermostThreadPosts(
+  client: MattermostClient,
+  postId: string,
+  signal?: AbortSignal,
+): Promise<MattermostPost[]> {
+  const data = await client.request<{
+    order: string[];
+    posts: Record<string, MattermostPost>;
+  }>(`/posts/${postId}/thread`, signal ? { signal } : undefined);
+  return (data.order ?? []).map((pid) => data.posts?.[pid]).filter(Boolean);
+}
+
 export async function uploadMattermostFile(
   client: MattermostClient,
   params: {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -711,7 +711,9 @@ export async function fetchMattermostThreadPosts(
     order: string[];
     posts: Record<string, MattermostPost>;
   }>(`/posts/${postId}/thread${query}`, signal ? { signal } : undefined);
-  const posts = (data.order ?? []).map((pid) => data.posts?.[pid]).filter(Boolean);
+  const posts: MattermostPost[] = (data.order ?? [])
+    .map((pid) => data.posts?.[pid])
+    .filter((p): p is MattermostPost => p != null);
   return posts.toSorted((a, b) => (a.create_at ?? 0) - (b.create_at ?? 0));
 }
 

--- a/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
+++ b/extensions/mattermost/src/mattermost/monitor-thread-backfill.ts
@@ -1,0 +1,190 @@
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MattermostClient, MattermostPost } from "./client.js";
+import type { HistoryEntry } from "./runtime-api.js";
+import { fetchMattermostThreadPosts } from "./thread-posts.js";
+
+type MattermostThreadBackfillFetcher = (
+  client: MattermostClient,
+  rootPostId: string,
+  options: { limit: number; signal?: AbortSignal },
+) => Promise<MattermostPost[]>;
+
+// Cap the per-thread backfill marker map so it cannot outgrow the 1000-key
+// `channelHistories` window it accompanies; an evicted thread simply
+// re-backfills on its next cold inbound turn.
+const MAX_THREAD_BACKFILL_MARKERS = 1000;
+
+// Evict oldest marker keys (Map insertion order = LRU) once the map exceeds the
+// cap. Kept local to the plugin so core history internals stay untouched.
+function evictOldThreadBackfillMarkers(markers: Map<string, string>): void {
+  while (markers.size > MAX_THREAD_BACKFILL_MARKERS) {
+    const oldestKey = markers.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    markers.delete(oldestKey);
+  }
+}
+
+export async function backfillMattermostThreadHistoryForMonitor(params: {
+  client: MattermostClient;
+  post: MattermostPost;
+  threadRootId: string | undefined;
+  historyKey: string | null;
+  baseSessionKey: string;
+  adoptBackfillSessionKey?: string;
+  historyLimit: number;
+  channelHistories: Map<string, HistoryEntry[]>;
+  threadBackfillMarkers: Map<string, string>;
+  threadBackfillInFlight: Map<string, Promise<void>>;
+  fetchThreadPosts?: MattermostThreadBackfillFetcher;
+  timeoutMs?: number;
+}): Promise<void> {
+  const {
+    client,
+    post,
+    threadRootId,
+    historyKey,
+    baseSessionKey,
+    adoptBackfillSessionKey,
+    historyLimit,
+    channelHistories,
+    threadBackfillMarkers,
+    threadBackfillInFlight,
+    fetchThreadPosts = fetchMattermostThreadPosts,
+    timeoutMs = 10_000,
+  } = params;
+  if (!threadRootId || !historyKey || historyLimit <= 0) {
+    return;
+  }
+
+  // One marker per thread history key: the value is the current session marker.
+  // This bounds marker memory and lookup cost to the number of live threads,
+  // instead of accumulating a `${historyKey}:${session}` entry for every session
+  // rotation and scanning the whole process-lifetime set on each candidate.
+  // Writes refresh LRU order and stay under the local 1000-key cap so the marker
+  // map cannot outgrow the `channelHistories` window it accompanies.
+  const setMarker = (session: string): void => {
+    threadBackfillMarkers.delete(historyKey);
+    threadBackfillMarkers.set(historyKey, session);
+    evictOldThreadBackfillMarkers(threadBackfillMarkers);
+  };
+
+  const currentMarker = threadBackfillMarkers.get(historyKey);
+  if (currentMarker === baseSessionKey) {
+    // Same-session marker already set. If a first cold turn is still fetching
+    // (zero-debounce inbound bursts overlap on the awaited network boundary),
+    // await that one bounded request so this turn reads the recovered window
+    // instead of replying without prior context. No in-flight entry means the
+    // fetch already completed, returned empty, timed out, or failed, and the
+    // completed marker intentionally suppresses a retry.
+    const inFlight = threadBackfillInFlight.get(historyKey);
+    if (inFlight) {
+      await inFlight.catch(() => {});
+    }
+    return;
+  }
+  // Adopt the earlier pending marker once the stored session id appears, so a
+  // same-session follow-up does not refetch while a later real session rotation
+  // still can.
+  if (adoptBackfillSessionKey && currentMarker === adoptBackfillSessionKey) {
+    setMarker(baseSessionKey);
+    return;
+  }
+  const hasPriorBackfillForThread = currentMarker !== undefined;
+
+  const existing = channelHistories.get(historyKey);
+  if (existing && existing.length > 0 && !hasPriorBackfillForThread) {
+    setMarker(baseSessionKey);
+    return;
+  }
+
+  // Set the completed-attempt marker before awaiting so overlapping same-session
+  // turns take the branch above and await this one operation. Publish the
+  // in-flight promise so those turns can wait for the recovered window; clear it
+  // in `finally` so the marker alone governs no-retry afterwards.
+  setMarker(baseSessionKey);
+  // Capture the marker this recovery owns so a stale older-session response
+  // that resolves last does not overwrite a newer session's recovered window.
+  // If the marker rotated while the fetch was in flight, skip the write.
+  const ownedMarker = baseSessionKey;
+  const recovery = (async () => {
+    const abort = new AbortController();
+    const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
+    try {
+      // Request one extra post so the window still fills after we drop the
+      // triggering post below when it is among the newest entries.
+      const threadPosts = await fetchThreadPosts(client, threadRootId, {
+        limit: historyLimit + 1,
+        signal: abort.signal,
+      });
+      if (threadPosts.length === 0) {
+        return;
+      }
+
+      // Filter current post before trimming so the history window is fully
+      // utilized even when the triggering post is among the newest entries.
+      const others = threadPosts.filter((p) => p.id !== post.id);
+      const windowed = others.slice(-historyLimit);
+      const entries: HistoryEntry[] = [];
+      for (const p of windowed) {
+        entries.push({
+          sender: p.user_id ?? "unknown",
+          body: p.message || "[attachment]",
+          timestamp: typeof p.create_at === "number" ? p.create_at : undefined,
+          messageId: p.id ?? undefined,
+        });
+      }
+      if (entries.length > 0 && threadBackfillMarkers.get(historyKey) === ownedMarker) {
+        channelHistories.set(historyKey, entries);
+      }
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  })();
+  threadBackfillInFlight.set(historyKey, recovery);
+  try {
+    await recovery;
+  } catch {
+    // Best-effort: server fetch failure or timeout should not block inbound dispatch.
+  } finally {
+    // Drop the in-flight handle once settled; the completed marker then governs
+    // no-retry, and only this owner clears its own operation.
+    if (threadBackfillInFlight.get(historyKey) === recovery) {
+      threadBackfillInFlight.delete(historyKey);
+    }
+  }
+}
+
+export async function backfillMattermostThreadHistoryForMonitorTurn(params: {
+  client: MattermostClient;
+  post: MattermostPost;
+  threadRootId: string | undefined;
+  historyKey: string | null;
+  historyLimit: number;
+  channelHistories: Map<string, HistoryEntry[]>;
+  threadBackfillMarkers: Map<string, string>;
+  threadBackfillInFlight: Map<string, Promise<void>>;
+  storePath: string;
+  sessionKey: string;
+}): Promise<void> {
+  const currentAgentSessionId = normalizeOptionalString(
+    getSessionEntry({ storePath: params.storePath, sessionKey: params.sessionKey })?.sessionId,
+  );
+  const baseSessionKey = currentAgentSessionId
+    ? `session:${currentAgentSessionId}`
+    : `pending:${params.sessionKey}`;
+  await backfillMattermostThreadHistoryForMonitor({
+    client: params.client,
+    post: params.post,
+    threadRootId: params.threadRootId,
+    historyKey: params.historyKey,
+    baseSessionKey,
+    adoptBackfillSessionKey: currentAgentSessionId ? `pending:${params.sessionKey}` : undefined,
+    historyLimit: params.historyLimit,
+    channelHistories: params.channelHistories,
+    threadBackfillMarkers: params.threadBackfillMarkers,
+    threadBackfillInFlight: params.threadBackfillInFlight,
+  });
+}

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -717,6 +717,89 @@ describe("mattermost inbound user posts", () => {
     await monitor;
   });
 
+  it("adopts a missing session marker so same-session failed backfills do not retry", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    const routeSessionKey = "mattermost:default:channel:chan-1";
+    const threadSessionKey = `${routeSessionKey}:thread:root-1`;
+    let storedSessionId: string | undefined;
+    mockState.abortController = undefined;
+    mockState.runtimeCore = createRuntimeCore(testConfig, {
+      mainSessionKey: routeSessionKey,
+      sessionKey: routeSessionKey,
+    });
+    mockState.getSessionEntry.mockImplementation((params: { sessionKey?: string }) => {
+      if (params.sessionKey !== threadSessionKey || !storedSessionId) {
+        return undefined;
+      }
+      return { sessionId: storedSessionId };
+    });
+    mockState.fetchMattermostThreadPosts.mockRejectedValueOnce(new Error("thread fetch timeout"));
+    mockState.dispatchReplyFromConfig.mockImplementation(async () => {
+      if (mockState.dispatchReplyFromConfig.mock.calls.length === 1) {
+        storedSessionId = "session-created-after-first-turn";
+      }
+      if (mockState.dispatchReplyFromConfig.mock.calls.length >= 2) {
+        abortController.abort();
+      }
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    const emitThreadPost = async (id: string, message: string) => {
+      await socket.emitMessage({
+        event: "posted",
+        data: {
+          channel_id: "chan-1",
+          channel_name: "town-square",
+          channel_display_name: "Town Square",
+          sender_name: "alice",
+          post: JSON.stringify({
+            id,
+            root_id: "root-1",
+            channel_id: "chan-1",
+            user_id: "user-1",
+            message,
+            create_at: 1_714_000_001_000,
+          }),
+        },
+        broadcast: {
+          channel_id: "chan-1",
+          user_id: "user-1",
+        },
+      });
+    };
+
+    await emitThreadPost("child-missing-1", "first cold turn");
+    await vi.waitFor(() => {
+      expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    });
+    expect(mockState.fetchMattermostThreadPosts).toHaveBeenCalledTimes(1);
+    expect(mockState.getSessionEntry).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-test-sessions.json",
+      sessionKey: threadSessionKey,
+    });
+
+    await emitThreadPost("child-missing-2", "same session follow-up");
+    await vi.waitFor(() => {
+      expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(2);
+    });
+    expect(mockState.fetchMattermostThreadPosts).toHaveBeenCalledTimes(1);
+
+    socket.emitClose(1000);
+    await monitor;
+  });
+
   it("does not read session storage for group thread posts dropped before admission", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -691,7 +691,7 @@ describe("mattermost inbound user posts", () => {
     expect(mockState.fetchMattermostThreadPosts).toHaveBeenLastCalledWith(
       expect.anything(),
       "root-1",
-      expect.any(AbortSignal),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx.Body).toContain(
       "context before restart",

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -717,6 +717,66 @@ describe("mattermost inbound user posts", () => {
     await monitor;
   });
 
+  it("does not read session storage for group thread posts dropped before admission", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const mentionConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "oncall",
+          dmPolicy: "open",
+          groupPolicy: "open",
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(mentionConfig);
+
+    const monitor = monitorMattermostProvider({
+      config: mentionConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "child-dropped-before-admission",
+          root_id: "root-1",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "plain thread chatter",
+          create_at: 1_714_000_001_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    abortController.abort();
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.dispatchReplyFromConfig).not.toHaveBeenCalled();
+    expect(mockState.getSessionEntry).not.toHaveBeenCalled();
+    expect(mockState.fetchMattermostThreadPosts).not.toHaveBeenCalled();
+  });
+
   it("dispatches a bare bot mention whose body is empty after normalization as a wake event", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -104,11 +104,14 @@ vi.mock("./client.js", async () => {
     ...actual,
     createMattermostClient: mockState.createMattermostClient,
     fetchMattermostMe: mockState.fetchMattermostMe,
-    fetchMattermostThreadPosts: mockState.fetchMattermostThreadPosts,
     normalizeMattermostBaseUrl: (value: string | undefined) => value?.trim() ?? "",
     updateMattermostPost: mockState.updateMattermostPost,
   };
 });
+
+vi.mock("./thread-posts.js", () => ({
+  fetchMattermostThreadPosts: mockState.fetchMattermostThreadPosts,
+}));
 
 vi.mock("./draft-stream.js", async () => {
   const actual = await vi.importActual<typeof import("./draft-stream.js")>("./draft-stream.js");

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -85,6 +85,8 @@ const mockState = vi.hoisted(() => ({
   dispatchReplyFromConfig: vi.fn(),
   enqueueSystemEvent: vi.fn(),
   fetchMattermostMe: vi.fn(),
+  fetchMattermostThreadPosts: vi.fn(),
+  getSessionEntry: vi.fn(),
   registerMattermostMonitorSlashCommands: vi.fn(),
   registerPluginHttpRoute: vi.fn(),
   recordMattermostThreadParticipation: vi.fn(),
@@ -102,6 +104,7 @@ vi.mock("./client.js", async () => {
     ...actual,
     createMattermostClient: mockState.createMattermostClient,
     fetchMattermostMe: mockState.fetchMattermostMe,
+    fetchMattermostThreadPosts: mockState.fetchMattermostThreadPosts,
     normalizeMattermostBaseUrl: (value: string | undefined) => value?.trim() ?? "",
     updateMattermostPost: mockState.updateMattermostPost,
   };
@@ -136,6 +139,16 @@ vi.mock("./thread-participation.js", async (importOriginal) => ({
   recordMattermostThreadParticipation: mockState.recordMattermostThreadParticipation,
 }));
 
+vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/session-store-runtime")>(
+    "openclaw/plugin-sdk/session-store-runtime",
+  );
+  return {
+    ...actual,
+    getSessionEntry: mockState.getSessionEntry,
+  };
+});
+
 vi.mock("./runtime-api.js", async () => {
   const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
   return {
@@ -164,14 +177,23 @@ vi.mock("./send.js", async () => {
   };
 });
 
+type RouteOverrideValue = string | (() => string);
+
+function resolveRouteOverrideValue(
+  value: RouteOverrideValue | undefined,
+  fallback: string,
+): string {
+  return typeof value === "function" ? value() : (value ?? fallback);
+}
+
 function createRuntimeCore(
   cfg: OpenClawConfig,
   routeOverride?: {
     accountId?: string;
     agentId?: string;
     lastRoutePolicy?: "main" | "session";
-    mainSessionKey?: string;
-    sessionKey?: string;
+    mainSessionKey?: RouteOverrideValue;
+    sessionKey?: RouteOverrideValue;
   },
   overrides: {
     inboundDebounceMs?: number;
@@ -329,8 +351,14 @@ function createRuntimeCore(
           accountId: routeOverride?.accountId ?? "default",
           agentId: routeOverride?.agentId ?? "main",
           lastRoutePolicy: routeOverride?.lastRoutePolicy ?? "main",
-          mainSessionKey: routeOverride?.mainSessionKey ?? "mattermost:default:channel:chan-1",
-          sessionKey: routeOverride?.sessionKey ?? "mattermost:default:channel:chan-1",
+          mainSessionKey: resolveRouteOverrideValue(
+            routeOverride?.mainSessionKey,
+            "mattermost:default:channel:chan-1",
+          ),
+          sessionKey: resolveRouteOverrideValue(
+            routeOverride?.sessionKey,
+            "mattermost:default:channel:chan-1",
+          ),
         }),
       },
       session: {
@@ -457,6 +485,8 @@ describe("mattermost inbound user posts", () => {
     mockState.resolveMattermostMedia.mockResolvedValue([]);
     mockState.resolveUserInfo.mockResolvedValue({ id: "user-1", username: "alice" });
     mockState.sendMessageMattermost.mockResolvedValue({});
+    mockState.fetchMattermostThreadPosts.mockResolvedValue([]);
+    mockState.getSessionEntry.mockReturnValue(undefined);
     mockState.dispatchReplyFromConfig.mockImplementation(async () => {
       mockState.abortController?.abort();
     });
@@ -557,6 +587,134 @@ describe("mattermost inbound user posts", () => {
     expect(verboseDebug).toHaveBeenCalledWith(
       `mattermost inbound: from=mattermost:channel:chan-1 len=205 preview="${"a".repeat(199)}"`,
     );
+  });
+
+  it("backfills cold Mattermost thread history once per agent session through the monitor path", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    const routeSessionKey = "mattermost:default:channel:chan-1";
+    const threadSessionKey = `${routeSessionKey}:thread:root-1`;
+    let storedSessionId = "session-before-restart";
+    mockState.abortController = undefined;
+    mockState.runtimeCore = createRuntimeCore(testConfig, {
+      mainSessionKey: routeSessionKey,
+      sessionKey: routeSessionKey,
+    });
+    mockState.getSessionEntry.mockImplementation((params: { sessionKey?: string }) => {
+      if (params.sessionKey !== threadSessionKey) {
+        return undefined;
+      }
+      return { sessionId: storedSessionId };
+    });
+    mockState.dispatchReplyFromConfig.mockImplementation(async () => {
+      if (mockState.dispatchReplyFromConfig.mock.calls.length >= 3) {
+        abortController.abort();
+      }
+    });
+    mockState.resolveUserInfo.mockImplementation(async (userId: string) => ({
+      id: userId,
+      username: userId === "user-2" ? "bob" : "alice",
+    }));
+    mockState.fetchMattermostThreadPosts
+      .mockResolvedValueOnce([
+        {
+          id: "root-1",
+          channel_id: "chan-1",
+          user_id: "user-2",
+          message: "context before restart",
+          create_at: 1_714_000_000_000,
+        },
+        {
+          id: "child-1",
+          root_id: "root-1",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "first post after restart",
+          create_at: 1_714_000_001_000,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "root-1",
+          channel_id: "chan-1",
+          user_id: "user-2",
+          message: "context after reset",
+          create_at: 1_714_000_000_000,
+        },
+      ]);
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    const emitThreadPost = async (id: string, message: string) => {
+      await socket.emitMessage({
+        event: "posted",
+        data: {
+          channel_id: "chan-1",
+          channel_name: "town-square",
+          channel_display_name: "Town Square",
+          sender_name: "alice",
+          post: JSON.stringify({
+            id,
+            root_id: "root-1",
+            channel_id: "chan-1",
+            user_id: "user-1",
+            message,
+            create_at: 1_714_000_001_000,
+          }),
+        },
+        broadcast: {
+          channel_id: "chan-1",
+          user_id: "user-1",
+        },
+      });
+    };
+
+    await emitThreadPost("child-1", "first post after restart");
+    await vi.waitFor(() => {
+      expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    });
+    expect(mockState.fetchMattermostThreadPosts).toHaveBeenCalledTimes(1);
+    expect(mockState.getSessionEntry).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-test-sessions.json",
+      sessionKey: threadSessionKey,
+    });
+    expect(mockState.fetchMattermostThreadPosts).toHaveBeenLastCalledWith(
+      expect.anything(),
+      "root-1",
+      expect.any(AbortSignal),
+    );
+    expect(mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx.Body).toContain(
+      "context before restart",
+    );
+
+    await emitThreadPost("child-2", "same session follow-up");
+    await vi.waitFor(() => {
+      expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(2);
+    });
+    expect(mockState.fetchMattermostThreadPosts).toHaveBeenCalledTimes(1);
+
+    storedSessionId = "session-after-slash-new";
+    await emitThreadPost("child-3", "after slash new");
+    await vi.waitFor(() => {
+      expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(3);
+    });
+    expect(mockState.fetchMattermostThreadPosts).toHaveBeenCalledTimes(2);
+    expect(mockState.dispatchReplyFromConfig.mock.calls.at(2)?.[0].ctx.Body).toContain(
+      "context after reset",
+    );
+
+    socket.emitClose(1000);
+    await monitor;
   });
 
   it("dispatches a bare bot mention whose body is empty after normalization as a wake event", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1042,21 +1042,16 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
     const channelHistories = new Map<string, HistoryEntry[]>();
     const threadsBackfilledThisSession = new Set<string>();
     const fetchThreadPosts = vi.fn(async () => [] as MattermostPost[]);
-    const resolveUserInfo = vi.fn(async (userId: string) => ({
-      id: userId,
-      username: userId.replace("user-", "member-"),
-    }));
 
     return {
       channelHistories,
       client,
       fetchThreadPosts,
-      resolveUserInfo,
       threadsBackfilledThisSession,
     };
   }
 
-  it("seeds a cold thread window from server history and filters the triggering post before trim", async () => {
+  it("seeds a cold thread window from server history without sender enrichment", async () => {
     const harness = createBackfillHarness();
     const currentPost = createPost({
       id: "current",
@@ -1081,13 +1076,12 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
 
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
     expect(harness.channelHistories.get(historyKey)).toStrictEqual([
       {
-        sender: "@member-2",
+        sender: "user-2",
         body: "old two",
         timestamp: 2,
         messageId: "old-2",
@@ -1107,7 +1101,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
   it("marks populated windows so same-session follow-ups do not refetch after history clears", async () => {
     const harness = createBackfillHarness();
     harness.channelHistories.set(historyKey, [
-      { sender: "@member-1", body: "already here", timestamp: 1, messageId: "old-1" },
+      { sender: "user-1", body: "already here", timestamp: 1, messageId: "old-1" },
     ]);
 
     await backfillMattermostThreadHistoryForMonitor({
@@ -1120,7 +1114,6 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
     harness.channelHistories.set(historyKey, []);
     await backfillMattermostThreadHistoryForMonitor({
@@ -1133,7 +1126,6 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
 
     expect(harness.fetchThreadPosts).not.toHaveBeenCalled();
@@ -1156,7 +1148,6 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
     await backfillMattermostThreadHistoryForMonitor({
       client: harness.client,
@@ -1168,7 +1159,6 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
 
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
@@ -1197,10 +1187,9 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
     harness.channelHistories.set(historyKey, [
-      { sender: "@member-1", body: "stale before reset", timestamp: 1, messageId: "old-1" },
+      { sender: "user-1", body: "stale before reset", timestamp: 1, messageId: "old-1" },
     ]);
     await backfillMattermostThreadHistoryForMonitor({
       client: harness.client,
@@ -1212,7 +1201,6 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       channelHistories: harness.channelHistories,
       threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
       fetchThreadPosts: harness.fetchThreadPosts,
-      resolveUserInfo: harness.resolveUserInfo,
     });
 
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(2);

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import * as clientModule from "./client.js";
-import type { MattermostClient } from "./client.js";
+import type { MattermostClient, MattermostPost } from "./client.js";
+import { backfillMattermostThreadHistoryForMonitor } from "./monitor.js";
 import {
   buildMattermostModelPickerSelectMessageSid,
   canFinalizeMattermostPreviewInPlace,
@@ -19,6 +20,7 @@ import {
 import { deliverMattermostReplyWithDraftPreview } from "./monitor-draft-delivery.js";
 import { evaluateMattermostMentionGate } from "./monitor-gating.js";
 import { processMattermostReplayGuardedPost } from "./monitor-replay.js";
+import type { HistoryEntry } from "./runtime-api.js";
 
 type MattermostMentionGateInput = Parameters<typeof evaluateMattermostMentionGate>[0];
 type MattermostRequireMentionResolverInput = Parameters<
@@ -1015,6 +1017,208 @@ describe("processMattermostReplayGuardedPost", () => {
 
     expect(handlePost).toHaveBeenCalledTimes(1);
     expect(visibleSideEffect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("backfillMattermostThreadHistoryForMonitor", () => {
+  const historyKey = "mattermost:thread:root-1";
+  const sessionBackfillKey = "session-before-reset";
+
+  function createPost(
+    params: Partial<MattermostPost> & Pick<MattermostPost, "id">,
+  ): MattermostPost {
+    return {
+      channel_id: "channel-1",
+      create_at: 1,
+      message: "",
+      root_id: "root-1",
+      user_id: "user-1",
+      ...params,
+    };
+  }
+
+  function createBackfillHarness() {
+    const client = createMattermostClientMock();
+    const channelHistories = new Map<string, HistoryEntry[]>();
+    const threadsBackfilledThisSession = new Set<string>();
+    const fetchThreadPosts = vi.fn(async () => [] as MattermostPost[]);
+    const resolveUserInfo = vi.fn(async (userId: string) => ({
+      id: userId,
+      username: userId.replace("user-", "member-"),
+    }));
+
+    return {
+      channelHistories,
+      client,
+      fetchThreadPosts,
+      resolveUserInfo,
+      threadsBackfilledThisSession,
+    };
+  }
+
+  it("seeds a cold thread window from server history and filters the triggering post before trim", async () => {
+    const harness = createBackfillHarness();
+    const currentPost = createPost({
+      id: "current",
+      create_at: 4,
+      message: "@bot continue",
+      user_id: "user-current",
+    });
+    harness.fetchThreadPosts.mockResolvedValueOnce([
+      createPost({ id: "old-1", create_at: 1, message: "old one", user_id: "user-1" }),
+      currentPost,
+      createPost({ id: "old-2", create_at: 2, message: "old two", user_id: "user-2" }),
+      createPost({ id: "old-3", create_at: 3, message: "", user_id: undefined }),
+    ]);
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: currentPost,
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 2,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
+    expect(harness.channelHistories.get(historyKey)).toStrictEqual([
+      {
+        sender: "@member-2",
+        body: "old two",
+        timestamp: 2,
+        messageId: "old-2",
+      },
+      {
+        sender: "unknown",
+        body: "[attachment]",
+        timestamp: 3,
+        messageId: "old-3",
+      },
+    ]);
+    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${sessionBackfillKey}`)).toBe(
+      true,
+    );
+  });
+
+  it("marks populated windows so same-session follow-ups do not refetch after history clears", async () => {
+    const harness = createBackfillHarness();
+    harness.channelHistories.set(historyKey, [
+      { sender: "@member-1", body: "already here", timestamp: 1, messageId: "old-1" },
+    ]);
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-1" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+    harness.channelHistories.set(historyKey, []);
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-2" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+
+    expect(harness.fetchThreadPosts).not.toHaveBeenCalled();
+    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${sessionBackfillKey}`)).toBe(
+      true,
+    );
+  });
+
+  it("marks failed fetch attempts so same-session follow-ups do not retry", async () => {
+    const harness = createBackfillHarness();
+    harness.fetchThreadPosts.mockRejectedValueOnce(new Error("thread fetch timeout"));
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-1" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-2" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
+    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${sessionBackfillKey}`)).toBe(
+      true,
+    );
+  });
+
+  it("allows the same thread to backfill again after the stored session id rotates", async () => {
+    const harness = createBackfillHarness();
+    harness.fetchThreadPosts
+      .mockResolvedValueOnce([
+        createPost({ id: "old-1", create_at: 1, message: "before reset", user_id: "user-1" }),
+      ])
+      .mockResolvedValueOnce([
+        createPost({ id: "new-1", create_at: 2, message: "after reset", user_id: "user-2" }),
+      ]);
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-1" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+    harness.channelHistories.set(historyKey, [
+      { sender: "@member-1", body: "stale before reset", timestamp: 1, messageId: "old-1" },
+    ]);
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-2" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: "session-after-reset",
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+      resolveUserInfo: harness.resolveUserInfo,
+    });
+
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(2);
+    expect(harness.channelHistories.get(historyKey)?.map((entry) => entry.body)).toStrictEqual([
+      "after reset",
+    ]);
   });
 });
 

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "../../runtime-api.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import * as clientModule from "./client.js";
 import type { MattermostClient, MattermostPost } from "./client.js";
-import { backfillMattermostThreadHistoryForMonitor } from "./monitor.js";
+import { backfillMattermostThreadHistoryForMonitor } from "./monitor-thread-backfill.js";
 import {
   buildMattermostModelPickerSelectMessageSid,
   canFinalizeMattermostPreviewInPlace,

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1167,6 +1167,71 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
     );
   });
 
+  it("adopts pending markers without blocking later session rotations", async () => {
+    const harness = createBackfillHarness();
+    const pendingSessionKey = "pending:mattermost:default:channel:chan-1:thread:root-1";
+    const createdSessionKey = "session:session-created-after-first-turn";
+    const resetSessionKey = "session:session-after-reset";
+    harness.fetchThreadPosts
+      .mockRejectedValueOnce(new Error("thread fetch timeout"))
+      .mockResolvedValueOnce([
+        createPost({ id: "new-1", create_at: 2, message: "after reset", user_id: "user-2" }),
+      ]);
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-1" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: pendingSessionKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
+    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${pendingSessionKey}`)).toBe(
+      true,
+    );
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-2" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: createdSessionKey,
+      adoptBackfillSessionKey: pendingSessionKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
+    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${createdSessionKey}`)).toBe(
+      true,
+    );
+    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${pendingSessionKey}`)).toBe(
+      false,
+    );
+
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-3" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: resetSessionKey,
+      adoptBackfillSessionKey: pendingSessionKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(2);
+    expect(harness.channelHistories.get(historyKey)?.map((entry) => entry.body)).toStrictEqual([
+      "after reset",
+    ]);
+  });
+
   it("allows the same thread to backfill again after the stored session id rotates", async () => {
     const harness = createBackfillHarness();
     harness.fetchThreadPosts

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1411,6 +1411,86 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
     expect(harness.threadBackfillInFlight.has(historyKey)).toBe(false);
     expect(harness.threadBackfillMarkers.get(historyKey)).toBe(sessionBackfillKey);
   });
+
+  it("ignores a stale session backfill completion when the marker has rotated", async () => {
+    const harness = createBackfillHarness();
+    const oldSessionKey = "session-before-rotation";
+    const newSessionKey = "session-after-rotation";
+    const currentPost = createPost({ id: "current", message: "@bot continue" });
+
+    // Gate the old session's fetch so it stays pending while the new session
+    // starts and completes its own recovery first.
+    let resolveOldFetch!: (posts: MattermostPost[]) => void;
+    const oldFetchStarted = new Promise<void>((resolveStarted) => {
+      harness.fetchThreadPosts.mockImplementationOnce(() => {
+        resolveStarted();
+        return new Promise<MattermostPost[]>((resolve) => {
+          resolveOldFetch = resolve;
+        });
+      });
+    });
+    // New session fetch resolves immediately with fresh data.
+    harness.fetchThreadPosts.mockResolvedValueOnce([
+      createPost({
+        id: "fresh-1",
+        create_at: 2,
+        message: "fresh context after rotation",
+        user_id: "user-1",
+      }),
+    ]);
+
+    // Start the old-session backfill without awaiting so it stays in-flight.
+    const oldTurn = backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: currentPost,
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: oldSessionKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+    await oldFetchStarted;
+
+    // New-session backfill: the marker rotates to the new session key and the
+    // resolve-last fetch completes before the old fetch is ungated.
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: currentPost,
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: newSessionKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+
+    // Now ungating the old fetch resolves it with stale data. The guard must
+    // detect that the marker no longer matches and skip the write.
+    resolveOldFetch([
+      createPost({
+        id: "stale-1",
+        create_at: 1,
+        message: "stale context from old session",
+        user_id: "user-1",
+      }),
+    ]);
+    await oldTurn;
+
+    // The window must contain the new session's data, not the stale data.
+    const windowPosts = harness.channelHistories.get(historyKey);
+    expect(windowPosts).toBeDefined();
+    expect(windowPosts!.map((e) => e.body)).toStrictEqual(["fresh context after rotation"]);
+    expect(windowPosts!.map((e) => e.body)).not.toContain("stale context from old session");
+
+    // Marker reflects the newer session that completed last.
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(newSessionKey);
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("buildMattermostModelPickerSelectMessageSid", () => {

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1041,6 +1041,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
     const client = createMattermostClientMock();
     const channelHistories = new Map<string, HistoryEntry[]>();
     const threadBackfillMarkers = new Map<string, string>();
+    const threadBackfillInFlight = new Map<string, Promise<void>>();
     const fetchThreadPosts = vi.fn(async () => [] as MattermostPost[]);
 
     return {
@@ -1048,6 +1049,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       client,
       fetchThreadPosts,
       threadBackfillMarkers,
+      threadBackfillInFlight,
     };
   }
 
@@ -1075,6 +1077,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 2,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
@@ -1117,6 +1120,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     harness.channelHistories.set(historyKey, []);
@@ -1129,6 +1133,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
@@ -1149,6 +1154,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     await backfillMattermostThreadHistoryForMonitor({
@@ -1160,6 +1166,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
@@ -1187,6 +1194,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
@@ -1202,6 +1210,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
@@ -1218,6 +1227,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(2);
@@ -1245,6 +1255,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     harness.channelHistories.set(historyKey, [
@@ -1259,6 +1270,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       historyLimit: 5,
       channelHistories: harness.channelHistories,
       threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
@@ -1266,6 +1278,138 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
     expect(harness.channelHistories.get(historyKey)?.map((entry) => entry.body)).toStrictEqual([
       "after reset",
     ]);
+  });
+
+  it("bounds the marker map at the local 1000-key cap and re-backfills an evicted thread", async () => {
+    const harness = createBackfillHarness();
+    harness.fetchThreadPosts.mockResolvedValue([
+      createPost({ id: "seed", create_at: 1, message: "seed", user_id: "user-1" }),
+    ]);
+    const firstKey = "mattermost:thread:root-evicted";
+
+    // Backfill the first thread, then 1000 further distinct threads. The first
+    // key is the oldest by insertion order, so the 1001st admitted thread must
+    // evict it under the local 1000-key marker cap.
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-evicted" }),
+      threadRootId: "root-evicted",
+      historyKey: firstKey,
+      baseSessionKey: "session-evicted",
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+    expect(harness.threadBackfillMarkers.has(firstKey)).toBe(true);
+
+    for (let i = 0; i < 1000; i++) {
+      await backfillMattermostThreadHistoryForMonitor({
+        client: harness.client,
+        post: createPost({ id: `current-${i}` }),
+        threadRootId: `root-${i}`,
+        historyKey: `mattermost:thread:root-${i}`,
+        baseSessionKey: `session-${i}`,
+        historyLimit: 5,
+        channelHistories: harness.channelHistories,
+        threadBackfillMarkers: harness.threadBackfillMarkers,
+        threadBackfillInFlight: harness.threadBackfillInFlight,
+        fetchThreadPosts: harness.fetchThreadPosts,
+      });
+    }
+
+    // Marker retention stays capped and the oldest key was evicted.
+    expect(harness.threadBackfillMarkers.size).toBe(1000);
+    expect(harness.threadBackfillMarkers.has(firstKey)).toBe(false);
+
+    // A thread whose marker was evicted and whose local window has since gone
+    // cold has no marker to suppress recovery, so its next inbound turn
+    // re-backfills from the server instead of being permanently starved.
+    harness.channelHistories.delete(firstKey);
+    const callsBefore = harness.fetchThreadPosts.mock.calls.length;
+    await backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-evicted-again" }),
+      threadRootId: "root-evicted",
+      historyKey: firstKey,
+      baseSessionKey: "session-evicted",
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+
+    expect(harness.fetchThreadPosts.mock.calls.length).toBe(callsBefore + 1);
+    expect(harness.threadBackfillMarkers.get(firstKey)).toBe("session-evicted");
+  });
+
+  it("makes a concurrent same-session cold turn await one in-flight backfill", async () => {
+    const harness = createBackfillHarness();
+    // Gate the first fetch so a second overlapping turn observes it in-flight.
+    let releaseFetch: (() => void) | undefined;
+    const fetchStarted = new Promise<void>((resolveStarted) => {
+      harness.fetchThreadPosts.mockImplementationOnce(async () => {
+        resolveStarted();
+        await new Promise<void>((resolveGate) => {
+          releaseFetch = resolveGate;
+        });
+        return [
+          createPost({ id: "old-1", create_at: 1, message: "prior context", user_id: "user-1" }),
+        ];
+      });
+    });
+
+    // Turn A starts the cold backfill and blocks inside the fetch.
+    const turnA = backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-a" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    });
+    await fetchStarted;
+
+    // Turn B arrives while A's fetch is still pending; it must await the same
+    // operation rather than skip and reply without prior context.
+    let turnBResolved = false;
+    const turnB = backfillMattermostThreadHistoryForMonitor({
+      client: harness.client,
+      post: createPost({ id: "current-b" }),
+      threadRootId: "root-1",
+      historyKey,
+      baseSessionKey: sessionBackfillKey,
+      historyLimit: 5,
+      channelHistories: harness.channelHistories,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
+      threadBackfillInFlight: harness.threadBackfillInFlight,
+      fetchThreadPosts: harness.fetchThreadPosts,
+    }).then(() => {
+      turnBResolved = true;
+    });
+
+    // B cannot resolve until A's gated fetch releases.
+    await Promise.resolve();
+    expect(turnBResolved).toBe(false);
+
+    releaseFetch?.();
+    await Promise.all([turnA, turnB]);
+
+    // Exactly one server fetch ran, and both turns see the recovered window.
+    expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
+    expect(turnBResolved).toBe(true);
+    expect(harness.channelHistories.get(historyKey)?.map((entry) => entry.body)).toStrictEqual([
+      "prior context",
+    ]);
+    // In-flight handle is cleared once settled; the marker governs no-retry.
+    expect(harness.threadBackfillInFlight.has(historyKey)).toBe(false);
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(sessionBackfillKey);
   });
 });
 

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1040,14 +1040,14 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
   function createBackfillHarness() {
     const client = createMattermostClientMock();
     const channelHistories = new Map<string, HistoryEntry[]>();
-    const threadsBackfilledThisSession = new Set<string>();
+    const threadBackfillMarkers = new Map<string, string>();
     const fetchThreadPosts = vi.fn(async () => [] as MattermostPost[]);
 
     return {
       channelHistories,
       client,
       fetchThreadPosts,
-      threadsBackfilledThisSession,
+      threadBackfillMarkers,
     };
   }
 
@@ -1074,11 +1074,17 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: sessionBackfillKey,
       historyLimit: 2,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
+    // Bounded request: historyLimit + 1 leaves room to drop the triggering post.
+    expect(harness.fetchThreadPosts).toHaveBeenCalledWith(
+      harness.client,
+      "root-1",
+      expect.objectContaining({ limit: 3 }),
+    );
     expect(harness.channelHistories.get(historyKey)).toStrictEqual([
       {
         sender: "user-2",
@@ -1093,9 +1099,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
         messageId: "old-3",
       },
     ]);
-    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${sessionBackfillKey}`)).toBe(
-      true,
-    );
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(sessionBackfillKey);
   });
 
   it("marks populated windows so same-session follow-ups do not refetch after history clears", async () => {
@@ -1112,7 +1116,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: sessionBackfillKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     harness.channelHistories.set(historyKey, []);
@@ -1124,14 +1128,12 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: sessionBackfillKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
     expect(harness.fetchThreadPosts).not.toHaveBeenCalled();
-    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${sessionBackfillKey}`)).toBe(
-      true,
-    );
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(sessionBackfillKey);
   });
 
   it("marks failed fetch attempts so same-session follow-ups do not retry", async () => {
@@ -1146,7 +1148,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: sessionBackfillKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     await backfillMattermostThreadHistoryForMonitor({
@@ -1157,14 +1159,12 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: sessionBackfillKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
-    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${sessionBackfillKey}`)).toBe(
-      true,
-    );
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(sessionBackfillKey);
   });
 
   it("adopts pending markers without blocking later session rotations", async () => {
@@ -1186,13 +1186,11 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: pendingSessionKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
-    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${pendingSessionKey}`)).toBe(
-      true,
-    );
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(pendingSessionKey);
 
     await backfillMattermostThreadHistoryForMonitor({
       client: harness.client,
@@ -1203,16 +1201,12 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       adoptBackfillSessionKey: pendingSessionKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(1);
-    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${createdSessionKey}`)).toBe(
-      true,
-    );
-    expect(harness.threadsBackfilledThisSession.has(`${historyKey}:${pendingSessionKey}`)).toBe(
-      false,
-    );
+    expect(harness.threadBackfillMarkers.get(historyKey)).toBe(createdSessionKey);
+    expect(harness.threadBackfillMarkers.get(historyKey)).not.toBe(pendingSessionKey);
 
     await backfillMattermostThreadHistoryForMonitor({
       client: harness.client,
@@ -1223,7 +1217,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       adoptBackfillSessionKey: pendingSessionKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     expect(harness.fetchThreadPosts).toHaveBeenCalledTimes(2);
@@ -1250,7 +1244,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: sessionBackfillKey,
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
     harness.channelHistories.set(historyKey, [
@@ -1264,7 +1258,7 @@ describe("backfillMattermostThreadHistoryForMonitor", () => {
       baseSessionKey: "session-after-reset",
       historyLimit: 5,
       channelHistories: harness.channelHistories,
-      threadsBackfilledThisSession: harness.threadsBackfilledThisSession,
+      threadBackfillMarkers: harness.threadBackfillMarkers,
       fetchThreadPosts: harness.fetchThreadPosts,
     });
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -6,6 +6,7 @@ import {
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
+import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -19,6 +20,7 @@ import { resolveMattermostAccount, resolveMattermostReplyToMode } from "./accoun
 import {
   createMattermostClient,
   fetchMattermostMe,
+  fetchMattermostThreadPosts,
   normalizeMattermostBaseUrl,
   type MattermostPost,
   type MattermostUser,
@@ -131,6 +133,96 @@ type MonitorMattermostOpts = {
   statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
   webSocketFactory?: MattermostWebSocketFactory;
 };
+
+type MattermostThreadBackfillFetcher = (
+  client: MattermostClient,
+  rootPostId: string,
+  signal?: AbortSignal,
+) => Promise<MattermostPost[]>;
+
+type MattermostThreadBackfillUserResolver = (
+  userId: string,
+) => Promise<MattermostUser | null | undefined>;
+
+export async function backfillMattermostThreadHistoryForMonitor(params: {
+  client: MattermostClient;
+  post: MattermostPost;
+  threadRootId: string | undefined;
+  historyKey: string | null;
+  baseSessionKey: string;
+  historyLimit: number;
+  channelHistories: Map<string, HistoryEntry[]>;
+  threadsBackfilledThisSession: Set<string>;
+  fetchThreadPosts?: MattermostThreadBackfillFetcher;
+  resolveUserInfo: MattermostThreadBackfillUserResolver;
+  timeoutMs?: number;
+}): Promise<void> {
+  const {
+    client,
+    post,
+    threadRootId,
+    historyKey,
+    baseSessionKey,
+    historyLimit,
+    channelHistories,
+    threadsBackfilledThisSession,
+    fetchThreadPosts = fetchMattermostThreadPosts,
+    resolveUserInfo,
+    timeoutMs = 10_000,
+  } = params;
+  if (!threadRootId || !historyKey || historyLimit <= 0) {
+    return;
+  }
+
+  const backfillKey = `${historyKey}:${baseSessionKey}`;
+  if (threadsBackfilledThisSession.has(backfillKey)) {
+    return;
+  }
+  const hasPriorBackfillForThread = [...threadsBackfilledThisSession].some((key) =>
+    key.startsWith(`${historyKey}:`),
+  );
+
+  const existing = channelHistories.get(historyKey);
+  if (existing && existing.length > 0 && !hasPriorBackfillForThread) {
+    threadsBackfilledThisSession.add(backfillKey);
+    return;
+  }
+
+  try {
+    const abort = new AbortController();
+    const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
+    try {
+      threadsBackfilledThisSession.add(backfillKey);
+      const threadPosts = await fetchThreadPosts(client, threadRootId, abort.signal);
+      if (threadPosts.length === 0) {
+        return;
+      }
+
+      // Filter current post before trimming so the history window is fully
+      // utilized even when the triggering post is among the newest entries.
+      const others = threadPosts.filter((p) => p.id !== post.id);
+      const windowed = others.slice(-historyLimit);
+      const entries: HistoryEntry[] = [];
+      for (const p of windowed) {
+        const user = await resolveUserInfo(p.user_id ?? "").catch(() => null);
+        const sender = user?.username ? `@${user.username}` : (p.user_id ?? "unknown");
+        entries.push({
+          sender,
+          body: p.message || "[attachment]",
+          timestamp: typeof p.create_at === "number" ? p.create_at : undefined,
+          messageId: p.id ?? undefined,
+        });
+      }
+      if (entries.length > 0) {
+        channelHistories.set(historyKey, entries);
+      }
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  } catch {
+    // Best-effort: server fetch failure or timeout should not block inbound dispatch.
+  }
+}
 
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
@@ -575,6 +667,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
+  // Per-(historyKey, agent-session) backfill tracking.
+  // Compound key binds the thread key to the current stored agent session id,
+  // which rotates on /new or session reset.  This way
+  // session reset gets its own first-sighting backfill, and marking
+  // non-empty first sightings prevents normal post-turn empty windows
+  // from re-triggering an unnecessary server fetch (kernel.ts:577 clears
+  // pending group history after a successful dispatch).
+  const threadsBackfilledThisSession = new Set<string>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const { groupPolicy, providerMissingFallbackApplied } =
@@ -1161,6 +1261,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
         const { effectiveReplyToId, sessionKey, parentSessionKey } = threadContext;
         const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
+        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+          agentId: route.agentId,
+        });
+        const currentAgentSessionId =
+          normalizeOptionalString(getSessionEntry({ storePath, sessionKey })?.sessionId) ??
+          sessionKey;
 
         const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
         const wasMentioned =
@@ -1265,6 +1371,34 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // Mention-only turns need non-empty agent text; the shared reply runner rejects empty
         // bodies before model invocation. The guard above ensures this fallback is a bot mention.
         const bodyForAgent = bodyText || rawText.trim();
+
+        // ── Thread history backfill: seed in-memory history from server ──
+        // After all admission gates pass (onchar / mention / empty-body drop),
+        // backfill thread history from the Mattermost server when the local
+        // in-memory window is genuinely cold for the current agent session.
+        //
+        // Compound key (historyKey + currentAgentSessionId): historyKey alone is
+        // stable across /new for the same thread channel, while route.sessionKey
+        // is also stable. The stored session id rotates on /new, so binding to
+        // it gives reset its own first-sighting backfill instead of being
+        // blocked by a stale monitor-lifetime marker.
+        //
+        // Active-thread guard: if a thread is first seen with a populated
+        // window, mark that session so the kernel clearing pending history
+        // after a successful turn does not make same-session follow-ups fetch.
+        //
+        // Best-effort — never blocks inbound dispatch.
+        await backfillMattermostThreadHistoryForMonitor({
+          client,
+          post,
+          threadRootId,
+          historyKey,
+          baseSessionKey: currentAgentSessionId,
+          historyLimit,
+          channelHistories,
+          threadsBackfilledThisSession,
+          resolveUserInfo,
+        });
 
         core.channel.activity.record({
           channel: "mattermost",
@@ -1374,10 +1508,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 normalizeEntry: normalizeMattermostAllowEntry,
               })
             : null;
-
-        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
-          agentId: route.agentId,
-        });
 
         const previewLine = truncateUtf16Safe(bodyText, 200).replace(/\n/g, "\\n");
         logVerboseMessage(

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1388,6 +1388,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // after a successful turn does not make same-session follow-ups fetch.
         //
         // Best-effort — never blocks inbound dispatch.
+        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+          agentId: route.agentId,
+        });
+        const currentAgentSessionId =
+          normalizeOptionalString(getSessionEntry({ storePath, sessionKey })?.sessionId) ??
+          sessionKey;
         await backfillMattermostThreadHistoryForMonitor({
           client,
           post,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -146,6 +146,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
   threadRootId: string | undefined;
   historyKey: string | null;
   baseSessionKey: string;
+  adoptBackfillSessionKey?: string;
   historyLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
   threadsBackfilledThisSession: Set<string>;
@@ -158,6 +159,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     threadRootId,
     historyKey,
     baseSessionKey,
+    adoptBackfillSessionKey,
     historyLimit,
     channelHistories,
     threadsBackfilledThisSession,
@@ -170,6 +172,14 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
 
   const backfillKey = `${historyKey}:${baseSessionKey}`;
   if (threadsBackfilledThisSession.has(backfillKey)) {
+    return;
+  }
+  const adoptBackfillKey = adoptBackfillSessionKey
+    ? `${historyKey}:${adoptBackfillSessionKey}`
+    : undefined;
+  if (adoptBackfillKey && threadsBackfilledThisSession.has(adoptBackfillKey)) {
+    threadsBackfilledThisSession.add(backfillKey);
+    threadsBackfilledThisSession.delete(adoptBackfillKey);
     return;
   }
   const hasPriorBackfillForThread = [...threadsBackfilledThisSession].some((key) =>
@@ -1369,11 +1379,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // backfill thread history from the Mattermost server when the local
         // in-memory window is genuinely cold for the current agent session.
         //
-        // Compound key (historyKey + currentAgentSessionId): historyKey alone is
-        // stable across /new for the same thread channel, while route.sessionKey
-        // is also stable. The stored session id rotates on /new, so binding to
-        // it gives reset its own first-sighting backfill instead of being
-        // blocked by a stale monitor-lifetime marker.
+        // Compound key (historyKey + backfill session marker): historyKey alone
+        // is stable across /new for the same thread channel, while route.sessionKey
+        // is also stable. The stored session id rotates on /new, so binding to it
+        // gives reset its own first-sighting backfill. If the first cold turn has
+        // not been recorded yet, use a pending marker and adopt it once the stored
+        // session id appears; this prevents a same-session follow-up fetch without
+        // blocking a later real session-id rotation.
         //
         // Active-thread guard: if a thread is first seen with a populated
         // window, mark that session so the kernel clearing pending history
@@ -1383,15 +1395,20 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
           agentId: route.agentId,
         });
-        const currentAgentSessionId =
-          normalizeOptionalString(getSessionEntry({ storePath, sessionKey })?.sessionId) ??
-          sessionKey;
+        const currentAgentSessionId = normalizeOptionalString(
+          getSessionEntry({ storePath, sessionKey })?.sessionId,
+        );
+        const backfillSessionMarker = currentAgentSessionId
+          ? `session:${currentAgentSessionId}`
+          : `pending:${sessionKey}`;
+        const adoptBackfillSessionKey = currentAgentSessionId ? `pending:${sessionKey}` : undefined;
         await backfillMattermostThreadHistoryForMonitor({
           client,
           post,
           threadRootId,
           historyKey,
-          baseSessionKey: currentAgentSessionId,
+          baseSessionKey: backfillSessionMarker,
+          adoptBackfillSessionKey,
           historyLimit,
           channelHistories,
           threadsBackfilledThisSession,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -6,7 +6,6 @@ import {
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
-import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -20,7 +19,6 @@ import { resolveMattermostAccount, resolveMattermostReplyToMode } from "./accoun
 import {
   createMattermostClient,
   fetchMattermostMe,
-  fetchMattermostThreadPosts,
   normalizeMattermostBaseUrl,
   type MattermostPost,
   type MattermostUser,
@@ -82,6 +80,7 @@ import {
   type MattermostMediaInfo,
 } from "./monitor-resources.js";
 import { registerMattermostMonitorSlashCommands } from "./monitor-slash.js";
+import { backfillMattermostThreadHistoryForMonitorTurn } from "./monitor-thread-backfill.js";
 import {
   createMattermostConnectOnce,
   type MattermostEventPayload,
@@ -133,159 +132,6 @@ type MonitorMattermostOpts = {
   statusSink?: (patch: Partial<ChannelAccountSnapshot>) => void;
   webSocketFactory?: MattermostWebSocketFactory;
 };
-
-type MattermostThreadBackfillFetcher = (
-  client: MattermostClient,
-  rootPostId: string,
-  options: { limit: number; signal?: AbortSignal },
-) => Promise<MattermostPost[]>;
-
-// Cap the per-thread backfill marker map so it cannot outgrow the 1000-key
-// `channelHistories` window it accompanies; an evicted thread simply
-// re-backfills on its next cold inbound turn.
-const MAX_THREAD_BACKFILL_MARKERS = 1000;
-
-// Evict oldest marker keys (Map insertion order = LRU) once the map exceeds the
-// cap. Kept local to the plugin so core history internals stay untouched.
-function evictOldThreadBackfillMarkers(markers: Map<string, string>): void {
-  while (markers.size > MAX_THREAD_BACKFILL_MARKERS) {
-    const oldestKey = markers.keys().next().value;
-    if (oldestKey === undefined) {
-      break;
-    }
-    markers.delete(oldestKey);
-  }
-}
-
-export async function backfillMattermostThreadHistoryForMonitor(params: {
-  client: MattermostClient;
-  post: MattermostPost;
-  threadRootId: string | undefined;
-  historyKey: string | null;
-  baseSessionKey: string;
-  adoptBackfillSessionKey?: string;
-  historyLimit: number;
-  channelHistories: Map<string, HistoryEntry[]>;
-  threadBackfillMarkers: Map<string, string>;
-  threadBackfillInFlight: Map<string, Promise<void>>;
-  fetchThreadPosts?: MattermostThreadBackfillFetcher;
-  timeoutMs?: number;
-}): Promise<void> {
-  const {
-    client,
-    post,
-    threadRootId,
-    historyKey,
-    baseSessionKey,
-    adoptBackfillSessionKey,
-    historyLimit,
-    channelHistories,
-    threadBackfillMarkers,
-    threadBackfillInFlight,
-    fetchThreadPosts = fetchMattermostThreadPosts,
-    timeoutMs = 10_000,
-  } = params;
-  if (!threadRootId || !historyKey || historyLimit <= 0) {
-    return;
-  }
-
-  // One marker per thread history key: the value is the current session marker.
-  // This bounds marker memory and lookup cost to the number of live threads,
-  // instead of accumulating a `${historyKey}:${session}` entry for every session
-  // rotation and scanning the whole process-lifetime set on each candidate.
-  // Writes refresh LRU order and stay under the local 1000-key cap so the marker
-  // map cannot outgrow the `channelHistories` window it accompanies.
-  const setMarker = (session: string): void => {
-    threadBackfillMarkers.delete(historyKey);
-    threadBackfillMarkers.set(historyKey, session);
-    evictOldThreadBackfillMarkers(threadBackfillMarkers);
-  };
-
-  const currentMarker = threadBackfillMarkers.get(historyKey);
-  if (currentMarker === baseSessionKey) {
-    // Same-session marker already set. If a first cold turn is still fetching
-    // (zero-debounce inbound bursts overlap on the awaited network boundary),
-    // await that one bounded request so this turn reads the recovered window
-    // instead of replying without prior context. No in-flight entry means the
-    // fetch already completed, returned empty, timed out, or failed, and the
-    // completed marker intentionally suppresses a retry.
-    const inFlight = threadBackfillInFlight.get(historyKey);
-    if (inFlight) {
-      await inFlight.catch(() => {});
-    }
-    return;
-  }
-  // Adopt the earlier pending marker once the stored session id appears, so a
-  // same-session follow-up does not refetch while a later real session rotation
-  // still can.
-  if (adoptBackfillSessionKey && currentMarker === adoptBackfillSessionKey) {
-    setMarker(baseSessionKey);
-    return;
-  }
-  const hasPriorBackfillForThread = currentMarker !== undefined;
-
-  const existing = channelHistories.get(historyKey);
-  if (existing && existing.length > 0 && !hasPriorBackfillForThread) {
-    setMarker(baseSessionKey);
-    return;
-  }
-
-  // Set the completed-attempt marker before awaiting so overlapping same-session
-  // turns take the branch above and await this one operation. Publish the
-  // in-flight promise so those turns can wait for the recovered window; clear it
-  // in `finally` so the marker alone governs no-retry afterwards.
-  setMarker(baseSessionKey);
-  // Capture the marker this recovery owns so a stale older-session response
-  // that resolves last does not overwrite a newer session's recovered window.
-  // If the marker rotated while the fetch was in flight, skip the write.
-  const ownedMarker = baseSessionKey;
-  const recovery = (async () => {
-    const abort = new AbortController();
-    const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
-    try {
-      // Request one extra post so the window still fills after we drop the
-      // triggering post below when it is among the newest entries.
-      const threadPosts = await fetchThreadPosts(client, threadRootId, {
-        limit: historyLimit + 1,
-        signal: abort.signal,
-      });
-      if (threadPosts.length === 0) {
-        return;
-      }
-
-      // Filter current post before trimming so the history window is fully
-      // utilized even when the triggering post is among the newest entries.
-      const others = threadPosts.filter((p) => p.id !== post.id);
-      const windowed = others.slice(-historyLimit);
-      const entries: HistoryEntry[] = [];
-      for (const p of windowed) {
-        entries.push({
-          sender: p.user_id ?? "unknown",
-          body: p.message || "[attachment]",
-          timestamp: typeof p.create_at === "number" ? p.create_at : undefined,
-          messageId: p.id ?? undefined,
-        });
-      }
-      if (entries.length > 0 && threadBackfillMarkers.get(historyKey) === ownedMarker) {
-        channelHistories.set(historyKey, entries);
-      }
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  })();
-  threadBackfillInFlight.set(historyKey, recovery);
-  try {
-    await recovery;
-  } catch {
-    // Best-effort: server fetch failure or timeout should not block inbound dispatch.
-  } finally {
-    // Drop the in-flight handle once settled; the completed marker then governs
-    // no-retry, and only this owner clears its own operation.
-    if (threadBackfillInFlight.get(historyKey) === recovery) {
-      threadBackfillInFlight.delete(historyKey);
-    }
-  }
-}
 
 type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
@@ -403,11 +249,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     allowPrivateNetwork: isPrivateNetworkOptInEnabled(account.config),
   });
 
-  // Wait for the Mattermost API to accept our bot token before proceeding.
-  // When a bot account is disabled and re-enabled, the session is invalidated
-  // and API calls return 401 until the account is fully active again.  Retrying
-  // here (with exponential backoff) keeps the monitor alive and prevents the
-  // framework's auto-restart budget from being exhausted.
   let botUser!: MattermostUser;
   await runWithReconnect(
     async () => {
@@ -442,15 +283,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   });
   const slashEnabled = getSlashCommandState(account.accountId) != null;
 
-  // ─── Interactive buttons registration ──────────────────────────────────────
-  // Derive a stable HMAC secret from the bot token so CLI and gateway share it.
   setInteractionSecret(account.accountId, botToken);
-
-  // Register HTTP callback endpoint for interactive button clicks.
-  // Mattermost POSTs to this URL when a user clicks a button action.
   const interactionPath = resolveInteractionCallbackPath(account.accountId);
-  // Recompute from config on each monitor start so reconnects or config reloads can refresh the
-  // cached callback URL for downstream callers such as `message action=send`.
   const callbackUrl = computeInteractionCallbackUrl(account.accountId, {
     gateway: cfg.gateway,
     interactions: account.config.interactions,
@@ -730,17 +564,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
-  // Thread backfill tracking: one marker per thread history key, valued by the
-  // current stored agent session id (which rotates on /new or session reset).
-  // Keeping a single current marker per thread bounds memory to live threads and
-  // still lets a session reset earn its own first-sighting backfill; marking
-  // non-empty first sightings prevents normal post-turn empty windows from
-  // re-triggering an unnecessary server fetch (kernel.ts:577 clears pending group
-  // history after a successful dispatch).
   const threadBackfillMarkers = new Map<string, string>();
-  // In-flight cold-recovery fetches keyed by thread history key, so overlapping
-  // same-session turns await one bounded request instead of replying without the
-  // recovered window. Cleared when the owning fetch settles.
   const threadBackfillInFlight = new Map<string, Promise<void>>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
@@ -1429,50 +1253,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           );
           return;
         }
-        // Mention-only turns need non-empty agent text; the shared reply runner rejects empty
-        // bodies before model invocation. The guard above ensures this fallback is a bot mention.
         const bodyForAgent = bodyText || rawText.trim();
 
-        // ── Thread history backfill: seed in-memory history from server ──
-        // After all admission gates pass (onchar / mention / empty-body drop),
-        // backfill thread history from the Mattermost server when the local
-        // in-memory window is genuinely cold for the current agent session.
-        //
-        // Read the stored agent session id here (not before the gates) so posts
-        // dropped before admission never touch the session store. The backfill
-        // marker binds historyKey to this session id: historyKey alone is stable
-        // across /new for the same thread, but the stored session id rotates on
-        // /new, so binding to it gives reset its own first-sighting backfill. If
-        // the first cold turn has not recorded a session id yet, use a pending
-        // marker and adopt it once the stored id appears; this prevents a
-        // same-session follow-up fetch without blocking a later session rotation.
-        //
-        // Active-thread guard: if a thread is first seen with a populated
-        // window, mark that session so the kernel clearing pending history
-        // after a successful turn does not make same-session follow-ups fetch.
-        //
-        // Best-effort — never blocks inbound dispatch.
-        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
-          agentId: route.agentId,
-        });
-        const currentAgentSessionId = normalizeOptionalString(
-          getSessionEntry({ storePath, sessionKey })?.sessionId,
-        );
-        const backfillSessionMarker = currentAgentSessionId
-          ? `session:${currentAgentSessionId}`
-          : `pending:${sessionKey}`;
-        const adoptBackfillSessionKey = currentAgentSessionId ? `pending:${sessionKey}` : undefined;
-        await backfillMattermostThreadHistoryForMonitor({
+        await backfillMattermostThreadHistoryForMonitorTurn({
           client,
           post,
           threadRootId,
           historyKey,
-          baseSessionKey: backfillSessionMarker,
-          adoptBackfillSessionKey,
           historyLimit,
           channelHistories,
           threadBackfillMarkers,
           threadBackfillInFlight,
+          storePath: core.channel.session.resolveStorePath(cfg.session?.store, {
+            agentId: route.agentId,
+          }),
+          sessionKey,
         });
 
         core.channel.activity.record({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -140,10 +140,6 @@ type MattermostThreadBackfillFetcher = (
   signal?: AbortSignal,
 ) => Promise<MattermostPost[]>;
 
-type MattermostThreadBackfillUserResolver = (
-  userId: string,
-) => Promise<MattermostUser | null | undefined>;
-
 export async function backfillMattermostThreadHistoryForMonitor(params: {
   client: MattermostClient;
   post: MattermostPost;
@@ -154,7 +150,6 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
   channelHistories: Map<string, HistoryEntry[]>;
   threadsBackfilledThisSession: Set<string>;
   fetchThreadPosts?: MattermostThreadBackfillFetcher;
-  resolveUserInfo: MattermostThreadBackfillUserResolver;
   timeoutMs?: number;
 }): Promise<void> {
   const {
@@ -167,7 +162,6 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     channelHistories,
     threadsBackfilledThisSession,
     fetchThreadPosts = fetchMattermostThreadPosts,
-    resolveUserInfo,
     timeoutMs = 10_000,
   } = params;
   if (!threadRootId || !historyKey || historyLimit <= 0) {
@@ -204,10 +198,8 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
       const windowed = others.slice(-historyLimit);
       const entries: HistoryEntry[] = [];
       for (const p of windowed) {
-        const user = await resolveUserInfo(p.user_id ?? "").catch(() => null);
-        const sender = user?.username ? `@${user.username}` : (p.user_id ?? "unknown");
         entries.push({
-          sender,
+          sender: p.user_id ?? "unknown",
           body: p.message || "[attachment]",
           timestamp: typeof p.create_at === "number" ? p.create_at : undefined,
           messageId: p.id ?? undefined,
@@ -1403,7 +1395,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           historyLimit,
           channelHistories,
           threadsBackfilledThisSession,
-          resolveUserInfo,
         });
 
         core.channel.activity.record({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -137,7 +137,7 @@ type MonitorMattermostOpts = {
 type MattermostThreadBackfillFetcher = (
   client: MattermostClient,
   rootPostId: string,
-  signal?: AbortSignal,
+  options: { limit: number; signal?: AbortSignal },
 ) => Promise<MattermostPost[]>;
 
 export async function backfillMattermostThreadHistoryForMonitor(params: {
@@ -149,7 +149,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
   adoptBackfillSessionKey?: string;
   historyLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
-  threadsBackfilledThisSession: Set<string>;
+  threadBackfillMarkers: Map<string, string>;
   fetchThreadPosts?: MattermostThreadBackfillFetcher;
   timeoutMs?: number;
 }): Promise<void> {
@@ -162,7 +162,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     adoptBackfillSessionKey,
     historyLimit,
     channelHistories,
-    threadsBackfilledThisSession,
+    threadBackfillMarkers,
     fetchThreadPosts = fetchMattermostThreadPosts,
     timeoutMs = 10_000,
   } = params;
@@ -170,25 +170,26 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     return;
   }
 
-  const backfillKey = `${historyKey}:${baseSessionKey}`;
-  if (threadsBackfilledThisSession.has(backfillKey)) {
+  // One marker per thread history key: the value is the current session marker.
+  // This bounds marker memory and lookup cost to the number of live threads,
+  // instead of accumulating a `${historyKey}:${session}` entry for every session
+  // rotation and scanning the whole process-lifetime set on each candidate.
+  const currentMarker = threadBackfillMarkers.get(historyKey);
+  if (currentMarker === baseSessionKey) {
     return;
   }
-  const adoptBackfillKey = adoptBackfillSessionKey
-    ? `${historyKey}:${adoptBackfillSessionKey}`
-    : undefined;
-  if (adoptBackfillKey && threadsBackfilledThisSession.has(adoptBackfillKey)) {
-    threadsBackfilledThisSession.add(backfillKey);
-    threadsBackfilledThisSession.delete(adoptBackfillKey);
+  // Adopt the earlier pending marker once the stored session id appears, so a
+  // same-session follow-up does not refetch while a later real session rotation
+  // still can.
+  if (adoptBackfillSessionKey && currentMarker === adoptBackfillSessionKey) {
+    threadBackfillMarkers.set(historyKey, baseSessionKey);
     return;
   }
-  const hasPriorBackfillForThread = [...threadsBackfilledThisSession].some((key) =>
-    key.startsWith(`${historyKey}:`),
-  );
+  const hasPriorBackfillForThread = currentMarker !== undefined;
 
   const existing = channelHistories.get(historyKey);
   if (existing && existing.length > 0 && !hasPriorBackfillForThread) {
-    threadsBackfilledThisSession.add(backfillKey);
+    threadBackfillMarkers.set(historyKey, baseSessionKey);
     return;
   }
 
@@ -196,8 +197,13 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     const abort = new AbortController();
     const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
     try {
-      threadsBackfilledThisSession.add(backfillKey);
-      const threadPosts = await fetchThreadPosts(client, threadRootId, abort.signal);
+      threadBackfillMarkers.set(historyKey, baseSessionKey);
+      // Request one extra post so the window still fills after we drop the
+      // triggering post below when it is among the newest entries.
+      const threadPosts = await fetchThreadPosts(client, threadRootId, {
+        limit: historyLimit + 1,
+        signal: abort.signal,
+      });
       if (threadPosts.length === 0) {
         return;
       }
@@ -669,14 +675,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
-  // Per-(historyKey, agent-session) backfill tracking.
-  // Compound key binds the thread key to the current stored agent session id,
-  // which rotates on /new or session reset.  This way
-  // session reset gets its own first-sighting backfill, and marking
-  // non-empty first sightings prevents normal post-turn empty windows
-  // from re-triggering an unnecessary server fetch (kernel.ts:577 clears
-  // pending group history after a successful dispatch).
-  const threadsBackfilledThisSession = new Set<string>();
+  // Thread backfill tracking: one marker per thread history key, valued by the
+  // current stored agent session id (which rotates on /new or session reset).
+  // Keeping a single current marker per thread bounds memory to live threads and
+  // still lets a session reset earn its own first-sighting backfill; marking
+  // non-empty first sightings prevents normal post-turn empty windows from
+  // re-triggering an unnecessary server fetch (kernel.ts:577 clears pending group
+  // history after a successful dispatch).
+  const threadBackfillMarkers = new Map<string, string>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const { groupPolicy, providerMissingFallbackApplied } =
@@ -1263,12 +1269,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
         const { effectiveReplyToId, sessionKey, parentSessionKey } = threadContext;
         const historyKey = resolveMattermostPendingHistoryKey({ kind, sessionKey });
-        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
-          agentId: route.agentId,
-        });
-        const currentAgentSessionId = normalizeOptionalString(
-          getSessionEntry({ storePath, sessionKey })?.sessionId,
-        );
 
         const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
         const wasMentioned =
@@ -1379,19 +1379,26 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // backfill thread history from the Mattermost server when the local
         // in-memory window is genuinely cold for the current agent session.
         //
-        // Compound key (historyKey + backfill session marker): historyKey alone
-        // is stable across /new for the same thread channel, while route.sessionKey
-        // is also stable. The stored session id rotates on /new, so binding to it
-        // gives reset its own first-sighting backfill. If the first cold turn has
-        // not been recorded yet, use a pending marker and adopt it once the stored
-        // session id appears; this prevents a same-session follow-up fetch without
-        // blocking a later real session-id rotation.
+        // Read the stored agent session id here (not before the gates) so posts
+        // dropped before admission never touch the session store. The backfill
+        // marker binds historyKey to this session id: historyKey alone is stable
+        // across /new for the same thread, but the stored session id rotates on
+        // /new, so binding to it gives reset its own first-sighting backfill. If
+        // the first cold turn has not recorded a session id yet, use a pending
+        // marker and adopt it once the stored id appears; this prevents a
+        // same-session follow-up fetch without blocking a later session rotation.
         //
         // Active-thread guard: if a thread is first seen with a populated
         // window, mark that session so the kernel clearing pending history
         // after a successful turn does not make same-session follow-ups fetch.
         //
         // Best-effort — never blocks inbound dispatch.
+        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+          agentId: route.agentId,
+        });
+        const currentAgentSessionId = normalizeOptionalString(
+          getSessionEntry({ storePath, sessionKey })?.sessionId,
+        );
         const backfillSessionMarker = currentAgentSessionId
           ? `session:${currentAgentSessionId}`
           : `pending:${sessionKey}`;
@@ -1405,7 +1412,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           adoptBackfillSessionKey,
           historyLimit,
           channelHistories,
-          threadsBackfilledThisSession,
+          threadBackfillMarkers,
         });
 
         core.channel.activity.record({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -235,6 +235,10 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
   // in-flight promise so those turns can wait for the recovered window; clear it
   // in `finally` so the marker alone governs no-retry afterwards.
   setMarker(baseSessionKey);
+  // Capture the marker this recovery owns so a stale older-session response
+  // that resolves last does not overwrite a newer session's recovered window.
+  // If the marker rotated while the fetch was in flight, skip the write.
+  const ownedMarker = baseSessionKey;
   const recovery = (async () => {
     const abort = new AbortController();
     const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
@@ -262,7 +266,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
           messageId: p.id ?? undefined,
         });
       }
-      if (entries.length > 0) {
+      if (entries.length > 0 && threadBackfillMarkers.get(historyKey) === ownedMarker) {
         channelHistories.set(historyKey, entries);
       }
     } finally {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -140,6 +140,23 @@ type MattermostThreadBackfillFetcher = (
   options: { limit: number; signal?: AbortSignal },
 ) => Promise<MattermostPost[]>;
 
+// Cap the per-thread backfill marker map so it cannot outgrow the 1000-key
+// `channelHistories` window it accompanies; an evicted thread simply
+// re-backfills on its next cold inbound turn.
+const MAX_THREAD_BACKFILL_MARKERS = 1000;
+
+// Evict oldest marker keys (Map insertion order = LRU) once the map exceeds the
+// cap. Kept local to the plugin so core history internals stay untouched.
+function evictOldThreadBackfillMarkers(markers: Map<string, string>): void {
+  while (markers.size > MAX_THREAD_BACKFILL_MARKERS) {
+    const oldestKey = markers.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    markers.delete(oldestKey);
+  }
+}
+
 export async function backfillMattermostThreadHistoryForMonitor(params: {
   client: MattermostClient;
   post: MattermostPost;
@@ -150,6 +167,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
   historyLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
   threadBackfillMarkers: Map<string, string>;
+  threadBackfillInFlight: Map<string, Promise<void>>;
   fetchThreadPosts?: MattermostThreadBackfillFetcher;
   timeoutMs?: number;
 }): Promise<void> {
@@ -163,6 +181,7 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     historyLimit,
     channelHistories,
     threadBackfillMarkers,
+    threadBackfillInFlight,
     fetchThreadPosts = fetchMattermostThreadPosts,
     timeoutMs = 10_000,
   } = params;
@@ -174,30 +193,52 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
   // This bounds marker memory and lookup cost to the number of live threads,
   // instead of accumulating a `${historyKey}:${session}` entry for every session
   // rotation and scanning the whole process-lifetime set on each candidate.
+  // Writes refresh LRU order and stay under the local 1000-key cap so the marker
+  // map cannot outgrow the `channelHistories` window it accompanies.
+  const setMarker = (session: string): void => {
+    threadBackfillMarkers.delete(historyKey);
+    threadBackfillMarkers.set(historyKey, session);
+    evictOldThreadBackfillMarkers(threadBackfillMarkers);
+  };
+
   const currentMarker = threadBackfillMarkers.get(historyKey);
   if (currentMarker === baseSessionKey) {
+    // Same-session marker already set. If a first cold turn is still fetching
+    // (zero-debounce inbound bursts overlap on the awaited network boundary),
+    // await that one bounded request so this turn reads the recovered window
+    // instead of replying without prior context. No in-flight entry means the
+    // fetch already completed, returned empty, timed out, or failed, and the
+    // completed marker intentionally suppresses a retry.
+    const inFlight = threadBackfillInFlight.get(historyKey);
+    if (inFlight) {
+      await inFlight.catch(() => {});
+    }
     return;
   }
   // Adopt the earlier pending marker once the stored session id appears, so a
   // same-session follow-up does not refetch while a later real session rotation
   // still can.
   if (adoptBackfillSessionKey && currentMarker === adoptBackfillSessionKey) {
-    threadBackfillMarkers.set(historyKey, baseSessionKey);
+    setMarker(baseSessionKey);
     return;
   }
   const hasPriorBackfillForThread = currentMarker !== undefined;
 
   const existing = channelHistories.get(historyKey);
   if (existing && existing.length > 0 && !hasPriorBackfillForThread) {
-    threadBackfillMarkers.set(historyKey, baseSessionKey);
+    setMarker(baseSessionKey);
     return;
   }
 
-  try {
+  // Set the completed-attempt marker before awaiting so overlapping same-session
+  // turns take the branch above and await this one operation. Publish the
+  // in-flight promise so those turns can wait for the recovered window; clear it
+  // in `finally` so the marker alone governs no-retry afterwards.
+  setMarker(baseSessionKey);
+  const recovery = (async () => {
     const abort = new AbortController();
     const timeoutId = setTimeout(() => abort.abort(), timeoutMs);
     try {
-      threadBackfillMarkers.set(historyKey, baseSessionKey);
       // Request one extra post so the window still fills after we drop the
       // triggering post below when it is among the newest entries.
       const threadPosts = await fetchThreadPosts(client, threadRootId, {
@@ -227,8 +268,18 @@ export async function backfillMattermostThreadHistoryForMonitor(params: {
     } finally {
       clearTimeout(timeoutId);
     }
+  })();
+  threadBackfillInFlight.set(historyKey, recovery);
+  try {
+    await recovery;
   } catch {
     // Best-effort: server fetch failure or timeout should not block inbound dispatch.
+  } finally {
+    // Drop the in-flight handle once settled; the completed marker then governs
+    // no-retry, and only this owner clears its own operation.
+    if (threadBackfillInFlight.get(historyKey) === recovery) {
+      threadBackfillInFlight.delete(historyKey);
+    }
   }
 }
 
@@ -683,6 +734,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
   // re-triggering an unnecessary server fetch (kernel.ts:577 clears pending group
   // history after a successful dispatch).
   const threadBackfillMarkers = new Map<string, string>();
+  // In-flight cold-recovery fetches keyed by thread history key, so overlapping
+  // same-session turns await one bounded request instead of replying without the
+  // recovered window. Cleared when the owning fetch settles.
+  const threadBackfillInFlight = new Map<string, Promise<void>>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const { groupPolicy, providerMissingFallbackApplied } =
@@ -1413,6 +1468,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           historyLimit,
           channelHistories,
           threadBackfillMarkers,
+          threadBackfillInFlight,
         });
 
         core.channel.activity.record({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1266,9 +1266,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
           agentId: route.agentId,
         });
-        const currentAgentSessionId =
-          normalizeOptionalString(getSessionEntry({ storePath, sessionKey })?.sessionId) ??
-          sessionKey;
+        const currentAgentSessionId = normalizeOptionalString(
+          getSessionEntry({ storePath, sessionKey })?.sessionId,
+        );
 
         const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
         const wasMentioned =
@@ -1392,12 +1392,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // after a successful turn does not make same-session follow-ups fetch.
         //
         // Best-effort — never blocks inbound dispatch.
-        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
-          agentId: route.agentId,
-        });
-        const currentAgentSessionId = normalizeOptionalString(
-          getSessionEntry({ storePath, sessionKey })?.sessionId,
-        );
         const backfillSessionMarker = currentAgentSessionId
           ? `session:${currentAgentSessionId}`
           : `pending:${sessionKey}`;

--- a/extensions/mattermost/src/mattermost/thread-posts.ts
+++ b/extensions/mattermost/src/mattermost/thread-posts.ts
@@ -1,0 +1,18 @@
+import type { MattermostClient, MattermostPost } from "./client.js";
+
+export async function fetchMattermostThreadPosts(
+  client: MattermostClient,
+  postId: string,
+  options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<MattermostPost[]> {
+  const { limit, signal } = options;
+  const query = typeof limit === "number" && limit > 0 ? `?perPage=${limit}&direction=up` : "";
+  const data = await client.request<{
+    order: string[];
+    posts: Record<string, MattermostPost>;
+  }>(`/posts/${postId}/thread${query}`, signal ? { signal } : undefined);
+  const posts: MattermostPost[] = (data.order ?? [])
+    .map((pid) => data.posts?.[pid])
+    .filter((p): p is MattermostPost => p != null);
+  return posts.toSorted((a, b) => (a.create_at ?? 0) - (b.create_at ?? 0));
+}

--- a/extensions/mattermost/src/mattermost/thread-posts.ts
+++ b/extensions/mattermost/src/mattermost/thread-posts.ts
@@ -6,7 +6,8 @@ export async function fetchMattermostThreadPosts(
   options: { limit?: number; signal?: AbortSignal } = {},
 ): Promise<MattermostPost[]> {
   const { limit, signal } = options;
-  const query = typeof limit === "number" && limit > 0 ? `?perPage=${limit}&direction=up` : "";
+  const perPage = typeof limit === "number" && limit > 0 ? Math.min(limit, 200) : 0;
+  const query = perPage > 0 ? `?perPage=${perPage}&direction=up` : "";
   const data = await client.request<{
     order: string[];
     posts: Record<string, MattermostPost>;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost users replying in an existing thread could lose earlier thread context after the OpenClaw monitor restarted or the agent session was reset.

Fixes #93204

## Why This Change Was Made

The Mattermost monitor now backfills a cold local thread-history window from the Mattermost thread endpoint after inbound admission gates pass. The backfill marker is keyed by the stored thread `sessionId`, not the stable route session key, so a real `/new` or session reset in a thread gets its own recovery fetch while same-session follow-ups avoid repeated server fetches.

When the first cold turn has no stored thread session entry yet, the monitor records a pending backfill marker and adopts it once `recordInboundSessionMeta` creates the stored session id. That keeps the marker stable for same-session follow-ups and failed-fetch no-retry, without blocking a later real session-id rotation.

Recovery is now bounded on three axes flagged in review:

- **Thread response size.** `fetchMattermostThreadPosts` requests only the newest `historyLimit + 1` posts via `?perPage=<limit>&direction=up`, then restores ascending chronological order. `GET /posts/{id}/thread` returns the entire thread at the Mattermost default (`perPage=0`), so an unbounded thread would otherwise allocate and parse on the inbound path. The endpoint reads camelCase `perPage` (not `per_page`), so the limit is actually applied.
- **Marker lifecycle.** Backfill tracking uses one marker per thread history key (`Map<historyKey, sessionId>`) instead of a process-lifetime `Set` of `historyKey:session` compound keys. A plugin-local 1000-key LRU cap (`evictOldThreadBackfillMarkers`, matching the `channelHistories` window size) keeps the marker map from outgrowing the history window it accompanies; the cap stays in the plugin rather than touching core history internals. An evicted thread simply re-backfills on its next cold inbound turn. The stored session id is read only after the admission gates, so dropped pre-admission posts never touch the session store.
- **Concurrent cold turns.** Under the default zero-debounce config, two first cold-thread messages can overlap on the awaited thread-history fetch. The first turn sets the completed-attempt marker and publishes a per-history-key in-flight promise; an overlapping same-session turn now awaits that one bounded fetch instead of seeing the marker and skipping into a context-free reply. The in-flight handle is cleared once the fetch settles, so afterward the marker alone governs the intentional one-attempt-per-session no-retry.

## User Impact

Mattermost thread replies keep useful prior context after restart or `/new`, without repeated thread-history requests, unbounded thread fetches, or unbounded per-session marker growth on long-lived monitors. Concurrent first cold-thread messages under zero-debounce no longer race into a context-free reply.

## Evidence

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts`: **3 files, 115 passed**. Covers stored thread `sessionId` rotation, same-session no-refetch, failed-fetch no-retry, dropped pre-admission posts, adopt-pending-marker without blocking later rotation, the initially-missing session entry path, marker-map eviction, and the new concurrent-turn deferred-fetch case.
- `oxlint` (repo binary) on the changed prod + test files: **passed**. `tsgo --noEmit -p extensions/mattermost/tsconfig.json`: **passed**.
- Bounded fetch asserted (`client.test.ts`): a limited call issues `?perPage=2&direction=up` and re-sorts ascending so callers still build history oldest-first.
- Bounded marker asserted (`monitor.test.ts`): the backfill requests `historyLimit + 1`, `threadBackfillMarkers.get(historyKey)` carries the current session marker across the rotation / no-refetch / no-retry / adopt paths, and the eviction test drives 1001 distinct threads to prove the marker map stays capped at 1000 (plugin-local LRU), the oldest key is evicted, and an evicted thread with a cold window re-backfills from the server.
- Concurrency asserted (`monitor.test.ts`): with the first cold fetch gated open, an overlapping same-session turn stays pending until that fetch releases, exactly one server fetch runs, both turns observe the recovered window, and the in-flight handle is cleared afterward so the marker governs no-retry.
- Rebased onto latest `origin/main` (0 behind). The only conflict was two independent `describe` blocks colliding in `client.test.ts` (`createMattermostDirectChannelWithRetry delay cap` from main and `fetchMattermostThreadPosts` from this branch); both were kept. Earlier exact-head repairs remain: the thread query uses Mattermost's documented camelCase `perPage` so the response bound is applied, and the chronological re-sort uses non-mutating `toSorted()` to satisfy the bundled-extension `unicorn/no-array-sort` lint lane.

Live proof: local Docker Mattermost Team Edition 10.11.21 at `http://localhost:8065`, with tokens and Mattermost ids redacted. The proof used real Mattermost REST auth, posts, and `/api/v4/posts/<root>/thread` through `monitorMattermostProvider`; a fake websocket only injected `posted` events into the monitor. The route/thread session key stayed stable while the stored thread `sessionId` rotated. Cold start included prior root/thread context, same-session server-only context stayed absent, and stored-thread-session reset included new server-only prior context:

```json
{
  "mattermost": "10.11.21 local Docker, token/id redacted",
  "routeSessionKey": "stable, redacted",
  "threadSessionKey": "stable, redacted",
  "threadSessionKeyStable": true,
  "storedThreadSessionIds": [
    "stored-session-before-reset",
    "stored-session-after-reset"
  ],
  "dispatchCount": 3,
  "firstColdStartContainsPriorThreadContext": true,
  "firstColdStartContainsRootContext": true,
  "sameSessionSkippedServerOnlyContext": true,
  "storedThreadSessionIdResetContainsNewPriorContext": true
}
```

Recent validation after the squash/fix:

```text
$ node scripts/check-extension-package-tsc-boundary.mjs --mode=compile
extension package boundary check passed

$ node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
Test Files  3 passed (3)
Tests  115 passed (115)
```

<details>
<summary>Recent proof commands</summary>

```bash
node scripts/check-extension-package-tsc-boundary.mjs --mode=compile
node scripts/run-vitest.mjs \
  extensions/mattermost/src/mattermost/client.test.ts \
  extensions/mattermost/src/mattermost/monitor.test.ts \
  extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
```

</details>

AI-assisted: built with Codex
