### PR TITLE
fix(telegram): show full think levels for live-discovered Ollama models

### DIFF
--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1135,11 +1135,16 @@ export const registerTelegramNativeCommands = ({
                 sessionKey: await resolveTargetSessionKey(),
               })
             : {};
+        const menuCatalog =
+          commandDefinition && menuNeedsModelContext
+            ? await loadModelCatalog({ config: runtimeCfg })
+            : undefined;
         const menu = commandDefinition
           ? resolveCommandArgMenu({
               command: commandDefinition,
               args: commandArgs,
               cfg: runtimeCfg,
+              catalog: menuCatalog,
               ...menuModelContext,
             })
           : null;


### PR DESCRIPTION
> **AI-assisted PR.** Implemented and verified with Claude (Claude Code).

## Summary

- **What**: Telegram /think inline menu was showing only `default, off` for live-discovered Ollama thinking models (e.g., `ollama/glm-5.2:cloud`), even though /think \<level\> commands like `/think medium` were accepted and functional.
- **Root cause**: The menu resolution path used `buildConfiguredModelCatalog()` which reads only statically-configured models. Models discovered at runtime (via the `{"ollama/*":{}}` pattern or automatic Ollama endpoint discovery) were missing from this catalog, so their `reasoning` capability was unavailable to the thinking profile resolver.
- **Fix**: Load the full runtime model catalog via `loadModelCatalog()` when building the command arg menu, ensuring all discovered models and their capabilities are available to the thinking level choice resolver.

Fixes #93835

## Real behavior proof (required for external PRs)

**Behavior addressed**:
Telegram /think menu now shows the correct thinking levels for live-discovered Ollama models instead of only `default, off`.

**Real environment tested**:
OpenClaw dev build with Ollama extension on macOS 26.5.1 with `ollama/glm-5.2:cloud` model discovered via Ollama endpoint.

**Exact steps or command run after this patch**:
```bash
# 1. Configure Ollama provider with runtime discovery
openclaw config set providers '{"ollama":{"baseUrl":"http://localhost:11434"}}'
# 2. Switch to an Ollama model that supports thinking/openclaw reason
/model ollama/glm-5.2:cloud
# 3. Open the /think inline menu in Telegram
/think
```

**Before-fix evidence**:
```
/model ollama/glm-5.2:cloud
/think
> Current thinking level: high
> Options: default, off
/think medium
> Thinking level set to medium.
```
The /think menu shows only `default, off` even though `/think medium` is accepted — the menu doesn't reflect the actual available levels.

**After-fix evidence**:
```
/model ollama/glm-5.2:cloud
/think
> Current thinking level: high
> Options: default, off, low, medium, high, max
```
The /think menu now shows all thinking levels supported by the Ollama model, consistent with what /think commands actually accept.

**Observed result after the fix**:
After loading the runtime model catalog, `resolveCommandArgMenu` has access to the full model reasoning capability metadata, enabling it to present all supported thinking levels for live-discovered models.

**What was not tested**:
- Non-Telegram channels (TUI, Discord) have separate menu resolution paths.
- Edge cases with models that lack reasoning capability entirely (should still show `default, off` correctly).

## Tests and validation

```
✓ extension build succeeds (TypeScript compilation)
✓ Existing bot-native-commands tests pass
```

## Risk / scope

- User visible behavior change: Yes (positive — menu now matches reality)
- Configuration/environment changes: No
- Security/credentials/network changes: No
- Highest risk point: None — the change is passing a richer catalog to an existing function parameter
- Mitigation: The `loadModelCatalog()` function is already used elsewhere in the same module for `resolveTelegramDefaultThinkingLevel`