### PR TITLE
[codex] fail configure fast without a tty

### DIFF
--- a/src/commands/configure.commands.test.ts
+++ b/src/commands/configure.commands.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { formatCliCommand } from "../cli/command-format.js";
+import { configureCommandFromSectionsArg } from "./configure.commands.js";
+
+const runConfigureWizardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./configure.wizard.js", () => ({
+  runConfigureWizard: runConfigureWizardMock,
+}));
+
+describe("configureCommandFromSectionsArg", () => {
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runConfigureWizardMock.mockResolvedValue(undefined);
+  });
+
+  it("fails closed without an interactive tty", async () => {
+    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false });
+
+    try {
+      await configureCommandFromSectionsArg(undefined, runtime);
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        [
+          "Configure needs an interactive TTY.",
+          `Use \`${formatCliCommand("openclaw config get")}\`, \`${formatCliCommand("openclaw config set")}\`, \`${formatCliCommand("openclaw config patch")}\`, or \`${formatCliCommand("openclaw config validate")}\` for non-interactive config changes.`,
+        ].join(" "),
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runConfigureWizardMock).not.toHaveBeenCalled();
+    } finally {
+      if (stdinDescriptor) {
+        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, "isTTY");
+      }
+      if (stdoutDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
+  });
+
+  it("runs the configure wizard when an interactive tty is available", async () => {
+    const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+
+    try {
+      await configureCommandFromSectionsArg(["model"], runtime);
+
+      expect(runConfigureWizardMock).toHaveBeenCalledWith(
+        { command: "configure", sections: ["model"] },
+        runtime,
+      );
+    } finally {
+      if (stdinDescriptor) {
+        Object.defineProperty(process.stdin, "isTTY", stdinDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, "isTTY");
+      }
+      if (stdoutDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", stdoutDescriptor);
+      } else {
+        Reflect.deleteProperty(process.stdout, "isTTY");
+      }
+    }
+  });
+});

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -6,7 +6,24 @@ import type { WizardSection } from "./configure.shared.js";
 import { CONFIGURE_WIZARD_SECTIONS, parseConfigureWizardSections } from "./configure.shared.js";
 import { runConfigureWizard } from "./configure.wizard.js";
 
+function requireInteractiveConfigureTty(runtime: RuntimeEnv): boolean {
+  if (process.stdin.isTTY && process.stdout.isTTY) {
+    return true;
+  }
+  runtime.error(
+    [
+      "Configure needs an interactive TTY.",
+      `Use \`${formatCliCommand("openclaw config get")}\`, \`${formatCliCommand("openclaw config set")}\`, \`${formatCliCommand("openclaw config patch")}\`, or \`${formatCliCommand("openclaw config validate")}\` for non-interactive config changes.`,
+    ].join(" "),
+  );
+  runtime.exit(1);
+  return false;
+}
+
 async function configureCommand(runtime: RuntimeEnv = defaultRuntime) {
+  if (!requireInteractiveConfigureTty(runtime)) {
+    return;
+  }
   await runConfigureWizard({ command: "configure" }, runtime);
 }
 
@@ -14,6 +31,9 @@ async function configureCommandWithSections(
   sections: WizardSection[],
   runtime: RuntimeEnv = defaultRuntime,
 ) {
+  if (!requireInteractiveConfigureTty(runtime)) {
+    return;
+  }
   await runConfigureWizard({ command: "configure", sections }, runtime);
 }
 


### PR DESCRIPTION
## Summary

Fail the interactive configure surface closed when stdin/stdout are not TTYs.

Before this patch, both `openclaw config` (without a subcommand) and `openclaw configure` still entered the Clack wizard on a pipe. In practice that printed interactive UI in automation and then crashed out with Node's `Detected unsettled top-level await` warning instead of giving a clean operator-facing error.

Closes #93953.

## Changes

- add a shared interactive-TTY guard in `src/commands/configure.commands.ts`
- apply it to both the full configure flow and the section-filtered flow
- add a focused regression test that covers the non-TTY rejection path and the normal interactive path

## Verification

- `node scripts/run-vitest.mjs src/commands/configure.commands.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `printf '' | node openclaw.mjs config` before the patch reproduced the dirty wizard exit
- `printf '' | node openclaw.mjs configure` before the patch reproduced the dirty wizard exit
- `printf '' | node scripts/run-node.mjs configure` after the patch now exits with the explicit TTY error instead of entering the wizard

## Real behavior proof

Behavior addressed: `config`/`configure` no longer enter the interactive wizard on non-TTY stdin/stdout.
Real environment tested: local macOS checkout with the repo source entrypoint.
Exact steps or command run after this patch: ran the focused Vitest file above, then ran `printf '' | node scripts/run-node.mjs configure`.
Evidence after fix: the command now prints `Configure needs an interactive TTY...` and stops before any wizard prompt.
Observed result after fix: the dirty `Detected unsettled top-level await` exit path is replaced by a fail-closed operator message.
What was not tested: full `pnpm build` completion was blocked by transient npm tarball fetch failures in this environment.
