### PR TITLE
fix(logging): warn when configured file writes fail

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -31,7 +31,7 @@ Each file rotates when the next write would exceed `logging.maxFileBytes`
 active file, such as `openclaw-YYYY-MM-DD.1.log`, and keeps writing to a fresh
 active log instead of suppressing diagnostics.
 
-You can override the path in `~/.openclaw/openclaw.json`:
+You can override the path in `~/.openclaw/openclaw.json` with a nonblank path:
 
 ```json
 {
@@ -40,6 +40,9 @@ You can override the path in `~/.openclaw/openclaw.json`:
   }
 }
 ```
+
+If an older config contains an empty or whitespace-only `logging.file`, run
+`openclaw doctor --fix` to remove it and restore the default log path.
 
 ## How to read logs
 

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -191,6 +191,16 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("removes a blank logging.file while preserving sibling settings", () => {
+    const res = normalizeCompatibilityConfigValues({
+      logging: { file: "   ", level: "debug" },
+    });
+
+    expect(res.config.logging).toEqual({ level: "debug" });
+    expect(res.changes).toContain("Removed blank logging.file; the default log path will be used.");
+    expect(validateConfigObject(res.config).ok).toBe(true);
+  });
+
   it("removes null workspace values from agents.list entries", () => {
     const res = normalizeCompatibilityConfigValues({
       agents: {

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -11,6 +11,20 @@ import {
   normalizeLegacyOpenAICodexModelsAddMetadata,
 } from "./legacy-config-core-normalizers.js";
 
+function repairBlankLoggingFile(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
+  const logging = cfg.logging;
+  if (typeof logging?.file !== "string" || logging.file.trim().length > 0) {
+    return cfg;
+  }
+
+  const { file: _file, ...rest } = logging;
+  changes.push("Removed blank logging.file; the default log path will be used.");
+  return {
+    ...cfg,
+    logging: Object.keys(rest).length > 0 ? rest : undefined,
+  };
+}
+
 function repairNullAgentWorkspaces(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
   const agents = cfg.agents?.list;
   if (!Array.isArray(agents)) {
@@ -87,6 +101,7 @@ export function normalizeCompatibilityConfigValues(
   }
   next = normalizeLegacyCommandsConfig(next, changes);
   next = normalizeLegacyOpenAICodexModelsAddMetadata(next, changes);
+  next = repairBlankLoggingFile(next, changes);
   next = repairNullAgentWorkspaces(next, changes);
   next = pruneBindingsForMissingAgents(next, changes);
 

--- a/src/config/logging-file-empty.test.ts
+++ b/src/config/logging-file-empty.test.ts
@@ -1,14 +1,14 @@
-// Schema-level tests for logging.file minimum-length validation.
+// Schema-level tests for logging.file blank-value compatibility.
 import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./validation.js";
 
 describe("logging.file config", () => {
-  it("rejects empty string for logging.file", () => {
+  it("keeps an empty logging.file validation-compatible", () => {
+    // Blank persisted values must not fail schema validation: the runtime
+    // trim/fallback treats them as unset, and rejecting here would break
+    // startup for configs that previously stored an empty file path.
     const res = validateConfigObject({ logging: { file: "" } });
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.issues[0]?.path).toBe("logging.file");
-    }
+    expect(res.ok).toBe(true);
   });
 
   it("accepts a non-empty logging.file", () => {

--- a/src/config/logging-file-empty.test.ts
+++ b/src/config/logging-file-empty.test.ts
@@ -1,0 +1,18 @@
+// Schema-level tests for logging.file minimum-length validation.
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("logging.file config", () => {
+  it("rejects empty string for logging.file", () => {
+    const res = validateConfigObject({ logging: { file: "" } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toBe("logging.file");
+    }
+  });
+
+  it("accepts a non-empty logging.file", () => {
+    const res = validateConfigObject({ logging: { file: "/var/log/openclaw.log" } });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/logging-file-empty.test.ts
+++ b/src/config/logging-file-empty.test.ts
@@ -1,18 +1,22 @@
-// Schema-level tests for logging.file blank-value compatibility.
+// Schema-level tests for logging.file blank-value validation.
 import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./validation.js";
 
 describe("logging.file config", () => {
-  it("keeps an empty logging.file validation-compatible", () => {
-    // Blank persisted values must not fail schema validation: the runtime
-    // trim/fallback treats them as unset, and rejecting here would break
-    // startup for configs that previously stored an empty file path.
-    const res = validateConfigObject({ logging: { file: "" } });
-    expect(res.ok).toBe(true);
+  it.each(["", "   ", "\t"])("rejects blank logging.file value %j", (file) => {
+    const res = validateConfigObject({ logging: { file } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toMatch(/logging\.file/);
+    }
   });
 
-  it("accepts a non-empty logging.file", () => {
-    const res = validateConfigObject({ logging: { file: "/var/log/openclaw.log" } });
+  it("preserves exact bytes of a nonblank logging.file", () => {
+    const file = "  /var/log/openclaw log.log  ";
+    const res = validateConfigObject({ logging: { file } });
     expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.logging?.file).toBe(file);
+    }
   });
 });

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -735,7 +735,12 @@ export const OpenClawSchema = z
     logging: z
       .strictObject({
         level: LoggingLevelSchema.optional(),
-        file: z.string().optional(),
+        file: z
+          .string()
+          .optional()
+          .refine((value) => value === undefined || value.trim().length > 0, {
+            message: "logging.file must not be blank",
+          }),
         maxFileBytes: z.number().int().positive().optional(),
         consoleLevel: LoggingLevelSchema.optional(),
         consoleStyle: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -735,7 +735,7 @@ export const OpenClawSchema = z
     logging: z
       .strictObject({
         level: LoggingLevelSchema.optional(),
-        file: z.string().min(1).optional(),
+        file: z.string().optional(),
         maxFileBytes: z.number().int().positive().optional(),
         consoleLevel: LoggingLevelSchema.optional(),
         consoleStyle: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -735,7 +735,7 @@ export const OpenClawSchema = z
     logging: z
       .strictObject({
         level: LoggingLevelSchema.optional(),
-        file: z.string().optional(),
+        file: z.string().min(1).optional(),
         maxFileBytes: z.number().int().positive().optional(),
         consoleLevel: LoggingLevelSchema.optional(),
         consoleStyle: z

--- a/src/logging/log-file-silent-failure.test.ts
+++ b/src/logging/log-file-silent-failure.test.ts
@@ -48,9 +48,15 @@ describe("logging.file silent failure", () => {
     expect(getResolvedLoggerSettings().file).toMatch(/\.log$/);
   });
 
-  it("trims trailing whitespace from a valid path", () => {
+  it("preserves exact bytes of a non-empty path (no silent trim)", () => {
+    // Non-empty configured paths are kept verbatim; only blank values fall back.
     setLoggerOverride({ level: "info", file: `${logPath}  `, maxFileBytes: 1024 * 1024 });
-    expect(getResolvedLoggerSettings().file).toBe(logPath);
+    expect(getResolvedLoggerSettings().file).toBe(`${logPath}  `);
+  });
+
+  it("preserves leading whitespace in a non-empty path", () => {
+    setLoggerOverride({ level: "info", file: `  ${logPath}`, maxFileBytes: 1024 * 1024 });
+    expect(getResolvedLoggerSettings().file).toBe(`  ${logPath}`);
   });
 
   it("emits stderr warning when file writes fail persistently", () => {

--- a/src/logging/log-file-silent-failure.test.ts
+++ b/src/logging/log-file-silent-failure.test.ts
@@ -2,7 +2,7 @@
 // stderr warnings when file writes fail persistently.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getLogger,
   getResolvedLoggerSettings,
@@ -86,5 +86,9 @@ describe("logging.file silent failure", () => {
       }
       fs.rmSync(readonlyDir, { recursive: true, force: true });
     }
+  });
+
+  afterAll(async () => {
+    await logPathTracker.cleanup();
   });
 });

--- a/src/logging/log-file-silent-failure.test.ts
+++ b/src/logging/log-file-silent-failure.test.ts
@@ -1,5 +1,4 @@
-// Log file silent failure tests cover empty paths, whitespace trimming, and
-// stderr warnings when file writes fail persistently.
+// Log file failure tests cover exact configured paths and one warning per failed-write episode.
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,82 +12,63 @@ import { createSuiteLogPathTracker } from "./log-test-helpers.js";
 
 const logPathTracker = createSuiteLogPathTracker("openclaw-log-fail-");
 
-describe("logging.file silent failure", () => {
+describe("logging.file write failures", () => {
   let logPath = "";
 
   beforeAll(async () => {
     await logPathTracker.setup();
   });
+
   beforeEach(() => {
     logPath = logPathTracker.nextPath();
     resetLogger();
     setLoggerOverride(null);
   });
+
   afterEach(() => {
     resetLogger();
     setLoggerOverride(null);
     vi.restoreAllMocks();
-    try {
-      fs.rmSync(logPath, { force: true });
-    } catch {
-      // best-effort cleanup
-    }
-  });
-
-  it("treats empty logging.file as unset and falls back to default", () => {
-    setLoggerOverride({ level: "info", file: "", maxFileBytes: 1024 * 1024 });
-    const settings = getResolvedLoggerSettings();
-    expect(settings.file).not.toBe("");
-    expect(settings.file).toMatch(/\.log$/);
-  });
-
-  it("treats whitespace-only logging.file as unset", () => {
-    setLoggerOverride({ level: "info", file: "   ", maxFileBytes: 1024 * 1024 });
-    expect(getResolvedLoggerSettings().file).not.toBe("   ");
-    expect(getResolvedLoggerSettings().file).toMatch(/\.log$/);
-  });
-
-  it("preserves exact bytes of a non-empty path (no silent trim)", () => {
-    // Non-empty configured paths are kept verbatim; only blank values fall back.
-    setLoggerOverride({ level: "info", file: `${logPath}  `, maxFileBytes: 1024 * 1024 });
-    expect(getResolvedLoggerSettings().file).toBe(`${logPath}  `);
-  });
-
-  it("preserves leading whitespace in a non-empty path", () => {
-    setLoggerOverride({ level: "info", file: `  ${logPath}`, maxFileBytes: 1024 * 1024 });
-    expect(getResolvedLoggerSettings().file).toBe(`  ${logPath}`);
-  });
-
-  it("emits stderr warning when file writes fail persistently", () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
-    // Create a read-only directory so that mkdirSync passes but appendFileSync fails.
-    const readonlyDir = logPathTracker.nextPath();
-    fs.mkdirSync(readonlyDir, { recursive: true });
-    const badPath = path.join(readonlyDir, "openclaw.log");
-    try {
-      fs.chmodSync(readonlyDir, 0o555);
-      setLoggerOverride({ level: "info", file: badPath, maxFileBytes: 1024 * 1024 });
-      const logger = getLogger();
-      logger.error("trigger");
-      logger.error("trigger-2");
-
-      const warnings = stderrSpy.mock.calls
-        .map(([c]) => String(c))
-        .filter((s) => s.includes("log file write failed"));
-      expect(warnings.length).toBeGreaterThanOrEqual(1);
-    } finally {
-      try {
-        fs.chmodSync(readonlyDir, 0o755);
-      } catch {
-        // best effort
-      }
-      fs.rmSync(readonlyDir, { recursive: true, force: true });
-    }
+    fs.rmSync(logPath, { recursive: true, force: true });
   });
 
   afterAll(async () => {
     await logPathTracker.cleanup();
+  });
+
+  it("writes to the exact configured path when it contains spaces", () => {
+    logPath = path.join(path.dirname(logPath), `openclaw log ${path.basename(logPath)}.log`);
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 1024 * 1024 });
+
+    expect(getResolvedLoggerSettings().file).toBe(logPath);
+    getLogger().info("exact-path-marker");
+
+    expect(fs.readFileSync(logPath, "utf8")).toContain("exact-path-marker");
+  });
+
+  it("warns once per failure episode and resets only after a successful append", () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    fs.mkdirSync(logPath, { recursive: true });
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 1024 * 1024 });
+    const logger = getLogger();
+
+    logger.error("failed-write-1");
+    logger.error("failed-write-2");
+    const getWriteFailureWarnings = () =>
+      stderrSpy.mock.calls
+        .map(([chunk]) => String(chunk))
+        .filter((line) => line.includes("log file write failed"));
+    expect(getWriteFailureWarnings()).toHaveLength(1);
+
+    fs.rmSync(logPath, { recursive: true, force: true });
+    logger.info("successful-write");
+    expect(fs.readFileSync(logPath, "utf8")).toContain("successful-write");
+
+    fs.rmSync(logPath, { force: true });
+    fs.mkdirSync(logPath);
+    logger.error("failed-write-after-recovery");
+    expect(getWriteFailureWarnings()).toHaveLength(2);
   });
 });

--- a/src/logging/log-file-silent-failure.test.ts
+++ b/src/logging/log-file-silent-failure.test.ts
@@ -1,0 +1,84 @@
+// Log file silent failure tests cover empty paths, whitespace trimming, and
+// stderr warnings when file writes fail persistently.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getLogger,
+  getResolvedLoggerSettings,
+  resetLogger,
+  setLoggerOverride,
+} from "../logging.js";
+import { createSuiteLogPathTracker } from "./log-test-helpers.js";
+
+const logPathTracker = createSuiteLogPathTracker("openclaw-log-fail-");
+
+describe("logging.file silent failure", () => {
+  let logPath = "";
+
+  beforeAll(async () => {
+    await logPathTracker.setup();
+  });
+  beforeEach(() => {
+    logPath = logPathTracker.nextPath();
+    resetLogger();
+    setLoggerOverride(null);
+  });
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    vi.restoreAllMocks();
+    try {
+      fs.rmSync(logPath, { force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  it("treats empty logging.file as unset and falls back to default", () => {
+    setLoggerOverride({ level: "info", file: "", maxFileBytes: 1024 * 1024 });
+    const settings = getResolvedLoggerSettings();
+    expect(settings.file).not.toBe("");
+    expect(settings.file).toMatch(/\.log$/);
+  });
+
+  it("treats whitespace-only logging.file as unset", () => {
+    setLoggerOverride({ level: "info", file: "   ", maxFileBytes: 1024 * 1024 });
+    expect(getResolvedLoggerSettings().file).not.toBe("   ");
+    expect(getResolvedLoggerSettings().file).toMatch(/\.log$/);
+  });
+
+  it("trims trailing whitespace from a valid path", () => {
+    setLoggerOverride({ level: "info", file: `${logPath}  `, maxFileBytes: 1024 * 1024 });
+    expect(getResolvedLoggerSettings().file).toBe(logPath);
+  });
+
+  it("emits stderr warning when file writes fail persistently", () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    // Create a read-only directory so that mkdirSync passes but appendFileSync fails.
+    const readonlyDir = logPathTracker.nextPath();
+    fs.mkdirSync(readonlyDir, { recursive: true });
+    const badPath = path.join(readonlyDir, "openclaw.log");
+    try {
+      fs.chmodSync(readonlyDir, 0o555);
+      setLoggerOverride({ level: "info", file: badPath, maxFileBytes: 1024 * 1024 });
+      const logger = getLogger();
+      logger.error("trigger");
+      logger.error("trigger-2");
+
+      const warnings = stderrSpy.mock.calls
+        .map(([c]) => String(c))
+        .filter((s) => s.includes("log file write failed"));
+      expect(warnings.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      try {
+        fs.chmodSync(readonlyDir, 0o755);
+      } catch {
+        // best effort
+      }
+      fs.rmSync(readonlyDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -541,8 +541,14 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const rawFile = typeof cfg?.file === "string" ? cfg.file.trim() : undefined;
-  const file = rawFile && rawFile.length > 0 ? rawFile : resolveDefaultActiveLogFile();
+  // Preserve the exact bytes of any non-empty configured path. Trimming here would
+  // silently rewrite a legitimate log path that contains leading/trailing spaces and
+  // write to a different file after upgrade. Trim is used only to detect blank values.
+  const configuredFile = typeof cfg?.file === "string" ? cfg.file : undefined;
+  const file =
+    configuredFile && configuredFile.trim().length > 0
+      ? configuredFile
+      : resolveDefaultActiveLogFile();
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -541,7 +541,8 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? resolveDefaultActiveLogFile();
+  const rawFile = typeof cfg?.file === "string" ? cfg.file.trim() : undefined;
+  const file = rawFile && rawFile.length > 0 ? rawFile : resolveDefaultActiveLogFile();
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }
@@ -591,6 +592,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   }
   let currentFileBytes = getCurrentLogFileBytes(activeFile);
   let warnedAboutRotationFailure = false;
+  let warnedAboutWriteFailure = false;
 
   logger.attachTransport((logObj: LogObj) => {
     try {
@@ -624,6 +626,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
         if (rotateLogFile(activeFile)) {
           currentFileBytes = getCurrentLogFileBytes(activeFile);
           warnedAboutRotationFailure = false;
+          warnedAboutWriteFailure = false;
         } else if (!warnedAboutRotationFailure) {
           warnedAboutRotationFailure = true;
           process.stderr.write(
@@ -633,6 +636,12 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
       }
       if (appendLogLine(activeFile, payload)) {
         currentFileBytes += payloadBytes;
+        warnedAboutWriteFailure = false;
+      } else if (!warnedAboutWriteFailure) {
+        warnedAboutWriteFailure = true;
+        process.stderr.write(
+          `[openclaw] log file write failed; continuing without file log file=${activeFile} (will retry silently; check path/permissions)\n`,
+        );
       }
     } catch {
       // never block on logging failures

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -541,14 +541,7 @@ function resolveSettings(): ResolvedSettings {
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  // Preserve the exact bytes of any non-empty configured path. Trimming here would
-  // silently rewrite a legitimate log path that contains leading/trailing spaces and
-  // write to a different file after upgrade. Trim is used only to detect blank values.
-  const configuredFile = typeof cfg?.file === "string" ? cfg.file : undefined;
-  const file =
-    configuredFile && configuredFile.trim().length > 0
-      ? configuredFile
-      : resolveDefaultActiveLogFile();
+  const file = cfg?.file ?? resolveDefaultActiveLogFile();
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }
@@ -632,7 +625,6 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
         if (rotateLogFile(activeFile)) {
           currentFileBytes = getCurrentLogFileBytes(activeFile);
           warnedAboutRotationFailure = false;
-          warnedAboutWriteFailure = false;
         } else if (!warnedAboutRotationFailure) {
           warnedAboutRotationFailure = true;
           process.stderr.write(


### PR DESCRIPTION
## What Problem This Solves

Operators using a configured log file could lose file logs without a diagnostic when appends failed. Blank persisted `logging.file` values were also accepted as canonical config even though they cannot identify a usable log file.

## Why This Change Was Made

The logger reports the first failed append in each uninterrupted failure episode and retries later writes without flooding stderr. A successful append clears the warning latch; successful rotation does not, because rotation alone does not prove that writes recovered.

Blank values are repaired at the configuration owner boundary rather than by a runtime fallback: canonical validation rejects empty or whitespace-only `logging.file`, and `openclaw doctor --fix` removes an existing blank field while preserving sibling logging settings. Nonblank paths are not trimmed or otherwise transformed.

## User Impact

Operators receive a concise stderr warning when the configured file cannot be written. Logging recovers on a later successful append without restart, and a later independent failure is reported again.

This is an intentional upgrade contract: configurations with `logging.file: ""` or whitespace now require `openclaw doctor --fix`, which removes that field and restores the default log path. The public logging guide documents this repair path.

## Evidence

- Regression tests cover blank schema rejection, byte-preserved nonblank paths, doctor migration while preserving sibling logging settings, one warning per contiguous append-failure episode, recovery on the same logger, and warning re-latching after a later failure.
- Rebased exact head: `4d510c8a16cca2165e75fe64a912b811ede7bc59`, based on current `openclaw/main` at rebase time.
- Exact-head GitHub workflow/review is being refreshed after this body update. The prior proof was recorded against the superseded head and is not represented as current-head proof.
- Documentation: `docs/logging.md` now requires a nonblank override path and directs existing blank configurations to `openclaw doctor --fix`.

## Risk checklist

- [x] One concern, one PR: configured file-log write diagnostics and invalid blank override repair.
- [x] Config contract tightening is paired with a core doctor migration and public operator guidance.
- [x] No runtime compatibility reader or fallback was added.
- [x] No SDK/protocol/auth/provider behavior change.
- [x] No new dependencies or CHANGELOG edit.
- [x] Allow edits by maintainers.
