### PR TITLE
fix(agents): route BTW through canonical Codex runtime

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1060,6 +1060,59 @@ describe("runBtwSideQuestion", () => {
     expect(streamSimpleMock).not.toHaveBeenCalled();
   });
 
+  it("preserves auto-selected session CLI BTW routing before resolving runtime auth", async () => {
+    const cleanup = vi.fn(async () => undefined);
+    const sessionEntry = createSessionEntry({
+      authProfileOverride: "anthropic:auto-cli",
+      authProfileOverrideSource: "auto",
+    });
+    const sessionStore = { [DEFAULT_SESSION_KEY]: sessionEntry };
+    prepareCliRunContextMock.mockResolvedValueOnce({
+      prepared: true,
+      preparedBackend: { cleanup },
+    });
+    executePreparedCliRunMock.mockResolvedValueOnce({ text: "Session Claude CLI answer." });
+    resolveSessionAuthProfileOverrideMock.mockImplementation(
+      async (params: { sessionEntry?: SessionEntry }) => {
+        if (params.sessionEntry) {
+          params.sessionEntry.authProfileOverride = "anthropic:api";
+          params.sessionEntry.authProfileOverrideSource = "auto";
+        }
+        return "anthropic:api";
+      },
+    );
+    mockDoneAnswer("Generic fallback answer.");
+
+    const result = await runSideQuestion({
+      cfg: {
+        auth: {
+          order: { anthropic: ["anthropic:api"] },
+          profiles: {
+            "anthropic:api": { provider: "anthropic", mode: "api_key" },
+            "anthropic:auto-cli": { provider: "claude-cli", mode: "oauth" },
+          },
+        },
+      } as never,
+      sessionEntry,
+      sessionStore,
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "Session Claude CLI answer." });
+    const prepareParams = mockArg(prepareCliRunContextMock, 0, 0) as {
+      provider?: string;
+      authProfileId?: string;
+      executionMode?: string;
+    };
+    expect(prepareParams.provider).toBe("claude-cli");
+    expect(prepareParams.executionMode).toBe("side-question");
+    expect(prepareParams.authProfileId).toBe("anthropic:auto-cli");
+    expect(resolveSessionAuthProfileOverrideMock).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(getApiKeyForModelMock).not.toHaveBeenCalled();
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+  });
+
   it("loads Claude CLI auth for BTW from persisted auth-store order", async () => {
     const staticAuthStore = {
       version: 1 as const,

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -676,6 +676,65 @@ describe("runBtwSideQuestion", () => {
     expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
 
+  it("reselects the Codex hook after resolving legacy openai-codex route state", async () => {
+    const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex test harness",
+      supports: (ctx) =>
+        ctx.provider === "openai"
+          ? { supported: true, priority: 100 }
+          : { supported: false, reason: "openai only" },
+      runAttempt: vi.fn(),
+      runSideQuestion: codexSideQuestionMock,
+    });
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-responses",
+    });
+    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:user@example.test");
+
+    const result = await runSideQuestion({
+      cfg: {
+        auth: {
+          order: {
+            openai: ["openai-codex:user@example.test"],
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+        },
+      } as never,
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "Codex side answer." });
+    expect(codexSideQuestionMock).toHaveBeenCalledTimes(1);
+    const sideQuestionParams = mockArg(codexSideQuestionMock, 0, 0) as {
+      provider?: string;
+      authProfileId?: string;
+    };
+    expect(sideQuestionParams.provider).toBe("openai");
+    expect(sideQuestionParams.authProfileId).toBe("openai-codex:user@example.test");
+    const authArgs = mockArg(resolveSessionAuthProfileOverrideMock, 0, 0) as {
+      provider?: string;
+      acceptedProviderIds?: string[];
+    };
+    expect(authArgs.provider).toBe("openai");
+    expect(authArgs.acceptedProviderIds).toEqual(["openai"]);
+    expect(streamSimpleMock).not.toHaveBeenCalled();
+    expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
+  });
+
   it("prepares deny-all sender policy before calling a plugin side-question hook", async () => {
     const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Policy answer." });
     registerAgentHarness({
@@ -690,7 +749,6 @@ describe("runBtwSideQuestion", () => {
       id: "gpt-5.5",
       api: "openai-responses",
     });
-
     await runSideQuestion({
       cfg: {
         channels: {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -35,6 +35,7 @@ import {
   resolvePluginHarnessPolicyToolsAllow,
   selectAgentHarness,
 } from "./harness/selection.js";
+import type { AgentHarness } from "./harness/types.js";
 import {
   resolveImageSanitizationLimits,
   type ImageSanitizationLimits,
@@ -323,15 +324,17 @@ async function resolveRuntimeModel(params: {
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }
+  const runtimeProvider = model.provider;
+  const runtimeModelId = model.id;
 
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg: params.cfg,
-    provider: params.provider,
+    provider: runtimeProvider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-      provider: params.provider,
+      provider: runtimeProvider,
       harnessRuntime: resolveAvailableAgentHarnessPolicy({
-        provider: params.provider,
-        modelId: params.model,
+        provider: runtimeProvider,
+        modelId: runtimeModelId,
         config: params.cfg,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
@@ -483,27 +486,41 @@ export async function runBtwSideQuestion(
     agentId: sessionAgentId,
     sessionKey: params.sessionKey,
   });
-  if (harness.runSideQuestion) {
-    const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      agentId: sessionAgentId,
-      agentDir: params.agentDir,
-      workspaceDir,
-      sessionEntry: params.sessionEntry,
-      sessionStore: params.sessionStore,
-      sessionKey: params.sessionKey,
-      storePath: params.storePath,
-      isNewSession: params.isNewSession,
-    });
+  let runtimeSelection: Awaited<ReturnType<typeof resolveRuntimeModel>> | undefined;
+  const resolveRuntimeSelection = async () => {
+    if (!runtimeSelection) {
+      runtimeSelection = await resolveRuntimeModel({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        agentId: sessionAgentId,
+        agentDir: params.agentDir,
+        workspaceDir,
+        sessionEntry: params.sessionEntry,
+        sessionStore: params.sessionStore,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        isNewSession: params.isNewSession,
+      });
+    }
+    return runtimeSelection;
+  };
+  const runHarnessSideQuestion = async (
+    selectedHarness: AgentHarness,
+    runtime: Awaited<ReturnType<typeof resolveRuntimeModel>>,
+  ): Promise<ReplyPayload | undefined> => {
+    if (!selectedHarness.runSideQuestion) {
+      throw new Error(
+        `Selected agent harness "${selectedHarness.id}" does not support /btw side questions.`,
+      );
+    }
     const toolsAllow = resolvePluginHarnessPolicyToolsAllow({
       config: params.cfg,
       sessionKey: params.sessionKey,
       sandboxSessionKey: params.sandboxSessionKey,
       agentId: sessionAgentId,
-      provider: model.provider,
-      modelId: model.id,
+      provider: runtime.model.provider,
+      modelId: runtime.model.id,
       messageProvider: params.messageProvider,
       messageChannel: params.messageChannel,
       spawnedBy: params.spawnedBy,
@@ -516,20 +533,23 @@ export async function runBtwSideQuestion(
       senderUsername: params.senderUsername,
       senderE164: params.senderE164,
     });
-    const result = await harness.runSideQuestion({
+    const result = await selectedHarness.runSideQuestion({
       ...params,
-      provider: model.provider,
-      model: model.id,
-      runtimeModel: model,
+      provider: runtime.model.provider,
+      model: runtime.model.id,
+      runtimeModel: runtime.model,
       sessionId,
       sessionFile,
       agentId: sessionAgentId,
       workspaceDir,
       ...(toolsAllow ? { toolsAllow } : {}),
-      authProfileId,
-      authProfileIdSource,
+      authProfileId: runtime.authProfileId,
+      authProfileIdSource: runtime.authProfileIdSource,
     });
     return { text: result.text };
+  };
+  if (harness.runSideQuestion) {
+    return runHarnessSideQuestion(harness, await resolveRuntimeSelection());
   }
   if (harness.id === "codex") {
     throw new Error(`Selected agent harness "${harness.id}" does not support /btw side questions.`);
@@ -560,6 +580,23 @@ export async function runBtwSideQuestion(
   }
   if (messages.length === 0 && !inFlightPrompt?.trim()) {
     throw new Error("No active session context.");
+  }
+
+  const runtimeSelectionForHarness = await resolveRuntimeSelection();
+  const runtimeHarness = selectAgentHarness({
+    provider: runtimeSelectionForHarness.model.provider,
+    modelId: runtimeSelectionForHarness.model.id,
+    config: params.cfg,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  if (runtimeHarness.runSideQuestion) {
+    return runHarnessSideQuestion(runtimeHarness, runtimeSelectionForHarness);
+  }
+  if (runtimeHarness.id === "codex") {
+    throw new Error(
+      `Selected agent harness "${runtimeHarness.id}" does not support /btw side questions.`,
+    );
   }
 
   const fallbackPolicy = resolveAvailableAgentHarnessPolicy({
@@ -626,19 +663,7 @@ export async function runBtwSideQuestion(
     });
   }
 
-  const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
-    cfg: params.cfg,
-    provider: params.provider,
-    model: params.model,
-    agentId: sessionAgentId,
-    agentDir: params.agentDir,
-    workspaceDir,
-    sessionEntry: params.sessionEntry,
-    sessionStore: params.sessionStore,
-    sessionKey: params.sessionKey,
-    storePath: params.storePath,
-    isNewSession: params.isNewSession,
-  });
+  const { model, authProfileId, authProfileIdSource } = runtimeSelectionForHarness;
   let externalCliAuthScope = resolveExternalCliAuthOverlayScopeFromSelection({
     provider: model.provider,
     cfg: params.cfg,

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -582,23 +582,6 @@ export async function runBtwSideQuestion(
     throw new Error("No active session context.");
   }
 
-  const runtimeSelectionForHarness = await resolveRuntimeSelection();
-  const runtimeHarness = selectAgentHarness({
-    provider: runtimeSelectionForHarness.model.provider,
-    modelId: runtimeSelectionForHarness.model.id,
-    config: params.cfg,
-    agentId: sessionAgentId,
-    sessionKey: params.sessionKey,
-  });
-  if (runtimeHarness.runSideQuestion) {
-    return runHarnessSideQuestion(runtimeHarness, runtimeSelectionForHarness);
-  }
-  if (runtimeHarness.id === "codex") {
-    throw new Error(
-      `Selected agent harness "${runtimeHarness.id}" does not support /btw side questions.`,
-    );
-  }
-
   const fallbackPolicy = resolveAvailableAgentHarnessPolicy({
     provider: params.provider,
     modelId: params.model,
@@ -661,6 +644,23 @@ export async function runBtwSideQuestion(
       messageProvider: params.messageProvider,
       currentChannelId: params.currentChannelId,
     });
+  }
+
+  const runtimeSelectionForHarness = await resolveRuntimeSelection();
+  const runtimeHarness = selectAgentHarness({
+    provider: runtimeSelectionForHarness.model.provider,
+    modelId: runtimeSelectionForHarness.model.id,
+    config: params.cfg,
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+  });
+  if (runtimeHarness.runSideQuestion) {
+    return runHarnessSideQuestion(runtimeHarness, runtimeSelectionForHarness);
+  }
+  if (runtimeHarness.id === "codex") {
+    throw new Error(
+      `Selected agent harness "${runtimeHarness.id}" does not support /btw side questions.`,
+    );
   }
 
   const { model, authProfileId, authProfileIdSource } = runtimeSelectionForHarness;


### PR DESCRIPTION
## Summary

- Extracts the BTW Codex side-question routing fix from #93183 while preserving contributor attribution.
- Routes standalone CLI providers through the canonical Codex runtime before registry or harness resolution.
- Fixes #88902.

## Verification

- `node scripts/run-vitest.mjs src/agents/btw.test.ts extensions/codex/src/app-server/side-question.test.ts`
- Rebased cleanly onto current `main`; `git diff --check origin/main...HEAD` passed.
