### PR TITLE
fix: make global tool loop breaker session-wide

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -87,6 +87,8 @@ Per-agent override (optional):
 
 For `exec`, no-progress checks compare stable command outcomes and ignore volatile runtime metadata such as duration, PID, session ID, and working directory. When a run id is available, recent tool-call history is evaluated only within that run so scheduled heartbeat cycles and fresh runs do not inherit stale loop counts from earlier runs.
 
+`globalCircuitBreakerThreshold` is session scoped. It aggregates repeated stable no-progress outcomes across tool patterns in the same run-scoped history, so once the threshold is reached the next tool call is blocked even when it uses a different tool or arguments. Individual detector toggles control their own warning and critical detectors; they do not opt out of the global breaker. One-off tool calls are not counted as no-progress evidence by themselves.
+
 ## Recommended setup
 
 - For smaller models, set `enabled: true` and leave the thresholds at their defaults. Flagship models rarely need rolling-history detection and can leave the master switch at `false` while still benefiting from the post-compaction guard.

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -27,7 +27,7 @@ import {
   runBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
-import { CRITICAL_THRESHOLD } from "./tool-loop-detection.js";
+import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
@@ -356,6 +356,40 @@ describe("before_tool_call loop detection behavior", () => {
 
     const result = await tool.execute(`read-${CRITICAL_THRESHOLD}`, params, undefined, undefined);
     expectToolLoopBlockedResult(result, "identical outcomes");
+  });
+
+  it("blocks a different tool after the global breaker threshold is reached", async () => {
+    const globalBreakerContext = {
+      ...enabledLoopDetectionContext,
+      loopDetection: {
+        enabled: true,
+        detectors: { genericRepeat: false, knownPollNoProgress: true, pingPong: true },
+      },
+    };
+    const readExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "same output" }],
+      details: { ok: true },
+    });
+    const searchExecute = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "search output" }],
+      details: { ok: true },
+    });
+    const readTool = createWrappedTool("read", readExecute, globalBreakerContext);
+    const searchTool = createWrappedTool("memory_search", searchExecute, globalBreakerContext);
+    const readParams = { path: "/tmp/file" };
+
+    for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+      await expectUnblockedToolExecution(readTool, `read-${i}`, readParams);
+    }
+
+    const result = await searchTool.execute(
+      "search-after-global-breaker",
+      { query: "still looping" },
+      undefined,
+      undefined,
+    );
+    expectToolLoopBlockedResult(result, "global circuit breaker");
+    expect(searchExecute).not.toHaveBeenCalled();
   });
 
   it("does not carry loop history across run ids", async () => {
@@ -909,6 +943,8 @@ describe("before_tool_call loop detection behavior", () => {
       await tool.execute("tool-call-proxy", params, undefined, undefined);
       await flush();
 
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(execute.mock.calls[0]?.[1]).toBe(params);
       const started = expectEventFields(emitted[0], {
         type: "tool.execution.started",
       });

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -372,6 +372,8 @@ function cloneParamsForAdjustedReplay(
   try {
     return { ok: true, value: structuredClone(params) };
   } catch {
+    // Execution already uses executeParams; replay bookkeeping is best-effort
+    // for cloneable hook-adjusted values only.
     return { ok: false };
   }
 }

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -569,6 +569,99 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks a different tool after the session-global no-progress threshold", () => {
+      const state = createState();
+      const fixture = createReadNoProgressFixture();
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+
+      const loopResult = detectToolCallLoop(
+        state,
+        "exec",
+        { command: "pwd" },
+        enabledLoopDetectionConfig,
+      );
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(GLOBAL_CIRCUIT_BREAKER_THRESHOLD);
+        expect(loopResult.message).toContain("global circuit breaker");
+      }
+    });
+
+    it("counts stable no-progress repeats across multiple tool patterns", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 4,
+        globalCircuitBreakerThreshold: 5,
+      };
+
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: "read",
+        toolParams: { path: "/tmp/a.txt" },
+        result: { content: [{ type: "text", text: "same read" }], details: { ok: true } },
+        count: 3,
+      });
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: "exec",
+        toolParams: { command: "pwd" },
+        result: {
+          content: [{ type: "text", text: "/workspace" }],
+          details: { status: "completed", exitCode: 0, aggregated: "/workspace" },
+        },
+        count: 2,
+        startIndex: 3,
+      });
+
+      const loopResult = detectToolCallLoop(state, "memory_search", { query: "next" }, config);
+
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(5);
+      }
+    });
+
+    it("does not count unrelated one-off tools as global no-progress", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 4,
+        globalCircuitBreakerThreshold: 5,
+      };
+
+      for (const [index, toolName] of [
+        "read",
+        "list",
+        "exec",
+        "memory_search",
+        "fetch",
+      ].entries()) {
+        recordSuccessfulCall(
+          state,
+          toolName,
+          { id: index },
+          { content: [{ type: "text", text: "same output" }], details: { ok: true } },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/tmp/out" }, config);
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("blocks repeated completed exec calls despite volatile runtime details", () => {
       const state = createState();
       const params = { command: "grafana-api.sh datasources" };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -449,6 +449,46 @@ function getNoProgressStreak(
   return { count: streak, latestResultHash };
 }
 
+function getGlobalNoProgressStreak(history: Array<{ argsHash: string; resultHash?: string }>): {
+  count: number;
+  latestResultHash?: string;
+  patternCount: number;
+} {
+  const patterns = new Map<string, { resultHash: string; count: number }>();
+  let latestResultHash: string | undefined;
+
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (typeof record?.resultHash !== "string" || !record.resultHash) {
+      continue;
+    }
+
+    const existing = patterns.get(record.argsHash);
+    if (!existing) {
+      patterns.set(record.argsHash, { resultHash: record.resultHash, count: 1 });
+      continue;
+    }
+    if (existing.resultHash !== record.resultHash) {
+      break;
+    }
+
+    existing.count += 1;
+    latestResultHash ??= record.resultHash;
+  }
+
+  let count = 0;
+  let patternCount = 0;
+  for (const pattern of patterns.values()) {
+    if (pattern.count < 2) {
+      continue;
+    }
+    count += pattern.count;
+    patternCount += 1;
+  }
+
+  return { count, latestResultHash, patternCount };
+}
+
 function getPingPongStreak(
   history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
   currentSignature: string,
@@ -575,6 +615,10 @@ export function detectToolCallLoop(
   const unknownToolStreak = getUnknownToolRepeatStreak(history, toolName);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
+  // The global breaker is session-scoped: it aggregates repeated stable outcomes
+  // across patterns, while one-off tools are not no-progress evidence by themselves.
+  const globalNoProgress = getGlobalNoProgressStreak(history);
+  const globalNoProgressStreak = globalNoProgress.count;
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
 
@@ -589,17 +633,17 @@ export function detectToolCallLoop(
     };
   }
 
-  if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
+  if (globalNoProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(
-      `Global circuit breaker triggered: ${toolName} repeated ${noProgressStreak} times with no progress`,
+      `Global circuit breaker triggered: session repeated ${globalNoProgressStreak} no-progress outcomes across ${globalNoProgress.patternCount} tool pattern(s)`,
     );
     return {
       stuck: true,
       level: "critical",
       detector: "global_circuit_breaker",
-      count: noProgressStreak,
-      message: `CRITICAL: ${toolName} has repeated identical no-progress outcomes ${noProgressStreak} times. Session execution blocked by global circuit breaker to prevent runaway loops.`,
-      warningKey: `global:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+      count: globalNoProgressStreak,
+      message: `CRITICAL: Session tool calls have repeated identical no-progress outcomes ${globalNoProgressStreak} times across tools. Session execution blocked by global circuit breaker to prevent runaway loops.`,
+      warningKey: `global:session:${globalNoProgress.latestResultHash ?? "none"}`,
     };
   }
 


### PR DESCRIPTION
Fixes #79252.

## Summary

This changes the loop detector's global circuit breaker from a per-tool-pattern count to a session-scoped no-progress fuse. Repeated stable no-progress outcomes now aggregate across tool names and argument hashes within the existing run-scoped history, so a loop cannot avoid the global threshold by rotating between different tools.

It also documents the session-scoped behavior and keeps adjusted-param replay bookkeeping best-effort when a hook-adjusted value cannot be cloned, without blocking the actual tool execution.

## Root Cause

`globalCircuitBreakerThreshold` reused the per-pattern `noProgressStreak` attached to the candidate tool call. That meant the "global" breaker only fired after one specific tool and argument pattern reached the threshold. A run could accumulate repeated stable no-progress outcomes across multiple tools without tripping the breaker.

## Changes

- Add session-global no-progress aggregation for repeated stable outcomes across recent run-scoped tool history.
- Keep unrelated one-off tool calls out of the global no-progress count.
- Preserve the existing detector-specific warning and critical paths.
- Add unit and wrapper e2e coverage for cross-tool and multi-pattern no-progress cases.
- Document the new `globalCircuitBreakerThreshold` semantics in the loop-detection docs.

## Duplicate Work Check

- Rebased onto fresh `origin/main` before push.
- Checked for an existing branch PR: none found for `harjothkhara:codex/79252-global-loop-breaker`.
- Earlier duplicate-work gate found no open PR for `79252 in:body`; the prior direct fix PR #79267 was closed unmerged, and #77318 covers a different consecutive-error/config-surface approach rather than this session-global breaker fix.

## Real behavior proof

Behavior addressed: `globalCircuitBreakerThreshold` now blocks after repeated stable no-progress outcomes across the session, even when the next blocked call uses a different tool.

Real environment tested: Local OpenClaw checkout on macOS, running the actual `src/agents/tool-loop-detection.ts` module through Node/tsx.

Exact steps or command run after this patch: Ran a Node runtime probe that imports `detectToolCallLoop`, `recordToolCall`, and `recordToolCallOutcome` from `src/agents/tool-loop-detection.ts`, records 30 stable `read` outcomes, then asks whether a different `memory_search` call is blocked.

Evidence after fix: Copied console output from the runtime probe:

```text
[agents/loop-detection] Global circuit breaker triggered: session repeated 30 no-progress outcomes across 1 tool pattern(s)
{
  "threshold": 30,
  "crossToolBlocked": true,
  "detector": "global_circuit_breaker",
  "count": 30,
  "nextTool": "memory_search",
  "oneOffBlocked": false
}
```

Observed result after fix: The live detector blocked the next `memory_search` call with `detector: "global_circuit_breaker"` after the session reached 30 repeated stable no-progress outcomes, and it did not block unrelated one-off tool calls.

What was not tested: Full repository check, broad CI lanes, and live channel/provider behavior were not run locally.

## Verification

- `node_modules/.bin/oxfmt --check src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts src/agents/agent-tools.before-tool-call.ts src/agents/agent-tools.before-tool-call.e2e.test.ts docs/tools/loop-detection.md`
- `git diff --check origin/main...HEAD`
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-79252 node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` via the bundled Python runtime: clean, no accepted/actionable findings.

## AI Assistance

This PR was implemented with AI assistance from Codex. The author reviewed the diff, ran the checks above, and kept the branch ready for maintainer edits.
