### PR TITLE
feat(diagnostics): expose memory pressure thresholds via config

### DIFF
--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -348,6 +348,25 @@ export type DiagnosticsConfig = {
   stuckSessionAbortMs?: number;
   /** Capture a redacted stability snapshot when memory pressure reaches critical. Default: false. */
   memoryPressureSnapshot?: boolean;
+  /** Override default memory pressure thresholds. All fields optional — unset fields use built-in defaults. */
+  memoryPressureThresholds?: {
+    /** RSS threshold in bytes for warning level. Default: 1.5 GiB. */
+    rssWarningBytes?: number;
+    /** RSS threshold in bytes for critical level. Default: 3 GiB. */
+    rssCriticalBytes?: number;
+    /** Heap used threshold in bytes for warning level. Default: 1 GiB. */
+    heapUsedWarningBytes?: number;
+    /** Heap used threshold in bytes for critical level. Default: 2 GiB. */
+    heapUsedCriticalBytes?: number;
+    /** RSS growth threshold in bytes for warning level within growthWindowMs. Default: 512 MiB. */
+    rssGrowthWarningBytes?: number;
+    /** RSS growth threshold in bytes for critical level within growthWindowMs. Default: 1 GiB. */
+    rssGrowthCriticalBytes?: number;
+    /** Time window in milliseconds for RSS growth detection. Default: 600000 (10 min). */
+    growthWindowMs?: number;
+    /** Minimum interval in milliseconds between repeated same-level/reason pressure events. Default: 300000 (5 min). */
+    pressureRepeatMs?: number;
+  };
   otel?: DiagnosticsOtelConfig;
   cacheTrace?: DiagnosticsCacheTraceConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -534,6 +534,18 @@ export const OpenClawSchema = z
         stuckSessionWarnMs: z.number().int().positive().optional(),
         stuckSessionAbortMs: z.number().int().positive().optional(),
         memoryPressureSnapshot: z.boolean().optional(),
+        memoryPressureThresholds: z
+          .object({
+            rssWarningBytes: z.number().int().positive().optional(),
+            rssCriticalBytes: z.number().int().positive().optional(),
+            heapUsedWarningBytes: z.number().int().positive().optional(),
+            heapUsedCriticalBytes: z.number().int().positive().optional(),
+            rssGrowthWarningBytes: z.number().int().positive().optional(),
+            rssGrowthCriticalBytes: z.number().int().positive().optional(),
+            growthWindowMs: z.number().int().positive().optional(),
+            pressureRepeatMs: z.number().int().positive().optional(),
+          })
+          .optional(),
         otel: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -75,6 +75,8 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "diagnostics.stuckSessionAbortMs", kind: "none" },
   { prefix: "diagnostics.memoryPressureSnapshot", kind: "hot" },
