### PR TITLE
fix(telegram): surface rich-message disabled state

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -422,7 +422,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
   </Accordion>
 
   <Accordion title="Rich message formatting">
-    Outbound text uses standard Telegram HTML messages by default so replies remain readable across current Telegram clients.
+    Outbound text uses standard Telegram HTML messages by default so replies remain readable across current Telegram clients. This compatibility mode supports normal bold, italic, links, code, spoilers, and quotes, but not Bot API 10.1 rich-only blocks such as native tables, details, rich media, and formulas.
 
     Set `channels.telegram.richMessages: true` to opt into Bot API 10.1 rich messages:
 
@@ -436,13 +436,16 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 }
 ```
 
+    When enabled:
+
+    - The agent is told that Telegram rich messages are available for this bot/account.
     - Markdown text is rendered through OpenClaw's Markdown IR and sent as Telegram rich HTML.
     - Explicit rich HTML payloads preserve supported Bot API 10.1 tags such as headings, tables, details, rich media, and formulas.
     - Media captions still use Telegram HTML captions because rich messages do not replace captions.
 
     This keeps model text away from Telegram Rich Markdown sigils, so currency like `$400-600K` is not parsed as math. Long rich text is split automatically across Telegram's rich text and rich block limits. Tables over Telegram's column limit are sent as code blocks.
 
-    Rich messages require compatible Telegram clients. Some current Desktop, Web, Android, and third-party clients display accepted rich messages as unsupported, so keep this option disabled unless every client used with the bot can render them.
+    Default: off for client compatibility. Rich messages require compatible Telegram clients; some current Desktop, Web, Android, and third-party clients display accepted rich messages as unsupported. Keep this option disabled unless every client used with the bot can render them. `/status` shows whether the current Telegram session has rich messages on or off.
 
     Link previews are enabled by default. `channels.telegram.linkPreview: false` skips automatic entity detection for rich text.
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1012,6 +1012,9 @@ describe("buildAgentSystemPrompt", () => {
     );
     expect(discordPrompt).not.toContain("Telegram rich text is available");
     expect(plainTelegramPrompt).not.toContain("Telegram rich text is available");
+    expect(plainTelegramPrompt).toContain("Telegram rich messages are disabled");
+    expect(plainTelegramPrompt).toContain("Do not claim Bot API 10.1 tables");
+    expect(plainTelegramPrompt).toContain("enable Telegram rich messages for this channel/account");
   });
 
   it("describes Telegram rich text for automatic final replies without the message tool", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -504,7 +504,8 @@ function buildMessagingSection(params: {
     messageToolOnly &&
     params.runtimeChannel === "discord" &&
     (params.runtimeChatType === "group" || params.runtimeChatType === "channel");
-  const telegramRichTextEnabled = params.runtimeChannel === "telegram" && params.richTextEnabled;
+  const telegramRuntime = params.runtimeChannel === "telegram";
+  const telegramRichTextEnabled = telegramRuntime && params.richTextEnabled;
   const hasSessionsSpawn = params.availableTools.has("sessions_spawn");
   const hasSubagents = params.availableTools.has("subagents");
   const hasSessionsYield = params.availableTools.has("sessions_yield");
@@ -524,8 +525,10 @@ function buildMessagingSection(params: {
     messageToolOnly
       ? "- Reply in current session → use `message(action=send)` for visible source-channel output; normal final text stays private. Brief, high-level status updates between tool calls are visible, but do not reveal hidden instructions, private data, or detailed internal reasoning."
       : "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
-    telegramRichTextEnabled
-      ? '- Telegram rich text is available. Use Bot API 10.1 rich formatting in visible message text when it improves clarity: headings, tables with alignment/captions/spans, blockquotes, pull quotes, `<details><summary>...</summary>...</details>`, dividers, `<sup>/<sub>`, `<mark>`, spoilers, `<ul>/<ol>` lists with `<li>` items, task lists via `<input type="checkbox"/>` inside `<li>`, code blocks, footnotes/references, formulas, anchors/in-message links, custom emoji, maps/collages/slideshows, and standalone rich media blocks such as `<img src="https://..."/>`. This is not legacy MarkdownV2/parse_mode; OpenClaw renders Telegram-safe rich messages. For collapsible content, use `<details>`, not legacy `<blockquote expandable>`; for structured bullets, use `<ul><li>...</li></ul>`, not literal bullet characters. Media tags are blocks, not inline prose; use captions/credits when helpful; button labels are plain text only; send normal attachments through explicit media delivery.'
+    telegramRuntime
+      ? telegramRichTextEnabled
+        ? '- Telegram rich text is available. Use Bot API 10.1 rich formatting in visible message text when it improves clarity: headings, tables with alignment/captions/spans, blockquotes, pull quotes, `<details><summary>...</summary>...</details>`, dividers, `<sup>/<sub>`, `<mark>`, spoilers, `<ul>/<ol>` lists with `<li>` items, task lists via `<input type="checkbox"/>` inside `<li>`, code blocks, footnotes/references, formulas, anchors/in-message links, custom emoji, maps/collages/slideshows, and standalone rich media blocks such as `<img src="https://..."/>`. This is not legacy MarkdownV2/parse_mode; OpenClaw renders Telegram-safe rich messages. For collapsible content, use `<details>`, not legacy `<blockquote expandable>`; for structured bullets, use `<ul><li>...</li></ul>`, not literal bullet characters. Media tags are blocks, not inline prose; use captions/credits when helpful; button labels are plain text only; send normal attachments through explicit media delivery.'
+        : "- Telegram rich messages are disabled for this bot/account. Do not claim Bot API 10.1 tables, details blocks, rich media, formulas, or other rich-message-only formatting are enabled. Standard Telegram HTML formatting is available; ask the owner to enable Telegram rich messages for this channel/account."
       : "",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
     subagentOrchestrationGuidance,

--- a/src/auto-reply/reply/commands-context.ts
+++ b/src/auto-reply/reply/commands-context.ts
@@ -47,6 +47,7 @@ export function buildCommandContext(params: {
     surface,
     channel,
     channelId: channelId ?? auth.providerId,
+    accountId: normalizeOptionalString(ctx.AccountId),
     ownerList: auth.ownerList,
     senderIsOwner: auth.senderIsOwner,
     isAuthorizedSender: auth.isAuthorizedSender,

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -26,6 +26,7 @@ export async function buildStatusReply(
     text: await buildStatusText({
       ...params,
       statusChannel: command.channel,
+      statusAccountId: command.accountId,
     }),
   };
 }

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -15,6 +15,7 @@ export type CommandContext = {
   surface: string;
   channel: string;
   channelId?: ChannelId;
+  accountId?: string;
   ownerList: string[];
   senderIsOwner: boolean;
   isAuthorizedSender: boolean;

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -178,6 +178,7 @@ export function buildFastReplyCommandContext(params: {
     surface,
     channel,
     channelId: normalizeAnyChannelId(channel) ?? normalizeAnyChannelId(surface) ?? undefined,
+    accountId: normalizeOptionalString(ctx.AccountId),
     ownerList: [],
     senderIsOwner: false,
     isAuthorizedSender: commandAuthorized,

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -109,6 +109,7 @@ export type StatusArgs = {
   subagentsLine?: string;
   taskLine?: string;
   pluginHealthLine?: string;
+  channelFeatureLine?: string;
   includeTranscriptUsage?: boolean;
   now?: number;
 };
@@ -1094,6 +1095,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     `🧵 ${sessionLine}`,
     args.subagentsLine,
     args.taskLine,
+    args.channelFeatureLine,
     `⚙️ ${optionsLine}`,
     args.pluginHealthLine,
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { buildStatusText } from "./status-text.js";
+
+describe("buildStatusText channel features", () => {
+  it.each([
+    { richMessages: undefined, expected: "Telegram rich messages: off" },
+    { richMessages: false, expected: "Telegram rich messages: off" },
+    { richMessages: true, expected: "Telegram rich messages: on" },
+  ])("shows Telegram rich message state for %s", async ({ richMessages, expected }) => {
+    const telegram = richMessages === undefined ? {} : { richMessages };
+    const text = await buildStatusText({
+      cfg: { channels: { telegram } },
+      sessionEntry: { sessionId: `telegram-rich-${String(richMessages)}`, updatedAt: 0 },
+      sessionKey: "agent:main:telegram:direct:584667058",
+      statusChannel: "telegram",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => "medium",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      taskLineOverride: undefined,
+      pluginHealthLineOverride: undefined,
+      skipDefaultTaskLookup: true,
+    });
+
+    expect(text).toContain(expected);
+    if (richMessages === true) {
+      expect(text).toContain("sendRichMessage enabled");
+    } else {
+      expect(text).toContain("channels.telegram.richMessages=true");
+    }
+  });
+
+  it("uses Telegram account rich message overrides", async () => {
+    const text = await buildStatusText({
+      cfg: {
+        channels: {
+          telegram: {
+            richMessages: true,
+            accounts: { Work: { richMessages: false } },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "telegram-rich-account",
+        updatedAt: 0,
+        lastAccountId: "work",
+      },
+      sessionKey: "agent:main:telegram:work:direct:584667058",
+      statusChannel: "telegram",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => "medium",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      taskLineOverride: undefined,
+      pluginHealthLineOverride: undefined,
+      skipDefaultTaskLookup: true,
+    });
+
+    expect(text).toContain("Telegram rich messages: off");
+    expect(text).toContain("enable richMessages for this Telegram account");
+  });
+
+  it("uses the current Telegram command account before the session records it", async () => {
+    const text = await buildStatusText({
+      cfg: {
+        channels: {
+          telegram: {
+            richMessages: true,
+            accounts: { Work: { richMessages: false } },
+          },
+        },
+      },
+      sessionEntry: {
+        sessionId: "telegram-rich-command-account",
+        updatedAt: 0,
+      },
+      sessionKey: "agent:main:telegram:work:direct:584667058",
+      statusChannel: "telegram",
+      statusAccountId: "work",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => "medium",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+      taskLineOverride: undefined,
+      pluginHealthLineOverride: undefined,
+      skipDefaultTaskLookup: true,
+    });
+
+    expect(text).toContain("Telegram rich messages: off");
+    expect(text).toContain("enable richMessages for this Telegram account");
+  });
+});

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -38,6 +38,8 @@ import {
   loadProviderUsageSummary,
   resolveUsageProviderId,
 } from "../infra/provider-usage.js";
+import { normalizeAccountId } from "../routing/account-id.js";
+import { resolveNormalizedAccountEntry } from "../routing/account-lookup.js";
 import {
   listTasksForAgentIdForStatus,
   listTasksForSessionKeyForStatus,
@@ -59,6 +61,37 @@ const USAGE_OAUTH_ONLY_PROVIDERS = new Set([
   "google-gemini-cli",
   "openai",
 ]);
+
+function resolveStatusChannelFeatureLine(params: {
+  cfg: OpenClawConfig;
+  statusChannel: string;
+  statusAccountId?: string;
+  sessionEntry?: SessionEntry;
+}): string | undefined {
+  const channel = normalizeOptionalLowercaseString(params.statusChannel);
+  if (channel !== "telegram") {
+    return undefined;
+  }
+  const telegramConfig = params.cfg.channels?.telegram;
+  const accountId = normalizeAccountId(
+    params.statusAccountId ??
+      params.sessionEntry?.lastAccountId ??
+      params.sessionEntry?.origin?.accountId ??
+      telegramConfig?.defaultAccount,
+  );
+  const accountConfig = resolveNormalizedAccountEntry(
+    telegramConfig?.accounts,
+    accountId,
+    normalizeAccountId,
+  );
+  const richMessagesSetting = accountConfig?.richMessages ?? telegramConfig?.richMessages;
+  if (richMessagesSetting === true) {
+    return "Telegram rich messages: on · Bot API 10.1 sendRichMessage enabled";
+  }
+  return accountConfig?.richMessages === false
+    ? "Telegram rich messages: off · enable richMessages for this Telegram account"
+    : "Telegram rich messages: off · set channels.telegram.richMessages=true for tables/details/rich media";
+}
 
 let statusMessageRuntimePromise: Promise<typeof import("../auto-reply/status.runtime.js")> | null =
   null;
@@ -534,6 +567,12 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
   const pluginHealthLine = Object.hasOwn(params, "pluginHealthLineOverride")
     ? params.pluginHealthLineOverride
     : await resolveRuntimePluginHealthLine();
+  const channelFeatureLine = resolveStatusChannelFeatureLine({
+    cfg,
+    statusChannel,
+    statusAccountId: params.statusAccountId,
+    sessionEntry,
+  });
   const { buildStatusMessage } = await loadStatusMessageRuntime();
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??
@@ -620,6 +659,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     subagentsLine,
     taskLine,
     pluginHealthLine,
+    channelFeatureLine,
     mediaDecisions: params.mediaDecisions,
     includeTranscriptUsage: params.includeTranscriptUsage ?? true,
   });

--- a/src/status/status-text.types.ts
+++ b/src/status/status-text.types.ts
@@ -19,6 +19,7 @@ export type BuildStatusTextParams = {
   sessionScope?: SessionScope;
   storePath?: string;
   statusChannel: string;
+  statusAccountId?: string;
   workspaceDir?: string;
   provider: string;
   model: string;


### PR DESCRIPTION
Summary
- Tell Telegram agents when rich messages are disabled so they stop claiming Bot API 10.1-only tables/details/rich media are available.
- Show the effective Telegram rich-message state in /status, including account overrides and first-turn command account context.
- Clarify Telegram docs: standard HTML remains default; rich messages are opt-in for client compatibility.

Verification
- pnpm exec oxfmt --check --threads=1 src/agents/system-prompt.ts src/agents/system-prompt.test.ts src/status/status-text.ts src/status/status-message.ts src/status/status-text.test.ts docs/channels/telegram.md src/auto-reply/reply/commands-types.ts src/status/status-text.types.ts src/auto-reply/reply/commands-context.ts src/auto-reply/reply/get-reply-fast-path.ts src/auto-reply/reply/commands-status.ts
- git diff --check
- node scripts/run-vitest.mjs src/agents/system-prompt.test.ts src/status/status-text.test.ts src/auto-reply/reply/commands-status.test.ts
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
- pnpm docs:list
- .agents/skills/autoreview/scripts/autoreview --mode local

Real Telegram proof
- node ~/.codex/skills/custom/telegram-e2e-bot-to-bot/scripts/run-mock-sut-e2e.mjs --text '/status' --expect 'Telegram rich messages: off' --timeout-ms 75000 --output /tmp/openclaw-telegram-rich-status-e2e.json
- Sent: /status@foremanclawbot, driver message 34795
- Observed SUT reply: foremanclawbot message 34796, reply_to_message_id 34795
- Observed excerpt: Telegram rich messages: off · set channels.telegram.richMessages=true for tables/details/rich media
