### PR TITLE
fix(cron): reject invalid absolute timestamps

### DIFF
--- a/src/cron/parse.test.ts
+++ b/src/cron/parse.test.ts
@@ -10,4 +10,26 @@ describe("parseAbsoluteTimeMs", () => {
   it("rejects digit-only timestamps outside the Date range", () => {
     expect(parseAbsoluteTimeMs(String(Number.MAX_SAFE_INTEGER))).toBeNull();
   });
+
+  it("parses ISO timestamps with UTC defaults and explicit offsets", () => {
+    expect(parseAbsoluteTimeMs("2026-02-28")).toBe(Date.parse("2026-02-28T00:00:00Z"));
+    expect(parseAbsoluteTimeMs("2026-02-28T12:34:56.789Z")).toBe(
+      Date.parse("2026-02-28T12:34:56.789Z"),
+    );
+    expect(parseAbsoluteTimeMs("2026-02-28T12:34:56+08:00")).toBe(
+      Date.parse("2026-02-28T12:34:56+08:00"),
+    );
+  });
+
+  it.each([
+    "2023-02-29",
+    "2026-02-31",
+    "2026-02-31T00:00:00Z",
+    "2026-04-31T12:34:56Z",
+    "2026-01-01T25:00:00Z",
+    "December 17, 2026 03:24:00",
+    "2026/12/17",
+  ])("rejects invalid absolute timestamp %s", (input) => {
+    expect(parseAbsoluteTimeMs(input)).toBeNull();
+  });
 });

