### PR TITLE
[Bug]: Discord message_tool_only turns can append stale tool-failed warning after successful message send

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -275,6 +275,26 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads).toEqual([]);
   });
 
+  it("suppresses stale tool-error warnings when message-tool delivery already occurred", () => {
+    // GitHub issue #93875 / PR #93925: Discord message_tool_only turns that
+    // deliver the visible reply via message(action=send) can still append a
+    // stale tool-failed warning because deliveredSourceReplyViaMessageTool was
+    // not counted as a user-facing assistant reply in the hasUserFacingAssistantReply
+    // initialization.
+    const payloads = buildPayloads({
+      didDeliverSourceReplyViaMessageTool: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+      messagingToolSourceReplyPayloads: [],
+      lastToolError: { toolName: "read", error: "file not found" },
+    });
+
+    // With the fix, hasUserFacingAssistantReply starts as true because
+    // deliveredSourceReplyViaMessageTool is included. Without it, the tool error
+    // would be surfaced as a stale warning even though the reply was already
+    // successfully delivered via the message tool.
+    expect(payloads).toHaveLength(0);
+  });
+
   it("preserves rich-only internal message-tool source replies", () => {
     const presentation = {
       blocks: [

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -504,7 +504,7 @@ export function buildEmbeddedRunPayloads(params: {
                 : []
         ).filter((text) => !shouldSuppressRawErrorText(text));
 
-  let hasUserFacingAssistantReply = hasSourceReplyPayload;
+  let hasUserFacingAssistantReply = hasSourceReplyPayload || deliveredSourceReplyViaMessageTool;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);
   let hasUserFacingFailureAcknowledgement = false;
   for (const text of answerTexts) {


### PR DESCRIPTION
> **AI-assisted PR.** Implemented and verified with Claude (Claude Code).

## Summary

- **What**: Discord messages sent via `message(action=send)` can still have stale tool-failed warnings appended after a successful message send.
- **Root cause**: `deliveredSourceReplyViaMessageTool` flags when a reply has been delivered via the message tool, but this flag was not considered in the `hasUserFacingAssistantReply` initialization. `resolveToolErrorWarningPolicy` then incorrectly concluded the turn had no user-visible reply and appended a stale warning.
- **Fix**: Add `deliveredSourceReplyViaMessageTool` to the `hasUserFacingAssistantReply` initialization so that replies delivered via message tool are properly recognized as user-facing.

Fixes #93875

## Real behavior proof

**Behavior or issue addressed**: Discord `message_tool_only` turns no longer append a stale tool-failed warning after a successful message send via `message(action=send)`. The one-line fix ensures `deliveredSourceReplyViaMessageTool` is recognized in `hasUserFacingAssistantReply` so the warning policy does not incorrectly flag successful deliveries.

**Real environment tested**: TypeScript compilation + embedded agent runner unit test suite on openclaw main branch with Node.js v24.13.1 on Linux x64.

**Exact steps or command run after this patch**:
Applied the one-line change to `src/agents/embedded-agent-runner/run/payloads.ts`, then ran:
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-embedded-agent.config.ts --reporter=verbose
```

**Evidence after fix**:
The change compiles cleanly and the full embedded agent runner test suite confirms no regressions:

```diff
-  let hasUserFacingAssistantReply = hasSourceReplyPayload;
+  let hasUserFacingAssistantReply = hasSourceReplyPayload || deliveredSourceReplyViaMessageTool;
```

The `deliveredSourceReplyViaMessageTool` flag is already set by the code path that handles `message(action=send)` deliveries and is used elsewhere to suppress redundant assistant artifacts. Adding it to `hasUserFacingAssistantReply` is the logical extension — when a reply was delivered via message tool, the user has seen it, so no warning should be appended.

Console output from the test run confirms 83/84 test files and 1478 tests pass as expected:

```
Test Files  83 passed | 1 failed (84)
     Tests  1478 passed | 58 skipped (1536)
  Duration  315.63s
```

The single failed suite (`attempt.spawn-workspace.context-engine.test.ts`) is a pre-existing hook timeout in an unrelated context-engine test — it also fails on the unmodified `main` branch and is unrelated to this payload change.

**Observed result after fix**:
- TypeScript compilation: no type errors
- All payload-related tests pass (no regressions)
- `hasUserFacingAssistantReply` now correctly accounts for message-tool deliveries
- The fix is a single boolean OR — minimal, safe, and consistent with how `deliveredSourceReplyViaMessageTool` is already used in the same module

**What was not tested**:
- Full end-to-end test with a running Discord bot and real chat channels was not performed due to environment constraints. The fix relies on the existing embedded agent runner test coverage for payload building and warning resolution logic.