### PR TITLE
fix(gateway): dedupe TTS status provider diagnostics [AI-assisted]

### DIFF
--- a/packages/speech-core/src/tts.test.ts
+++ b/packages/speech-core/src/tts.test.ts
@@ -115,6 +115,7 @@ const {
   buildTtsSystemPromptHint,
   getTtsPersona,
   getTtsProvider,
+  isTtsProviderConfigured,
   listSpeechVoices,
   maybeApplyTtsToPayload,
   resolveTtsProviderOrder,
@@ -477,6 +478,20 @@ describe("speech-core native voice-note routing", () => {
     expect(order).toEqual(["openai", "google", "elevenlabs"]);
     expect(listSpeechProvidersMock).not.toHaveBeenCalled();
     expect(getSpeechProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves provider default timeouts for prepared configuration checks", () => {
+    const isConfigured = vi.fn(() => true);
+    const provider = createMockSpeechProvider("slow", {
+      defaultTimeoutMs: 60_000,
+      isConfigured,
+    });
+    const cfg = {} as OpenClawConfig;
+    const config = resolveTtsConfig(cfg);
+    getSpeechProviderMock.mockClear();
+
+    expect(isTtsProviderConfigured(config, provider, cfg)).toBe(true);
+    expect(isConfigured).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 60_000 }));
   });
 
   it("caps oversized provider default TTS timeouts before synthesis", async () => {

--- a/packages/speech-core/src/tts.test.ts
+++ b/packages/speech-core/src/tts.test.ts
@@ -117,6 +117,7 @@ const {
   getTtsProvider,
   listSpeechVoices,
   maybeApplyTtsToPayload,
+  resolveTtsProviderOrder,
   resolveTtsConfig,
   setSummarizationEnabled,
   setTtsMaxLength,
@@ -456,6 +457,26 @@ describe("speech-core native voice-note routing", () => {
     });
 
     expect(listVoicesMock).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 45_000 }));
