### PR TITLE
fix(provider-usage): honor proxy env for usage fetch

### DIFF
--- a/src/infra/provider-usage.load.plugin.test.ts
+++ b/src/infra/provider-usage.load.plugin.test.ts
@@ -3,9 +3,37 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProviderUsageFetch } from "../test-utils/provider-usage-fetch.js";
 
 const resolveProviderUsageSnapshotWithPluginMock = vi.fn();
+const { EnvHttpProxyAgent, envAgentSpy, loadUndiciRuntimeDeps, undiciFetch } = vi.hoisted(() => {
+  const envAgentSpyLocal = vi.fn();
+  const undiciFetchLocal = vi.fn();
+  class EnvHttpProxyAgentLocal {
+    static lastCreated: EnvHttpProxyAgentLocal | undefined;
+
+    constructor(public readonly options?: Record<string, unknown>) {
+      EnvHttpProxyAgentLocal.lastCreated = this;
+      envAgentSpyLocal(options);
+    }
+  }
+  const loadUndiciRuntimeDepsLocal = vi.fn(() => ({
+    EnvHttpProxyAgent: EnvHttpProxyAgentLocal,
+    FormData: globalThis.FormData,
+    fetch: undiciFetchLocal,
+  }));
+
+  return {
+    EnvHttpProxyAgent: EnvHttpProxyAgentLocal,
+    envAgentSpy: envAgentSpyLocal,
+    loadUndiciRuntimeDeps: loadUndiciRuntimeDepsLocal,
+    undiciFetch: undiciFetchLocal,
+  };
+});
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: () => ({}),
+}));
+
+vi.mock("./net/undici-runtime.js", () => ({
+  loadUndiciRuntimeDeps,
 }));
 
 vi.mock("../plugins/provider-runtime.js", async () => {
@@ -30,6 +58,7 @@ function requireFirstPluginUsageCall(): {
     token?: unknown;
     authProfileId?: unknown;
     timeoutMs?: unknown;
+    fetchFn?: unknown;
   };
 } {
   const [call] = resolveProviderUsageSnapshotWithPluginMock.mock.calls;
@@ -47,8 +76,24 @@ function requireFirstPluginUsageCall(): {
       token?: unknown;
       authProfileId?: unknown;
       timeoutMs?: unknown;
+      fetchFn?: unknown;
     };
   };
+}
+
+function requireFetchFn(value: unknown): typeof fetch {
+  if (typeof value !== "function") {
+    throw new Error("expected provider usage context fetch");
+  }
+  return value as typeof fetch;
+}
+
+function requireUndiciFetchInit(): Record<string, unknown> {
+  const init = undiciFetch.mock.calls[0]?.[1];
+  if (!init || typeof init !== "object" || Array.isArray(init)) {
+    throw new Error("expected undici fetch init");
+  }
+  return init as Record<string, unknown>;
 }
 
 describe("provider-usage.load plugin boundary", () => {
@@ -57,6 +102,10 @@ describe("provider-usage.load plugin boundary", () => {
   });
 
   beforeEach(() => {
+    envAgentSpy.mockClear();
+    loadUndiciRuntimeDeps.mockClear();
+    undiciFetch.mockReset();
+    EnvHttpProxyAgent.lastCreated = undefined;
     resolveProviderUsageSnapshotWithPluginMock.mockReset();
     resolveProviderUsageSnapshotWithPluginMock.mockResolvedValue(null);
   });
@@ -76,6 +125,7 @@ describe("provider-usage.load plugin boundary", () => {
         now: usageNow,
         auth: [{ provider: "github-copilot", token: "copilot-token" }],
         fetch: mockFetch as unknown as typeof fetch,
+        env: {},
       }),
     ).resolves.toEqual({
       updatedAt: usageNow,
@@ -115,6 +165,7 @@ describe("provider-usage.load plugin boundary", () => {
             hookProvider: "codex",
           },
         ],
+        env: {},
       }),
     ).resolves.toEqual({
       updatedAt: usageNow,
@@ -132,5 +183,89 @@ describe("provider-usage.load plugin boundary", () => {
     expect(pluginCall.context?.provider).toBe("openai");
     expect(pluginCall.context?.token).toBe("codex-app-server");
     expect(pluginCall.context?.authProfileId).toBe("openai:work");
+  });
+
+  it("passes an env proxy fetch into plugin usage context when no explicit fetch is supplied", async () => {
+    undiciFetch.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    resolveProviderUsageSnapshotWithPluginMock.mockImplementationOnce(async (params: unknown) => {
+      if (!params || typeof params !== "object" || Array.isArray(params)) {
+        throw new Error("expected plugin params");
+      }
+      const context = (params as { context?: { fetchFn?: unknown } }).context;
+      await requireFetchFn(context?.fetchFn)("https://chatgpt.com/backend-api/wham/usage");
+      return {
+        provider: "openai",
+        displayName: "Codex",
+        windows: [{ label: "5h", usedPercent: 7 }],
+      };
+    });
+
+    await expect(
+      loadProviderUsageSummary({
+        now: usageNow,
+        auth: [{ provider: "openai", token: "codex-token", accountId: "acc-1" }],
+        env: {
+          HTTP_PROXY: "",
+          HTTPS_PROXY: "http://proxy.test:8080",
+        },
+      }),
+    ).resolves.toEqual({
+      updatedAt: usageNow,
+      providers: [
+        {
+          provider: "openai",
+          displayName: "Codex",
+          windows: [{ label: "5h", usedPercent: 7 }],
+        },
+      ],
+    });
+
+    expect(envAgentSpy).toHaveBeenCalledWith({ httpsProxy: "http://proxy.test:8080" });
+    expect(undiciFetch).toHaveBeenCalledOnce();
+    const [input] = undiciFetch.mock.calls[0] ?? [];
+    expect(input).toBe("https://chatgpt.com/backend-api/wham/usage");
+    expect(requireUndiciFetchInit().dispatcher).toBe(EnvHttpProxyAgent.lastCreated);
+  });
+
+  it("keeps an explicit fetch ahead of proxy env for plugin usage context", async () => {
+    const explicitFetch = vi.fn(async () => new Response("{}", { status: 200 }));
+    resolveProviderUsageSnapshotWithPluginMock.mockImplementationOnce(async (params: unknown) => {
+      if (!params || typeof params !== "object" || Array.isArray(params)) {
+        throw new Error("expected plugin params");
+      }
+      const context = (params as { context?: { fetchFn?: unknown } }).context;
+      await requireFetchFn(context?.fetchFn)("https://chatgpt.com/backend-api/wham/usage");
+      return {
+        provider: "openai",
+        displayName: "Codex",
+        windows: [{ label: "5h", usedPercent: 9 }],
+      };
+    });
+
+    await expect(
+      loadProviderUsageSummary({
+        now: usageNow,
+        auth: [{ provider: "openai", token: "codex-token", accountId: "acc-1" }],
+        env: {
+          HTTP_PROXY: "",
+          HTTPS_PROXY: "http://proxy.test:8080",
+        },
+        fetch: explicitFetch as unknown as typeof fetch,
+      }),
+    ).resolves.toEqual({
+      updatedAt: usageNow,
+      providers: [
+        {
+          provider: "openai",
+          displayName: "Codex",
+          windows: [{ label: "5h", usedPercent: 9 }],
+        },
+      ],
+    });
+
+    expect(explicitFetch).toHaveBeenCalledOnce();
+    expect(loadUndiciRuntimeDeps).not.toHaveBeenCalled();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -222,6 +222,7 @@ describe("provider-usage.load", () => {
         loadProviderUsageSummary({
           now: usageNow,
           auth: [{ provider: "xiaomi", token: "token-x" }],
+          env: {},
           fetch: undefined,
         }),
       ).rejects.toThrow("fetch is not available");

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -2,6 +2,7 @@
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
 import { resolveProviderUsageSnapshotWithPlugin } from "../plugins/provider-runtime.js";
 import { resolveFetch } from "./fetch.js";
+import { resolveProxyFetchFromEnv } from "./net/proxy-fetch.js";
 import { type ProviderAuth, resolveProviderAuths } from "./provider-usage.auth.js";
 import {
   DEFAULT_TIMEOUT_MS,
@@ -90,7 +91,9 @@ export async function loadProviderUsageSummary(
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const config = opts.config ?? getRuntimeConfig();
   const env = opts.env ?? process.env;
-  const fetchFn = resolveFetch(opts.fetch);
+  const fetchFn = opts.fetch
+    ? resolveFetch(opts.fetch)
+    : (resolveProxyFetchFromEnv(env) ?? resolveFetch());
   if (!fetchFn) {
     throw new Error("fetch is not available");
   }

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -127,13 +127,6 @@ export type QueueEvent =
       raw: Record<string, unknown>;
     };
 
-/** Claude channel permission notification payload before it is assigned an event cursor. */
-type ClaudePermissionRequest = {
-  toolName: string;
-  description: string;
-  inputPreview: string;
-};
-
 /** Cursor and optional session filter used by event polling and waiting. */
 export type WaitFilter = {
   afterCursor: number;


### PR DESCRIPTION
Closes #78714.

Summary:
- Prefer an explicit provider-usage fetch when supplied.
- Otherwise use the existing env proxy fetch helper before falling back to global fetch, so Codex usage snapshots inherit HTTP(S)_PROXY.
- Add plugin-boundary coverage that executes the usage context fetch through a local EnvHttpProxyAgent path and verifies explicit fetch still wins.
- Remove one unused Claude permission helper type that currently fails prod lint/types on latest main.

## Real behavior proof

- Behavior addressed: Codex provider usage fetch selection now honors HTTP(S)_PROXY when no explicit fetch is supplied, while an explicit fetch still takes precedence.
- Real environment tested: Local macOS source checkout at `6b04ad0bb7`, Node v24.15.0, with a local HTTP proxy server. A fake token was used and no real ChatGPT/OAuth request completed.
- Exact steps or command run after this patch: Ran a `node --import tsx --input-type=module` source-runtime probe that called `resolveProxyFetchFromEnv({ HTTPS_PROXY: localProxy })` for `https://chatgpt.com/backend-api/wham/usage`; the local proxy returned 502 after recording the tunnel request.
- Evidence after fix: Terminal output from the local proxy probe:

```json
{
  "proof": "env proxy fetch routes Codex usage URL through local HTTPS_PROXY",
  "proxyUrl": "http://127.0.0.1:<local-port>",
  "result": {
    "error": "fetch failed"
  },
  "proxyRequests": [
    {
      "method": "CONNECT",
      "url": "chatgpt.com:443",
      "host": "chatgpt.com"
    }
  ]
}
```

- Observed result after fix: The local proxy recorded `CONNECT chatgpt.com:443`, showing the Codex usage URL was routed through the env proxy path instead of direct Node fetch.
- What was not tested: No live ChatGPT/OAuth usage request was sent; the local proof proxy intentionally returned 502 after capturing the tunnel.
