### PR TITLE
fix(cron): treat isolated setup phases as progress

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -96,6 +96,12 @@ function assertCronRuntimeAuthorityCandidate(params: {
 type CronPromptRunResult = Awaited<ReturnType<typeof runCliAgent>>;
 type CronEmbeddedRuntime = typeof import("./run-embedded.runtime.js");
 type CronSubagentRegistryRuntime = typeof import("./run-subagent-registry.runtime.js");
+type CronRunnerStartedInfo = {
+  lifecycleGeneration?: string;
+  isFallback?: boolean;
+  provider?: string;
+  model?: string;
+};
 
 const cronEmbeddedRuntimeLoader = createLazyImportLoader<CronEmbeddedRuntime>(
   () => import("./run-embedded.runtime.js"),
@@ -276,7 +282,7 @@ function createCronPromptExecutor(params: {
   setRunContinuationCliExecutionProvider?: (provider?: string) => Promise<void>;
   abortSignal?: AbortSignal;
   abortReason: () => string;
-  onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
+  onExecutionStarted?: (info?: CronRunnerStartedInfo) => void;
   onExecutionPhase?: (
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
@@ -364,6 +370,7 @@ function createCronPromptExecutor(params: {
     hasNewGeneratedMediaTaskForSessionKey(params.runSessionKey, attemptMediaTaskIds);
 
   const runPrompt = async (promptText: string) => {
+    let candidateStarted = false;
     const userTurnTranscriptRecorder =
       pendingUserTurn?.promptText === promptText
         ? pendingUserTurn.recorder
@@ -444,6 +451,24 @@ function createCronPromptExecutor(params: {
       canFallbackAfterError: () => !currentAttemptCommittedMedia(),
       mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
+        const isFallback = candidateStarted;
+        candidateStarted = true;
+        const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) =>
+          params.onExecutionStarted?.({
+            ...info,
+            ...(isFallback ? { isFallback: true } : {}),
+            provider: providerOverride,
+            model: modelOverride,
+          });
+        const notifyExecutionPhase = (
+          info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
+            Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
+        ) =>
+          params.onExecutionPhase?.({
+            ...info,
+            provider: providerOverride,
+            model: modelOverride,
+          });
         let contextEngineTurnCandidate: ContextEngineTurnAttemptFacts | undefined;
         attemptMediaTaskIds = getGeneratedMediaTaskIdsForSessionKey(params.runSessionKey);
         if (params.abortSignal?.aborted) {
@@ -601,8 +626,8 @@ function createCronPromptExecutor(params: {
                 ),
                 scheduledToolPolicy,
                 abortSignal: params.abortSignal,
-                onExecutionStarted: params.onExecutionStarted,
-                onExecutionPhase: params.onExecutionPhase,
+                onExecutionStarted: notifyExecutionStarted,
+                onExecutionPhase: notifyExecutionPhase,
                 bootstrapContextMode,
                 bootstrapContextRunKind: "cron",
                 bootstrapPromptWarningSignaturesSeen,
@@ -733,8 +758,8 @@ function createCronPromptExecutor(params: {
             contextEngineTurnCandidate = facts;
           },
           abortSignal: params.abortSignal,
-          onExecutionStarted: params.onExecutionStarted,
-          onExecutionPhase: params.onExecutionPhase,
+          onExecutionStarted: notifyExecutionStarted,
+          onExecutionPhase: notifyExecutionPhase,
           onLaneWait: params.onLaneWait,
           bootstrapPromptWarningSignaturesSeen,
           bootstrapPromptWarningSignature,
@@ -834,7 +859,7 @@ export async function executeCronRun(params: {
   abortSignal?: AbortSignal;
   abortReason: () => string;
   isAborted: () => boolean;
-  onExecutionStarted?: (info?: { lifecycleGeneration?: string }) => void;
+  onExecutionStarted?: (info?: CronRunnerStartedInfo) => void;
   onExecutionPhase?: (
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
       Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,

--- a/src/cron/isolated-agent/run.interim-retry.test.ts
+++ b/src/cron/isolated-agent/run.interim-retry.test.ts
@@ -81,9 +81,11 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
   };
 
   it("regression, retries once when cron returns interim acknowledgement and no descendants were spawned", async () => {
+    const onExecutionStarted = vi.fn();
     usePayloadTextExtraction();
     runEmbeddedAgentMock
       .mockImplementationOnce(async (request) => {
+        request.onExecutionStarted?.();
         request.userTurnTranscriptRecorder?.markRuntimePersisted({
           role: "user",
           content: "test",
@@ -97,17 +99,25 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
           meta: { agentMeta: { usage: { input: 10, output: 20 } } },
         };
       })
-      .mockResolvedValueOnce({
-        payloads: [
-          {
-            text: "SF is 62F and SD is 67F. SD is warmer by 5F.",
-          },
-        ],
-        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      .mockImplementationOnce(async (request) => {
+        request.onExecutionStarted?.();
+        return {
+          payloads: [
+            {
+              text: "SF is 62F and SD is 67F. SD is warmer by 5F.",
+            },
+          ],
+          meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+        };
       });
 
     mockRunCronFallbackPassthrough();
-    await runTurnAndExpectOk(2, 2);
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({ onExecutionStarted }),
+    );
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
     const firstCall = requireEmbeddedAgentCall(0);
     const continuationCall = requireEmbeddedAgentCall(1);
     expect(continuationCall.prompt).toContain("previous response was only an acknowledgement");
@@ -116,6 +126,10 @@ describe("runCronIsolatedAgentTurn — interim ack retry", () => {
     );
     expect(firstCall.suppressNextUserMessagePersistence).toBe(false);
     expect(continuationCall.suppressNextUserMessagePersistence).toBe(false);
+    expect(onExecutionStarted.mock.calls.map(([info]) => info?.isFallback)).toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 
   it("does not retry when the first turn is already a concrete result", async () => {

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -1,5 +1,5 @@
 // Payload fallback tests cover fallback prompt payloads for isolated cron runs.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
@@ -184,6 +184,39 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
     expect(fallbackRequest.mergeExhaustedResult).toBe(
       mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
     );
+  });
+
+  it("marks only later candidates in one prompt as fallback runners", async () => {
+    const onExecutionStarted = vi.fn();
+    const onExecutionPhase = vi.fn();
+    runEmbeddedAgentMock.mockImplementation(async (request) => {
+      request.onExecutionStarted?.();
+      request.onExecutionPhase?.({ phase: "runtime_plugins" });
+      return {
+        payloads: [{ text: "fallback ok" }],
+        meta: { agentMeta: {} },
+      };
+    });
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      await run(provider, model);
+      const result = await run("openai", "gpt-5");
+      return { result, provider: "openai", model: "gpt-5", attempts: [] };
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({ onExecutionStarted, onExecutionPhase }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(onExecutionStarted).toHaveBeenCalledTimes(2);
+    expect(onExecutionStarted.mock.calls.map(([info]) => info)).toEqual([
+      expect.objectContaining({ provider: "openai", model: "gpt-5.4" }),
+      expect.objectContaining({ provider: "openai", model: "gpt-5", isFallback: true }),
+    ]);
+    expect(onExecutionPhase.mock.calls.map(([info]) => info)).toEqual([
+      expect.objectContaining({ provider: "openai", model: "gpt-5.4" }),
+      expect.objectContaining({ provider: "openai", model: "gpt-5" }),
+    ]);
   });
 
   it("plans Anthropic fallbacks canonically while executing compatible attempts through Claude CLI", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -130,7 +130,12 @@ export async function runCronIsolatedAgentTurn(params: {
   let runContextOwnerToken: string | undefined;
   let runLifecycleGeneration = admittedLifecycleGeneration;
   let executionStarted = false;
-  const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) => {
+  const notifyExecutionStarted = (info?: {
+    lifecycleGeneration?: string;
+    isFallback?: boolean;
+    provider?: string;
+    model?: string;
+  }) => {
     executionStarted = true;
     if (info?.lifecycleGeneration) {
       runLifecycleGeneration = info.lifecycleGeneration;
@@ -140,9 +145,10 @@ export async function runCronIsolatedAgentTurn(params: {
       agentId: prepared.context.agentId,
       sessionId: prepared.context.currentRunSessionId(),
       sessionKey: prepared.context.runSessionKey,
+      ...(info?.isFallback === true ? { isFallback: true } : {}),
       phase: "runner_entered",
-      provider: prepared.context.liveSelection.provider,
-      model: prepared.context.liveSelection.model,
+      provider: info?.provider ?? prepared.context.liveSelection.provider,
+      model: info?.model ?? prepared.context.liveSelection.model,
     });
   };
   const notifyExecutionPhase = (

--- a/src/cron/service/agent-watchdog.test.ts
+++ b/src/cron/service/agent-watchdog.test.ts
@@ -14,6 +14,14 @@ const executionPhases = [
   "model_call_started",
 ] as const satisfies readonly CronAgentExecutionPhase[];
 
+const initialSetupPhases = [
+  "workspace",
+  "runtime_plugins",
+  "model_resolution",
+  "auth",
+  "context_engine",
+] as const satisfies readonly CronAgentExecutionPhase[];
+
 const fallbackSetupPhases = [
   "runtime_plugins",
   "model_resolution",
@@ -98,6 +106,48 @@ describe("cron agent setup watchdog", () => {
     expect(watchdog.observedLaneWait()).toBe(false);
   });
 
+  it("keeps the pre-execution watchdog armed for runner entry alone", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 3,
+      triggerTimeout,
+    });
+    const execution = { jobId: "runner-entry-only-job", phase: "runner_entered" } as const;
+
+    watchdog.start();
+    watchdog.noteRunnerStarted(execution);
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS);
+
+    expect(triggerTimeout).toHaveBeenCalledExactlyOnceWith(
+      preExecutionTimeoutErrorMessage(execution),
+    );
+    watchdog.dispose();
+  });
+
+  it.each(initialSetupPhases)(
+    "lets initial %s progress use the configured job timeout",
+    async (phase) => {
+      vi.useFakeTimers();
+      const triggerTimeout = vi.fn();
+      const watchdog = createCronAgentWatchdog({
+        deferUntilRunner: true,
+        jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 3,
+        triggerTimeout,
+      });
+      const jobId = "initial-setup-progress-job";
+
+      watchdog.start();
+      watchdog.noteRunnerStarted({ jobId, phase: "runner_entered" });
+      watchdog.notePhase({ jobId, phase });
+      await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS);
+
+      expect(triggerTimeout).not.toHaveBeenCalled();
+      watchdog.dispose();
+    },
+  );
+
   it.each(
     executionPhases.flatMap((executionPhase) =>
       fallbackSetupPhases.map((fallbackPhase) => ({ executionPhase, fallbackPhase })),
@@ -117,6 +167,7 @@ describe("cron agent setup watchdog", () => {
       watchdog.start();
       watchdog.noteRunnerStarted({ jobId, phase: "runner_entered" });
       watchdog.notePhase({ jobId, phase: executionPhase });
+      watchdog.noteRunnerStarted({ jobId, phase: "runner_entered", isFallback: true });
       watchdog.notePhase({ jobId, phase: fallbackPhase });
 
       await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS - 1);
@@ -129,4 +180,58 @@ describe("cron agent setup watchdog", () => {
       watchdog.dispose();
     },
   );
+
+  it.each(executionPhases)(
+    "keeps the fallback watchdog armed across later setup progress after %s",
+    async (executionPhase) => {
+      vi.useFakeTimers();
+      const triggerTimeout = vi.fn();
+      const watchdog = createCronAgentWatchdog({
+        deferUntilRunner: true,
+        jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 3,
+        triggerTimeout,
+      });
+      const jobId = "fallback-progress-job";
+
+      watchdog.start();
+      watchdog.noteRunnerStarted({ jobId, phase: "runner_entered" });
+      watchdog.notePhase({ jobId, phase: executionPhase });
+      watchdog.noteRunnerStarted({ jobId, phase: "runner_entered", isFallback: true });
+      watchdog.notePhase({ jobId, phase: "runtime_plugins" });
+      await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS / 2);
+      watchdog.notePhase({ jobId, phase: "model_resolution" });
+      watchdog.notePhase({ jobId, phase: "auth" });
+      await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS / 2);
+
+      expect(triggerTimeout).toHaveBeenCalledExactlyOnceWith(
+        preExecutionTimeoutErrorMessage({ jobId, phase: "auth" }),
+      );
+      watchdog.dispose();
+    },
+  );
+
+  it("gives a fallback a fresh guard when the initial runner made no progress", async () => {
+    vi.useFakeTimers();
+    const triggerTimeout = vi.fn();
+    const watchdog = createCronAgentWatchdog({
+      deferUntilRunner: true,
+      jobTimeoutMs: CRON_AGENT_SETUP_WATCHDOG_MS * 3,
+      triggerTimeout,
+    });
+    const jobId = "fallback-after-stalled-runner-job";
+
+    watchdog.start();
+    watchdog.noteRunnerStarted({ jobId, phase: "runner_entered" });
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS - 1);
+    watchdog.noteRunnerStarted({ jobId, phase: "runner_entered", isFallback: true });
+    await vi.advanceTimersByTimeAsync(CRON_AGENT_SETUP_WATCHDOG_MS - 1);
+
+    expect(triggerTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(triggerTimeout).toHaveBeenCalledExactlyOnceWith(
+      preExecutionTimeoutErrorMessage({ jobId, phase: "runner_entered", isFallback: true }),
+    );
+    watchdog.dispose();
+  });
 });

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -19,7 +19,8 @@ const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
 type CronAgentWatchdogState =
   | "waiting_for_runner"
-  | "waiting_for_execution"
+  | "waiting_for_initial_progress"
+  | "waiting_for_fallback_execution"
   | "executing"
   | "timed_out"
   | "disposed";
@@ -114,12 +115,14 @@ export function createCronAgentWatchdog(params: {
     clearTimeout(preExecutionTimeoutId);
     preExecutionTimeoutId = undefined;
   };
+  const isWaitingForExecution = () =>
+    state === "waiting_for_initial_progress" || state === "waiting_for_fallback_execution";
   const startPreExecutionTimeout = () => {
-    if (preExecutionTimeoutId || state !== "waiting_for_execution") {
+    if (preExecutionTimeoutId || !isWaitingForExecution()) {
       return;
     }
     preExecutionTimeoutId = setTimeout(() => {
-      if (state === "waiting_for_execution") {
+      if (isWaitingForExecution()) {
         setTimedOut(preExecutionTimeoutErrorMessage(activeExecution));
       }
     }, resolveCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs));
@@ -128,24 +131,15 @@ export function createCronAgentWatchdog(params: {
     if (!info) {
       return;
     }
-    const previousPhase = activeExecution?.phase;
     activeExecution = { ...activeExecution, ...info };
     const stage = info.phase ? CRON_AGENT_PHASE_WATCHDOG_STAGE[info.phase] : undefined;
-    // A fallback attempt can return to setup-like phases after execution began;
-    // re-arm pre-execution timing so the fallback path cannot stall silently.
-    if (
-      state === "executing" &&
-      previousPhase !== undefined &&
-      CRON_AGENT_PHASE_WATCHDOG_STAGE[previousPhase] === "execution" &&
-      stage === "pre_execution"
-    ) {
-      // Model fallback can move from an execution phase back into setup-like
-      // phases; restart the pre-execution watchdog so fallback stalls are seen.
-      state = "waiting_for_execution";
-      startPreExecutionTimeout();
-      return;
-    }
-    if (stage === "execution") {
+    const observedInitialProgress =
+      state === "waiting_for_initial_progress" &&
+      info.phase !== undefined &&
+      info.phase !== "runner_entered";
+    const observedFallbackExecution =
+      state === "waiting_for_fallback_execution" && stage === "execution";
+    if (observedInitialProgress || observedFallbackExecution) {
       state = "executing";
       clearPreExecutionTimeout();
     }
@@ -179,8 +173,11 @@ export function createCronAgentWatchdog(params: {
       }
       clearSetupTimeout();
       startTimeout();
-      if (state !== "executing") {
-        state = "waiting_for_execution";
+      if (info?.isFallback === true) {
+        clearPreExecutionTimeout();
+        state = "waiting_for_fallback_execution";
+      } else if (state === "waiting_for_runner") {
+        state = "waiting_for_initial_progress";
       }
       noteExecutionProgress(info);
       startPreExecutionTimeout();

--- a/src/cron/service/timer.timeout-watchdog.test.ts
+++ b/src/cron/service/timer.timeout-watchdog.test.ts
@@ -403,7 +403,7 @@ describe("cron service timer regressions", () => {
     }
   });
 
-  it("times out isolated agent runs that stall before execution starts (#74803)", async () => {
+  it("lets isolated setup progress use the configured job timeout (#93912)", async () => {
     vi.useFakeTimers();
     try {
       const store = timerRegressionFixtures.makeStorePath();
@@ -451,13 +451,23 @@ describe("cron service timer regressions", () => {
               sessionKey: "agent:main:cron:isolated-pre-model-timeout-74803:run:cron-run-session",
               phase: "runner_entered",
             });
-            onExecutionPhase?.({
-              jobId: "isolated-pre-model-timeout-74803",
-              agentId: "main",
-              sessionId: "cron-run-session",
-              sessionKey: "agent:main:cron:isolated-pre-model-timeout-74803:run:cron-run-session",
-              phase: "context_engine",
-            });
+            for (const phase of [
+              "workspace",
+              "runtime_plugins",
+              "before_agent_reply",
+              "runtime_plugins",
+              "model_resolution",
+              "auth",
+              "context_engine",
+            ] as const) {
+              onExecutionPhase?.({
+                jobId: "isolated-pre-model-timeout-74803",
+                agentId: "main",
+                sessionId: "cron-run-session",
+                sessionKey: "agent:main:cron:isolated-pre-model-timeout-74803:run:cron-run-session",
+                phase,
+              });
+            }
             started.resolve();
             abortSignal?.addEventListener(
               "abort",
@@ -476,16 +486,21 @@ describe("cron service timer regressions", () => {
       await started.promise;
       await vi.advanceTimersByTimeAsync(60_100);
       now += 60_100;
+      expect(abortObserved).toBe(false);
+      expect(cleanupTimedOutAgentRun).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_139_900);
+      now += 1_139_900;
       await timerPromise;
 
       const job = requireJob(state, "isolated-pre-model-timeout-74803");
       expect(abortObserved).toBe(true);
       expect(job.state.lastStatus).toBe("error");
-      expect(job.state.lastError).toContain("stalled before execution start");
+      expect(job.state.lastError).toContain("job execution timed out");
       expect(job.state.lastError).toContain("context-engine");
       expect(abortReason).toMatchObject({
         name: "TimeoutError",
-        message: expect.stringContaining("context-engine"),
+        message: expect.stringContaining("job execution timed out"),
       });
       expect(cleanupTimedOutAgentRun).toHaveBeenCalledTimes(1);
       const cleanupArgs = requireRecord(firstMockArg(cleanupTimedOutAgentRun));
@@ -691,7 +706,7 @@ describe("cron service timer regressions", () => {
     },
   );
 
-  it("re-arms the pre-execution watchdog when before_agent_reply does not claim (#82811)", async () => {
+  it("re-arms the pre-execution watchdog when a fallback runner returns to setup (#82811)", async () => {
     vi.useFakeTimers();
     try {
       const store = timerRegressionFixtures.makeStorePath();
@@ -752,6 +767,13 @@ describe("cron service timer regressions", () => {
             onExecutionPhase?.({
               jobId: "isolated-before-agent-reply-unhandled-82811",
               phase: "before_agent_reply",
+            });
+            onExecutionStarted?.({
+              jobId: "isolated-before-agent-reply-unhandled-82811",
+              phase: "runner_entered",
+              isFallback: true,
+              provider: "fallback-provider",
+              model: "fallback-model",
             });
             onExecutionPhase?.({
               jobId: "isolated-before-agent-reply-unhandled-82811",

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -256,6 +256,8 @@ export type CronAgentExecutionStarted = {
   agentId?: string;
   sessionId?: string;
   sessionKey?: string;
+  /** True when this runner belongs to a later candidate in the same fallback chain. */
+  isFallback?: boolean;
   phase?: CronAgentExecutionPhase;
   provider?: string;
   model?: string;


### PR DESCRIPTION
Closes #93912

## What Problem This Solves

Fixes an issue where operators running isolated cron agent jobs could see healthy model setup aborted as "stalled before execution start" after 60 seconds, even when the job had a longer configured timeout and continued reporting setup progress.

## Why This Change Was Made

The cron watchdog now treats the first valid setup phase after runner entry as progress and leaves the configured job timeout authoritative. Runner entry without any progress remains bounded, and genuine later candidates in the same model-fallback chain receive a fresh 60-second pre-execution guard that setup phases cannot clear. Interim-ack continuations and live model-switch retries are not mislabeled as fallbacks.

This is a maintainer rewrite of @parthjayaram's original fix and preserves their commit credit. It does not change timeout defaults, cron configuration, delivery, provider routing, or channel behavior.

## User Impact

Isolated cron jobs with slow but healthy workspace/plugin/model/auth/context setup can use their configured timeout instead of being killed at 60 seconds. Jobs that truly stall before progress—including fallback candidates—still fail within the bounded watchdog interval.

## Evidence

Before the production fix, a boundary regression that starts an isolated runner, emits `context_engine`, and configures `timeoutSeconds: 1200` failed after 60.1 seconds because the abort had already fired.

After the fix:

- `node scripts/run-vitest.mjs src/cron/service/agent-watchdog.test.ts src/cron/service/timer.timeout-watchdog.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.interim-retry.test.ts` — 4 files, 81 tests passed.
- The boundary test stays alive after 60.1 seconds and then aborts at the configured 1,200-second wall timeout.
- Runner-only, true fallback, fresh-fallback-budget, fallback-attribution, and interim-continuation branches are covered.
- 20/20 consecutive focused watchdog/timer stress iterations passed (61 tests each).
- `node scripts/check-changed.mjs -- <8 changed files>` passed formatting, lint, core/test typechecks, dead-code, import-cycle, and policy guards.
- Codex autoreview reported no accepted/actionable findings; an independent read-only P0-P3 lifecycle review was clean after two findings were fixed.

No live scheduled provider/channel run was performed. This is deterministic owner-boundary regression and stress proof, not live-provider evidence.