+  // Threshold values only read at heartbeat init — require restart to take effect.
+  { prefix: "diagnostics.memoryPressureThresholds", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -61,7 +61,7 @@ function normalizeMemoryUsage(memory: NodeJS.MemoryUsage): DiagnosticMemoryUsage
 function resolveThresholds(
   thresholds?: DiagnosticMemoryThresholds,
 ): Required<DiagnosticMemoryThresholds> {
-  return {
+  const resolved: Required<DiagnosticMemoryThresholds> = {
     rssWarningBytes: thresholds?.rssWarningBytes ?? DEFAULT_RSS_WARNING_BYTES,
     rssCriticalBytes: thresholds?.rssCriticalBytes ?? DEFAULT_RSS_CRITICAL_BYTES,
     heapUsedWarningBytes: thresholds?.heapUsedWarningBytes ?? DEFAULT_HEAP_WARNING_BYTES,
@@ -71,6 +71,26 @@ function resolveThresholds(
     growthWindowMs: thresholds?.growthWindowMs ?? DEFAULT_GROWTH_WINDOW_MS,
     pressureRepeatMs: thresholds?.pressureRepeatMs ?? DEFAULT_PRESSURE_REPEAT_MS,
   };
+  // Validate warning thresholds do not exceed critical thresholds.
+  if (resolved.rssWarningBytes > resolved.rssCriticalBytes) {
+    log.warn(
+      `config: diagnostics.memoryPressureThresholds.rssWarningBytes (${resolved.rssWarningBytes}) exceeds rssCriticalBytes (${resolved.rssCriticalBytes}), clamping to critical value`,
+    );
+    resolved.rssWarningBytes = resolved.rssCriticalBytes;
+  }
+  if (resolved.heapUsedWarningBytes > resolved.heapUsedCriticalBytes) {
+    log.warn(
+      `config: diagnostics.memoryPressureThresholds.heapUsedWarningBytes (${resolved.heapUsedWarningBytes}) exceeds heapUsedCriticalBytes (${resolved.heapUsedCriticalBytes}), clamping to critical value`,
+    );
+    resolved.heapUsedWarningBytes = resolved.heapUsedCriticalBytes;
+  }
+  if (resolved.rssGrowthWarningBytes > resolved.rssGrowthCriticalBytes) {
+    log.warn(
+      `config: diagnostics.memoryPressureThresholds.rssGrowthWarningBytes (${resolved.rssGrowthWarningBytes}) exceeds rssGrowthCriticalBytes (${resolved.rssGrowthCriticalBytes}), clamping to critical value`,
+    );
+    resolved.rssGrowthWarningBytes = resolved.rssGrowthCriticalBytes;
+  }
+  return resolved;
 }
 
 function pickThresholdPressure(params: {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1242,6 +1242,7 @@ export function startDiagnosticHeartbeat(
       emitDiagnosticMemorySample({
         emitSample: shouldRecordMemorySample,
         writeCriticalBundle: shouldWriteCriticalMemoryPressureBundle(heartbeatConfig),
+        thresholds: heartbeatConfig?.diagnostics?.memoryPressureThresholds,
         resolveSessionStorePaths: () => resolveDiagnosticSessionStorePaths(heartbeatConfig),
       });
     }


### PR DESCRIPTION
## Summary
Expose RSS and heap-used memory pressure thresholds via `diagnostics.memoryPressureThresholds` config option, allowing operators to tune thresholds for production deployments with many concurrent agents.

Fixes #93817

## Changes
- Add `memoryPressureThresholds` optional field to `DiagnosticsConfig` type with all 8 sub-fields (rssWarningBytes, rssCriticalBytes, heapUsedWarningBytes, heapUsedCriticalBytes, rssGrowthWarningBytes, rssGrowthCriticalBytes, growthWindowMs, pressureRepeatMs)
- Add Zod validation schema for the new config block
- Wire config thresholds through to `emitDiagnosticMemorySample()` so user-provided values reach `resolveThresholds()`
- Add validation in `resolveThresholds()` that clamps warning thresholds to their corresponding critical threshold if warning > critical (logs a warning)
- Register `diagnostics.memoryPressureThresholds` prefix in reload plan as `kind: "none"` (threshold changes require restart)

## Usage example
```yaml
diagnostics:
  memoryPressureThresholds:
    rssWarningBytes: 3221225472       # 3 GiB
    rssCriticalBytes: 6442450944      # 6 GiB
    heapUsedWarningBytes: 2147483648  # 2 GiB
    heapUsedCriticalBytes: 4294967296 # 4 GiB
```

When unset, all fields fall back to the existing built-in defaults (1.5 GiB RSS warning, 3 GiB critical, etc.), maintaining full backward compatibility.

## Real behavior proof

**Behavior addressed**: Add diagnostics.memoryPressureThresholds config option

**Real setup tested**: Unit tests on this worktree
- **Runtime**: node

**Exact steps or command run after fix**:

```bash
npx vitest run src/logging/diagnostic-memory.test.ts
```

**After-fix evidence**:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Observed result after the fix**: All 11 existing tests pass. The change is additive - all fields default to existing values when unset.

**What was not tested**: Integration/e2e test with actual gateway process. Config validation via the `zod-schema.test.ts` test suite (ran with exit code 0, passes existing tests).

## Tests and validation
- `diagnostic-memory.test.ts`: 11/11 passed
- All config schema tests pass with exit code 0
- Warning <= critical clamping validation added to `resolveThresholds()`

## Risk checklist
Did user-visible behavior change? (`No`)
Did config, environment, or migration behavior change? (`Yes` - new optional config field)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)
What is the highest-risk area?
- Misconfigured thresholds (warning > critical) - handled via clamping with logged warning
How is that risk mitigated?
- Validation in `resolveThresholds()` clamps and warns instead of producing silent incorrect behavior
- All fields are optional and fall back to existing defaults when unset
- Zod schema validates all fields as positive integers

## Current review state
What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- Maintainer review of the proposed config surface and threshold names

Which bot or reviewer comments were addressed?
- N/A - ClawSweeper review on issue did not complete due to Codex infrastructure failure

Co-Authored-By: Claude <noreply@anthropic.com>