### PR TITLE
fix(agents): bound auth refresh without releasing token ownership

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -55,7 +55,13 @@ To reduce that, OpenClaw treats the auth profile store as a **token sink**:
   re-authentication instead of falling back to external CLI token material.
   Codex CLI bootstrap is narrower still: it can only seed an empty
   `openai:default`-style profile before OpenClaw owns OAuth for that
-  provider; after that, OpenClaw-owned refreshes stay canonical
+  provider. When that credential first needs rotation, OpenClaw re-reads the
+  native Codex credential under the refresh lock. If Codex already replaced
+  the rejected bearer with a different usable bearer, OpenClaw uses that
+  native result without claiming ownership. Metadata-only changes do not
+  suppress a requested refresh. Otherwise, OpenClaw atomically records a
+  successful changed rotation in SQLite. That SQLite profile is canonical
+  afterward; OpenClaw never writes the rotation back to the native Codex store
 - status/startup paths scope external CLI discovery to the provider set
   already configured, so an unrelated CLI login store is not probed for a
   single-provider setup
@@ -180,11 +186,14 @@ Profiles store an `expires` timestamp. At runtime:
 - if a secondary agent reads an inherited main-agent OAuth profile, the
   refresh writes back to the main agent store instead of copying the refresh
   token into the secondary agent store
