### PR TITLE
fix(update): use configured npm registry for update metadata

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3728,6 +3728,12 @@ describe("update-cli", () => {
         "i",
       ),
     );
+    expect(vi.mocked(resolveNpmChannelTag)).toHaveBeenCalledWith(
+      expect.objectContaining({ command: installCommand }),
+    );
+    expect(vi.mocked(fetchNpmPackageTargetStatus)).toHaveBeenCalledWith(
+      expect.objectContaining({ command: installCommand }),
+    );
     const installOptions = requiredInstallCall[1] as { timeoutMs?: number };
     expect(typeof installOptions.timeoutMs).toBe("number");
   });
@@ -6397,7 +6403,9 @@ describe("update-cli", () => {
     expect(
       vi
         .mocked(runCommandWithTimeout)
-        .mock.calls.some((call) => Array.isArray(call[0]) && call[0][0] === "npm"),
+        .mock.calls.some(
+          (call) => Array.isArray(call[0]) && call[0][0] === "npm" && call[0][1] === "i",
+        ),
     ).toBe(shouldRunPackageUpdate);
   });
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2215,6 +2215,15 @@ describe("update-cli", () => {
     await updateCommand({ yes: true });
 
     expectPackageInstallSpec("openclaw@latest");
+    const preflightParams = vi.mocked(fetchNpmPackageTargetStatus).mock.calls[0]?.[0];
+    expect(preflightParams).toEqual(
+      expect.objectContaining({
+        target: "latest",
+        spec: "openclaw@latest",
+        cwd: process.cwd(),
+      }),
+    );
+    expect(packageInstallCommandCall()?.[1].env).toBe(preflightParams?.env);
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
     expect(
       vi

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -98,7 +98,7 @@ export { readPackageName, readPackageVersion };
 export async function resolveTargetVersion(
   tag: string,
   timeoutMs?: number,
-  options: { spec?: string; cwd?: string; env?: NodeJS.ProcessEnv } = {},
+  options: { spec?: string; command?: string; cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Promise<string | null> {
   if (!canResolveRegistryVersionForPackageTarget(tag)) {
     return null;
@@ -111,6 +111,7 @@ export async function resolveTargetVersion(
     tag,
     timeoutMs,
     spec: options.spec,
+    command: options.command,
     cwd: options.cwd,
     env: options.env,
   });

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -98,6 +98,7 @@ export { readPackageName, readPackageVersion };
 export async function resolveTargetVersion(
   tag: string,
   timeoutMs?: number,
+  options: { spec?: string; cwd?: string; env?: NodeJS.ProcessEnv } = {},
 ): Promise<string | null> {
   if (!canResolveRegistryVersionForPackageTarget(tag)) {
     return null;
@@ -106,7 +107,13 @@ export async function resolveTargetVersion(
   if (direct) {
     return direct;
   }
-  const res = await fetchNpmTagVersion({ tag, timeoutMs });
+  const res = await fetchNpmTagVersion({
+    tag,
+    timeoutMs,
+    spec: options.spec,
+    cwd: options.cwd,
+    env: options.env,
+  });
   return res.version ?? null;
 }
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1045,8 +1045,14 @@ async function resolvePackageRuntimePreflightError(params: {
   tag: string;
   timeoutMs?: number;
   nodeRunner?: string;
+  spec?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
 }): Promise<string | null> {
   if (!canResolveRegistryVersionForPackageTarget(params.tag)) {
+    return null;
+  }
+  if (params.spec && !canResolveRegistryVersionForPackageTarget(params.spec)) {
     return null;
   }
   const target = params.tag.trim();
@@ -1055,7 +1061,10 @@ async function resolvePackageRuntimePreflightError(params: {
   }
   const status = await fetchNpmPackageTargetStatus({
     target,
+    spec: params.spec,
     timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
   });
   if (status.error) {
     return null;
@@ -1503,13 +1512,14 @@ async function runPackageInstallUpdate(params: {
   invocationCwd?: string;
   honorPackageRoot?: boolean;
   nodeRunner?: string;
+  installEnv?: NodeJS.ProcessEnv;
 }): Promise<UpdateRunResult> {
   const manager = await resolveGlobalManager({
     root: params.root,
     installKind: params.installKind,
     timeoutMs: params.timeoutMs,
   });
-  const installEnv = await createGlobalInstallEnv();
+  const installEnv = params.installEnv ?? (await createGlobalInstallEnv());
   const runCommand = createGlobalCommandRunner();
   const installTarget = await resolveGlobalInstallTarget({
     manager,
@@ -3286,6 +3296,8 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   let downgradeRisk = false;
   let fallbackToLatest = false;
   let packageInstallSpec: string | null = null;
+  let packageInstallEnv: NodeJS.ProcessEnv | undefined;
+  let packageInstallCwd: string | undefined;
   let packageAlreadyCurrent = false;
   let managedServiceRootRedirect: ManagedServiceRootRedirect | null = null;
   // Resolved independently of the root redirect so it covers the common case
@@ -3340,11 +3352,27 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   }
 
   if (updateInstallKind !== "git") {
+    packageInstallEnv = await createGlobalInstallEnv();
+    packageInstallCwd = tryResolveInvocationCwd();
     currentVersion = switchToPackage ? null : await readPackageVersion(root);
     if (explicitTag) {
-      targetVersion = await resolveTargetVersion(tag, timeoutMs);
+      const explicitSpec = resolveGlobalInstallSpec({
+        packageName: DEFAULT_PACKAGE_NAME,
+        tag,
+        env: packageInstallEnv,
+      });
+      targetVersion = await resolveTargetVersion(tag, timeoutMs, {
+        spec: explicitSpec,
+        cwd: packageInstallCwd,
+        env: packageInstallEnv,
+      });
     } else {
-      targetVersion = await resolveNpmChannelTag({ channel, timeoutMs }).then((resolved) => {
+      targetVersion = await resolveNpmChannelTag({
+        channel,
+        timeoutMs,
+        cwd: packageInstallCwd,
+        env: packageInstallEnv,
+      }).then((resolved) => {
         tag = resolved.tag;
         fallbackToLatest = channel === "beta" && resolved.tag === "latest";
         return resolved.version;
@@ -3367,7 +3395,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     packageInstallSpec = resolveGlobalInstallSpec({
       packageName: DEFAULT_PACKAGE_NAME,
       tag,
-      env: process.env,
+      env: packageInstallEnv,
     });
   }
 
@@ -3485,8 +3513,11 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   if (updateInstallKind === "package") {
     const runtimePreflightError = await resolvePackageRuntimePreflightError({
       tag,
+      spec: packageInstallSpec ?? undefined,
       timeoutMs,
       nodeRunner: managedServiceNodeRunner,
+      cwd: packageInstallCwd,
+      env: packageInstallEnv,
     });
     if (runtimePreflightError) {
       defaultRuntime.error(runtimePreflightError);
@@ -3591,6 +3622,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
             honorPackageRoot:
               managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
             nodeRunner: managedServiceNodeRunner,
+            installEnv: packageInstallEnv,
           })
         : await runGitUpdate({
             root,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -91,6 +91,7 @@ import {
   resolveGlobalInstallTarget,
   resolveGlobalInstallSpec,
   resolvePnpmGlobalDirFromGlobalRoot,
+  type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
 import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runner.js";
@@ -1046,6 +1047,7 @@ async function resolvePackageRuntimePreflightError(params: {
   timeoutMs?: number;
   nodeRunner?: string;
   spec?: string;
+  command?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
 }): Promise<string | null> {
@@ -1063,6 +1065,7 @@ async function resolvePackageRuntimePreflightError(params: {
     target,
     spec: params.spec,
     timeoutMs: params.timeoutMs,
+    command: params.command,
     cwd: params.cwd,
     env: params.env,
   });
@@ -1513,21 +1516,25 @@ async function runPackageInstallUpdate(params: {
   honorPackageRoot?: boolean;
   nodeRunner?: string;
   installEnv?: NodeJS.ProcessEnv;
+  installTarget?: ResolvedGlobalInstallTarget;
 }): Promise<UpdateRunResult> {
-  const manager = await resolveGlobalManager({
-    root: params.root,
-    installKind: params.installKind,
-    timeoutMs: params.timeoutMs,
-  });
   const installEnv = params.installEnv ?? (await createGlobalInstallEnv());
   const runCommand = createGlobalCommandRunner();
-  const installTarget = await resolveGlobalInstallTarget({
-    manager,
-    runCommand,
-    timeoutMs: params.timeoutMs,
-    pkgRoot: params.root,
-    honorPackageRoot: params.honorPackageRoot === true,
-  });
+  let installTarget = params.installTarget;
+  if (!installTarget) {
+    const manager = await resolveGlobalManager({
+      root: params.root,
+      installKind: params.installKind,
+      timeoutMs: params.timeoutMs,
+    });
+    installTarget = await resolveGlobalInstallTarget({
+      manager,
+      runCommand,
+      timeoutMs: params.timeoutMs,
+      pkgRoot: params.root,
+      honorPackageRoot: params.honorPackageRoot === true,
+    });
+  }
   const pkgRoot = installTarget.packageRoot;
   const packageName =
     (pkgRoot ? await readPackageName(pkgRoot) : await readPackageName(params.root)) ??
@@ -1630,7 +1637,7 @@ async function runPackageInstallUpdate(params: {
 
   return {
     status: packageUpdate.failedStep ? "error" : "ok",
-    mode: manager,
+    mode: installTarget.manager,
     root: packageUpdate.verifiedPackageRoot ?? params.root,
     reason: packageUpdate.failedStep ? packageUpdate.failedStep.name : undefined,
     before: { version: beforeVersion },
@@ -3298,6 +3305,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   let packageInstallSpec: string | null = null;
   let packageInstallEnv: NodeJS.ProcessEnv | undefined;
   let packageInstallCwd: string | undefined;
+  let packageInstallTarget: ResolvedGlobalInstallTarget | undefined;
   let packageAlreadyCurrent = false;
   let managedServiceRootRedirect: ManagedServiceRootRedirect | null = null;
   // Resolved independently of the root redirect so it covers the common case
@@ -3354,6 +3362,23 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   if (updateInstallKind !== "git") {
     packageInstallEnv = await createGlobalInstallEnv();
     packageInstallCwd = tryResolveInvocationCwd();
+    if (updateInstallKind === "package") {
+      const manager = await resolveGlobalManager({
+        root,
+        installKind,
+        timeoutMs: updateStepTimeoutMs,
+      });
+      packageInstallTarget = await resolveGlobalInstallTarget({
+        manager,
+        runCommand: createGlobalCommandRunner(),
+        timeoutMs: updateStepTimeoutMs,
+        pkgRoot: root,
+        honorPackageRoot:
+          managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
+      });
+    }
+    const npmMetadataCommand =
+      packageInstallTarget?.manager === "npm" ? packageInstallTarget.command : undefined;
     currentVersion = switchToPackage ? null : await readPackageVersion(root);
     if (explicitTag) {
       const explicitSpec = resolveGlobalInstallSpec({
@@ -3363,6 +3388,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
       });
       targetVersion = await resolveTargetVersion(tag, timeoutMs, {
         spec: explicitSpec,
+        command: npmMetadataCommand,
         cwd: packageInstallCwd,
         env: packageInstallEnv,
       });
@@ -3370,6 +3396,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
       targetVersion = await resolveNpmChannelTag({
         channel,
         timeoutMs,
+        command: npmMetadataCommand,
         cwd: packageInstallCwd,
         env: packageInstallEnv,
       }).then((resolved) => {
@@ -3516,6 +3543,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
       spec: packageInstallSpec ?? undefined,
       timeoutMs,
       nodeRunner: managedServiceNodeRunner,
+      command: packageInstallTarget?.manager === "npm" ? packageInstallTarget.command : undefined,
       cwd: packageInstallCwd,
       env: packageInstallEnv,
     });
@@ -3623,6 +3651,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
               managedServiceRootRedirect !== null || managedServiceNodeRunner !== undefined,
             nodeRunner: managedServiceNodeRunner,
             installEnv: packageInstallEnv,
+            installTarget: packageInstallTarget,
           })
         : await runGitUpdate({
             root,

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
@@ -74,6 +74,10 @@ describe("resolveNpmChannelTag", () => {
     runCommand = runCommandMock as unknown as NpmMetadataCommandRunner;
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("delegates package target metadata to npm view with global config scope", async () => {
     versionByTag.latest = "1.0.4";
     const env = { ...process.env, NPM_CONFIG_USERCONFIG: "/tmp/openclaw-user-npmrc" };
@@ -82,6 +86,7 @@ describe("resolveNpmChannelTag", () => {
       fetchNpmPackageTargetStatus({
         target: "latest",
         spec: "openclaw@latest",
+        command: "/opt/openclaw/node/bin/npm",
         timeoutMs: 1000,
         cwd: "/tmp/openclaw-project",
         env,
@@ -94,7 +99,15 @@ describe("resolveNpmChannelTag", () => {
     });
 
     expect(runCommandMock).toHaveBeenCalledWith(
-      ["npm", "view", "openclaw@latest", "version", "engines.node", "--json", "--global"],
+      [
+        "/opt/openclaw/node/bin/npm",
+        "view",
+        "openclaw@latest",
+        "version",
+        "engines.node",
+        "--json",
+        "--global",
+      ],
       expect.objectContaining({
         timeoutMs: 1000,
         cwd: "/tmp/openclaw-project",
@@ -153,6 +166,7 @@ describe("resolveNpmChannelTag", () => {
         await expect(
           fetchNpmPackageTargetStatus({
             target: "latest",
+            command: "npm",
             timeoutMs: 10_000,
             cwd: project,
             env: {
@@ -178,6 +192,31 @@ describe("resolveNpmChannelTag", () => {
         });
       }
     });
+  });
+
+  it("uses the public registry when no npm command is available", async () => {
+    const fetch = vi.fn(async () => {
+      return {
+        ok: true,
+        json: async () => ({
+          version: "2026.6.8",
+          engines: { node: ">=22.19.0" },
+        }),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(
+      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
+    ).resolves.toEqual({
+      target: "latest",
+      version: "2026.6.8",
+      nodeEngine: ">=22.19.0",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/openclaw/latest",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("falls back to latest when beta is older", async () => {

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -1,7 +1,9 @@
 // Covers update status, dependency status, and registry fetch helpers.
 import fs from "node:fs/promises";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
@@ -43,38 +45,144 @@ describe("compareSemverStrings", () => {
 });
 
 describe("resolveNpmChannelTag", () => {
+  type NpmMetadataCommandRunner = NonNullable<
+    Parameters<typeof fetchNpmPackageTargetStatus>[0]["runCommand"]
+  >;
+
   let versionByTag: Record<string, string | null>;
+  let runCommand: NpmMetadataCommandRunner;
+  let runCommandMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     versionByTag = {};
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url =
-          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-        const tag = decodeURIComponent(url.split("/").pop() ?? "");
-        const version = versionByTag[tag] ?? null;
-        return {
-          ok: version != null,
-          status: version != null ? 200 : 404,
-          json: async () => ({
-            version,
-            engines: version != null ? { node: ">=22.19.0" } : undefined,
-          }),
-        } as Response;
+    runCommandMock = vi.fn(async (argv: string[]) => {
+      const spec = String(argv[2] ?? "");
+      const tag = spec.slice(spec.lastIndexOf("@") + 1);
+      const version = versionByTag[tag] ?? null;
+      return {
+        stdout:
+          version == null
+            ? ""
+            : JSON.stringify({
+                version,
+                "engines.node": ">=22.19.0",
+              }),
+        stderr: version == null ? "npm ERR! 404 Not Found" : "",
+        code: version == null ? 1 : 0,
+      };
+    });
+    runCommand = runCommandMock as unknown as NpmMetadataCommandRunner;
+  });
+
+  it("delegates package target metadata to npm view with global config scope", async () => {
+    versionByTag.latest = "1.0.4";
+    const env = { ...process.env, NPM_CONFIG_USERCONFIG: "/tmp/openclaw-user-npmrc" };
+
+    await expect(
+      fetchNpmPackageTargetStatus({
+        target: "latest",
+        spec: "openclaw@latest",
+        timeoutMs: 1000,
+        cwd: "/tmp/openclaw-project",
+        env,
+        runCommand,
+      }),
+    ).resolves.toEqual({
+      target: "latest",
+      version: "1.0.4",
+      nodeEngine: ">=22.19.0",
+    });
+
+    expect(runCommandMock).toHaveBeenCalledWith(
+      ["npm", "view", "openclaw@latest", "version", "engines.node", "--json", "--global"],
+      expect.objectContaining({
+        timeoutMs: 1000,
+        cwd: "/tmp/openclaw-project",
+        env,
       }),
     );
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
+  it("uses npm global scope, user config auth, and ignores project npmrc for real metadata", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-npm-view-" }, async (base) => {
+      const requests: Array<{ url: string; authorization?: string }> = [];
+      const server = http.createServer((req, res) => {
+        requests.push({
+          url: req.url ?? "",
+          authorization: req.headers.authorization,
+        });
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            name: "openclaw",
+            "dist-tags": { latest: "2026.6.6" },
+            versions: {
+              "2026.6.6": {
+                name: "openclaw",
+                version: "2026.6.6",
+                engines: { node: ">=22.19.0" },
+                dist: {
+                  tarball: "http://example.invalid/openclaw-2026.6.6.tgz",
+                  shasum: "0".repeat(40),
+                },
+              },
+            },
+          }),
+        );
+      });
+
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address() as AddressInfo;
+        const registry = `http://127.0.0.1:${address.port}/user/`;
+        const project = path.join(base, "project");
+        const home = path.join(base, "home");
+        const userConfig = path.join(home, ".npmrc");
+        await fs.mkdir(project, { recursive: true });
+        await fs.mkdir(home, { recursive: true });
+        await fs.writeFile(path.join(project, ".npmrc"), "registry=http://127.0.0.1:9/project/\n");
+        await fs.writeFile(
+          userConfig,
+          [`registry=${registry}`, `//127.0.0.1:${address.port}/user/:_authToken=test-token`].join(
+            "\n",
+          ),
+        );
+
+        await expect(
+          fetchNpmPackageTargetStatus({
+            target: "latest",
+            timeoutMs: 10_000,
+            cwd: project,
+            env: {
+              ...process.env,
+              HOME: home,
+              NPM_CONFIG_USERCONFIG: userConfig,
+            },
+          }),
+        ).resolves.toEqual({
+          target: "latest",
+          version: "2026.6.6",
+          nodeEngine: ">=22.19.0",
+        });
+
+        expect(requests.some((request) => request.url.startsWith("/user/openclaw"))).toBe(true);
+        expect(requests.some((request) => request.url.startsWith("/project/"))).toBe(false);
+        expect(requests.some((request) => request.authorization === "Bearer test-token")).toBe(
+          true,
+        );
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((err) => (err ? reject(err) : resolve()));
+        });
+      }
+    });
   });
 
   it("falls back to latest when beta is older", async () => {
     versionByTag.beta = "1.0.0-beta.1";
     versionByTag.latest = "1.0.1-1";
 
-    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
     expect(resolved).toEqual({ tag: "latest", version: "1.0.1-1" });
   });
@@ -83,7 +191,7 @@ describe("resolveNpmChannelTag", () => {
     versionByTag.beta = "1.0.2-beta.1";
     versionByTag.latest = "1.0.1-1";
 
-    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
     expect(resolved).toEqual({ tag: "beta", version: "1.0.2-beta.1" });
   });
@@ -92,7 +200,7 @@ describe("resolveNpmChannelTag", () => {
     versionByTag.beta = "1.0.1-beta.2";
     versionByTag.latest = "1.0.1";
 
-    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000 });
+    const resolved = await resolveNpmChannelTag({ channel: "beta", timeoutMs: 1000, runCommand });
 
     expect(resolved).toEqual({ tag: "latest", version: "1.0.1" });
   });
@@ -100,7 +208,9 @@ describe("resolveNpmChannelTag", () => {
   it("keeps non-beta channels unchanged", async () => {
     versionByTag.latest = "1.0.3";
 
-    await expect(resolveNpmChannelTag({ channel: "stable", timeoutMs: 1000 })).resolves.toEqual({
+    await expect(
+      resolveNpmChannelTag({ channel: "stable", timeoutMs: 1000, runCommand }),
+    ).resolves.toEqual({
       tag: "latest",
       version: "1.0.3",
     });
@@ -110,36 +220,42 @@ describe("resolveNpmChannelTag", () => {
     versionByTag.latest = "1.0.4";
 
     await expect(
-      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000 }),
+      fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 1000, runCommand }),
     ).resolves.toEqual({
       target: "latest",
       version: "1.0.4",
       nodeEngine: ">=22.19.0",
     });
-    await expect(fetchNpmTagVersion({ tag: "latest", timeoutMs: 1000 })).resolves.toEqual({
+    await expect(
+      fetchNpmTagVersion({ tag: "latest", timeoutMs: 1000, runCommand }),
+    ).resolves.toEqual({
       tag: "latest",
       version: "1.0.4",
     });
-    await expect(fetchNpmLatestVersion({ timeoutMs: 1000 })).resolves.toEqual({
+    await expect(fetchNpmLatestVersion({ timeoutMs: 1000, runCommand })).resolves.toEqual({
       latestVersion: "1.0.4",
       error: undefined,
     });
     versionByTag.beta = "1.0.5-beta.1";
     await expect(
-      fetchNpmRegistryVersionForChannel({ channel: "beta", timeoutMs: 1000 }),
+      fetchNpmRegistryVersionForChannel({ channel: "beta", timeoutMs: 1000, runCommand }),
     ).resolves.toEqual({
       latestVersion: "1.0.5-beta.1",
       tag: "beta",
     });
-    await expect(fetchNpmTagVersion({ tag: "beta", timeoutMs: 1000 })).resolves.toEqual({
-      tag: "beta",
-      version: "1.0.5-beta.1",
-      error: undefined,
-    });
-    await expect(fetchNpmTagVersion({ tag: "missing", timeoutMs: 1000 })).resolves.toEqual({
+    await expect(fetchNpmTagVersion({ tag: "beta", timeoutMs: 1000, runCommand })).resolves.toEqual(
+      {
+        tag: "beta",
+        version: "1.0.5-beta.1",
+        error: undefined,
+      },
+    );
+    await expect(
+      fetchNpmTagVersion({ tag: "missing", timeoutMs: 1000, runCommand }),
+    ).resolves.toEqual({
       tag: "missing",
       version: null,
-      error: "HTTP 404",
+      error: "npm view failed: npm ERR! 404 Not Found",
     });
   });
 });

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -56,7 +56,7 @@ describe("resolveNpmChannelTag", () => {
   beforeEach(() => {
     versionByTag = {};
     runCommandMock = vi.fn(async (argv: string[]) => {
-      const spec = String(argv[2] ?? "");
+      const spec = argv[2] ?? "";
       const tag = spec.slice(spec.lastIndexOf("@") + 1);
       const version = versionByTag[tag] ?? null;
       return {
@@ -131,7 +131,9 @@ describe("resolveNpmChannelTag", () => {
         );
       });
 
-      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
       try {
         const address = server.address() as AddressInfo;
         const registry = `http://127.0.0.1:${address.port}/user/`;

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
@@ -103,6 +104,38 @@ function formatNpmViewError(res: { stdout: string; stderr: string }): string {
 function packageTargetSpec(params: { target: string; spec?: string }): string {
   const spec = params.spec?.trim();
   return spec || `openclaw@${params.target.trim() || "latest"}`;
+}
+
+async function fetchPublicNpmPackageTargetStatus(params: {
+  target: string;
+  timeoutMs: number;
+}): Promise<NpmPackageTargetStatus> {
+  try {
+    const res = await fetchWithTimeout(
+      `https://registry.npmjs.org/openclaw/${encodeURIComponent(params.target)}`,
+      {},
+      Math.max(250, params.timeoutMs),
+    );
+    if (!res.ok) {
+      return {
+        target: params.target,
+        version: null,
+        nodeEngine: null,
+        error: `HTTP ${res.status}`,
+      };
+    }
+    const json = (await res.json()) as {
+      version?: unknown;
+      engines?: { node?: unknown };
+    };
+    return {
+      target: params.target,
+      version: toOptionalTrimmedString(json.version),
+      nodeEngine: toOptionalTrimmedString(json.engines?.node),
+    };
+  } catch (err) {
+    return { target: params.target, version: null, nodeEngine: null, error: String(err) };
+  }
 }
 
 export function formatGitInstallLabel(update: UpdateCheckResult): string | null {
@@ -387,17 +420,21 @@ export async function fetchNpmPackageTargetStatus(params: {
   target: string;
   timeoutMs?: number;
   spec?: string;
+  command?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   runCommand?: NpmMetadataCommandRunner;
 }): Promise<NpmPackageTargetStatus> {
   const timeoutMs = params.timeoutMs ?? 3500;
   const target = params.target;
+  if (!params.command && !params.runCommand) {
+    return await fetchPublicNpmPackageTargetStatus({ target, timeoutMs });
+  }
   const runCommand = params.runCommand ?? runCommandWithTimeout;
   try {
     const res = await runCommand(
       [
-        "npm",
+        params.command ?? "npm",
         "view",
         packageTargetSpec({ target, spec: params.spec }),
         "version",
@@ -431,6 +468,7 @@ export async function fetchNpmTagVersion(params: {
   tag: string;
   timeoutMs?: number;
   spec?: string;
+  command?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   runCommand?: NpmMetadataCommandRunner;
@@ -439,6 +477,7 @@ export async function fetchNpmTagVersion(params: {
     target: params.tag,
     timeoutMs: params.timeoutMs,
     spec: params.spec,
+    command: params.command,
     cwd: params.cwd,
     env: params.env,
     runCommand: params.runCommand,
@@ -453,6 +492,7 @@ export async function fetchNpmTagVersion(params: {
 export async function resolveNpmChannelTag(params: {
   channel: UpdateChannel;
   timeoutMs?: number;
+  command?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   runCommand?: NpmMetadataCommandRunner;
@@ -461,6 +501,7 @@ export async function resolveNpmChannelTag(params: {
   const channelStatus = await fetchNpmTagVersion({
     tag: channelTag,
     timeoutMs: params.timeoutMs,
+    command: params.command,
     cwd: params.cwd,
     env: params.env,
     runCommand: params.runCommand,
@@ -472,6 +513,7 @@ export async function resolveNpmChannelTag(params: {
   const latestStatus = await fetchNpmTagVersion({
     tag: "latest",
     timeoutMs: params.timeoutMs,
+    command: params.command,
     cwd: params.cwd,
     env: params.env,
     runCommand: params.runCommand,

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runCommandWithTimeout } from "../process/exec.js";
-import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
@@ -58,6 +57,53 @@ export type UpdateCheckResult = {
   deps?: DepsStatus;
   registry?: RegistryStatus;
 };
+
+type NpmMetadataCommandRunner = (
+  argv: string[],
+  options: {
+    timeoutMs: number;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    maxOutputBytes?: number;
+  },
+) => Promise<{
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}>;
+
+function toOptionalTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parseNpmPackageTargetMetadata(raw: string): {
+  version: string | null;
+  nodeEngine: string | null;
+} {
+  const parsed = JSON.parse(raw.trim()) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { version: null, nodeEngine: null };
+  }
+  const rec = parsed as Record<string, unknown>;
+  const engines = rec.engines && typeof rec.engines === "object" ? rec.engines : null;
+  const nodeEngine =
+    toOptionalTrimmedString(rec["engines.node"]) ??
+    (engines ? toOptionalTrimmedString((engines as Record<string, unknown>).node) : null);
+  return {
+    version: toOptionalTrimmedString(rec.version),
+    nodeEngine,
+  };
+}
+
+function formatNpmViewError(res: { stdout: string; stderr: string }): string {
+  const raw = (res.stderr.trim() || res.stdout.trim()).split("\n").slice(-3).join("\n");
+  return raw ? `npm view failed: ${raw}` : "npm view failed";
+}
+
+function packageTargetSpec(params: { target: string; spec?: string }): string {
+  const spec = params.spec?.trim();
+  return spec || `openclaw@${params.target.trim() || "latest"}`;
+}
 
 export function formatGitInstallLabel(update: UpdateCheckResult): string | null {
   if (update.installKind !== "git") {
@@ -300,8 +346,17 @@ export async function checkDepsStatus(params: {
 
 export async function fetchNpmLatestVersion(params?: {
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<RegistryStatus> {
-  const res = await fetchNpmTagVersion({ tag: "latest", timeoutMs: params?.timeoutMs });
+  const res = await fetchNpmTagVersion({
+    tag: "latest",
+    timeoutMs: params?.timeoutMs,
+    cwd: params?.cwd,
+    env: params?.env,
+    runCommand: params?.runCommand,
+  });
   return {
     latestVersion: res.version,
     error: res.error,
@@ -311,10 +366,16 @@ export async function fetchNpmLatestVersion(params?: {
 export async function fetchNpmRegistryVersionForChannel(params: {
   channel: UpdateChannel;
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<RegistryStatus> {
   const res = await resolveNpmChannelTag({
     channel: params.channel,
     timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
   });
   return {
     latestVersion: res.version,
@@ -325,24 +386,41 @@ export async function fetchNpmRegistryVersionForChannel(params: {
 export async function fetchNpmPackageTargetStatus(params: {
   target: string;
   timeoutMs?: number;
+  spec?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<NpmPackageTargetStatus> {
   const timeoutMs = params.timeoutMs ?? 3500;
   const target = params.target;
+  const runCommand = params.runCommand ?? runCommandWithTimeout;
   try {
-    const res = await fetchWithTimeout(
-      `https://registry.npmjs.org/openclaw/${encodeURIComponent(target)}`,
-      {},
-      Math.max(250, timeoutMs),
+    const res = await runCommand(
+      [
+        "npm",
+        "view",
+        packageTargetSpec({ target, spec: params.spec }),
+        "version",
+        "engines.node",
+        "--json",
+        "--global",
+      ],
+      {
+        timeoutMs: Math.max(250, timeoutMs),
+        cwd: params.cwd,
+        env: params.env,
+        maxOutputBytes: 1024 * 1024,
+      },
     );
-    if (!res.ok) {
-      return { target, version: null, nodeEngine: null, error: `HTTP ${res.status}` };
+    if (res.code !== 0) {
+      return {
+        target,
+        version: null,
+        nodeEngine: null,
+        error: formatNpmViewError(res),
+      };
     }
-    const json = (await res.json()) as {
-      version?: unknown;
-      engines?: { node?: unknown };
-    };
-    const version = typeof json?.version === "string" ? json.version : null;
-    const nodeEngine = typeof json?.engines?.node === "string" ? json.engines.node : null;
+    const { version, nodeEngine } = parseNpmPackageTargetMetadata(res.stdout);
     return { target, version, nodeEngine };
   } catch (err) {
     return { target, version: null, nodeEngine: null, error: String(err) };
@@ -352,10 +430,18 @@ export async function fetchNpmPackageTargetStatus(params: {
 export async function fetchNpmTagVersion(params: {
   tag: string;
   timeoutMs?: number;
+  spec?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<NpmTagStatus> {
   const res = await fetchNpmPackageTargetStatus({
     target: params.tag,
     timeoutMs: params.timeoutMs,
+    spec: params.spec,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
   });
   return {
     tag: params.tag,
@@ -367,14 +453,29 @@ export async function fetchNpmTagVersion(params: {
 export async function resolveNpmChannelTag(params: {
   channel: UpdateChannel;
   timeoutMs?: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: NpmMetadataCommandRunner;
 }): Promise<{ tag: string; version: string | null }> {
   const channelTag = channelToNpmTag(params.channel);
-  const channelStatus = await fetchNpmTagVersion({ tag: channelTag, timeoutMs: params.timeoutMs });
+  const channelStatus = await fetchNpmTagVersion({
+    tag: channelTag,
+    timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
+  });
   if (params.channel !== "beta") {
     return { tag: channelTag, version: channelStatus.version };
   }
 
-  const latestStatus = await fetchNpmTagVersion({ tag: "latest", timeoutMs: params.timeoutMs });
+  const latestStatus = await fetchNpmTagVersion({
+    tag: "latest",
+    timeoutMs: params.timeoutMs,
+    cwd: params.cwd,
+    env: params.env,
+    runCommand: params.runCommand,
+  });
   if (!latestStatus.version) {
     return { tag: channelTag, version: channelStatus.version };
   }


### PR DESCRIPTION
## Summary

- Extracts the npm update-metadata fix from #93537 while preserving contributor attribution.
- Uses the package manager that owns the installation for npm metadata, with a public npm-registry fallback for non-npm runtimes.
- Fixes #79140.

## Verification

- `node scripts/run-vitest.mjs src/infra/update-check.test.ts src/cli/update-cli.test.ts`
- `node scripts/run-vitest.mjs src/infra/update-startup.test.ts`
- `OPENCLAW_TESTBOX=1 pnpm check:changed` was run in Blacksmith Testbox. Pre-typecheck checks passed; typecheck is blocked by unchanged `origin/main` TS6133 in `src/agents/model-picker-visibility.ts:7`.
