### PR TITLE
fix(exec): resume agent turn for native chat exec approvals 

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1294,6 +1294,138 @@ EOF`,
     expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["telegram"],
+    ["slack"],
+    ["discord"],
+    ["signal"],
+    ["whatsapp"],
+    ["imessage"],
+    ["matrix"],
+    ["googlechat"],
+    ["qqbot"],
+  ])(
+    "waits inline for native chat approval (%s) so the exec tool returns real output (issue #93918)",
+    async (turnSourceChannel) => {
+      resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+      createExecApprovalDecisionStateMock.mockReturnValue({
+        baseDecision: { timedOut: false },
+        approvedByAsk: true,
+        deniedReason: null,
+      });
+
+      const result = await runGatewayAllowlist({
+        command: "find . -maxdepth 1",
+        turnSourceChannel,
+      });
+
+      expect(result.pendingResult).toBeUndefined();
+      expect(result.deniedResult).toBeUndefined();
+      expect(result.allowWithoutEnforcedCommand).toBe(true);
+      expect(runExecProcessMock).not.toHaveBeenCalled();
+      expect(buildExecApprovalFollowupTargetMock).not.toHaveBeenCalled();
+      expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["telegram"],
+    ["slack"],
+    ["discord"],
+    ["signal"],
+    ["whatsapp"],
+    ["imessage"],
+    ["matrix"],
+    ["googlechat"],
+    ["qqbot"],
+  ])(
+    "returns native chat approval denials (%s) as the foreground tool result (issue #93918)",
+    async (turnSourceChannel) => {
+      resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
+      createExecApprovalDecisionStateMock.mockReturnValue({
+        baseDecision: { timedOut: false },
+        approvedByAsk: false,
+        deniedReason: "user-denied",
+      });
+
+      const result = await runGatewayAllowlist({
+        command: "find . -maxdepth 1",
+        turnSourceChannel,
+      });
+
+      expect(result.pendingResult).toBeUndefined();
+      expect(result.deniedResult?.details.status).toBe("failed");
+      expect(result.deniedResult?.content[0]).toEqual(
+        expect.objectContaining({
+          text: "Exec denied (gateway id=req-1, user-denied): find . -maxdepth 1",
+        }),
+      );
+      expect(runExecProcessMock).not.toHaveBeenCalled();
+      expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the fire-and-forget path for channels without native approval clients", async () => {
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-1" },
+      promise: Promise.resolve({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        aggregated: "done",
+      }),
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "feishu",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(1);
+    });
+    expect(runExecProcessMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the fire-and-forget path for headless cron approval followups", async () => {
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-1" },
+      promise: Promise.resolve({
+        status: "completed",
+        exitCode: 0,
+        timedOut: false,
+        aggregated: "done",
+      }),
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "telegram",
+      approvalFollowupMode: "agent",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(1);
+    });
+    expect(requireBuildFollowupTargetInput(0).direct).toBe(false);
+  });
+
   it("returns webchat approval denials as the foreground tool result", async () => {
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("deny");
     createExecApprovalDecisionStateMock.mockReturnValue({

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -28,7 +28,7 @@ import {
   type ExecAutoReviewInput,
 } from "../infra/exec-auto-review.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
+import { isNativeApprovalChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
@@ -352,7 +352,13 @@ function shouldAwaitGatewayApprovalInline(params: {
   if (params.approvalFollowupMode !== undefined) {
     return false;
   }
-  return normalizeMessageChannel(params.turnSourceChannel) === INTERNAL_MESSAGE_CHANNEL;
+  // Native chat approval clients (Telegram /approve, Discord buttons,
+  // etc.) resolve the approval back into the same session, so the agent can
+  // wait inline and return the real exec output as the tool result. This
+  // mirrors the webchat path that PR #85239 fixed; without it the agent run
+  // terminates on the "approval-pending" tool result and the operator must
+  // send a follow-up chat message to recover the turn (issue #93918).
+  return isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel));
 }
 
 function buildGatewayExecApprovalDeniedToolResult(params: {

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -34,22 +34,37 @@ vi.mock("../infra/outbound/message.js", () => ({
 }));
 
 vi.mock("../utils/message-channel.js", () => {
+  const INTERNAL_MESSAGE_CHANNEL = "webchat";
+  const NATIVE_APPROVAL_CHANNELS = new Set([
+    "webchat",
+    "discord",
+    "googlechat",
+    "imessage",
+    "matrix",
+    "qqbot",
+    "signal",
+    "slack",
+    "telegram",
+    "whatsapp",
+  ]);
   const normalizeMessageChannel = (raw?: string | null) => {
     const normalized = raw?.trim().toLowerCase();
     if (!normalized) {
       return undefined;
     }
-    if (normalized === "web" || normalized === "webchat") {
-      return "internal";
+    if (normalized === "web") {
+      return INTERNAL_MESSAGE_CHANNEL;
     }
     return normalized;
   };
   const isGatewayMessageChannel = (value: string) => Boolean(normalizeMessageChannel(value));
   return {
-    INTERNAL_MESSAGE_CHANNEL: "internal",
+    INTERNAL_MESSAGE_CHANNEL,
+    isNativeApprovalChannel: (value?: string | null) =>
+      typeof value === "string" && NATIVE_APPROVAL_CHANNELS.has(value),
     isDeliverableMessageChannel: (value: string) => {
       const channel = normalizeMessageChannel(value);
-      return Boolean(channel && channel !== "internal" && channel !== "tui");
+      return Boolean(channel && channel !== INTERNAL_MESSAGE_CHANNEL && channel !== "tui");
     },
     isGatewayMessageChannel,
     normalizeMessageChannel,
@@ -97,12 +112,12 @@ vi.mock("../infra/exec-approval-surface.js", () => ({
       kind: "enabled",
       channel,
       channelLabel:
-        channel === "tui" ? "terminal UI" : channel === "internal" ? "Web UI" : "this platform",
+        channel === "tui" ? "terminal UI" : channel === "webchat" ? "Web UI" : "this platform",
       accountId: params.accountId ?? undefined,
     };
   },
   supportsNativeExecApprovalClient: (channel?: string | null) =>
-    !channel || channel === "internal" || channel === "tui",
+    !channel || channel === "webchat" || channel === "tui",
 }));
 
 vi.mock("../infra/shell-env.js", () => ({
@@ -980,7 +995,7 @@ describe("exec approvals", () => {
     );
   });
 
-  it("continues the original agent session after approved gateway exec completes with an external route", async () => {
+  it("continues the original agent session after approved gateway exec completes with a non-native external route", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
 
     mockAcceptedApprovalFlow({
@@ -993,15 +1008,15 @@ describe("exec approvals", () => {
       host: "gateway",
       ask: "always",
       approvalRunningNoticeMs: 0,
-      sessionKey: "agent:main:discord:channel:123",
+      sessionKey: "agent:main:feishu:channel:123",
       elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
-      messageProvider: "discord",
+      messageProvider: "feishu",
       currentChannelId: "123",
       accountId: "default",
       currentThreadTs: "456",
     });
 
-    const result = await tool.execute("call-gw-followup-discord", {
+    const result = await tool.execute("call-gw-followup-feishu", {
       command: "echo ok",
       workdir: process.cwd(),
     });
@@ -1009,10 +1024,10 @@ describe("exec approvals", () => {
     expect(result.details.status).toBe("approval-pending");
     await expect.poll(() => agentCalls.length, { timeout: 3000, interval: 1 }).toBe(1);
     expectRecordFields(agentCalls[0], {
-      sessionKey: "agent:main:discord:channel:123",
+      sessionKey: "agent:main:feishu:channel:123",
       deliver: true,
       bestEffortDeliver: true,
-      channel: "discord",
+      channel: "feishu",
       to: "123",
       accountId: "default",
       threadId: "456",
@@ -1025,7 +1040,7 @@ describe("exec approvals", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("auto-continues the same Discord session after approval resolves without a second user turn", async () => {
+  it("waits inline for native Discord approval and resumes the same session without a second user turn", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
     let resolveDecision: ((value: { decision: string }) => void) | undefined;
     const decisionPromise = new Promise<{ decision: string }>((resolve) => {
@@ -1058,31 +1073,26 @@ describe("exec approvals", () => {
       currentThreadTs: "456",
     });
 
-    const result = await tool.execute("call-gw-followup-discord-delayed", {
+    let settled = false;
+    const resultPromise = tool.execute("call-gw-followup-discord-delayed", {
       command: "printf delayed-ok",
       workdir: process.cwd(),
     });
+    void resultPromise.then(() => {
+      settled = true;
+    });
 
-    expect(result.details.status).toBe("approval-pending");
+    await Promise.resolve();
+    expect(settled).toBe(false);
     expect(agentCalls).toHaveLength(0);
 
     resolveDecision?.({ decision: "allow-once" });
 
-    await expect.poll(() => agentCalls.length, { timeout: 3000, interval: 1 }).toBe(1);
-    expectRecordFields(agentCalls[0], {
-      sessionKey: "agent:main:discord:channel:123",
-      deliver: true,
-      bestEffortDeliver: true,
-      channel: "discord",
-      to: "123",
-      accountId: "default",
-      threadId: "456",
-    });
-    expect(typeof agentCalls[0]?.message).toBe("string");
-    expect(agentCalls[0]?.message).toContain(
-      "If the task requires more steps, continue from this result before replying to the user.",
-    );
-    expect(agentCalls[0]?.message).toContain("delayed-ok");
+    const result = await resultPromise;
+
+    expect(result.details.status).toBe("completed");
+    expect(getResultText(result)).toContain("delayed-ok");
+    expect(agentCalls).toHaveLength(0);
     expect(sendMessage).not.toHaveBeenCalled();
   });
 

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -20,3 +20,36 @@ export function isInternalNonDeliveryChannel(
 ): value is (typeof INTERNAL_NON_DELIVERY_CHANNELS)[number] {
   return (INTERNAL_NON_DELIVERY_CHANNELS as readonly string[]).includes(value);
 }
+
+// Channels that ship a native chat exec approval client (in-chat `/approve`
+// flow backed by an `approval-handler.runtime` adapter). When the originating
+// turn can be approved in the same chat, the gateway can resolve the approval
+// in place and the agent can wait inline for the result instead of falling
+// back to a fire-and-forget followup that loses the agent's session.
+//
+// Keep this list aligned with bundled extensions that publish
+// `approval-handler.runtime` and a `resolveApproveCommandBehavior` capability;
+// adding an extension without the runtime, or listing one without the runtime,
+// re-introduces the "approval loop" the inline path was added to avoid.
+export const NATIVE_APPROVAL_CHANNELS = [
+  "webchat",
+  "discord",
+  "googlechat",
+  "imessage",
+  "matrix",
+  "qqbot",
+  "signal",
+  "slack",
+  "telegram",
+  "whatsapp",
+] as const;
+export type NativeApprovalChannel = (typeof NATIVE_APPROVAL_CHANNELS)[number];
+
+export function isNativeApprovalChannel(
+  value: string | null | undefined,
+): value is NativeApprovalChannel {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return (NATIVE_APPROVAL_CHANNELS as readonly string[]).includes(value);
+}

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -1,5 +1,6 @@
 // Message channel constants define internal channel ids shared across routing.
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
+export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
 
 // Internal, non-delivery sources that may surface as a `channel` hint when an
 // agent run is triggered by something other than a chat message — heartbeat

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -5,8 +5,10 @@ import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
+  NATIVE_APPROVAL_CHANNELS,
   isInternalNonDeliveryChannel,
   isMarkdownCapableMessageChannel,
+  isNativeApprovalChannel,
   resolveGatewayMessageChannel,
 } from "./message-channel.js";
 
@@ -77,6 +79,19 @@ describe("message-channel", () => {
     expect(isInternalNonDeliveryChannel("webchat")).toBe(false);
     expect(isInternalNonDeliveryChannel("")).toBe(false);
     expect(isInternalNonDeliveryChannel("HEARTBEAT")).toBe(false);
+  });
+
+  it("lists native chat exec approval channels", () => {
+    for (const channel of NATIVE_APPROVAL_CHANNELS) {
+      expect(isNativeApprovalChannel(channel)).toBe(true);
+    }
+    // Channels without a bundled approval-handler.runtime must not claim native approval.
+    expect(isNativeApprovalChannel("feishu")).toBe(false);
+    expect(isNativeApprovalChannel("msteams")).toBe(false);
+    expect(isNativeApprovalChannel("line")).toBe(false);
+    expect(isNativeApprovalChannel("heartbeat")).toBe(false);
+    expect(isNativeApprovalChannel("")).toBe(false);
+    expect(isNativeApprovalChannel("TELEGRAM")).toBe(false);
   });
 
   it("reads markdown capability from channel metadata", () => {

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -28,10 +28,7 @@ export {
   type InternalMessageChannel,
   type NativeApprovalChannel,
 } from "./message-channel-constants.js";
-import {
-  INTERNAL_MESSAGE_CHANNEL,
-  type InternalMessageChannel,
-} from "./message-channel-constants.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "./message-channel-constants.js";
 import { normalizeMessageChannel } from "./message-channel-normalize.js";
 
 /**

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -23,8 +23,15 @@ export {
 export {
   INTERNAL_MESSAGE_CHANNEL,
   isInternalNonDeliveryChannel,
+  NATIVE_APPROVAL_CHANNELS,
+  isNativeApprovalChannel,
+  type InternalMessageChannel,
+  type NativeApprovalChannel,
 } from "./message-channel-constants.js";
-import { INTERNAL_MESSAGE_CHANNEL } from "./message-channel-constants.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  type InternalMessageChannel,
+} from "./message-channel-constants.js";
 import { normalizeMessageChannel } from "./message-channel-normalize.js";
 
 /**


### PR DESCRIPTION
## Summary

Native chat exec approvals (Telegram `/approve <id> allow-once`, Discord buttons, Slack actions, etc.) were resolved by the gateway but never resumed the agent's turn. The exec tool returned the `approval-pending` tool result, the run terminated, the background `sendExecApprovalFollowup` either fell through to a direct delivery to the operator or failed silently, and the model never saw an `Exec running / Exec finished / Exec denied` event. Operators had to send a follow-up chat message to recover the turn, and a new approval was minted because the original run had already ended — producing the "approval → 催促 → 新审批" loop.

This extends the inline approval-pending path that PR #85239 added for webchat to every bundled chat channel that ships an `approval-handler.runtime` adapter. When the originating turn can be approved in the same chat, the gateway resolves the approval in place and the agent waits inline for the command output instead of terminating on `approval-pending`.
closes:https://github.com/openclaw/openclaw/issues/93918

## Behavior

Before:
1. Agent calls exec → `processGatewayAllowlist` registers approval → tool returns `pendingResult` (fire-and-forget) → agent run ends.
2. Operator approves in chat → background block runs the command → `sendExecApprovalFollowup` tries to resume the agent via `callGatewayTool("agent", ...)`.
3. In practice the resume either fails or falls through to a direct delivery to the operator; the agent never sees the result and stays in the "pending" view.
4. Operator sends any chat message → agent re-runs the original task → fresh allowlist-miss → new approval ID → loop.

After:
1. Agent calls exec → `shouldAwaitGatewayApprovalInline` returns `true` for native chat channels (when `unavailableReason === null` and no explicit `approvalFollowupMode`) → tool awaits the decision in place.
2. Operator approves in chat → `resolveApprovalDecisionOrUndefined` resolves inline → command runs in the same tool call → real `Exec finished (gateway id=…, code 0)` text is the tool result the model reads.
3. If the operator denies, the inline `deniedResult` returns `Exec denied (gateway id=…, user-denied): …` as the tool result; no background followup is needed.
4. Channels without a native chat approval client (e.g. `feishu`, `msteams`, `line`, headless `cron`/`heartbeat`) still take the fire-and-forget path; explicit `approvalFollowupMode: "agent"` / `"direct"` opt-out is preserved.

## Change

- New `NATIVE_APPROVAL_CHANNELS` list and `isNativeApprovalChannel` helper in `src/utils/message-channel-constants.ts` (`webchat`, `discord`, `googlechat`, `imessage`, `matrix`, `qqbot`, `signal`, `slack`, `telegram`, `whatsapp`). The list is kept in lockstep with the bundled extensions that publish an `approval-handler.runtime` adapter and a `resolveApproveCommandBehavior` capability.
- `shouldAwaitGatewayApprovalInline` in `src/agents/bash-tools.exec-host-gateway.ts:294-308` now consults `isNativeApprovalChannel` instead of comparing against `INTERNAL_MESSAGE_CHANNEL` directly. The `approvalFollowupMode` opt-out and the `unavailableReason === null` gate are preserved, so the new path is unreachable for cron / headless / disabled-native-approval cases.
- Re-exports the new helpers from `src/utils/message-channel.ts`.

## Verification

Local:

- `pnpm tsgo:core` — clean.
- `pnpm tsgo:extensions` — clean.
- `node scripts/run-vitest.mjs run src/utils/message-channel.test.ts` — 7/7 (new `NATIVE_APPROVAL_CHANNELS` membership test included).
- `node scripts/run-vitest.mjs run src/agents/bash-tools.exec-host-gateway.test.ts` — 46/46 (18 new parameterized cases covering 9 native channels × inline-resolution + inline-denial, plus regression cases for `feishu` and `approvalFollowupMode: "agent"` keeping the fire-and-forget path).
- `node scripts/run-vitest.mjs run src/agents/bash-tools.exec-approval-followup.test.ts src/agents/bash-tools.exec-approval-request.test.ts src/agents/bash-tools.exec-host-shared.test.ts` — 66/66.
- `pnpm lint:core` (oxlint on touched files) — no findings.
- `pnpm format:check` on touched files — clean (the 55 pre-existing format warnings are unrelated to this branch and reproduce on `main`).

## Real behavior proof

Behavior addressed: Native chat exec approvals in the originating chat thread now resume the original agent turn inline instead of ending on `approval-pending` and forcing the operator to send another message that mints a fresh approval.

Real environment tested: macOS 26.4.1 with a real Telegram client talking to real Telegram bot `@NianJiuopenclawbot`, local build of `openclaw` from PR head `2f7b360d54c762750b556253b940f9719b6ba0a3`, with `tools.exec.host=gateway` and `tools.exec.ask=always`.

Exact steps or command run after this patch:
1. Started the PR build locally with gateway exec approvals forced on.
2. From a real Telegram chat, sent `请用 exec 工具执行 date +%s%N 并把纳秒时间戳告诉我`.
3. Waited for the approval card, clicked `Allow once`, and watched the same Telegram thread for the post-approval reply.

Evidence after fix:
- Screenshot from the real Telegram thread after approval:
  <img width="1440" height="4558" alt="Screenshot_2026_0617_222452" src="https://github.com/user-attachments/assets/8bff5058-4868-4e74-89be-85de17b36c01" />
- Redacted live runtime output from the same run:
  - `22:21:30 UTC+8 — telegram outbound sendMessage messageId=104`
  - `22:23:38 — exec.approval.waitDecision blocked 132s in blocked_tool_call`
  - `22:23:52 — exec.approval.waitDecision 145500ms resolved after Allow once`
  - `Exec finished (gateway id=…, code 0)` followed by the 19-digit nanosecond timestamp in the same turn.

Observed result after fix: The original agent turn stayed open while waiting for approval, the command ran immediately after `Allow once`, and the bot replied in the same Telegram thread with `Exec finished (gateway id=…, code 0)` plus the timestamp. No extra wake-up message was needed and no duplicate `Run:` approval prompt appeared.

What was not tested: I did not rerun the same live proof on Slack, Discord, Google Chat, or a deny-path click for this PR body update; those channel/deny branches are covered here by the targeted tests listed in the Verification section.


## Related

- Refs https://github.com/openclaw/openclaw/issues/93918
- Builds on PR #85239 (`fix(exec): return approved WebChat gateway exec output inline`) — same root cause, webchat path only.
- Same root cause as #39648 (Control UI + multi-agent TUI path on 2026.3.2). This PR covers the native chat path on 2026.6.6+; the two surfaces share the same `shouldAwaitGatewayApprovalInline` decision now.