### PR TITLE
fix(slack): forward identity (username/icon) to chat.update for edited messages (fixes #58737)

### DIFF
--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -10,7 +10,7 @@ import { createSlackWebClient, getSlackWriteClient } from "./client.js";
 import { buildSlackEditTextPayload } from "./edit-text.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
-import { sendMessageSlack } from "./send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
 export type SlackActionClientOpts = {
@@ -272,15 +272,32 @@ export async function editSlackMessage(
   channelId: string,
   messageId: string,
   content: string,
-  opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
+  opts: SlackActionClientOpts & {
+    blocks?: (Block | KnownBlock)[];
+    identity?: SlackSendIdentity;
+  } = {},
 ) {
   const client = await getClient(opts, "write");
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
+  const identity = opts.identity;
   await client.chat.update({
     channel: channelId,
     ts: messageId,
     text: buildSlackEditTextPayload(content, blocks),
     ...(blocks ? { blocks } : {}),
+    ...(identity?.iconUrl
+      ? {
+          ...(identity.username ? { username: identity.username } : {}),
+          icon_url: identity.iconUrl,
+        }
+      : identity?.iconEmoji
+        ? {
+            ...(identity.username ? { username: identity.username } : {}),
+            icon_emoji: identity.iconEmoji,
+          }
+        : identity?.username
+          ? { username: identity.username }
+          : {}),
   });
 }
 

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -88,6 +88,7 @@ export function createSlackDraftStream(params: {
           cfg: params.cfg,
           token: params.token,
           accountId: params.accountId,
+          identity: params.identity,
           ...(blocks ? { blocks } : {}),
         });
         return;


### PR DESCRIPTION
## Summary

Forward `SlackSendIdentity` (username, icon_url, icon_emoji) from the draft-stream edit call path into `editSlackMessage`, so that edited messages retain the agent's custom display name and avatar.

## Problem

Slack's `chat.update` API silently drops `username`/`icon_url`/`icon_emoji` when not provided. The `editSlackMessage` function never forwarded identity fields, so edited messages always appeared as the default bot identity — even when the agent had a custom name or avatar configured.

The `send()` path in `draft-stream.ts` already passes `identity`, but the `edit()` path at line 88 omits it.

## Changes

- `extensions/slack/src/actions.ts`: Add optional `identity?: SlackSendIdentity` to `editSlackMessage` opts, forward `username`/`icon_url`/`icon_emoji` to `chat.update` payload
- `extensions/slack/src/draft-stream.ts`: Pass `identity: params.identity` to the `edit()` call

## How to Test

- Configure a Slack agent with a custom `emoji` or `username` identity
- Send a message that triggers a draft-stream edit (e.g., streaming a long response)
- Verify the edited message retains the custom identity (name + avatar)

## Real behavior proof

- **Behavior addressed:** Slack `chat.update` edited messages now carry identity fields (username, icon_url, icon_emoji) matching the agent's configured display identity
- **Environment tested:** macOS 26.4.1, openclaw main branch (d320e693), Node.js
- **Steps run after the patch:**
  1. Cherry-picked the identity-forwarding fix onto a fresh branch from upstream/main
  2. Ran TypeScript type-check: `npx tsc --noEmit --project extensions/slack/tsconfig.json` — passed with zero errors
  3. Ran draft-stream verification suite: `node scripts/run-vitest.mjs run extensions/slack/src/draft-stream.test.ts` — 11/11 passed
  4. Verified the edit path now accepts and forwards identity fields via grep
- **Evidence after fix:**
```
$ grep -n 'identity' extensions/slack/src/actions.ts
13:import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
275:    identity?: SlackSendIdentity;
280:  const identity = opts.identity;
285:    ...(identity?.iconUrl

$ grep -n 'identity: params.identity' extensions/slack/src/draft-stream.ts
91:          identity: params.identity,

$ npx tsc --noEmit --project extensions/slack/tsconfig.json
(no errors)

$ node scripts/run-vitest.mjs run extensions/slack/src/draft-stream.test.ts
 ✓  extension-slack  extensions/slack/src/draft-stream.test.ts (11 tests) 9ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```
- **Observed result after fix:** `editSlackMessage` now accepts `identity` and forwards all three fields to `chat.update`. The draft-stream edit path passes identity from params, matching the send path behavior. TypeScript compiles cleanly, all 11 draft-stream verifications pass.
- **What was not tested:** Live Slack API round-trip (requires Slack workspace + bot token). The fix follows the exact same pattern as the existing `send()` identity forwarding at line 100 of `draft-stream.ts`.
