### PR TITLE
fix(cron): persist overflow catch-up deferral IDs on state to survive read RPCs (fixes #93935)

### DIFF
--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -244,6 +244,7 @@ export function createMockCronStateForJobs(params: {
     warnedInvalidPersistedJobKeys: new Set<string>(),
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
+    pendingCatchupDeferralJobIds: new Set<string>(),
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -207,7 +207,13 @@ async function ensureLoadedForRead(state: CronServiceState) {
   }
   // Use the maintenance-only version so that read-only operations never
   // advance a past-due nextRunAtMs without executing the job (#16156).
-  const changed = recomputeNextRunsForMaintenance(state);
+  // Exempt pending catchup deferrals so staggered overflow slots survive
+  // read RPCs (cron list/status) until their catch-up tick fires (#93935).
+  const changed = recomputeNextRunsForMaintenance(state, {
+    skipFutureRepairJobIds: state.pendingCatchupDeferralJobIds.size > 0
+      ? state.pendingCatchupDeferralJobIds
+      : undefined,
+  });
   if (changed) {
     await persist(state);
   }
@@ -257,6 +263,13 @@ export async function start(state: CronServiceState) {
     skipJobIds: interruptedJobIds.size > 0 ? interruptedJobIds : undefined,
     deferAgentTurnJobs: true,
   });
+
+  // Persist deferred catchup IDs on state so maintenance recomputes from
+  // read RPCs, finalize, and empty-due ticks do not clobber the staggered
+  // nextRunAtMs before the catch-up tick fires.
+  if (deferredCatchupJobIds.size > 0) {
+    state.pendingCatchupDeferralJobIds = new Set(deferredCatchupJobIds);
+  }
 
   await locked(state, async () => {
     // Startup catch-up already persisted the latest in-memory store state, and
@@ -681,7 +694,12 @@ async function skipInvalidPersistedManualRun(params: {
     emit(params.state, { jobId: params.job.id, action: "removed" });
   }
 
-  recomputeNextRunsForMaintenance(params.state, { recomputeExpired: true });
+  recomputeNextRunsForMaintenance(params.state, {
+    recomputeExpired: true,
+    skipFutureRepairJobIds: params.state.pendingCatchupDeferralJobIds.size > 0
+      ? params.state.pendingCatchupDeferralJobIds
+      : undefined,
+  });
   await persist(params.state);
   armTimer(params.state);
 }
@@ -788,7 +806,12 @@ async function inspectManualRunPreflight(
     // Normalize job tick state (clears stale runningAtMs markers) before
     // checking if already running, so a stale marker from a crashed Phase-1
     // persist does not block manual triggers for up to STUCK_RUN_MS (#17554).
-    recomputeNextRunsForMaintenance(state);
+    // Exempt pending catchup deferrals (#93935).
+    recomputeNextRunsForMaintenance(state, {
+      skipFutureRepairJobIds: state.pendingCatchupDeferralJobIds.size > 0
+        ? state.pendingCatchupDeferralJobIds
+        : undefined,
+    });
     const job = findJobOrThrow(state, id);
     try {
       assertSupportedJobSpec(job);
@@ -1001,7 +1024,12 @@ async function finishPreparedManualRun(
         snapshot: postRunSnapshot,
         removed: postRunRemoved,
       });
-      recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+      recomputeNextRunsForMaintenance(state, {
+        recomputeExpired: true,
+        skipFutureRepairJobIds: state.pendingCatchupDeferralJobIds.size > 0
+          ? state.pendingCatchupDeferralJobIds
+          : undefined,
+      });
       await persist(state);
       finalized = true;
     });

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -209,6 +209,14 @@ export type CronServiceState = {
   pendingQuarantineConfigJobs: QuarantinedCronConfigJob[];
   lastQuarantineFailureWarnKey: string | null;
   storeLoadedAtMs: number | null;
+  /**
+   * Job IDs with a pending staggered catch-up deferral from startup overflow.
+   * These are exempt from `shouldRepairFutureCronNextRunAtMs` so that
+   * maintenance recomputes (read RPCs, finalize, empty-due ticks) do not
+   * advance their staggered `nextRunAtMs` to the natural next slot before
+   * the catch-up tick fires.
+   */
+  pendingCatchupDeferralJobIds: Set<string>;
 };
 
 /** Creates mutable cron service state with a concrete clock dependency. */
@@ -228,6 +236,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
     storeLoadedAtMs: null,
+    pendingCatchupDeferralJobIds: new Set<string>(),
   };
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1180,9 +1180,14 @@ export async function onTimer(state: CronServiceState) {
         // Use maintenance-only recompute to avoid advancing past-due nextRunAtMs
         // values without execution. This prevents jobs from being silently skipped
         // when the timer wakes up but findDueJobs returns empty (see #13992).
+        // Exempt pending catchup deferrals so staggered overflow slots survive
+        // empty-due maintenance ticks (#93935).
         const changed = recomputeNextRunsForMaintenance(state, {
           recomputeExpired: true,
           nowMs: dueCheckNow,
+          skipFutureRepairJobIds: state.pendingCatchupDeferralJobIds.size > 0
+            ? state.pendingCatchupDeferralJobIds
+            : undefined,
         });
         if (changed) {
           await persist(state);
@@ -1294,7 +1299,13 @@ export async function onTimer(state: CronServiceState) {
           // locked block.  The full recomputeNextRuns would silently skip
           // those jobs (advancing nextRunAtMs without execution), causing
           // daily cron schedules to jump 48 h instead of 24 h (#17852).
-          recomputeNextRunsForMaintenance(state);
+          // Exempt pending catchup deferrals so staggered overflow slots
+          // survive finalize recomputes (#93935).
+          recomputeNextRunsForMaintenance(state, {
+            skipFutureRepairJobIds: state.pendingCatchupDeferralJobIds.size > 0
+              ? state.pendingCatchupDeferralJobIds
+              : undefined,
+          });
           await persist(state);
         });
         finalizationSucceeded = finalizedResults.length > 0;


### PR DESCRIPTION
## Summary

Fixes the cron startup overflow catch-up deferral being silently dropped when any read RPC (`cron list`/`status`) or timer tick runs before the staggered catch-up slot fires.

When a cron job's startup catch-up overflows `maxMissedJobsPerRestart`, the deferred job's `nextRunAtMs` is advanced to its natural next slot (e.g., tomorrow 09:00 for a daily job) by any call to `recomputeNextRunsForMaintenance` — because the deferred job IDs were only passed as a local skip set in `start()`'s maintenance pass. All other callers ran with the default-enabled future-slot repair, clobbering the staggered slot.

## Related Issue

Fixes #93935

## Type of Change

- [x] Bug fix (non-breaking)

## Changes Made

- `src/cron/service/state.ts`: Add `pendingCatchupDeferralJobIds: Set<string>` to `CronServiceState` so deferred job IDs survive across maintenance calls
- `src/cron/service/ops.ts`: Persist deferred catchup IDs on state after `runMissedJobs`; pass `skipFutureRepairJobIds` from state in `ensureLoadedForRead`, `skipInvalidPersistedManualRun`, `inspectManualRunPreflight`, and `finishPreparedManualRun`
- `src/cron/service/timer.ts`: Pass `skipFutureRepairJobIds` from state in the empty-due maintenance tick and `finalizeCompletedResults`

## How to Test

1. Have more than `maxMissedJobsPerRestart` non-agentTurn cron jobs overdue after gateway downtime
2. Start the cron service — `runMissedJobs` defers overflow to `now + stagger`
3. Issue `cron list` or `cron status` before the staggered tick fires
4. Verify the deferred job's `nextRunAtMs` still points to the staggered slot, not the natural next slot

## Real behavior proof

- **Behavior addressed:** Cron startup overflow catch-up deferral silently dropped by read RPCs (cron list/status) and timer ticks, causing missed daily jobs to skip an entire period
- **Environment tested:** macOS 26.4.1, Node v24.3.0, OpenClaw worktree at `fix/cron-overflow-deferral-persist-v3`
- **Steps run after the patch:**
```
node scripts/run-vitest.mjs run src/cron/service.startup-overflow-clobber.test.ts src/cron/service/ops.regression.test.ts src/cron/service/timer.regression.test.ts src/cron/service.jobs.test.ts src/cron/service/ops.test.ts src/cron/service/state.test.ts
```
- **Evidence after fix:**
```
src/cron/service.jobs.test.ts (66 tests) — passed
src/cron/service.startup-overflow-clobber.test.ts (2 tests) — passed
src/cron/service/ops.regression.test.ts (9 tests) — passed
src/cron/service/timer.regression.test.ts (63 tests) — passed
src/cron/service/ops.test.ts (19 tests) — passed
src/cron/service/state.test.ts (2 tests) — passed
Total: 161 tests passed across 6 files
```
- **Observed result after fix:** All cron service tests pass. The `pendingCatchupDeferralJobIds` field is correctly propagated to all `recomputeNextRunsForMaintenance` call sites.
- **What was not tested:** Live gateway restart with real overflow scenario (requires >5 overdue cron jobs and gateway downtime). The fix follows the established pattern from #93810 and extends it to all callers.
