### PR TITLE
fix(macos): preserve approvals migration data

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -368,7 +368,7 @@ enum ExecApprovalsStore {
                 tempURL.path,
                 targetURL.path,
                 nil,
-                copyfile_flags_t(COPYFILE_EXCL))
+                copyfile_flags_t(COPYFILE_DATA | COPYFILE_EXCL))
             if copied == -1 {
                 if errno == EEXIST {
                     try? FileManager().removeItem(at: tempURL)


### PR DESCRIPTION
## Summary

- Extracts the macOS approvals migration data-preservation fix from #93188 as its own attribution-preserving change.
- Copies the file data fork during the migration so approvals are not silently discarded.

## Verification

- Darwin `copyfile` probe: `COPYFILE_EXCL` drops payload data; `COPYFILE_DATA | COPYFILE_EXCL` preserves it.
- Existing `ExecApprovalsStoreRefactorTests` exercises the migrated-content path.
- `swift test --package-path apps/macos --filter ExecApprovalsStoreRefactorTests` is blocked before the OpenClaw test target by missing `SwiftUIMacros` and `PreviewsMacros` dependencies in `swiftui-math`.
