### PR TITLE
fix(secrets): pass infrastructure env vars to exec secret provider child process

### DIFF
--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -48,6 +48,13 @@ const DEFAULT_MAX_BATCH_BYTES = 256 * 1024;
 const DEFAULT_FILE_MAX_BYTES = 1024 * 1024;
 const DEFAULT_FILE_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_TIMEOUT_MS = 5_000;
+
+/** Infrastructure env vars commonly needed by secret-provider CLIs (self-hosted URLs, etc.). */
+const DEFAULT_EXEC_PROVIDER_PASS_ENV = [
+  "BWS_SERVER_URL",
+  "INFISICAL_API_URL",
+  "VAULT_ADDR",
+];
 const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
@@ -735,7 +742,16 @@ async function resolveExecRefs(params: {
     });
   }
 
+  // Start with known-safe infrastructure env vars that secret-provider CLIs
+  // commonly need (self-hosted server URLs, etc.) — these are configuration
+  // endpoints, not secrets.
   const childEnv: NodeJS.ProcessEnv = {};
+  for (const key of DEFAULT_EXEC_PROVIDER_PASS_ENV) {
+    const value = params.env[key];
+    if (value !== undefined) {
+      childEnv[key] = value;
+    }
+  }
   for (const key of params.providerConfig.passEnv ?? []) {
     const value = params.env[key];
     if (value !== undefined) {


### PR DESCRIPTION
## Summary
- Fixes #93851 — exec-backed secret providers did not pass infrastructure config URLs to resolver scripts
- Root cause: `childEnv` started as empty `{}`, only including explicit `passEnv` + `env` entries
- Fix: add `DEFAULT_EXEC_PROVIDER_PASS_ENV` with known-safe infrastructure URL env vars

## Changes
`src/secrets/resolve.ts` — 1 file, +16 lines

Default forwarded env vars:
| Env var | Purpose |
|---------|---------|
| `BWS_SERVER_URL` | Bitwarden Secrets Manager self-hosted URL |
| `INFISICAL_API_URL` | Infisical self-hosted API endpoint |
| `VAULT_ADDR` | HashiCorp Vault server address |

These are configuration endpoints, not secrets. Users can still use `passEnv` for additional vars.

## Risk checklist
Did user-visible behavior change? (`Yes`) — exec resolver scripts now receive infrastructure URL env vars
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`) — only non-secret config URLs are forwarded
What is the highest-risk area? — Forwarding additional env vars to child processes
How is that risk mitigated? — Only explicitly whitelisted config URLs. No API keys or credentials. Users control which vars via passEnv.