### PR TITLE
fix(ollama): show full thinking levels for live-discovered models in /think menu

### DIFF
--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -56,5 +56,12 @@ export function resolveThinkingProfile({
 }: {
   reasoning?: boolean;
 }): ProviderThinkingProfile {
-  return reasoning ? OLLAMA_REASONING_THINKING_PROFILE : OLLAMA_NON_REASONING_THINKING_PROFILE;
+  // When reasoning is not explicitly configured (live-discovered models),
+  // default to the reasoning profile because Ollama models typically
+  // support thinking capabilities even when unknown to the catalog.
+  // Explicit reasoning:false from config still yields the off-only profile.
+  if (reasoning === false) {
+    return OLLAMA_NON_REASONING_THINKING_PROFILE;
+  }
+  return OLLAMA_REASONING_THINKING_PROFILE;
 }


### PR DESCRIPTION
## Summary
- Fixes #93835 — Telegram /think menu showed only "default, off" for live-discovered Ollama models despite them supporting thinking
- Root cause: `resolveThinkingProfile` used ternary `reasoning ? full : off-only` — `reasoning:undefined` (live-discovered, not in catalog) fell to off-only
- Fix: check `reasoning === false` explicitly; undefined (live-discovered) now returns the full reasoning profile

## Changes
`extensions/ollama/provider-policy-api.ts` — 1 file, +8/-1

## Decision table
| reasoning value | Before | After |
|---|---|---|
| `true` (explicitly configured) | `["off","low","medium","high","max"]` | unchanged |
| `false` (explicitly disabled) | `["off"]` | unchanged |
| `undefined` (live-discovered) | `["off"]` ❌ | `["off","low","medium","high","max"]` ✅ |

## Risk checklist
Did user-visible behavior change? (`Yes`) — /think menu now shows full thinking levels for undiscovered Ollama models
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)
What is the highest-risk area? — Models that truly do NOT support thinking will now show thinking levels they can't use
How is that risk mitigated? — Setting explicit `reasoning:false` in the model config still yields the off-only profile. Ollama models generally support thinking.
