### PR TITLE
fix(usage): handle total-only usage in response usage line format

### DIFF
--- a/src/auto-reply/reply/agent-runner-usage-line.test.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.test.ts
@@ -1,7 +1,42 @@
 // Tests usage-line formatting for agent runner completion summaries.
 import { describe, expect, it } from "vitest";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
-import { appendUsageLine } from "./agent-runner-usage-line.js";
+import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
+
+describe("formatResponseUsageLine", () => {
+  it("handles total-only usage without input/output split", () => {
+    const result = formatResponseUsageLine({
+      usage: { total: 1250 },
+      showCost: false,
+    });
+    expect(result).toBe("Usage: 1.3k total");
+  });
+
+  it("handles total-only usage with cost estimation", () => {
+    const result = formatResponseUsageLine({
+      usage: { total: 1250 },
+      showCost: true,
+      costConfig: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+    });
+    expect(result).toContain("Usage: 1.3k total");
+  });
+
+  it("returns null for empty usage", () => {
+    const result = formatResponseUsageLine({
+      usage: {},
+      showCost: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for undefined usage", () => {
+    const result = formatResponseUsageLine({
+      usage: undefined,
+      showCost: false,
+    });
+    expect(result).toBeNull();
+  });
+});
 
 describe("appendUsageLine", () => {
   it("preserves reply payload metadata when appending usage text", () => {

--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -15,6 +15,7 @@ export const formatResponseUsageLine = (params: {
     output?: number;
     cacheRead?: number;
     cacheWrite?: number;
+    total?: number;
   };
   showCost: boolean;
   costConfig?: ModelCostConfig;

--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -25,8 +25,22 @@ export const formatResponseUsageLine = (params: {
   }
   const input = usage.input;
   const output = usage.output;
-  if (typeof input !== "number" && typeof output !== "number") {
+  const total = usage.total;
+  if (typeof input !== "number" && typeof output !== "number" && typeof total !== "number") {
     return null;
+  }
+  // Handle total-only usage when input/output are not available
+  if (typeof input !== "number" && typeof output !== "number" && typeof total === "number") {
+    const cost =
+      params.showCost
+        ? estimateUsageCost({
+            usage: { input: total, output: 0 },
+            cost: params.costConfig,
+          })
+        : undefined;
+    const costLabel = params.showCost ? formatUsd(cost) : undefined;
+    const suffix = costLabel ? ` · est ${costLabel}` : "";
+    return `Usage: ${formatTokenCount(total)} total${suffix}`;
   }
   const inputLabel = typeof input === "number" ? formatTokenCount(input) : "?";
   const outputLabel = typeof output === "number" ? formatTokenCount(output) : "?";


### PR DESCRIPTION
## Summary

- Fixes `/usage` no longer displaying in Telegram after upgrading to 2026.6.8 — the usage API response changed to return a single `total` field instead of separate `input`/`output` breakdown for some model providers
- The `formatResponseUsageLine` function only handled `input`+`output` split, returning `null` when neither was present
- Fix adds `total` field support: when only `total` is available, formats it as `"Usage: Xk total"` with optional cost estimation
- Out of scope: non-Telegram usage display (Slack, Discord, CLI `/status`) — those routes still provide split `input`/`output`
- Success: `/usage` shows footer in Telegram again

## Linked context

Closes #93905

Related: Telegram usage display was introduced in the 2026.6.x series, but the new `total`-only usage response format from some providers was not handled

## Real behavior proof (required for external PRs)

**Behavior addressed**: `formatResponseUsageLine` returned `null` for usage responses that contain only `total` (no `input`/`output` split), causing Telegram `/usage` to show no footer.

**Real environment tested**: Linux x86_64, Node 24, OpenClaw local dev instance with vitest test runner

**Exact steps or command run after this patch**:

```bash
npx vitest run src/auto-reply/reply/agent-runner-usage-line.test.ts --reporter=verbose
```

**Evidence after fix**:

```
 ✓ |auto-reply| formatResponseUsageLine > handles total-only usage without input/output split
 ✓ |auto-reply| formatResponseUsageLine > handles total-only usage with cost estimation
 ✓ |auto-reply| formatResponseUsageLine > returns null for empty usage
 ✓ |auto-reply| formatResponseUsageLine > returns null for undefined usage
 ✓ |auto-reply| appendUsageLine > preserves reply payload metadata when appending usage text
```

**Observed result after fix**: All 5 tests pass. Total-only usage now correctly renders as `"Usage: 1.3k total"` instead of returning null.

**What was not tested**: End-to-end Telegram message sending (requires running Telegram bot with credentials)

**Proof limitations or environment constraints**: Test coverage via vitest; real Telegram integration depends on bot token and configured webhook

## Tests and validation

```bash
npx vitest run src/auto-reply/reply/agent-runner-usage-line.test.ts --reporter=verbose
```

Regression coverage: 4 new test cases cover total-only, empty, and undefined usage formats. Existing tests unchanged and passing.

What failed before fix: `formatResponseUsageLine({ usage: { total: 1250 }, showCost: false })` returned `null` instead of `"Usage: 1.3k total"`.

## Risk checklist

Did user-visible behavior change? (`Yes`) — Telegram `/usage` now shows footer again when the API returns total-only usage

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area? — Low risk; new code path only activates when `total` is present without `input`/`output`, otherwise existing behavior is unchanged

How is that risk mitigated? — TypeScript type ensures `total` field is optional; existing `input`+`output` paths are completely unchanged

## Current review state

What is the next action? — Maintainer review

What is still waiting on author, maintainer, CI, or external proof? — Nothing from author side