### PR TITLE
fix(whatsapp): restart listener on selfChatMode config change

### DIFF
--- a/extensions/whatsapp/index.test.ts
+++ b/extensions/whatsapp/index.test.ts
@@ -15,7 +15,7 @@ describe("whatsapp bundled entries", () => {
 
   it("declares account config as channel-restart reload metadata", () => {
     expect(whatsappPlugin.reload).toEqual({
-      configPrefixes: ["web", "channels.whatsapp.accounts"],
+      configPrefixes: ["web", "channels.whatsapp.accounts", "channels.whatsapp.selfChatMode"],
       noopPrefixes: ["channels.whatsapp"],
     });
   });

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -181,7 +181,7 @@ export function createWhatsAppPluginBase(params: {
     // the broad `channels.whatsapp` noop prefix below otherwise swallows it as a
     // hot no-op and leaves the account connected until a full restart.
     reload: {
-      configPrefixes: ["web", "channels.whatsapp.accounts"],
+      configPrefixes: ["web", "channels.whatsapp.accounts", "channels.whatsapp.selfChatMode"],
       noopPrefixes: ["channels.whatsapp"],
     },
     gatewayMethodDescriptors: [{ name: "web.login.start" }, { name: "web.login.wait" }],

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -160,7 +160,7 @@ describe("buildGatewayReloadPlan", () => {
       resolveAccount: () => ({}),
     },
     reload: {
-      configPrefixes: ["web", "channels.whatsapp.accounts"],
+      configPrefixes: ["web", "channels.whatsapp.accounts", "channels.whatsapp.selfChatMode"],
       noopPrefixes: ["channels.whatsapp"],
     },
   };
@@ -232,6 +232,14 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartGateway).toBe(false);
     expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
     expect(plan.hotReasons).toEqual(changedPaths);
+    expect(plan.noopPaths).toStrictEqual([]);
+  });
+
+  it("restarts the WhatsApp channel when selfChatMode changes (configPrefix wins over broad noop prefix)", () => {
+    const plan = buildGatewayReloadPlan(["channels.whatsapp.selfChatMode"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
+    expect(plan.hotReasons).toContain("channels.whatsapp.selfChatMode");
     expect(plan.noopPaths).toStrictEqual([]);
   });
 

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -5,8 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ConfigWriteNotification } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { consumeGatewaySigusr1RestartIntent } from "../infra/restart.js";
+import {
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
+} from "../plugins/runtime.js";
 import { createEmptyRuntimeWebToolsMetadata } from "../secrets/runtime-fast-path.js";
 import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { diffConfigPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
@@ -141,7 +146,13 @@ vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
   disposeAllSessionMcpRuntimes: hoisted.disposeAllSessionMcpRuntimes,
 }));
 
-function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() }) {
+function createReloadHandlersForTest(
+  logReload = { info: vi.fn(), warn: vi.fn() },
+  channels?: {
+    start: (channel: ChannelKind) => Promise<void>;
+    stop: (channel: ChannelKind) => Promise<void>;
+  },
+) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
   const heartbeatRunner = {
     stop: vi.fn(),
@@ -158,8 +169,8 @@ function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() 
       channelHealthMonitor: null,
     }),
     setState: vi.fn(),
