### PR TITLE
fix(nodes): guard node catalog and pairing-list scalar fields against non-string entries

### DIFF
--- a/src/cli/nodes-cli/pairing-render.test.ts
+++ b/src/cli/nodes-cli/pairing-render.test.ts
@@ -1,0 +1,41 @@
+// Pending pairing render tests cover crash-safety for malformed pairing-list scalars.
+import { describe, expect, it } from "vitest";
+import { parsePairingList } from "../../shared/node-list-parse.js";
+import { renderPendingPairingRequestsTable } from "./pairing-render.js";
+
+const theme = {
+  heading: (text: string) => text,
+  warn: (text: string) => text,
+  muted: (text: string) => text,
+};
+
+describe("cli/nodes-cli/pairing-render", () => {
+  it("renders pending rows parsed from malformed scalars without throwing", () => {
+    // node.pair.list rows are blind-cast from the pairing file; non-string requestId/nodeId/
+    // displayName/remoteIp once crashed the renderer's .trim()/sanitizeTerminalText calls.
+    const { pending } = parsePairingList({
+      pending: [{ requestId: 7, nodeId: {}, displayName: 42, remoteIp: 99, ts: 1 }],
+    });
+
+    expect(() =>
+      renderPendingPairingRequestsTable({ pending, now: 1000, tableWidth: 80, theme }),
+    ).not.toThrow();
+  });
+
+  it("keeps a valid pending label after normalization", () => {
+    const { pending } = parsePairingList({
+      pending: [
+        { requestId: "r1", nodeId: "n1", displayName: "Phone", remoteIp: "10.0.0.1", ts: 1 },
+      ],
+    });
+
+    const { table } = renderPendingPairingRequestsTable({
+      pending,
+      now: 1000,
+      tableWidth: 80,
+      theme,
+    });
+    expect(table).toContain("Phone");
+    expect(table).toContain("10.0.0.1");
+  });
+});

--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -444,4 +444,40 @@ describe("gateway/node-catalog", () => {
     expect(nodes[0]?.caps).toEqual(["camera"]);
     expect(nodes[0]?.commands).toEqual(["system.run"]);
   });
+
+  it("normalizes non-string scalar fields from malformed pairing records (no nodes-status crash)", () => {
+    // Paired/pending records are blind-cast from disk, so every formatter-facing scalar can be a
+    // non-string; before this guard a `nodes status` formatter (.trim() / sanitizeTerminalText) threw.
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [
+        pairedDevice({
+          deviceId: "mac-1",
+          clientId: 456 as unknown as string,
+          clientMode: 789 as unknown as string,
+        }),
+      ],
+      pairedNodes: [
+        pairedNode({
+          nodeId: "mac-1",
+          version: 123 as unknown as string,
+          displayName: 321 as unknown as string,
+          platform: 11 as unknown as string,
+          remoteIp: 22 as unknown as string,
+          deviceFamily: 33 as unknown as string,
+          modelIdentifier: 44 as unknown as string,
+        }),
+      ],
+      connectedNodes: [],
+    });
+
+    const node = getKnownNode(catalog, "mac-1");
+    expect(node?.version).toBeUndefined();
+    expect(node?.displayName).toBeUndefined();
+    expect(node?.clientId).toBeUndefined();
+    expect(node?.clientMode).toBeUndefined();
+    expect(node?.platform).toBeUndefined();
+    expect(node?.remoteIp).toBeUndefined();
+    expect(node?.deviceFamily).toBeUndefined();
+    expect(node?.modelIdentifier).toBeUndefined();
+  });
 });

--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -480,4 +480,25 @@ describe("gateway/node-catalog", () => {
     expect(node?.deviceFamily).toBeUndefined();
     expect(node?.modelIdentifier).toBeUndefined();
   });
+
+  it("drops blind-cast pairing entries whose required id is not a string", () => {
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [
+        pairedDevice({ deviceId: "good-node" }),
+        // A corrupted pairing file can carry a non-string id; without the catalog id guard
+        // these would key the maps and crash listKnownNodes' nodeId.localeCompare sort.
+        pairedDevice({ deviceId: 7 as unknown as string }),
+      ],
+      pairedNodes: [
+        pairedNode({ nodeId: "good-node" }),
+        pairedNode({ nodeId: {} as unknown as string }),
+      ],
+      pendingNodes: [pendingNode({ nodeId: [] as unknown as string })],
+      connectedNodes: [],
+    });
+
+    const nodes = listKnownNodes(catalog);
+    expect(nodes.map((entry) => entry.nodeId)).toEqual(["good-node"]);
+    expect(getKnownNode(catalog, "good-node")).not.toBeNull();
+  });
 });

