### PR TITLE
[codex] fix setup health hint command surface

### DIFF
--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -46,6 +46,16 @@ describe("registerSetupCommand", () => {
     await program.parseAsync(args, { from: "user" });
   }
 
+  function getSetupOptionFlags(): string[] {
+    const program = new Command();
+    registerSetupCommand(program);
+    const setup = program.commands.find((command) => command.name() === "setup");
+    if (!setup) {
+      throw new Error("expected setup command");
+    }
+    return setup.options.map((option) => option.long);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     setupCommandMock.mockResolvedValue(undefined);
@@ -94,6 +104,11 @@ describe("registerSetupCommand", () => {
     expect(lastWizardOptions()?.importSource).toBe("/tmp/hermes");
     expect(lastWizardOptions()?.importSecrets).toBe(true);
     expect(setupCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("does not expose onboard-only health and daemon flags", () => {
+    expect(getSetupOptionFlags()).not.toContain("--install-daemon");
+    expect(getSetupOptionFlags()).not.toContain("--skip-health");
   });
 
   it("reports setup errors through runtime", async () => {

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -763,6 +764,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
   it("explains local health failure when no daemon was requested", async () => {
     await withStateDir("state-local-health-hint-", async (stateDir) => {
+      const workspace = path.join(stateDir, "openclaw");
+      const installDaemonCommand = formatCliCommand(
+        "openclaw onboard --non-interactive --accept-risk ... --install-daemon",
+      );
+      const skipHealthCommand = formatCliCommand(
+        "openclaw onboard --non-interactive --accept-risk ... --skip-health",
+      );
       waitForGatewayReachableMock = vi.fn(async () => ({
         ok: false,
         detail: "socket closed: 1006 abnormal closure",
@@ -773,7 +781,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           {
             nonInteractive: true,
             mode: "local",
-            workspace: path.join(stateDir, "openclaw"),
+            workspace,
             authChoice: "skip",
             skipSkills: true,
             skipHealth: false,
@@ -783,7 +791,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           runtime,
         ),
       ).rejects.toThrow(
-        /only waits for an already-running gateway unless you pass --install-daemon[\s\S]*--skip-health/,
+        new RegExp(
+          [
+            "only waits for an already-running gateway unless you run",
+            `\`${installDaemonCommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\``,
+            `\`${skipHealthCommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\``,
+          ].join("[\\s\\S]*"),
+        ),
       );
     });
   }, 60_000);

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -342,8 +342,8 @@ export async function runNonInteractiveLocalSetup(params: {
         diagnostics,
         hints: !opts.installDaemon
           ? [
-              "Non-interactive local setup only waits for an already-running gateway unless you pass --install-daemon.",
-              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run with \`--install-daemon\`, or use \`--skip-health\`.`,
+              `Non-interactive local setup only waits for an already-running gateway unless you run \`${formatCliCommand("openclaw onboard --non-interactive --accept-risk ... --install-daemon")}\`.`,
+              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run with \`${formatCliCommand("openclaw onboard --non-interactive --accept-risk ... --install-daemon")}\`, or use \`${formatCliCommand("openclaw onboard --non-interactive --accept-risk ... --skip-health")}\`.`,
               process.platform === "win32"
                 ? "Native Windows managed gateway install tries Scheduled Tasks first and falls back to a per-user Startup-folder login item when task creation is denied."
                 : undefined,


### PR DESCRIPTION
## Summary

Fix the non-interactive local setup health hint so it points to the real command surface.

When `openclaw setup --non-interactive --accept-risk` falls into the onboarding health-check path and no managed gateway was requested, the failure message used to suggest `--install-daemon` / `--skip-health` as if they were `setup` flags. Those flags only exist on `openclaw onboard`, so the remediation was misleading.

Closes #93947.

## Changes

- keep `setup` free of onboard-only daemon/health flags in the command registration test
- update the non-interactive local health failure hint to recommend `openclaw onboard --non-interactive --accept-risk ... --install-daemon` and `... --skip-health`
- lock the new hint text with a regression test

## Verification

- `node scripts/run-vitest.mjs src/cli/program/register.setup.test.ts`
- `node scripts/run-vitest.mjs src/commands/onboard-non-interactive.gateway.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `env -i HOME="$HOME" PATH="$PATH" TERM=dumb OPENCLAW_STATE_DIR="$TMP_STATE/state" OPENCLAW_CONFIG_PATH="$TMP_STATE/state/openclaw.json" node openclaw.mjs onboard --non-interactive --accept-risk --workspace "$TMP_STATE/workspace" --auth-choice skip --skip-skills --gateway-bind loopback`

## Real behavior proof

Behavior addressed: non-interactive setup health failure hints no longer tell users to use unsupported `setup` flags.
Real environment tested: local macOS checkout with built CLI entrypoint and isolated OpenClaw state dir.
Exact steps or command run after this patch: ran the focused Vitest files above, then ran isolated `openclaw onboard --non-interactive --accept-risk ...` without a running gateway.
Evidence after fix: the failure output now points to `openclaw onboard --non-interactive --accept-risk ... --install-daemon` and `... --skip-health`.
Observed result after fix: the remediation text matches the actual CLI surface instead of suggesting unsupported `setup` flags.
What was not tested: broad changed lanes / remote Testbox coverage.
