### PR TITLE
fix: reset tailscale serve before reconfiguring to prevent redundant entries

### DIFF
--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -28,6 +28,10 @@ export async function startGatewayTailscaleExposure(params: {
 
   try {
     if (params.tailscaleMode === "serve") {
+      // Reset existing serve entries to prevent redundant accumulations
+      // from previous gateway runs (tailscale serve is append-only).
+      await disableTailscaleServe(undefined, params.serviceName?.trim() || undefined).catch(() => {});
+
       if (params.preserveFunnel === true) {
         const funnelCovers = await hasTailscaleFunnelRouteForPort(params.port);
         if (funnelCovers) {


### PR DESCRIPTION
## Summary

 is append-only — each gateway restart adds new entries without removing old ones. This causes  or  when stale entries with invalid hostnames or wrong ports accumulate.

## Fix

Add a  call (which runs `tailscale serve reset`) before `enableTailscaleServe` in `startGatewayTailscaleExposure` to ensure a clean state on every gateway startup.

## Testing

Reproduced the issue by restarting the gateway multiple times — `tailscale serve status` showed 3 redundant entries. After this fix, only the expected entries remain after each restart.

Fixes #93936