-    startChannel: vi.fn(async () => {}),
-    stopChannel: vi.fn(async () => {}),
+    startChannel: channels?.start ?? vi.fn(async () => {}),
+    stopChannel: channels?.stop ?? vi.fn(async () => {}),
     stopPostReadySidecars: vi.fn(),
     reloadPlugins: vi.fn(
       async (): Promise<GatewayPluginReloadResult> => ({
@@ -888,6 +899,42 @@ describe("gateway channel hot reload handlers", () => {
       }
     }
   }
+
+  it("restarts WhatsApp when the planner receives a selfChatMode change", async () => {
+    const whatsappPlugin = {
+      ...createChannelTestPluginBase({ id: "whatsapp" }),
+      reload: {
+        configPrefixes: ["web", "channels.whatsapp.accounts", "channels.whatsapp.selfChatMode"],
+        noopPrefixes: ["channels.whatsapp"],
+      },
+    };
+    const registry = createTestRegistry([
+      { pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" },
+    ]);
+    const events: string[] = [];
+    const channels = {
+      stop: vi.fn(async (channel: ChannelKind) => {
+        events.push(`stop:${channel}`);
+      }),
+      start: vi.fn(async (channel: ChannelKind) => {
+        events.push(`start:${channel}`);
+      }),
+    };
+
+    pinActivePluginChannelRegistry(registry);
+    try {
+      const plan = buildGatewayReloadPlan(["channels.whatsapp.selfChatMode"]);
+      const { applyHotReload } = createReloadHandlersForTest(undefined, channels);
+
+      expect(plan.restartGateway).toBe(false);
+      expect(plan.restartChannels).toEqual(new Set(["whatsapp"]));
+      await withChannelReloadsEnabled(() => applyHotReload(plan, {}));
+
+      expect(events).toEqual(["stop:whatsapp", "start:whatsapp"]);
+    } finally {
+      releasePinnedPluginChannelRegistry(registry);
+    }
+  });
 
   it("continues restarting later channels after a hot-reload stop failure", async () => {
     const events: string[] = [];


### PR DESCRIPTION
## Root Cause

`extensions/whatsapp/src/shared.ts:185` lists `channels.whatsapp` as a `noopPrefix`, so changing `channels.whatsapp.selfChatMode` does not trigger a WhatsApp listener restart; the connect-time presence value stays stale until a full restart. The `noopPrefixes` rules are checked after `configPrefixes` rules in the reload planner, but the specific `selfChatMode` key was never listed in `configPrefixes`, so it fell through to the broad `channels.whatsapp` noop match.

## Summary

- WhatsApp `selfChatMode` config changes were silently ignored as hot no-ops, leaving stale presence until a full gateway restart.
- This PR adds `"channels.whatsapp.selfChatMode"` to the `configPrefixes` array in the WhatsApp plugin reload config, matching the existing pattern for `"channels.whatsapp.accounts"`, so the channel restarts when `selfChatMode` changes.
- Fixes #86888

## Verification

- `pnpm test extensions/whatsapp/index.test.ts` — 3/3 passed
- `pnpm test src/gateway/config-reload.test.ts` — 352/352 passed (total 355/355)
- Autoreview: clean — no accepted/actionable findings

## Real behavior proof

Behavior addressed: WhatsApp `selfChatMode` config change did not trigger a WhatsApp channel restart, leaving stale presence behavior until a full gateway restart.

Real environment tested: Linux (4.19.112-2.el8.x86_64), Node v24.15.0, branch `fix/issue-86888-whatsapp-selfchatmode-reload` at commit `83b809b3a2`.

Exact steps or command run after this patch:
```bash
pnpm test extensions/whatsapp/index.test.ts
pnpm test src/gateway/config-reload.test.ts
```

Evidence after fix:
```console
$ pnpm test extensions/whatsapp/index.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ pnpm test src/gateway/config-reload.test.ts
 Test Files  4 passed (4)
      Tests  352 passed (352)
```

Observed result after fix: All 355 tests pass. The new test `"restarts the WhatsApp channel when selfChatMode changes (configPrefix wins over broad noop prefix)"` confirms that changing `channels.whatsapp.selfChatMode` triggers a channel restart (not a restartGateway or noop), validating the specific prefix match ordering in `buildGatewayReloadPlan`. The existing test `"keeps other channels.whatsapp.* changes as hot no-ops"` still passes, confirming that other `channels.whatsapp.*` paths remain unaffected.

What was not tested: Full E2E WhatsApp connection test (requires real WhatsApp credentials). The fix relies on the same `reload.configPrefixes` pattern already proven by `channels.whatsapp.accounts` in production.
