### PR TITLE
docs(cli): document --log-level global flag

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -39,14 +39,15 @@ Use the setup commands by intent:
 
 ## Global flags
 
-| Flag                    | Purpose                                                               |
-| ----------------------- | --------------------------------------------------------------------- |
-| `--dev`                 | Isolate state under `~/.openclaw-dev` and shift default ports         |
-| `--profile <name>`      | Isolate state under `~/.openclaw-<name>`                              |
-| `--container <name>`    | Target a named container for execution                                |
-| `--no-color`            | Disable ANSI colors (`NO_COLOR=1` is also respected)                  |
-| `--update`              | Shorthand for [`openclaw update`](/cli/update) (source installs only) |
-| `-V`, `--version`, `-v` | Print version and exit                                                |
+| Flag                    | Purpose                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `--dev`                 | Isolate state under `~/.openclaw-dev` and shift default ports                                              |
+| `--profile <name>`      | Isolate state under `~/.openclaw-<name>`                                                                   |
+| `--container <name>`    | Target a named container for execution                                                                     |
+| `--log-level <level>`   | Global log level override for file + console: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace` |
+| `--no-color`            | Disable ANSI colors (`NO_COLOR=1` is also respected)                                                       |
+| `--update`              | Shorthand for [`openclaw update`](/cli/update) (source installs only)                                      |
+| `-V`, `--version`, `-v` | Print version and exit                                                                                     |
 
 ## Output modes
 


### PR DESCRIPTION
## What Problem This Solves

Users reading the CLI reference (`docs/cli/index.md`) cannot discover the `--log-level <level>` global flag: it is a real program-level option but was missing from the authoritative "Global flags" table, which lists every other global (`--dev`, `--profile`, `--container`, `--no-color`, `--update`, `-V/--version`). The flag was only mentioned in `docs/logging.md`, so anyone consulting the canonical flags table to raise log verbosity (e.g. for debugging) would conclude the option does not exist. This is a documentation-discoverability gap for every CLI user; the fix makes the reference match the actual program interface.

## Evidence

The flag is real and global, verified against the live source on `main`:

- **Registered as a global option** — `src/cli/program/help.ts` (around line 74) calls `.option("--log-level <level>", "Global log level override for file + console (${CLI_LOG_LEVEL_VALUES})", ...)`, attached to the root program (not a subcommand), confirming it is a program-level global.
- **Applied globally at runtime** — `src/cli/program/preaction.ts` reads `root.getOptionValueSource("logLevel")` / `root.opts().logLevel` in the pre-action hook, so the override takes effect across the whole program.
- **Accepted values match the doc text** — `src/logging/levels.ts` `ALLOWED_LOG_LEVELS` enumerates exactly `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`, which is the value list written into the new table row.
- **Before/after behavior** — before: the Global flags table omitted `--log-level`, so the only documented home was `docs/logging.md`. After: the table includes a `--log-level <level>` row whose description and value list are aligned to `help.ts` and `levels.ts`. The change is docs-only (single Markdown table row in `docs/cli/index.md`), so there is no code path to test; the evidence is the source-registration trace above proving the documented flag exists and is global.

## Summary

The CLI reference's Global flags table (`docs/cli/index.md`) lists `--dev`, `--profile`, `--container`, `--no-color`, `--update`, and `-V/--version`, but omits `--log-level <level>` — which is also a program-level global option:

- Registered at `src/cli/program/help.ts` via `.option("--log-level <level>", ...)` with description "Global log level override for file + console".
- Applied globally in `src/cli/program/preaction.ts`.
- Accepted values from `src/logging/levels.ts` `ALLOWED_LOG_LEVELS`: `silent`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.

It was previously only mentioned in `docs/logging.md`, not in this authoritative global-flags reference table.

## Changes

Added a `--log-level <level>` row to the Global flags table, with description aligned to the `help.ts` option text and the accepted level values.

<!-- codex-rescue-machine-readable-real-behavior-proof -->
## Real behavior proof

Behavior addressed: The CLI reference's Global flags table did not list the real program-level --log-level <level> flag, so users relying on docs/cli/index.md could not discover the global log-level override even though the CLI registers and applies it globally.

Real environment tested: Local PR head worktree fork/fix/docs-loglevel-flag, using the real repository files. This is a docs-only PR, so the proof checks the live source registration and the updated documentation table rather than an application runtime path.

Exact steps or command run after this patch: Ran git worktree add --detach /tmp/openclaw-proof-93942 fork/fix/docs-loglevel-flag, then ran rg -n -- '--log-level|ALLOWED_LOG_LEVELS|logLevel' docs/cli/index.md src/cli/program/help.ts src/cli/program/preaction.ts src/logging/levels.ts.

Evidence after fix: Terminal output from the PR head worktree:
```text
src/cli/program/help.ts:74:      "--log-level <level>",
src/logging/levels.ts:2:export const ALLOWED_LOG_LEVELS = [
src/logging/levels.ts:12:export type LogLevel = (typeof ALLOWED_LOG_LEVELS)[number];
src/logging/levels.ts:19:  return ALLOWED_LOG_LEVELS.includes(candidate as LogLevel) ? (candidate as LogLevel) : undefined;
src/cli/program/preaction.ts:61:  if (root.getOptionValueSource("logLevel") !== "cli") {
src/cli/program/preaction.ts:64:  const logLevel = root.opts<Record<string, unknown>>().logLevel;
src/cli/program/preaction.ts:65:  return typeof logLevel === "string" ? (logLevel as LogLevel) : undefined;
```
The PR diff also adds the docs/cli/index.md Global flags row for --log-level <level> with the accepted values silent, fatal, error, warn, info, debug, trace.

Observed result after fix: The documented Global flags table now includes the same --log-level <level> option that src/cli/program/help.ts registers on the root program, and the accepted values match src/logging/levels.ts. The runtime pre-action source lookup confirms the option is applied as a global CLI override.

What was not tested: No full docs site build or browser rendering pass was run; this is a single Markdown table-row documentation update verified against source registration and value definitions.