--- a/src/cron/parse.test.ts
+++ b/src/cron/parse.test.ts
@@ -16,6 +16,7 @@ describe("parseAbsoluteTimeMs", () => {
     expect(parseAbsoluteTimeMs("2026-02-28T12:34:56.789Z")).toBe(
       Date.parse("2026-02-28T12:34:56.789Z"),
     );
+    expect(parseAbsoluteTimeMs("2026-02-28T24:00:00Z")).toBe(Date.parse("2026-02-28T24:00:00Z"));
     expect(parseAbsoluteTimeMs("2026-02-28T12:34:56+08:00")).toBe(
       Date.parse("2026-02-28T12:34:56+08:00"),
     );

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -43,17 +43,18 @@ function isValidIsoAbsolute(raw: string) {
   const minute = Number(minuteRaw);
   const second = Number(secondRaw);
   const millisecond = fractionRaw ? Number(fractionRaw.slice(1, 4).padEnd(3, "0")) : 0;
+  const isEndOfDay = hour === 24 && minute === 0 && second === 0 && millisecond === 0;
 
   // Date.parse rolls invalid calendar dates; cron must reject them before scheduling.
   const probe = new Date(0);
   probe.setUTCFullYear(year, month - 1, day);
-  probe.setUTCHours(hour, minute, second, millisecond);
+  probe.setUTCHours(isEndOfDay ? 0 : hour, minute, second, millisecond);
 
   return (
     probe.getUTCFullYear() === year &&
     probe.getUTCMonth() === month - 1 &&
     probe.getUTCDate() === day &&
-    probe.getUTCHours() === hour &&
+    probe.getUTCHours() === (isEndOfDay ? 0 : hour) &&
     probe.getUTCMinutes() === minute &&
     probe.getUTCSeconds() === second &&
     probe.getUTCMilliseconds() === millisecond

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -4,6 +4,8 @@ import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 const ISO_TZ_RE = /(Z|[+-]\d{2}:?\d{2})$/i;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_DATE_TIME_RE = /^\d{4}-\d{2}-\d{2}T/;
+const ISO_ABSOLUTE_RE =
+  /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(\.\d+)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?)?$/;
 
 function normalizeUtcIso(raw: string) {
   if (ISO_TZ_RE.test(raw)) {
@@ -18,6 +20,46 @@ function normalizeUtcIso(raw: string) {
   return raw;
 }
 
+function isValidIsoAbsolute(raw: string) {
+  const match = ISO_ABSOLUTE_RE.exec(raw);
+  if (!match) {
+    return false;
+  }
+
+  const [
+    ,
+    yearRaw,
+    monthRaw,
+    dayRaw,
+    hourRaw = "0",
+    minuteRaw = "0",
+    secondRaw = "0",
+    fractionRaw,
+  ] = match;
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  const hour = Number(hourRaw);
+  const minute = Number(minuteRaw);
+  const second = Number(secondRaw);
+  const millisecond = fractionRaw ? Number(fractionRaw.slice(1, 4).padEnd(3, "0")) : 0;
+
+  // Date.parse rolls invalid calendar dates; cron must reject them before scheduling.
+  const probe = new Date(0);
+  probe.setUTCFullYear(year, month - 1, day);
+  probe.setUTCHours(hour, minute, second, millisecond);
+
+  return (
+    probe.getUTCFullYear() === year &&
+    probe.getUTCMonth() === month - 1 &&
+    probe.getUTCDate() === day &&
+    probe.getUTCHours() === hour &&
+    probe.getUTCMinutes() === minute &&
+    probe.getUTCSeconds() === second &&
+    probe.getUTCMilliseconds() === millisecond
+  );
+}
+
 /** Parses absolute cron timestamps from epoch milliseconds or ISO-like strings normalized to UTC. */
 export function parseAbsoluteTimeMs(input: string): number | null {
   const raw = input.trim();
@@ -29,6 +71,9 @@ export function parseAbsoluteTimeMs(input: string): number | null {
     if (n !== undefined && Number.isFinite(new Date(n).getTime())) {
       return n;
     }
+    return null;
+  }
+  if (!isValidIsoAbsolute(raw)) {
     return null;
   }
   const parsed = Date.parse(normalizeUtcIso(raw));


### PR DESCRIPTION
## Summary

`parseAbsoluteTimeMs` (`src/cron/parse.ts`) accepts invalid absolute timestamps. For non-numeric input it goes straight to `Date.parse(normalizeUtcIso(raw))` and only checks the result is finite — but V8's `Date.parse` silently rolls invalid calendar dates over (`2026-02-31T00:00:00Z` → `2026-03-03`) and accepts non-ISO free text (e.g. `December 17, 2026 03:24:00`).

Reachable path: `normalizeCronJobCreate` (`src/cron/normalize.ts`) normalizes the bad input into a valid-looking ISO string → `validateScheduleTimestamp` (`src/cron/validate-timestamp.ts`) trusts the parser result → it is used for scheduling in `src/cron/service/jobs.ts`. A user-supplied invalid absolute cron time is therefore silently accepted and scheduled at the wrong instant instead of being rejected.

## Changes

- `parseAbsoluteTimeMs`: added `isValidIsoAbsolute`, which re-reads the parsed UTC components to reject `Date.parse`'s calendar rollover (so `2026-02-31` no longer becomes `2026-03-03`), and rejects non-ISO free-text formats before `Date.parse`. Numeric / `NaN` inputs were already rejected; this closes the lenient-`Date.parse` gap. +67 across 2 files (one is the test).

## Real behavior proof

**Behavior addressed**: invalid absolute timestamps (rolled-over calendar dates, non-ISO text) are now rejected (`null`) instead of silently coerced into a valid instant.

**Evidence (real exported function)**: pre-fix, `parseAbsoluteTimeMs("2026-02-31T00:00:00Z")` returns `1772496000000` (Feb 31 accepted, rolled to Mar 3); post-fix it returns `null`.

**Test**: `src/cron/parse.test.ts` drives the real exported `parseAbsoluteTimeMs` — valid ISO / UTC-default / offset still parse, while invalid calendar dates / invalid times / non-ISO text are now rejected. Negative control: the invalid-date assertions fail pre-fix and pass post-fix.

**Local run**: `node scripts/run-vitest.mjs src/cron/parse.test.ts` → 1 file passed, 10 tests passed.

## Scope / context

No linked issue — found via gap analysis on the cron timestamp path. Competing PRs checked (`parseAbsoluteTimeMs`, "cron time parse", "cron invalid date"): #91656 is test coverage, #72449/#69574 handle undefined/null, #70046 is HH:MM/timezone — none address this calendar-rollover / non-ISO acceptance gap.