+  });
+
+  it("resolves provider fallback order from an existing provider inventory", () => {
+    installSpeechProviders([createMockSpeechProvider("unused", { autoSelectOrder: 1 })]);
+    listSpeechProvidersMock.mockClear();
+    getSpeechProviderMock.mockClear();
+    const providers = [
+      createMockSpeechProvider("openai", {
+        aliases: ["OPENAI-ALIAS"],
+        autoSelectOrder: 5,
+      }),
+      createMockSpeechProvider("google", { autoSelectOrder: 1 }),
+      createMockSpeechProvider("elevenlabs", { autoSelectOrder: 3 }),
+    ];
+
+    const order = resolveTtsProviderOrder("  OPENAI-ALIAS  ", undefined, providers);
+
+    expect(order).toEqual(["openai", "google", "elevenlabs"]);
+    expect(listSpeechProvidersMock).not.toHaveBeenCalled();
+    expect(getSpeechProviderMock).not.toHaveBeenCalled();
   });
 
   it("caps oversized provider default TTS timeouts before synthesis", async () => {

--- a/packages/speech-core/src/tts.ts
+++ b/packages/speech-core/src/tts.ts
@@ -333,8 +333,11 @@ function applyVoiceModelToSpeechProviderConfig(params: {
   };
 }
 
-function sortSpeechProvidersForAutoSelection(cfg?: OpenClawConfig) {
-  return listSpeechProviders(cfg).toSorted((left, right) => {
+function sortSpeechProvidersForAutoSelection(
+  cfg?: OpenClawConfig,
+  providers?: readonly SpeechProviderPlugin[],
+) {
+  return [...(providers ?? listSpeechProviders(cfg))].toSorted((left, right) => {
     const leftOrder = left.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
     const rightOrder = right.autoSelectOrder ?? Number.MAX_SAFE_INTEGER;
     if (leftOrder !== rightOrder) {
@@ -342,6 +345,28 @@ function sortSpeechProvidersForAutoSelection(cfg?: OpenClawConfig) {
     }
     return left.id.localeCompare(right.id);
   });
+}
+
+function canonicalizeSpeechProviderIdFromInventory(
+  providerId: string | undefined,
+  cfg?: OpenClawConfig,
+  providers?: readonly SpeechProviderPlugin[],
+) {
+  const normalized = normalizeSpeechProviderId(providerId);
+  if (!normalized) {
+    return undefined;
+  }
+  if (!providers) {
+    return canonicalizeSpeechProviderId(providerId, cfg);
+  }
+  return (
+    providers.find(
+      (provider) =>
+        normalizeSpeechProviderId(provider.id) === normalized ||
+        (provider.aliases?.some((alias) => normalizeSpeechProviderId(alias) === normalized) ??
+          false),
+    )?.id ?? normalized
+  );
 }
 
 function resolveTtsRuntimeConfig(cfg: OpenClawConfig): OpenClawConfig {
@@ -1004,17 +1029,24 @@ function shouldDeliverTtsAsVoice(params: {
   return params.voiceCompatible === true || delivery.transcodesAudio === true;
 }
 
-export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConfig): TtsProvider[] {
+export function resolveTtsProviderOrder(
+  primary: TtsProvider,
+  cfg?: OpenClawConfig,
+  providers?: readonly SpeechProviderPlugin[],
+): TtsProvider[] {
   const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : undefined;
-  const normalizedPrimary = canonicalizeSpeechProviderId(primary, effectiveCfg) ?? primary;
+  const normalizedPrimary =
+    canonicalizeSpeechProviderIdFromInventory(primary, effectiveCfg, providers) ?? primary;
   const ordered = new Set<TtsProvider>([normalizedPrimary]);
   for (const ref of resolveVoiceModelRefs(effectiveCfg?.agents?.defaults?.voiceModel)) {
-    const provider = canonicalizeSpeechProviderId(ref.provider, effectiveCfg) ?? ref.provider;
+    const provider =
+      canonicalizeSpeechProviderIdFromInventory(ref.provider, effectiveCfg, providers) ??
+      ref.provider;
     if (provider !== normalizedPrimary) {
       ordered.add(provider);
     }
   }
-  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg)) {
+  for (const provider of sortSpeechProvidersForAutoSelection(effectiveCfg, providers)) {
     const normalized = provider.id;
     if (normalized !== normalizedPrimary) {
       ordered.add(normalized);

--- a/packages/speech-core/src/tts.ts
+++ b/packages/speech-core/src/tts.ts
@@ -1082,11 +1082,12 @@ function resolvePrimaryTtsProviderCandidate(
 
 export function isTtsProviderConfigured(
   config: ResolvedTtsConfig,
-  provider: TtsProvider,
+  provider: TtsProvider | SpeechProviderPlugin,
   cfg?: OpenClawConfig,
 ): boolean {
   const effectiveCfg = cfg ? resolveTtsRuntimeConfig(cfg) : config.sourceConfig;
-  const resolvedProvider = getSpeechProvider(provider, effectiveCfg);
+  const resolvedProvider =
+    typeof provider === "string" ? getSpeechProvider(provider, effectiveCfg) : provider;
   if (!resolvedProvider) {
     return false;
   }

--- a/src/gateway/server-methods/tts.test.ts
+++ b/src/gateway/server-methods/tts.test.ts
@@ -180,7 +180,10 @@ describe("ttsHandlers", () => {
     const observedTurns: string[] = [];
     setImmediate(() => observedTurns.push("sibling"));
 
-    await ttsHandlers["tts.status"]({
+    await expectDefined(
+      ttsHandlers["tts.status"],
+      'ttsHandlers["tts.status"] test invariant',
+    )({
       params: {},
       respond,
       context: { getRuntimeConfig: mocks.getRuntimeConfig },

--- a/src/gateway/server-methods/tts.test.ts
+++ b/src/gateway/server-methods/tts.test.ts
@@ -5,12 +5,24 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import type { SpeechProviderPlugin } from "../../plugins/types.js";
 import { expectGatewayErrorResponse } from "./gateway-response.test-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({})),
+  getResolvedSpeechProviderConfig: vi.fn((_config: unknown, provider: string) => ({
+    id: provider,
+  })),
+  getTtsPersona: vi.fn(() => undefined),
+  getTtsProvider: vi.fn(() => "openai"),
+  isTtsEnabled: vi.fn(() => true),
+  listSpeechProviders: vi.fn<() => SpeechProviderPlugin[]>(() => []),
+  listTtsPersonas: vi.fn(() => []),
   resolveExplicitTtsOverrides: vi.fn(() => ({})),
+  resolveTtsAutoMode: vi.fn(() => false),
   resolveTtsConfig: vi.fn(() => ({ maxTextLength: 4096 })),
+  resolveTtsPrefsPath: vi.fn(() => "/tmp/tts.json"),
+  resolveTtsProviderOrder: vi.fn(() => ["openai"]),
   synthesizeSpeech: vi.fn(
     async (): Promise<{
       success: boolean;
@@ -44,22 +56,21 @@ vi.mock("../../config/config.js", () => ({
 vi.mock("../../tts/provider-registry.js", () => ({
   canonicalizeSpeechProviderId: vi.fn(),
   getSpeechProvider: vi.fn(),
-  listSpeechProviders: vi.fn(() => []),
+  listSpeechProviders: mocks.listSpeechProviders,
 }));
 
 vi.mock("../../tts/tts.js", () => ({
-  getResolvedSpeechProviderConfig: vi.fn(),
-  getTtsPersona: vi.fn(() => undefined),
-  getTtsProvider: vi.fn(() => "openai"),
-  isTtsEnabled: vi.fn(() => true),
-  isTtsProviderConfigured: vi.fn(() => true),
-  listTtsPersonas: vi.fn(() => []),
+  getResolvedSpeechProviderConfig: mocks.getResolvedSpeechProviderConfig,
+  getTtsPersona: mocks.getTtsPersona,
+  getTtsProvider: mocks.getTtsProvider,
+  isTtsEnabled: mocks.isTtsEnabled,
+  listTtsPersonas: mocks.listTtsPersonas,
   resolveExplicitTtsOverrides:
     mocks.resolveExplicitTtsOverrides as typeof import("../../tts/tts.js").resolveExplicitTtsOverrides,
-  resolveTtsAutoMode: vi.fn(() => false),
+  resolveTtsAutoMode: mocks.resolveTtsAutoMode,
   resolveTtsConfig: mocks.resolveTtsConfig,
-  resolveTtsPrefsPath: vi.fn(() => "/tmp/tts.json"),
-  resolveTtsProviderOrder: vi.fn(() => ["openai"]),
+  resolveTtsPrefsPath: mocks.resolveTtsPrefsPath,
+  resolveTtsProviderOrder: mocks.resolveTtsProviderOrder,
   setTtsEnabled: vi.fn(),
   setTtsPersona: vi.fn(),
   setTtsProvider: vi.fn(),
@@ -71,10 +82,32 @@ describe("ttsHandlers", () => {
   beforeEach(() => {
     mocks.getRuntimeConfig.mockReset();
     mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.getResolvedSpeechProviderConfig.mockReset();
+    mocks.getResolvedSpeechProviderConfig.mockImplementation(
+      (_config: unknown, provider: string) => ({
+        id: provider,
+      }),
+    );
+    mocks.getTtsPersona.mockReset();
+    mocks.getTtsPersona.mockReturnValue(undefined);
+    mocks.getTtsProvider.mockReset();
+    mocks.getTtsProvider.mockReturnValue("openai");
+    mocks.isTtsEnabled.mockReset();
+    mocks.isTtsEnabled.mockReturnValue(true);
+    mocks.listSpeechProviders.mockReset();
+    mocks.listSpeechProviders.mockReturnValue([]);
+    mocks.listTtsPersonas.mockReset();
+    mocks.listTtsPersonas.mockReturnValue([]);
     mocks.resolveExplicitTtsOverrides.mockReset();
     mocks.resolveExplicitTtsOverrides.mockReturnValue({});
+    mocks.resolveTtsAutoMode.mockReset();
+    mocks.resolveTtsAutoMode.mockReturnValue(false);
     mocks.resolveTtsConfig.mockReset();
     mocks.resolveTtsConfig.mockReturnValue({ maxTextLength: 4096 });
+    mocks.resolveTtsPrefsPath.mockReset();
+    mocks.resolveTtsPrefsPath.mockReturnValue("/tmp/tts.json");
+    mocks.resolveTtsProviderOrder.mockReset();
+    mocks.resolveTtsProviderOrder.mockReturnValue(["openai"]);
     mocks.synthesizeSpeech.mockReset();
     mocks.synthesizeSpeech.mockResolvedValue({
       success: true,
@@ -91,6 +124,65 @@ describe("ttsHandlers", () => {
       outputFormat: "mp3",
       voiceCompatible: false,
     });
+  });
+
+  it("yields before TTS status provider diagnostics and reuses one configured-state pass", async () => {
+    const openaiConfigured = vi.fn(() => true);
+    const googleConfigured = vi.fn(() => true);
+    const providers: SpeechProviderPlugin[] = [
+      {
+        id: "openai",
+        label: "OpenAI",
+        isConfigured: openaiConfigured,
+        synthesize: vi.fn(async () => ({
+          audioBuffer: Buffer.from("openai-audio"),
+          outputFormat: "mp3",
+          fileExtension: ".mp3",
+          voiceCompatible: false,
+        })),
+      },
+      {
+        id: "google",
+        label: "Google",
+        isConfigured: googleConfigured,
+        synthesize: vi.fn(async () => ({
+          audioBuffer: Buffer.from("google-audio"),
+          outputFormat: "mp3",
+          fileExtension: ".mp3",
+          voiceCompatible: false,
+        })),
+      },
+    ];
+    mocks.listSpeechProviders.mockReturnValue(providers);
+    mocks.resolveTtsProviderOrder.mockReturnValue(["openai", "google"]);
+
+    const { ttsHandlers } = await import("./tts.js");
+    const respond = vi.fn();
+    const observedTurns: string[] = [];
+    setImmediate(() => observedTurns.push("sibling"));
+
+    await ttsHandlers["tts.status"]({
+      params: {},
+      respond,
+      context: { getRuntimeConfig: mocks.getRuntimeConfig },
+    } as never);
+
+    expect(observedTurns).toEqual(["sibling"]);
+    expect(mocks.listSpeechProviders).toHaveBeenCalledOnce();
+    expect(mocks.resolveTtsProviderOrder).toHaveBeenCalledWith("openai", {}, providers);
+    expect(openaiConfigured).toHaveBeenCalledOnce();
+    expect(googleConfigured).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        fallbackProvider: "google",
+        fallbackProviders: ["google"],
+        providerStates: [
+          { id: "openai", label: "OpenAI", configured: true },
+          { id: "google", label: "Google", configured: true },
+        ],
+      }),
+    );
   });
 
   it("returns INVALID_REQUEST when TTS override validation fails", async () => {

--- a/src/gateway/server-methods/tts.test.ts
+++ b/src/gateway/server-methods/tts.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { SpeechProviderPlugin } from "../../plugins/types.js";
@@ -16,6 +17,14 @@ const mocks = vi.hoisted(() => ({
   getTtsPersona: vi.fn(() => undefined),
   getTtsProvider: vi.fn(() => "openai"),
   isTtsEnabled: vi.fn(() => true),
+  isTtsProviderConfigured: vi.fn(
+    (_config: unknown, provider: SpeechProviderPlugin, cfg: OpenClawConfig) =>
+      provider.isConfigured({
+        cfg,
+        providerConfig: { id: provider.id },
+        timeoutMs: provider.defaultTimeoutMs ?? 30_000,
+      }),
+  ),
   listSpeechProviders: vi.fn<() => SpeechProviderPlugin[]>(() => []),
   listTtsPersonas: vi.fn(() => []),
   resolveExplicitTtsOverrides: vi.fn(() => ({})),
@@ -64,6 +73,7 @@ vi.mock("../../tts/tts.js", () => ({
   getTtsPersona: mocks.getTtsPersona,
   getTtsProvider: mocks.getTtsProvider,
   isTtsEnabled: mocks.isTtsEnabled,
+  isTtsProviderConfigured: mocks.isTtsProviderConfigured,
   listTtsPersonas: mocks.listTtsPersonas,
   resolveExplicitTtsOverrides:
     mocks.resolveExplicitTtsOverrides as typeof import("../../tts/tts.js").resolveExplicitTtsOverrides,
@@ -94,6 +104,15 @@ describe("ttsHandlers", () => {
     mocks.getTtsProvider.mockReturnValue("openai");
     mocks.isTtsEnabled.mockReset();
     mocks.isTtsEnabled.mockReturnValue(true);
+    mocks.isTtsProviderConfigured.mockReset();
+    mocks.isTtsProviderConfigured.mockImplementation(
+      (_config: unknown, provider: SpeechProviderPlugin, cfg: OpenClawConfig) =>
+        provider.isConfigured({
+          cfg,
+          providerConfig: { id: provider.id },
+          timeoutMs: provider.defaultTimeoutMs ?? 30_000,
+        }),
+    );
     mocks.listSpeechProviders.mockReset();
     mocks.listSpeechProviders.mockReturnValue([]);
     mocks.listTtsPersonas.mockReset();
@@ -170,6 +189,7 @@ describe("ttsHandlers", () => {
     expect(observedTurns).toEqual(["sibling"]);
     expect(mocks.listSpeechProviders).toHaveBeenCalledOnce();
     expect(mocks.resolveTtsProviderOrder).toHaveBeenCalledWith("openai", {}, providers);
+    expect(mocks.isTtsProviderConfigured).toHaveBeenCalledTimes(2);
     expect(openaiConfigured).toHaveBeenCalledOnce();
     expect(googleConfigured).toHaveBeenCalledOnce();
     expect(respond).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -16,7 +16,6 @@ import {
   getTtsPersona,
   getTtsProvider,
   isTtsEnabled,
-  isTtsProviderConfigured,
   listTtsPersonas,
   resolveExplicitTtsOverrides,
   resolveTtsAutoMode,
@@ -33,6 +32,12 @@ import { formatForLog } from "../ws-log.js";
 import { inferSpeechMimeType } from "./speech-mime.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+function yieldBeforeTtsStatusDiagnostics(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
 /** Gateway request handlers for TTS status, preference mutation, and synthesis. */
 export const ttsHandlers: GatewayRequestHandlers = {
   "tts.status": async ({ respond, context }) => {
@@ -43,20 +48,32 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const provider = getTtsProvider(config, prefsPath);
       const persona = getTtsPersona(config, prefsPath);
       const autoMode = resolveTtsAutoMode({ config, prefsPath });
-      const fallbackProviders = resolveTtsProviderOrder(provider, cfg)
-        .slice(1)
-        .filter((candidate) => isTtsProviderConfigured(config, candidate, cfg));
-      // Report configured state per provider so the UI can explain why fallback
-      // order differs from the complete provider registry.
-      const providerStates = listSpeechProviders(cfg).map((candidate) => ({
-        id: candidate.id,
-        label: candidate.label,
-        configured: candidate.isConfigured({
+      await yieldBeforeTtsStatusDiagnostics();
+      const speechProviders = listSpeechProviders(cfg);
+      const configuredByProvider = new Map<string, boolean>();
+      const isProviderConfigured = (candidate: (typeof speechProviders)[number]) => {
+        const cached = configuredByProvider.get(candidate.id);
+        if (cached !== undefined) {
+          return cached;
+        }
+        const configured = candidate.isConfigured({
           cfg,
           providerConfig: getResolvedSpeechProviderConfig(config, candidate.id, cfg),
           timeoutMs: config.timeoutMs,
-        }),
+        });
+        configuredByProvider.set(candidate.id, configured);
+        return configured;
+      };
+      // Provider diagnostics can cold-load plugin metadata, so the same pass
+      // feeds UI state and fallback filtering instead of rescanning providers.
+      const providerStates = speechProviders.map((candidate) => ({
+        id: candidate.id,
+        label: candidate.label,
+        configured: isProviderConfigured(candidate),
       }));
+      const fallbackProviders = resolveTtsProviderOrder(provider, cfg, speechProviders)
+        .slice(1)
+        .filter((candidate) => configuredByProvider.get(candidate) === true);
       respond(true, {
         enabled: isTtsEnabled(config, prefsPath),
         auto: autoMode,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -16,6 +16,7 @@ import {
   getTtsPersona,
   getTtsProvider,
   isTtsEnabled,
+  isTtsProviderConfigured,
   listTtsPersonas,
   resolveExplicitTtsOverrides,
   resolveTtsAutoMode,
@@ -56,11 +57,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
         if (cached !== undefined) {
           return cached;
         }
-        const configured = candidate.isConfigured({
-          cfg,
-          providerConfig: getResolvedSpeechProviderConfig(config, candidate.id, cfg),
-          timeoutMs: config.timeoutMs,
-        });
+        const configured = isTtsProviderConfigured(config, candidate, cfg);
         configuredByProvider.set(candidate.id, configured);
         return configured;
       };


### PR DESCRIPTION
## Summary

Fixes #81355.

This keeps the already-merged `applyPluginAutoEnable` cache fix intact and addresses the remaining `tts.status` Gateway hot path. The status handler now yields once before synchronous provider diagnostics, builds the config-aware speech provider inventory once, and reuses that same inventory/configured-state pass for both `providerStates` and fallback filtering.

Best-fix rationale: this preserves the existing `tts.status` response shape and config-aware provider inventory contract, avoids changing the synchronous `SpeechProviderPlugin.isConfigured` SDK contract, and keeps the blast radius to `tts.status` plus the provider-order helper.

## Real behavior proof

Behavior addressed: `tts.status` no longer performs duplicate provider inventory/configured-state work before responding, and it yields before provider diagnostics so sibling Gateway RPCs can run.

Real environment tested: Local OpenClaw source checkout on this PR branch with an isolated real Gateway process, temp HOME/state/config, normal Gateway WebSocket client, real speech-provider plugin metadata loading enabled, and channel/background sidecars skipped. This was not a mocked handler call.

Exact steps or command run after this patch:

- `node --import tsx --input-type=module -e '<isolated Gateway tts.status proof using test/helpers/openclaw-test-instance.ts and src/gateway/test-helpers.e2e.ts>'`
- The proof config used `messages.tts.provider: "openai"` with `messages.tts.providers.openai.apiKey: "test-openai-key"` and `messages.tts.providers.microsoft: {}`; the Gateway env removed `OPENCLAW_SKIP_PROVIDERS`, set `OPENCLAW_TEST_MINIMAL_GATEWAY=0`, and kept channel sidecars skipped through the existing test helper.
- `node scripts/run-vitest.mjs src/gateway/server-methods/tts.test.ts packages/speech-core/src/tts.test.ts src/tts/provider-registry.test.ts src/plugins/contracts/tts.contract.test.ts src/plugins/capability-provider-runtime.test.ts`
- `git diff --check`
- `gh pr checks 93868 --repo openclaw/openclaw --watch=false`

Evidence after fix:

```json
{
  "ok": true,
  "branch": "codex/81355-tts-status-provider-diagnostics",
  "providerIds": ["microsoft", "openai"],
  "secondProviderIds": ["microsoft", "openai"],
  "providerStateCount": 2,
  "configuredProviders": ["microsoft", "openai"],
  "enabled": true,
  "provider": "openai",
  "fallbackProvider": "microsoft",
  "fallbackProviders": ["microsoft"],
  "prefsPathSuffix": ".openclaw/settings/tts.json",
  "firstElapsedMs": 320,
  "secondElapsedMs": 1,
  "totalElapsedMs": 6527,
  "siblingTurnBeforeCompletion": true,
  "stableProviderStates": true
}
```

Focused Vitest proof also passed 5 shards. The active-registry probe returned `ok: true`, `elapsedMs: 3`, `immediateAtRespond: true`, and `providerStates: ["openai", "acme-speech"]`. Current PR checks are green, including `Critical Quality (gateway-runtime-boundary)`, `check-lint`, `check-additional-boundaries-a`, `Real behavior proof`, and the Node/core CI shards selected for this diff.

Observed result after fix: In a running Gateway, `tts.status` responds successfully over the normal WebSocket RPC path, reports real provider diagnostics for configured speech providers, preserves the public status shape and configured provider, returns the expected fallback list, and keeps provider diagnostics stable across repeated calls. The local sibling event-loop turn completed before the status call finished, matching the intended pre-diagnostics yield.

What was not tested: No live Control UI browser/dashboard session and no external TTS synthesis request were exercised. The real Gateway proof used fake local provider config only to satisfy configured-state diagnostics and did not call external provider APIs.

## Tests and validation

- `node --import tsx --input-type=module -e '<isolated Gateway tts.status proof using test/helpers/openclaw-test-instance.ts and src/gateway/test-helpers.e2e.ts>'`
- `node scripts/run-vitest.mjs src/gateway/server-methods/tts.test.ts packages/speech-core/src/tts.test.ts src/tts/provider-registry.test.ts src/plugins/contracts/tts.contract.test.ts src/plugins/capability-provider-runtime.test.ts`
- `git diff --check`
- `gh pr checks 93868 --repo openclaw/openclaw --watch=false`
- Local structured autoreview: clean after addressing accepted findings

## Risk checklist

- [x] Preserves public `tts.status` payload shape
- [x] Preserves config-aware provider inventory behavior
- [x] Does not change plugin SDK `isConfigured` sync contract
- [x] Does not touch the already-shipped `applyPluginAutoEnable` cache path
- [x] No config, migration, dependency, lockfile, or docs surface changed

## Current review state

Stage 2 blind review completed:

- Reviewer A: no blocking runtime/correctness findings
- Reviewer B: raised a provider-inventory contract risk; fixed by preserving `listSpeechProviders(cfg)` as the status inventory source

Autoreview completed cleanly after two accepted findings were fixed:

- typed the Gateway test provider mock to avoid `never[]`
- normalized inventory-backed provider alias matching

AI-assisted: this PR was implemented with Codex assistance; the human author should review and own the final diff before marking ready.
