### PR TITLE
fix(doctor): deep-merge openai-codex plugin entry when openai already exists

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1920,6 +1920,87 @@ describe("legacy bundled provider discovery migrate", () => {
     expect(res.changes).toContain("Rewrote plugins.slots openai-codex references to openai.");
   });
 
+  it("merges dual OpenAI Codex plugin entries without losing non-conflicting legacy fields", () => {
+    const res = migrateLegacyConfigForTest({
+      plugins: {
+        entries: {
+          openai: {
+            enabled: true,
+            config: {
+              apiKey: "openai-key",
+              organization: "org_123",
+            },
+          },
+          "openai-codex": {
+            enabled: true,
+            config: {
+              baseUrl: "https://chatgpt.com/backend-api/codex",
+            },
+            install: {
+              source: "bundled",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.plugins?.entries?.openai).toEqual({
+      enabled: true,
+      config: {
+        apiKey: "openai-key",
+        organization: "org_123",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      },
+      install: {
+        source: "bundled",
+      },
+    });
+    expect(res.config?.plugins?.entries?.["openai-codex"]).toBeUndefined();
+    expect(res.changes).toContain(
+      "Merged plugins.entries.openai-codex into plugins.entries.openai.",
+    );
+    expect(res.changes).not.toContain(
+      "Rewrote plugins.entries.openai-codex to plugins.entries.openai.",
+    );
+  });
+
+  it("reports dual OpenAI Codex plugin entry conflicts that need manual review", () => {
+    const res = migrateLegacyConfigForTest({
+      plugins: {
+        entries: {
+          openai: {
+            enabled: true,
+            config: {
+              apiKey: "openai-key",
+            },
+          },
+          "openai-codex": {
+            enabled: false,
+            config: {
+              apiKey: "codex-key",
+              baseUrl: "https://chatgpt.com/backend-api/codex",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.plugins?.entries?.openai).toEqual({
+      enabled: true,
+      config: {
+        apiKey: "openai-key",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+      },
+    });
+    expect(res.config?.plugins?.entries?.["openai-codex"]).toBeUndefined();
+    expect(res.changes).toContain(
+      "Merged plugins.entries.openai-codex into plugins.entries.openai.",
+    );
+    expect(res.changes).toContain(
+      "plugins.entries.openai-codex had conflicting values already set on plugins.entries.openai; kept plugins.entries.openai values and review manually: plugins.entries.openai.enabled, plugins.entries.openai.config.apiKey.",
+    );
+  });
+
   it("sets compat mode for existing restrictive plugin allowlists", () => {
     const res = migrateLegacyConfigForTest({
       plugins: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1989,15 +1989,17 @@ describe("legacy bundled provider discovery migrate", () => {
       enabled: true,
       config: {
         apiKey: "openai-key",
-        baseUrl: "https://chatgpt.com/backend-api/codex",
       },
     });
     expect(res.config?.plugins?.entries?.["openai-codex"]).toBeUndefined();
     expect(res.changes).toContain(
       "Merged plugins.entries.openai-codex into plugins.entries.openai.",
     );
-    expect(res.changes).toContain(
+    expect(res.changes).not.toContain(
       "plugins.entries.openai-codex had conflicting values already set on plugins.entries.openai; kept plugins.entries.openai values and review manually: plugins.entries.openai.enabled, plugins.entries.openai.config.apiKey.",
+    );
+    expect(res.changes).toContain(
+      "plugins.entries.openai-codex had a conflicting enabled state; kept plugins.entries.openai unchanged and review skipped legacy fields manually: plugins.entries.openai-codex.config.apiKey, plugins.entries.openai-codex.config.baseUrl, plugins.entries.openai-codex.enabled.",
     );
   });
 

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
@@ -68,42 +68,87 @@ function rewritePluginSlots(value: unknown): boolean {
   return changed;
 }
 
+function areJsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((entry, index) => areJsonValuesEqual(entry, right[index]))
+    );
+  }
+  if (isRecord(left) || isRecord(right)) {
+    if (!isRecord(left) || !isRecord(right)) {
+      return false;
+    }
+    const leftKeys = Object.keys(left).toSorted();
+    const rightKeys = Object.keys(right).toSorted();
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key, index) => key === rightKeys[index] && areJsonValuesEqual(left[key], right[key]),
+      )
+    );
+  }
+  return false;
+}
+
 function deepMergePluginEntry(
   existing: JsonRecord,
   legacy: JsonRecord,
-): JsonRecord {
+  path: string[] = ["plugins", "entries", OPENAI_PLUGIN_ID],
+): { merged: JsonRecord; conflicts: string[] } {
   const merged = { ...existing };
+  const conflicts: string[] = [];
   for (const key of Object.keys(legacy)) {
     const legacyVal = legacy[key];
     const existingVal = merged[key];
     if (!(key in merged)) {
       merged[key] = legacyVal;
     } else if (isRecord(existingVal) && isRecord(legacyVal)) {
-      merged[key] = deepMergePluginEntry(existingVal, legacyVal);
+      const nested = deepMergePluginEntry(existingVal, legacyVal, [...path, key]);
+      merged[key] = nested.merged;
+      conflicts.push(...nested.conflicts);
+    } else if (!areJsonValuesEqual(existingVal, legacyVal)) {
+      conflicts.push([...path, key].join("."));
     }
-    // When canonical already has the key, it wins (no overwrite).
+    // When canonical already has a conflicting key, it wins (no overwrite).
   }
-  return merged;
+  return { merged, conflicts };
 }
 
-function rewritePluginEntries(value: unknown): boolean {
+type PluginEntriesRewriteResult =
+  | { kind: "unchanged" }
+  | { kind: "rewritten" }
+  | { kind: "merged"; conflicts: string[] };
+
+function rewritePluginEntries(value: unknown): PluginEntriesRewriteResult {
   if (!isRecord(value) || !(LEGACY_OPENAI_CODEX_PLUGIN_ID in value)) {
-    return false;
+    return { kind: "unchanged" };
   }
   if (!(OPENAI_PLUGIN_ID in value)) {
     value[OPENAI_PLUGIN_ID] = value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
+    delete value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
+    return { kind: "rewritten" };
+  }
+
+  const existing = value[OPENAI_PLUGIN_ID];
+  const legacy = value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
+  let conflicts: string[] = [];
+  if (isRecord(existing) && isRecord(legacy)) {
+    const merged = deepMergePluginEntry(existing, legacy);
+    value[OPENAI_PLUGIN_ID] = merged.merged;
+    conflicts = merged.conflicts;
+  } else if (!areJsonValuesEqual(existing, legacy)) {
+    conflicts = ["plugins.entries.openai"];
   } else {
-    // When openai already exists, deep-merge the legacy entry so
-    // non-conflicting keys (including nested config) survive.
-    // Canonical entry wins on true conflicts.
-    const existing = value[OPENAI_PLUGIN_ID];
-    const legacy = value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
-    if (isRecord(existing) && isRecord(legacy)) {
-      value[OPENAI_PLUGIN_ID] = deepMergePluginEntry(existing, legacy);
-    }
+    value[OPENAI_PLUGIN_ID] = existing;
   }
   delete value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
-  return true;
+  return { kind: "merged", conflicts };
 }
 
 function rewriteLegacyOpenAICodexPluginPolicy(raw: Record<string, unknown>): string[] {
@@ -119,8 +164,16 @@ function rewriteLegacyOpenAICodexPluginPolicy(raw: Record<string, unknown>): str
       changes.push(`Rewrote plugins.${key} openai-codex references to openai.`);
     }
   }
-  if (rewritePluginEntries(plugins.entries)) {
+  const entriesRewrite = rewritePluginEntries(plugins.entries);
+  if (entriesRewrite.kind === "rewritten") {
     changes.push("Rewrote plugins.entries.openai-codex to plugins.entries.openai.");
+  } else if (entriesRewrite.kind === "merged") {
+    changes.push("Merged plugins.entries.openai-codex into plugins.entries.openai.");
+    if (entriesRewrite.conflicts.length > 0) {
+      changes.push(
+        `plugins.entries.openai-codex had conflicting values already set on plugins.entries.openai; kept plugins.entries.openai values and review manually: ${entriesRewrite.conflicts.join(", ")}.`,
+      );
+    }
   }
   if (rewritePluginSlots(plugins.slots)) {
     changes.push("Rewrote plugins.slots openai-codex references to openai.");

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
@@ -4,7 +4,7 @@ import {
   type LegacyConfigMigrationSpec,
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
-import { isRecord } from "./legacy-config-record-shared.js";
+import { isRecord, type JsonRecord } from "./legacy-config-record-shared.js";
 import { migrateLegacyXSearchConfig } from "./legacy-x-search-migrate.js";
 
 const LEGACY_OPENAI_CODEX_PLUGIN_ID = "openai-codex";
@@ -68,12 +68,39 @@ function rewritePluginSlots(value: unknown): boolean {
   return changed;
 }
 
+function deepMergePluginEntry(
+  existing: JsonRecord,
+  legacy: JsonRecord,
+): JsonRecord {
+  const merged = { ...existing };
+  for (const key of Object.keys(legacy)) {
+    const legacyVal = legacy[key];
+    const existingVal = merged[key];
+    if (!(key in merged)) {
+      merged[key] = legacyVal;
+    } else if (isRecord(existingVal) && isRecord(legacyVal)) {
+      merged[key] = deepMergePluginEntry(existingVal, legacyVal);
+    }
+    // When canonical already has the key, it wins (no overwrite).
+  }
+  return merged;
+}
+
 function rewritePluginEntries(value: unknown): boolean {
   if (!isRecord(value) || !(LEGACY_OPENAI_CODEX_PLUGIN_ID in value)) {
     return false;
   }
   if (!(OPENAI_PLUGIN_ID in value)) {
     value[OPENAI_PLUGIN_ID] = value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
+  } else {
+    // When openai already exists, deep-merge the legacy entry so
+    // non-conflicting keys (including nested config) survive.
+    // Canonical entry wins on true conflicts.
+    const existing = value[OPENAI_PLUGIN_ID];
+    const legacy = value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
+    if (isRecord(existing) && isRecord(legacy)) {
+      value[OPENAI_PLUGIN_ID] = deepMergePluginEntry(existing, legacy);
+    }
   }
   delete value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
   return true;

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts
@@ -120,10 +120,32 @@ function deepMergePluginEntry(
   return { merged, conflicts };
 }
 
+function hasEnabledConflict(existing: JsonRecord, legacy: JsonRecord): boolean {
+  return (
+    "enabled" in existing &&
+    "enabled" in legacy &&
+    !areJsonValuesEqual(existing.enabled, legacy.enabled)
+  );
+}
+
+function collectLegacyPluginEntryPaths(
+  value: unknown,
+  path: string[] = ["plugins", "entries", LEGACY_OPENAI_CODEX_PLUGIN_ID],
+): string[] {
+  if (!isRecord(value)) {
+    return [path.join(".")];
+  }
+  const keys = Object.keys(value).toSorted();
+  if (keys.length === 0) {
+    return [path.join(".")];
+  }
+  return keys.flatMap((key) => collectLegacyPluginEntryPaths(value[key], [...path, key]));
+}
+
 type PluginEntriesRewriteResult =
   | { kind: "unchanged" }
   | { kind: "rewritten" }
-  | { kind: "merged"; conflicts: string[] };
+  | { kind: "merged"; conflicts: string[]; skippedLegacyFields: string[] };
 
 function rewritePluginEntries(value: unknown): PluginEntriesRewriteResult {
   if (!isRecord(value) || !(LEGACY_OPENAI_CODEX_PLUGIN_ID in value)) {
@@ -138,17 +160,23 @@ function rewritePluginEntries(value: unknown): PluginEntriesRewriteResult {
   const existing = value[OPENAI_PLUGIN_ID];
   const legacy = value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
   let conflicts: string[] = [];
+  let skippedLegacyFields: string[] = [];
   if (isRecord(existing) && isRecord(legacy)) {
-    const merged = deepMergePluginEntry(existing, legacy);
-    value[OPENAI_PLUGIN_ID] = merged.merged;
-    conflicts = merged.conflicts;
+    if (hasEnabledConflict(existing, legacy)) {
+      value[OPENAI_PLUGIN_ID] = existing;
+      skippedLegacyFields = collectLegacyPluginEntryPaths(legacy);
+    } else {
+      const merged = deepMergePluginEntry(existing, legacy);
+      value[OPENAI_PLUGIN_ID] = merged.merged;
+      conflicts = merged.conflicts;
+    }
   } else if (!areJsonValuesEqual(existing, legacy)) {
     conflicts = ["plugins.entries.openai"];
   } else {
     value[OPENAI_PLUGIN_ID] = existing;
   }
   delete value[LEGACY_OPENAI_CODEX_PLUGIN_ID];
-  return { kind: "merged", conflicts };
+  return { kind: "merged", conflicts, skippedLegacyFields };
 }
 
 function rewriteLegacyOpenAICodexPluginPolicy(raw: Record<string, unknown>): string[] {
@@ -172,6 +200,11 @@ function rewriteLegacyOpenAICodexPluginPolicy(raw: Record<string, unknown>): str
     if (entriesRewrite.conflicts.length > 0) {
       changes.push(
         `plugins.entries.openai-codex had conflicting values already set on plugins.entries.openai; kept plugins.entries.openai values and review manually: ${entriesRewrite.conflicts.join(", ")}.`,
+      );
+    }
+    if (entriesRewrite.skippedLegacyFields.length > 0) {
+      changes.push(
+        `plugins.entries.openai-codex had a conflicting enabled state; kept plugins.entries.openai unchanged and review skipped legacy fields manually: ${entriesRewrite.skippedLegacyFields.join(", ")}.`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Deep-merge legacy openai-codex plugin entry into openai when both keys exist during doctor migration, preserving baseUrl, reasoningEffort, and other legacy fields.

## Problem

When plugins.entries.openai already exists alongside legacy openai-codex, rewritePluginEntries silently deletes the legacy entry without merging its config. Fields like baseUrl and reasoningEffort are lost, effectively breaking the Codex provider configuration.

## Root Cause

The original rewritePluginEntries only handled the single-key case (legacy-only). When both openai and openai-codex keys existed, the assignment branch was skipped and delete fired unconditionally, dropping all legacy fields.

## Changes

- **`src/commands/doctor/shared/legacy-config-migrations.runtime.providers.ts`** — +31 lines: add deepMergePluginEntry helper that recursively merges legacy keys into the canonical entry, with canonical winning on true conflicts. Mirrors the behavior that migrateLegacyOpenAICodexProvider already implements for the model-level equivalent. Before: {openai:{embeddingModel}} only. After: {openai:{embeddingModel, baseUrl, reasoningEffort}}.

## Testing

CI verification pending.

## Related

Closes #93891