-- externally managed CLI credentials (Claude CLI, narrow Codex CLI bootstrap;
-  see [The token sink](#the-token-sink-why-it-exists)) are re-read instead of
-  spending a copied refresh token. If a managed refresh fails, OpenClaw
-  reports the affected profile for re-authentication instead of returning
-  external CLI token material.
+- externally managed CLI credentials are re-read from their owner when the
+  provider contract requires it. For narrow Codex CLI bootstrap, that fresh
+  read happens under the global refresh lock immediately before the first
+  rotation. A usable bearer already changed by Codex remains native;
+  otherwise, a successful changed rotation is inserted into SQLite and all
+  later refreshes use that canonical row. If a managed refresh fails,
+  OpenClaw reports the affected profile for re-authentication instead of
+  returning stale external CLI token material.
 
 The refresh flow is automatic; you generally do not need to manage tokens manually.
 

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -42,6 +42,10 @@ type MockCacheResult = {
   warnings: string[];
 };
 
+const agentRuntimeMocks = vi.hoisted(() => ({
+  resolveApiKeyForProfile: vi.fn(),
+}));
+
 const computerUseServiceMocks = vi.hoisted(() => ({
   ensureCodexComputerUseSharedPluginCache: vi.fn<
     (_params: { forceRefresh?: boolean }) => Promise<MockCacheResult>
@@ -74,7 +78,7 @@ const computerUseServiceMocks = vi.hoisted(() => ({
 const providerRuntimeMocks = vi.hoisted(() => ({
   formatProviderAuthProfileApiKeyWithPlugin: vi.fn(),
   refreshProviderOAuthCredentialWithPlugin: vi.fn(
-    async (params: { provider?: string; context: { refresh: string } }) => {
+    async (params: { provider?: string; config?: unknown; context: { refresh: string } }) => {
       const refreshed = await oauthMocks.refreshOpenAICodexToken(params.context.refresh);
       return refreshed
         ? {
@@ -95,6 +99,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
     resolveApiKeyForProfile: async (
       params: Parameters<typeof actual.resolveApiKeyForProfile>[0],
     ) => {
+      agentRuntimeMocks.resolveApiKeyForProfile(params);
       const credential = params.store.profiles[params.profileId];
       if (!credential) {
         return null;
@@ -120,12 +125,13 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
       if (params.forceRefresh || (oauthCredential.expires ?? 0) <= Date.now()) {
         const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
           provider: oauthCredential.provider,
+          config: params.cfg,
           context: oauthCredential,
         });
         if (refreshed?.access) {
           oauthCredential = refreshed as typeof oauthCredential;
           params.store.profiles[params.profileId] = oauthCredential;
-          if (params.agentDir || process.env.OPENCLAW_STATE_DIR) {
+          if (!params.useRuntimeOAuthStore && (params.agentDir || process.env.OPENCLAW_STATE_DIR)) {
             actual.saveAuthProfileStore(params.store, params.agentDir);
           }
         }
@@ -138,21 +144,6 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         typeof formatted === "string" && formatted ? formatted : oauthCredential.access;
       return apiKey
         ? { apiKey, provider: oauthCredential.provider, email: oauthCredential.email }
-        : null;
-    },
-    refreshOAuthCredentialForRuntime: async (
-      params: Parameters<typeof actual.refreshOAuthCredentialForRuntime>[0],
-    ) => {
-      const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
-        provider: params.credential.provider,
-        context: params.credential,
-      });
-      return refreshed
-        ? {
-            ...params.credential,
-            ...refreshed,
-            type: "oauth" as const,
-          }
         : null;
     },
   };
@@ -188,6 +179,7 @@ vi.mock("./desktop-app-paths.js", async (importOriginal) => {
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();
+  agentRuntimeMocks.resolveApiKeyForProfile.mockClear();
   oauthMocks.refreshOpenAICodexToken.mockReset();
   providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockReset();
   providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockClear();
@@ -1941,18 +1933,17 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("serializes concurrent refreshes of the same scoped OAuth profile", async () => {
+  it("routes scoped OAuth refreshes through the canonical resolver with config", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
-    let resolveRefresh:
-      | ((value: { access: string; refresh: string; expires: number; accountId: string }) => void)
-      | undefined;
-    oauthMocks.refreshOpenAICodexToken.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          resolveRefresh = resolve;
-        }),
-    );
+    const config = {
+      auth: { order: { openai: ["openai:work"] } },
+    };
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "scoped-refreshed-access",
+      refresh: "scoped-refreshed-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "scoped-refreshed-account",
+    });
     const authProfileStore: AuthProfileStore = {
       version: 1,
       profiles: {
@@ -1967,49 +1958,89 @@ describe("bridgeCodexAppServerStartOptions", () => {
       },
     };
     try {
-      const first = applyCodexAppServerAuthProfile({
-        client: { request } as never,
-        agentDir,
-        authProfileId: "openai:work",
-        authProfileStore,
+      await expect(
+        refreshCodexAppServerAuthTokens({
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+          config,
+        }),
+      ).resolves.toEqual({
+        accessToken: "scoped-refreshed-access",
+        chatgptAccountId: "scoped-refreshed-account",
+        chatgptPlanType: null,
       });
-      const second = applyCodexAppServerAuthProfile({
-        client: { request } as never,
-        agentDir,
-        authProfileId: "openai:work",
-        authProfileStore,
-      });
-      await vi.waitFor(() => expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(1));
 
-      resolveRefresh?.({
+      expect(agentRuntimeMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: config,
+          store: authProfileStore,
+          profileId: "openai:work",
+          forceRefresh: true,
+          useRuntimeOAuthStore: true,
+        }),
+      );
+      expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config,
+          provider: "openai",
+        }),
+      );
+      expect(authProfileStore.profiles["openai:work"]).toMatchObject({
         access: "scoped-refreshed-access",
         refresh: "scoped-refreshed-refresh",
-        expires: Date.now() + 60_000,
-        accountId: "scoped-refreshed-account",
-      });
-      await Promise.all([first, second]);
-
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledTimes(1);
-      expect(request).toHaveBeenCalledTimes(2);
-      expect(request).toHaveBeenNthCalledWith(1, "account/login/start", {
-        type: "chatgptAuthTokens",
-        accessToken: "scoped-refreshed-access",
-        chatgptAccountId: "scoped-refreshed-account",
-        chatgptPlanType: null,
-      });
-      expect(request).toHaveBeenNthCalledWith(2, "account/login/start", {
-        type: "chatgptAuthTokens",
-        accessToken: "scoped-refreshed-access",
-        chatgptAccountId: "scoped-refreshed-account",
-        chatgptPlanType: null,
       });
     } finally {
-      resolveRefresh?.({
-        access: "cleanup-access",
-        refresh: "cleanup-refresh",
-        expires: Date.now() + 60_000,
-        accountId: "cleanup-account",
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("routes persisted OAuth refreshes through the canonical resolver with config", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const config = {
+      auth: { order: { openai: ["openai:work"] } },
+    };
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "persisted-refreshed-access",
+      refresh: "persisted-refreshed-refresh",
+      expires: Date.now() + 60_000,
+      accountId: "persisted-account",
+    });
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai:work",
+        credential: {
+          type: "oauth",
+          provider: "openai",
+          access: "persisted-access",
+          refresh: "persisted-refresh",
+          expires: Date.now() - 60_000,
+          accountId: "persisted-account",
+        },
       });
+
+      await refreshCodexAppServerAuthTokens({
+        agentDir,
+        authProfileId: "openai:work",
+        config,
+      });
+
+      expect(agentRuntimeMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: config,
+          profileId: "openai:work",
+          forceRefresh: true,
+          useRuntimeOAuthStore: false,
+        }),
+      );
+      expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config,
+          provider: "openai",
+        }),
+      );
+    } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
   });
@@ -2421,6 +2452,9 @@ describe("bridgeCodexAppServerStartOptions", () => {
     const agentDir = path.join(root, "agent");
     const codexHome = path.join(root, "codex-cli");
     const authProfileStorePath = path.join(agentDir, "auth-profiles.json");
+    const config = {
+      auth: { order: { openai: ["openai:default"] } },
+    };
     vi.stubEnv("CODEX_HOME", codexHome);
     oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
       access: "fresh-cli-access-token",
@@ -2431,7 +2465,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     try {
       await writeCodexCliAuthFile(codexHome);
 
-      await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
+      await expect(refreshCodexAppServerAuthTokens({ agentDir, config })).resolves.toEqual({
         accessToken: "fresh-cli-access-token",
         chatgptAccountId: "account-cli-refreshed",
         chatgptPlanType: null,
@@ -2439,6 +2473,20 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
       await expectPathMissing(authProfileStorePath);
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
+      expect(agentRuntimeMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: config,
+          profileId: "openai:default",
+          forceRefresh: true,
+          useRuntimeOAuthStore: true,
+        }),
+      );
+      expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config,
+          provider: "openai",
+        }),
+      );
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -43,6 +43,7 @@ type MockCacheResult = {
 };
 
 const agentRuntimeMocks = vi.hoisted(() => ({
+  refreshOAuthCredentialForRuntime: vi.fn(),
   resolveApiKeyForProfile: vi.fn(),
 }));
 
@@ -96,6 +97,29 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-runtime")>();
   return {
     ...actual,
+    refreshOAuthCredentialForRuntime: async (
+      params: Parameters<typeof actual.refreshOAuthCredentialForRuntime>[0],
+    ) => {
+      agentRuntimeMocks.refreshOAuthCredentialForRuntime(params);
+      if (
+        params.forceRefresh === false &&
+        params.credential.expires > Date.now() &&
+        params.credential.access.trim()
+      ) {
+        return params.credential;
+      }
+      const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
+        provider: params.credential.provider,
+        config: params.cfg,
+        context: params.credential,
+      });
+      if (!refreshed?.access) {
+        return null;
+      }
+      const oauthCredential = refreshed as typeof params.credential;
+      params.store.profiles[params.profileId] = oauthCredential;
+      return oauthCredential;
+    },
     resolveApiKeyForProfile: async (
       params: Parameters<typeof actual.resolveApiKeyForProfile>[0],
     ) => {
@@ -131,7 +155,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         if (refreshed?.access) {
           oauthCredential = refreshed as typeof oauthCredential;
           params.store.profiles[params.profileId] = oauthCredential;
-          if (!params.useRuntimeOAuthStore && (params.agentDir || process.env.OPENCLAW_STATE_DIR)) {
+          if (params.agentDir || process.env.OPENCLAW_STATE_DIR) {
             actual.saveAuthProfileStore(params.store, params.agentDir);
           }
         }
@@ -179,6 +203,7 @@ vi.mock("./desktop-app-paths.js", async (importOriginal) => {
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();
+  agentRuntimeMocks.refreshOAuthCredentialForRuntime.mockClear();
   agentRuntimeMocks.resolveApiKeyForProfile.mockClear();
   oauthMocks.refreshOpenAICodexToken.mockReset();
   providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockReset();
@@ -1971,15 +1996,14 @@ describe("bridgeCodexAppServerStartOptions", () => {
         chatgptPlanType: null,
       });
 
-      expect(agentRuntimeMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+      expect(agentRuntimeMocks.refreshOAuthCredentialForRuntime).toHaveBeenCalledWith(
         expect.objectContaining({
           cfg: config,
           store: authProfileStore,
           profileId: "openai:work",
-          forceRefresh: true,
-          useRuntimeOAuthStore: true,
         }),
       );
+      expect(agentRuntimeMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
       expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
         expect.objectContaining({
           config,
@@ -2031,7 +2055,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
           cfg: config,
           profileId: "openai:work",
           forceRefresh: true,
-          useRuntimeOAuthStore: false,
         }),
       );
       expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
@@ -2473,14 +2496,13 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
       await expectPathMissing(authProfileStorePath);
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
-      expect(agentRuntimeMocks.resolveApiKeyForProfile).toHaveBeenCalledWith(
+      expect(agentRuntimeMocks.refreshOAuthCredentialForRuntime).toHaveBeenCalledWith(
         expect.objectContaining({
           cfg: config,
           profileId: "openai:default",
-          forceRefresh: true,
-          useRuntimeOAuthStore: true,
         }),
       );
+      expect(agentRuntimeMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
       expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
         expect.objectContaining({
           config,

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1644,6 +1644,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
           accountId: "persisted-account",
         },
       );
+      expect(agentRuntimeMocks.refreshCodexCliOAuthCredentialForRuntime).not.toHaveBeenCalled();
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -43,6 +43,7 @@ type MockCacheResult = {
 };
 
 const agentRuntimeMocks = vi.hoisted(() => ({
+  refreshCodexCliOAuthCredentialForRuntime: vi.fn(),
   refreshOAuthCredentialForRuntime: vi.fn(),
   resolveApiKeyForProfile: vi.fn(),
 }));
@@ -101,24 +102,18 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
       params: Parameters<typeof actual.refreshOAuthCredentialForRuntime>[0],
     ) => {
       agentRuntimeMocks.refreshOAuthCredentialForRuntime(params);
-      if (
-        params.forceRefresh === false &&
-        params.credential.expires > Date.now() &&
-        params.credential.access.trim()
-      ) {
-        return params.credential;
-      }
       const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
         provider: params.credential.provider,
         config: params.cfg,
         context: params.credential,
       });
-      if (!refreshed?.access) {
-        return null;
-      }
-      const oauthCredential = refreshed as typeof params.credential;
-      params.store.profiles[params.profileId] = oauthCredential;
-      return oauthCredential;
+      return refreshed
+        ? {
+            ...params.credential,
+            ...refreshed,
+            type: "oauth" as const,
+          }
+        : null;
     },
     resolveApiKeyForProfile: async (
       params: Parameters<typeof actual.resolveApiKeyForProfile>[0],
@@ -145,8 +140,22 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
       if (credential.type !== "oauth") {
         return null;
       }
-      let oauthCredential = credential;
-      if (params.forceRefresh || (oauthCredential.expires ?? 0) <= Date.now()) {
+      const canonicalStore = actual.loadAuthProfileStoreWithoutExternalProfiles(params.agentDir);
+      const canonical = canonicalStore.profiles[params.profileId];
+      let oauthCredential =
+        canonical?.type === "oauth" && canonical.provider === credential.provider
+          ? canonical
+          : credential;
+      const anotherCallerReplacedRejectedBearer = Boolean(
+        params.forceRefresh &&
+        oauthCredential.access.trim() &&
+        oauthCredential.expires > Date.now() + 5 * 60_000 &&
+        oauthCredential.access !== credential.access,
+      );
+      if (
+        !anotherCallerReplacedRejectedBearer &&
+        (params.forceRefresh || (oauthCredential.expires ?? 0) <= Date.now())
+      ) {
         const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
           provider: oauthCredential.provider,
           config: params.cfg,
@@ -154,9 +163,9 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
         });
         if (refreshed?.access) {
           oauthCredential = refreshed as typeof oauthCredential;
-          params.store.profiles[params.profileId] = oauthCredential;
-          if (params.agentDir || process.env.OPENCLAW_STATE_DIR) {
-            actual.saveAuthProfileStore(params.store, params.agentDir);
+          if (canonical?.type === "oauth") {
+            canonicalStore.profiles[params.profileId] = oauthCredential;
+            actual.saveAuthProfileStore(canonicalStore, params.agentDir);
           }
         }
       }
@@ -169,6 +178,35 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
       return apiKey
         ? { apiKey, provider: oauthCredential.provider, email: oauthCredential.email }
         : null;
+    },
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth-runtime")>();
+  return {
+    ...actual,
+    refreshCodexCliOAuthCredentialForRuntime: async (
+      params: Parameters<typeof actual.refreshCodexCliOAuthCredentialForRuntime>[0],
+    ) => {
+      agentRuntimeMocks.refreshCodexCliOAuthCredentialForRuntime(params);
+      const credential = params.store.profiles[params.profileId];
+      if (!credential || credential.type !== "oauth") {
+        return null;
+      }
+      const refreshed = await providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin({
+        provider: credential.provider,
+        config: params.cfg,
+        context: credential,
+      });
+      if (!refreshed) {
+        return null;
+      }
+      const managed = { ...credential, ...refreshed, type: "oauth" as const };
+      params.store.profiles[params.profileId] = managed;
+      const { saveAuthProfileStore } = await import("openclaw/plugin-sdk/agent-runtime");
+      saveAuthProfileStore(params.store, params.agentDir);
+      return managed;
     },
   };
 });
@@ -203,6 +241,7 @@ vi.mock("./desktop-app-paths.js", async (importOriginal) => {
 afterEach(() => {
   vi.unstubAllEnvs();
   clearRuntimeAuthProfileStoreSnapshots();
+  agentRuntimeMocks.refreshCodexCliOAuthCredentialForRuntime.mockClear();
   agentRuntimeMocks.refreshOAuthCredentialForRuntime.mockClear();
   agentRuntimeMocks.resolveApiKeyForProfile.mockClear();
   oauthMocks.refreshOpenAICodexToken.mockReset();
@@ -1610,19 +1649,14 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("keeps a prepared persisted store aligned across rotating refresh tokens", async () => {
+  it("routes distinct remote-exec prepared clones through persisted rotation ownership", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    oauthMocks.refreshOpenAICodexToken
-      .mockResolvedValueOnce({
-        access: "first-rotated-access",
-        refresh: "first-rotated-refresh",
-        expires: Date.now() + 60_000,
-      })
-      .mockResolvedValueOnce({
-        access: "second-rotated-access",
-        refresh: "second-rotated-refresh",
-        expires: Date.now() + 60_000,
-      });
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "first-rotated-access",
+      refresh: "first-rotated-refresh",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "remote-exec-account",
+    });
     try {
       upsertAuthProfile({
         agentDir,
@@ -1632,31 +1666,43 @@ describe("bridgeCodexAppServerStartOptions", () => {
           provider: "openai",
           access: "initial-access",
           refresh: "initial-refresh",
-          expires: Date.now() + 60_000,
-          accountId: "rotating-account",
+          expires: Date.now() + 10 * 60_000,
+          accountId: "remote-exec-account",
         },
       });
-      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      const preparedSnapshot = loadAuthProfileStoreForSecretsRuntime(agentDir);
+      // Remote-exec workers receive detached prepared stores. Snapshot
+      // publication in this process cannot update either caller's copy.
+      const firstPreparedStore = structuredClone(preparedSnapshot);
+      const secondPreparedStore = structuredClone(preparedSnapshot);
+      expect(secondPreparedStore).not.toBe(firstPreparedStore);
 
       await refreshCodexAppServerAuthTokens({
         agentDir,
         authProfileId: "openai:work",
-        authProfileStore,
+        authProfileStore: firstPreparedStore,
       });
       await refreshCodexAppServerAuthTokens({
         agentDir,
         authProfileId: "openai:work",
-        authProfileStore,
+        authProfileStore: secondPreparedStore,
       });
 
-      expect(oauthMocks.refreshOpenAICodexToken.mock.calls).toEqual([
-        ["initial-refresh"],
-        ["first-rotated-refresh"],
-      ]);
-      expect(authProfileStore.profiles["openai:work"]).toMatchObject({
-        access: "second-rotated-access",
-        refresh: "second-rotated-refresh",
+      expect(oauthMocks.refreshOpenAICodexToken.mock.calls).toEqual([["initial-refresh"]]);
+      expect(firstPreparedStore.profiles["openai:work"]).toMatchObject({
+        access: "first-rotated-access",
+        refresh: "first-rotated-refresh",
       });
+      expect(secondPreparedStore.profiles["openai:work"]).toMatchObject({
+        access: "first-rotated-access",
+        refresh: "first-rotated-refresh",
+      });
+      expect(loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:work"]).toMatchObject(
+        {
+          access: "first-rotated-access",
+          refresh: "first-rotated-refresh",
+        },
+      );
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -1953,67 +1999,6 @@ describe("bridgeCodexAppServerStartOptions", () => {
           accountId: "account-b",
         },
       );
-    } finally {
-      await fs.rm(agentDir, { recursive: true, force: true });
-    }
-  });
-
-  it("routes scoped OAuth refreshes through the canonical resolver with config", async () => {
-    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    const config = {
-      auth: { order: { openai: ["openai:work"] } },
-    };
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "scoped-refreshed-access",
-      refresh: "scoped-refreshed-refresh",
-      expires: Date.now() + 60_000,
-      accountId: "scoped-refreshed-account",
-    });
-    const authProfileStore: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        "openai:work": {
-          type: "oauth",
-          provider: "openai",
-          access: "scoped-expired-access",
-          refresh: "scoped-refresh",
-          expires: Date.now() - 60_000,
-          accountId: "scoped-account",
-        },
-      },
-    };
-    try {
-      await expect(
-        refreshCodexAppServerAuthTokens({
-          agentDir,
-          authProfileId: "openai:work",
-          authProfileStore,
-          config,
-        }),
-      ).resolves.toEqual({
-        accessToken: "scoped-refreshed-access",
-        chatgptAccountId: "scoped-refreshed-account",
-        chatgptPlanType: null,
-      });
-
-      expect(agentRuntimeMocks.refreshOAuthCredentialForRuntime).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cfg: config,
-          store: authProfileStore,
-          profileId: "openai:work",
-        }),
-      );
-      expect(agentRuntimeMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
-      expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
-        expect.objectContaining({
-          config,
-          provider: "openai",
-        }),
-      );
-      expect(authProfileStore.profiles["openai:work"]).toMatchObject({
-        access: "scoped-refreshed-access",
-        refresh: "scoped-refreshed-refresh",
-      });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -2470,14 +2455,11 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("answers refresh from native Codex CLI OAuth without persisting an OpenClaw profile", async () => {
+  it("promotes the first native Codex CLI OAuth rotation into OpenClaw storage", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const agentDir = path.join(root, "agent");
     const codexHome = path.join(root, "codex-cli");
     const authProfileStorePath = path.join(agentDir, "auth-profiles.json");
-    const config = {
-      auth: { order: { openai: ["openai:default"] } },
-    };
     vi.stubEnv("CODEX_HOME", codexHome);
     oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
       access: "fresh-cli-access-token",
@@ -2488,7 +2470,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
     try {
       await writeCodexCliAuthFile(codexHome);
 
-      await expect(refreshCodexAppServerAuthTokens({ agentDir, config })).resolves.toEqual({
+      await expect(refreshCodexAppServerAuthTokens({ agentDir })).resolves.toEqual({
         accessToken: "fresh-cli-access-token",
         chatgptAccountId: "account-cli-refreshed",
         chatgptPlanType: null,
@@ -2496,19 +2478,61 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
       await expectPathMissing(authProfileStorePath);
       expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("cli-refresh-token");
-      expect(agentRuntimeMocks.refreshOAuthCredentialForRuntime).toHaveBeenCalledWith(
+      expect(agentRuntimeMocks.refreshCodexCliOAuthCredentialForRuntime).toHaveBeenCalledWith(
         expect.objectContaining({
-          cfg: config,
           profileId: "openai:default",
+          forceRefresh: true,
         }),
       );
+      expect(
+        loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:default"],
+      ).toMatchObject({
+        access: "fresh-cli-access-token",
+        refresh: "fresh-cli-refresh-token",
+      });
+      expect(agentRuntimeMocks.refreshOAuthCredentialForRuntime).not.toHaveBeenCalled();
       expect(agentRuntimeMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
-      expect(providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin).toHaveBeenCalledWith(
-        expect.objectContaining({
-          config,
-          provider: "openai",
-        }),
-      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("routes a detached native Codex snapshot to the already-promoted SQLite rotation", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const agentDir = path.join(root, "agent");
+    const codexHome = path.join(root, "codex-cli");
+    vi.stubEnv("CODEX_HOME", codexHome);
+    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+      access: "promoted-cli-access-token",
+      refresh: "promoted-cli-refresh-token",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "account-cli-refreshed",
+    });
+    try {
+      await writeCodexCliAuthFile(codexHome);
+      const prepared = resolveCodexAppServerAuthProfileStore({ agentDir });
+      const firstPreparedStore = structuredClone(prepared);
+      const secondPreparedStore = structuredClone(prepared);
+
+      await expect(
+        refreshCodexAppServerAuthTokens({ agentDir, authProfileStore: firstPreparedStore }),
+      ).resolves.toMatchObject({ accessToken: "promoted-cli-access-token" });
+      await expect(
+        refreshCodexAppServerAuthTokens({ agentDir, authProfileStore: secondPreparedStore }),
+      ).resolves.toMatchObject({ accessToken: "promoted-cli-access-token" });
+
+      expect(oauthMocks.refreshOpenAICodexToken.mock.calls).toEqual([["cli-refresh-token"]]);
+      expect(firstPreparedStore.profiles["openai:default"]).toMatchObject({
+        access: "promoted-cli-access-token",
+      });
+      expect(secondPreparedStore.profiles["openai:default"]).toMatchObject({
+        access: "promoted-cli-access-token",
+      });
+      expect(
+        loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:default"],
+      ).toMatchObject({ access: "promoted-cli-access-token" });
+      expect(agentRuntimeMocks.refreshCodexCliOAuthCredentialForRuntime).toHaveBeenCalledTimes(1);
+      expect(agentRuntimeMocks.resolveApiKeyForProfile).toHaveBeenCalledTimes(1);
     } finally {
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -11,6 +11,7 @@ import {
   ensureAuthProfileStore,
   findPersistedAuthProfileCredential,
   loadAuthProfileStoreForSecretsRuntime,
+  refreshOAuthCredentialForRuntime,
   resolveAuthProfileOrder,
   resolveProviderIdForAuth,
   resolveApiKeyForProfile,
@@ -1196,18 +1197,35 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(persistedCredential.provider)
       ? persistedCredential
       : undefined;
-  const useRuntimeOAuthStore = useScopedCredential || !persistedOAuthCredential;
+  if (useScopedCredential || !persistedOAuthCredential) {
+    const runtimeCredential = store.profiles[profileId];
+    const refreshedRuntimeCredential =
+      runtimeCredential?.type === "oauth"
+        ? await refreshOAuthCredentialForRuntime({
+            store,
+            profileId,
+            credential: runtimeCredential,
+            cfg: params.config,
+            agentDir: ownerAgentDir,
+            forceRefresh: params.forceRefresh,
+          })
+        : undefined;
+    if (!refreshedRuntimeCredential?.access?.trim()) {
+      throw new Error(`Codex app-server auth profile "${profileId}" could not refresh.`);
+    }
+    if (isDeepStrictEqual(params.store.profiles[profileId], credential)) {
+      params.store.profiles[profileId] = refreshedRuntimeCredential;
+    }
+    return refreshedRuntimeCredential;
+  }
   const resolved = await resolveApiKeyForProfile({
     cfg: params.config,
     store,
     profileId,
     agentDir: ownerAgentDir,
     forceRefresh: params.forceRefresh,
-    useRuntimeOAuthStore,
   });
-  const refreshed = useRuntimeOAuthStore
-    ? store.profiles[profileId]
-    : loadAuthProfileStoreForSecretsRuntime(ownerAgentDir).profiles[profileId];
+  const refreshed = loadAuthProfileStoreForSecretsRuntime(ownerAgentDir).profiles[profileId];
   const refreshedOAuthCredential =
     refreshed?.type === "oauth" && isCodexAppServerAuthProvider(refreshed.provider)
       ? refreshed

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -11,7 +11,6 @@ import {
   ensureAuthProfileStore,
   findPersistedAuthProfileCredential,
   loadAuthProfileStoreForSecretsRuntime,
-  refreshOAuthCredentialForRuntime,
   resolveAuthProfileOrder,
   resolveProviderIdForAuth,
   resolveApiKeyForProfile,
@@ -21,10 +20,7 @@ import {
   type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
-import {
-  hasUsableOAuthCredential,
-  resolveOpenAICodexAuthIdentity,
-} from "openclaw/plugin-sdk/provider-auth";
+import { resolveOpenAICodexAuthIdentity } from "openclaw/plugin-sdk/provider-auth";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
 import {
   resolveCodexAppServerHomeDir,
@@ -85,10 +81,6 @@ const activeComputerUseArtifactReconciliations = new Map<
 >();
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
 export type CodexAppServerAuthRequirement = "api-key" | "subscription";
-const scopedOAuthRefreshQueues = new WeakMap<
-  AuthProfileStore,
-  Map<string, Promise<OAuthCredential>>
->();
 
 export async function bridgeCodexAppServerStartOptions(params: {
   startOptions: CodexAppServerStartOptions;
@@ -440,14 +432,24 @@ export async function resolveCodexAppServerAuthAccountCacheKey(params: {
     return undefined;
   }
   if (credential.type === "api_key") {
-    const resolved = await resolveApiKeyForProfile({ store, profileId, agentDir });
+    const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
+      store,
+      profileId,
+      agentDir,
+    });
     const apiKey = resolved?.apiKey?.trim();
     return apiKey
       ? `${resolveChatgptAccountId(profileId, credential)}:${fingerprintApiKeyAuthProfileCacheKey(apiKey)}`
       : resolveChatgptAccountId(profileId, credential);
   }
   if (credential.type === "token") {
-    const resolved = await resolveApiKeyForProfile({ store, profileId, agentDir });
+    const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
+      store,
+      profileId,
+      agentDir,
+    });
     const accessToken = resolved?.apiKey?.trim();
     return accessToken
       ? `${resolveChatgptAccountId(profileId, credential)}:${fingerprintTokenAuthProfileCacheKey(accessToken)}`
@@ -1113,6 +1115,7 @@ async function resolveLoginParamsForCredential(
   // reject opaque provider credentials.
   if (credential.type === "api_key") {
     const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
       store: params.preferStoreCredential
         ? params.store
         : ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false }),
@@ -1124,6 +1127,7 @@ async function resolveLoginParamsForCredential(
   }
   if (credential.type === "token") {
     const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
       store: params.preferStoreCredential
         ? params.store
         : ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false }),
@@ -1192,37 +1196,17 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(persistedCredential.provider)
       ? persistedCredential
       : undefined;
-  const ownerCredential = store.profiles[profileId];
-  const overlaidOAuthCredential =
-    ownerCredential?.type === "oauth" && isCodexAppServerAuthProvider(ownerCredential.provider)
-      ? ownerCredential
-      : undefined;
-  if (useScopedCredential && overlaidOAuthCredential) {
-    return await resolveScopedOAuthCredential({
-      store,
-      profileId,
-      credential: overlaidOAuthCredential,
-      forceRefresh: params.forceRefresh,
-    });
-  }
-  if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
-    const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
-      credential: overlaidOAuthCredential,
-    });
-    if (!refreshedRuntimeCredential?.access?.trim()) {
-      throw new Error(`Codex app-server auth profile "${profileId}" could not refresh.`);
-    }
-    store.profiles[profileId] = refreshedRuntimeCredential;
-    return refreshedRuntimeCredential;
-  }
+  const useRuntimeOAuthStore = useScopedCredential || !persistedOAuthCredential;
   const resolved = await resolveApiKeyForProfile({
+    cfg: params.config,
     store,
     profileId,
     agentDir: ownerAgentDir,
-    forceRefresh: params.forceRefresh && Boolean(persistedOAuthCredential),
+    forceRefresh: params.forceRefresh,
+    useRuntimeOAuthStore,
   });
-  const refreshed = useScopedCredential
-    ? undefined
+  const refreshed = useRuntimeOAuthStore
+    ? store.profiles[profileId]
     : loadAuthProfileStoreForSecretsRuntime(ownerAgentDir).profiles[profileId];
   const refreshedOAuthCredential =
     refreshed?.type === "oauth" && isCodexAppServerAuthProvider(refreshed.provider)
@@ -1277,52 +1261,6 @@ function hasMatchingOAuthIdentity(persisted: OAuthCredential, supplied: OAuthCre
   const persistedEmail = persisted.email?.trim().toLowerCase();
   const suppliedEmail = supplied.email?.trim().toLowerCase();
   return Boolean(persistedEmail && suppliedEmail && persistedEmail === suppliedEmail);
-}
-
-async function resolveScopedOAuthCredential(params: {
-  store: AuthProfileStore;
-  profileId: string;
-  credential: OAuthCredential;
-  forceRefresh: boolean;
-}): Promise<OAuthCredential> {
-  const existingRefresh = scopedOAuthRefreshQueues.get(params.store)?.get(params.profileId);
-  if (existingRefresh) {
-    return await existingRefresh;
-  }
-  if (!params.forceRefresh && hasUsableOAuthCredential(params.credential)) {
-    return params.credential;
-  }
-
-  const storeRefreshes = scopedOAuthRefreshQueues.get(params.store) ?? new Map();
-  scopedOAuthRefreshQueues.set(params.store, storeRefreshes);
-  const refresh = (async () => {
-    const current = params.store.profiles[params.profileId];
-    const credential = current?.type === "oauth" ? current : params.credential;
-    if (!params.forceRefresh && hasUsableOAuthCredential(credential)) {
-      return credential;
-    }
-    const refreshed = await refreshOAuthCredentialForRuntime({ credential });
-    if (!refreshed?.access?.trim()) {
-      throw new Error(`Codex app-server auth profile "${params.profileId}" could not refresh.`);
-    }
-    if (!isDeepStrictEqual(params.store.profiles[params.profileId], credential)) {
-      throw new Error(
-        `Codex app-server auth profile "${params.profileId}" changed while refreshing.`,
-      );
-    }
-    params.store.profiles[params.profileId] = refreshed;
-    return refreshed;
-  })();
-  storeRefreshes.set(params.profileId, refresh);
-  try {
-    return await refresh;
-  } finally {
-    // Scoped stores are process-local; serialize their rotating refresh token
-    // and release the queue entry with the refresh that owns it.
-    if (storeRefreshes.get(params.profileId) === refresh) {
-      storeRefreshes.delete(params.profileId);
-    }
-  }
 }
 
 // Runtime consumes canonical auth state; doctor owns retired profile-id migration.

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -25,7 +25,10 @@ import {
   hasUsableOAuthCredential,
   resolveOpenAICodexAuthIdentity,
 } from "openclaw/plugin-sdk/provider-auth";
-import { refreshCodexCliOAuthCredentialForRuntime } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  isCodexCliOAuthRuntimeProfile,
+  refreshCodexCliOAuthCredentialForRuntime,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
 import {
   resolveCodexAppServerHomeDir,
@@ -1213,7 +1216,7 @@ async function resolveOAuthCredentialForCodexAppServer(
   if (
     !persistedOAuthCredential &&
     overlaidOAuthCredential &&
-    store.runtimeExternalCliProfileIds?.includes(profileId)
+    isCodexCliOAuthRuntimeProfile({ store, profileId })
   ) {
     if (!params.forceRefresh) {
       // Native Codex remains the read owner until app-server rejects the
@@ -1286,7 +1289,7 @@ function shouldUseScopedOAuthCredential(params: {
   config?: AuthProfileOrderConfig;
 }): boolean {
   if (
-    params.store.runtimeExternalCliProfileIds?.includes(params.profileId) &&
+    isCodexCliOAuthRuntimeProfile({ store: params.store, profileId: params.profileId }) &&
     params.persistedCredential?.type === "oauth" &&
     resolveProviderIdForAuth(params.persistedCredential.provider, { config: params.config }) ===
       resolveProviderIdForAuth(params.suppliedCredential.provider, { config: params.config })

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -21,7 +21,11 @@ import {
   type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
-import { resolveOpenAICodexAuthIdentity } from "openclaw/plugin-sdk/provider-auth";
+import {
+  hasUsableOAuthCredential,
+  resolveOpenAICodexAuthIdentity,
+} from "openclaw/plugin-sdk/provider-auth";
+import { refreshCodexCliOAuthCredentialForRuntime } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";
 import {
   resolveCodexAppServerHomeDir,
@@ -82,6 +86,10 @@ const activeComputerUseArtifactReconciliations = new Map<
 >();
 type AuthProfileOrderConfig = Parameters<typeof resolveAuthProfileOrder>[0]["cfg"];
 export type CodexAppServerAuthRequirement = "api-key" | "subscription";
+const scopedOAuthRefreshQueues = new WeakMap<
+  AuthProfileStore,
+  Map<string, Promise<OAuthCredential>>
+>();
 
 export async function bridgeCodexAppServerStartOptions(params: {
   startOptions: CodexAppServerStartOptions;
@@ -1197,30 +1205,56 @@ async function resolveOAuthCredentialForCodexAppServer(
     isCodexAppServerAuthProvider(persistedCredential.provider)
       ? persistedCredential
       : undefined;
-  if (useScopedCredential || !persistedOAuthCredential) {
-    const runtimeCredential = store.profiles[profileId];
-    const refreshedRuntimeCredential =
-      runtimeCredential?.type === "oauth"
-        ? await refreshOAuthCredentialForRuntime({
-            store,
-            profileId,
-            credential: runtimeCredential,
-            cfg: params.config,
-            agentDir: ownerAgentDir,
-            forceRefresh: params.forceRefresh,
-          })
-        : undefined;
+  const ownerCredential = store.profiles[profileId];
+  const overlaidOAuthCredential =
+    ownerCredential?.type === "oauth" && isCodexAppServerAuthProvider(ownerCredential.provider)
+      ? ownerCredential
+      : undefined;
+  if (
+    !persistedOAuthCredential &&
+    overlaidOAuthCredential &&
+    store.runtimeExternalCliProfileIds?.includes(profileId)
+  ) {
+    if (!params.forceRefresh) {
+      // Native Codex remains the read owner until app-server rejects the
+      // bearer and asks for refresh; only that boundary can promote rotation.
+      return overlaidOAuthCredential;
+    }
+    const managedCredential = await refreshCodexCliOAuthCredentialForRuntime({
+      store,
+      profileId,
+      agentDir: ownerAgentDir,
+      cfg: params.config,
+      forceRefresh: params.forceRefresh,
+    });
+    if (!managedCredential?.access?.trim()) {
+      throw new Error(`Codex app-server auth profile "${profileId}" could not refresh.`);
+    }
+    return managedCredential;
+  }
+  if (useScopedCredential && overlaidOAuthCredential) {
+    return await resolveScopedOAuthCredential({
+      store,
+      profileId,
+      credential: overlaidOAuthCredential,
+      forceRefresh: params.forceRefresh,
+    });
+  }
+  if (params.forceRefresh && !persistedOAuthCredential && overlaidOAuthCredential) {
+    const refreshedRuntimeCredential = await refreshOAuthCredentialForRuntime({
+      credential: overlaidOAuthCredential,
+    });
     if (!refreshedRuntimeCredential?.access?.trim()) {
       throw new Error(`Codex app-server auth profile "${profileId}" could not refresh.`);
     }
-    if (isDeepStrictEqual(params.store.profiles[profileId], credential)) {
-      params.store.profiles[profileId] = refreshedRuntimeCredential;
-    }
+    store.profiles[profileId] = refreshedRuntimeCredential;
     return refreshedRuntimeCredential;
   }
   const resolved = await resolveApiKeyForProfile({
     cfg: params.config,
-    store,
+    // Carry the prepared caller's rejected bearer into the locked manager.
+    // The manager rereads SQLite and deduplicates a concurrent rotation.
+    store: params.forceRefresh && params.preferStoreCredential ? params.store : store,
     profileId,
     agentDir: ownerAgentDir,
     forceRefresh: params.forceRefresh,
@@ -1251,6 +1285,16 @@ function shouldUseScopedOAuthCredential(params: {
   suppliedCredential: OAuthCredential;
   config?: AuthProfileOrderConfig;
 }): boolean {
+  if (
+    params.store.runtimeExternalCliProfileIds?.includes(params.profileId) &&
+    params.persistedCredential?.type === "oauth" &&
+    resolveProviderIdForAuth(params.persistedCredential.provider, { config: params.config }) ===
+      resolveProviderIdForAuth(params.suppliedCredential.provider, { config: params.config })
+  ) {
+    // A first native Codex rotation may have promoted while this prepared
+    // store was detached. SQLite owns the profile from that point forward.
+    return false;
+  }
   if (!params.store.runtimePersistedProfileIds?.includes(params.profileId)) {
     return true;
   }
@@ -1279,6 +1323,52 @@ function hasMatchingOAuthIdentity(persisted: OAuthCredential, supplied: OAuthCre
   const persistedEmail = persisted.email?.trim().toLowerCase();
   const suppliedEmail = supplied.email?.trim().toLowerCase();
   return Boolean(persistedEmail && suppliedEmail && persistedEmail === suppliedEmail);
+}
+
+async function resolveScopedOAuthCredential(params: {
+  store: AuthProfileStore;
+  profileId: string;
+  credential: OAuthCredential;
+  forceRefresh: boolean;
+}): Promise<OAuthCredential> {
+  const existingRefresh = scopedOAuthRefreshQueues.get(params.store)?.get(params.profileId);
+  if (existingRefresh) {
+    return await existingRefresh;
+  }
+  if (!params.forceRefresh && hasUsableOAuthCredential(params.credential)) {
+    return params.credential;
+  }
+
+  const storeRefreshes = scopedOAuthRefreshQueues.get(params.store) ?? new Map();
+  scopedOAuthRefreshQueues.set(params.store, storeRefreshes);
+  const refresh = (async () => {
+    const current = params.store.profiles[params.profileId];
+    const credential = current?.type === "oauth" ? current : params.credential;
+    if (!params.forceRefresh && hasUsableOAuthCredential(credential)) {
+      return credential;
+    }
+    const refreshed = await refreshOAuthCredentialForRuntime({ credential });
+    if (!refreshed?.access?.trim()) {
+      throw new Error(`Codex app-server auth profile "${params.profileId}" could not refresh.`);
+    }
+    if (!isDeepStrictEqual(params.store.profiles[params.profileId], credential)) {
+      throw new Error(
+        `Codex app-server auth profile "${params.profileId}" changed while refreshing.`,
+      );
+    }
+    params.store.profiles[params.profileId] = refreshed;
+    return refreshed;
+  })();
+  storeRefreshes.set(params.profileId, refresh);
+  try {
+    return await refresh;
+  } finally {
+    // Scoped stores are process-local; serialize their rotating refresh token
+    // and release the queue entry with the refresh that owns it.
+    if (storeRefreshes.get(params.profileId) === refresh) {
+      storeRefreshes.delete(params.profileId);
+    }
+  }
 }
 
 // Runtime consumes canonical auth state; doctor owns retired profile-id migration.

--- a/extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts
@@ -1,7 +1,16 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import {
+  loadAuthProfileStoreForSecretsRuntime,
+  saveAuthProfileStore,
+} from "openclaw/plugin-sdk/agent-runtime";
+import {
+  createEmptyPluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import type { CodexModelListResponse, CodexTurnCompletedNotification } from "./protocol.js";
@@ -14,6 +23,20 @@ type CodexAuthFile = {
   tokens?: { access_token?: string; account_id?: string };
 };
 
+function corruptJwtSignature(token: string): string {
+  const segments = token.split(".");
+  const signature = segments[2];
+  if (segments.length !== 3 || !signature) {
+    throw new Error("The current Codex access credential is not a signed JWT.");
+  }
+  const replacement = signature[0] === "A" ? "B" : "A";
+  const corruptedSignature = `${replacement}${signature.slice(1)}`;
+  if (Buffer.from(corruptedSignature, "base64url").equals(Buffer.from(signature, "base64url"))) {
+    throw new Error("JWT signature corruption did not change the decoded signature.");
+  }
+  return `${segments[0]}.${segments[1]}.${corruptedSignature}`;
+}
+
 describeLive("Codex app-server real auth refresh boundary", () => {
   it("recovers a real provider turn through OpenClaw's refresh handler", async () => {
     const auth = JSON.parse(
@@ -24,103 +47,154 @@ describeLive("Codex app-server real auth refresh boundary", () => {
     if (!accessToken || !accountId) {
       throw new Error("A current Codex ChatGPT login is required for this live proof.");
     }
-    const invalidAccessToken = `${accessToken.slice(0, -1)}${accessToken.endsWith("A") ? "B" : "A"}`;
+    const invalidAccessToken = corruptJwtSignature(accessToken);
+    expect(invalidAccessToken === accessToken).toBe(false);
 
     await withTempDir("openclaw-codex-auth-refresh-live-", async (root) => {
-      const profileId = "openai:boundary-proof";
-      const store = {
-        version: 1 as const,
-        profiles: {
-          [profileId]: {
-            type: "token" as const,
-            provider: "openai",
-            token: invalidAccessToken,
-            accountId,
+      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+        const profileId = "openai:boundary-proof";
+        const placeholderRefresh = "ephemeral-live-boundary-placeholder";
+        const agentDir = path.join(root, "agent");
+        await fs.mkdir(agentDir, { recursive: true });
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: {
+              [profileId]: {
+                type: "oauth",
+                provider: "openai",
+                access: invalidAccessToken,
+                refresh: placeholderRefresh,
+                expires: Date.now() + 60 * 60_000,
+                accountId,
+              },
+            },
           },
-        },
-      };
-      const runtime = resolveCodexAppServerRuntimeOptions({
-        pluginConfig: { appServer: { homeScope: "local" } },
-        env: {},
-      });
-      const workspace = path.join(root, "workspace");
-      await fs.mkdir(workspace, { recursive: true });
-      let refreshRequests = 0;
-      const client = await createIsolatedCodexAppServerClient({
-        startOptions: {
-          ...runtime.start,
-          clearEnv: ["CODEX_ACCESS_TOKEN", "CODEX_API_KEY", "OPENAI_API_KEY"],
-        },
-        agentDir: path.join(root, "agent"),
-        authProfileId: profileId,
-        authProfileStore: store,
-        authRequirement: "subscription",
-        timeoutMs: 120_000,
-        onStartedClient: (startedClient) => {
-          startedClient.addRequestHandler((request) => {
-            if (request.method === "account/chatgptAuthTokens/refresh") {
-              refreshRequests += 1;
-            }
-            return undefined;
+          agentDir,
+        );
+        const store = loadAuthProfileStoreForSecretsRuntime(agentDir);
+        expect(store.runtimePersistedProfileIds?.includes(profileId)).toBe(true);
+        let providerRefreshes = 0;
+        const registry = createEmptyPluginRegistry();
+        registry.providers.push({
+          pluginId: "openai-live-boundary",
+          source: "live-test",
+          provider: {
+            id: "openai",
+            label: "OpenAI live auth boundary",
+            auth: [],
+            refreshOAuth: async (credential) => {
+              // Keep the operator's rotating grant out of this proof. This
+              // in-process hook injects only the current access credential.
+              providerRefreshes += 1;
+              expect(credential.access === invalidAccessToken).toBe(true);
+              expect(credential.refresh === placeholderRefresh).toBe(true);
+              const lockEntries = await fs.readdir(
+                path.join(root, "state", "locks", "oauth-refresh"),
+              );
+              expect(lockEntries.some((entry) => entry.endsWith(".lock"))).toBe(true);
+              return {
+                ...credential,
+                access: accessToken,
+                expires: Date.now() + 60 * 60_000,
+              };
+            },
+          },
+        });
+        setActivePluginRegistry(registry, "codex-auth-boundary-live");
+        try {
+          const runtime = resolveCodexAppServerRuntimeOptions({
+            pluginConfig: {
+              appServer: {
+                homeScope: "local",
+              },
+            },
+            env: process.env,
           });
-        },
-      });
-      try {
-        // The app-server has the invalid token already. Only the installed
-        // OpenClaw server-request handler can observe this replacement.
-        store.profiles[profileId].token = accessToken;
+          const workspace = path.join(root, "workspace");
+          await fs.mkdir(workspace, { recursive: true });
+          let refreshRequests = 0;
+          const client = await createIsolatedCodexAppServerClient({
+            startOptions: {
+              ...runtime.start,
+              clearEnv: ["CODEX_ACCESS_TOKEN", "CODEX_API_KEY", "OPENAI_API_KEY"],
+            },
+            agentDir,
+            authProfileId: profileId,
+            authProfileStore: store,
+            authRequirement: "subscription",
+            timeoutMs: 120_000,
+            onStartedClient: (startedClient) => {
+              startedClient.addRequestHandler((request) => {
+                if (request.method === "account/chatgptAuthTokens/refresh") {
+                  refreshRequests += 1;
+                }
+                return undefined;
+              });
+            },
+          });
+          try {
+            const listed = await client.request<CodexModelListResponse>(
+              "model/list",
+              { limit: 100, cursor: null, includeHidden: false },
+              { timeoutMs: 60_000 },
+            );
+            const modelId =
+              listed.data.find((model) => model.isDefault)?.model ?? listed.data[0]?.model;
+            if (!modelId) {
+              throw new Error("Codex model/list returned no models");
+            }
 
-        const listed = await client.request<CodexModelListResponse>(
-          "model/list",
-          { limit: 100, cursor: null, includeHidden: false },
-          { timeoutMs: 60_000 },
-        );
-        const modelId =
-          listed.data.find((model) => model.isDefault)?.model ?? listed.data[0]?.model;
-        if (!modelId) {
-          throw new Error("Codex model/list returned no models");
-        }
-
-        let complete!: (value: CodexTurnCompletedNotification) => void;
-        const completed = new Promise<CodexTurnCompletedNotification>((resolve) => {
-          complete = resolve;
-        });
-        client.addNotificationHandler((notification) => {
-          if (notification.method === "turn/completed") {
-            complete(notification.params as CodexTurnCompletedNotification);
+            let complete!: (value: CodexTurnCompletedNotification) => void;
+            const completed = new Promise<CodexTurnCompletedNotification>((resolve) => {
+              complete = resolve;
+            });
+            client.addNotificationHandler((notification) => {
+              if (notification.method === "turn/completed") {
+                complete(notification.params as CodexTurnCompletedNotification);
+              }
+            });
+            const started = await client.request(
+              "thread/start",
+              {
+                model: modelId,
+                cwd: workspace,
+                approvalPolicy: "never",
+                sandbox: "read-only",
+                threadSource: "user",
+              },
+              { timeoutMs: 120_000 },
+            );
+            await client.request(
+              "turn/start",
+              {
+                threadId: started.thread.id,
+                input: [{ type: "text", text: "Reply with exactly LIVE_REFRESH_OK." }],
+              },
+              { timeoutMs: 120_000 },
+            );
+            const result = await Promise.race([
+              completed,
+              new Promise<never>((_, reject) => {
+                setTimeout(() => reject(new Error("live refresh turn timed out")), 180_000).unref();
+              }),
+            ]);
+            expect(result.turn.status).toBe("completed");
+            expect(JSON.stringify(result.turn.items)).toContain("LIVE_REFRESH_OK");
+            expect(refreshRequests).toBe(1);
+            expect(providerRefreshes).toBe(1);
+            expect(store.profiles[profileId].access === accessToken).toBe(true);
+            expect(store.profiles[profileId].refresh === placeholderRefresh).toBe(true);
+            const persistedStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+            expect(persistedStore.profiles[profileId].access === accessToken).toBe(true);
+            expect(persistedStore.profiles[profileId].refresh === placeholderRefresh).toBe(true);
+          } finally {
+            await client.closeAndWait();
           }
-        });
-        const started = await client.request(
-          "thread/start",
-          {
-            model: modelId,
-            cwd: workspace,
-            approvalPolicy: "never",
-            sandbox: "read-only",
-            threadSource: "user",
-          },
-          { timeoutMs: 120_000 },
-        );
-        await client.request(
-          "turn/start",
-          {
-            threadId: started.thread.id,
-            input: [{ type: "text", text: "Reply with exactly LIVE_REFRESH_OK." }],
-          },
-          { timeoutMs: 120_000 },
-        );
-        const result = await Promise.race([
-          completed,
-          new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error("live refresh turn timed out")), 180_000).unref();
-          }),
-        ]);
-        expect(result.turn.status, JSON.stringify(result.turn.error)).toBe("completed");
-        expect(JSON.stringify(result.turn.items)).toContain("LIVE_REFRESH_OK");
-        expect(refreshRequests).toBe(1);
-      } finally {
-        await client.closeAndWait();
-      }
+        } finally {
+          resetPluginRuntimeStateForTest();
+        }
+      });
     });
   }, 300_000);
 });

--- a/extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts
@@ -183,11 +183,19 @@ describeLive("Codex app-server real auth refresh boundary", () => {
             expect(JSON.stringify(result.turn.items)).toContain("LIVE_REFRESH_OK");
             expect(refreshRequests).toBe(1);
             expect(providerRefreshes).toBe(1);
-            expect(store.profiles[profileId].access === accessToken).toBe(true);
-            expect(store.profiles[profileId].refresh === placeholderRefresh).toBe(true);
+            const runtimeProfile = store.profiles[profileId];
+            if (runtimeProfile?.type !== "oauth") {
+              throw new Error("expected runtime OAuth profile after refresh");
+            }
+            expect(runtimeProfile.access === accessToken).toBe(true);
+            expect(runtimeProfile.refresh === placeholderRefresh).toBe(true);
             const persistedStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
-            expect(persistedStore.profiles[profileId].access === accessToken).toBe(true);
-            expect(persistedStore.profiles[profileId].refresh === placeholderRefresh).toBe(true);
+            const persistedProfile = persistedStore.profiles[profileId];
+            if (persistedProfile?.type !== "oauth") {
+              throw new Error("expected persisted OAuth profile after refresh");
+            }
+            expect(persistedProfile.access === accessToken).toBe(true);
+            expect(persistedProfile.refresh === placeholderRefresh).toBe(true);
           } finally {
             await client.closeAndWait();
           }

--- a/extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import type { CodexModelListResponse, CodexTurnCompletedNotification } from "./protocol.js";
+import { createIsolatedCodexAppServerClient } from "./shared-client.js";
+
+const LIVE = process.env.OPENCLAW_LIVE_TEST === "1" && process.env.OPENCLAW_LIVE_CODEX_AUTH === "1";
+const describeLive = LIVE ? describe : describe.skip;
+
+type CodexAuthFile = {
+  tokens?: { access_token?: string; account_id?: string };
+};
+
+describeLive("Codex app-server real auth refresh boundary", () => {
+  it("recovers a real provider turn through OpenClaw's refresh handler", async () => {
+    const auth = JSON.parse(
+      await fs.readFile(path.join(os.homedir(), ".codex", "auth.json"), "utf8"),
+    ) as CodexAuthFile;
+    const accessToken = auth.tokens?.access_token?.trim();
+    const accountId = auth.tokens?.account_id?.trim();
+    if (!accessToken || !accountId) {
+      throw new Error("A current Codex ChatGPT login is required for this live proof.");
+    }
+    const invalidAccessToken = `${accessToken.slice(0, -1)}${accessToken.endsWith("A") ? "B" : "A"}`;
+
+    await withTempDir("openclaw-codex-auth-refresh-live-", async (root) => {
+      const profileId = "openai:boundary-proof";
+      const store = {
+        version: 1 as const,
+        profiles: {
+          [profileId]: {
+            type: "token" as const,
+            provider: "openai",
+            token: invalidAccessToken,
+            accountId,
+          },
+        },
+      };
+      const runtime = resolveCodexAppServerRuntimeOptions({
+        pluginConfig: { appServer: { homeScope: "local" } },
+        env: {},
+      });
+      const workspace = path.join(root, "workspace");
+      await fs.mkdir(workspace, { recursive: true });
+      let refreshRequests = 0;
+      const client = await createIsolatedCodexAppServerClient({
+        startOptions: {
+          ...runtime.start,
+          clearEnv: ["CODEX_ACCESS_TOKEN", "CODEX_API_KEY", "OPENAI_API_KEY"],
+        },
+        agentDir: path.join(root, "agent"),
+        authProfileId: profileId,
+        authProfileStore: store,
+        authRequirement: "subscription",
+        timeoutMs: 120_000,
+        onStartedClient: (startedClient) => {
+          startedClient.addRequestHandler((request) => {
+            if (request.method === "account/chatgptAuthTokens/refresh") {
+              refreshRequests += 1;
+            }
+            return undefined;
+          });
+        },
+      });
+      try {
+        // The app-server has the invalid token already. Only the installed
+        // OpenClaw server-request handler can observe this replacement.
+        store.profiles[profileId].token = accessToken;
+
+        const listed = await client.request<CodexModelListResponse>(
+          "model/list",
+          { limit: 100, cursor: null, includeHidden: false },
+          { timeoutMs: 60_000 },
+        );
+        const modelId =
+          listed.data.find((model) => model.isDefault)?.model ?? listed.data[0]?.model;
+        if (!modelId) {
+          throw new Error("Codex model/list returned no models");
+        }
+
+        let complete!: (value: CodexTurnCompletedNotification) => void;
+        const completed = new Promise<CodexTurnCompletedNotification>((resolve) => {
+          complete = resolve;
+        });
+        client.addNotificationHandler((notification) => {
+          if (notification.method === "turn/completed") {
+            complete(notification.params as CodexTurnCompletedNotification);
+          }
+        });
+        const started = await client.request(
+          "thread/start",
+          {
+            model: modelId,
+            cwd: workspace,
+            approvalPolicy: "never",
+            sandbox: "read-only",
+            threadSource: "user",
+          },
+          { timeoutMs: 120_000 },
+        );
+        await client.request(
+          "turn/start",
+          {
+            threadId: started.thread.id,
+            input: [{ type: "text", text: "Reply with exactly LIVE_REFRESH_OK." }],
+          },
+          { timeoutMs: 120_000 },
+        );
+        const result = await Promise.race([
+          completed,
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error("live refresh turn timed out")), 180_000).unref();
+          }),
+        ]);
+        expect(result.turn.status, JSON.stringify(result.turn.error)).toBe("completed");
+        expect(JSON.stringify(result.turn.items)).toContain("LIVE_REFRESH_OK");
+        expect(refreshRequests).toBe(1);
+      } finally {
+        await client.closeAndWait();
+      }
+    });
+  }, 300_000);
+});

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -23,12 +23,16 @@ export const MINIMAX_CLI_PROFILE_ID = "minimax-portal:minimax-cli";
 // introduces the `refresh_token_reused` race the lock is meant to prevent.
 //
 // Retry budget note: keep the MINIMUM cumulative retry window comfortably
-// above OAUTH_REFRESH_CALL_TIMEOUT_MS so waiters do not give up while a
-// legitimate slow refresh is still within its allowed runtime budget.
+// above OAUTH_REFRESH_INLOCK_TIMEOUT_MS (the full held-lock ceiling, which is
+// wider than the network-call timeout) so a waiter never surfaces
+// refresh_contention while the owner is still within its legitimate in-lock
+// runtime budget. With retries=22 the jitter-free floor is 162.7s (12.7s over
+// the 150s in-lock ceiling) and the jittered max stays under the 180s stale
+// window: 100+200+...+6400 (attempts 0-6) + 15*10_000 (capped attempts 7-21).
 /** Cross-agent lock policy for shared OAuth refresh operations. */
 export const OAUTH_REFRESH_LOCK_OPTIONS = {
   retries: {
-    retries: 20,
+    retries: 22,
     factor: 2,
     minTimeout: 100,
     maxTimeout: 10_000,
@@ -44,6 +48,19 @@ export const OAUTH_REFRESH_LOCK_OPTIONS = {
 // by a waiter while the owner is still doing legitimate work.
 /** Maximum duration for one OAuth refresh call inside the refresh lock. */
 export const OAUTH_REFRESH_CALL_TIMEOUT_MS = 120_000;
+
+// Hard upper bound on the ENTIRE held-lock critical section, not just the
+// network refresh call. The section also runs an in-lock keychain store load
+// (which on darwin can hit securityd) and provider buildApiKey hooks; if either
+// hangs while the cross-agent lock is held, every same-key refresher chain
+// stalls on the in-process gate or blocks acquiring the file lock. This bounds
+// the whole body so a wedged keychain/hook cannot pin the lock indefinitely.
+// Sits between the call timeout (so the network call's tighter budget fires
+// first) and the stale window (so a waiter never reclaims the lock while the
+// owner is still within its allowed runtime).
+// Invariant: OAUTH_REFRESH_CALL_TIMEOUT_MS < OAUTH_REFRESH_INLOCK_TIMEOUT_MS < OAUTH_REFRESH_LOCK_OPTIONS.stale.
+/** Maximum duration for the full held-lock OAuth refresh critical section. */
+export const OAUTH_REFRESH_INLOCK_TIMEOUT_MS = 150_000;
 
 /** Freshness window for syncing external CLI auth into auth profiles. */
 export const EXTERNAL_CLI_SYNC_TTL_MS = 15 * 60 * 1000;

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -17,18 +17,12 @@ export const OPENAI_CODEX_DEFAULT_PROFILE_ID = "openai:default";
 /** @deprecated MiniMax provider-owned CLI profile id; do not use from third-party plugins. */
 export const MINIMAX_CLI_PROFILE_ID = "minimax-portal:minimax-cli";
 
-// Invariant: OAUTH_REFRESH_CALL_TIMEOUT_MS < OAUTH_REFRESH_LOCK_OPTIONS.stale
-// so a legitimate refresh's critical section always finishes well before
-// peers would treat the lock as reclaimable. Violating this invariant re-
-// introduces the `refresh_token_reused` race the lock is meant to prevent.
-//
 // Retry budget note: keep the MINIMUM cumulative retry window comfortably
 // above OAUTH_REFRESH_INLOCK_TIMEOUT_MS (the full held-lock ceiling, which is
-// wider than the network-call timeout) so a waiter never surfaces
-// refresh_contention while the owner is still within its legitimate in-lock
-// runtime budget. With retries=22 the jitter-free floor is 162.7s (12.7s over
-// the 150s in-lock ceiling) and the jittered max stays under the 180s stale
-// window: 100+200+...+6400 (attempts 0-6) + 15*10_000 (capped attempts 7-21).
+// wider than the network-call timeout) so the caller deadline fires before a
+// waiter surfaces refresh_contention. With retries=22 the jitter-free floor is
+// 162.7s (12.7s over the 150s caller deadline): 100+200+...+6400 (attempts
+// 0-6) + 15*10_000 (capped attempts 7-21).
 /** Cross-agent lock policy for shared OAuth refresh operations. */
 export const OAUTH_REFRESH_LOCK_OPTIONS = {
   retries: {
@@ -41,23 +35,20 @@ export const OAUTH_REFRESH_LOCK_OPTIONS = {
   stale: 180_000,
 } as const;
 
-// Hard upper bound on a single OAuth refresh call (plugin hook + HTTP
-// token-exchange). Any refresh that runs longer than this is aborted and
-// surfaced as a refresh failure. Keep strictly below
-// OAUTH_REFRESH_LOCK_OPTIONS.stale so the lock is never treated as stale
-// by a waiter while the owner is still doing legitimate work.
-/** Maximum duration for one OAuth refresh call inside the refresh lock. */
+// Caller deadline for one OAuth refresh call (plugin hook + HTTP exchange).
+// Provider hooks have no shared cancellation contract, so expiry abandons the
+// caller while the file-lock owner retains the lock until the call settles.
+/** Maximum caller wait for one OAuth refresh call inside the refresh lock. */
 export const OAUTH_REFRESH_CALL_TIMEOUT_MS = 120_000;
 
 // Hard upper bound on the ENTIRE held-lock critical section, not just the
 // network refresh call. The section also runs an in-lock keychain store load
 // (which on darwin can hit securityd) and provider buildApiKey hooks; if either
-// hangs while the cross-agent lock is held, every same-key refresher chain
-// stalls on the in-process gate or blocks acquiring the file lock. This bounds
-// the whole body so a wedged keychain/hook cannot pin the lock indefinitely.
-// Sits between the call timeout (so the network call's tighter budget fires
-// first) and the stale window (so a waiter never reclaims the lock while the
-// owner is still within its allowed runtime).
+// hangs while the cross-agent lock is held, every same-key caller otherwise
+// waits indefinitely. Expiry releases the caller, but the lock remains owned
+// until the uncancellable work settles so no peer can reuse a rotating token.
+// Sits between the call timeout and the stale metadata window; live-PID locks
+// are never reclaimed from age alone.
 // Invariant: OAUTH_REFRESH_CALL_TIMEOUT_MS < OAUTH_REFRESH_INLOCK_TIMEOUT_MS < OAUTH_REFRESH_LOCK_OPTIONS.stale.
 /** Maximum duration for the full held-lock OAuth refresh critical section. */
 export const OAUTH_REFRESH_INLOCK_TIMEOUT_MS = 150_000;

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -18,9 +18,9 @@ export const OPENAI_CODEX_DEFAULT_PROFILE_ID = "openai:default";
 export const MINIMAX_CLI_PROFILE_ID = "minimax-portal:minimax-cli";
 
 // Retry budget note: keep the MINIMUM cumulative retry window comfortably
-// above OAUTH_REFRESH_INLOCK_TIMEOUT_MS (the full held-lock ceiling, which is
-// wider than the network-call timeout) so the caller deadline fires before a
-// waiter surfaces refresh_contention. With retries=22 the jitter-free floor is
+// above OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS (the full queue/lock owner ceiling,
+// which is wider than the network-call timeout) so the caller deadline fires
+// before a waiter surfaces refresh_contention. With retries=22 the jitter-free floor is
 // 162.7s (12.7s over the 150s caller deadline): 100+200+...+6400 (attempts
 // 0-6) + 15*10_000 (capped attempts 7-21).
 /** Cross-agent lock policy for shared OAuth refresh operations. */
@@ -41,17 +41,14 @@ export const OAUTH_REFRESH_LOCK_OPTIONS = {
 /** Maximum caller wait for one OAuth refresh call inside the refresh lock. */
 export const OAUTH_REFRESH_CALL_TIMEOUT_MS = 120_000;
 
-// Hard upper bound on the ENTIRE held-lock critical section, not just the
-// network refresh call. The section also runs an in-lock keychain store load
-// (which on darwin can hit securityd) and provider buildApiKey hooks; if either
-// hangs while the cross-agent lock is held, every same-key caller otherwise
-// waits indefinitely. Expiry releases the caller, but the lock remains owned
-// until the uncancellable work settles so no peer can reuse a rotating token.
+// Hard upper bound on queue admission plus the held-lock critical section.
+// Expiry releases a waiting caller before admission; an admitted owner keeps
+// the lock until uncancellable work settles so no peer reuses a rotating token.
 // Sits between the call timeout and the stale metadata window; live-PID locks
 // are never reclaimed from age alone.
-// Invariant: OAUTH_REFRESH_CALL_TIMEOUT_MS < OAUTH_REFRESH_INLOCK_TIMEOUT_MS < OAUTH_REFRESH_LOCK_OPTIONS.stale.
-/** Maximum duration for the full held-lock OAuth refresh critical section. */
-export const OAUTH_REFRESH_INLOCK_TIMEOUT_MS = 150_000;
+// Invariant: OAUTH_REFRESH_CALL_TIMEOUT_MS < OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS < OAUTH_REFRESH_LOCK_OPTIONS.stale.
+/** Maximum caller wait across queue admission and OAuth refresh ownership. */
+export const OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS = 150_000;
 
 /** Freshness window for syncing external CLI auth into auth profiles. */
 export const EXTERNAL_CLI_SYNC_TTL_MS = 15 * 60 * 1000;

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -35,14 +35,20 @@ type ExternalCliAuthProfileOptions = {
   profileIds?: Iterable<string>;
 };
 
+type ExternalCliCredentialReadOptions = Pick<
+  ExternalCliAuthProfileOptions,
+  "allowKeychainPrompt"
+> & {
+  /** Bypass the discovery cache when rotating a single-use refresh token. */
+  fresh?: boolean;
+};
+
 type ExternalCliSyncProvider = {
   profileId: string;
   profileAliases?: readonly string[];
   provider: string;
   aliases?: readonly string[];
-  readCredentials: (
-    options?: Pick<ExternalCliAuthProfileOptions, "allowKeychainPrompt">,
-  ) => OAuthCredential | null;
+  readCredentials: (options?: ExternalCliCredentialReadOptions) => OAuthCredential | null;
   // bootstrapOnly providers adopt the external CLI credential only to
   // seed an empty slot; once a local OAuth credential exists for the
   // profile, the local refresh token is treated as canonical and the
@@ -75,7 +81,7 @@ const EXTERNAL_CLI_SYNC_PROVIDERS: ExternalCliSyncProvider[] = [
     aliases: ["openai", "codex", "codex-cli", "codex-app-server"],
     readCredentials: (options) =>
       readCodexCliCredentialsCached({
-        ttlMs: EXTERNAL_CLI_SYNC_TTL_MS,
+        ttlMs: options?.fresh ? 0 : EXTERNAL_CLI_SYNC_TTL_MS,
         allowKeychainPrompt: options?.allowKeychainPrompt,
       }),
     bootstrapOnly: true,
@@ -174,6 +180,7 @@ export function readExternalCliBootstrapCredential(params: {
   credential: OAuthCredential;
   allowInlineOAuthTokenMaterial?: boolean;
   allowKeychainPrompt?: boolean;
+  fresh?: boolean;
 }): OAuthCredential | null {
   const provider = resolveExternalCliSyncProvider(params);
   if (!provider) {
@@ -190,7 +197,10 @@ export function readExternalCliBootstrapCredential(params: {
     return null;
   }
   return normalizeExternalCliCredentialProvider(
-    provider.readCredentials({ allowKeychainPrompt: params.allowKeychainPrompt }),
+    provider.readCredentials({
+      allowKeychainPrompt: params.allowKeychainPrompt,
+      fresh: params.fresh,
+    }),
     params.credential.provider,
   );
 }

--- a/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
@@ -6,6 +6,7 @@
 import { afterAll, vi } from "vitest";
 
 const fileLockPassthroughMock = vi.hoisted(() => ({
+  FILE_LOCK_TIMEOUT_ERROR_CODE: "file_lock_timeout",
   drainFileLockStateForTest: async () => undefined,
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),

--- a/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression: an in-lock OAuth critical section abandoned by its deadline must
+ * not persist or mirror credentials after the global refresh lock is released,
+ * because a successor refresher may already own the key.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { testing as externalAuthTesting } from "./external-auth.test-support.js";
+import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+} from "./store.js";
+import type { OAuthCredential, OAuthCredentials } from "./types.js";
+
+// Shrink the in-lock deadline so a real-timer test can observe an abandoned
+// critical section. The network-call timeout stays larger so the SECTION
+// deadline (not the inner call timeout) is what abandons the running body.
+vi.mock("./constants.js", async () => {
+  const actual = await vi.importActual<typeof import("./constants.js")>("./constants.js");
+  return {
+    ...actual,
+    OAUTH_REFRESH_INLOCK_TIMEOUT_MS: 150,
+    OAUTH_REFRESH_CALL_TIMEOUT_MS: 5_000,
+  };
+});
+
+const tempDirs: string[] = [];
+
+async function withOAuthAgentDirs(
+  prefix: string,
+  run: (dirs: { mainAgentDir: string; agentDir: string }) => Promise<void>,
+): Promise<void> {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(tempRoot);
+  await withEnvAsync({ OPENCLAW_STATE_DIR: tempRoot }, async () => {
+    const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+    const agentDir = path.join(tempRoot, "agents", "sub", "agent");
+    await withEnvAsync({ OPENCLAW_AGENT_DIR: mainAgentDir }, async () => {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.mkdir(mainAgentDir, { recursive: true });
+      await run({ mainAgentDir, agentDir });
+    });
+  });
+}
+
+beforeEach(() => {
+  externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
+  clearRuntimeAuthProfileStoreSnapshots();
+});
+
+afterEach(async () => {
+  externalAuthTesting.resetResolveExternalAuthProfilesForTest();
+  clearRuntimeAuthProfileStoreSnapshots();
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("abandoned in-lock OAuth refresh write-back", () => {
+  it("does not persist or mirror a refresh that completes after the section deadline", async () => {
+    await withOAuthAgentDirs("oauth-manager-abandoned-writeback-", async ({ agentDir }) => {
+      const profileId = "openai:oauth";
+      const staleCredential: OAuthCredential = {
+        type: "oauth",
+        provider: "openai",
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+      };
+      saveAuthProfileStore({ version: 1, profiles: { [profileId]: staleCredential } }, agentDir, {
+        filterExternalAuthProfiles: false,
+      });
+
+      // The refresh call outlives the (shrunken) in-lock deadline, then
+      // completes with rotated tokens only after the section was abandoned.
+      let resolveRefresh: ((value: OAuthCredentials) => void) | undefined;
+      const refreshCredential = vi.fn(
+        () =>
+          new Promise<OAuthCredentials>((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, credential) => credential.access,
+        refreshCredential,
+        readBootstrapCredential: () => null,
+        isRefreshTokenReusedError: () => false,
+      });
+
+      await expect(
+        manager.resolveOAuthAccess({
+          store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+            allowKeychainPrompt: false,
+          }),
+          profileId,
+          credential: staleCredential,
+          agentDir,
+        }),
+      ).rejects.toBeInstanceOf(OAuthManagerRefreshError);
+      expect(refreshCredential).toHaveBeenCalledTimes(1);
+
+      // Let the abandoned continuation settle with rotated credentials; the
+      // ownership guard must discard the write-back instead of persisting it.
+      resolveRefresh?.({
+        access: "rotated-access",
+        refresh: "rotated-refresh",
+        expires: Date.now() + 60_000,
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+
+      clearRuntimeAuthProfileStoreSnapshots();
+      const subStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      });
+      expect(subStore.profiles[profileId]).toMatchObject({
+        access: "expired-access",
+        refresh: "expired-refresh",
+      });
+      const mainStore = ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
+        allowKeychainPrompt: false,
+      });
+      expect(mainStore.profiles[profileId]).toBeUndefined();
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
@@ -1,6 +1,6 @@
 /**
- * Regression: an in-lock OAuth critical section abandoned by its caller
- * deadline must retain the global refresh lock until provider work settles.
+ * Regression: OAuth callers are bounded before queue admission while an
+ * abandoned owner retains the global refresh lock until provider work settles.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -13,14 +13,13 @@ import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
 import { ensureAuthProfileStoreWithoutExternalProfiles, saveAuthProfileStore } from "./store.js";
 import type { OAuthCredential, OAuthCredentials } from "./types.js";
 
-// Shrink the in-lock deadline so a real-timer test can observe an abandoned
-// critical section. The call deadline stays larger so the section deadline is
-// what abandons the caller while the provider operation remains in flight.
+// Shrink the ownership deadline so a real-timer test can observe both the
+// owner and its queued follower expire while provider work remains in flight.
 vi.mock("./constants.js", async () => {
   const actual = await vi.importActual<typeof import("./constants.js")>("./constants.js");
   return {
     ...actual,
-    OAUTH_REFRESH_INLOCK_TIMEOUT_MS: 150,
+    OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS: 150,
     OAUTH_REFRESH_CALL_TIMEOUT_MS: 5_000,
   };
 });
@@ -53,8 +52,8 @@ afterEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
 });
 
-describe("abandoned in-lock OAuth refresh write-back", () => {
-  it("retains refresh ownership until an abandoned provider call settles", async () => {
+describe("abandoned OAuth refresh write-back", () => {
+  it("bounds queued callers while retaining refresh ownership through write-back", async () => {
     await withOAuthAgentDirs("oauth-manager-abandoned-writeback-", async ({ agentDir }) => {
       const profileId = "openai:oauth";
       const staleCredential: OAuthCredential = {
@@ -68,8 +67,8 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
         filterExternalAuthProfiles: false,
       });
 
-      // The refresh call outlives the (shrunken) in-lock deadline, then
-      // completes with rotated tokens only after the section was abandoned.
+      // The refresh call outlives the (shrunken) ownership deadline, then
+      // completes with rotated tokens only after both callers were abandoned.
       let resolveRefresh: ((value: OAuthCredentials) => void) | undefined;
       const refreshCredential = vi
         .fn<(credential: OAuthCredential) => Promise<OAuthCredentials>>()
@@ -113,21 +112,58 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
         agentDir,
         forceRefresh: true,
       });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-      // The successor may enter the in-process queue, but it must not reach the
-      // rotating-token provider while the abandoned call still owns the lock.
+      const successorOutcome = await Promise.race([
+        successor.then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({ error, status: "rejected" as const }),
+        ),
+        new Promise<{ status: "guard-expired" }>((resolve) => {
+          setTimeout(() => resolve({ status: "guard-expired" }), 300);
+        }),
+      ]);
+      // The follower's absolute deadline starts before queue admission. It
+      // expires without reaching the provider or extending the retained owner.
       expect(refreshCredential).toHaveBeenCalledTimes(1);
 
       // Let the abandoned continuation settle. Its rotated tokens are stored
-      // before the lock releases, so the successor uses the winning rotation.
+      // before the lock releases. A fresh caller then adopts that rotation.
       resolveRefresh?.({
         access: "rotated-access",
         refresh: "rotated-refresh",
         expires: Date.now() + 10 * 60_000,
       });
-      await expect(successor).resolves.toMatchObject({
+      await vi.waitFor(() => {
+        clearRuntimeAuthProfileStoreSnapshots();
+        const stored = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        });
+        expect(stored.profiles[profileId]).toMatchObject({
+          access: "rotated-access",
+          refresh: "rotated-refresh",
+        });
+        const main = ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
+          allowKeychainPrompt: false,
+        });
+        expect(main.profiles[profileId]).toMatchObject({
+          access: "rotated-access",
+          refresh: "rotated-refresh",
+        });
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(successorOutcome.status).toBe("rejected");
+      if (successorOutcome.status === "rejected") {
+        expect(successorOutcome.error).toBeInstanceOf(OAuthManagerRefreshError);
+      }
+      await expect(
+        manager.resolveOAuthAccess({
+          store: secondPreparedStore,
+          profileId,
+          credential: staleCredential,
+          agentDir,
+        }),
+      ).resolves.toMatchObject({
         apiKey: "rotated-access",
         credential: {
           access: "rotated-access",

--- a/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
@@ -78,17 +78,7 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
             new Promise<OAuthCredentials>((resolve) => {
               resolveRefresh = resolve;
             }),
-        )
-        .mockImplementationOnce(async (credential) => {
-          // The abandoned owner must durably retain its successful rotation
-          // before the queued successor begins.
-          expect(credential.refresh).toBe("rotated-refresh");
-          return {
-            access: "successor-access",
-            refresh: "successor-refresh",
-            expires: Date.now() + 60_000,
-          };
-        });
+        );
       const manager = createOAuthManager({
         buildApiKey: async (_provider, credential) => credential.access,
         refreshCredential,
@@ -96,11 +86,12 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
         isRefreshTokenReusedError: () => false,
       });
 
+      const firstPreparedStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      });
       await expect(
         manager.resolveOAuthAccess({
-          store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-            allowKeychainPrompt: false,
-          }),
+          store: firstPreparedStore,
           profileId,
           credential: staleCredential,
           agentDir,
@@ -108,13 +99,19 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
       ).rejects.toBeInstanceOf(OAuthManagerRefreshError);
       expect(refreshCredential).toHaveBeenCalledTimes(1);
 
+      clearRuntimeAuthProfileStoreSnapshots();
+      const secondPreparedStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      });
+      expect(secondPreparedStore).not.toBe(firstPreparedStore);
+      // Prepared/remote-exec clients can hold distinct snapshots or live in
+      // distinct processes. SQLite plus the file lock owns their handoff.
       const successor = manager.resolveOAuthAccess({
-        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-          allowKeychainPrompt: false,
-        }),
+        store: secondPreparedStore,
         profileId,
         credential: staleCredential,
         agentDir,
+        forceRefresh: true,
       });
       await new Promise((resolve) => {
         setTimeout(resolve, 100);
@@ -128,116 +125,32 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
       resolveRefresh?.({
         access: "rotated-access",
         refresh: "rotated-refresh",
-        expires: Date.now() + 60_000,
+        expires: Date.now() + 10 * 60_000,
       });
       await expect(successor).resolves.toMatchObject({
-        apiKey: "successor-access",
+        apiKey: "rotated-access",
         credential: {
-          access: "successor-access",
-          refresh: "successor-refresh",
+          access: "rotated-access",
+          refresh: "rotated-refresh",
         },
       });
-      expect(refreshCredential).toHaveBeenCalledTimes(2);
+      expect(refreshCredential).toHaveBeenCalledTimes(1);
 
       clearRuntimeAuthProfileStoreSnapshots();
       const subStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
         allowKeychainPrompt: false,
       });
       expect(subStore.profiles[profileId]).toMatchObject({
-        access: "successor-access",
-        refresh: "successor-refresh",
+        access: "rotated-access",
+        refresh: "rotated-refresh",
       });
       const mainStore = ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
         allowKeychainPrompt: false,
       });
       expect(mainStore.profiles[profileId]).toMatchObject({
-        access: "successor-access",
-        refresh: "successor-refresh",
+        access: "rotated-access",
+        refresh: "rotated-refresh",
       });
-    });
-  });
-
-  it("retains and serializes late refreshes in a runtime-only supplied store", async () => {
-    await withOAuthAgentDirs("oauth-manager-runtime-writeback-", async ({ agentDir }) => {
-      const profileId = "openai:scoped";
-      const staleCredential: OAuthCredential = {
-        type: "oauth",
-        provider: "openai",
-        access: "scoped-expired-access",
-        refresh: "scoped-expired-refresh",
-        expires: Date.now() - 60_000,
-      };
-      const store = { version: 1 as const, profiles: { [profileId]: staleCredential } };
-      let resolveRefresh: ((value: OAuthCredentials) => void) | undefined;
-      const refreshCredential = vi
-        .fn<(credential: OAuthCredential) => Promise<OAuthCredentials>>()
-        .mockImplementationOnce(
-          () =>
-            new Promise<OAuthCredentials>((resolve) => {
-              resolveRefresh = resolve;
-            }),
-        )
-        .mockImplementationOnce(async (credential) => {
-          expect(credential.refresh).toBe("scoped-rotated-refresh");
-          return {
-            access: "scoped-successor-access",
-            refresh: "scoped-successor-refresh",
-            expires: Date.now() + 60_000,
-          };
-        });
-      const manager = createOAuthManager({
-        buildApiKey: async (_provider, credential) => credential.access,
-        refreshCredential,
-        readBootstrapCredential: () => null,
-        isRefreshTokenReusedError: () => false,
-      });
-
-      await expect(
-        manager.resolveOAuthAccess({
-          store,
-          profileId,
-          credential: staleCredential,
-          agentDir,
-          useRuntimeStore: true,
-        }),
-      ).rejects.toBeInstanceOf(OAuthManagerRefreshError);
-
-      const successor = manager.resolveOAuthAccess({
-        store,
-        profileId,
-        credential: staleCredential,
-        agentDir,
-        useRuntimeStore: true,
-      });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-      expect(refreshCredential).toHaveBeenCalledTimes(1);
-
-      resolveRefresh?.({
-        access: "scoped-rotated-access",
-        refresh: "scoped-rotated-refresh",
-        expires: Date.now() + 60_000,
-      });
-      await expect(successor).resolves.toMatchObject({
-        apiKey: "scoped-successor-access",
-      });
-      expect(store.profiles[profileId]).toMatchObject({
-        access: "scoped-successor-access",
-        refresh: "scoped-successor-refresh",
-      });
-
-      clearRuntimeAuthProfileStoreSnapshots();
-      expect(
-        ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
-          allowKeychainPrompt: false,
-        }).profiles[profileId],
-      ).toBeUndefined();
-      expect(
-        ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
-          allowKeychainPrompt: false,
-        }).profiles[profileId],
-      ).toBeUndefined();
     });
   });
 });

--- a/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
@@ -1,12 +1,11 @@
 /**
- * Regression: an in-lock OAuth critical section abandoned by its deadline must
- * not persist or mirror credentials after the global refresh lock is released,
- * because a successor refresher may already own the key.
+ * Regression: an in-lock OAuth critical section abandoned by its caller
+ * deadline must retain the global refresh lock until provider work settles.
  */
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
@@ -18,8 +17,8 @@ import {
 import type { OAuthCredential, OAuthCredentials } from "./types.js";
 
 // Shrink the in-lock deadline so a real-timer test can observe an abandoned
-// critical section. The network-call timeout stays larger so the SECTION
-// deadline (not the inner call timeout) is what abandons the running body.
+// critical section. The call deadline stays larger so the section deadline is
+// what abandons the caller while the provider operation remains in flight.
 vi.mock("./constants.js", async () => {
   const actual = await vi.importActual<typeof import("./constants.js")>("./constants.js");
   return {
@@ -29,14 +28,13 @@ vi.mock("./constants.js", async () => {
   };
 });
 
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withOAuthAgentDirs(
   prefix: string,
   run: (dirs: { mainAgentDir: string; agentDir: string }) => Promise<void>,
 ): Promise<void> {
-  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(tempRoot);
+  const tempRoot = tempDirs.make(prefix);
   await withEnvAsync({ OPENCLAW_STATE_DIR: tempRoot }, async () => {
     const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
     const agentDir = path.join(tempRoot, "agents", "sub", "agent");
@@ -53,14 +51,13 @@ beforeEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
 });
 
-afterEach(async () => {
+afterEach(() => {
   externalAuthTesting.resetResolveExternalAuthProfilesForTest();
   clearRuntimeAuthProfileStoreSnapshots();
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
 
 describe("abandoned in-lock OAuth refresh write-back", () => {
-  it("does not persist or mirror a refresh that completes after the section deadline", async () => {
+  it("retains refresh ownership until an abandoned provider call settles", async () => {
     await withOAuthAgentDirs("oauth-manager-abandoned-writeback-", async ({ agentDir }) => {
       const profileId = "openai:oauth";
       const staleCredential: OAuthCredential = {
@@ -77,12 +74,22 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
       // The refresh call outlives the (shrunken) in-lock deadline, then
       // completes with rotated tokens only after the section was abandoned.
       let resolveRefresh: ((value: OAuthCredentials) => void) | undefined;
-      const refreshCredential = vi.fn(
-        () =>
-          new Promise<OAuthCredentials>((resolve) => {
-            resolveRefresh = resolve;
-          }),
-      );
+      const refreshCredential = vi
+        .fn<(credential: OAuthCredential) => Promise<OAuthCredentials>>()
+        .mockImplementationOnce(
+          () =>
+            new Promise<OAuthCredentials>((resolve) => {
+              resolveRefresh = resolve;
+            }),
+        )
+        .mockImplementationOnce(async (credential) => {
+          expect(credential.refresh).toBe("expired-refresh");
+          return {
+            access: "successor-access",
+            refresh: "successor-refresh",
+            expires: Date.now() + 60_000,
+          };
+        });
       const manager = createOAuthManager({
         buildApiKey: async (_provider, credential) => credential.access,
         refreshCredential,
@@ -102,29 +109,52 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
       ).rejects.toBeInstanceOf(OAuthManagerRefreshError);
       expect(refreshCredential).toHaveBeenCalledTimes(1);
 
-      // Let the abandoned continuation settle with rotated credentials; the
-      // ownership guard must discard the write-back instead of persisting it.
+      const successor = manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential: staleCredential,
+        agentDir,
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      // The successor may enter the in-process queue, but it must not reach the
+      // rotating-token provider while the abandoned call still owns the lock.
+      expect(refreshCredential).toHaveBeenCalledTimes(1);
+
+      // Let the abandoned continuation settle. Its tokens are discarded, the
+      // lock releases, and only then may the successor rotate the stored token.
       resolveRefresh?.({
         access: "rotated-access",
         refresh: "rotated-refresh",
         expires: Date.now() + 60_000,
       });
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
+      await expect(successor).resolves.toMatchObject({
+        apiKey: "successor-access",
+        credential: {
+          access: "successor-access",
+          refresh: "successor-refresh",
+        },
       });
+      expect(refreshCredential).toHaveBeenCalledTimes(2);
 
       clearRuntimeAuthProfileStoreSnapshots();
       const subStore = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
         allowKeychainPrompt: false,
       });
       expect(subStore.profiles[profileId]).toMatchObject({
-        access: "expired-access",
-        refresh: "expired-refresh",
+        access: "successor-access",
+        refresh: "successor-refresh",
       });
       const mainStore = ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
         allowKeychainPrompt: false,
       });
-      expect(mainStore.profiles[profileId]).toBeUndefined();
+      expect(mainStore.profiles[profileId]).toMatchObject({
+        access: "successor-access",
+        refresh: "successor-refresh",
+      });
     });
   });
 });

--- a/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts
@@ -9,11 +9,8 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { withEnvAsync } from "../../test-utils/env.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
-import {
-  clearRuntimeAuthProfileStoreSnapshots,
-  ensureAuthProfileStoreWithoutExternalProfiles,
-  saveAuthProfileStore,
-} from "./store.js";
+import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles, saveAuthProfileStore } from "./store.js";
 import type { OAuthCredential, OAuthCredentials } from "./types.js";
 
 // Shrink the in-lock deadline so a real-timer test can observe an abandoned
@@ -83,7 +80,9 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
             }),
         )
         .mockImplementationOnce(async (credential) => {
-          expect(credential.refresh).toBe("expired-refresh");
+          // The abandoned owner must durably retain its successful rotation
+          // before the queued successor begins.
+          expect(credential.refresh).toBe("rotated-refresh");
           return {
             access: "successor-access",
             refresh: "successor-refresh",
@@ -124,8 +123,8 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
       // rotating-token provider while the abandoned call still owns the lock.
       expect(refreshCredential).toHaveBeenCalledTimes(1);
 
-      // Let the abandoned continuation settle. Its tokens are discarded, the
-      // lock releases, and only then may the successor rotate the stored token.
+      // Let the abandoned continuation settle. Its rotated tokens are stored
+      // before the lock releases, so the successor uses the winning rotation.
       resolveRefresh?.({
         access: "rotated-access",
         refresh: "rotated-refresh",
@@ -155,6 +154,90 @@ describe("abandoned in-lock OAuth refresh write-back", () => {
         access: "successor-access",
         refresh: "successor-refresh",
       });
+    });
+  });
+
+  it("retains and serializes late refreshes in a runtime-only supplied store", async () => {
+    await withOAuthAgentDirs("oauth-manager-runtime-writeback-", async ({ agentDir }) => {
+      const profileId = "openai:scoped";
+      const staleCredential: OAuthCredential = {
+        type: "oauth",
+        provider: "openai",
+        access: "scoped-expired-access",
+        refresh: "scoped-expired-refresh",
+        expires: Date.now() - 60_000,
+      };
+      const store = { version: 1 as const, profiles: { [profileId]: staleCredential } };
+      let resolveRefresh: ((value: OAuthCredentials) => void) | undefined;
+      const refreshCredential = vi
+        .fn<(credential: OAuthCredential) => Promise<OAuthCredentials>>()
+        .mockImplementationOnce(
+          () =>
+            new Promise<OAuthCredentials>((resolve) => {
+              resolveRefresh = resolve;
+            }),
+        )
+        .mockImplementationOnce(async (credential) => {
+          expect(credential.refresh).toBe("scoped-rotated-refresh");
+          return {
+            access: "scoped-successor-access",
+            refresh: "scoped-successor-refresh",
+            expires: Date.now() + 60_000,
+          };
+        });
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, credential) => credential.access,
+        refreshCredential,
+        readBootstrapCredential: () => null,
+        isRefreshTokenReusedError: () => false,
+      });
+
+      await expect(
+        manager.resolveOAuthAccess({
+          store,
+          profileId,
+          credential: staleCredential,
+          agentDir,
+          useRuntimeStore: true,
+        }),
+      ).rejects.toBeInstanceOf(OAuthManagerRefreshError);
+
+      const successor = manager.resolveOAuthAccess({
+        store,
+        profileId,
+        credential: staleCredential,
+        agentDir,
+        useRuntimeStore: true,
+      });
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      expect(refreshCredential).toHaveBeenCalledTimes(1);
+
+      resolveRefresh?.({
+        access: "scoped-rotated-access",
+        refresh: "scoped-rotated-refresh",
+        expires: Date.now() + 60_000,
+      });
+      await expect(successor).resolves.toMatchObject({
+        apiKey: "scoped-successor-access",
+      });
+      expect(store.profiles[profileId]).toMatchObject({
+        access: "scoped-successor-access",
+        refresh: "scoped-successor-refresh",
+      });
+
+      clearRuntimeAuthProfileStoreSnapshots();
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }).profiles[profileId],
+      ).toBeUndefined();
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
+          allowKeychainPrompt: false,
+        }).profiles[profileId],
+      ).toBeUndefined();
     });
   });
 });

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -11,6 +11,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import {
+  OAUTH_REFRESH_CALL_TIMEOUT_MS,
+  OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
+  OAUTH_REFRESH_LOCK_OPTIONS,
+} from "./constants.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
 import {
@@ -290,6 +295,35 @@ describe("createOAuthManager", () => {
       cfg,
       agentDir: undefined,
     });
+  });
+
+  it("keeps the in-lock critical-section deadline between the call timeout and the stale window", () => {
+    // The held-lock critical section (keychain load + buildApiKey + network
+    // refresh) is now wrapped by withRefreshCallTimeout(OAUTH_REFRESH_INLOCK_TIMEOUT_MS)
+    // so a wedged in-lock op cannot pin the cross-agent lock. The budget must sit
+    // above the network call timeout (so the tighter network budget fires first)
+    // and below the stale window (so a waiter never reclaims the lock while the
+    // owner is still within its allowed runtime). A timing-based behavior test is
+    // impractical here because the surrounding withFileLock uses a real file lock
+    // that does not coordinate with fake timers; the deadline mechanism itself is
+    // covered by withRuntimeAuthRefreshDeadline's tests and the auth-controller
+    // cold-start regression test.
+    expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS);
+    expect(OAUTH_REFRESH_INLOCK_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_LOCK_OPTIONS.stale);
+  });
+
+  it("keeps the minimum lock-wait retry budget above the in-lock owner deadline", () => {
+    // A peer waiter uses OAUTH_REFRESH_LOCK_OPTIONS to retry the file lock; if
+    // its guaranteed (jitter-free) cumulative wait can expire before the owner's
+    // full held-lock ceiling (OAUTH_REFRESH_INLOCK_TIMEOUT_MS), the waiter would
+    // surface refresh_contention while the owner is still legitimately in budget.
+    // Randomization only lengthens delays, so the floor is the worst case.
+    const { retries, factor, minTimeout, maxTimeout } = OAUTH_REFRESH_LOCK_OPTIONS.retries;
+    let minBudgetMs = 0;
+    for (let attempt = 0; attempt < retries; attempt++) {
+      minBudgetMs += Math.min(maxTimeout, minTimeout * factor ** attempt);
+    }
+    expect(minBudgetMs).toBeGreaterThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS + 10_000);
   });
 
   it("does not overlay external auth while checking main-store adoption", async () => {

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -11,11 +11,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withEnvAsync } from "../../test-utils/env.js";
-import {
-  OAUTH_REFRESH_CALL_TIMEOUT_MS,
-  OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
-  OAUTH_REFRESH_LOCK_OPTIONS,
-} from "./constants.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
 import {
@@ -295,35 +290,6 @@ describe("createOAuthManager", () => {
       cfg,
       agentDir: undefined,
     });
-  });
-
-  it("keeps the in-lock critical-section deadline between the call timeout and the stale window", () => {
-    // The held-lock critical section (keychain load + buildApiKey + network
-    // refresh) is now wrapped by withRefreshCallTimeout(OAUTH_REFRESH_INLOCK_TIMEOUT_MS)
-    // so a wedged in-lock op cannot pin the cross-agent lock. The budget must sit
-    // above the network call timeout (so the tighter network budget fires first)
-    // and below the stale window (so a waiter never reclaims the lock while the
-    // owner is still within its allowed runtime). A timing-based behavior test is
-    // impractical here because the surrounding withFileLock uses a real file lock
-    // that does not coordinate with fake timers; the deadline mechanism itself is
-    // covered by withRuntimeAuthRefreshDeadline's tests and the auth-controller
-    // cold-start regression test.
-    expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS);
-    expect(OAUTH_REFRESH_INLOCK_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_LOCK_OPTIONS.stale);
-  });
-
-  it("keeps the minimum lock-wait retry budget above the in-lock owner deadline", () => {
-    // A peer waiter uses OAUTH_REFRESH_LOCK_OPTIONS to retry the file lock; if
-    // its guaranteed (jitter-free) cumulative wait can expire before the owner's
-    // full held-lock ceiling (OAUTH_REFRESH_INLOCK_TIMEOUT_MS), the waiter would
-    // surface refresh_contention while the owner is still legitimately in budget.
-    // Randomization only lengthens delays, so the floor is the worst case.
-    const { retries, factor, minTimeout, maxTimeout } = OAUTH_REFRESH_LOCK_OPTIONS.retries;
-    let minBudgetMs = 0;
-    for (let attempt = 0; attempt < retries; attempt++) {
-      minBudgetMs += Math.min(maxTimeout, minTimeout * factor ** attempt);
-    }
-    expect(minBudgetMs).toBeGreaterThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS + 10_000);
   });
 
   it("does not overlay external auth while checking main-store adoption", async () => {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -57,6 +57,11 @@ type OAuthManagerAdapter = {
     profileId: string;
     credential: OAuthCredential;
   }) => OAuthCredential | null;
+  readAuthoritativeBootstrapCredential?: (params: {
+    store: AuthProfileStore;
+    profileId: string;
+    credential: OAuthCredential;
+  }) => OAuthCredential | null;
   isRefreshTokenReusedError: (error: unknown) => boolean;
 };
 
@@ -149,6 +154,17 @@ function hasOAuthCredentialChanged(
     previous.access !== current.access ||
     previous.refresh !== current.refresh ||
     previous.expires !== current.expires
+  );
+}
+
+function isSafeExternalOAuthPromotion(
+  existing: OAuthCredential,
+  incoming: OAuthCredential,
+): boolean {
+  return (
+    existing.provider === incoming.provider &&
+    (areOAuthCredentialsEquivalent(existing, incoming) ||
+      hasMatchingOAuthIdentity(existing, incoming))
   );
 }
 
@@ -503,6 +519,58 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return result !== null && saved;
   }
 
+  async function promoteExternalOAuthCredentialWithStoreLock(params: {
+    agentDir?: string;
+    profileId: string;
+    source: OAuthCredential;
+    refreshed: OAuthCredential;
+  }): Promise<OAuthCredential | null> {
+    let resolved: OAuthCredential | null = null;
+    const result = await updateAuthProfileStoreWithLock({
+      agentDir: params.agentDir,
+      updater: (store) => {
+        const existing = store.profiles[params.profileId];
+        if (existing) {
+          if (
+            existing.type === "oauth" &&
+            existing.provider === params.refreshed.provider &&
+            (areOAuthCredentialsEquivalent(existing, params.source) ||
+              hasMatchingOAuthIdentity(existing, params.refreshed))
+          ) {
+            // Rotation already happened upstream. A same-identity CAS loser
+            // must commit the winning token or the token family is bricked.
+            store.profiles[params.profileId] = { ...params.refreshed };
+            resolved = params.refreshed;
+            return true;
+          }
+          if (
+            existing.type === "oauth" &&
+            hasUsableOAuthCredential(existing) &&
+            existing.provider === params.source.provider
+          ) {
+            // A different-identity relog won the race. Never overwrite it;
+            // adopt only a credential that can satisfy the current request.
+            resolved = existing;
+          }
+          return false;
+        }
+        if (!isSafeExternalOAuthPromotion(params.source, params.refreshed)) {
+          return false;
+        }
+        if (!hasOAuthCredentialChanged(params.source, params.refreshed)) {
+          // A provider may report success without rotating. Return it to the
+          // caller, but do not turn unchanged native state into SQLite state.
+          resolved = params.refreshed;
+          return false;
+        }
+        store.profiles[params.profileId] = { ...params.refreshed };
+        resolved = params.refreshed;
+        return true;
+      },
+    });
+    return result === null ? null : resolved;
+  }
+
   async function resolveOAuthCredentialAfterPersistMiss(params: {
     agentDir?: string;
     profileId: string;
@@ -533,24 +601,50 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return result === null ? null : adopted;
   }
 
+  async function resolveChangedUsableCredential(params: {
+    forceRefresh?: boolean;
+    attempted: OAuthCredential;
+    candidate: OAuthCredential;
+    agentDir?: string;
+    cfg?: OpenClawConfig;
+  }): Promise<ResolvedOAuthAccess | null> {
+    if (
+      !params.forceRefresh ||
+      params.candidate.provider !== params.attempted.provider ||
+      !hasUsableOAuthCredential(params.candidate)
+    ) {
+      return null;
+    }
+    const [attemptedApiKey, candidateApiKey] = await Promise.all([
+      adapter.buildApiKey(params.attempted.provider, params.attempted, {
+        cfg: params.cfg,
+        agentDir: params.agentDir,
+      }),
+      adapter.buildApiKey(params.candidate.provider, params.candidate, {
+        cfg: params.cfg,
+        agentDir: params.agentDir,
+      }),
+    ]);
+    if (attemptedApiKey === candidateApiKey) {
+      return null;
+    }
+    return { apiKey: candidateApiKey, credential: params.candidate };
+  }
+
   async function doRefreshOAuthTokenWithLock(params: {
-    store: AuthProfileStore;
     profileId: string;
     provider: string;
+    callerCredential: OAuthCredential;
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
-    useRuntimeStore?: boolean;
     attemptedCredentials?: OAuthCredential[];
+    externalCliCredential?: OAuthCredential;
   }): Promise<ResolvedOAuthAccess | null> {
-    const ownerAgentDir = params.useRuntimeStore
-      ? undefined
-      : resolvePersistedAuthProfileOwnerAgentDir(params);
-    const authPath = params.useRuntimeStore
-      ? undefined
-      : ownerAgentDir
-        ? resolveAuthProfileDatabasePath(ownerAgentDir)
-        : resolveSharedAuthStorePath();
+    const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
+    const authPath = ownerAgentDir
+      ? resolveAuthProfileDatabasePath(ownerAgentDir)
+      : resolveSharedAuthStorePath();
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
@@ -564,11 +658,60 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           // A deadline returns control to the caller but retains the file lock
           // until this body settles. The owner completes safe writeback before
           // releasing the rotating token, even after the caller has left.
-          const store = params.useRuntimeStore
-            ? params.store
-            : loadStoredOAuthRefreshStore(ownerAgentDir);
-          const cred = store.profiles[params.profileId];
-          if (!cred || cred.type !== "oauth") {
+          const store = loadStoredOAuthRefreshStore(ownerAgentDir);
+          const storedCredential = store.profiles[params.profileId];
+          if (storedCredential && storedCredential.type !== "oauth") {
+            return null;
+          }
+          const changedStoredCredential = storedCredential
+            ? await resolveChangedUsableCredential({
+                forceRefresh: params.forceRefresh,
+                attempted: params.callerCredential,
+                candidate: storedCredential,
+                agentDir: params.agentDir,
+                cfg: params.cfg,
+              })
+            : null;
+          if (changedStoredCredential) {
+            // The caller rejected an older prepared snapshot. Another owner
+            // already rotated it, so reuse SQLite instead of rotating again.
+            return changedStoredCredential;
+          }
+          let cred = storedCredential;
+          let promotingExternalCliCredential = false;
+          if (!cred && params.externalCliCredential) {
+            const authoritative = adapter.readAuthoritativeBootstrapCredential?.({
+              store,
+              profileId: params.profileId,
+              credential: params.externalCliCredential,
+            });
+            if (
+              !authoritative ||
+              authoritative.provider !== params.externalCliCredential.provider
+            ) {
+              return null;
+            }
+            const changedAuthoritativeCredential = await resolveChangedUsableCredential({
+              forceRefresh: params.forceRefresh,
+              attempted: params.callerCredential,
+              candidate: authoritative,
+              agentDir: params.agentDir,
+              cfg: params.cfg,
+            });
+            if (changedAuthoritativeCredential) {
+              // Native Codex was refreshed or re-logged after this prepared
+              // snapshot. Return the reread source without claiming SQLite.
+              return changedAuthoritativeCredential;
+            }
+            if (!isSafeExternalOAuthPromotion(params.externalCliCredential, authoritative)) {
+              return null;
+            }
+            // The fresh CLI read occurs under the global refresh lock. Only
+            // this exact native identity may seed SQLite after rotation.
+            cred = authoritative;
+            promotingExternalCliCredential = true;
+          }
+          if (!cred) {
             return null;
           }
           let credentialToRefresh = cred;
@@ -583,7 +726,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             };
           }
 
-          if (!params.useRuntimeStore && params.agentDir) {
+          if (params.agentDir) {
             try {
               const mainStore = loadStoredOAuthRefreshStore(undefined);
               const mainCred = mainStore.profiles[params.profileId];
@@ -635,11 +778,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             }
           }
 
-          const externallyManaged = adapter.readBootstrapCredential({
-            store,
-            profileId: params.profileId,
-            credential: cred,
-          });
+          const externallyManaged = promotingExternalCliCredential
+            ? null
+            : adapter.readBootstrapCredential({
+                store,
+                profileId: params.profileId,
+                credential: cred,
+              });
           if (externallyManaged) {
             if (externallyManaged.provider !== cred.provider) {
               authProfilesLog.warn(
@@ -663,14 +808,12 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 !areOAuthCredentialsEquivalent(cred, externallyManaged)
               ) {
                 store.profiles[params.profileId] = { ...externallyManaged };
-                if (!params.useRuntimeStore) {
-                  await saveOAuthCredentialWithStoreLock({
-                    agentDir: ownerAgentDir,
-                    profileId: params.profileId,
-                    expected: cred,
-                    credential: externallyManaged,
-                  });
-                }
+                await saveOAuthCredentialWithStoreLock({
+                  agentDir: ownerAgentDir,
+                  profileId: params.profileId,
+                  expected: cred,
+                  credential: externallyManaged,
+                });
               }
               credentialToRefresh = externallyManaged;
               if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
@@ -709,22 +852,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           if (!refreshedCredentials) {
             return null;
           }
-          if (params.useRuntimeStore) {
-            const current = store.profiles[params.profileId];
-            if (
-              current?.type !== "oauth" ||
-              (!areOAuthCredentialsEquivalent(current, credentialToRefresh) &&
-                !areOAuthCredentialsEquivalent(current, cred))
-            ) {
-              throw new Error(`OAuth profile "${params.profileId}" changed while refreshing`);
+          if (promotingExternalCliCredential) {
+            const promoted = await promoteExternalOAuthCredentialWithStoreLock({
+              agentDir: ownerAgentDir,
+              profileId: params.profileId,
+              source: credentialToRefresh,
+              refreshed: refreshedCredentials,
+            });
+            if (!promoted) {
+              return null;
             }
-            store.profiles[params.profileId] = refreshedCredentials;
+            store.profiles[params.profileId] = promoted;
             return {
-              apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
+              apiKey: await adapter.buildApiKey(promoted.provider, promoted, {
                 cfg: params.cfg,
                 agentDir: params.agentDir,
               }),
-              credential: refreshedCredentials,
+              credential: promoted,
             };
           }
           store.profiles[params.profileId] = refreshedCredentials;
@@ -788,14 +932,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   async function refreshOAuthTokenWithLock(params: {
-    store: AuthProfileStore;
     profileId: string;
     provider: string;
+    callerCredential: OAuthCredential;
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
-    useRuntimeStore?: boolean;
     attemptedCredentials?: OAuthCredential[];
+    externalCliCredential?: OAuthCredential;
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
     return await refreshQueue.enqueue(key, () => doRefreshOAuthTokenWithLock(params));
@@ -808,16 +952,15 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
-    useRuntimeStore?: boolean;
+    externalCliCredential?: OAuthCredential;
   }): Promise<ResolvedOAuthAccess | null> {
-    const adoptedCredential = params.useRuntimeStore
-      ? params.credential
-      : (adoptNewerMainOAuthCredential({
-          store: params.store,
-          profileId: params.profileId,
-          agentDir: params.agentDir,
-          credential: params.credential,
-        }) ?? params.credential);
+    const adoptedCredential =
+      adoptNewerMainOAuthCredential({
+        store: params.store,
+        profileId: params.profileId,
+        agentDir: params.agentDir,
+        credential: params.credential,
+      }) ?? params.credential;
     const effectiveCredential = resolveEffectiveOAuthCredentialCore({
       store: params.store,
       profileId: params.profileId,
@@ -838,20 +981,18 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
     try {
       const refreshed = await refreshOAuthTokenWithLock({
-        store: params.store,
         profileId: params.profileId,
         provider: params.credential.provider,
+        callerCredential: params.credential,
         agentDir: params.agentDir,
         cfg: params.cfg,
         forceRefresh: params.forceRefresh,
-        useRuntimeStore: params.useRuntimeStore,
         attemptedCredentials,
+        externalCliCredential: params.externalCliCredential,
       });
       return refreshed;
     } catch (error) {
-      const refreshedStore = params.useRuntimeStore
-        ? params.store
-        : loadStoredOAuthRefreshStore(params.agentDir);
+      const refreshedStore = loadStoredOAuthRefreshStore(params.agentDir);
       const refreshed = refreshedStore.profiles[params.profileId];
       if (
         refreshed?.type === "oauth" &&
@@ -871,7 +1012,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         };
       }
       if (
-        !params.useRuntimeStore &&
         adapter.isRefreshTokenReusedError(error) &&
         refreshed?.type === "oauth" &&
         refreshed.provider === params.credential.provider &&
@@ -895,14 +1035,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         }
         try {
           const retried = await refreshOAuthTokenWithLock({
-            store: params.store,
             profileId: params.profileId,
             provider: params.credential.provider,
+            callerCredential: params.credential,
             agentDir: params.agentDir,
             cfg: params.cfg,
             forceRefresh: params.forceRefresh,
-            useRuntimeStore: params.useRuntimeStore,
             attemptedCredentials,
+            externalCliCredential: params.externalCliCredential,
           });
           if (retried) {
             return retried;
@@ -912,7 +1052,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           // and final wrapped error path below.
         }
       }
-      if (!params.useRuntimeStore && params.agentDir) {
+      if (params.agentDir) {
         try {
           const mainStore = ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
             allowKeychainPrompt: false,

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -983,7 +983,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       const refreshed = await refreshOAuthTokenWithLock({
         profileId: params.profileId,
         provider: params.credential.provider,
-        callerCredential: params.credential,
+        // This is the bearer actually selected for the failed attempt. Passing
+        // the pre-adoption worker credential makes unchanged main state look rotated.
+        callerCredential: effectiveCredential,
         agentDir: params.agentDir,
         cfg: params.cfg,
         forceRefresh: params.forceRefresh,
@@ -1037,7 +1039,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           const retried = await refreshOAuthTokenWithLock({
             profileId: params.profileId,
             provider: params.credential.provider,
-            callerCredential: params.credential,
+            callerCredential: effectiveCredential,
             agentDir: params.agentDir,
             cfg: params.cfg,
             forceRefresh: params.forceRefresh,

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -12,8 +12,8 @@ import { redactSensitiveText } from "../../logging/redact.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import {
   OAUTH_REFRESH_CALL_TIMEOUT_MS,
-  OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
   OAUTH_REFRESH_LOCK_OPTIONS,
+  OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS,
   authProfilesLog,
 } from "./constants.js";
 import { hasUsableOAuthCredential } from "./credential-state.js";
@@ -380,38 +380,49 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return `${provider}\u0000${profileId}`;
   }
 
-  async function withRetainedRefreshLockDeadline<T>(
-    lockPath: string,
-    sectionLabel: string,
-    fn: (params: {
-      withCallerDeadline: <R>(
-        label: string,
-        timeoutMs: number,
-        operation: () => Promise<R>,
-      ) => Promise<R>;
-    }) => Promise<T>,
-  ): Promise<T> {
+  type OAuthRefreshCallerDeadline = {
+    isAbandoned: () => boolean;
+    race: <T>(operation: Promise<T>) => Promise<T>;
+    withCallerDeadline: <T>(
+      label: string,
+      timeoutMs: number,
+      operation: () => Promise<T>,
+    ) => Promise<T>;
+  };
+
+  function createOAuthRefreshCallerDeadline(params: {
+    label: string;
+    timeoutMs: number;
+  }): OAuthRefreshCallerDeadline {
     let callerAbandoned = false;
     let rejectCallerDeadline: (error: Error) => void = () => undefined;
     const callerDeadline = new Promise<never>((_resolve, reject) => {
       rejectCallerDeadline = reject;
     });
-    const abandonCallerAfter = async <R>(
+    const abandonCaller = (label: string, timeoutMs: number) => {
+      if (callerAbandoned) {
+        return;
+      }
+      callerAbandoned = true;
+      rejectCallerDeadline(
+        new Error(`OAuth refresh call "${label}" exceeded hard timeout (${timeoutMs}ms)`),
+      );
+    };
+    const ownershipTimeout = setTimeout(
+      () => abandonCaller(params.label, params.timeoutMs),
+      params.timeoutMs,
+    );
+    const withCallerDeadline = async <T>(
       label: string,
       timeoutMs: number,
-      operation: () => Promise<R>,
-    ): Promise<R> => {
+      operation: () => Promise<T>,
+    ): Promise<T> => {
+      if (callerAbandoned) {
+        throw new Error(`OAuth refresh call "${label}" exceeded caller ownership deadline`);
+      }
       let timeoutHandle: NodeJS.Timeout | undefined;
       try {
-        timeoutHandle = setTimeout(() => {
-          if (callerAbandoned) {
-            return;
-          }
-          callerAbandoned = true;
-          rejectCallerDeadline(
-            new Error(`OAuth refresh call "${label}" exceeded hard timeout (${timeoutMs}ms)`),
-          );
-        }, timeoutMs);
+        timeoutHandle = setTimeout(() => abandonCaller(label, timeoutMs), timeoutMs);
         return await operation();
       } finally {
         if (timeoutHandle) {
@@ -419,22 +430,38 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         }
       }
     };
-    const lockedOperation = withFileLock(
-      lockPath,
-      OAUTH_REFRESH_LOCK_OPTIONS,
-      async () =>
-        await abandonCallerAfter(
-          sectionLabel,
-          OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
-          async () =>
-            await fn({
-              withCallerDeadline: abandonCallerAfter,
-            }),
-        ),
-    );
-    // The race only bounds this caller. lockedOperation keeps the lock alive
-    // until the provider hook settles, preventing a second rotating-token use.
-    return await Promise.race([lockedOperation, callerDeadline]);
+    return {
+      isAbandoned: () => callerAbandoned,
+      race: async <T>(operation: Promise<T>): Promise<T> => {
+        try {
+          return await Promise.race([operation, callerDeadline]);
+        } finally {
+          clearTimeout(ownershipTimeout);
+        }
+      },
+      withCallerDeadline,
+    };
+  }
+
+  async function withRetainedRefreshLock<T>(
+    lockPath: string,
+    callerDeadline: OAuthRefreshCallerDeadline,
+    fn: (params: {
+      withCallerDeadline: <R>(
+        label: string,
+        timeoutMs: number,
+        operation: () => Promise<R>,
+      ) => Promise<R>;
+    }) => Promise<T>,
+  ): Promise<T | null> {
+    return await withFileLock(lockPath, OAUTH_REFRESH_LOCK_OPTIONS, async () => {
+      if (callerDeadline.isAbandoned()) {
+        return null;
+      }
+      return await fn({
+        withCallerDeadline: callerDeadline.withCallerDeadline,
+      });
+    });
   }
 
   async function mirrorRefreshedCredentialIntoMainStore(params: {
@@ -640,6 +667,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     forceRefresh?: boolean;
     attemptedCredentials?: OAuthCredential[];
     externalCliCredential?: OAuthCredential;
+    callerDeadline: OAuthRefreshCallerDeadline;
   }): Promise<ResolvedOAuthAccess | null> {
     const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
     const authPath = ownerAgentDir
@@ -648,12 +676,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
-      // Bound the caller's wait for the entire held-lock critical section. The
-      // lock lifetime still follows uncancellable provider work so a timed-out
-      // caller cannot let a successor reuse the same rotating refresh token.
-      return await withRetainedRefreshLockDeadline(
+      return await withRetainedRefreshLock(
         globalRefreshLockPath,
-        `${params.provider} oauth refresh critical section`,
+        params.callerDeadline,
         async ({ withCallerDeadline }) => {
           // A deadline returns control to the caller but retains the file lock
           // until this body settles. The owner completes safe writeback before
@@ -942,7 +967,19 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     externalCliCredential?: OAuthCredential;
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
-    return await refreshQueue.enqueue(key, () => doRefreshOAuthTokenWithLock(params));
+    const callerDeadline = createOAuthRefreshCallerDeadline({
+      label: `${params.provider} oauth refresh ownership`,
+      timeoutMs: OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS,
+    });
+    const queuedOperation = refreshQueue.enqueue(key, async () => {
+      if (callerDeadline.isAbandoned()) {
+        return null;
+      }
+      return await doRefreshOAuthTokenWithLock({ ...params, callerDeadline });
+    });
+    // The race bounds this caller from queue admission onward. If provider work
+    // already began, queuedOperation remains the queue tail until safe writeback.
+    return await callerDeadline.race(queuedOperation);
   }
 
   async function resolveOAuthAccess(params: {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -12,6 +12,7 @@ import { redactSensitiveText } from "../../logging/redact.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import {
   OAUTH_REFRESH_CALL_TIMEOUT_MS,
+  OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
   OAUTH_REFRESH_LOCK_OPTIONS,
   authProfilesLog,
 } from "./constants.js";
@@ -510,188 +511,206 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
-      return await withFileLock(globalRefreshLockPath, OAUTH_REFRESH_LOCK_OPTIONS, async () => {
-        const store = loadStoredOAuthRefreshStore(ownerAgentDir);
-        const cred = store.profiles[params.profileId];
-        if (!cred || cred.type !== "oauth") {
-          return null;
-        }
-        let credentialToRefresh = cred;
+      // Bound the ENTIRE held-lock critical section (keychain store load +
+      // buildApiKey + network refresh), not just the network call, so a wedged
+      // keychain/hook cannot pin the cross-agent lock and chain-stall every
+      // same-key refresher.
+      return await withFileLock(globalRefreshLockPath, OAUTH_REFRESH_LOCK_OPTIONS, () =>
+        withRefreshCallTimeout(
+          `${params.provider} oauth refresh critical section`,
+          OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
+          async () => {
+            const store = loadStoredOAuthRefreshStore(ownerAgentDir);
+            const cred = store.profiles[params.profileId];
+            if (!cred || cred.type !== "oauth") {
+              return null;
+            }
+            let credentialToRefresh = cred;
 
-        if (!params.forceRefresh && hasUsableOAuthCredential(cred)) {
-          return {
-            apiKey: await adapter.buildApiKey(cred.provider, cred, {
-              cfg: params.cfg,
-              agentDir: params.agentDir,
-            }),
-            credential: cred,
-          };
-        }
-
-        if (params.agentDir) {
-          try {
-            const mainStore = loadStoredOAuthRefreshStore(undefined);
-            const mainCred = mainStore.profiles[params.profileId];
-            if (
-              mainCred?.type === "oauth" &&
-              mainCred.provider === cred.provider &&
-              hasUsableOAuthCredential(mainCred) &&
-              !params.forceRefresh &&
-              isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
-            ) {
-              store.profiles[params.profileId] = { ...mainCred };
-              authProfilesLog.info(
-                "adopted fresh OAuth credential from main store (under refresh lock)",
-                {
-                  profileId: params.profileId,
-                  agentDir: params.agentDir,
-                  expires: new Date(mainCred.expires).toISOString(),
-                },
-              );
+            if (!params.forceRefresh && hasUsableOAuthCredential(cred)) {
               return {
-                apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {
+                apiKey: await adapter.buildApiKey(cred.provider, cred, {
                   cfg: params.cfg,
                   agentDir: params.agentDir,
                 }),
-                credential: mainCred,
+                credential: cred,
               };
-            } else if (
-              mainCred?.type === "oauth" &&
-              mainCred.provider === cred.provider &&
-              hasUsableOAuthCredential(mainCred) &&
-              !isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
-            ) {
-              authProfilesLog.warn(
-                "refused to adopt fresh main-store OAuth credential: identity mismatch",
-                {
-                  profileId: params.profileId,
-                  agentDir: params.agentDir,
-                },
-              );
             }
-          } catch (err) {
-            authProfilesLog.debug("inside-lock main-store adoption failed; proceeding to refresh", {
-              profileId: params.profileId,
-              error: formatErrorMessage(err),
-            });
-          }
-        }
 
-        const externallyManaged = adapter.readBootstrapCredential({
-          store,
-          profileId: params.profileId,
-          credential: cred,
-        });
-        if (externallyManaged) {
-          if (externallyManaged.provider !== cred.provider) {
-            authProfilesLog.warn("refused external oauth bootstrap credential: provider mismatch", {
+            if (params.agentDir) {
+              try {
+                const mainStore = loadStoredOAuthRefreshStore(undefined);
+                const mainCred = mainStore.profiles[params.profileId];
+                if (
+                  mainCred?.type === "oauth" &&
+                  mainCred.provider === cred.provider &&
+                  hasUsableOAuthCredential(mainCred) &&
+                  !params.forceRefresh &&
+                  isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
+                ) {
+                  store.profiles[params.profileId] = { ...mainCred };
+                  authProfilesLog.info(
+                    "adopted fresh OAuth credential from main store (under refresh lock)",
+                    {
+                    profileId: params.profileId,
+                    agentDir: params.agentDir,
+                    expires: new Date(mainCred.expires).toISOString(),
+                    },
+                  );
+                  return {
+                    apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {
+                      cfg: params.cfg,
+                      agentDir: params.agentDir,
+                    }),
+                    credential: mainCred,
+                  };
+                } else if (
+                  mainCred?.type === "oauth" &&
+                  mainCred.provider === cred.provider &&
+                  hasUsableOAuthCredential(mainCred) &&
+                  !isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
+                ) {
+                  authProfilesLog.warn(
+                    "refused to adopt fresh main-store OAuth credential: identity mismatch",
+                    {
+                      profileId: params.profileId,
+                      agentDir: params.agentDir,
+                    },
+                  );
+                }
+              } catch (err) {
+                authProfilesLog.debug(
+                  "inside-lock main-store adoption failed; proceeding to refresh",
+                  {
+                  profileId: params.profileId,
+                  error: formatErrorMessage(err),
+                  },
+                );
+              }
+            }
+
+            const externallyManaged = adapter.readBootstrapCredential({
+              store,
               profileId: params.profileId,
-              provider: cred.provider,
+              credential: cred,
             });
-          } else if (!isSafeToAdoptBootstrapOAuthIdentity(cred, externallyManaged)) {
-            authProfilesLog.warn(
-              "refused external oauth bootstrap credential: identity mismatch or missing binding",
-              {
-                profileId: params.profileId,
-                provider: cred.provider,
+            if (externallyManaged) {
+              if (externallyManaged.provider !== cred.provider) {
+                authProfilesLog.warn("refused external oauth bootstrap credential: provider mismatch", {
+                  profileId: params.profileId,
+                  provider: cred.provider,
+                });
+              } else if (!isSafeToAdoptBootstrapOAuthIdentity(cred, externallyManaged)) {
+                authProfilesLog.warn(
+                  "refused external oauth bootstrap credential: identity mismatch or missing binding",
+                  {
+                    profileId: params.profileId,
+                    provider: cred.provider,
+                  },
+                );
+              } else {
+                if (
+                  shouldReplaceStoredOAuthCredential(cred, externallyManaged) &&
+                  !areOAuthCredentialsEquivalent(cred, externallyManaged)
+                ) {
+                  store.profiles[params.profileId] = { ...externallyManaged };
+                  await saveOAuthCredentialWithStoreLock({
+                    agentDir: ownerAgentDir,
+                    profileId: params.profileId,
+                    expected: cred,
+                    credential: externallyManaged,
+                  });
+                }
+                credentialToRefresh = externallyManaged;
+                if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
+                  return {
+                    apiKey: await adapter.buildApiKey(
+                      externallyManaged.provider,
+                      externallyManaged,
+                      {
+                        cfg: params.cfg,
+                        agentDir: params.agentDir,
+                      },
+                    ),
+                    credential: externallyManaged,
+                  };
+                }
+              }
+            }
+
+            if (normalizeSecretInputString(credentialToRefresh.refresh) === undefined) {
+              return null;
+            }
+            const refreshedCredentials = await withRefreshCallTimeout(
+              `refreshOAuthCredential(${cred.provider})`,
+              OAUTH_REFRESH_CALL_TIMEOUT_MS,
+              async () => {
+                params.attemptedCredentials?.push(credentialToRefresh);
+                const refreshed = await adapter.refreshCredential(credentialToRefresh, {
+                  cfg: params.cfg,
+                  agentDir: params.agentDir,
+                });
+                return refreshed
+                  ? ({
+                      ...credentialToRefresh,
+                      ...refreshed,
+                      type: "oauth",
+                    } satisfies OAuthCredential)
+                  : null;
               },
             );
-          } else {
-            if (
-              shouldReplaceStoredOAuthCredential(cred, externallyManaged) &&
-              !areOAuthCredentialsEquivalent(cred, externallyManaged)
-            ) {
-              store.profiles[params.profileId] = { ...externallyManaged };
-              await saveOAuthCredentialWithStoreLock({
+            if (!refreshedCredentials) {
+              return null;
+            }
+            store.profiles[params.profileId] = refreshedCredentials;
+            const persisted = await saveOAuthCredentialWithStoreLock({
+              agentDir: ownerAgentDir,
+              profileId: params.profileId,
+              expected:
+                credentialToRefresh === cred ||
+                areOAuthCredentialsEquivalent(credentialToRefresh, cred)
+                  ? credentialToRefresh
+                  : [credentialToRefresh, cred],
+              credential: refreshedCredentials,
+            });
+            if (!persisted) {
+              const recovered = await resolveOAuthCredentialAfterPersistMiss({
                 agentDir: ownerAgentDir,
                 profileId: params.profileId,
-                expected: cred,
-                credential: externallyManaged,
+                refreshed: refreshedCredentials,
               });
+              if (!recovered) {
+                throw new Error("Failed to persist refreshed OAuth credential");
+              }
+              if (recovered !== refreshedCredentials) {
+                return {
+                  apiKey: await adapter.buildApiKey(recovered.provider, recovered, {
+                    cfg: params.cfg,
+                    agentDir: params.agentDir,
+                  }),
+                  credential: recovered,
+                };
+              }
             }
-            credentialToRefresh = externallyManaged;
-            if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
-              return {
-                apiKey: await adapter.buildApiKey(externallyManaged.provider, externallyManaged, {
-                  cfg: params.cfg,
-                  agentDir: params.agentDir,
-                }),
-                credential: externallyManaged,
-              };
+            if (ownerAgentDir) {
+              const mainPath = resolveSharedAuthStorePath();
+              if (mainPath !== authPath) {
+                await mirrorRefreshedCredentialIntoMainStore({
+                  profileId: params.profileId,
+                  refreshed: refreshedCredentials,
+                });
+              }
             }
-          }
-        }
-
-        if (normalizeSecretInputString(credentialToRefresh.refresh) === undefined) {
-          return null;
-        }
-        const refreshedCredentials = await withRefreshCallTimeout(
-          `refreshOAuthCredential(${cred.provider})`,
-          OAUTH_REFRESH_CALL_TIMEOUT_MS,
-          async () => {
-            params.attemptedCredentials?.push(credentialToRefresh);
-            const refreshed = await adapter.refreshCredential(credentialToRefresh, {
-              cfg: params.cfg,
-              agentDir: params.agentDir,
-            });
-            return refreshed
-              ? ({
-                  ...credentialToRefresh,
-                  ...refreshed,
-                  type: "oauth",
-                } satisfies OAuthCredential)
-              : null;
-          },
-        );
-        if (!refreshedCredentials) {
-          return null;
-        }
-        store.profiles[params.profileId] = refreshedCredentials;
-        const persisted = await saveOAuthCredentialWithStoreLock({
-          agentDir: ownerAgentDir,
-          profileId: params.profileId,
-          expected:
-            credentialToRefresh === cred || areOAuthCredentialsEquivalent(credentialToRefresh, cred)
-              ? credentialToRefresh
-              : [credentialToRefresh, cred],
-          credential: refreshedCredentials,
-        });
-        if (!persisted) {
-          const recovered = await resolveOAuthCredentialAfterPersistMiss({
-            agentDir: ownerAgentDir,
-            profileId: params.profileId,
-            refreshed: refreshedCredentials,
-          });
-          if (!recovered) {
-            throw new Error("Failed to persist refreshed OAuth credential");
-          }
-          if (recovered !== refreshedCredentials) {
             return {
-              apiKey: await adapter.buildApiKey(recovered.provider, recovered, {
+              apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
                 cfg: params.cfg,
                 agentDir: params.agentDir,
               }),
-              credential: recovered,
+              credential: refreshedCredentials,
             };
-          }
-        }
-        if (ownerAgentDir) {
-          const mainPath = resolveSharedAuthStorePath();
-          if (mainPath !== authPath) {
-            await mirrorRefreshedCredentialIntoMainStore({
-              profileId: params.profileId,
-              refreshed: refreshedCredentials,
-            });
-          }
-        }
-        return {
-          apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
-            cfg: params.cfg,
-            agentDir: params.agentDir,
-          }),
-          credential: refreshedCredentials,
-        };
-      });
+          },
+        ),
+      );
     } catch (error) {
       if (isGlobalRefreshLockTimeoutError(error, globalRefreshLockPath)) {
         throw buildRefreshContentionError({

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -288,10 +288,13 @@ export function resolveEffectiveOAuthCredentialCore(params: {
     return params.credential;
   }
   if (!isSafeToAdoptBootstrapOAuthIdentity(params.credential, imported)) {
-    authProfilesLog.warn("refused external oauth bootstrap credential: identity mismatch or missing binding", {
-      profileId: params.profileId,
-      provider: params.credential.provider,
-    });
+    authProfilesLog.warn(
+      "refused external oauth bootstrap credential: identity mismatch or missing binding",
+      {
+        profileId: params.profileId,
+        provider: params.credential.provider,
+      },
+    );
     return params.credential;
   }
   const shouldBootstrap = shouldBootstrapFromExternalCliCredential({
@@ -361,16 +364,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return `${provider}\u0000${profileId}`;
   }
 
-  // Ownership token for a deadline-bounded section. The deadline cannot cancel
-  // provider hooks, so it abandons the caller while the cross-agent file lock
-  // remains held until the running body settles.
-  type RefreshSectionOwnership = { state: "owned" | "abandoned" };
-
   async function withRetainedRefreshLockDeadline<T>(
     lockPath: string,
     sectionLabel: string,
     fn: (params: {
-      ownership: RefreshSectionOwnership;
       withCallerDeadline: <R>(
         label: string,
         timeoutMs: number,
@@ -378,7 +375,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       ) => Promise<R>;
     }) => Promise<T>,
   ): Promise<T> {
-    const ownership: RefreshSectionOwnership = { state: "owned" };
+    let callerAbandoned = false;
     let rejectCallerDeadline: (error: Error) => void = () => undefined;
     const callerDeadline = new Promise<never>((_resolve, reject) => {
       rejectCallerDeadline = reject;
@@ -391,10 +388,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       let timeoutHandle: NodeJS.Timeout | undefined;
       try {
         timeoutHandle = setTimeout(() => {
-          if (ownership.state === "abandoned") {
+          if (callerAbandoned) {
             return;
           }
-          ownership.state = "abandoned";
+          callerAbandoned = true;
           rejectCallerDeadline(
             new Error(`OAuth refresh call "${label}" exceeded hard timeout (${timeoutMs}ms)`),
           );
@@ -415,7 +412,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
           async () =>
             await fn({
-              ownership,
               withCallerDeadline: abandonCallerAfter,
             }),
         ),
@@ -428,15 +424,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   async function mirrorRefreshedCredentialIntoMainStore(params: {
     profileId: string;
     refreshed: OAuthCredential;
-    isWriteAllowed?: () => boolean;
   }): Promise<void> {
     try {
       await updateAuthProfileStoreWithLock({
         agentDir: undefined,
         updater: (store) => {
-          if (params.isWriteAllowed && !params.isWriteAllowed()) {
-            return false;
-          }
           const existing = store.profiles[params.profileId];
           const decision = shouldMirrorRefreshedOAuthCredential({
             existing,
@@ -444,9 +436,12 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           });
           if (!decision.shouldMirror) {
             if (decision.reason === "identity-mismatch-or-regression") {
-              authProfilesLog.warn("refused to mirror OAuth credential: identity mismatch or regression", {
-                profileId: params.profileId,
-              });
+              authProfilesLog.warn(
+                "refused to mirror OAuth credential: identity mismatch or regression",
+                {
+                  profileId: params.profileId,
+                },
+              );
             }
             return false;
           }
@@ -473,15 +468,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     profileId: string;
     expected: OAuthCredential | OAuthCredential[];
     credential: OAuthCredential;
-    isWriteAllowed?: () => boolean;
   }): Promise<boolean> {
     let saved = false;
     const result = await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
       updater: (store) => {
-        if (params.isWriteAllowed && !params.isWriteAllowed()) {
-          return false;
-        }
         const existing = store.profiles[params.profileId];
         const expectedCredentials = Array.isArray(params.expected)
           ? params.expected
@@ -516,7 +507,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     profileId: string;
     refreshed: OAuthCredential;
-    isWriteAllowed?: () => boolean;
   }): Promise<OAuthCredential | null> {
     // Single locked pass decides both outcomes so no relog can slip between a
     // pre-read and the update: same identity persists the rotation, different
@@ -525,9 +515,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     const result = await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
       updater: (store) => {
-        if (params.isWriteAllowed && !params.isWriteAllowed()) {
-          return false;
-        }
         const existing = store.profiles[params.profileId];
         if (existing?.type !== "oauth" || existing.provider !== params.refreshed.provider) {
           return false;
@@ -547,17 +534,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   async function doRefreshOAuthTokenWithLock(params: {
+    store: AuthProfileStore;
     profileId: string;
     provider: string;
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
+    useRuntimeStore?: boolean;
     attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
-    const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
-    const authPath = ownerAgentDir
-      ? resolveAuthProfileDatabasePath(ownerAgentDir)
-      : resolveSharedAuthStorePath();
+    const ownerAgentDir = params.useRuntimeStore
+      ? undefined
+      : resolvePersistedAuthProfileOwnerAgentDir(params);
+    const authPath = params.useRuntimeStore
+      ? undefined
+      : ownerAgentDir
+        ? resolveAuthProfileDatabasePath(ownerAgentDir)
+        : resolveSharedAuthStorePath();
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
@@ -567,25 +560,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       return await withRetainedRefreshLockDeadline(
         globalRefreshLockPath,
         `${params.provider} oauth refresh critical section`,
-        async ({ ownership: sectionOwnership, withCallerDeadline }) => {
+        async ({ withCallerDeadline }) => {
           // A deadline returns control to the caller but retains the file lock
-          // until this body settles. Persist owners also re-check under their
-          // own store lock so a concurrent relog cannot be clobbered.
-          const ownsSection = (): boolean => sectionOwnership.state === "owned";
-          const continuationAllowed = (
-            step: "refresh" | "persist" | "mirror" | "result",
-          ): boolean => {
-            if (sectionOwnership.state === "owned") {
-              return true;
-            }
-            authProfilesLog.debug("discarded abandoned OAuth refresh continuation after in-lock deadline", {
-              profileId: params.profileId,
-              provider: params.provider,
-              step,
-            });
-            return false;
-          };
-          const store = loadStoredOAuthRefreshStore(ownerAgentDir);
+          // until this body settles. The owner completes safe writeback before
+          // releasing the rotating token, even after the caller has left.
+          const store = params.useRuntimeStore
+            ? params.store
+            : loadStoredOAuthRefreshStore(ownerAgentDir);
           const cred = store.profiles[params.profileId];
           if (!cred || cred.type !== "oauth") {
             return null;
@@ -602,7 +583,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             };
           }
 
-          if (params.agentDir) {
+          if (!params.useRuntimeStore && params.agentDir) {
             try {
               const mainStore = loadStoredOAuthRefreshStore(undefined);
               const mainCred = mainStore.profiles[params.profileId];
@@ -614,11 +595,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
               ) {
                 store.profiles[params.profileId] = { ...mainCred };
-                authProfilesLog.info("adopted fresh OAuth credential from main store (under refresh lock)", {
-                  profileId: params.profileId,
-                  agentDir: params.agentDir,
-                  expires: new Date(mainCred.expires).toISOString(),
-                });
+                authProfilesLog.info(
+                  "adopted fresh OAuth credential from main store (under refresh lock)",
+                  {
+                    profileId: params.profileId,
+                    agentDir: params.agentDir,
+                    expires: new Date(mainCred.expires).toISOString(),
+                  },
+                );
                 return {
                   apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {
                     cfg: params.cfg,
@@ -632,16 +616,22 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 hasUsableOAuthCredential(mainCred) &&
                 !isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
               ) {
-                authProfilesLog.warn("refused to adopt fresh main-store OAuth credential: identity mismatch", {
-                  profileId: params.profileId,
-                  agentDir: params.agentDir,
-                });
+                authProfilesLog.warn(
+                  "refused to adopt fresh main-store OAuth credential: identity mismatch",
+                  {
+                    profileId: params.profileId,
+                    agentDir: params.agentDir,
+                  },
+                );
               }
             } catch (err) {
-              authProfilesLog.debug("inside-lock main-store adoption failed; proceeding to refresh", {
-                profileId: params.profileId,
-                error: formatErrorMessage(err),
-              });
+              authProfilesLog.debug(
+                "inside-lock main-store adoption failed; proceeding to refresh",
+                {
+                  profileId: params.profileId,
+                  error: formatErrorMessage(err),
+                },
+              );
             }
           }
 
@@ -652,10 +642,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           });
           if (externallyManaged) {
             if (externallyManaged.provider !== cred.provider) {
-              authProfilesLog.warn("refused external oauth bootstrap credential: provider mismatch", {
-                profileId: params.profileId,
-                provider: cred.provider,
-              });
+              authProfilesLog.warn(
+                "refused external oauth bootstrap credential: provider mismatch",
+                {
+                  profileId: params.profileId,
+                  provider: cred.provider,
+                },
+              );
             } else if (!isSafeToAdoptBootstrapOAuthIdentity(cred, externallyManaged)) {
               authProfilesLog.warn(
                 "refused external oauth bootstrap credential: identity mismatch or missing binding",
@@ -670,19 +663,17 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 !areOAuthCredentialsEquivalent(cred, externallyManaged)
               ) {
                 store.profiles[params.profileId] = { ...externallyManaged };
-                await saveOAuthCredentialWithStoreLock({
-                  agentDir: ownerAgentDir,
-                  profileId: params.profileId,
-                  expected: cred,
-                  credential: externallyManaged,
-                  isWriteAllowed: ownsSection,
-                });
+                if (!params.useRuntimeStore) {
+                  await saveOAuthCredentialWithStoreLock({
+                    agentDir: ownerAgentDir,
+                    profileId: params.profileId,
+                    expected: cred,
+                    credential: externallyManaged,
+                  });
+                }
               }
               credentialToRefresh = externallyManaged;
               if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
-                if (!continuationAllowed("result")) {
-                  return null;
-                }
                 return {
                   apiKey: await adapter.buildApiKey(externallyManaged.provider, externallyManaged, {
                     cfg: params.cfg,
@@ -695,9 +686,6 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
 
           if (normalizeSecretInputString(credentialToRefresh.refresh) === undefined) {
-            return null;
-          }
-          if (!continuationAllowed("refresh")) {
             return null;
           }
           const refreshedCredentials = await withCallerDeadline(
@@ -721,8 +709,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           if (!refreshedCredentials) {
             return null;
           }
-          if (!continuationAllowed("persist")) {
-            return null;
+          if (params.useRuntimeStore) {
+            const current = store.profiles[params.profileId];
+            if (
+              current?.type !== "oauth" ||
+              (!areOAuthCredentialsEquivalent(current, credentialToRefresh) &&
+                !areOAuthCredentialsEquivalent(current, cred))
+            ) {
+              throw new Error(`OAuth profile "${params.profileId}" changed while refreshing`);
+            }
+            store.profiles[params.profileId] = refreshedCredentials;
+            return {
+              apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
+                cfg: params.cfg,
+                agentDir: params.agentDir,
+              }),
+              credential: refreshedCredentials,
+            };
           }
           store.profiles[params.profileId] = refreshedCredentials;
           const persisted = await saveOAuthCredentialWithStoreLock({
@@ -734,21 +737,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                 ? credentialToRefresh
                 : [credentialToRefresh, cred],
             credential: refreshedCredentials,
-            isWriteAllowed: ownsSection,
           });
-          if (!continuationAllowed("persist")) {
-            return null;
-          }
           if (!persisted) {
             const recovered = await resolveOAuthCredentialAfterPersistMiss({
               agentDir: ownerAgentDir,
               profileId: params.profileId,
               refreshed: refreshedCredentials,
-              isWriteAllowed: ownsSection,
             });
-            if (!continuationAllowed("persist")) {
-              return null;
-            }
             if (!recovered) {
               throw new Error("Failed to persist refreshed OAuth credential");
             }
@@ -762,23 +757,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
               };
             }
           }
-          // Re-check after the persist await: the deadline may have fired
-          // mid-write, in which case the mirror must not run either.
-          if (!continuationAllowed("mirror")) {
-            return null;
-          }
           if (ownerAgentDir) {
             const mainPath = resolveSharedAuthStorePath();
             if (mainPath !== authPath) {
               await mirrorRefreshedCredentialIntoMainStore({
                 profileId: params.profileId,
                 refreshed: refreshedCredentials,
-                isWriteAllowed: ownsSection,
               });
             }
-          }
-          if (!continuationAllowed("result")) {
-            return null;
           }
           return {
             apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
@@ -802,11 +788,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   async function refreshOAuthTokenWithLock(params: {
+    store: AuthProfileStore;
     profileId: string;
     provider: string;
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
+    useRuntimeStore?: boolean;
     attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
@@ -820,14 +808,16 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
+    useRuntimeStore?: boolean;
   }): Promise<ResolvedOAuthAccess | null> {
-    const adoptedCredential =
-      adoptNewerMainOAuthCredential({
-        store: params.store,
-        profileId: params.profileId,
-        agentDir: params.agentDir,
-        credential: params.credential,
-      }) ?? params.credential;
+    const adoptedCredential = params.useRuntimeStore
+      ? params.credential
+      : (adoptNewerMainOAuthCredential({
+          store: params.store,
+          profileId: params.profileId,
+          agentDir: params.agentDir,
+          credential: params.credential,
+        }) ?? params.credential);
     const effectiveCredential = resolveEffectiveOAuthCredentialCore({
       store: params.store,
       profileId: params.profileId,
@@ -848,16 +838,20 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
     try {
       const refreshed = await refreshOAuthTokenWithLock({
+        store: params.store,
         profileId: params.profileId,
         provider: params.credential.provider,
         agentDir: params.agentDir,
         cfg: params.cfg,
         forceRefresh: params.forceRefresh,
+        useRuntimeStore: params.useRuntimeStore,
         attemptedCredentials,
       });
       return refreshed;
     } catch (error) {
-      const refreshedStore = loadStoredOAuthRefreshStore(params.agentDir);
+      const refreshedStore = params.useRuntimeStore
+        ? params.store
+        : loadStoredOAuthRefreshStore(params.agentDir);
       const refreshed = refreshedStore.profiles[params.profileId];
       if (
         refreshed?.type === "oauth" &&
@@ -877,6 +871,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         };
       }
       if (
+        !params.useRuntimeStore &&
         adapter.isRefreshTokenReusedError(error) &&
         refreshed?.type === "oauth" &&
         refreshed.provider === params.credential.provider &&
@@ -900,11 +895,13 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         }
         try {
           const retried = await refreshOAuthTokenWithLock({
+            store: params.store,
             profileId: params.profileId,
             provider: params.credential.provider,
             agentDir: params.agentDir,
             cfg: params.cfg,
             forceRefresh: params.forceRefresh,
+            useRuntimeStore: params.useRuntimeStore,
             attemptedCredentials,
           });
           if (retried) {
@@ -915,7 +912,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           // and final wrapped error path below.
         }
       }
-      if (params.agentDir) {
+      if (!params.useRuntimeStore && params.agentDir) {
         try {
           const mainStore = ensureAuthProfileStoreWithoutExternalProfiles(undefined, {
             allowKeychainPrompt: false,

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -288,13 +288,10 @@ export function resolveEffectiveOAuthCredentialCore(params: {
     return params.credential;
   }
   if (!isSafeToAdoptBootstrapOAuthIdentity(params.credential, imported)) {
-    authProfilesLog.warn(
-      "refused external oauth bootstrap credential: identity mismatch or missing binding",
-      {
-        profileId: params.profileId,
-        provider: params.credential.provider,
-      },
-    );
+    authProfilesLog.warn("refused external oauth bootstrap credential: identity mismatch or missing binding", {
+      profileId: params.profileId,
+      provider: params.credential.provider,
+    });
     return params.credential;
   }
   const shouldBootstrap = shouldBootstrapFromExternalCliCredential({
@@ -365,41 +362,81 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
   }
 
   // Ownership token for a deadline-bounded section. The deadline cannot cancel
-  // the running body, only abandon it; once "abandoned" the surrounding
-  // cross-agent file lock is released and a peer refresher may own this key,
-  // so the stale continuation must not persist or mirror credentials.
+  // provider hooks, so it abandons the caller while the cross-agent file lock
+  // remains held until the running body settles.
   type RefreshSectionOwnership = { state: "owned" | "abandoned" };
 
-  async function withRefreshCallTimeout<T>(
-    label: string,
-    timeoutMs: number,
-    fn: (ownership: RefreshSectionOwnership) => Promise<T>,
+  async function withRetainedRefreshLockDeadline<T>(
+    lockPath: string,
+    sectionLabel: string,
+    fn: (params: {
+      ownership: RefreshSectionOwnership;
+      withCallerDeadline: <R>(
+        label: string,
+        timeoutMs: number,
+        operation: () => Promise<R>,
+      ) => Promise<R>;
+    }) => Promise<T>,
   ): Promise<T> {
-    let timeoutHandle: NodeJS.Timeout | undefined;
     const ownership: RefreshSectionOwnership = { state: "owned" };
-    try {
-      return await new Promise<T>((resolve, reject) => {
+    let rejectCallerDeadline: (error: Error) => void = () => undefined;
+    const callerDeadline = new Promise<never>((_resolve, reject) => {
+      rejectCallerDeadline = reject;
+    });
+    const abandonCallerAfter = async <R>(
+      label: string,
+      timeoutMs: number,
+      operation: () => Promise<R>,
+    ): Promise<R> => {
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      try {
         timeoutHandle = setTimeout(() => {
+          if (ownership.state === "abandoned") {
+            return;
+          }
           ownership.state = "abandoned";
-          reject(new Error(`OAuth refresh call "${label}" exceeded hard timeout (${timeoutMs}ms)`));
+          rejectCallerDeadline(
+            new Error(`OAuth refresh call "${label}" exceeded hard timeout (${timeoutMs}ms)`),
+          );
         }, timeoutMs);
-        fn(ownership).then(resolve, reject);
-      });
-    } finally {
-      if (timeoutHandle) {
-        clearTimeout(timeoutHandle);
+        return await operation();
+      } finally {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+        }
       }
-    }
+    };
+    const lockedOperation = withFileLock(
+      lockPath,
+      OAUTH_REFRESH_LOCK_OPTIONS,
+      async () =>
+        await abandonCallerAfter(
+          sectionLabel,
+          OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
+          async () =>
+            await fn({
+              ownership,
+              withCallerDeadline: abandonCallerAfter,
+            }),
+        ),
+    );
+    // The race only bounds this caller. lockedOperation keeps the lock alive
+    // until the provider hook settles, preventing a second rotating-token use.
+    return await Promise.race([lockedOperation, callerDeadline]);
   }
 
   async function mirrorRefreshedCredentialIntoMainStore(params: {
     profileId: string;
     refreshed: OAuthCredential;
+    isWriteAllowed?: () => boolean;
   }): Promise<void> {
     try {
       await updateAuthProfileStoreWithLock({
         agentDir: undefined,
         updater: (store) => {
+          if (params.isWriteAllowed && !params.isWriteAllowed()) {
+            return false;
+          }
           const existing = store.profiles[params.profileId];
           const decision = shouldMirrorRefreshedOAuthCredential({
             existing,
@@ -407,12 +444,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           });
           if (!decision.shouldMirror) {
             if (decision.reason === "identity-mismatch-or-regression") {
-              authProfilesLog.warn(
-                "refused to mirror OAuth credential: identity mismatch or regression",
-                {
-                  profileId: params.profileId,
-                },
-              );
+              authProfilesLog.warn("refused to mirror OAuth credential: identity mismatch or regression", {
+                profileId: params.profileId,
+              });
             }
             return false;
           }
@@ -439,11 +473,15 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     profileId: string;
     expected: OAuthCredential | OAuthCredential[];
     credential: OAuthCredential;
+    isWriteAllowed?: () => boolean;
   }): Promise<boolean> {
     let saved = false;
     const result = await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
       updater: (store) => {
+        if (params.isWriteAllowed && !params.isWriteAllowed()) {
+          return false;
+        }
         const existing = store.profiles[params.profileId];
         const expectedCredentials = Array.isArray(params.expected)
           ? params.expected
@@ -478,6 +516,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     profileId: string;
     refreshed: OAuthCredential;
+    isWriteAllowed?: () => boolean;
   }): Promise<OAuthCredential | null> {
     // Single locked pass decides both outcomes so no relog can slip between a
     // pre-read and the update: same identity persists the rotation, different
@@ -486,6 +525,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     const result = await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
       updater: (store) => {
+        if (params.isWriteAllowed && !params.isWriteAllowed()) {
+          return false;
+        }
         const existing = store.profiles[params.profileId];
         if (existing?.type !== "oauth" || existing.provider !== params.refreshed.provider) {
           return false;
@@ -519,230 +561,233 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     const globalRefreshLockPath = resolveOAuthRefreshLockPath(params.provider, params.profileId);
 
     try {
-      // Bound the ENTIRE held-lock critical section (keychain store load +
-      // buildApiKey + network refresh), not just the network call, so a wedged
-      // keychain/hook cannot pin the cross-agent lock and chain-stall every
-      // same-key refresher.
-      return await withFileLock(globalRefreshLockPath, OAUTH_REFRESH_LOCK_OPTIONS, () =>
-        withRefreshCallTimeout(
-          `${params.provider} oauth refresh critical section`,
-          OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
-          async (sectionOwnership) => {
-            // The in-lock deadline cannot cancel this body; once it fires the
-            // file lock is released and a successor refresher may own this
-            // key. Every persist/mirror below re-checks ownership and no-ops
-            // when abandoned so a stale continuation cannot clobber the
-            // successor's credentials.
-            const writeBackAllowed = (step: "adopt-bootstrap" | "persist" | "mirror"): boolean => {
-              if (sectionOwnership.state === "owned") {
-                return true;
-              }
-              log.debug("discarded abandoned OAuth refresh write-back after in-lock deadline", {
-                profileId: params.profileId,
-                provider: params.provider,
-                step,
-              });
-              return false;
-            };
-            const store = loadStoredOAuthRefreshStore(ownerAgentDir);
-            const cred = store.profiles[params.profileId];
-            if (!cred || cred.type !== "oauth") {
-              return null;
+      // Bound the caller's wait for the entire held-lock critical section. The
+      // lock lifetime still follows uncancellable provider work so a timed-out
+      // caller cannot let a successor reuse the same rotating refresh token.
+      return await withRetainedRefreshLockDeadline(
+        globalRefreshLockPath,
+        `${params.provider} oauth refresh critical section`,
+        async ({ ownership: sectionOwnership, withCallerDeadline }) => {
+          // A deadline returns control to the caller but retains the file lock
+          // until this body settles. Persist owners also re-check under their
+          // own store lock so a concurrent relog cannot be clobbered.
+          const ownsSection = (): boolean => sectionOwnership.state === "owned";
+          const continuationAllowed = (
+            step: "refresh" | "persist" | "mirror" | "result",
+          ): boolean => {
+            if (sectionOwnership.state === "owned") {
+              return true;
             }
-            let credentialToRefresh = cred;
-
-            if (!params.forceRefresh && hasUsableOAuthCredential(cred)) {
-              return {
-                apiKey: await adapter.buildApiKey(cred.provider, cred, {
-                  cfg: params.cfg,
-                  agentDir: params.agentDir,
-                }),
-                credential: cred,
-              };
-            }
-
-            if (params.agentDir) {
-              try {
-                const mainStore = loadStoredOAuthRefreshStore(undefined);
-                const mainCred = mainStore.profiles[params.profileId];
-                if (
-                  mainCred?.type === "oauth" &&
-                  mainCred.provider === cred.provider &&
-                  hasUsableOAuthCredential(mainCred) &&
-                  !params.forceRefresh &&
-                  isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
-                ) {
-                  store.profiles[params.profileId] = { ...mainCred };
-                  authProfilesLog.info(
-                    "adopted fresh OAuth credential from main store (under refresh lock)",
-                    {
-                    profileId: params.profileId,
-                    agentDir: params.agentDir,
-                    expires: new Date(mainCred.expires).toISOString(),
-                    },
-                  );
-                  return {
-                    apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {
-                      cfg: params.cfg,
-                      agentDir: params.agentDir,
-                    }),
-                    credential: mainCred,
-                  };
-                } else if (
-                  mainCred?.type === "oauth" &&
-                  mainCred.provider === cred.provider &&
-                  hasUsableOAuthCredential(mainCred) &&
-                  !isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
-                ) {
-                  authProfilesLog.warn(
-                    "refused to adopt fresh main-store OAuth credential: identity mismatch",
-                    {
-                      profileId: params.profileId,
-                      agentDir: params.agentDir,
-                    },
-                  );
-                }
-              } catch (err) {
-                authProfilesLog.debug(
-                  "inside-lock main-store adoption failed; proceeding to refresh",
-                  {
-                  profileId: params.profileId,
-                  error: formatErrorMessage(err),
-                  },
-                );
-              }
-            }
-
-            const externallyManaged = adapter.readBootstrapCredential({
-              store,
+            authProfilesLog.debug("discarded abandoned OAuth refresh continuation after in-lock deadline", {
               profileId: params.profileId,
-              credential: cred,
+              provider: params.provider,
+              step,
             });
-            if (externallyManaged) {
-              if (externallyManaged.provider !== cred.provider) {
-                authProfilesLog.warn("refused external oauth bootstrap credential: provider mismatch", {
-                  profileId: params.profileId,
-                  provider: cred.provider,
-                });
-              } else if (!isSafeToAdoptBootstrapOAuthIdentity(cred, externallyManaged)) {
-                authProfilesLog.warn(
-                  "refused external oauth bootstrap credential: identity mismatch or missing binding",
-                  {
-                    profileId: params.profileId,
-                    provider: cred.provider,
-                  },
-                );
-              } else {
-                if (
-                  shouldReplaceStoredOAuthCredential(cred, externallyManaged) &&
-                  !areOAuthCredentialsEquivalent(cred, externallyManaged) &&
-                  writeBackAllowed("adopt-bootstrap")
-                ) {
-                  store.profiles[params.profileId] = { ...externallyManaged };
-                  await saveOAuthCredentialWithStoreLock({
-                    agentDir: ownerAgentDir,
-                    profileId: params.profileId,
-                    expected: cred,
-                    credential: externallyManaged,
-                  });
-                }
-                credentialToRefresh = externallyManaged;
-                if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
-                  return {
-                    apiKey: await adapter.buildApiKey(
-                      externallyManaged.provider,
-                      externallyManaged,
-                      {
-                        cfg: params.cfg,
-                        agentDir: params.agentDir,
-                      },
-                    ),
-                    credential: externallyManaged,
-                  };
-                }
-              }
-            }
+            return false;
+          };
+          const store = loadStoredOAuthRefreshStore(ownerAgentDir);
+          const cred = store.profiles[params.profileId];
+          if (!cred || cred.type !== "oauth") {
+            return null;
+          }
+          let credentialToRefresh = cred;
 
-            if (normalizeSecretInputString(credentialToRefresh.refresh) === undefined) {
-              return null;
-            }
-            const refreshedCredentials = await withRefreshCallTimeout(
-              `refreshOAuthCredential(${cred.provider})`,
-              OAUTH_REFRESH_CALL_TIMEOUT_MS,
-              async () => {
-                params.attemptedCredentials?.push(credentialToRefresh);
-                const refreshed = await adapter.refreshCredential(credentialToRefresh, {
-                  cfg: params.cfg,
-                  agentDir: params.agentDir,
-                });
-                return refreshed
-                  ? ({
-                      ...credentialToRefresh,
-                      ...refreshed,
-                      type: "oauth",
-                    } satisfies OAuthCredential)
-                  : null;
-              },
-            );
-            if (!refreshedCredentials) {
-              return null;
-            }
-            if (!writeBackAllowed("persist")) {
-              return null;
-            }
-            store.profiles[params.profileId] = refreshedCredentials;
-            const persisted = await saveOAuthCredentialWithStoreLock({
-              agentDir: ownerAgentDir,
-              profileId: params.profileId,
-              expected:
-                credentialToRefresh === cred ||
-                areOAuthCredentialsEquivalent(credentialToRefresh, cred)
-                  ? credentialToRefresh
-                  : [credentialToRefresh, cred],
-              credential: refreshedCredentials,
-            });
-            if (!persisted) {
-              const recovered = await resolveOAuthCredentialAfterPersistMiss({
-                agentDir: ownerAgentDir,
-                profileId: params.profileId,
-                refreshed: refreshedCredentials,
-              });
-              if (!recovered) {
-                throw new Error("Failed to persist refreshed OAuth credential");
-              }
-              if (recovered !== refreshedCredentials) {
-                return {
-                  apiKey: await adapter.buildApiKey(recovered.provider, recovered, {
-                    cfg: params.cfg,
-                    agentDir: params.agentDir,
-                  }),
-                  credential: recovered,
-                };
-              }
-            }
-            // Re-check after the persist await: the deadline may have fired
-            // mid-write, in which case the mirror must not run either.
-            if (!writeBackAllowed("mirror")) {
-              return null;
-            }
-            if (ownerAgentDir) {
-              const mainPath = resolveSharedAuthStorePath();
-              if (mainPath !== authPath) {
-                await mirrorRefreshedCredentialIntoMainStore({
-                  profileId: params.profileId,
-                  refreshed: refreshedCredentials,
-                });
-              }
-            }
+          if (!params.forceRefresh && hasUsableOAuthCredential(cred)) {
             return {
-              apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
+              apiKey: await adapter.buildApiKey(cred.provider, cred, {
                 cfg: params.cfg,
                 agentDir: params.agentDir,
               }),
-              credential: refreshedCredentials,
+              credential: cred,
             };
-          },
-        ),
+          }
+
+          if (params.agentDir) {
+            try {
+              const mainStore = loadStoredOAuthRefreshStore(undefined);
+              const mainCred = mainStore.profiles[params.profileId];
+              if (
+                mainCred?.type === "oauth" &&
+                mainCred.provider === cred.provider &&
+                hasUsableOAuthCredential(mainCred) &&
+                !params.forceRefresh &&
+                isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
+              ) {
+                store.profiles[params.profileId] = { ...mainCred };
+                authProfilesLog.info("adopted fresh OAuth credential from main store (under refresh lock)", {
+                  profileId: params.profileId,
+                  agentDir: params.agentDir,
+                  expires: new Date(mainCred.expires).toISOString(),
+                });
+                return {
+                  apiKey: await adapter.buildApiKey(mainCred.provider, mainCred, {
+                    cfg: params.cfg,
+                    agentDir: params.agentDir,
+                  }),
+                  credential: mainCred,
+                };
+              } else if (
+                mainCred?.type === "oauth" &&
+                mainCred.provider === cred.provider &&
+                hasUsableOAuthCredential(mainCred) &&
+                !isSafeToAdoptMainStoreOAuthIdentity(cred, mainCred)
+              ) {
+                authProfilesLog.warn("refused to adopt fresh main-store OAuth credential: identity mismatch", {
+                  profileId: params.profileId,
+                  agentDir: params.agentDir,
+                });
+              }
+            } catch (err) {
+              authProfilesLog.debug("inside-lock main-store adoption failed; proceeding to refresh", {
+                profileId: params.profileId,
+                error: formatErrorMessage(err),
+              });
+            }
+          }
+
+          const externallyManaged = adapter.readBootstrapCredential({
+            store,
+            profileId: params.profileId,
+            credential: cred,
+          });
+          if (externallyManaged) {
+            if (externallyManaged.provider !== cred.provider) {
+              authProfilesLog.warn("refused external oauth bootstrap credential: provider mismatch", {
+                profileId: params.profileId,
+                provider: cred.provider,
+              });
+            } else if (!isSafeToAdoptBootstrapOAuthIdentity(cred, externallyManaged)) {
+              authProfilesLog.warn(
+                "refused external oauth bootstrap credential: identity mismatch or missing binding",
+                {
+                  profileId: params.profileId,
+                  provider: cred.provider,
+                },
+              );
+            } else {
+              if (
+                shouldReplaceStoredOAuthCredential(cred, externallyManaged) &&
+                !areOAuthCredentialsEquivalent(cred, externallyManaged)
+              ) {
+                store.profiles[params.profileId] = { ...externallyManaged };
+                await saveOAuthCredentialWithStoreLock({
+                  agentDir: ownerAgentDir,
+                  profileId: params.profileId,
+                  expected: cred,
+                  credential: externallyManaged,
+                  isWriteAllowed: ownsSection,
+                });
+              }
+              credentialToRefresh = externallyManaged;
+              if (!params.forceRefresh && hasUsableOAuthCredential(externallyManaged)) {
+                if (!continuationAllowed("result")) {
+                  return null;
+                }
+                return {
+                  apiKey: await adapter.buildApiKey(externallyManaged.provider, externallyManaged, {
+                    cfg: params.cfg,
+                    agentDir: params.agentDir,
+                  }),
+                  credential: externallyManaged,
+                };
+              }
+            }
+          }
+
+          if (normalizeSecretInputString(credentialToRefresh.refresh) === undefined) {
+            return null;
+          }
+          if (!continuationAllowed("refresh")) {
+            return null;
+          }
+          const refreshedCredentials = await withCallerDeadline(
+            `refreshOAuthCredential(${cred.provider})`,
+            OAUTH_REFRESH_CALL_TIMEOUT_MS,
+            async () => {
+              params.attemptedCredentials?.push(credentialToRefresh);
+              const refreshed = await adapter.refreshCredential(credentialToRefresh, {
+                cfg: params.cfg,
+                agentDir: params.agentDir,
+              });
+              return refreshed
+                ? ({
+                    ...credentialToRefresh,
+                    ...refreshed,
+                    type: "oauth",
+                  } satisfies OAuthCredential)
+                : null;
+            },
+          );
+          if (!refreshedCredentials) {
+            return null;
+          }
+          if (!continuationAllowed("persist")) {
+            return null;
+          }
+          store.profiles[params.profileId] = refreshedCredentials;
+          const persisted = await saveOAuthCredentialWithStoreLock({
+            agentDir: ownerAgentDir,
+            profileId: params.profileId,
+            expected:
+              credentialToRefresh === cred ||
+              areOAuthCredentialsEquivalent(credentialToRefresh, cred)
+                ? credentialToRefresh
+                : [credentialToRefresh, cred],
+            credential: refreshedCredentials,
+            isWriteAllowed: ownsSection,
+          });
+          if (!continuationAllowed("persist")) {
+            return null;
+          }
+          if (!persisted) {
+            const recovered = await resolveOAuthCredentialAfterPersistMiss({
+              agentDir: ownerAgentDir,
+              profileId: params.profileId,
+              refreshed: refreshedCredentials,
+              isWriteAllowed: ownsSection,
+            });
+            if (!continuationAllowed("persist")) {
+              return null;
+            }
+            if (!recovered) {
+              throw new Error("Failed to persist refreshed OAuth credential");
+            }
+            if (recovered !== refreshedCredentials) {
+              return {
+                apiKey: await adapter.buildApiKey(recovered.provider, recovered, {
+                  cfg: params.cfg,
+                  agentDir: params.agentDir,
+                }),
+                credential: recovered,
+              };
+            }
+          }
+          // Re-check after the persist await: the deadline may have fired
+          // mid-write, in which case the mirror must not run either.
+          if (!continuationAllowed("mirror")) {
+            return null;
+          }
+          if (ownerAgentDir) {
+            const mainPath = resolveSharedAuthStorePath();
+            if (mainPath !== authPath) {
+              await mirrorRefreshedCredentialIntoMainStore({
+                profileId: params.profileId,
+                refreshed: refreshedCredentials,
+                isWriteAllowed: ownsSection,
+              });
+            }
+          }
+          if (!continuationAllowed("result")) {
+            return null;
+          }
+          return {
+            apiKey: await adapter.buildApiKey(cred.provider, refreshedCredentials, {
+              cfg: params.cfg,
+              agentDir: params.agentDir,
+            }),
+            credential: refreshedCredentials,
+          };
+        },
       );
     } catch (error) {
       if (isGlobalRefreshLockTimeoutError(error, globalRefreshLockPath)) {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -364,18 +364,26 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return `${provider}\u0000${profileId}`;
   }
 
+  // Ownership token for a deadline-bounded section. The deadline cannot cancel
+  // the running body, only abandon it; once "abandoned" the surrounding
+  // cross-agent file lock is released and a peer refresher may own this key,
+  // so the stale continuation must not persist or mirror credentials.
+  type RefreshSectionOwnership = { state: "owned" | "abandoned" };
+
   async function withRefreshCallTimeout<T>(
     label: string,
     timeoutMs: number,
-    fn: () => Promise<T>,
+    fn: (ownership: RefreshSectionOwnership) => Promise<T>,
   ): Promise<T> {
     let timeoutHandle: NodeJS.Timeout | undefined;
+    const ownership: RefreshSectionOwnership = { state: "owned" };
     try {
       return await new Promise<T>((resolve, reject) => {
         timeoutHandle = setTimeout(() => {
+          ownership.state = "abandoned";
           reject(new Error(`OAuth refresh call "${label}" exceeded hard timeout (${timeoutMs}ms)`));
         }, timeoutMs);
-        fn().then(resolve, reject);
+        fn(ownership).then(resolve, reject);
       });
     } finally {
       if (timeoutHandle) {
@@ -519,7 +527,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         withRefreshCallTimeout(
           `${params.provider} oauth refresh critical section`,
           OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
-          async () => {
+          async (sectionOwnership) => {
+            // The in-lock deadline cannot cancel this body; once it fires the
+            // file lock is released and a successor refresher may own this
+            // key. Every persist/mirror below re-checks ownership and no-ops
+            // when abandoned so a stale continuation cannot clobber the
+            // successor's credentials.
+            const writeBackAllowed = (step: "adopt-bootstrap" | "persist" | "mirror"): boolean => {
+              if (sectionOwnership.state === "owned") {
+                return true;
+              }
+              log.debug("discarded abandoned OAuth refresh write-back after in-lock deadline", {
+                profileId: params.profileId,
+                provider: params.provider,
+                step,
+              });
+              return false;
+            };
             const store = loadStoredOAuthRefreshStore(ownerAgentDir);
             const cred = store.profiles[params.profileId];
             if (!cred || cred.type !== "oauth") {
@@ -611,7 +635,8 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
               } else {
                 if (
                   shouldReplaceStoredOAuthCredential(cred, externallyManaged) &&
-                  !areOAuthCredentialsEquivalent(cred, externallyManaged)
+                  !areOAuthCredentialsEquivalent(cred, externallyManaged) &&
+                  writeBackAllowed("adopt-bootstrap")
                 ) {
                   store.profiles[params.profileId] = { ...externallyManaged };
                   await saveOAuthCredentialWithStoreLock({
@@ -662,6 +687,9 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             if (!refreshedCredentials) {
               return null;
             }
+            if (!writeBackAllowed("persist")) {
+              return null;
+            }
             store.profiles[params.profileId] = refreshedCredentials;
             const persisted = await saveOAuthCredentialWithStoreLock({
               agentDir: ownerAgentDir,
@@ -691,6 +719,11 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
                   credential: recovered,
                 };
               }
+            }
+            // Re-check after the persist await: the deadline may have fired
+            // mid-write, in which case the mirror must not run either.
+            if (!writeBackAllowed("mirror")) {
+              return null;
             }
             if (ownerAgentDir) {
               const mainPath = resolveSharedAuthStorePath();

--- a/src/agents/auth-profiles/oauth-refresh-timeout.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-timeout.test.ts
@@ -1,10 +1,14 @@
 /**
  * Tests OAuth refresh timeout invariants.
- * Guards the relationship between per-refresh hard timeout, stale lock window,
- * and retry budget.
+ * Guards the relationship between caller deadlines, stale lock metadata, and
+ * the contention retry budget.
  */
 import { describe, expect, it } from "vitest";
-import { OAUTH_REFRESH_CALL_TIMEOUT_MS, OAUTH_REFRESH_LOCK_OPTIONS } from "./constants.js";
+import {
+  OAUTH_REFRESH_CALL_TIMEOUT_MS,
+  OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
+  OAUTH_REFRESH_LOCK_OPTIONS,
+} from "./constants.js";
 
 function computeMinimumRetryBudgetMs(): number {
   let total = 0;
@@ -21,29 +25,22 @@ function computeMinimumRetryBudgetMs(): number {
   return total;
 }
 
-describe("OAuth refresh call timeout (invariants)", () => {
-  it("OAUTH_REFRESH_CALL_TIMEOUT_MS is strictly below OAUTH_REFRESH_LOCK_OPTIONS.stale", () => {
-    // The whole point of the two constants: the refresh call must always
-    // finish (or time out) before peers would consider the lock reclaimable.
-    // If this invariant ever regresses, the #26322 race can come back.
-    expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_LOCK_OPTIONS.stale);
+describe("OAuth refresh caller deadlines (invariants)", () => {
+  it("keeps the provider-call deadline below the whole-section deadline", () => {
+    expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS);
   });
 
   it("OAUTH_REFRESH_CALL_TIMEOUT_MS has a reasonable floor for OAuth token exchanges", () => {
     // 30s is a sane lower bound: typical OAuth refresh RTT is <5s, but a
     // cold TCP/TLS handshake + plugin bootstrap can push into double-digit
-    // seconds. Anything below 30s would start false-positive aborting.
+    // seconds. Anything below 30s would start false-positive timing out.
     expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
   });
 
-  it("OAUTH_REFRESH_LOCK_OPTIONS.stale leaves a generous safety margin beyond the call timeout", () => {
-    // Require at least 30s of headroom between the refresh deadline and
-    // the stale threshold: enough to cover normal scheduling jitter and
-    // the file-lock release round-trip without letting peers reclaim a
-    // still-active lock.
-    expect(OAUTH_REFRESH_LOCK_OPTIONS.stale - OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeGreaterThanOrEqual(
-      30_000,
-    );
+  it("keeps the whole-section deadline below the stale metadata window", () => {
+    // Live-PID owners are never reclaimed from age alone. This margin keeps
+    // incomplete/malformed sidecar classification outside the caller budget.
+    expect(OAUTH_REFRESH_INLOCK_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_LOCK_OPTIONS.stale);
   });
 
   it("OAUTH_REFRESH_LOCK_OPTIONS.stale is well above the slow-refresh ceiling", () => {
@@ -53,9 +50,9 @@ describe("OAuth refresh call timeout (invariants)", () => {
     expect(OAUTH_REFRESH_LOCK_OPTIONS.stale).toBeGreaterThan(60_000);
   });
 
-  it("OAUTH_REFRESH_LOCK_OPTIONS retry budget outlasts the refresh call timeout", () => {
-    // Waiters should not exhaust their retry budget while a legitimate slow
-    // refresh is still within its allowed runtime budget.
-    expect(computeMinimumRetryBudgetMs()).toBeGreaterThan(OAUTH_REFRESH_CALL_TIMEOUT_MS);
+  it("OAUTH_REFRESH_LOCK_OPTIONS retry budget outlasts the whole-section caller deadline", () => {
+    // The current caller should observe its deadline before a peer waiting on
+    // retained ownership reports refresh contention.
+    expect(computeMinimumRetryBudgetMs()).toBeGreaterThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS);
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-timeout.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-timeout.test.ts
@@ -6,8 +6,8 @@
 import { describe, expect, it } from "vitest";
 import {
   OAUTH_REFRESH_CALL_TIMEOUT_MS,
-  OAUTH_REFRESH_INLOCK_TIMEOUT_MS,
   OAUTH_REFRESH_LOCK_OPTIONS,
+  OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS,
 } from "./constants.js";
 
 function computeMinimumRetryBudgetMs(): number {
@@ -26,8 +26,8 @@ function computeMinimumRetryBudgetMs(): number {
 }
 
 describe("OAuth refresh caller deadlines (invariants)", () => {
-  it("keeps the provider-call deadline below the whole-section deadline", () => {
-    expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS);
+  it("keeps the provider-call deadline below the ownership deadline", () => {
+    expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS);
   });
 
   it("OAUTH_REFRESH_CALL_TIMEOUT_MS has a reasonable floor for OAuth token exchanges", () => {
@@ -37,10 +37,10 @@ describe("OAuth refresh caller deadlines (invariants)", () => {
     expect(OAUTH_REFRESH_CALL_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
   });
 
-  it("keeps the whole-section deadline below the stale metadata window", () => {
+  it("keeps the ownership deadline below the stale metadata window", () => {
     // Live-PID owners are never reclaimed from age alone. This margin keeps
     // incomplete/malformed sidecar classification outside the caller budget.
-    expect(OAUTH_REFRESH_INLOCK_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_LOCK_OPTIONS.stale);
+    expect(OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS).toBeLessThan(OAUTH_REFRESH_LOCK_OPTIONS.stale);
   });
 
   it("OAUTH_REFRESH_LOCK_OPTIONS.stale is well above the slow-refresh ceiling", () => {
@@ -50,9 +50,9 @@ describe("OAuth refresh caller deadlines (invariants)", () => {
     expect(OAUTH_REFRESH_LOCK_OPTIONS.stale).toBeGreaterThan(60_000);
   });
 
-  it("OAUTH_REFRESH_LOCK_OPTIONS retry budget outlasts the whole-section caller deadline", () => {
+  it("OAUTH_REFRESH_LOCK_OPTIONS retry budget outlasts the ownership deadline", () => {
     // The current caller should observe its deadline before a peer waiting on
     // retained ownership reports refresh contention.
-    expect(computeMinimumRetryBudgetMs()).toBeGreaterThan(OAUTH_REFRESH_INLOCK_TIMEOUT_MS);
+    expect(computeMinimumRetryBudgetMs()).toBeGreaterThan(OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS);
   });
 });

--- a/src/agents/auth-profiles/oauth-test-utils.ts
+++ b/src/agents/auth-profiles/oauth-test-utils.ts
@@ -88,7 +88,7 @@ export async function removeOAuthTestTempRoot(tempRoot: string): Promise<void> {
 }
 
 /** Read a persisted auth profile store, falling back to an empty store. */
-export function readAuthProfileStoreForTest(agentDir: string): AuthProfileStore {
+export function readAuthProfileStoreForTest(agentDir?: string): AuthProfileStore {
   return loadPersistedAuthProfileStore(agentDir) ?? { version: 1, profiles: {} };
 }
 

--- a/src/agents/auth-profiles/oauth.mirror-refresh.test.ts
+++ b/src/agents/auth-profiles/oauth.mirror-refresh.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { getOAuthApiKey } from "../../llm/oauth.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import "./oauth-file-lock-passthrough.test-support.js";
@@ -32,6 +33,7 @@ const {
   refreshProviderOAuthCredentialWithPluginMock,
   formatProviderAuthProfileApiKeyWithPluginMock,
 } = getOAuthProviderRuntimeMocks();
+const getOAuthApiKeyMock = vi.mocked(getOAuthApiKey);
 
 function expectPersistedOpenAICodexProfile(
   credential: AuthProfileStore["profiles"][string],
@@ -486,6 +488,73 @@ describe("resolveApiKeyForProfile OAuth refresh mirror-to-main (#26322)", () => 
       }),
     ).rejects.toThrow(/OAuth token refresh failed for openai/);
     expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not satisfy a reused-token retry from unchanged main-agent credentials", async () => {
+    const profileId = "openai:default";
+    const provider = "openai";
+    const accountId = "acct-shared";
+
+    const subAgentDir = path.join(tempRoot, "agents", "sub-reused-catch", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider, accountId }), subAgentDir);
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth",
+            provider,
+            access: "main-existing-access",
+            refresh: "main-existing-refresh",
+            expires: Date.now() + 60 * 60 * 1000,
+            accountId,
+          },
+        },
+      },
+      mainAgentDir,
+    );
+
+    getOAuthApiKeyMock.mockClear();
+    getOAuthApiKeyMock
+      .mockImplementationOnce(async (_provider, credentials) => {
+        expect(credentials.openai?.access).toBe("main-existing-access");
+        const rotatedLocal = requireOAuthCredential(
+          createExpiredOauthStore({ profileId, provider, accountId }),
+          profileId,
+        );
+        saveAuthProfileStore(
+          {
+            version: 1,
+            profiles: {
+              [profileId]: {
+                ...rotatedLocal,
+                refresh: "rotated-but-still-expired-refresh",
+              },
+            },
+          },
+          subAgentDir,
+        );
+        throw new Error(
+          '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
+        );
+      })
+      .mockImplementationOnce(async (_provider, credentials) => {
+        expect(credentials.openai?.access).toBe("main-existing-access");
+        throw new Error("upstream 503 service unavailable");
+      });
+
+    const failure = await resolveApiKeyForProfileInTest(resolveApiKeyForProfile, {
+      store: ensureAuthProfileStore(subAgentDir),
+      profileId,
+      agentDir: subAgentDir,
+      forceRefresh: true,
+    }).catch((error: unknown) => error);
+    expect(String(failure)).toContain("refresh_token_reused");
+    expect(
+      requireOAuthCredential(readAuthProfileStoreForTest(subAgentDir), profileId).refresh,
+    ).toBe("rotated-but-still-expired-refresh");
+    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(2);
   });
 
   it("mirrors refreshed credentials produced by the plugin-refresh path", async () => {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -272,7 +272,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     expect(store.runtimePersistedProfileIds).toEqual([profileId]);
   });
 
-  it("hands one promoted rotation to distinct prepared callers before their forced retries", async () => {
+  it("promotes one native rotation for distinct agent owners and prepared callers", async () => {
     const profileId = "openai:default";
     const nativeCredential: OAuthCredential = {
       type: "oauth",
@@ -291,6 +291,13 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     const firstStore = createPreparedStore();
     const secondStore = createPreparedStore();
     expect(secondStore).not.toBe(firstStore);
+    const stateRoot = path.resolve(agentDir, "../../..");
+    const firstAgentDir = path.join(stateRoot, "agents", "worker-a", "agent");
+    const secondAgentDir = path.join(stateRoot, "agents", "worker-b", "agent");
+    await Promise.all([
+      fs.mkdir(firstAgentDir, { recursive: true }),
+      fs.mkdir(secondAgentDir, { recursive: true }),
+    ]);
     readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
     let finishFirst: ((credential: OAuthCredential) => void) | undefined;
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
@@ -303,7 +310,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     const first = refreshCodexCliOAuthCredentialForRuntime({
       store: firstStore,
       profileId,
-      agentDir,
+      agentDir: firstAgentDir,
       forceRefresh: true,
     });
     await vi.waitFor(() =>
@@ -312,7 +319,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     const second = refreshCodexCliOAuthCredentialForRuntime({
       store: secondStore,
       profileId,
-      agentDir,
+      agentDir: secondAgentDir,
       forceRefresh: true,
     });
     await new Promise((resolve) => setTimeout(resolve, 25));
@@ -331,6 +338,8 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
       refresh: "first-rotated-refresh",
     });
+    expect((await readPersistedStore(firstAgentDir)).profiles[profileId]).toBeUndefined();
+    expect((await readPersistedStore(secondAgentDir)).profiles[profileId]).toBeUndefined();
     expect(firstStore.runtimePersistedProfileIds).toEqual([profileId]);
     expect(secondStore.runtimePersistedProfileIds).toEqual([profileId]);
   });

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import { FILE_LOCK_TIMEOUT_ERROR_CODE, resetFileLockStateForTest } from "../../infra/file-lock.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -52,7 +53,10 @@ const {
   buildProviderAuthDoctorHintWithPluginMock,
 } = vi.hoisted(() => ({
   refreshProviderOAuthCredentialWithPluginMock: vi.fn(
-    async (_params?: { context?: unknown }): Promise<OAuthCredential | undefined> => undefined,
+    async (_params?: {
+      config?: OpenClawConfig;
+      context?: unknown;
+    }): Promise<OAuthCredential | undefined> => undefined,
   ),
   formatProviderAuthProfileApiKeyWithPluginMock: vi.fn(() => undefined),
   buildProviderAuthDoctorHintWithPluginMock: vi.fn(async () => undefined),
@@ -73,8 +77,12 @@ vi.mock("../../llm/oauth.js", () => ({
 }));
 
 vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
-  resolveProviderOAuthCredentialWithPlugin: async (params: { credential: OAuthCredential }) => {
+  resolveProviderOAuthCredentialWithPlugin: async (params: {
+    config?: OpenClawConfig;
+    credential: OAuthCredential;
+  }) => {
     const credential = await refreshProviderOAuthCredentialWithPluginMock({
+      config: params.config,
       context: params.credential,
     });
     return credential
@@ -476,6 +484,56 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
         accountId: "acct-rotated",
       },
     );
+  });
+
+  it("keeps configured provider context available during in-lock refresh", async () => {
+    const profileId = "openai:default";
+    const cfg = {
+      auth: {
+        profiles: {
+          [profileId]: { provider: "openai", mode: "oauth" },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://configured-openai.example.test/v1",
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider: "openai" }), agentDir);
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) =>
+      params?.config === cfg
+        ? {
+            type: "oauth",
+            provider: "openai",
+            access: "configured-access-token",
+            refresh: "configured-refresh-token",
+            expires: Date.now() + 86_400_000,
+          }
+        : undefined,
+    );
+
+    await expect(
+      resolveApiKeyForProfile({
+        cfg,
+        store: ensureAuthProfileStore(agentDir),
+        profileId,
+        agentDir,
+      }),
+    ).resolves.toMatchObject({
+      apiKey: "configured-access-token",
+      provider: "openai",
+    });
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledWith({
+      config: cfg,
+      context: expect.objectContaining({
+        provider: "openai",
+        type: "oauth",
+      }),
+    });
   });
 
   it("refreshes imported Codex credentials into the canonical auth store without writing back to .codex", async () => {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -25,7 +25,12 @@ import {
 import { clearRuntimeAuthProfileStoreSnapshots } from "./runtime-snapshots.js";
 import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
-import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import type {
+  AuthProfileCredential,
+  AuthProfileStore,
+  OAuthCredential,
+  RuntimeAuthProfileStore,
+} from "./types.js";
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
 let refreshCodexCliOAuthCredentialForRuntime: typeof import("./oauth.js").refreshCodexCliOAuthCredentialForRuntime;
 let resolveApiKeyForProviderCore: typeof import("../model-auth.js").resolveApiKeyForProviderCore;
@@ -126,7 +131,7 @@ function mockRotatedOpenAICodexRefresh() {
 }
 
 function expectPersistedOpenAICodexProfile(
-  credential: AuthProfileStore["profiles"][string],
+  credential: AuthProfileCredential | undefined,
   metadata: Record<string, unknown> = {},
 ): void {
   expect(credential?.type).toBe("oauth");
@@ -134,6 +139,18 @@ function expectPersistedOpenAICodexProfile(
   for (const [key, value] of Object.entries(metadata)) {
     expect(credential?.[key as keyof typeof credential]).toBe(value);
   }
+}
+
+function createCodexCliRuntimeStore(
+  profileId: string,
+  credential: OAuthCredential,
+): RuntimeAuthProfileStore {
+  return {
+    version: 1,
+    profiles: { [profileId]: credential },
+    runtimeExternalProfileIds: [profileId],
+    runtimeExternalCliProfileIds: [profileId],
+  };
 }
 
 function resolveOpenAICodexProfile(params: { profileId: string; agentDir: string }) {
@@ -223,12 +240,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 60_000,
       accountId: "acct-native",
     };
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: { [profileId]: nativeCredential },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    };
+    const store = createCodexCliRuntimeStore(profileId, nativeCredential);
     const freshNativeCredential = {
       ...nativeCredential,
       // Metadata-only changes do not prove that Codex replaced the bearer
@@ -282,12 +294,8 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 60_000,
       accountId: "acct-native",
     };
-    const createPreparedStore = (): AuthProfileStore => ({
-      version: 1,
-      profiles: { [profileId]: { ...nativeCredential } },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    });
+    const createPreparedStore = () =>
+      createCodexCliRuntimeStore(profileId, { ...nativeCredential });
     const firstStore = createPreparedStore();
     const secondStore = createPreparedStore();
     expect(secondStore).not.toBe(firstStore);
@@ -299,12 +307,12 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       fs.mkdir(secondAgentDir, { recursive: true }),
     ]);
     readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
-    let finishFirst: ((credential: OAuthCredential) => void) | undefined;
+    const firstRefresh: { resolve?: (credential: OAuthCredential) => void } = {};
+    const firstRefreshResult = new Promise<OAuthCredential>((resolve) => {
+      firstRefresh.resolve = resolve;
+    });
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
-      async () =>
-        await new Promise<OAuthCredential>((resolve) => {
-          finishFirst = resolve;
-        }),
+      async () => await firstRefreshResult,
     );
 
     const first = refreshCodexCliOAuthCredentialForRuntime({
@@ -322,10 +330,15 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       agentDir: secondAgentDir,
       forceRefresh: true,
     });
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25);
+    });
     expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
 
-    finishFirst?.({
+    expectDefined(
+      firstRefresh.resolve,
+      "first refresh resolver test invariant",
+    )({
       ...nativeCredential,
       access: "first-rotated-access",
       refresh: "first-rotated-refresh",
@@ -392,12 +405,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 60_000,
       accountId: "acct-native",
     };
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: { [profileId]: nativeCredential },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    };
+    const store = createCodexCliRuntimeStore(profileId, nativeCredential);
     readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
     refreshProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({ ...nativeCredential });
 
@@ -431,12 +439,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() + 10 * 60_000,
       accountId: "acct-fresh-login",
     };
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: { [profileId]: nativeCredential },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    };
+    const store = createCodexCliRuntimeStore(profileId, nativeCredential);
     readCodexCliCredentialsCachedMock.mockReturnValue(freshCredential);
 
     await expect(
@@ -476,12 +479,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
 
     await expect(
       refreshCodexCliOAuthCredentialForRuntime({
-        store: {
-          version: 1,
-          profiles: { [profileId]: nativeCredential },
-          runtimeExternalProfileIds: [profileId],
-          runtimeExternalCliProfileIds: [profileId],
-        },
+        store: createCodexCliRuntimeStore(profileId, nativeCredential),
         profileId,
         agentDir,
         forceRefresh: true,
@@ -527,12 +525,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 60_000,
       accountId: "acct-native",
     };
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: { [profileId]: nativeCredential },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    };
+    const store = createCodexCliRuntimeStore(profileId, nativeCredential);
     readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       saveAuthProfileStore(
@@ -581,12 +574,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       expires: Date.now() - 60_000,
       accountId: "acct-native",
     };
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: { [profileId]: nativeCredential },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    };
+    const store = createCodexCliRuntimeStore(profileId, nativeCredential);
     readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
       saveAuthProfileStore(
@@ -650,12 +638,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       accountId: "acct-relogin",
     };
     saveAuthProfileStore({ version: 1, profiles: { [profileId]: managedCredential } }, agentDir);
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: { [profileId]: nativeCredential },
-      runtimeExternalProfileIds: [profileId],
-      runtimeExternalCliProfileIds: [profileId],
-    };
+    const store = createCodexCliRuntimeStore(profileId, nativeCredential);
     await expect(
       refreshCodexCliOAuthCredentialForRuntime({
         store,

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -27,6 +27,7 @@ import { resolveAuthProfileDatabasePath } from "./sqlite.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
+let refreshCodexCliOAuthCredentialForRuntime: typeof import("./oauth.js").refreshCodexCliOAuthCredentialForRuntime;
 let resolveApiKeyForProviderCore: typeof import("../model-auth.js").resolveApiKeyForProviderCore;
 let hasAvailableAuthForProvider: typeof import("../model-auth.js").hasAvailableAuthForProvider;
 let markAuthProfileSuccess: typeof import("./profiles.js").markAuthProfileSuccess;
@@ -170,7 +171,8 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
 
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-refresh-fallback-"));
-    ({ resolveApiKeyForProfile } = await import("./oauth.js"));
+    ({ refreshCodexCliOAuthCredentialForRuntime, resolveApiKeyForProfile } =
+      await import("./oauth.js"));
     ({ hasAvailableAuthForProvider, resolveApiKeyForProviderCore } =
       await import("../model-auth.js"));
     ({ markAuthProfileSuccess } = await import("./profiles.js"));
@@ -209,6 +211,456 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
   afterAll(async () => {
     closeOpenClawAgentDatabasesForTest();
     await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("promotes only a freshly reread changed Codex CLI rotation into SQLite", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "native-access",
+      refresh: "native-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-native",
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: { [profileId]: nativeCredential },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    };
+    const freshNativeCredential = {
+      ...nativeCredential,
+      // Metadata-only changes do not prove that Codex replaced the bearer
+      // rejected by app-server, so force-refresh must still call the provider.
+      expires: Date.now() + 10 * 60_000,
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValue(freshNativeCredential);
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) => {
+      expect(requireOAuthContext(params?.context).access).toBe("native-access");
+      return {
+        ...freshNativeCredential,
+        access: "rotated-access-token",
+        refresh: "rotated-refresh-token",
+        expires: Date.now() + 86_400_000,
+      };
+    });
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({
+      access: "rotated-access-token",
+      refresh: "rotated-refresh-token",
+    });
+
+    expect(readCodexCliCredentialsCachedMock).toHaveBeenCalledWith({
+      allowKeychainPrompt: false,
+      ttlMs: 0,
+    });
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+      access: "rotated-access-token",
+      refresh: "rotated-refresh-token",
+    });
+    expect(store.runtimeExternalCliProfileIds).toBeUndefined();
+    expect(store.runtimeExternalProfileIds).toBeUndefined();
+    expect(store.runtimePersistedProfileIds).toEqual([profileId]);
+  });
+
+  it("hands one promoted rotation to distinct prepared callers before their forced retries", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "native-access",
+      refresh: "native-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-native",
+    };
+    const createPreparedStore = (): AuthProfileStore => ({
+      version: 1,
+      profiles: { [profileId]: { ...nativeCredential } },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    });
+    const firstStore = createPreparedStore();
+    const secondStore = createPreparedStore();
+    expect(secondStore).not.toBe(firstStore);
+    readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
+    let finishFirst: ((credential: OAuthCredential) => void) | undefined;
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        await new Promise<OAuthCredential>((resolve) => {
+          finishFirst = resolve;
+        }),
+    );
+
+    const first = refreshCodexCliOAuthCredentialForRuntime({
+      store: firstStore,
+      profileId,
+      agentDir,
+      forceRefresh: true,
+    });
+    await vi.waitFor(() =>
+      expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1),
+    );
+    const second = refreshCodexCliOAuthCredentialForRuntime({
+      store: secondStore,
+      profileId,
+      agentDir,
+      forceRefresh: true,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+
+    finishFirst?.({
+      ...nativeCredential,
+      access: "first-rotated-access",
+      refresh: "first-rotated-refresh",
+      expires: Date.now() + 10 * 60_000,
+    });
+    await expect(first).resolves.toMatchObject({ refresh: "first-rotated-refresh" });
+    await expect(second).resolves.toMatchObject({ refresh: "first-rotated-refresh" });
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expect(readCodexCliCredentialsCachedMock).toHaveBeenCalledTimes(1);
+    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+      refresh: "first-rotated-refresh",
+    });
+    expect(firstStore.runtimePersistedProfileIds).toEqual([profileId]);
+    expect(secondStore.runtimePersistedProfileIds).toEqual([profileId]);
+  });
+
+  it("rotates again when the current SQLite credential is the rejected attempt", async () => {
+    const profileId = "openai:default";
+    const currentCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "current-access",
+      refresh: "current-refresh",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "acct-native",
+    };
+    saveAuthProfileStore({ version: 1, profiles: { [profileId]: currentCredential } }, agentDir);
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async (params) => {
+      expect(requireOAuthContext(params?.context).refresh).toBe("current-refresh");
+      return {
+        ...currentCredential,
+        access: "next-access",
+        refresh: "next-refresh",
+        expires: Date.now() + 20 * 60_000,
+      };
+    });
+    const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+
+    await expect(
+      resolveApiKeyForProfile({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({ apiKey: "next-access" });
+
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+      access: "next-access",
+      refresh: "next-refresh",
+    });
+  });
+
+  it("does not persist an unchanged native Codex CLI refresh result", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "native-access",
+      refresh: "native-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-native",
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: { [profileId]: nativeCredential },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
+    refreshProviderOAuthCredentialWithPluginMock.mockResolvedValueOnce({ ...nativeCredential });
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({ refresh: "native-refresh" });
+
+    expect((await readPersistedStore(agentDir)).profiles[profileId]).toBeUndefined();
+    expect(store.runtimeExternalCliProfileIds).toEqual([profileId]);
+  });
+
+  it("adopts a usable fresh native reread without provider rotation or SQLite promotion", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "prepared-access",
+      refresh: "prepared-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-prepared",
+    };
+    const freshCredential: OAuthCredential = {
+      ...nativeCredential,
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "acct-fresh-login",
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: { [profileId]: nativeCredential },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValue(freshCredential);
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      accountId: "acct-fresh-login",
+    });
+
+    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect((await readPersistedStore(agentDir)).profiles[profileId]).toBeUndefined();
+    expect(store.runtimeExternalCliProfileIds).toEqual([profileId]);
+  });
+
+  it("rejects an expired fresh native reread with a different identity before rotation", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "prepared-access",
+      refresh: "prepared-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-prepared",
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValue({
+      ...nativeCredential,
+      access: "fresh-access",
+      refresh: "fresh-refresh",
+      accountId: "acct-fresh-login",
+    });
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store: {
+          version: 1,
+          profiles: { [profileId]: nativeCredential },
+          runtimeExternalProfileIds: [profileId],
+          runtimeExternalCliProfileIds: [profileId],
+        },
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toBeNull();
+
+    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect((await readPersistedStore(agentDir)).profiles[profileId]).toBeUndefined();
+  });
+
+  it("does not promote arbitrary supplied OAuth without Codex CLI provenance", async () => {
+    const profileId = "openai:default";
+    const credential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "supplied-access",
+      refresh: "supplied-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-supplied",
+    };
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store: { version: 1, profiles: { [profileId]: credential } },
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toBeNull();
+
+    expect(readCodexCliCredentialsCachedMock).not.toHaveBeenCalled();
+    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expect((await readPersistedStore(agentDir)).profiles[profileId]).toBeUndefined();
+  });
+
+  it("commits the rotated token when a same-identity SQLite row wins the insert race", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "native-access",
+      refresh: "native-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-native",
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: { [profileId]: nativeCredential },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              ...nativeCredential,
+              access: "racing-access",
+              refresh: "native-refresh",
+            },
+          },
+        },
+        agentDir,
+      );
+      return {
+        ...nativeCredential,
+        access: "rotated-access",
+        refresh: "rotated-refresh",
+        expires: Date.now() + 60_000,
+      };
+    });
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({ refresh: "rotated-refresh" });
+
+    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+      access: "rotated-access",
+      refresh: "rotated-refresh",
+    });
+  });
+
+  it("adopts a usable different-identity SQLite relog that wins the insert race", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "native-access",
+      refresh: "native-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-native",
+    };
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: { [profileId]: nativeCredential },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    };
+    readCodexCliCredentialsCachedMock.mockReturnValue({ ...nativeCredential });
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "openai",
+              access: "relogin-access",
+              refresh: "relogin-refresh",
+              expires: Date.now() + 10 * 60_000,
+              accountId: "acct-relogin",
+            },
+          },
+        },
+        agentDir,
+      );
+      return {
+        ...nativeCredential,
+        access: "rotated-native-access",
+        refresh: "rotated-native-refresh",
+        expires: Date.now() + 60_000,
+      };
+    });
+
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({
+      access: "relogin-access",
+      refresh: "relogin-refresh",
+      accountId: "acct-relogin",
+    });
+    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+      refresh: "relogin-refresh",
+      accountId: "acct-relogin",
+    });
+  });
+
+  it("adopts usable authoritative SQLite despite a stale native prepared identity", async () => {
+    const profileId = "openai:default";
+    const nativeCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "native-access",
+      refresh: "native-refresh",
+      expires: Date.now() - 60_000,
+      accountId: "acct-native",
+    };
+    const managedCredential: OAuthCredential = {
+      type: "oauth",
+      provider: "openai",
+      access: "managed-access",
+      refresh: "managed-refresh",
+      expires: Date.now() + 10 * 60_000,
+      accountId: "acct-relogin",
+    };
+    saveAuthProfileStore({ version: 1, profiles: { [profileId]: managedCredential } }, agentDir);
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: { [profileId]: nativeCredential },
+      runtimeExternalProfileIds: [profileId],
+      runtimeExternalCliProfileIds: [profileId],
+    };
+    await expect(
+      refreshCodexCliOAuthCredentialForRuntime({
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      }),
+    ).resolves.toMatchObject({ refresh: "managed-refresh" });
+
+    expect(readCodexCliCredentialsCachedMock).not.toHaveBeenCalled();
+    expect(refreshProviderOAuthCredentialWithPluginMock).not.toHaveBeenCalled();
+    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+      refresh: "managed-refresh",
+    });
   });
 
   it("fails closed instead of using matching cached Codex CLI credentials when openai refresh fails", async () => {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -110,7 +110,7 @@ afterAll(() => {
   vi.resetModules();
 });
 
-async function readPersistedStore(agentDir: string): Promise<AuthProfileStore> {
+async function readPersistedStore(agentDir?: string): Promise<AuthProfileStore> {
   return readAuthProfileStoreForTest(agentDir);
 }
 
@@ -263,7 +263,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       ttlMs: 0,
     });
     expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
-    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+    expectPersistedOpenAICodexProfile((await readPersistedStore()).profiles[profileId], {
       access: "rotated-access-token",
       refresh: "rotated-refresh-token",
     });
@@ -335,7 +335,7 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
     await expect(second).resolves.toMatchObject({ refresh: "first-rotated-refresh" });
     expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
     expect(readCodexCliCredentialsCachedMock).toHaveBeenCalledTimes(1);
-    expectPersistedOpenAICodexProfile((await readPersistedStore(agentDir)).profiles[profileId], {
+    expectPersistedOpenAICodexProfile((await readPersistedStore()).profiles[profileId], {
       refresh: "first-rotated-refresh",
     });
     expect((await readPersistedStore(firstAgentDir)).profiles[profileId]).toBeUndefined();

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -286,7 +286,8 @@ export async function refreshCodexCliOAuthCredentialForRuntime(params: {
     store: params.store,
     profileId: params.profileId,
     credential,
-    agentDir: params.agentDir,
+    // Native Codex is one machine-wide source. Omitting agentDir selects the
+    // one main SQLite owner, not whichever agent requested rotation first.
     cfg: params.cfg,
     forceRefresh: params.forceRefresh,
     externalCliCredential: credential,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -54,7 +54,12 @@ import {
   loadAuthProfileStoreWithoutExternalProfiles,
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "./store.js";
-import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
+import type {
+  AuthProfileCredential,
+  AuthProfileStore,
+  OAuthCredential,
+  RuntimeAuthProfileStore,
+} from "./types.js";
 
 function listOAuthProviderIds(): string[] {
   if (typeof getOAuthProviders !== "function") {
@@ -272,12 +277,10 @@ export async function refreshCodexCliOAuthCredentialForRuntime(params: {
   cfg?: OpenClawConfig;
   forceRefresh?: boolean;
 }): Promise<OAuthCredential | null> {
-  if (
-    params.profileId !== OPENAI_CODEX_DEFAULT_PROFILE_ID ||
-    !params.store.runtimeExternalCliProfileIds?.includes(params.profileId)
-  ) {
+  if (!isCodexCliOAuthRuntimeProfile({ store: params.store, profileId: params.profileId })) {
     return null;
   }
+  const runtimeStore = params.store as RuntimeAuthProfileStore;
   const credential = params.store.profiles[params.profileId];
   if (!credential || credential.type !== "oauth") {
     return null;
@@ -310,17 +313,29 @@ export async function refreshCodexCliOAuthCredentialForRuntime(params: {
     if (params.store.runtimeExternalProfileIds?.length === 0) {
       params.store.runtimeExternalProfileIds = undefined;
     }
-    params.store.runtimeExternalCliProfileIds = params.store.runtimeExternalCliProfileIds?.filter(
+    runtimeStore.runtimeExternalCliProfileIds = runtimeStore.runtimeExternalCliProfileIds?.filter(
       (profileId) => profileId !== params.profileId,
     );
-    if (params.store.runtimeExternalCliProfileIds?.length === 0) {
-      params.store.runtimeExternalCliProfileIds = undefined;
+    if (runtimeStore.runtimeExternalCliProfileIds?.length === 0) {
+      runtimeStore.runtimeExternalCliProfileIds = undefined;
     }
     params.store.runtimePersistedProfileIds = [
       ...new Set([...(params.store.runtimePersistedProfileIds ?? []), params.profileId]),
     ].toSorted();
   }
   return resolved.credential;
+}
+
+/** Local bundled-runtime guard for the built-in Codex CLI provenance marker. */
+export function isCodexCliOAuthRuntimeProfile(params: {
+  store: AuthProfileStore;
+  profileId: string;
+}): boolean {
+  const store = params.store as RuntimeAuthProfileStore;
+  return (
+    params.profileId === OPENAI_CODEX_DEFAULT_PROFILE_ID &&
+    store.runtimeExternalCliProfileIds?.includes(params.profileId) === true
+  );
 }
 
 /** Clear in-process OAuth refresh queues between isolated tests. */

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -183,6 +183,8 @@ type ResolveApiKeyForProfileParams = {
   agentDir?: string;
   forceRefresh?: boolean;
   allowProfileFallback?: boolean;
+  /** Refresh and replace this in-memory profile without persisting or mirroring it. */
+  useRuntimeOAuthStore?: boolean;
 };
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
@@ -282,6 +284,7 @@ async function tryResolveOAuthProfile(
     agentDir: params.agentDir,
     cfg,
     forceRefresh: params.forceRefresh,
+    useRuntimeStore: params.useRuntimeOAuthStore,
   });
   if (!resolved) {
     return null;
@@ -494,6 +497,7 @@ export async function resolveApiKeyForProfile(
       credential: cred,
       cfg,
       forceRefresh: params.forceRefresh,
+      useRuntimeStore: params.useRuntimeOAuthStore,
     });
     if (!resolved) {
       return null;
@@ -567,6 +571,7 @@ export async function resolveApiKeyForProfile(
           profileId: fallbackProfileId,
           agentDir: params.agentDir,
           forceRefresh: params.forceRefresh,
+          useRuntimeOAuthStore: params.useRuntimeOAuthStore,
         });
         if (fallbackResolved) {
           return fallbackResolved;

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -45,6 +45,10 @@ import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { clearLastGoodProfileWithLock } from "./profiles.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import {
+  getRuntimeExternalCliProfileIds,
+  setRuntimeExternalCliProfileIds,
+} from "./runtime-external-profile-references.js";
+import {
   getRuntimeAuthProfileStoreSnapshotCore,
   hasRuntimeAuthProfileStoreSnapshot,
   setRuntimeAuthProfileStoreSnapshot,
@@ -54,12 +58,7 @@ import {
   loadAuthProfileStoreWithoutExternalProfiles,
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "./store.js";
-import type {
-  AuthProfileCredential,
-  AuthProfileStore,
-  OAuthCredential,
-  RuntimeAuthProfileStore,
-} from "./types.js";
+import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
 
 function listOAuthProviderIds(): string[] {
   if (typeof getOAuthProviders !== "function") {
@@ -280,7 +279,6 @@ export async function refreshCodexCliOAuthCredentialForRuntime(params: {
   if (!isCodexCliOAuthRuntimeProfile({ store: params.store, profileId: params.profileId })) {
     return null;
   }
-  const runtimeStore = params.store as RuntimeAuthProfileStore;
   const credential = params.store.profiles[params.profileId];
   if (!credential || credential.type !== "oauth") {
     return null;
@@ -313,12 +311,12 @@ export async function refreshCodexCliOAuthCredentialForRuntime(params: {
     if (params.store.runtimeExternalProfileIds?.length === 0) {
       params.store.runtimeExternalProfileIds = undefined;
     }
-    runtimeStore.runtimeExternalCliProfileIds = runtimeStore.runtimeExternalCliProfileIds?.filter(
-      (profileId) => profileId !== params.profileId,
+    setRuntimeExternalCliProfileIds(
+      params.store,
+      getRuntimeExternalCliProfileIds(params.store).filter(
+        (profileId) => profileId !== params.profileId,
+      ),
     );
-    if (runtimeStore.runtimeExternalCliProfileIds?.length === 0) {
-      runtimeStore.runtimeExternalCliProfileIds = undefined;
-    }
     params.store.runtimePersistedProfileIds = [
       ...new Set([...(params.store.runtimePersistedProfileIds ?? []), params.profileId]),
     ].toSorted();
@@ -331,10 +329,9 @@ export function isCodexCliOAuthRuntimeProfile(params: {
   store: AuthProfileStore;
   profileId: string;
 }): boolean {
-  const store = params.store as RuntimeAuthProfileStore;
   return (
     params.profileId === OPENAI_CODEX_DEFAULT_PROFILE_ID &&
-    store.runtimeExternalCliProfileIds?.includes(params.profileId) === true
+    getRuntimeExternalCliProfileIds(params.store).includes(params.profileId)
   );
 }
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -28,7 +28,11 @@ import {
 } from "../../secrets/runtime-degraded-state.js";
 import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
-import { authProfilesLog, CLAUDE_CLI_PROFILE_ID } from "./constants.js";
+import {
+  authProfilesLog,
+  CLAUDE_CLI_PROFILE_ID,
+  OPENAI_CODEX_DEFAULT_PROFILE_ID,
+} from "./constants.js";
 import {
   evaluateStoredCredentialEligibility,
   resolveTokenExpiryState,
@@ -47,6 +51,7 @@ import {
 } from "./runtime-snapshots.js";
 import {
   loadAuthProfileStoreForSecretsRuntime,
+  loadAuthProfileStoreWithoutExternalProfiles,
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
@@ -214,21 +219,24 @@ async function refreshOAuthCredential(
   return result?.newCredentials ?? null;
 }
 
-/** Refresh one runtime-owned OAuth profile without persisting or mirroring it. */
+/**
+ * Refresh one caller-scoped OAuth credential without persistence or mirroring.
+ * This shipped direct contract stays process-local; internal persisted Codex
+ * callers use the manager-owned path below. A future SDK major can reconsider
+ * the split after native source-owner writeback has an upstream contract.
+ */
 export async function refreshOAuthCredentialForRuntime(params: {
-  store: AuthProfileStore;
-  profileId: string;
   credential: OAuthCredential;
   cfg?: OpenClawConfig;
-  agentDir?: string;
-  forceRefresh?: boolean;
 }): Promise<OAuthCredential | null> {
-  const resolved = await oauthManager.resolveOAuthAccess({
-    ...params,
-    forceRefresh: params.forceRefresh ?? true,
-    useRuntimeStore: true,
-  });
-  return resolved?.credential ?? null;
+  const refreshed = await refreshOAuthCredential(params.credential, { cfg: params.cfg });
+  return refreshed
+    ? {
+        ...params.credential,
+        ...refreshed,
+        type: "oauth",
+      }
+    : null;
 }
 
 const oauthManager = createOAuthManager({
@@ -240,8 +248,79 @@ const oauthManager = createOAuthManager({
       profileId,
       credential,
     }),
+  readAuthoritativeBootstrapCredential: ({ store, profileId, credential }) =>
+    readExternalCliBootstrapCredential({
+      store,
+      profileId,
+      credential,
+      allowInlineOAuthTokenMaterial: true,
+      allowKeychainPrompt: false,
+      fresh: true,
+    }),
   isRefreshTokenReusedError,
 });
+
+/**
+ * Refresh a proven external-CLI runtime profile under the canonical OAuth
+ * manager. The first changed rotation is inserted into SQLite atomically;
+ * unchanged CLI credentials remain runtime-only and the CLI source is read-only.
+ */
+export async function refreshCodexCliOAuthCredentialForRuntime(params: {
+  store: AuthProfileStore;
+  profileId: string;
+  agentDir?: string;
+  cfg?: OpenClawConfig;
+  forceRefresh?: boolean;
+}): Promise<OAuthCredential | null> {
+  if (
+    params.profileId !== OPENAI_CODEX_DEFAULT_PROFILE_ID ||
+    !params.store.runtimeExternalCliProfileIds?.includes(params.profileId)
+  ) {
+    return null;
+  }
+  const credential = params.store.profiles[params.profileId];
+  if (!credential || credential.type !== "oauth") {
+    return null;
+  }
+  const resolved = await oauthManager.resolveOAuthAccess({
+    store: params.store,
+    profileId: params.profileId,
+    credential,
+    agentDir: params.agentDir,
+    cfg: params.cfg,
+    forceRefresh: params.forceRefresh,
+    externalCliCredential: credential,
+  });
+  if (!resolved) {
+    return null;
+  }
+  params.store.profiles[params.profileId] = resolved.credential;
+
+  // The store transaction publishes runtime snapshots after commit. Align
+  // this caller's prepared clone with the same canonical SQLite row.
+  const managed = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir).profiles[
+    params.profileId
+  ];
+  if (managed?.type === "oauth" && isDeepStrictEqual(managed, resolved.credential)) {
+    params.store.profiles[params.profileId] = managed;
+    params.store.runtimeExternalProfileIds = params.store.runtimeExternalProfileIds?.filter(
+      (profileId) => profileId !== params.profileId,
+    );
+    if (params.store.runtimeExternalProfileIds?.length === 0) {
+      params.store.runtimeExternalProfileIds = undefined;
+    }
+    params.store.runtimeExternalCliProfileIds = params.store.runtimeExternalCliProfileIds?.filter(
+      (profileId) => profileId !== params.profileId,
+    );
+    if (params.store.runtimeExternalCliProfileIds?.length === 0) {
+      params.store.runtimeExternalCliProfileIds = undefined;
+    }
+    params.store.runtimePersistedProfileIds = [
+      ...new Set([...(params.store.runtimePersistedProfileIds ?? []), params.profileId]),
+    ].toSorted();
+  }
+  return resolved.credential;
+}
 
 /** Clear in-process OAuth refresh queues between isolated tests. */
 function resetOAuthRefreshQueuesForTest(): void {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -183,8 +183,6 @@ type ResolveApiKeyForProfileParams = {
   agentDir?: string;
   forceRefresh?: boolean;
   allowProfileFallback?: boolean;
-  /** Refresh and replace this in-memory profile without persisting or mirroring it. */
-  useRuntimeOAuthStore?: boolean;
 };
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
@@ -216,19 +214,21 @@ async function refreshOAuthCredential(
   return result?.newCredentials ?? null;
 }
 
-/** Refresh one OAuth credential and merge provider-returned token fields. */
+/** Refresh one runtime-owned OAuth profile without persisting or mirroring it. */
 export async function refreshOAuthCredentialForRuntime(params: {
+  store: AuthProfileStore;
+  profileId: string;
   credential: OAuthCredential;
   cfg?: OpenClawConfig;
+  agentDir?: string;
+  forceRefresh?: boolean;
 }): Promise<OAuthCredential | null> {
-  const refreshed = await refreshOAuthCredential(params.credential, { cfg: params.cfg });
-  return refreshed
-    ? {
-        ...params.credential,
-        ...refreshed,
-        type: "oauth",
-      }
-    : null;
+  const resolved = await oauthManager.resolveOAuthAccess({
+    ...params,
+    forceRefresh: params.forceRefresh ?? true,
+    useRuntimeStore: true,
+  });
+  return resolved?.credential ?? null;
 }
 
 const oauthManager = createOAuthManager({
@@ -284,7 +284,6 @@ async function tryResolveOAuthProfile(
     agentDir: params.agentDir,
     cfg,
     forceRefresh: params.forceRefresh,
-    useRuntimeStore: params.useRuntimeOAuthStore,
   });
   if (!resolved) {
     return null;
@@ -497,7 +496,6 @@ export async function resolveApiKeyForProfile(
       credential: cred,
       cfg,
       forceRefresh: params.forceRefresh,
-      useRuntimeStore: params.useRuntimeOAuthStore,
     });
     if (!resolved) {
       return null;
@@ -571,7 +569,6 @@ export async function resolveApiKeyForProfile(
           profileId: fallbackProfileId,
           agentDir: params.agentDir,
           forceRefresh: params.forceRefresh,
-          useRuntimeOAuthStore: params.useRuntimeOAuthStore,
         });
         if (fallbackResolved) {
           return fallbackResolved;

--- a/src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts
@@ -1,0 +1,247 @@
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { looksLikeSecretSentinel, resolveSecretSentinel } from "../../../secrets/sentinel.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import type { ResolvedProviderAuth } from "../../model-auth.js";
+import { RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS } from "../../runtime-auth-refresh.js";
+import { RUNTIME_AUTH_REFRESH_RETRY_MS, type RuntimeAuthState } from "./helpers.js";
+
+const mocks = vi.hoisted(() => ({
+  prepareProviderRuntimeAuth: vi.fn(),
+  getApiKeyForModelCore: vi.fn(),
+}));
+
+vi.mock("../../../plugins/provider-runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../plugins/provider-runtime.js")>(
+    "../../../plugins/provider-runtime.js",
+  );
+  return {
+    ...actual,
+    prepareProviderRuntimeAuth: mocks.prepareProviderRuntimeAuth,
+  };
+});
+
+vi.mock("../../model-auth.js", async () => {
+  const actual = await vi.importActual<typeof import("../../model-auth.js")>("../../model-auth.js");
+  return {
+    ...actual,
+    getApiKeyForModelCore: mocks.getApiKeyForModelCore,
+  };
+});
+
+import { createEmbeddedRunAuthController } from "./auth-controller.js";
+
+type MutableAuthControllerHarness = {
+  runtimeModel: Model;
+  effectiveModel: Model;
+  apiKeyInfo: ResolvedProviderAuth | null;
+  lastProfileId?: string;
+  runtimeAuthState: RuntimeAuthState | null;
+  profileIndex: number;
+};
+
+function createTestModel(): Model {
+  return {
+    id: "test-model",
+    name: "test-model",
+    provider: "custom-openai",
+    api: "openai-responses",
+    baseUrl: "https://old.example.com/v1",
+    headers: { Authorization: "Bearer stale-token" },
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8_000,
+    maxTokens: 4_000,
+  };
+}
+
+function createHarness(): MutableAuthControllerHarness {
+  return {
+    runtimeModel: createTestModel(),
+    effectiveModel: createTestModel(),
+    apiKeyInfo: null,
+    runtimeAuthState: null,
+    profileIndex: 0,
+  };
+}
+
+function createController(params: {
+  harness: MutableAuthControllerHarness;
+  setRuntimeApiKey(provider: string, apiKey: string): void;
+}) {
+  const authStore: AuthProfileStore = { version: 1, profiles: {} };
+  return createEmbeddedRunAuthController({
+    config: undefined,
+    agentDir: "/tmp/agent",
+    workspaceDir: "/tmp/workspace",
+    authStore,
+    authStorage: { setRuntimeApiKey: params.setRuntimeApiKey },
+    profileCandidates: ["default"],
+    initialThinkLevel: "medium",
+    attemptedThinking: new Set(),
+    fallbackConfigured: false,
+    allowTransientCooldownProbe: false,
+    getProvider: () => "custom-openai",
+    getModelId: () => "test-model",
+    getRuntimeModel: () => params.harness.runtimeModel,
+    setRuntimeModel: (next) => {
+      params.harness.runtimeModel = next;
+    },
+    getEffectiveModel: () => params.harness.effectiveModel,
+    setEffectiveModel: (next) => {
+      params.harness.effectiveModel = next;
+    },
+    getApiKeyInfo: () => params.harness.apiKeyInfo,
+    setApiKeyInfo: (next) => {
+      params.harness.apiKeyInfo = next;
+    },
+    getLastProfileId: () => params.harness.lastProfileId,
+    setLastProfileId: (next) => {
+      params.harness.lastProfileId = next;
+    },
+    getRuntimeAuthState: () => params.harness.runtimeAuthState,
+    setRuntimeAuthState: (next) => {
+      params.harness.runtimeAuthState = next;
+    },
+    getRuntimeAuthRefreshCancelled: () => false,
+    setRuntimeAuthRefreshCancelled: () => undefined,
+    getProfileIndex: () => params.harness.profileIndex,
+    setProfileIndex: (next) => {
+      params.harness.profileIndex = next;
+    },
+    setThinkLevel: () => undefined,
+    log: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+    },
+  });
+}
+
+function expectProtectedRuntimeValue(value: string | undefined, plaintext: string): void {
+  expect(value).not.toBe(plaintext);
+  expect(looksLikeSecretSentinel(value ?? "")).toBe(true);
+  expect(resolveSecretSentinel(value ?? "")).toBe(plaintext);
+}
+
+describe("createEmbeddedRunAuthController refresh deadlines", () => {
+  beforeEach(() => {
+    mocks.prepareProviderRuntimeAuth.mockReset();
+    mocks.getApiKeyForModelCore.mockReset();
+  });
+
+  it("releases the in-flight refresh handle when a refresh hangs past the hard deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+      mocks.getApiKeyForModelCore.mockResolvedValue({
+        apiKey: "source-api-key",
+        mode: "api-key",
+        profileId: "default",
+        source: "env",
+      });
+      let call = 0;
+      mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
+        call += 1;
+        if (call === 1) {
+          return {
+            apiKey: "runtime-api-key",
+            baseUrl: "https://runtime.example.com/v1",
+            request: { auth: { mode: "header", headerName: "api-key", value: "runtime-token" } },
+            expiresAt: Date.now() + 60_000,
+          };
+        }
+        return new Promise(() => {});
+      });
+      const controller = createController({ harness, setRuntimeApiKey });
+
+      await controller.initializeAuthProfile();
+      await vi.advanceTimersByTimeAsync(5_000);
+      const inflight = harness.runtimeAuthState?.refreshInFlight;
+      expect(typeof inflight?.then).toBe("function");
+
+      const rejection = expect(inflight).rejects.toThrow(/exceeded hard deadline/);
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await rejection;
+      expect(harness.runtimeAuthState?.refreshInFlight).not.toBe(inflight);
+      controller.stopRuntimeAuthRefreshTimer();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards a deadline-abandoned refresh completion after a successful retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+      const staleRefresh = createDeferred<{ apiKey: string; expiresAt: number }>();
+      mocks.getApiKeyForModelCore.mockResolvedValue({
+        apiKey: "source-api-key",
+        mode: "api-key",
+        profileId: "default",
+        source: "env",
+      });
+      let call = 0;
+      mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
+        call += 1;
+        if (call === 1) {
+          return { apiKey: "runtime-api-key", expiresAt: Date.now() + 60_000 };
+        }
+        if (call === 2) {
+          return staleRefresh.promise;
+        }
+        return { apiKey: "retry-runtime-api-key", expiresAt: Date.now() + 60_000 };
+      });
+      const controller = createController({ harness, setRuntimeApiKey });
+
+      await controller.initializeAuthProfile();
+      await vi.advanceTimersByTimeAsync(5_000);
+      const inflight = harness.runtimeAuthState?.refreshInFlight;
+      const rejection = expect(inflight).rejects.toThrow(/exceeded hard deadline/);
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await rejection;
+
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_RETRY_MS);
+      expectProtectedRuntimeValue(setRuntimeApiKey.mock.calls.at(-1)?.[1], "retry-runtime-api-key");
+
+      staleRefresh.resolve({ apiKey: "stale-runtime-api-key", expiresAt: Date.now() + 5_000 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expectProtectedRuntimeValue(setRuntimeApiKey.mock.calls.at(-1)?.[1], "retry-runtime-api-key");
+      const staleWrites = setRuntimeApiKey.mock.calls.filter(
+        ([, apiKey]) => resolveSecretSentinel(apiKey) === "stale-runtime-api-key",
+      );
+      expect(staleWrites).toHaveLength(0);
+      controller.stopRuntimeAuthRefreshTimer();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails over instead of hanging when cold-start auth prep exceeds the hard deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+      mocks.getApiKeyForModelCore.mockResolvedValue({
+        apiKey: "source-api-key",
+        mode: "api-key",
+        profileId: "default",
+        source: "env",
+      });
+      mocks.prepareProviderRuntimeAuth.mockImplementation(() => new Promise(() => {}));
+      const controller = createController({ harness, setRuntimeApiKey });
+
+      const init = controller.initializeAuthProfile();
+      const rejection = expect(init).rejects.toBeTruthy();
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts
@@ -70,6 +70,7 @@ function createHarness(): MutableAuthControllerHarness {
 function createController(params: {
   harness: MutableAuthControllerHarness;
   setRuntimeApiKey(provider: string, apiKey: string): void;
+  profileCandidates?: string[];
 }) {
   const authStore: AuthProfileStore = { version: 1, profiles: {} };
   return createEmbeddedRunAuthController({
@@ -80,7 +81,7 @@ function createController(params: {
     authStorage: {
       setRuntimeApiKey: (provider, apiKey) => params.setRuntimeApiKey(provider, apiKey),
     },
-    profileCandidates: ["default"],
+    profileCandidates: params.profileCandidates ?? ["default"],
     initialThinkLevel: "medium",
     attemptedThinking: new Set(),
     fallbackConfigured: false,
@@ -242,6 +243,73 @@ describe("createEmbeddedRunAuthController refresh deadlines", () => {
       const rejection = expect(init).rejects.toBeTruthy();
       await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
       await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the selected fallback after the timed-out credential read settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+      const staleCredential = createDeferred<ResolvedProviderAuth>();
+      mocks.getApiKeyForModelCore.mockImplementation(async ({ profileId }) => {
+        if (profileId === "first") {
+          return await staleCredential.promise;
+        }
+        return {
+          apiKey: "backup-source-key",
+          mode: "api-key",
+          profileId: "backup",
+          source: "profile:backup",
+        };
+      });
+      mocks.prepareProviderRuntimeAuth.mockResolvedValue({
+        apiKey: "backup-runtime-key",
+        baseUrl: "https://backup.example.com/v1",
+        request: {
+          auth: { mode: "header", headerName: "x-profile-token", value: "backup-token" },
+        },
+      });
+      const controller = createController({
+        harness,
+        setRuntimeApiKey,
+        profileCandidates: ["first", "backup"],
+      });
+
+      const init = controller.initializeAuthProfile();
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await init;
+      expect(harness.lastProfileId).toBe("backup");
+      expect(harness.apiKeyInfo?.profileId).toBe("backup");
+      expect(harness.runtimeAuthState?.profileId).toBe("backup");
+      expect(harness.runtimeModel.baseUrl).toBe("https://backup.example.com/v1");
+      expectProtectedRuntimeValue(
+        harness.runtimeModel.headers?.["x-profile-token"],
+        "backup-token",
+      );
+      expectProtectedRuntimeValue(setRuntimeApiKey.mock.calls.at(-1)?.[1], "backup-runtime-key");
+
+      staleCredential.resolve({
+        apiKey: "stale-source-key",
+        mode: "api-key",
+        profileId: "first",
+        source: "profile:first",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(harness.lastProfileId).toBe("backup");
+      expect(harness.apiKeyInfo?.profileId).toBe("backup");
+      expect(harness.runtimeAuthState?.profileId).toBe("backup");
+      expect(harness.runtimeModel.baseUrl).toBe("https://backup.example.com/v1");
+      expectProtectedRuntimeValue(
+        harness.runtimeModel.headers?.["x-profile-token"],
+        "backup-token",
+      );
+      expectProtectedRuntimeValue(setRuntimeApiKey.mock.calls.at(-1)?.[1], "backup-runtime-key");
+      expect(setRuntimeApiKey).toHaveBeenCalledTimes(1);
+      controller.stopRuntimeAuthRefreshTimer();
     } finally {
       vi.useRealTimers();
     }

--- a/src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts
@@ -77,7 +77,9 @@ function createController(params: {
     agentDir: "/tmp/agent",
     workspaceDir: "/tmp/workspace",
     authStore,
-    authStorage: { setRuntimeApiKey: params.setRuntimeApiKey },
+    authStorage: {
+      setRuntimeApiKey: (provider, apiKey) => params.setRuntimeApiKey(provider, apiKey),
+    },
     profileCandidates: ["default"],
     initialThinkLevel: "medium",
     attemptedThinking: new Set(),

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -17,7 +17,7 @@ import { OAuthRefreshFailureError } from "../../auth-profiles/oauth-refresh-fail
 import { resolveAuthProfileOrder } from "../../auth-profiles/order.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "../../auth-profiles/store.js";
 import { FailoverError } from "../../failover-error.js";
-import type { RuntimeAuthState } from "./helpers.js";
+import { RUNTIME_AUTH_REFRESH_RETRY_MS, type RuntimeAuthState } from "./helpers.js";
 
 const mocks = vi.hoisted(() => ({
   prepareProviderRuntimeAuth: vi.fn(),
@@ -979,6 +979,82 @@ describe("createEmbeddedRunAuthController", () => {
       // The wedged handle is no longer the active in-flight handle.
       expect(getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight).not.toBe(inflight);
 
+      controller.stopRuntimeAuthRefreshTimer();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards a deadline-abandoned refresh completion after a successful retry", async () => {
+    // Regression for the stale write-back class: the hard deadline abandons a
+    // hung refresh without cancelling it. Once the retry installs fresh
+    // credentials, the abandoned continuation's eventual completion must fail
+    // the generation stale-check and no-op instead of overwriting them.
+    vi.useFakeTimers();
+    try {
+      const harness = createMutableAuthControllerHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+      const staleRefresh = createDeferred<{ apiKey: string; expiresAt: number }>();
+
+      mocks.getApiKeyForModel.mockResolvedValue({
+        apiKey: "source-api-key",
+        mode: "api-key",
+        profileId: "default",
+        source: "env",
+      });
+
+      let call = 0;
+      mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
+        call += 1;
+        if (call === 1) {
+          return { apiKey: "runtime-api-key", expiresAt: Date.now() + 60_000 };
+        }
+        if (call === 2) {
+          // First scheduled refresh hangs past the hard deadline.
+          return staleRefresh.promise;
+        }
+        return { apiKey: "retry-runtime-api-key", expiresAt: Date.now() + 60_000 };
+      });
+
+      const controller = createMutableEmbeddedRunAuthController({
+        harness,
+        setRuntimeApiKey,
+        profileCandidates: ["default"],
+      });
+
+      await controller.initializeAuthProfile();
+
+      // Scheduled refresh (min delay 5s) hangs; the deadline abandons it.
+      await vi.advanceTimersByTimeAsync(5_000);
+      const inflight = getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight;
+      const rejection = expect(inflight).rejects.toThrow(/exceeded hard deadline/);
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await rejection;
+
+      // Runtime keys cross this sink as redaction sentinels, so assert on the
+      // resolved plaintext rather than the raw argument.
+      const expectLastRuntimeApiKey = (plaintext: string) => {
+        const lastCall = setRuntimeApiKey.mock.calls.at(-1);
+        expect(lastCall?.[0]).toBe("custom-openai");
+        expectProtectedRuntimeValue(lastCall?.[1], plaintext);
+      };
+
+      // The scheduled-retry lane recovers with fresh credentials.
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_RETRY_MS);
+      expectLastRuntimeApiKey("retry-runtime-api-key");
+
+      // The abandoned refresh finally settles with stale credentials; the
+      // bumped generation must make its write-back a no-op.
+      staleRefresh.resolve({ apiKey: "stale-runtime-api-key", expiresAt: Date.now() + 5_000 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expectLastRuntimeApiKey("retry-runtime-api-key");
+      const staleWrites = setRuntimeApiKey.mock.calls.filter(
+        ([, apiKey]) =>
+          apiKey === "stale-runtime-api-key" ||
+          resolveSecretSentinel(apiKey) === "stale-runtime-api-key",
+      );
+      expect(staleWrites).toHaveLength(0);
       controller.stopRuntimeAuthRefreshTimer();
     } finally {
       vi.useRealTimers();

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -17,7 +17,7 @@ import { OAuthRefreshFailureError } from "../../auth-profiles/oauth-refresh-fail
 import { resolveAuthProfileOrder } from "../../auth-profiles/order.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "../../auth-profiles/store.js";
 import { FailoverError } from "../../failover-error.js";
-import { RUNTIME_AUTH_REFRESH_RETRY_MS, type RuntimeAuthState } from "./helpers.js";
+import type { RuntimeAuthState } from "./helpers.js";
 
 const mocks = vi.hoisted(() => ({
   prepareProviderRuntimeAuth: vi.fn(),
@@ -42,7 +42,6 @@ vi.mock("../../model-auth.js", async () => {
   };
 });
 
-import { RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS } from "../../runtime-auth-refresh.js";
 import {
   createEmbeddedRunAuthController,
   resolveEmbeddedAuthCooldownProbePolicy,
@@ -919,177 +918,6 @@ describe("createEmbeddedRunAuthController", () => {
       const storedBackupApiKey = setRuntimeApiKey.mock.calls.at(-1)?.[1];
       expectProtectedRuntimeValue(storedBackupApiKey, "backup-runtime-api-key");
       controller.stopRuntimeAuthRefreshTimer();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("releases the in-flight refresh handle when a refresh hangs past the hard deadline", async () => {
-    // Regression for the rh-bot gateway freeze: a provider auth hook that never
-    // settles left `refreshInFlight` pending forever, and every later model turn
-    // deadlocked at `await refreshInFlight`. The hard deadline must force the
-    // handle to settle so the single-flight cannot wedge the whole gateway.
-    vi.useFakeTimers();
-    try {
-      const harness = createMutableAuthControllerHarness();
-      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
-
-      mocks.getApiKeyForModelCore.mockResolvedValue({
-        apiKey: "source-api-key",
-        mode: "api-key",
-        profileId: "default",
-        source: "env",
-      });
-
-      let call = 0;
-      mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
-        call += 1;
-        if (call === 1) {
-          // Initial exchange resolves so a refresh gets scheduled (expiry soon).
-          return {
-            apiKey: "runtime-api-key",
-            baseUrl: "https://runtime.example.com/v1",
-            request: {
-              auth: { mode: "header", headerName: "api-key", value: "runtime-token" },
-            },
-            expiresAt: Date.now() + 60_000,
-          };
-        }
-        // Every scheduled refresh hangs forever — the provider auth hook wedge.
-        return new Promise(() => {});
-      });
-
-      const controller = createMutableEmbeddedRunAuthController({
-        harness,
-        setRuntimeApiKey,
-        profileCandidates: ["default"],
-      });
-
-      await controller.initializeAuthProfile();
-
-      // Fire the scheduled refresh (min delay 5s); it hangs, so the handle is set.
-      await vi.advanceTimersByTimeAsync(5_000);
-      const inflight = getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight;
-      expect(typeof inflight?.then).toBe("function");
-
-      // Before the fix this stayed pending forever. The hard deadline rejects it.
-      const rejection = expect(inflight).rejects.toThrow(/exceeded hard deadline/);
-      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
-      await rejection;
-      // The wedged handle is no longer the active in-flight handle.
-      expect(getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight).not.toBe(inflight);
-
-      controller.stopRuntimeAuthRefreshTimer();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("discards a deadline-abandoned refresh completion after a successful retry", async () => {
-    // Regression for the stale write-back class: the hard deadline abandons a
-    // hung refresh without cancelling it. Once the retry installs fresh
-    // credentials, the abandoned continuation's eventual completion must fail
-    // the generation stale-check and no-op instead of overwriting them.
-    vi.useFakeTimers();
-    try {
-      const harness = createMutableAuthControllerHarness();
-      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
-      const staleRefresh = createDeferred<{ apiKey: string; expiresAt: number }>();
-
-      mocks.getApiKeyForModelCore.mockResolvedValue({
-        apiKey: "source-api-key",
-        mode: "api-key",
-        profileId: "default",
-        source: "env",
-      });
-
-      let call = 0;
-      mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
-        call += 1;
-        if (call === 1) {
-          return { apiKey: "runtime-api-key", expiresAt: Date.now() + 60_000 };
-        }
-        if (call === 2) {
-          // First scheduled refresh hangs past the hard deadline.
-          return staleRefresh.promise;
-        }
-        return { apiKey: "retry-runtime-api-key", expiresAt: Date.now() + 60_000 };
-      });
-
-      const controller = createMutableEmbeddedRunAuthController({
-        harness,
-        setRuntimeApiKey,
-        profileCandidates: ["default"],
-      });
-
-      await controller.initializeAuthProfile();
-
-      // Scheduled refresh (min delay 5s) hangs; the deadline abandons it.
-      await vi.advanceTimersByTimeAsync(5_000);
-      const inflight = getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight;
-      const rejection = expect(inflight).rejects.toThrow(/exceeded hard deadline/);
-      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
-      await rejection;
-
-      // Runtime keys cross this sink as redaction sentinels, so assert on the
-      // resolved plaintext rather than the raw argument.
-      const expectLastRuntimeApiKey = (plaintext: string) => {
-        const lastCall = setRuntimeApiKey.mock.calls.at(-1);
-        expect(lastCall?.[0]).toBe("custom-openai");
-        expectProtectedRuntimeValue(lastCall?.[1], plaintext);
-      };
-
-      // The scheduled-retry lane recovers with fresh credentials.
-      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_RETRY_MS);
-      expectLastRuntimeApiKey("retry-runtime-api-key");
-
-      // The abandoned refresh finally settles with stale credentials; the
-      // bumped generation must make its write-back a no-op.
-      staleRefresh.resolve({ apiKey: "stale-runtime-api-key", expiresAt: Date.now() + 5_000 });
-      await vi.advanceTimersByTimeAsync(0);
-
-      expectLastRuntimeApiKey("retry-runtime-api-key");
-      const staleWrites = setRuntimeApiKey.mock.calls.filter(
-        ([, apiKey]) =>
-          apiKey === "stale-runtime-api-key" ||
-          resolveSecretSentinel(apiKey) === "stale-runtime-api-key",
-      );
-      expect(staleWrites).toHaveLength(0);
-      controller.stopRuntimeAuthRefreshTimer();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("fails over instead of hanging when cold-start auth prep exceeds the hard deadline", async () => {
-    // The #93952 deadline originally covered only refreshRuntimeAuth. The
-    // cold-start / profile-rotation path (initializeAuthProfile -> applyApiKeyInfo
-    // -> prepareProviderRuntimeAuth) is the exact hook that hung in the rh-bot
-    // incident AND the path a watchdog kickstart lands on first. It must also be
-    // backstopped so a fresh boot can never re-wedge the lane.
-    vi.useFakeTimers();
-    try {
-      const harness = createMutableAuthControllerHarness();
-      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
-      mocks.getApiKeyForModelCore.mockResolvedValue({
-        apiKey: "source-api-key",
-        mode: "api-key",
-        profileId: "default",
-        source: "env",
-      });
-      // The provider auth hook hangs forever on cold start.
-      mocks.prepareProviderRuntimeAuth.mockImplementation(() => new Promise(() => {}));
-
-      const controller = createMutableEmbeddedRunAuthController({
-        harness,
-        setRuntimeApiKey,
-        profileCandidates: ["default"],
-      });
-
-      const init = controller.initializeAuthProfile();
-      const rejection = expect(init).rejects.toBeTruthy();
-      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
-      await rejection;
     } finally {
       vi.useRealTimers();
     }

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -985,6 +985,40 @@ describe("createEmbeddedRunAuthController", () => {
     }
   });
 
+  it("fails over instead of hanging when cold-start auth prep exceeds the hard deadline", async () => {
+    // The #93952 deadline originally covered only refreshRuntimeAuth. The
+    // cold-start / profile-rotation path (initializeAuthProfile -> applyApiKeyInfo
+    // -> prepareProviderRuntimeAuth) is the exact hook that hung in the rh-bot
+    // incident AND the path a watchdog kickstart lands on first. It must also be
+    // backstopped so a fresh boot can never re-wedge the lane.
+    vi.useFakeTimers();
+    try {
+      const harness = createMutableAuthControllerHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+      mocks.getApiKeyForModel.mockResolvedValue({
+        apiKey: "source-api-key",
+        mode: "api-key",
+        profileId: "default",
+        source: "env",
+      });
+      // The provider auth hook hangs forever on cold start.
+      mocks.prepareProviderRuntimeAuth.mockImplementation(() => new Promise(() => {}));
+
+      const controller = createMutableEmbeddedRunAuthController({
+        harness,
+        setRuntimeApiKey,
+        profileCandidates: ["default"],
+      });
+
+      const init = controller.initializeAuthProfile();
+      const rejection = expect(init).rejects.toBeTruthy();
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   describe("aws-sdk auth without explicit API key (IMDS / instance role)", () => {
     it("injects runtime auth when prepareProviderRuntimeAuth resolves credentials", async () => {
       const harness = createMutableAuthControllerHarness();

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -934,7 +934,7 @@ describe("createEmbeddedRunAuthController", () => {
       const harness = createMutableAuthControllerHarness();
       const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
 
-      mocks.getApiKeyForModel.mockResolvedValue({
+      mocks.getApiKeyForModelCore.mockResolvedValue({
         apiKey: "source-api-key",
         mode: "api-key",
         profileId: "default",
@@ -996,7 +996,7 @@ describe("createEmbeddedRunAuthController", () => {
       const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
       const staleRefresh = createDeferred<{ apiKey: string; expiresAt: number }>();
 
-      mocks.getApiKeyForModel.mockResolvedValue({
+      mocks.getApiKeyForModelCore.mockResolvedValue({
         apiKey: "source-api-key",
         mode: "api-key",
         profileId: "default",
@@ -1071,7 +1071,7 @@ describe("createEmbeddedRunAuthController", () => {
     try {
       const harness = createMutableAuthControllerHarness();
       const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
-      mocks.getApiKeyForModel.mockResolvedValue({
+      mocks.getApiKeyForModelCore.mockResolvedValue({
         apiKey: "source-api-key",
         mode: "api-key",
         profileId: "default",

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -42,6 +42,7 @@ vi.mock("../../model-auth.js", async () => {
   };
 });
 
+import { RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS } from "../../runtime-auth-refresh.js";
 import {
   createEmbeddedRunAuthController,
   resolveEmbeddedAuthCooldownProbePolicy,
@@ -917,6 +918,67 @@ describe("createEmbeddedRunAuthController", () => {
       expect(harness.runtimeModel.headers?.["api-key"]).toBe(backupHeader);
       const storedBackupApiKey = setRuntimeApiKey.mock.calls.at(-1)?.[1];
       expectProtectedRuntimeValue(storedBackupApiKey, "backup-runtime-api-key");
+      controller.stopRuntimeAuthRefreshTimer();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases the in-flight refresh handle when a refresh hangs past the hard deadline", async () => {
+    // Regression for the rh-bot gateway freeze: a provider auth hook that never
+    // settles left `refreshInFlight` pending forever, and every later model turn
+    // deadlocked at `await refreshInFlight`. The hard deadline must force the
+    // handle to settle so the single-flight cannot wedge the whole gateway.
+    vi.useFakeTimers();
+    try {
+      const harness = createMutableAuthControllerHarness();
+      const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+
+      mocks.getApiKeyForModel.mockResolvedValue({
+        apiKey: "source-api-key",
+        mode: "api-key",
+        profileId: "default",
+        source: "env",
+      });
+
+      let call = 0;
+      mocks.prepareProviderRuntimeAuth.mockImplementation(async () => {
+        call += 1;
+        if (call === 1) {
+          // Initial exchange resolves so a refresh gets scheduled (expiry soon).
+          return {
+            apiKey: "runtime-api-key",
+            baseUrl: "https://runtime.example.com/v1",
+            request: {
+              auth: { mode: "header", headerName: "api-key", value: "runtime-token" },
+            },
+            expiresAt: Date.now() + 60_000,
+          };
+        }
+        // Every scheduled refresh hangs forever — the provider auth hook wedge.
+        return new Promise(() => {});
+      });
+
+      const controller = createMutableEmbeddedRunAuthController({
+        harness,
+        setRuntimeApiKey,
+        profileCandidates: ["default"],
+      });
+
+      await controller.initializeAuthProfile();
+
+      // Fire the scheduled refresh (min delay 5s); it hangs, so the handle is set.
+      await vi.advanceTimersByTimeAsync(5_000);
+      const inflight = getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight;
+      expect(typeof inflight?.then).toBe("function");
+
+      // Before the fix this stayed pending forever. The hard deadline rejects it.
+      const rejection = expect(inflight).rejects.toThrow(/exceeded hard deadline/);
+      await vi.advanceTimersByTimeAsync(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS);
+      await rejection;
+      // The wedged handle is no longer the active in-flight handle.
+      expect(getRuntimeAuthSnapshot(harness.runtimeAuthState)?.refreshInFlight).not.toBe(inflight);
+
       controller.stopRuntimeAuthRefreshTimer();
     } finally {
       vi.useRealTimers();

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -21,7 +21,6 @@ import {
   type FailoverReason,
 } from "../../embedded-agent-helpers.js";
 import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
-import { shouldUseTransientCooldownProbeSlot } from "../../failover-policy.js";
 import { renderAuthProfileFailoverCopy } from "../../failover/user-copy.js";
 import {
   getApiKeyForModelCore,
@@ -44,7 +43,10 @@ import {
   RuntimeAuthDeadlineError,
   withRuntimeAuthRefreshDeadline,
 } from "../../runtime-auth-refresh.js";
-import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
+import {
+  resolveAuthProfileFailureReason,
+  resolveEmbeddedAuthCooldownProbePolicy,
+} from "./auth-profile-failure-policy.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 import {
   RUNTIME_AUTH_REFRESH_MARGIN_MS,
@@ -66,48 +68,7 @@ type LogLike = {
   warn(message: string): void;
 };
 
-/** Decides whether one automatic profile may bypass its current cooldown. */
-export function resolveEmbeddedAuthCooldownProbePolicy(params: {
-  authStore: AuthProfileStore;
-  profileCandidates: Array<string | undefined>;
-  lockedProfileId?: string;
-  modelId: string;
-  allowTransientCooldownProbe: boolean;
-}): { probeProfileIds: ReadonlySet<string>; unavailableReason: FailoverReason | null } {
-  const autoProfileCandidates = params.profileCandidates.filter(
-    (candidate): candidate is string =>
-      typeof candidate === "string" && candidate.length > 0 && candidate !== params.lockedProfileId,
-  );
-  const allAutoProfilesInCooldown =
-    autoProfileCandidates.length > 0 &&
-    autoProfileCandidates.every((candidate) =>
-      isProfileInCooldown(params.authStore, candidate, undefined, params.modelId),
-    );
-  const unavailableReason = allAutoProfilesInCooldown
-    ? (resolveProfilesUnavailableReason({
-        store: params.authStore,
-        profileIds: autoProfileCandidates,
-      }) ?? "unknown")
-    : null;
-  const probeProfileIds = new Set<string>();
-  if (
-    params.allowTransientCooldownProbe &&
-    allAutoProfilesInCooldown &&
-    shouldUseTransientCooldownProbeSlot(unavailableReason)
-  ) {
-    for (const candidate of autoProfileCandidates) {
-      const candidateReason =
-        resolveProfilesUnavailableReason({
-          store: params.authStore,
-          profileIds: [candidate],
-        }) ?? "unknown";
-      if (shouldUseTransientCooldownProbeSlot(candidateReason)) {
-        probeProfileIds.add(candidate);
-      }
-    }
-  }
-  return { probeProfileIds, unavailableReason };
-}
+export { resolveEmbeddedAuthCooldownProbePolicy } from "./auth-profile-failure-policy.js";
 
 /**
  * Coordinates auth profile selection, runtime auth preparation/refresh, and

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -41,6 +41,7 @@ import {
 import {
   clampRuntimeAuthRefreshDelayMs,
   RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
+  RuntimeAuthDeadlineError,
   withRuntimeAuthRefreshDeadline,
 } from "../../runtime-auth-refresh.js";
 import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
@@ -325,6 +326,19 @@ export function createEmbeddedRunAuthController(params: {
     )
       .catch((err: unknown) => {
         const runtimeModel = params.getRuntimeModel();
+        if (err instanceof RuntimeAuthDeadlineError) {
+          // The deadline abandons refreshOperation without cancelling it, and
+          // the continuation still holds this generation's stale-check
+          // snapshot. Bump the generation so the abandoned completion fails
+          // that check instead of overwriting credentials a retry installs.
+          const activeState = params.getRuntimeAuthState();
+          if (activeState && activeState.generation === refreshGeneration) {
+            activeState.generation = refreshGeneration + 1;
+            params.log.debug(
+              `Invalidated runtime auth generation ${refreshGeneration} for ${runtimeModel.provider}; deadline abandoned an in-flight refresh.`,
+            );
+          }
+        }
         params.log.warn(
           `Runtime auth refresh failed for ${runtimeModel.provider}: ${formatErrorMessage(err)}`,
         );

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -38,7 +38,11 @@ import {
   protectPreparedProviderRuntimeAuth,
   unwrapSecretSentinelsForProviderEgress,
 } from "../../provider-secret-egress.js";
-import { clampRuntimeAuthRefreshDelayMs } from "../../runtime-auth-refresh.js";
+import {
+  clampRuntimeAuthRefreshDelayMs,
+  RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
+  withRuntimeAuthRefreshDeadline,
+} from "../../runtime-auth-refresh.js";
 import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 import {
@@ -260,7 +264,7 @@ export function createEmbeddedRunAuthController(params: {
     // after another profile or credential has already become active.
     const refreshGeneration = runtimeAuthState.generation;
     const refreshProfileId = runtimeAuthState.profileId;
-    const refreshPromise: Promise<void> = (async () => {
+    const refreshOperation: Promise<void> = (async () => {
       const currentRuntimeAuthState = params.getRuntimeAuthState();
       const sourceApiKey = currentRuntimeAuthState?.sourceApiKey.trim() ?? "";
       if (!sourceApiKey) {
@@ -303,7 +307,15 @@ export function createEmbeddedRunAuthController(params: {
           `Runtime auth refreshed for ${runtimeModel.provider}; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
         );
       }
-    })()
+    })();
+    // Hard backstop: a provider auth hook, keychain read, or cross-agent lock
+    // wait that never settles must not leave `refreshInFlight` pending forever,
+    // or every later model turn deadlocks awaiting it (see #88xx rh-bot freeze).
+    const refreshPromise: Promise<void> = withRuntimeAuthRefreshDeadline(
+      refreshOperation,
+      RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
+      params.getRuntimeModel().provider,
+    )
       .catch((err: unknown) => {
         const runtimeModel = params.getRuntimeModel();
         params.log.warn(
@@ -312,12 +324,12 @@ export function createEmbeddedRunAuthController(params: {
         throw err;
       })
       .finally(() => {
+        // Clear whenever this promise is still the active in-flight handle.
+        // Intentionally not gated on generation: a profile rotation during a
+        // slow/hung refresh must still release the handle it owns, otherwise the
+        // stale handle wedges the new generation's refreshes.
         const activeState = params.getRuntimeAuthState();
-        if (
-          activeState &&
-          activeState.generation === refreshGeneration &&
-          activeState.refreshInFlight === refreshPromise
-        ) {
+        if (activeState && activeState.refreshInFlight === refreshPromise) {
           activeState.refreshInFlight = undefined;
         }
       });

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -234,6 +234,13 @@ export function createEmbeddedRunAuthController(params: {
     });
   };
 
+  // Single hard-deadline backstop applied at EVERY auth boundary that can block
+  // on a provider hook, keychain read, or cross-agent lock/gate. Without it, any
+  // one of those hanging leaves the model-turn lane deadlocked (the rh-bot
+  // freeze). Covers the refresh path AND the cold-start/profile-rotation path.
+  const withAuthDeadline = <T>(work: Promise<T>, label: string): Promise<T> =>
+    withRuntimeAuthRefreshDeadline(work, RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS, label);
+
   const clearRuntimeAuthRefreshTimer = () => {
     const runtimeAuthState = params.getRuntimeAuthState();
     if (!runtimeAuthState?.refreshTimer) {
@@ -311,9 +318,8 @@ export function createEmbeddedRunAuthController(params: {
     // Hard backstop: a provider auth hook, keychain read, or cross-agent lock
     // wait that never settles must not leave `refreshInFlight` pending forever,
     // or every later model turn deadlocks awaiting it (see #88xx rh-bot freeze).
-    const refreshPromise: Promise<void> = withRuntimeAuthRefreshDeadline(
+    const refreshPromise: Promise<void> = withAuthDeadline(
       refreshOperation,
-      RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
       params.getRuntimeModel().provider,
     )
       .catch((err: unknown) => {
@@ -537,10 +543,13 @@ export function createEmbeddedRunAuthController(params: {
 
   const applyApiKeyInfo = async (candidate?: string, attemptIndex?: number): Promise<void> => {
     const preparedModel = await params.prepareModelForAuthProfile?.(candidate, attemptIndex);
-    const apiKeyInfo = await resolveApiKeyForCandidate(
-      candidate,
-      preparedModel?.runtimeModel,
-      preparedModel?.allowAuthProfileFallback,
+    const apiKeyInfo = await withAuthDeadline(
+      resolveApiKeyForCandidate(
+        candidate,
+        preparedModel?.runtimeModel,
+        preparedModel?.allowAuthProfileFallback,
+      ),
+      `${params.getRuntimeModel().provider} credential resolution`,
     );
     if (
       preparedModel?.authRequirement &&
@@ -572,12 +581,15 @@ export function createEmbeddedRunAuthController(params: {
       const runtimeModel = params.getRuntimeModel();
       const AWS_SDK_AUTH_SENTINEL = "__aws_sdk_auth__";
       try {
-        const preparedAuth = await prepareRuntimeAuthForModel({
-          runtimeModel,
-          apiKey: AWS_SDK_AUTH_SENTINEL,
-          authMode: apiKeyInfo.mode,
-          profileId: apiKeyInfo.profileId,
-        });
+        const preparedAuth = await withAuthDeadline(
+          prepareRuntimeAuthForModel({
+            runtimeModel,
+            apiKey: AWS_SDK_AUTH_SENTINEL,
+            authMode: apiKeyInfo.mode,
+            profileId: apiKeyInfo.profileId,
+          }),
+          `${runtimeModel.provider} runtime auth`,
+        );
         applyPreparedRuntimeRequestOverrides({ runtimeModel, preparedAuth: preparedAuth ?? {} });
         if (preparedAuth?.apiKey) {
           clearRuntimeAuthRefreshTimer();
@@ -612,12 +624,15 @@ export function createEmbeddedRunAuthController(params: {
     commitPreparedModel(preparedModel);
     let runtimeAuthHandled = false;
     const runtimeModel = params.getRuntimeModel();
-    const preparedAuth = await prepareRuntimeAuthForModel({
-      runtimeModel,
-      apiKey: apiKeyInfo.apiKey,
-      authMode: apiKeyInfo.mode,
-      profileId: apiKeyInfo.profileId,
-    });
+    const preparedAuth = await withAuthDeadline(
+      prepareRuntimeAuthForModel({
+        runtimeModel,
+        apiKey: apiKeyInfo.apiKey,
+        authMode: apiKeyInfo.mode,
+        profileId: apiKeyInfo.profileId,
+      }),
+      `${runtimeModel.provider} runtime auth`,
+    );
     applyPreparedRuntimeRequestOverrides({ runtimeModel, preparedAuth: preparedAuth ?? {} });
     if (preparedAuth?.apiKey) {
       clearRuntimeAuthRefreshTimer();

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -317,7 +317,8 @@ export function createEmbeddedRunAuthController(params: {
     })();
     // Hard backstop: a provider auth hook, keychain read, or cross-agent lock
     // wait that never settles must not leave `refreshInFlight` pending forever,
-    // or every later model turn deadlocks awaiting it (see #88xx rh-bot freeze).
+    // or every later model turn deadlocks awaiting it, freezing the gateway
+    // until restart (observed in production).
     const refreshPromise: Promise<void> = withAuthDeadline(
       refreshOperation,
       params.getRuntimeModel().provider,

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -1,7 +1,13 @@
+import {
+  type AuthProfileStore,
+  isProfileInCooldown,
+  resolveProfilesUnavailableReason,
+} from "../../auth-profiles.js";
 /**
  * Resolves why an auth profile failed during provider auth selection.
  */
 import type { AuthProfileFailureReason } from "../../auth-profiles/types.js";
+import { shouldUseTransientCooldownProbeSlot } from "../../failover-policy.js";
 import type { FailoverReason } from "../../failover/signal.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 
@@ -47,4 +53,47 @@ export function resolveAuthProfileFailureReason(params: {
     return null;
   }
   return params.failoverReason;
+}
+
+/** Decides whether one automatic profile may bypass its current cooldown. */
+export function resolveEmbeddedAuthCooldownProbePolicy(params: {
+  authStore: AuthProfileStore;
+  profileCandidates: Array<string | undefined>;
+  lockedProfileId?: string;
+  modelId: string;
+  allowTransientCooldownProbe: boolean;
+}): { probeProfileIds: ReadonlySet<string>; unavailableReason: FailoverReason | null } {
+  const autoProfileCandidates = params.profileCandidates.filter(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && candidate.length > 0 && candidate !== params.lockedProfileId,
+  );
+  const allAutoProfilesInCooldown =
+    autoProfileCandidates.length > 0 &&
+    autoProfileCandidates.every((candidate) =>
+      isProfileInCooldown(params.authStore, candidate, undefined, params.modelId),
+    );
+  const unavailableReason = allAutoProfilesInCooldown
+    ? (resolveProfilesUnavailableReason({
+        store: params.authStore,
+        profileIds: autoProfileCandidates,
+      }) ?? "unknown")
+    : null;
+  const probeProfileIds = new Set<string>();
+  if (
+    params.allowTransientCooldownProbe &&
+    allAutoProfilesInCooldown &&
+    shouldUseTransientCooldownProbeSlot(unavailableReason)
+  ) {
+    for (const candidate of autoProfileCandidates) {
+      const candidateReason =
+        resolveProfilesUnavailableReason({
+          store: params.authStore,
+          profileIds: [candidate],
+        }) ?? "unknown";
+      if (shouldUseTransientCooldownProbeSlot(candidateReason)) {
+        probeProfileIds.add(candidate);
+      }
+    }
+  }
+  return { probeProfileIds, unavailableReason };
 }

--- a/src/agents/runtime-auth-refresh.test.ts
+++ b/src/agents/runtime-auth-refresh.test.ts
@@ -1,8 +1,10 @@
 // Verifies runtime auth refresh timers stay within safe JavaScript timer bounds.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OAUTH_REFRESH_INLOCK_TIMEOUT_MS } from "./auth-profiles/constants.js";
 import {
   clampRuntimeAuthRefreshDelayMs,
   RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
+  RuntimeAuthDeadlineError,
   withRuntimeAuthRefreshDeadline,
 } from "./runtime-auth-refresh.js";
 
@@ -33,14 +35,17 @@ describe("withRuntimeAuthRefreshDeadline", () => {
     vi.useRealTimers();
   });
 
-  it("rejects once the deadline elapses when the work never settles", async () => {
+  it("rejects with the typed deadline error once the deadline elapses", async () => {
     vi.useFakeTimers();
     // A provider auth hook that hangs forever — the exact wedge that froze the
-    // gateway. The backstop must reject so the single-flight handle can clear.
+    // gateway. The backstop must reject so the single-flight handle can clear,
+    // and callers rely on the error type to invalidate abandoned continuations.
     const hung = new Promise<string>(() => {});
     const raced = withRuntimeAuthRefreshDeadline(hung, 1_000, "openai");
-    const assertion = expect(raced).rejects.toThrow(
-      /Runtime auth operation for openai exceeded hard deadline \(1000ms\)/,
+    const assertion = expect(raced).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof RuntimeAuthDeadlineError &&
+        err.message.includes("Runtime auth operation for openai exceeded hard deadline (1000ms)"),
     );
     await vi.advanceTimersByTimeAsync(1_000);
     await assertion;
@@ -68,8 +73,13 @@ describe("withRuntimeAuthRefreshDeadline", () => {
     );
   });
 
-  it("keeps the default hard timeout at or above the OAuth manager call + stale-lock budget", () => {
-    // OAuth manager: 120s call timeout + 180s peer stale-lock window.
-    expect(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000 + 180_000);
+  it("keeps the default hard timeout above two serialized in-lock budgets with headroom", () => {
+    // Worst legitimate case: wait out a peer's full in-lock critical section,
+    // then run our own (2 x OAUTH_REFRESH_INLOCK_TIMEOUT_MS). Explicit headroom
+    // ensures legitimate contention never misreports as a hard timeout.
+    const minHeadroomMs = 30_000;
+    expect(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS).toBeGreaterThan(
+      2 * OAUTH_REFRESH_INLOCK_TIMEOUT_MS + minHeadroomMs,
+    );
   });
 });

--- a/src/agents/runtime-auth-refresh.test.ts
+++ b/src/agents/runtime-auth-refresh.test.ts
@@ -40,7 +40,7 @@ describe("withRuntimeAuthRefreshDeadline", () => {
     const hung = new Promise<string>(() => {});
     const raced = withRuntimeAuthRefreshDeadline(hung, 1_000, "openai");
     const assertion = expect(raced).rejects.toThrow(
-      /Runtime auth refresh for openai exceeded hard deadline \(1000ms\)/,
+      /Runtime auth operation for openai exceeded hard deadline \(1000ms\)/,
     );
     await vi.advanceTimersByTimeAsync(1_000);
     await assertion;
@@ -68,7 +68,7 @@ describe("withRuntimeAuthRefreshDeadline", () => {
     );
   });
 
-  it("keeps the default hard timeout above the OAuth manager call + stale-lock budget", () => {
+  it("keeps the default hard timeout at or above the OAuth manager call + stale-lock budget", () => {
     // OAuth manager: 120s call timeout + 180s peer stale-lock window.
     expect(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000 + 180_000);
   });

--- a/src/agents/runtime-auth-refresh.test.ts
+++ b/src/agents/runtime-auth-refresh.test.ts
@@ -1,6 +1,10 @@
 // Verifies runtime auth refresh timers stay within safe JavaScript timer bounds.
-import { describe, expect, it } from "vitest";
-import { clampRuntimeAuthRefreshDelayMs } from "./runtime-auth-refresh.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clampRuntimeAuthRefreshDelayMs,
+  RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
+  withRuntimeAuthRefreshDeadline,
+} from "./runtime-auth-refresh.js";
 
 describe("clampRuntimeAuthRefreshDelayMs", () => {
   it("clamps far-future refresh delays to a timer-safe ceiling", () => {
@@ -21,5 +25,51 @@ describe("clampRuntimeAuthRefreshDelayMs", () => {
         minDelayMs: 60_000,
       }),
     ).toBe(60_000);
+  });
+});
+
+describe("withRuntimeAuthRefreshDeadline", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects once the deadline elapses when the work never settles", async () => {
+    vi.useFakeTimers();
+    // A provider auth hook that hangs forever — the exact wedge that froze the
+    // gateway. The backstop must reject so the single-flight handle can clear.
+    const hung = new Promise<string>(() => {});
+    const raced = withRuntimeAuthRefreshDeadline(hung, 1_000, "openai");
+    const assertion = expect(raced).rejects.toThrow(
+      /Runtime auth refresh for openai exceeded hard deadline \(1000ms\)/,
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
+  });
+
+  it("resolves with the work value when the work settles before the deadline", async () => {
+    vi.useFakeTimers();
+    const raced = withRuntimeAuthRefreshDeadline(Promise.resolve("ok"), 5_000, "openai");
+    await expect(raced).resolves.toBe("ok");
+  });
+
+  it("propagates the work rejection when it settles before the deadline", async () => {
+    vi.useFakeTimers();
+    const raced = withRuntimeAuthRefreshDeadline(
+      Promise.reject(new Error("refresh boom")),
+      5_000,
+      "openai",
+    );
+    await expect(raced).rejects.toThrow("refresh boom");
+  });
+
+  it("passes work through unbounded when the timeout is non-positive", async () => {
+    await expect(withRuntimeAuthRefreshDeadline(Promise.resolve("ok"), 0, "openai")).resolves.toBe(
+      "ok",
+    );
+  });
+
+  it("keeps the default hard timeout above the OAuth manager call + stale-lock budget", () => {
+    // OAuth manager: 120s call timeout + 180s peer stale-lock window.
+    expect(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000 + 180_000);
   });
 });

--- a/src/agents/runtime-auth-refresh.test.ts
+++ b/src/agents/runtime-auth-refresh.test.ts
@@ -1,6 +1,6 @@
 // Verifies runtime auth refresh timers stay within safe JavaScript timer bounds.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { OAUTH_REFRESH_INLOCK_TIMEOUT_MS } from "./auth-profiles/constants.js";
+import { OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS } from "./auth-profiles/constants.js";
 import {
   clampRuntimeAuthRefreshDelayMs,
   RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS,
@@ -73,13 +73,12 @@ describe("withRuntimeAuthRefreshDeadline", () => {
     );
   });
 
-  it("keeps the default hard timeout above two serialized in-lock budgets with headroom", () => {
-    // Worst legitimate case: wait out a peer's full in-lock critical section,
-    // then run our own (2 x OAUTH_REFRESH_INLOCK_TIMEOUT_MS). Explicit headroom
-    // ensures legitimate contention never misreports as a hard timeout.
+  it("keeps the default hard timeout above two ownership budgets with headroom", () => {
+    // A reused-token recovery can run two consecutive manager attempts. Explicit
+    // headroom ensures recovery never misreports as a hard timeout.
     const minHeadroomMs = 30_000;
     expect(RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS).toBeGreaterThan(
-      2 * OAUTH_REFRESH_INLOCK_TIMEOUT_MS + minHeadroomMs,
+      2 * OAUTH_REFRESH_OWNERSHIP_TIMEOUT_MS + minHeadroomMs,
     );
   });
 });

--- a/src/agents/runtime-auth-refresh.ts
+++ b/src/agents/runtime-auth-refresh.ts
@@ -16,14 +16,29 @@ export function clampRuntimeAuthRefreshDelayMs(params: {
   return resolveSafeTimeoutDelayMs(params.refreshAt - params.now, { minMs: params.minDelayMs });
 }
 
-// Hard backstop for a single runtime auth refresh. Covers at least the OAuth
-// manager's own call timeout (120s) plus a peer's stale-lock window (180s) so a
-// legitimately slow cross-agent refresh still completes, while any refresh that
-// hangs indefinitely (a provider auth hook, keychain/lock wait, or token
-// endpoint that never settles) is forced to reject. Without this backstop the
-// single-flight `refreshInFlight` promise can stay pending forever and every
-// subsequent model turn deadlocks awaiting it.
-export const RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS = 300_000;
+// Hard backstop for a single runtime auth refresh. The worst legitimate case
+// is two serialized in-lock budgets: waiting out a peer's held refresh lock
+// for its full critical section (OAUTH_REFRESH_INLOCK_TIMEOUT_MS, 150s) and
+// then running our own (another 150s) = 300s. 360s keeps 60s of real headroom
+// above that so legitimate contention never misreports as a hard timeout,
+// while any refresh that hangs indefinitely (a provider auth hook,
+// keychain/lock wait, or token endpoint that never settles) is still forced to
+// reject. Without this backstop the single-flight `refreshInFlight` promise
+// can stay pending forever and every subsequent model turn deadlocks awaiting
+// it.
+export const RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS = 360_000;
+
+/**
+ * Thrown when the hard deadline fires and abandons still-running auth work.
+ * The work cannot be cancelled, so callers use this type to invalidate any
+ * state snapshot the abandoned continuation could later write back.
+ */
+export class RuntimeAuthDeadlineError extends Error {
+  constructor(label: string, timeoutMs: number) {
+    super(`Runtime auth operation for ${label} exceeded hard deadline (${timeoutMs}ms)`);
+    this.name = "RuntimeAuthDeadlineError";
+  }
+}
 
 /**
  * Races a runtime auth operation (refresh, cold-start prep, profile rotation)
@@ -46,9 +61,7 @@ export async function withRuntimeAuthRefreshDeadline<T>(
       work,
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
-          reject(
-            new Error(`Runtime auth operation for ${label} exceeded hard deadline (${timeoutMs}ms)`),
-          );
+          reject(new RuntimeAuthDeadlineError(label, timeoutMs));
         }, timeoutMs);
         timer.unref?.();
       }),

--- a/src/agents/runtime-auth-refresh.ts
+++ b/src/agents/runtime-auth-refresh.ts
@@ -16,7 +16,7 @@ export function clampRuntimeAuthRefreshDelayMs(params: {
   return resolveSafeTimeoutDelayMs(params.refreshAt - params.now, { minMs: params.minDelayMs });
 }
 
-// Hard backstop for a single runtime auth refresh. Sits above the OAuth
+// Hard backstop for a single runtime auth refresh. Covers at least the OAuth
 // manager's own call timeout (120s) plus a peer's stale-lock window (180s) so a
 // legitimately slow cross-agent refresh still completes, while any refresh that
 // hangs indefinitely (a provider auth hook, keychain/lock wait, or token
@@ -26,10 +26,11 @@ export function clampRuntimeAuthRefreshDelayMs(params: {
 export const RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS = 300_000;
 
 /**
- * Races a runtime auth refresh against a hard deadline so the caller's promise
- * always settles. On timeout the underlying work is abandoned (it cannot be
- * cancelled) and a descriptive error is thrown; the caller clears any
- * single-flight handle in its own `finally`.
+ * Races a runtime auth operation (refresh, cold-start prep, profile rotation)
+ * against a hard deadline so the caller's promise always settles. On timeout
+ * the underlying work is abandoned (it cannot be cancelled) and a descriptive
+ * error is thrown; the caller clears any single-flight handle in its own
+ * `finally`.
  */
 export async function withRuntimeAuthRefreshDeadline<T>(
   work: Promise<T>,
@@ -46,7 +47,7 @@ export async function withRuntimeAuthRefreshDeadline<T>(
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
           reject(
-            new Error(`Runtime auth refresh for ${label} exceeded hard deadline (${timeoutMs}ms)`),
+            new Error(`Runtime auth operation for ${label} exceeded hard deadline (${timeoutMs}ms)`),
           );
         }, timeoutMs);
         timer.unref?.();

--- a/src/agents/runtime-auth-refresh.ts
+++ b/src/agents/runtime-auth-refresh.ts
@@ -1,7 +1,8 @@
 /**
  * Runtime auth refresh timer helper.
  *
- * Clamps refresh deadlines before they are passed to setTimeout.
+ * Clamps refresh deadlines before they are passed to setTimeout and backstops a
+ * single refresh against a hard deadline.
  */
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 
@@ -13,4 +14,47 @@ export function clampRuntimeAuthRefreshDelayMs(params: {
   minDelayMs: number;
 }): number {
   return resolveSafeTimeoutDelayMs(params.refreshAt - params.now, { minMs: params.minDelayMs });
+}
+
+// Hard backstop for a single runtime auth refresh. Sits above the OAuth
+// manager's own call timeout (120s) plus a peer's stale-lock window (180s) so a
+// legitimately slow cross-agent refresh still completes, while any refresh that
+// hangs indefinitely (a provider auth hook, keychain/lock wait, or token
+// endpoint that never settles) is forced to reject. Without this backstop the
+// single-flight `refreshInFlight` promise can stay pending forever and every
+// subsequent model turn deadlocks awaiting it.
+export const RUNTIME_AUTH_REFRESH_HARD_TIMEOUT_MS = 300_000;
+
+/**
+ * Races a runtime auth refresh against a hard deadline so the caller's promise
+ * always settles. On timeout the underlying work is abandoned (it cannot be
+ * cancelled) and a descriptive error is thrown; the caller clears any
+ * single-flight handle in its own `finally`.
+ */
+export async function withRuntimeAuthRefreshDeadline<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return await work;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(`Runtime auth refresh for ${label} exceeded hard deadline (${timeoutMs}ms)`),
+          );
+        }, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }

--- a/src/agents/runtime-auth-refresh.ts
+++ b/src/agents/runtime-auth-refresh.ts
@@ -16,12 +16,10 @@ export function clampRuntimeAuthRefreshDelayMs(params: {
   return resolveSafeTimeoutDelayMs(params.refreshAt - params.now, { minMs: params.minDelayMs });
 }
 
-// Hard backstop for a single runtime auth refresh. The worst legitimate case
-// is two serialized in-lock budgets: waiting out a peer's held refresh lock
-// for its full critical section (OAUTH_REFRESH_INLOCK_TIMEOUT_MS, 150s) and
-// then running our own (another 150s) = 300s. 360s keeps 60s of real headroom
-// above that so legitimate contention never misreports as a hard timeout,
-// while any refresh that hangs indefinitely (a provider auth hook,
+// Hard backstop for a runtime auth refresh. Reused-token recovery can run two
+// consecutive caller ownership budgets (2 x 150s). 360s keeps 60s of headroom
+// so recovery never misreports as a hard timeout, while any refresh that hangs
+// indefinitely (a provider auth hook,
 // keychain/lock wait, or token endpoint that never settles) is still forced to
 // reject. Without this backstop the single-flight `refreshInFlight` promise
 // can stay pending forever and every subsequent model turn deadlocks awaiting

--- a/src/plugin-sdk/agent-runtime-oauth-compat.test.ts
+++ b/src/plugin-sdk/agent-runtime-oauth-compat.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { refreshOAuthCredentialForRuntime, type OAuthCredential } from "./agent-runtime.js";
+
+describe("agent-runtime OAuth compatibility", () => {
+  it("retains the shipped direct-refresh call shape", () => {
+    const credential: OAuthCredential = {
+      type: "oauth",
+      provider: "contract-provider",
+      access: "access",
+      refresh: "refresh",
+      expires: 1,
+    };
+    const params = {
+      credential,
+      cfg: {},
+    } satisfies Parameters<typeof refreshOAuthCredentialForRuntime>[0];
+
+    expect(params).toEqual({ credential, cfg: {} });
+    expect(refreshOAuthCredentialForRuntime).toBeTypeOf("function");
+  });
+});

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -15,6 +15,7 @@ import { escapeHtml } from "../shared/html-escape.js";
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
 export { removeProviderAuthProfilesWithLock } from "../agents/auth-profiles/profiles.js";
 export { removeAuthProfileConfig } from "../plugins/provider-auth-helpers.js";
+export { refreshCodexCliOAuthCredentialForRuntime } from "../agents/auth-profiles/oauth.js";
 export {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -15,7 +15,10 @@ import { escapeHtml } from "../shared/html-escape.js";
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
 export { removeProviderAuthProfilesWithLock } from "../agents/auth-profiles/profiles.js";
 export { removeAuthProfileConfig } from "../plugins/provider-auth-helpers.js";
-export { refreshCodexCliOAuthCredentialForRuntime } from "../agents/auth-profiles/oauth.js";
+export {
+  isCodexCliOAuthRuntimeProfile,
+  refreshCodexCliOAuthCredentialForRuntime,
+} from "../agents/auth-profiles/oauth.js";
 export {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,


### PR DESCRIPTION
## What Problem This Solves

OAuth refresh could outlive the caller that requested it, while the queue and file-lock owners released or retried on different clocks. That created two bad outcomes: a timed-out run could write late auth state into a later run, and multiple Codex app-server clients could rotate the same refresh grant from separate runtime snapshots.

This PR gives the shared OAuth manager one ownership model. The caller gets an absolute deadline before queue admission. The admitted owner keeps the provider refresh, SQLite writeback, and file lock until that work settles, even when the original caller has already timed out. Followers reuse the completed canonical row instead of starting another refresh.

## Why This Change Was Made

The bug belongs to the auth lifecycle owner, not the embedded runner or Codex bridge. The final shape keeps those boundaries separate:

- `src/agents/auth-profiles/oauth-manager.ts` owns queue admission, file-lock ownership, provider refresh, compare-and-swap persistence, and follower adoption.
- `src/agents/embedded-agent-runner/run/auth-controller.ts` owns the caller-visible hard deadline and fences all late controller state by generation, profile, and source.
- `extensions/codex/src/app-server/auth-bridge.ts` routes persisted and native-Codex-provenance credentials through the manager. Truly caller-scoped, non-CLI runtime credentials keep the shipped direct helper path.
- First native Codex rotation rereads the authoritative source inside the global lock with `ttlMs: 0` and `allowKeychainPrompt: false`, then promotes only a successful changed credential into the canonical main-agent SQLite row. It never writes `.codex` state.
- The shipped public `refreshOAuthCredentialForRuntime({ credential, cfg? })` contract remains source-compatible. The manager path stays private-local; the public Plugin SDK surface does not grow.

No config/default, protocol, SQLite schema, schema-version, migration, or dependency surface changes. `AUTH_STORE_VERSION` remains `1`.

## User Impact

A hung provider refresh now fails the waiting agent turn within its caller budget without abandoning auth ownership. The in-flight owner still finishes once, writes the canonical result, and lets later callers adopt it. Concurrent local agents and prepared remote-exec snapshots no longer start duplicate first-rotation work against separate per-agent stores; native Codex promotion converges on the shared main-agent SQLite owner.

The normal native Codex runtime-only refresh path remains available. Cross-host coordination of native Codex storage is not claimed here: that needs an approved source-owner refresh-and-commit contract or an upstream cross-process storage API.

## Evidence

### Exact branch state

- Head: `04fe642fb7c45d6a057de28e9256243aeab57953`. That is `da26ac7ae58da198de4f136e9851d7cf5bf35873` plus one test-only commit rewriting the real-binary live test.
- Frozen upstream `main`: `7642587232f1de780be55d83a1ed860a1f5bd294`, the same base as #112932's head.
- `git range-diff` of the previously documented head `ad7be82ca620` against `da26ac7`: 11 of 15 commits `=`. The other 4 differ only in import lines and `auth-bridge.test.ts`, which moved with upstream #128370 (app-server 0.149.1) and #129052. The bundled `@openai/codex` is now 0.149.1.

### Focused and static proof (`04fe642`, M4)

- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/auth-bridge.test.ts src/agents/auth-profiles/oauth-manager.abandoned-writeback.test.ts src/agents/auth-profiles/oauth-refresh-timeout.test.ts src/agents/auth-profiles/oauth.mirror-refresh.test.ts src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts src/agents/embedded-agent-runner/run/auth-controller.deadline.test.ts src/agents/runtime-auth-refresh.test.ts src/plugin-sdk/agent-runtime-oauth-compat.test.ts`: 172/172 passed in 56 s.
- `oxfmt --check`, `oxlint` and `tsgo` are clean on the rewritten live test. The `tsgo` run was positive-controlled with an injected TS2322.
- Earlier surface proof, carried from `ad7be82`: `pnpm plugin-sdk:surface:check` on the patch-identical predecessor reported unchanged public counts (`4,340` exports / `2,581` callables), private-local-only counts (`2,950` / `1,804`), and `0` forbidden subpaths. Hosted CI run 32765428436 passed at `ad7be82`: https://github.com/openclaw/openclaw/actions/runs/32765428436. Hosted CI at `da26ac7` ([run 32900546171](https://github.com/openclaw/openclaw/actions/runs/32900546171)) failed only `model-resolution-consistency.test.ts`, a file outside this PR that failed the same way on #112932 at the same base. That file passes 8/8 in isolation at the base.

### Causal coverage (unit tests; production code unchanged by `04fe642`)

- Caller deadline starts before queue admission. A timed-out follower cannot begin provider work after its budget expires.
- Once provider work starts, the queue and file-lock owner retain ownership through SQLite writeback. A fresh caller then adopts the completed row.
- Distinct prepared stores and distinct agent directories converge on one canonical main-agent row and one provider refresh.
- Forced refresh dedupes by the actual rejected bearer: a newly current different access token is adopted; metadata-only changes with the same access token still rotate.
- Initial refresh and `refresh_token_reused` retry both carry the effective attempted credential, so unchanged shared state cannot masquerade as a fresh credential.
- First native promotion requires explicit Codex external-CLI provenance. Arbitrary supplied OAuth cannot authorize SQLite takeover.
- Wrong identity, unusable relogin state, and stale compare-and-swap races fail closed before adopting external state. Same-identity rotation losers persist the successful rotated credential under the manager invariant.
- Controller coverage includes A timeout -> B success -> A late settlement and proves the late A result cannot overwrite B's profile/source/API-key state.

### Real-boundary proof and honest limits

`extensions/codex/src/app-server/auth-refresh-boundary.real-binary.live.test.ts` now drives the bundled `@openai/codex` 0.149.1 app-server through the first native `openai:default` promotion, using synthetic credentials only. The native login is a synthetic `CODEX_HOME/auth.json`. The ChatGPT backend is a loopback fake wired in through `-c openai_base_url` and `-c chatgpt_base_url`. The token exchange is the in-process provider `refreshOAuth` hook. The old version of this test read the operator's real `~/.codex/auth.json`, stored `openai:boundary-proof` and completed a real turn, so it never entered the native branch.

Measured at `04fe642` on the M4, under `env -i` with an empty HOME and `sandbox-exec` denying non-loopback outbound, `/usr/bin/security`, SecurityServer, and reads of the real user's credential directories (each fence positive-controlled). The full transcript is in https://github.com/openclaw/openclaw/pull/93952#issuecomment-5734127298.

- **Allowed case (2/2 passed).** Before the turn there is no SQLite row for `openai:default`, only the native overlay with Codex CLI provenance. The app-server sends one `account/chatgptAuthTokens/refresh`. The provider hook runs once, under the refresh lock, on the grant reread from `CODEX_HOME`. The backend sees the stale bearer, then the fresh one. The rotated grant becomes the canonical main SQLite row, and the native `auth.json` stays byte-identical.
- **Denied case.** The native home is logged into another account before the first refresh. The result is no SQLite row and zero provider refreshes, the other account's bearer never reaches the backend, the turn fails, and Codex reports `ChatGPT workspace changed before Codex token refresh`.
- **Branch-entry control.** With the native-branch condition in `auth-bridge.ts` disabled, the allowed case fails on `expect(seen.promotedRow).toBe(true)`. The app-server retried refresh 6 times with the stale bearer and no row was written.

Not proven: a real `auth.openai.com/oauth/token` rotation, which is not reachable without a code change because the token URL is hardcoded behind an exact-host SSRF allowlist; chatgpt.com acceptance; revoked-account behavior; Codex Keychain and `auto` stores (the managed app-server runs with `cli_auth_credentials_store="ephemeral"`); and cross-OS or cross-host behavior. No real credential was read, copied or rotated.

### Current Codex dependency contract

Official Codex snapshot `4aa52f2cb2cdffa9c826f9e4e421a5435a05af06` was personally inspected:

- `codex-rs/app-server-protocol/src/protocol/common.rs:21-36,1703-1706`: `chatgptAuthTokens` is externally supplied, memory-only auth; the host owns `account/chatgptAuthTokens/refresh`.
- `codex-rs/app-server/src/external_auth.rs:18,33-81,85-96`: the app server sends the previous account ID, applies a 10-second request timeout, redacts refresh/parser errors, validates the response, and makes the returned auth current.
- `codex-rs/login/src/auth/manager.rs:240-267,2729-2819,2908-2953,2970-2988`: external auth owns resolve/refresh; Codex reloads before authority refresh, skips when auth changed, records permanent failure only for the unchanged attempt, commits external ChatGPT auth to process-local ephemeral storage, and persists native ChatGPT refresh through its selected storage.
- `codex-rs/login/src/auth/storage.rs:38-60,191-218,231-317,354-445,455-524` and `codex-rs/config/src/types.rs:105-117`: file, keyring, auto, and process-local ephemeral stores are distinct owner modes. File save is truncate/write/flush; the process-local ephemeral map is keyed by Codex home.

### LOC and ownership justification

Against base `7642587` at `04fe642`:
- Production, counting `oauth-test-utils.ts` as production: `+814/-271` (net `+543`).
- Tests and test support: `+1,777/-130` (net `+1,647`). `04fe642` alone is `+283/-97`, all in the live test.
- Docs: `+15/-6` (net `+9`).
- Aggregate: `+2,606/-407` across 21 files.

The positive production delta establishes one missing ownership/security boundary across caller deadline, queue admission, file lock, provider refresh, SQLite compare-and-swap, canonical main-owner promotion, snapshot reload, and controller late-result fencing. It does not add a product/config capability.

### ClawSweeper rank-up moves and merge order

The latest durable [ClawSweeper review](https://github.com/openclaw/openclaw/pull/93952#issuecomment-4726450629) covers `da26ac7`. It reports overall readiness 2/6, proof confidence 2/6 and patch quality 3/6, with one P2 (the live test did not reach the native promotion branch) and the promotion-authority security concern. `04fe642` answers the P2 with the measurement above. The remaining gates are not waived:

1. Current-version allowed and denied app-server proof for first native promotion now exists with synthetic credentials and a loopback backend. Real token-endpoint rotation and chatgpt.com acceptance remain unproven.
2. Account reassignment before refresh is measured end to end (denied case above). Real revoked-account final-effect proof remains open.

PR [#112932](https://github.com/openclaw/openclaw/pull/112932) must land first. The current conflict with moving `main` is intentionally not being chased while #112932 remains open. Its head is now `21a5f1c1fe6e548003c4a302b3bf4b38d968132a` on the same frozen base `7642587`, with current-head synthetic authority proof in https://github.com/openclaw/openclaw/pull/112932#issuecomment-5734103984. The two branches overlap in five OAuth files: `docs/concepts/oauth.md`, `src/agents/auth-profiles/external-cli-sync.ts`, `src/agents/auth-profiles/oauth-manager.ts`, `src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts`, and `src/agents/auth-profiles/oauth.ts`. `git merge-tree --write-tree` of the two heads conflicts in the first four. After #112932 lands, this branch requires a fresh rebase, combined owner/integration proof (both harnesses rerun), exact-head CI, and exact-head ClawSweeper review. It must not merge first.

Explicit auth/storage-owner acceptance remains required for the first-rotation native-to-SQLite ownership handoff, deadline/writeback semantics, and the known cross-host limitation. Required exact-head CI and `clownfish/exact-merge` must also pass after the final post-#112932 rebase.

