### PR TITLE
fix(matrix): recognize MiniMax mm: namespaced reasoning tags in monitor suppression

### DIFF
--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -182,8 +182,9 @@ describe("deliverMatrixReplies", () => {
       cfg,
       replies: [
         { text: "Reasoning:\n_hidden_" },
+        { text: "<mm:think>secret</mm:think>" },
         { text: "<think>still hidden</think>" },
-        { text: "Visible answer" },
+        { text: "thinking about it" },
       ],
       roomId: "room:5",
       client: {} as MatrixClient,
@@ -194,7 +195,7 @@ describe("deliverMatrixReplies", () => {
 
     expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
     expect(sendCall(0)[0]).toBe("room:5");
-    expect(sendCall(0)[1]).toBe("Visible answer");
+    expect(sendCall(0)[1]).toBe("thinking about it");
     expect(sendOptions(0).cfg).toBe(cfg);
   });
 

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -5,9 +5,10 @@ import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
-const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+const THINKING_TAG_RE =
+  /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 const THINKING_BLOCK_RE =
-  /<\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  /<\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
 
 function shouldSuppressReasoningReplyText(text?: string): boolean {
   if (typeof text !== "string") {


### PR DESCRIPTION
## Summary

#93767 brought MiniMax `mm:` namespace support to reasoning-tag handling and noted the same `antml:`-only / no-namespace pattern is duplicated across monitor paths. Those have since been covered — src paths (#93806, merged), Slack monitor preview (#93874, merged), iMessage monitor (#93820) — leaving the **Matrix monitor's hand-rolled suppression fallback** as the last gap:

- `extensions/matrix/src/matrix/monitor/replies.ts` — `THINKING_TAG_RE` / `THINKING_BLOCK_RE`, used by `shouldSuppressReasoningReplyText` (the content-based fallback when a reply isn't already flagged `isReasoning`). Both regexes were still `(?:think(?:ing)?|thought|antthinking)` — no `antml:`, no `mm:`.

Result: a reply containing only `<mm:think>…</mm:think>` that wasn't pre-flagged `isReasoning` is not recognized as reasoning and gets delivered verbatim into the Matrix room, leaking the internal chain-of-thought.

## Changes

- Both `THINKING_TAG_RE` and `THINKING_BLOCK_RE`: `(?:think(?:ing)?|thought|antthinking)` → `(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)`, matching the shared contract in `src/shared/text/reasoning-tags.ts`. The change is strictly confined to the two regex constants — `shouldSuppressReasoningReplyText` and the delivery semantics are untouched (orthogonal to in-flight PRs #93696/#93830 which alter delivery routing).

## Real behavior proof

**Behavior addressed**: a Matrix reply whose content is only a MiniMax `mm:`-namespaced reasoning tag (`<mm:think>…</mm:think>`) and is not pre-flagged `isReasoning` must be recognized as reasoning by the monitor fallback and suppressed (not delivered into the room), instead of being sent verbatim and leaking the chain-of-thought. A plain visible reply must still be delivered.

**Real environment tested**: Node v22.22.0 + tsx, driving the real production function `deliverMatrixReplies` imported directly from the patched `extensions/matrix/src/matrix/monitor/replies.ts` (which calls the changed `shouldSuppressReasoningReplyText` / `THINKING_TAG_RE` / `THINKING_BLOCK_RE`). The only mocked boundary is the outermost Matrix transport `../send.js` (a stub recording what is actually handed to `sendMessageMatrix`), redirected via a node 22 `module.register()` loader hook; the runtime is injected through the real `setMatrixRuntime`. Read-back boundary = the messages the transport actually receives.

**Exact steps or command run after this patch**:
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/replies.test.ts --run`
- standalone real-runtime harness `proof.mts`: `register(loader)` → dynamic-import patched `replies.ts` → `setMatrixRuntime(stub)` → `deliverMatrixReplies({ replies: [{ text: "<mm:think>secret-reasoning-should-be-hidden</mm:think>" }, { text: "the real visible answer" }], roomId: "room:proof", replyToMode: "off", … })` → assert what reached the transport stub.
- Negative control: restore the parent-commit `replies.ts` (revert the regex change) and re-run the same harness.

**Evidence after fix**:
- Vitest: `Test Files 1 passed (1) / Tests 6 passed (6)`.
- Harness (patched):
  ```
  messages actually delivered to transport: ["the real visible answer"]
  mm: reasoning secret LEAKED to transport : false
  plain visible answer delivered           : true
  RESULT: PASS (patched) — mm: reasoning suppressed (not delivered), visible answer delivered.
  ```
- Harness (negative control, fix reverted):
  ```
  messages actually delivered to transport: ["<mm:think>secret-reasoning-should-be-hidden</mm:think>","the real visible answer"]
  mm: reasoning secret LEAKED to transport : true
  RESULT: BUG (pre-patch / reverted) — mm: reasoning tag NOT recognized -> secret leaked to transport.
  ```

**Observed result after fix**: with the patch, the `<mm:think>…</mm:think>` reply is suppressed by `shouldSuppressReasoningReplyText` and never handed to `sendMessageMatrix` (transport receives only `the real visible answer`); reverting the two regex constants makes the same reply leak verbatim into the transport. This confirms the regex change is what closes the leak, and that ordinary visible text is still delivered (no over-suppression).

**What was not tested**: a live Matrix homeserver / federation round-trip and the real `sendMessageMatrix` network path were stubbed at the transport boundary; this proof exercises the suppression decision and the exact content handed to the transport, not Matrix server delivery, encryption, or chunking on a real room.

## Scope / context

Final follow-up in the #93767 `mm:` series (src #93806, Slack #93874 merged; iMessage #93820 open). Matrix and iMessage were the two hand-rolled fallback gaps; iMessage is #93820, this closes Matrix. Orthogonal to #93696/#93830 (delivery routing) — confined to the regex constants.
