### PR TITLE
fix(slack): recognize MiniMax mm: namespaced reasoning tags in monitor preview

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1829,6 +1829,31 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(updates.join("\n")).not.toContain("Checking Reading");
   });
 
+  it("extracts mm:think reasoning snapshots for Slack progress draft previews", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      {
+        kind: "reasoning",
+        text: "<mm:think>Reading\nChecking</mm:think>",
+        isReasoningSnapshot: true,
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: { streaming: { progress: { label: "Shelling" } } },
+      }),
+    );
+
+    expect(draftStream.update).toHaveBeenLastCalledWith(
+      ["Shelling", "• Reading Checking"].join("\n"),
+    );
+    const updates = draftStream.update.mock.calls.map((call) => String(call[0]));
+    expect(updates.join("\n")).toContain("Reading Checking");
+  });
+
   it("keeps plain Slack reasoning content that starts with Thinking", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -122,7 +122,8 @@ const UNICODE_TO_SLACK: Record<string, string> = {
   "🛠️": "hammer_and_wrench",
   "💻": "computer",
 };
-const SLACK_REASONING_TAG_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+const SLACK_REASONING_TAG_RE =
+  /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 const SLACK_REASONING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Reasoning:\s*/iu;
 const SLACK_THINKING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Thinking\.{0,3}(?=\s*(?:\n|_))/iu;
 


### PR DESCRIPTION
## Summary

#93767 added MiniMax `mm:` namespace support to reasoning-tag handling across 9 files, and its description explicitly noted the same `antml:`-only / no-namespace pattern is duplicated in "the slack/imessage/matrix monitors". The src-side paths were since covered (#93806, merged) and the iMessage monitor too (#93820), but the **Slack monitor reasoning-tag regex was still missed**:

- `extensions/slack/src/monitor/message-handler/dispatch.ts:125` — `SLACK_REASONING_TAG_RE`, which feeds `extractSlackReasoningTagText` → the streaming "Reasoning" progress preview (`normalizeSlackReasoningProgressLine` / `pushReasoningProgress`).

Result: when a MiniMax model inlines its chain-of-thought as `<mm:think>…</mm:think>`, the regex doesn't match, `extractSlackReasoningTagText` returns empty, and the shared `stripReasoningTagsFromText` (already `mm:`-aware) strips the whole block — so the MiniMax reasoning never shows up in Slack's streaming Reasoning progress indicator (a functional parity gap, not a leak).

## Changes

- `SLACK_REASONING_TAG_RE`: `(?:think(?:ing)?|thought|antthinking)` → `(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)`, aligning with `src/shared/text/reasoning-tags.ts` and #93767's pattern. The `(?:antml:|mm:)?` prefix is added to `think`/`thought` only; `antthinking` and the open/close capture group are untouched. +27/-1 across 2 files (one is the test).

## Real behavior proof

**Behavior addressed**: MiniMax `mm:`-namespaced reasoning tags are now recognized by the Slack monitor preview extractor, matching `antml:`/bare behavior (and the already-merged Telegram/iMessage monitors).

**Test (real exported function)**: added an end-to-end case in `dispatch.preview-fallback.test.ts` that drives the **real exported** `dispatchPreparedSlackMessage` — streaming a reasoning entry `<mm:think>Reading\nChecking</mm:think>` and asserting the final Slack progress draft preview contains `• Reading Checking` (the extracted reasoning), not an empty/stripped line. A bare `<think>` case is retained as a no-regression control.

**Negative control (logic)**: pre-fix, `SLACK_REASONING_TAG_RE` does not match `<mm:think>` → `extractSlackReasoningTagText` returns `""` → the fallback `stripReasoningTagsFromText` (mm-aware) removes the whole block → the preview shows no reasoning; post-fix the regex matches → the reasoning is extracted into the preview.

**What was not run locally**: the test was not executed in this worktree (fresh worktree without `node_modules`; skipped `pnpm install` to avoid a heavy monorepo install). CI runs the added test.

## Scope / context

Narrow follow-up to #93767 (whose own description named the slack monitor as a missed spot), in the same series as merged #93806 (src paths) and #93820 (iMessage monitor). Slack and Matrix were the two remaining monitors; this covers Slack. Not intended to close the umbrella issue #89473 — purely the narrow `mm:` recognition fix that #93767 established the precedent for.