--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -452,6 +452,7 @@ describe("gateway/node-catalog", () => {
       pairedDevices: [
         pairedDevice({
           deviceId: "mac-1",
+          displayName: 654 as unknown as string,
           clientId: 456 as unknown as string,
           clientMode: 789 as unknown as string,
         }),
@@ -479,6 +480,35 @@ describe("gateway/node-catalog", () => {
     expect(node?.remoteIp).toBeUndefined();
     expect(node?.deviceFamily).toBeUndefined();
     expect(node?.modelIdentifier).toBeUndefined();
+  });
+
+  it("falls through a non-string higher-priority scalar to a valid lower-priority value", () => {
+    // A corrupted live (higher-priority) scalar must be treated as ABSENT so the valid paired
+    // (lower-priority) value still surfaces, instead of the malformed value suppressing it.
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [pairedDevice({ deviceId: "mac-1" })],
+      pairedNodes: [
+        pairedNode({ nodeId: "mac-1", displayName: "Node Display", platform: "linux" }),
+      ],
+      connectedNodes: [
+        {
+          nodeId: "mac-1",
+          connId: "conn-1",
+          client: {} as never,
+          displayName: 42 as unknown as string,
+          platform: {} as unknown as string,
+          declaredCaps: [],
+          caps: [],
+          declaredCommands: [],
+          commands: [],
+          connectedAtMs: 1,
+        },
+      ],
+    });
+
+    const node = getKnownNode(catalog, "mac-1");
+    expect(node?.displayName).toBe("Node Display");
+    expect(node?.platform).toBe("linux");
   });
 
   it("drops blind-cast pairing entries whose required id is not a string", () => {

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -1,6 +1,9 @@
 // Gateway node catalog builder.
 // Merges paired devices, approved node records, and live websocket sessions.
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { normalizeSortedUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { hasEffectivePairedDeviceRole, type PairedDevice } from "../infra/device-pairing.js";
 import {
@@ -75,6 +78,13 @@ type KnownNodeCatalog = {
 
 function uniqueSortedStrings(...items: Array<readonly unknown[] | undefined>): string[] {
   return normalizeSortedUniqueTrimmedStringList(items.flatMap((item) => item ?? []));
+}
+
+// Catalog scalars come from blind-cast pairing records, so coerce every formatter-facing optional
+// string scalar to a trimmed string or undefined: a non-string would crash `nodes status`/`nodes
+// list` formatters (.trim(), sanitizeTerminalText/stripAnsi). Scalar analog of uniqueSortedStrings.
+function firstNormalizedString(...values: unknown[]): string | undefined {
+  return normalizeOptionalString(values.find((value) => value != null));
 }
 
 function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSource {
@@ -182,7 +192,7 @@ function resolveEffectiveLastSeen(params: {
   }
   return {
     lastSeenAtMs: newest.atMs,
-    lastSeenReason: newest.reason,
+    lastSeenReason: normalizeOptionalString(newest.reason),
   };
 }
 
@@ -197,30 +207,59 @@ function buildEffectiveKnownNode(entry: {
   const lastSeen = resolveEffectiveLastSeen({ live, devicePairing, nodePairing });
   return {
     nodeId,
-    displayName:
-      live?.displayName ??
-      nodePairing?.displayName ??
-      devicePairing?.displayName ??
+    displayName: firstNormalizedString(
+      live?.displayName,
+      nodePairing?.displayName,
+      devicePairing?.displayName,
       pendingNodePairing?.displayName,
-    platform:
-      live?.platform ??
-      nodePairing?.platform ??
-      devicePairing?.platform ??
+    ),
+    platform: firstNormalizedString(
+      live?.platform,
+      nodePairing?.platform,
+      devicePairing?.platform,
       pendingNodePairing?.platform,
-    version: live?.version ?? nodePairing?.version ?? pendingNodePairing?.version,
-    coreVersion: live?.coreVersion ?? nodePairing?.coreVersion ?? pendingNodePairing?.coreVersion,
-    uiVersion: live?.uiVersion ?? nodePairing?.uiVersion ?? pendingNodePairing?.uiVersion,
-    clientId: live?.clientId ?? devicePairing?.clientId ?? pendingNodePairing?.clientId,
-    clientMode: live?.clientMode ?? devicePairing?.clientMode ?? pendingNodePairing?.clientMode,
-    deviceFamily:
-      live?.deviceFamily ?? nodePairing?.deviceFamily ?? pendingNodePairing?.deviceFamily,
-    modelIdentifier:
-      live?.modelIdentifier ?? nodePairing?.modelIdentifier ?? pendingNodePairing?.modelIdentifier,
-    remoteIp:
-      live?.remoteIp ??
-      nodePairing?.remoteIp ??
-      devicePairing?.remoteIp ??
+    ),
+    version: firstNormalizedString(
+      live?.version,
+      nodePairing?.version,
+      pendingNodePairing?.version,
+    ),
+    coreVersion: firstNormalizedString(
+      live?.coreVersion,
+      nodePairing?.coreVersion,
+      pendingNodePairing?.coreVersion,
+    ),
+    uiVersion: firstNormalizedString(
+      live?.uiVersion,
+      nodePairing?.uiVersion,
+      pendingNodePairing?.uiVersion,
+    ),
+    clientId: firstNormalizedString(
+      live?.clientId,
+      devicePairing?.clientId,
+      pendingNodePairing?.clientId,
+    ),
+    clientMode: firstNormalizedString(
+      live?.clientMode,
+      devicePairing?.clientMode,
+      pendingNodePairing?.clientMode,
+    ),
+    deviceFamily: firstNormalizedString(
+      live?.deviceFamily,
+      nodePairing?.deviceFamily,
+      pendingNodePairing?.deviceFamily,
+    ),
+    modelIdentifier: firstNormalizedString(
+      live?.modelIdentifier,
+      nodePairing?.modelIdentifier,
+      pendingNodePairing?.modelIdentifier,
+    ),
+    remoteIp: firstNormalizedString(
+      live?.remoteIp,
+      nodePairing?.remoteIp,
+      devicePairing?.remoteIp,
       pendingNodePairing?.remoteIp,
+    ),
     caps: live ? uniqueSortedStrings(live.caps) : uniqueSortedStrings(nodePairing?.caps),
     commands: live
       ? uniqueSortedStrings(live.commands)

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -87,6 +87,12 @@ function firstNormalizedString(...values: unknown[]): string | undefined {
   return normalizeOptionalString(values.find((value) => value != null));
 }
 
+// Blind-cast pairing records can carry a non-string id; a node with no addressable string
+// id is unusable and would crash the id-based catalog sort/format, so drop it entirely.
+function hasAddressableId(value: unknown): boolean {
+  return normalizeOptionalString(value) !== undefined;
+}
+
 function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSource {
   return {
     nodeId: entry.deviceId,
@@ -310,15 +316,22 @@ export function createKnownNodeCatalog(params: {
 }): KnownNodeCatalog {
   const devicePairingById = new Map(
     params.pairedDevices
-      .filter((entry) => hasEffectivePairedDeviceRole(entry, "node"))
+      .filter(
+        (entry) => hasAddressableId(entry.deviceId) && hasEffectivePairedDeviceRole(entry, "node"),
+      )
       .map((entry) => [entry.deviceId, buildDevicePairingSource(entry)]),
   );
   const nodePairingById = new Map(
-    (params.pairedNodes ?? []).map((entry) => [entry.nodeId, buildApprovedNodeSource(entry)]),
+    (params.pairedNodes ?? [])
+      .filter((entry) => hasAddressableId(entry.nodeId))
+      .map((entry) => [entry.nodeId, buildApprovedNodeSource(entry)]),
   );
   const pendingNodePairingById = new Map<string, KnownNodePendingSource>();
   // listNodePairing returns newest requests first; keep the current approval action per node.
   for (const entry of params.pendingNodes ?? []) {
+    if (!hasAddressableId(entry.nodeId)) {
+      continue;
+    }
     if (!pendingNodePairingById.has(entry.nodeId)) {
       pendingNodePairingById.set(entry.nodeId, buildPendingNodeSource(entry));
     }

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -84,7 +84,16 @@ function uniqueSortedStrings(...items: Array<readonly unknown[] | undefined>): s
 // string scalar to a trimmed string or undefined: a non-string would crash `nodes status`/`nodes
 // list` formatters (.trim(), sanitizeTerminalText/stripAnsi). Scalar analog of uniqueSortedStrings.
 function firstNormalizedString(...values: unknown[]): string | undefined {
-  return normalizeOptionalString(values.find((value) => value != null));
+  // Treat a non-string (or empty) higher-priority value as ABSENT and fall through, instead of
+  // letting `find` pick the first non-null value and normalize it to undefined — which would
+  // suppress a valid lower-priority string. Return the first value that yields a trimmed string.
+  for (const value of values) {
+    const normalized = normalizeOptionalString(value);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+  }
+  return undefined;
 }
 
 // Blind-cast pairing records can carry a non-string id; a node with no addressable string

--- a/src/shared/node-list-parse.test.ts
+++ b/src/shared/node-list-parse.test.ts
@@ -61,21 +61,29 @@ describe("shared/node-list-parse", () => {
     });
   });
 
-  it("normalizes non-string scalars from malformed pairing rows", () => {
+  it("drops pairing rows with a non-string or empty required id instead of emitting empty-id sentinels", () => {
     const { pending, paired } = parsePairingList({
-      pending: [{ requestId: 7, nodeId: {}, displayName: 42, remoteIp: 99, platform: true, ts: 1 }],
-      paired: [{ nodeId: 5, displayName: { x: 1 }, remoteIp: [], token: 3, lastSeenReason: 0 }],
+      pending: [
+        { requestId: 7, nodeId: {}, ts: 1 }, // non-string required ids -> dropped
+        { requestId: "  ", nodeId: "n0", ts: 2 }, // whitespace-only requestId -> dropped
+        { requestId: "r1", nodeId: "n1", displayName: 42, remoteIp: 99, platform: true, ts: 3 },
+      ],
+      paired: [
+        { nodeId: 5, token: 3 }, // non-string nodeId -> dropped
+        { nodeId: "n2", displayName: { x: 1 }, remoteIp: [], lastSeenReason: 0 },
+      ],
     });
-    // Required ids coerce to "", optional scalars normalize to undefined — no non-string survives
-    // for the CLI renderers that call .trim()/sanitizeTerminalText on these fields.
-    expect(pending[0]).toMatchObject({ requestId: "", nodeId: "" });
+    // A malformed required id drops the whole row (no "" sentinel a consumer would trust); the valid
+    // row survives with optional scalars normalized to undefined so renderers never trim a non-string.
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({ requestId: "r1", nodeId: "n1" });
     expect(pending[0].displayName).toBeUndefined();
     expect(pending[0].remoteIp).toBeUndefined();
     expect(pending[0].platform).toBeUndefined();
-    expect(paired[0]).toMatchObject({ nodeId: "" });
+    expect(paired).toHaveLength(1);
+    expect(paired[0]).toMatchObject({ nodeId: "n2" });
     expect(paired[0].displayName).toBeUndefined();
     expect(paired[0].remoteIp).toBeUndefined();
-    expect(paired[0].token).toBeUndefined();
     expect(paired[0].lastSeenReason).toBeUndefined();
   });
 });

--- a/src/shared/node-list-parse.test.ts
+++ b/src/shared/node-list-parse.test.ts
@@ -60,4 +60,22 @@ describe("shared/node-list-parse", () => {
       paired: [{ nodeId: "n1" }],
     });
   });
+
+  it("normalizes non-string scalars from malformed pairing rows", () => {
+    const { pending, paired } = parsePairingList({
+      pending: [{ requestId: 7, nodeId: {}, displayName: 42, remoteIp: 99, platform: true, ts: 1 }],
+      paired: [{ nodeId: 5, displayName: { x: 1 }, remoteIp: [], token: 3, lastSeenReason: 0 }],
+    });
+    // Required ids coerce to "", optional scalars normalize to undefined — no non-string survives
+    // for the CLI renderers that call .trim()/sanitizeTerminalText on these fields.
+    expect(pending[0]).toMatchObject({ requestId: "", nodeId: "" });
+    expect(pending[0].displayName).toBeUndefined();
+    expect(pending[0].remoteIp).toBeUndefined();
+    expect(pending[0].platform).toBeUndefined();
+    expect(paired[0]).toMatchObject({ nodeId: "" });
+    expect(paired[0].displayName).toBeUndefined();
+    expect(paired[0].remoteIp).toBeUndefined();
+    expect(paired[0].token).toBeUndefined();
+    expect(paired[0].lastSeenReason).toBeUndefined();
+  });
 });

--- a/src/shared/node-list-parse.ts
+++ b/src/shared/node-list-parse.ts
@@ -1,12 +1,54 @@
 // Node list parsing helpers normalize node inventory records from CLI output.
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { NodeListNode, PairedNode, PairingList, PendingRequest } from "./node-list-types.js";
+
+// pending/paired rows are blind-cast from a permissive pairing file, so any scalar can be
+// non-string. CLI renderers call `.trim()`/`sanitizeTerminalText` on them (these rows bypass
+// the gateway node catalog), so normalize at this shared parse boundary to keep every
+// consumer crash-safe.
+function coerceRequiredString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizePendingRequest(row: PendingRequest): PendingRequest {
+  return {
+    ...row,
+    requestId: coerceRequiredString(row.requestId),
+    nodeId: coerceRequiredString(row.nodeId),
+    displayName: normalizeOptionalString(row.displayName),
+    platform: normalizeOptionalString(row.platform),
+    version: normalizeOptionalString(row.version),
+    coreVersion: normalizeOptionalString(row.coreVersion),
+    uiVersion: normalizeOptionalString(row.uiVersion),
+    remoteIp: normalizeOptionalString(row.remoteIp),
+  };
+}
+
+function normalizePairedNode(row: PairedNode): PairedNode {
+  return {
+    ...row,
+    nodeId: coerceRequiredString(row.nodeId),
+    token: normalizeOptionalString(row.token),
+    displayName: normalizeOptionalString(row.displayName),
+    platform: normalizeOptionalString(row.platform),
+    version: normalizeOptionalString(row.version),
+    coreVersion: normalizeOptionalString(row.coreVersion),
+    uiVersion: normalizeOptionalString(row.uiVersion),
+    remoteIp: normalizeOptionalString(row.remoteIp),
+    lastSeenReason: normalizeOptionalString(row.lastSeenReason),
+  };
+}
 
 /** Extracts pending and paired node arrays from permissive node.pair.list payloads. */
 export function parsePairingList(value: unknown): PairingList {
   const obj = asRecord(value);
-  const pending = Array.isArray(obj.pending) ? (obj.pending as PendingRequest[]) : [];
-  const paired = Array.isArray(obj.paired) ? (obj.paired as PairedNode[]) : [];
+  const pending = Array.isArray(obj.pending)
+    ? (obj.pending as PendingRequest[]).map(normalizePendingRequest)
+    : [];
+  const paired = Array.isArray(obj.paired)
+    ? (obj.paired as PairedNode[]).map(normalizePairedNode)
+    : [];
   return { pending, paired };
 }
 

--- a/src/shared/node-list-parse.ts
+++ b/src/shared/node-list-parse.ts
@@ -7,15 +7,19 @@ import type { NodeListNode, PairedNode, PairingList, PendingRequest } from "./no
 // non-string. CLI renderers call `.trim()`/`sanitizeTerminalText` on them (these rows bypass
 // the gateway node catalog), so normalize at this shared parse boundary to keep every
 // consumer crash-safe.
-function coerceRequiredString(value: unknown): string {
-  return typeof value === "string" ? value : "";
-}
-
-function normalizePendingRequest(row: PendingRequest): PendingRequest {
+// A pending/paired row needs an addressable string id to be approved, keyed, or rendered. A
+// non-string required id drops the row entirely rather than becoming an empty-string sentinel that
+// downstream consumers would treat as a real id.
+function normalizePendingRequest(row: PendingRequest): PendingRequest | null {
+  const requestId = normalizeOptionalString(row.requestId);
+  const nodeId = normalizeOptionalString(row.nodeId);
+  if (requestId === undefined || nodeId === undefined) {
+    return null;
+  }
   return {
     ...row,
-    requestId: coerceRequiredString(row.requestId),
-    nodeId: coerceRequiredString(row.nodeId),
+    requestId,
+    nodeId,
     displayName: normalizeOptionalString(row.displayName),
     platform: normalizeOptionalString(row.platform),
     version: normalizeOptionalString(row.version),
@@ -25,10 +29,14 @@ function normalizePendingRequest(row: PendingRequest): PendingRequest {
   };
 }
 
-function normalizePairedNode(row: PairedNode): PairedNode {
+function normalizePairedNode(row: PairedNode): PairedNode | null {
+  const nodeId = normalizeOptionalString(row.nodeId);
+  if (nodeId === undefined) {
+    return null;
+  }
   return {
     ...row,
-    nodeId: coerceRequiredString(row.nodeId),
+    nodeId,
     token: normalizeOptionalString(row.token),
     displayName: normalizeOptionalString(row.displayName),
     platform: normalizeOptionalString(row.platform),
@@ -44,10 +52,14 @@ function normalizePairedNode(row: PairedNode): PairedNode {
 export function parsePairingList(value: unknown): PairingList {
   const obj = asRecord(value);
   const pending = Array.isArray(obj.pending)
-    ? (obj.pending as PendingRequest[]).map(normalizePendingRequest)
+    ? (obj.pending as PendingRequest[])
+        .map(normalizePendingRequest)
+        .filter((row): row is PendingRequest => row !== null)
     : [];
   const paired = Array.isArray(obj.paired)
-    ? (obj.paired as PairedNode[]).map(normalizePairedNode)
+    ? (obj.paired as PairedNode[])
+        .map(normalizePairedNode)
+        .filter((row): row is PairedNode => row !== null)
     : [];
   return { pending, paired };
 }


### PR DESCRIPTION
## Summary

`buildEffectiveKnownNode` in `src/gateway/node-catalog.ts` emits the node **scalar** fields raw from the pairing sources, while only the array fields (`caps`/`commands`) are hardened via `uniqueSortedStrings`. Those sources (paired devices, approved nodes, pending requests) are blind-cast from disk (`coercePairingStateRecord` and the node-pairing loaders do no per-field type check), so a malformed/legacy record with a **non-string** `version` / `displayName` / `clientId` / `clientMode` reaches the catalog intact.

The `openclaw nodes status` CLI formatters in `src/cli/nodes-cli/register.status.ts` then call `node.version?.trim()` (line 54), `node.clientId?.trim()` (97), `node.clientMode?.trim()` (98), and `node.displayName?.trim()` (106). `?.` guards `null`/`undefined` but **not a number**, so one malformed record throws `TypeError: ...trim is not a function` and crashes the entire `nodes status` output.

This normalizes those four scalars through `normalizeOptionalString` at the `buildEffectiveKnownNode` chokepoint — mirroring the existing caps/commands array hardening in the same function. Non-string entries become `undefined`; valid strings are preserved. The other string scalars (`platform`, `coreVersion`, `uiVersion`, …) are already normalized at the formatter and are never `.trim()`'d unguarded, so they are intentionally left as-is.

### Changes
- `src/gateway/node-catalog.ts` — normalize `displayName` / `version` / `clientId` / `clientMode` at the catalog chokepoint
- `src/gateway/node-catalog.test.ts` — regression test feeding non-string scalars through the real disk sources

## Real behavior proof

Behavior addressed: a non-string `version`/`displayName`/`clientId`/`clientMode` from a malformed pairing record crashed the `nodes status` formatters (`?.trim()` on a number); the catalog now normalizes them to `undefined`.

Real environment tested: a direct-call harness importing the real `src/gateway/node-catalog.ts`, run with the repo's `tsx`, Node 22.22.1, no model / provider / channel credentials and no network (pure logic, no SQLite). The "before" column reverts only that one source file to `origin/main`.

Exact steps or command run after this patch:
```bash
# nc-proof.mts builds a catalog from malformed disk sources (non-string scalars),
# lists the node, then runs exactly what the nodes-status formatters do: node.<field>?.trim()
tsx nc-proof.mts                                                       # AFTER (this branch)
git stash push -- src/gateway/node-catalog.ts && tsx nc-proof.mts && git stash pop   # BEFORE (origin/main)
```

Evidence after fix:
```
########## AFTER FIX (this branch) ##########
catalog scalars: {}
OK     nodes-status version?.trim() -> undefined
OK     nodes-status displayName?.trim() -> undefined
OK     nodes-status clientId?.trim() -> undefined
OK     nodes-status clientMode?.trim() -> undefined

########## BEFORE FIX (origin/main) ##########
catalog scalars: {"version":123,"displayName":456,"clientId":789,"clientMode":111}
THROW  nodes-status version?.trim() -> trim is not a function
THROW  nodes-status displayName?.trim() -> trim is not a function
THROW  nodes-status clientId?.trim() -> trim is not a function
THROW  nodes-status clientMode?.trim() -> trim is not a function
```

Observed result after fix: each non-string scalar that previously threw is normalized to `undefined`, so the formatters' `.trim()` is safely skipped and `nodes status` renders instead of crashing; valid string scalars are preserved.

What was not tested: end-to-end `openclaw nodes status` against a hand-crafted on-disk pairing file with a non-string scalar. The pure-function repro exercises the exact crash; reachability is confirmed by source (the pairing loaders blind-cast records and the source builders copy scalars without type checks).

## Additional checks

`node-catalog.test.ts` passes (48 cases, including the new scalar test alongside the existing malformed-caps test). Formatter, static analysis, and type checks pass for the changed files. Mirrors the existing caps/commands chokepoint hardening; net +12 source LOC for the four-field guard.
