### PR TITLE
docs: fix two broken cross-reference anchors

### DIFF
--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -37,7 +37,7 @@ that agent; if you copy credentials manually, copy only portable static
 `api_key` or `token` profiles.
 </Warning>
 
-Skills are loaded from each agent workspace plus shared roots such as `~/.openclaw/skills`, then filtered by the effective agent skill allowlist when configured. Use `agents.defaults.skills` for a shared baseline and `agents.list[].skills` for per-agent replacement. See [Skills: per-agent vs shared](/tools/skills#per-agent-vs-shared-skills) and [Skills: agent skill allowlists](/tools/skills#agent-skill-allowlists).
+Skills are loaded from each agent workspace plus shared roots such as `~/.openclaw/skills`, then filtered by the effective agent skill allowlist when configured. Use `agents.defaults.skills` for a shared baseline and `agents.list[].skills` for per-agent replacement. See [Skills: per-agent vs shared](/tools/skills#per-agent-vs-shared-skills) and [Skills: agent skill allowlists](/tools/skills#agent-allowlists).
 
 The Gateway can host **one agent** (default) or **many agents** side-by-side.
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -160,7 +160,7 @@ it disabled for read-only shared skill roots.
 
 Related:
 
-- [Skills config](/tools/skills-config#symlinked-sibling-repos)
+- [Skills config](/tools/skills-config#symlinked-skill-roots)
 - [Configuration examples](/gateway/configuration-examples#symlinked-sibling-skill-repo)
 
 ## Anthropic 429 extra usage required for long context


### PR DESCRIPTION
## Summary

Two documentation cross-reference links point to anchors that don't exist on their target pages, so they land at the page top instead of the intended section:

- `docs/concepts/multi-agent.md` linked `/tools/skills#agent-skill-allowlists`, but the heading on `docs/tools/skills.md` is `## Agent allowlists` (slug `#agent-allowlists`).
- `docs/gateway/troubleshooting.md` linked `/tools/skills-config#symlinked-sibling-repos`, but the heading on `docs/tools/skills-config.md` is `## Symlinked skill roots` (slug `#symlinked-skill-roots`).

## Changes

Corrected both anchors to match the actual target headings (verified present: `skills.md` `## Agent allowlists` at line 77, `skills-config.md` `## Symlinked skill roots` at line 353). The sibling anchor `#per-agent-vs-shared-skills` on the same multi-agent line is valid and left untouched.

## Verification

## Real behavior proof

Behavior addressed: Both cross-reference URLs now resolve to headings that exist in their target Markdown pages.
Real environment tested: Fresh PR checkout on Crabbox AWS.
Exact steps or command run after this patch: `node scripts/docs-link-audit.mjs`; exact link and target-heading assertions; `git diff --check`.
Evidence after fix: Copied terminal output from Crabbox run `run_cfd4a54078ae`:

```text
checked_internal_links=4466
broken_links=0
targeted-anchor-proof=ok
```
Observed result after fix: The repository-wide internal-link audit and both targeted anchor assertions passed.
What was not tested: A full Mintlify render; its anchor-check command was blocked before execution by an unrelated missing transitive `openapi-types` package in `@mintlify/scraping`.
