### PR TITLE
feat(telegram): export sender isBot field to agent context (fixes #40838)

### DIFF
--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -421,6 +421,7 @@ export async function buildTelegramInboundContextPayload(params: {
       name: senderName,
       username: senderUsername || undefined,
       id: senderId || undefined,
+      isBot: msg.from?.is_bot === true,
     },
     previousTimestamp,
     envelope: envelopeOptions,
@@ -521,6 +522,7 @@ export async function buildTelegramInboundContextPayload(params: {
       ...(senderId ? { id: senderId } : {}),
       name: senderName,
       username: senderUsername || undefined,
+      isBot: msg.from?.is_bot === true,
     },
     conversation: {
       kind: conversationKind,


### PR DESCRIPTION
## What does this PR do?

Exports the `isBot` sender field to agent context for Telegram messages. Currently, the `SenderFacts` type (`src/channels/turn/types.ts:63`) declares `isBot?: boolean` and the QQBot extension populates it, but Telegram never sets it — creating a gap where agents cannot distinguish bot senders from human senders on Telegram.

## Related Issue

Fixes #40838

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `extensions/telegram/src/bot-message-context.session.ts`: Add `isBot: msg.from?.is_bot === true` to both sender object literals (group history recording at line ~424 and inbound context at line ~525). This fills the existing `SenderFacts.isBot` type gap using the Telegram Bot API `msg.from.is_bot` field that is already available on every inbound message.

## How to Test

1. Build: `pnpm build`
2. Send a message from a Telegram bot account to a group where OpenClaw is present
3. The agent's inbound context should now include `sender.isBot: true` for bot senders and `sender.isBot: false` for human senders

## Real behavior proof

- **Behavior addressed:** Telegram extension does not populate `SenderFacts.isBot` despite the type declaring it. Agents cannot determine if a Telegram message sender is a bot.
- **Environment tested:** macOS 26.4.1, Node v22, pnpm build
- **Steps run after the patch:**
```
pnpm build
```
- **Evidence after fix:**
```
grep -n 'isBot' extensions/telegram/src/bot-message-context.session.ts
424:      isBot: msg.from?.is_bot === true,
525:      isBot: msg.from?.is_bot === true,
```
- **Observed result after fix:** Both sender object literals now include `isBot: msg.from?.is_bot === true`. The value is sourced from Telegram's native `msg.from.is_bot` field. QQBot already follows the same pattern at `extensions/qqbot/src/engine/gateway/gateway.ts:80`.
- **What was not tested:** Live Telegram message roundtrip (requires Telegram bot token and group configuration). The change is a direct field pass-through from the existing Telegram Bot API `msg.from.is_bot` boolean.

## Checklist

- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for duplicates
- [x] Only related changes
- [x] Build passes
- [x] Verified type compatibility (`SenderFacts.isBot` already declared)
