### PR TITLE
fix(ssh): reject hostnames with stray leading or trailing colons in parseSshTarget

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -29,4 +29,11 @@ describe("parseSshTarget", () => {
     expect(parseSshTarget("me@-badhost")).toBeNull();
     expect(parseSshTarget("-oProxyCommand=echo")).toBeNull();
   });
+
+  it("rejects hostnames with stray leading or trailing colons", () => {
+    expect(parseSshTarget("host:")).toBeNull();
+    expect(parseSshTarget(":22")).toBeNull();
+    expect(parseSshTarget("user@:22")).toBeNull();
+    expect(parseSshTarget("user@host:")).toBeNull();
+  });
 });

--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -31,9 +31,13 @@ describe("parseSshTarget", () => {
   });
 
   it("rejects hostnames with stray leading or trailing colons", () => {
+    // Default-port branch: the whole host part keeps the stray colon.
     expect(parseSshTarget("host:")).toBeNull();
     expect(parseSshTarget(":22")).toBeNull();
     expect(parseSshTarget("user@:22")).toBeNull();
     expect(parseSshTarget("user@host:")).toBeNull();
+    // Explicit-port branch: the port split slices a stray colon into the host.
+    expect(parseSshTarget("host::22")).toBeNull();
+    expect(parseSshTarget(":host:22")).toBeNull();
   });
 });

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -54,6 +54,11 @@ export function parseSshTarget(raw: string): SshParsedTarget | null {
   if (!hostPart) {
     return null;
   }
+  // Reject host parts with leading/trailing colons (e.g. "host:", ":22")
+  // that would otherwise flow into SSH config HostName fields and break connections.
+  if (hostPart.startsWith(":") || hostPart.endsWith(":")) {
+    return null;
+  }
   // Security: Reject hostnames starting with '-' to prevent argument injection
   if (hostPart.startsWith("-")) {
     return null;

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -21,6 +21,13 @@ export type SshTunnel = {
   stop: () => Promise<void>;
 };
 
+// Reject hosts that would corrupt the SSH HostName field or enable argument
+// injection: a leading '-' becomes an ssh option, and a stray leading/trailing
+// ':' (e.g. sliced from "host::22") produces an invalid HostName.
+function isMalformedHost(host: string): boolean {
+  return host.startsWith("-") || host.startsWith(":") || host.endsWith(":");
+}
+
 export function parseSshTarget(raw: string): SshParsedTarget | null {
   const trimmed = raw.trim().replace(/^ssh\s+/, "");
   if (!trimmed) {
@@ -44,8 +51,7 @@ export function parseSshTarget(raw: string): SshParsedTarget | null {
     if (!host || port === undefined || port > 65535) {
       return null;
     }
-    // Security: Reject hostnames starting with '-' to prevent argument injection
-    if (host.startsWith("-")) {
+    if (isMalformedHost(host)) {
       return null;
     }
     return { user: userPart, host, port };
@@ -54,13 +60,7 @@ export function parseSshTarget(raw: string): SshParsedTarget | null {
   if (!hostPart) {
     return null;
   }
-  // Reject host parts with leading/trailing colons (e.g. "host:", ":22")
-  // that would otherwise flow into SSH config HostName fields and break connections.
-  if (hostPart.startsWith(":") || hostPart.endsWith(":")) {
-    return null;
-  }
-  // Security: Reject hostnames starting with '-' to prevent argument injection
-  if (hostPart.startsWith("-")) {
+  if (isMalformedHost(hostPart)) {
     return null;
   }
   return { user: userPart, host: hostPart, port: 22 };


### PR DESCRIPTION
## Summary

`parseSshTarget` currently returns a `host` field that still contains a stray colon when the input has a trailing colon or a leading colon (e.g. `"host:"`, `":22"`, `"user@host:"`). The value flows directly into generated SSH config files (see `src/agents/sandbox/ssh.ts:537`) and the `ssh` CLI argv, which causes the resulting connection to fail with an invalid `HostName`.

This patch adds a guard that rejects any `host` part that starts or ends with `:`. Existing valid inputs (`"host"`, `"host:22"`, `"user@host:22"`) keep working.

## Linked context

N/A (no existing issue)

## Real behavior proof

- **Behavior or issue addressed:** `parseSshTarget` returned `{ host: "host:", port: 22 }` for input `"host:"` instead of rejecting it as invalid.
- **Real environment tested:** Node 22.19, Linux x86_64, local checkout of openclaw/openclaw main (bfc5e49291), TypeScript source executed directly via tsx.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx /tmp/verify-parseSshTarget.mjs
  ```
  Script imports `parseSshTarget` from the patched source and runs 7 inputs covering regressions and edge cases.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```
  === parseSshTarget runtime verification ===

  [PASS] input="host:" (trailing colon without port)
         expected: invalid → null
         got:      null

  [PASS] input=":22" (leading colon without host)
         expected: invalid → null
         got:      null

  [PASS] input="user@:22" (user with leading-colon host)
         expected: invalid → null
         got:      null

  [PASS] input="user@host:" (user@host with trailing colon)
         expected: invalid → null
         got:      null

  [PASS] input="host" (plain hostname)
         expected: valid → object
         got:      {"host":"host","port":22}

  [PASS] input="host:22" (host:port)
         expected: valid → object
         got:      {"host":"host","port":22}

  [PASS] input="me@example.com:2222" (user@host:port)
         expected: valid → object
         got:      {"user":"me","host":"example.com","port":2222}

  === ALL PASSED ===
  ```

- **Observed result after fix:** All 4 previously-broken inputs now correctly return `null`; all 3 previously-valid inputs continue to return correct parsed objects.
- **What was not tested:** End-to-end SSH tunnel creation with these edge-case inputs (covered by the null rejection + existing callers already null-check `parseSshTarget` result before using).

## Tests and validation

```
$ pnpm test src/infra/ssh-tunnel.test.ts
✓ Test Files  1 passed (1)
✓ Tests       4 passed (4)

$ pnpm build
✓ built successfully
```

## Risk checklist

- [x] Does this change affect user-visible behavior? **No** — invalid inputs that previously produced broken SSH configs are now rejected early with a clear null return.
- [x] Does this change affect configuration? **No**
- [x] Does this change affect security? **Yes (positive)** — reduces risk of malformed host values reaching the SSH CLI argv.
- [x] Does this change affect plugins or providers? **No**
- [x] Does this change affect docs? **No**
- [x] Is this change backwards-compatible? **Yes** — all previously-valid inputs remain valid; only previously-broken inputs are now rejected instead of producing garbage.
