### PR TITLE
fix(opencode-go): streaming completes when provider ends responses

### DIFF
--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -18,10 +18,12 @@ interface FakeStreamController {
 function createFakeBaseStream(): {
   stream: StreamLike;
   controller: FakeStreamController;
+  getReturnCalls(): number;
 } {
   const queued: IteratorResult<AnyEvent>[] = [];
   const waiters: ((result: IteratorResult<AnyEvent>) => void)[] = [];
   let finished = false;
+  let returnCalls = 0;
 
   const iterator: AsyncIterator<AnyEvent> = {
     next(): Promise<IteratorResult<AnyEvent>> {
@@ -36,6 +38,7 @@ function createFakeBaseStream(): {
       });
     },
     return(): Promise<IteratorResult<AnyEvent>> {
+      returnCalls += 1;
       finished = true;
       while (waiters.length > 0) {
         waiters.shift()!({ value: undefined, done: true });
@@ -76,7 +79,7 @@ function createFakeBaseStream(): {
     },
   };
 
-  return { stream, controller };
+  return { stream, controller, getReturnCalls: () => returnCalls };
 }
 
 describe("createOpencodeGoStalledStreamWrapper", () => {
@@ -111,11 +114,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     });
 
     const downstream = await Promise.resolve(
-      wrapper(
-        { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
-        {} as any,
-        {} as any,
-      ),
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
     );
     expect(downstream).toBeDefined();
     if (!downstream) {
@@ -162,15 +161,8 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     await consumer;
   });
 
-  it("does not abort during slow time-to-first-byte (idle timer arms only after first event)", async () => {
-    // Regression for the timer-lifecycle bug: arming the idle timer before
-    // the first upstream event would abort slow time-to-first-byte requests
-    // (e.g. opencode-go cron runs that deliberately leave the runtime's
-    // first-event watchdog uncapped via resolveLlmIdleTimeoutMs). The
-    // wrapper must not arm its own idle timer until an upstream event has
-    // been observed and forwarded.
-    const { stream: baseStream, controller } = createFakeBaseStream();
-    void baseStream;
+  it("aborts and releases the underlying stream when no first event arrives", async () => {
+    const { stream: baseStream, getReturnCalls } = createFakeBaseStream();
     let abortCalled = false;
     const capturedSignals: AbortSignal[] = [];
 
@@ -190,11 +182,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     });
 
     const downstream = await Promise.resolve(
-      wrapper(
-        { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
-        {} as any,
-        {} as any,
-      ),
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
     );
     expect(downstream).toBeDefined();
     if (!downstream) {
@@ -208,16 +196,157 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
       }
     })();
 
-    // Advance wall clock well beyond idleTimeoutMs WITHOUT any upstream
-    // event. The wrapper must not have armed the timer yet.
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(6_000);
 
-    expect(abortCalled).toBe(false);
-    expect(received).toHaveLength(0);
+    expect(capturedSignals).toHaveLength(1);
+    expect(abortCalled).toBe(true);
+    expect(getReturnCalls()).toBe(1);
+    expect(
+      received.some((event) => event.type === "error" && (event as any).reason === "aborted"),
+    ).toBe(true);
 
-    // Cleanup
-    controller.end();
     await consumer;
+  });
+
+  it("aborts stream creation when the upstream stream promise never resolves", async () => {
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return new Promise<StreamLike>(() => undefined);
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream) {
+        received.push(event);
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    expect(abortCalled).toBe(true);
+    expect(
+      received.some((event) => event.type === "error" && (event as any).reason === "aborted"),
+    ).toBe(true);
+    await consumer;
+  });
+
+  it("aborts through the fallback combined signal when no first event arrives", async () => {
+    const originalAny = AbortSignal.any;
+    (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = undefined;
+    const { stream: baseStream } = createFakeBaseStream();
+    let abortCalled = false;
+
+    try {
+      const underlying = vi.fn((_model, _context, options) => {
+        if (options?.signal) {
+          options.signal.addEventListener("abort", () => {
+            abortCalled = true;
+          });
+        }
+        return baseStream;
+      });
+
+      const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+        provider: "opencode-go",
+        idleTimeoutMs: 5_000,
+      });
+
+      const downstream = await Promise.resolve(
+        wrapper(
+          { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+          {} as any,
+          { signal: new AbortController().signal } as any,
+        ),
+      );
+      expect(downstream).toBeDefined();
+      if (!downstream) {
+        return;
+      }
+
+      const consumer = (async () => {
+        for await (const _event of downstream) {
+          // drain
+        }
+      })();
+
+      await vi.advanceTimersByTimeAsync(6_000);
+
+      expect(abortCalled).toBe(true);
+      await consumer;
+    } finally {
+      (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = originalAny;
+    }
+  });
+
+  it("cleans up fallback AbortSignal listeners after natural completion", async () => {
+    const originalAny = AbortSignal.any;
+    (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = undefined;
+    const sourceController = new AbortController();
+    const addEventListener = vi.spyOn(sourceController.signal, "addEventListener");
+    const removeEventListener = vi.spyOn(sourceController.signal, "removeEventListener");
+    const { stream: baseStream, controller } = createFakeBaseStream();
+
+    try {
+      const wrapper = createOpencodeGoStalledStreamWrapper(vi.fn(() => baseStream) as any, {
+        provider: "opencode-go",
+        idleTimeoutMs: 5_000,
+      });
+
+      const downstream = await Promise.resolve(
+        wrapper(
+          { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+          {} as any,
+          { signal: sourceController.signal } as any,
+        ),
+      );
+      expect(downstream).toBeDefined();
+      if (!downstream) {
+        return;
+      }
+
+      const received: AnyEvent[] = [];
+      const consumer = (async () => {
+        for await (const event of downstream) {
+          received.push(event);
+        }
+      })();
+
+      const partial = {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        stopReason: "stop",
+      };
+      controller.emit({ type: "start", partial } as any);
+      controller.emit({ type: "done", reason: "stop", message: partial } as any);
+      await consumer;
+
+      expect(received.some((event) => event.type === "done")).toBe(true);
+      expect(addEventListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true });
+      expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = originalAny;
+      addEventListener.mockRestore();
+      removeEventListener.mockRestore();
+    }
   });
 
   it("preserves normal delayed usage-only completion without aborting", async () => {
@@ -245,11 +374,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     });
 
     const downstream = await Promise.resolve(
-      wrapper(
-        { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
-        {} as any,
-        {} as any,
-      ),
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
     );
     expect(downstream).toBeDefined();
     if (!downstream) {

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -18,7 +18,7 @@ interface FakeStreamController {
 function createFakeBaseStream(): {
   stream: StreamLike;
   controller: FakeStreamController;
-  getReturnCalls(): number;
+  getReturnCalls: () => number;
 } {
   const queued: IteratorResult<AnyEvent>[] = [];
   const waiters: ((result: IteratorResult<AnyEvent>) => void)[] = [];
@@ -80,6 +80,23 @@ function createFakeBaseStream(): {
   };
 
   return { stream, controller, getReturnCalls: () => returnCalls };
+}
+
+function disableAbortSignalAny(): PropertyDescriptor | undefined {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", {
+    configurable: true,
+    value: undefined,
+  });
+  return descriptor;
+}
+
+function restoreAbortSignalAny(descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(AbortSignal, "any", descriptor);
+  } else {
+    Reflect.deleteProperty(AbortSignal, "any");
+  }
 }
 
 describe("createOpencodeGoStalledStreamWrapper", () => {
@@ -189,8 +206,8 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     }
 
     const consumer = (async () => {
-      for await (const _event of downstream) {
-        // drain
+      for await (const event of downstream) {
+        void event;
       }
     })();
 
@@ -303,8 +320,8 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     }
 
     const consumer = (async () => {
-      for await (const _event of downstream) {
-        // drain
+      for await (const event of downstream) {
+        void event;
       }
     })();
 
@@ -379,7 +396,9 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
           abortCalled = true;
         });
       }
-      return new Promise<StreamLike>(() => undefined);
+      return new Promise<StreamLike>(() => {
+        // keep pending
+      });
     });
 
     const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
@@ -412,8 +431,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
   });
 
   it("aborts through the fallback combined signal when no first event arrives", async () => {
-    const originalAny = AbortSignal.any;
-    (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = undefined;
+    const abortSignalAnyDescriptor = disableAbortSignalAny();
     const { stream: baseStream } = createFakeBaseStream();
     let abortCalled = false;
 
@@ -445,8 +463,8 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
       }
 
       const consumer = (async () => {
-        for await (const _event of downstream) {
-          // drain
+        for await (const event of downstream) {
+          void event;
         }
       })();
 
@@ -455,13 +473,12 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
       expect(abortCalled).toBe(true);
       await consumer;
     } finally {
-      (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = originalAny;
+      restoreAbortSignalAny(abortSignalAnyDescriptor);
     }
   });
 
   it("cleans up fallback AbortSignal listeners after natural completion", async () => {
-    const originalAny = AbortSignal.any;
-    (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = undefined;
+    const abortSignalAnyDescriptor = disableAbortSignalAny();
     const sourceController = new AbortController();
     const addEventListener = vi.spyOn(sourceController.signal, "addEventListener");
     const removeEventListener = vi.spyOn(sourceController.signal, "removeEventListener");
@@ -505,7 +522,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
       expect(addEventListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true });
       expect(removeEventListener).toHaveBeenCalledWith("abort", expect.any(Function));
     } finally {
-      (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = originalAny;
+      restoreAbortSignalAny(abortSignalAnyDescriptor);
       addEventListener.mockRestore();
       removeEventListener.mockRestore();
     }

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -161,6 +161,99 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     await consumer;
   });
 
+  it("uses a longer first-event timeout than the inter-event idle timeout", async () => {
+    const { stream: baseStream } = createFakeBaseStream();
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+      firstEventTimeoutMs: 10_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const consumer = (async () => {
+      for await (const _event of downstream) {
+        // drain
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(abortCalled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(abortCalled).toBe(true);
+    await consumer;
+  });
+
+  it("honors explicit opencode-go provider request timeout above the wrapper idle default", async () => {
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+      firstEventTimeoutMs: 5_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper(
+        { provider: "opencode-go", id: "deepseek-v4-flash", requestTimeoutMs: 10_000 } as any,
+        {} as any,
+        {} as any,
+      ),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const consumer = (async () => {
+      for await (const _event of downstream) {
+        // drain
+      }
+    })();
+
+    const partial = {
+      role: "assistant",
+      content: [{ type: "text", text: "slow" }],
+      stopReason: undefined,
+    };
+    controller.emit({ type: "start", partial } as any);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(abortCalled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(abortCalled).toBe(true);
+    await consumer;
+  });
+
   it("aborts and releases the underlying stream when no first event arrives", async () => {
     const { stream: baseStream, getReturnCalls } = createFakeBaseStream();
     let abortCalled = false;

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -169,9 +169,13 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
 
     // And it pushed a terminal error event to the downstream consumer.
     const terminal = received.find(
-      (event) => event.type === "error" && (event as any).reason === "aborted",
+      (event) => event.type === "error" && (event as any).reason === "error",
     );
     expect(terminal).toBeDefined();
+    expect((terminal as any)?.error).toMatchObject({
+      stopReason: "error",
+      errorMessage: "opencode-go stream timed out after provider-owned SSE boundary stalled",
+    });
 
     // Cleanup: end base stream so consumer promise resolves.
     controller.end();
@@ -487,7 +491,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     expect(abortCalled).toBe(true);
     expect(getReturnCalls()).toBe(1);
     expect(
-      received.some((event) => event.type === "error" && (event as any).reason === "aborted"),
+      received.some((event) => event.type === "error" && (event as any).reason === "error"),
     ).toBe(true);
 
     await consumer;
@@ -531,7 +535,7 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
 
     expect(abortCalled).toBe(true);
     expect(
-      received.some((event) => event.type === "error" && (event as any).reason === "aborted"),
+      received.some((event) => event.type === "error" && (event as any).reason === "error"),
     ).toBe(true);
     await consumer;
   });

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -1,0 +1,234 @@
+// Opencode Go stream termination wrapper tests cover provider-owned raw SSE
+// boundary behavior for stalled OpenAI-compatible streams.
+import type {
+  AssistantMessageEvent,
+  AssistantMessageEventStreamContract,
+} from "openclaw/plugin-sdk/llm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpencodeGoStalledStreamWrapper } from "./stream-termination.js";
+
+type AnyEvent = AssistantMessageEvent;
+type StreamLike = AssistantMessageEventStreamContract;
+
+interface FakeStreamController {
+  emit(event: AnyEvent): void;
+  end(): void;
+}
+
+function createFakeBaseStream(): {
+  stream: StreamLike;
+  controller: FakeStreamController;
+} {
+  const queued: IteratorResult<AnyEvent>[] = [];
+  const waiters: ((result: IteratorResult<AnyEvent>) => void)[] = [];
+  let finished = false;
+
+  const iterator: AsyncIterator<AnyEvent> = {
+    next(): Promise<IteratorResult<AnyEvent>> {
+      if (queued.length > 0) {
+        return Promise.resolve(queued.shift()!);
+      }
+      if (finished) {
+        return Promise.resolve({ value: undefined, done: true });
+      }
+      return new Promise((resolve) => {
+        waiters.push(resolve);
+      });
+    },
+    return(): Promise<IteratorResult<AnyEvent>> {
+      finished = true;
+      while (waiters.length > 0) {
+        waiters.shift()!({ value: undefined, done: true });
+      }
+      return Promise.resolve({ value: undefined, done: true });
+    },
+  };
+
+  const stream: StreamLike = {
+    [Symbol.asyncIterator]() {
+      return iterator;
+    },
+    push() {
+      // unused: the wrapper pushes its own events into a separate stream.
+    },
+    end() {
+      // unused: the wrapper ends its own stream.
+    },
+    result() {
+      return Promise.reject(new Error("fake base stream result not used"));
+    },
+  };
+
+  const controller: FakeStreamController = {
+    emit(event: AnyEvent) {
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter({ value: event, done: false });
+      } else {
+        queued.push({ value: event, done: false });
+      }
+    },
+    end() {
+      finished = true;
+      while (waiters.length > 0) {
+        waiters.shift()!({ value: undefined, done: true });
+      }
+    },
+  };
+
+  return { stream, controller };
+}
+
+describe("createOpencodeGoStalledStreamWrapper", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aborts underlying stream when progress stalls after first delta (raw SSE boundary)", async () => {
+    // Arrange: a fake base stream that emits a start + one text_delta, then stalls.
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    void baseStream;
+    let abortCalled = false;
+    const capturedSignals: AbortSignal[] = [];
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        capturedSignals.push(options.signal);
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+    });
+
+    const downstream = wrapper(
+      { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+      {} as any,
+      {} as any,
+    );
+    expect(downstream).toBeDefined();
+
+    // Drain wrapper events in the background.
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream!) {
+        received.push(event);
+      }
+    })();
+
+    // Emit a start + one text delta — that proves the provider side has produced tokens.
+    const partial = {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      stopReason: undefined,
+    };
+    controller.emit({ type: "start", partial } as any);
+    controller.emit({
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "hi",
+      partial,
+    } as any);
+
+    // Advance wall clock beyond idleTimeoutMs without any new progress.
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    // Assert: wrapper called abort on its injected AbortController (forwarded as options.signal).
+    expect(capturedSignals).toHaveLength(1);
+    expect(abortCalled).toBe(true);
+
+    // And it pushed a terminal error event to the downstream consumer.
+    const terminal = received.find(
+      (event) => event.type === "error" && (event as any).reason === "aborted",
+    );
+    expect(terminal).toBeDefined();
+
+    // Cleanup: end base stream so consumer promise resolves.
+    controller.end();
+    await consumer;
+  });
+
+  it("preserves normal delayed usage-only completion without aborting", async () => {
+    // Arrange: a fake base stream that streams a normal completion, including
+    // a long quiet gap before the final usage-only delta — but well within the
+    // idle timeout. The wrapper must not abort.
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    void baseStream;
+    let abortCalled = false;
+    const capturedSignals: AbortSignal[] = [];
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        capturedSignals.push(options.signal);
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+    });
+
+    const downstream = wrapper(
+      { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+      {} as any,
+      {} as any,
+    );
+    expect(downstream).toBeDefined();
+
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream!) {
+        received.push(event);
+      }
+    })();
+
+    const partial = {
+      role: "assistant",
+      content: [{ type: "text", text: "hello" }],
+      stopReason: "stop",
+    };
+    controller.emit({ type: "start", partial } as any);
+    controller.emit({
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "hello",
+      partial,
+    } as any);
+
+    // Simulate a delayed final chunk after a short (sub-timeout) quiet gap.
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    // Final completion event arrives before idle timeout fires.
+    controller.emit({
+      type: "done",
+      reason: "stop",
+      message: partial,
+    } as any);
+
+    // Advance well past the idle timeout — wrapper should NOT have fired.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(abortCalled).toBe(false);
+
+    // Downstream must contain all forwarded events including the done event.
+    const doneEvent = received.find((event) => event.type === "done");
+    expect(doneEvent).toBeDefined();
+
+    // Cleanup
+    controller.end();
+    await consumer;
+  });
+});

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -110,17 +110,22 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
       idleTimeoutMs: 5_000,
     });
 
-    const downstream = wrapper(
-      { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
-      {} as any,
-      {} as any,
+    const downstream = await Promise.resolve(
+      wrapper(
+        { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+        {} as any,
+        {} as any,
+      ),
     );
     expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
 
     // Drain wrapper events in the background.
     const received: AnyEvent[] = [];
     const consumer = (async () => {
-      for await (const event of downstream!) {
+      for await (const event of downstream) {
         received.push(event);
       }
     })();
@@ -181,16 +186,21 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
       idleTimeoutMs: 5_000,
     });
 
-    const downstream = wrapper(
-      { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
-      {} as any,
-      {} as any,
+    const downstream = await Promise.resolve(
+      wrapper(
+        { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+        {} as any,
+        {} as any,
+      ),
     );
     expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
 
     const received: AnyEvent[] = [];
     const consumer = (async () => {
-      for await (const event of downstream!) {
+      for await (const event of downstream) {
         received.push(event);
       }
     })();

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -288,6 +288,70 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     expect(received.some((event) => event.type === "done")).toBe(true);
   });
 
+  it("keeps the first-event window after synthetic block-start events until a provider delta", async () => {
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+      firstEventTimeoutMs: 10_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream) {
+        received.push(event);
+      }
+    })();
+
+    const partial = {
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      stopReason: undefined,
+    };
+    controller.emit({ type: "start", partial } as any);
+    controller.emit({ type: "text_start", contentIndex: 0, partial } as any);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(abortCalled).toBe(false);
+
+    const message = {
+      ...partial,
+      content: [{ type: "text", text: "hello" }],
+      stopReason: "stop",
+    };
+    controller.emit({
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "hello",
+      partial: message,
+    } as any);
+    controller.emit({ type: "done", reason: "stop", message } as any);
+    await consumer;
+
+    expect(abortCalled).toBe(false);
+    expect(received.some((event) => event.type === "text_delta")).toBe(true);
+    expect(received.some((event) => event.type === "done")).toBe(true);
+  });
+
   it("honors explicit opencode-go provider request timeout above the wrapper idle default", async () => {
     const { stream: baseStream, controller } = createFakeBaseStream();
     let abortCalled = false;
@@ -336,6 +400,48 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     expect(abortCalled).toBe(false);
 
     await vi.advanceTimersByTimeAsync(5_000);
+    expect(abortCalled).toBe(true);
+    await consumer;
+  });
+
+  it("honors explicit opencode-go provider request timeout below wrapper defaults", async () => {
+    const { stream: baseStream } = createFakeBaseStream();
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+      firstEventTimeoutMs: 10_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper(
+        { provider: "opencode-go", id: "deepseek-v4-flash", requestTimeoutMs: 2_000 } as any,
+        {} as any,
+        {} as any,
+      ),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const consumer = (async () => {
+      for await (const event of downstream) {
+        void event;
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(2_500);
     expect(abortCalled).toBe(true);
     await consumer;
   });

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -202,6 +202,75 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     await consumer;
   });
 
+  it("keeps the first-event window after an openai-completions synthetic start", async () => {
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    let abortCalled = false;
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+      firstEventTimeoutMs: 10_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper({ provider: "opencode-go", id: "deepseek-v4-flash" } as any, {} as any, {} as any),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream) {
+        received.push(event);
+      }
+    })();
+
+    const partial = {
+      role: "assistant",
+      content: [],
+      stopReason: undefined,
+    };
+    controller.emit({ type: "start", partial } as any);
+
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect(abortCalled).toBe(false);
+
+    controller.emit({
+      type: "text_delta",
+      contentIndex: 0,
+      delta: "hello",
+      partial: {
+        ...partial,
+        content: [{ type: "text", text: "hello" }],
+      },
+    } as any);
+    controller.emit({
+      type: "done",
+      reason: "stop",
+      message: {
+        ...partial,
+        content: [{ type: "text", text: "hello" }],
+        stopReason: "stop",
+      },
+    } as any);
+    await consumer;
+
+    expect(abortCalled).toBe(false);
+    expect(received.some((event) => event.type === "text_delta")).toBe(true);
+    expect(received.some((event) => event.type === "done")).toBe(true);
+  });
+
   it("honors explicit opencode-go provider request timeout above the wrapper idle default", async () => {
     const { stream: baseStream, controller } = createFakeBaseStream();
     let abortCalled = false;

--- a/extensions/opencode-go/stream-termination.test.ts
+++ b/extensions/opencode-go/stream-termination.test.ts
@@ -162,6 +162,64 @@ describe("createOpencodeGoStalledStreamWrapper", () => {
     await consumer;
   });
 
+  it("does not abort during slow time-to-first-byte (idle timer arms only after first event)", async () => {
+    // Regression for the timer-lifecycle bug: arming the idle timer before
+    // the first upstream event would abort slow time-to-first-byte requests
+    // (e.g. opencode-go cron runs that deliberately leave the runtime's
+    // first-event watchdog uncapped via resolveLlmIdleTimeoutMs). The
+    // wrapper must not arm its own idle timer until an upstream event has
+    // been observed and forwarded.
+    const { stream: baseStream, controller } = createFakeBaseStream();
+    void baseStream;
+    let abortCalled = false;
+    const capturedSignals: AbortSignal[] = [];
+
+    const underlying = vi.fn((_model, _context, options) => {
+      if (options?.signal) {
+        capturedSignals.push(options.signal);
+        options.signal.addEventListener("abort", () => {
+          abortCalled = true;
+        });
+      }
+      return baseStream;
+    });
+
+    const wrapper = createOpencodeGoStalledStreamWrapper(underlying as any, {
+      provider: "opencode-go",
+      idleTimeoutMs: 5_000,
+    });
+
+    const downstream = await Promise.resolve(
+      wrapper(
+        { provider: "opencode-go", id: "deepseek-v4-flash" } as any,
+        {} as any,
+        {} as any,
+      ),
+    );
+    expect(downstream).toBeDefined();
+    if (!downstream) {
+      return;
+    }
+
+    const received: AnyEvent[] = [];
+    const consumer = (async () => {
+      for await (const event of downstream) {
+        received.push(event);
+      }
+    })();
+
+    // Advance wall clock well beyond idleTimeoutMs WITHOUT any upstream
+    // event. The wrapper must not have armed the timer yet.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(abortCalled).toBe(false);
+    expect(received).toHaveLength(0);
+
+    // Cleanup
+    controller.end();
+    await consumer;
+  });
+
   it("preserves normal delayed usage-only completion without aborting", async () => {
     // Arrange: a fake base stream that streams a normal completion, including
     // a long quiet gap before the final usage-only delta — but well within the

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -101,25 +101,25 @@ function combineAbortSignals(signals: (AbortSignal | undefined)[]): {
   };
 }
 
-function buildAbortedErrorEvent(partial: AssistantMessage | undefined): AssistantMessageEvent {
+const STALLED_STREAM_ERROR_MESSAGE =
+  "opencode-go stream timed out after provider-owned SSE boundary stalled";
+
+function buildStalledErrorEvent(partial: AssistantMessage | undefined): AssistantMessageEvent {
   if (partial) {
     return {
       type: "error",
-      reason: "aborted",
+      reason: "error",
       error: {
         ...partial,
-        stopReason: "aborted",
-        errorMessage: "opencode-go stream stalled; aborted at provider-owned SSE boundary",
+        stopReason: "error",
+        errorMessage: STALLED_STREAM_ERROR_MESSAGE,
       },
     };
   }
   return {
     type: "error",
-    reason: "aborted",
-    error: synthesizeMinimalAssistantMessage(
-      "opencode-go stream stalled; aborted at provider-owned SSE boundary",
-      "aborted",
-    ),
+    reason: "error",
+    error: synthesizeMinimalAssistantMessage(STALLED_STREAM_ERROR_MESSAGE, "error"),
   };
 }
 
@@ -287,7 +287,7 @@ export function createOpencodeGoStalledStreamWrapper(
       controller.abort(new Error("opencode-go stream stalled"));
       combinedSignal.cleanup();
       releaseBaseStream();
-      output.push(buildAbortedErrorEvent(lastSeenPartial));
+      output.push(buildStalledErrorEvent(lastSeenPartial));
       output.end();
     };
 

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -1,10 +1,7 @@
 // Opencode Go stream termination wrapper aborts stalled OpenAI-compatible
 // SSE streams at the provider-owned raw boundary, before the shared runtime
 // stuck-session recovery kicks in.
-import type {
-  AssistantMessage,
-  AssistantMessageEvent,
-} from "openclaw/plugin-sdk/llm";
+import type { AssistantMessage, AssistantMessageEvent } from "openclaw/plugin-sdk/llm";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 
@@ -40,26 +37,30 @@ function isOpencodeGoModel(model: unknown, providerId: string): boolean {
     : false;
 }
 
-function combineAbortSignals(signals: (AbortSignal | undefined)[]): AbortSignal {
+function combineAbortSignals(signals: (AbortSignal | undefined)[]): {
+  signal: AbortSignal;
+  cleanup(): void;
+} {
   const present = signals.filter((signal): signal is AbortSignal => Boolean(signal));
   if (present.length === 0) {
-    return new AbortController().signal;
+    return { signal: new AbortController().signal, cleanup: () => undefined };
   }
   if (present.length === 1) {
-    return present[0];
+    return { signal: present[0], cleanup: () => undefined };
   }
-  // Prefer the platform combiner when available; otherwise subscribe manually.
-  const anyFn = (AbortSignal as unknown as {
-    any?: (signals: AbortSignal[]) => AbortSignal;
-  }).any;
+  const anyFn = (
+    AbortSignal as unknown as {
+      any?: (signals: AbortSignal[]) => AbortSignal;
+    }
+  ).any;
   if (typeof anyFn === "function") {
-    return anyFn(present);
+    return { signal: anyFn(present), cleanup: () => undefined };
   }
   const controller = new AbortController();
   const alreadyAborted = present.find((signal) => signal.aborted);
   if (alreadyAborted) {
     controller.abort((alreadyAborted as { reason?: unknown }).reason);
-    return controller.signal;
+    return { signal: controller.signal, cleanup: () => undefined };
   }
   const unsubscribe: Array<() => void> = [];
   for (const signal of present) {
@@ -67,7 +68,15 @@ function combineAbortSignals(signals: (AbortSignal | undefined)[]): AbortSignal 
     signal.addEventListener("abort", onAbort, { once: true });
     unsubscribe.push(() => signal.removeEventListener("abort", onAbort));
   }
-  return controller.signal;
+  return {
+    signal: controller.signal,
+    cleanup() {
+      for (const remove of unsubscribe) {
+        remove();
+      }
+      unsubscribe.length = 0;
+    },
+  };
 }
 
 function buildAbortedErrorEvent(partial: AssistantMessage | undefined): AssistantMessageEvent {
@@ -92,9 +101,7 @@ function buildAbortedErrorEvent(partial: AssistantMessage | undefined): Assistan
   };
 }
 
-function buildUnterminatedErrorEvent(
-  partial: AssistantMessage | undefined,
-): AssistantMessageEvent {
+function buildUnterminatedErrorEvent(partial: AssistantMessage | undefined): AssistantMessageEvent {
   if (partial) {
     return {
       type: "error",
@@ -149,7 +156,14 @@ function synthesizeMinimalAssistantMessage(
     api: "openai-completions",
     provider: "opencode-go",
     model: "",
-    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
     stopReason,
     errorMessage,
     timestamp: Date.now(),
@@ -158,17 +172,18 @@ function synthesizeMinimalAssistantMessage(
 
 /**
  * Wraps an opencode-go provider stream function so that an SSE socket that
- * produces tokens and then silently stalls is aborted at the provider-owned
- * raw boundary via the injected AbortSignal, instead of waiting for the much
- * later shared runtime stuck-session recovery.
+ * fails to deliver a first event or stops producing progress is aborted at the
+ * provider-owned raw boundary via the injected AbortSignal, instead of waiting
+ * for the much later shared runtime stuck-session recovery.
  *
  * Behavior:
  * - Provider-scoped: only applies when `model.provider === options.provider`.
- * - Idle-based: every event forwarded from the underlying stream refreshes
- *   the idle timer; if no event arrives within `idleTimeoutMs`, the wrapper
- *   calls `controller.abort()` on the AbortSignal injected into the
- *   underlying call (so the OpenAI SDK request is genuinely interrupted, not
- *   just the iterator) and pushes a terminal `error` event downstream.
+ * - Idle-based: the timer covers stream creation, first event delivery, and
+ *   every gap between forwarded events; if no event arrives within
+ *   `idleTimeoutMs`, the wrapper calls `controller.abort()` on the AbortSignal
+ *   injected into the underlying call (so the OpenAI SDK request is genuinely
+ *   interrupted, not just the iterator) and pushes a terminal `error` event
+ *   downstream.
  * - Terminal-safe: when the underlying stream emits `done` or `error`, the
  *   wrapper forwards the event, clears all timers, and ends the stream.
  *
@@ -181,9 +196,7 @@ export function createOpencodeGoStalledStreamWrapper(
   options: OpencodeGoStalledStreamWrapperOptions,
 ): ProviderStreamFn {
   if (!options || options.idleTimeoutMs <= 0) {
-    throw new Error(
-      "createOpencodeGoStalledStreamWrapper requires idleTimeoutMs > 0",
-    );
+    throw new Error("createOpencodeGoStalledStreamWrapper requires idleTimeoutMs > 0");
   }
   const providerId = options.provider;
   const idleTimeoutMs = options.idleTimeoutMs;
@@ -193,115 +206,133 @@ export function createOpencodeGoStalledStreamWrapper(
       return underlying(model, context, callOptions);
     }
 
+    const output = createAssistantMessageEventStream();
     const controller = new AbortController();
-    const injectedSignal = combineAbortSignals([
+    const combinedSignal = combineAbortSignals([
       (callOptions as { signal?: AbortSignal } | undefined)?.signal,
       controller.signal,
     ]);
     const wrappedOptions = {
       ...callOptions,
-      signal: injectedSignal,
+      signal: combinedSignal.signal,
+    };
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let lastSeenPartial: AssistantMessage | undefined;
+    let settled = false;
+    let baseIterator: AsyncIterator<AssistantMessageEvent> | undefined;
+
+    const clearIdleTimer = () => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
     };
 
-    const baseStreamResult = underlying(model, context, wrappedOptions);
+    const cleanup = () => {
+      clearIdleTimer();
+      combinedSignal.cleanup();
+    };
 
-    const attach = (baseStream: AsyncIterable<AssistantMessageEvent>) => {
-      const output = createAssistantMessageEventStream();
-      let idleTimer: ReturnType<typeof setTimeout> | undefined;
-      let lastSeenPartial: AssistantMessage | undefined;
-      let settled = false;
-      let underlyingDone = false;
+    const releaseBaseStream = () => {
+      if (baseIterator?.return) {
+        void Promise.resolve(baseIterator.return()).catch(() => undefined);
+      }
+    };
 
-      const clearIdleTimer = () => {
-        if (idleTimer !== undefined) {
-          clearTimeout(idleTimer);
-          idleTimer = undefined;
+    const finishWith = (event: AssistantMessageEvent) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      output.push(event);
+      output.end(
+        event.type === "done" ? (event as { message: AssistantMessage }).message : undefined,
+      );
+    };
+
+    const abortStalledStream = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearIdleTimer();
+      controller.abort(new Error("opencode-go stream stalled"));
+      combinedSignal.cleanup();
+      releaseBaseStream();
+      output.push(buildAbortedErrorEvent(lastSeenPartial));
+      output.end();
+    };
+
+    const armIdleTimer = () => {
+      clearIdleTimer();
+      idleTimer = setTimeout(abortStalledStream, idleTimeoutMs);
+      idleTimer.unref?.();
+    };
+
+    const trackPartial = (event: AssistantMessageEvent) => {
+      const partial =
+        (event as { partial?: AssistantMessage; message?: AssistantMessage }).partial ??
+        (event as { message?: AssistantMessage }).message;
+      if (partial) {
+        lastSeenPartial = partial;
+      }
+    };
+
+    const releaseResolvedStream = (baseStream: AsyncIterable<AssistantMessageEvent>) => {
+      const iterator = baseStream[Symbol.asyncIterator]();
+      if (iterator.return) {
+        void Promise.resolve(iterator.return()).catch(() => undefined);
+      }
+    };
+
+    armIdleTimer();
+    let baseStreamResult: ReturnType<ProviderStreamFn>;
+    try {
+      baseStreamResult = underlying(model, context, wrappedOptions);
+    } catch (error) {
+      cleanup();
+      throw error;
+    }
+
+    void (async () => {
+      try {
+        const baseStream = await Promise.resolve(
+          baseStreamResult as Awaited<ReturnType<ProviderStreamFn>>,
+        );
+        if (settled) {
+          releaseResolvedStream(baseStream as AsyncIterable<AssistantMessageEvent>);
+          return;
         }
-      };
-
-      const armIdleTimer = () => {
-        clearIdleTimer();
-        idleTimer = setTimeout(() => {
+        baseIterator = (baseStream as AsyncIterable<AssistantMessageEvent>)[Symbol.asyncIterator]();
+        for (;;) {
+          const result = await baseIterator.next();
           if (settled) {
             return;
           }
-          settled = true;
-          clearIdleTimer();
-          try {
-            controller.abort(new Error("opencode-go stream stalled"));
-          } catch {
-            // AbortController.abort never throws in spec; ignore defensively.
-          }
-          output.push(buildAbortedErrorEvent(lastSeenPartial));
-          output.end();
-        }, idleTimeoutMs);
-      };
-
-      const finishWith = (event: AssistantMessageEvent) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearIdleTimer();
-        output.push(event);
-        output.end(event.type === "done" ? (event as { message: AssistantMessage }).message : undefined);
-      };
-
-      const trackPartial = (event: AssistantMessageEvent) => {
-        const partial = (event as { partial?: AssistantMessage; message?: AssistantMessage }).partial
-          ?? (event as { message?: AssistantMessage }).message;
-        if (partial) {
-          lastSeenPartial = partial;
-        }
-      };
-
-      void (async () => {
-        try {
-          // Arm the idle timer only AFTER the first upstream event. The
-          // reported bug is a stall AFTER provider progress, and arming
-          // earlier would abort slow time-to-first-byte requests that the
-          // runtime deliberately leaves uncapped for cron runs
-          // (`resolveLlmIdleTimeoutMs` returns 0 for cron without explicit
-          // timeout). The runtime's own first-event timeout governs the
-          // pre-progress window.
-          for await (const event of baseStream) {
-            if (event.type === "done" || event.type === "error") {
-              trackPartial(event);
-              underlyingDone = true;
-              finishWith(event);
-              return;
-            }
-            trackPartial(event);
-            output.push(event);
-            // Refresh the idle window: any forward-progress (text delta,
-            // tool delta, thinking delta, usage-only chunk, etc.) means the
-            // underlying SSE is still alive.
-            armIdleTimer();
-          }
-          if (!underlyingDone && !settled) {
-            // Underlying iterator ended without an explicit terminal event.
-            // Surface it as an error so downstream consumers do not hang.
+          if (result.done) {
             finishWith(buildUnterminatedErrorEvent(lastSeenPartial));
+            return;
           }
-        } catch (error) {
-          if (!settled) {
-            finishWith(buildCaughtErrorEvent(lastSeenPartial, error));
+          const event = result.value;
+          if (event.type === "done" || event.type === "error") {
+            trackPartial(event);
+            finishWith(event);
+            return;
           }
-        } finally {
-          clearIdleTimer();
+          trackPartial(event);
+          output.push(event);
+          armIdleTimer();
         }
-      })();
+      } catch (error) {
+        if (!settled) {
+          finishWith(buildCaughtErrorEvent(lastSeenPartial, error));
+        }
+      } finally {
+        cleanup();
+      }
+    })();
 
-      return output;
-    };
-
-    if (
-      baseStreamResult &&
-      typeof baseStreamResult === "object" &&
-      "then" in baseStreamResult
-    ) {
-      return Promise.resolve(baseStreamResult).then(attach) as ReturnType<ProviderStreamFn>;
-    }
-    return attach(baseStreamResult as AsyncIterable<AssistantMessageEvent>);
+    return output;
   };
 }

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -48,9 +48,14 @@ function validTimeoutMs(value: unknown): number | undefined {
 }
 
 function resolveTimeoutMs(model: unknown, fallbackMs: number): number {
-  return Math.max(
-    validTimeoutMs((model as { requestTimeoutMs?: unknown })?.requestTimeoutMs) ?? 0,
-    fallbackMs,
+  return validTimeoutMs((model as { requestTimeoutMs?: unknown })?.requestTimeoutMs) ?? fallbackMs;
+}
+
+function isProviderProgressEvent(event: AssistantMessageEvent): boolean {
+  return (
+    event.type === "text_delta" ||
+    event.type === "thinking_delta" ||
+    event.type === "toolcall_delta"
   );
 }
 
@@ -348,7 +353,7 @@ export function createOpencodeGoStalledStreamWrapper(
           }
           trackPartial(event);
           output.push(event);
-          if (event.type !== "start") {
+          if (isProviderProgressEvent(event)) {
             armIdleTimer();
           }
         }

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -24,11 +24,15 @@ export interface OpencodeGoStalledStreamWrapperOptions {
 }
 
 /**
- * Default idle window used in production. Tuned to be far above normal
- * delayed usage-only chunk gaps (sub-second) and far below the runtime's
- * stuck-session recovery (~622s) so provider-owned termination wins.
+ * Default idle window used in production. Matches the runtime's shared
+ * `DEFAULT_LLM_IDLE_TIMEOUT_MS` (120s) so non-cron interactive runs see
+ * no behavior change versus the existing watchdog, while cron runs — for
+ * which the runtime disables its idle watchdog entirely
+ * (`resolveLlmIdleTimeoutMs` returns 0 when `trigger === "cron"` and no
+ * explicit timeout is set) — finally get a provider-owned termination
+ * well before the ~622s stuck-session recovery kicks in.
  */
-export const OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT = 30_000;
+export const OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT = 120_000;
 
 function isOpencodeGoModel(model: unknown, providerId: string): boolean {
   return Boolean(model) && typeof model === "object"

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -257,7 +257,13 @@ export function createOpencodeGoStalledStreamWrapper(
 
       void (async () => {
         try {
-          armIdleTimer();
+          // Arm the idle timer only AFTER the first upstream event. The
+          // reported bug is a stall AFTER provider progress, and arming
+          // earlier would abort slow time-to-first-byte requests that the
+          // runtime deliberately leaves uncapped for cron runs
+          // (`resolveLlmIdleTimeoutMs` returns 0 for cron without explicit
+          // timeout). The runtime's own first-event timeout governs the
+          // pre-progress window.
           for await (const event of baseStream) {
             if (event.type === "done" || event.type === "error") {
               trackPartial(event);

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -1,0 +1,297 @@
+// Opencode Go stream termination wrapper aborts stalled OpenAI-compatible
+// SSE streams at the provider-owned raw boundary, before the shared runtime
+// stuck-session recovery kicks in.
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+} from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+
+type ProviderStreamFn = NonNullable<ProviderWrapStreamFnContext["streamFn"]>;
+
+export interface OpencodeGoStalledStreamWrapperOptions {
+  /**
+   * Provider id this wrapper applies to. Calls whose model.provider does not
+   * match are forwarded untouched so the wrapper stays provider-scoped.
+   */
+  provider: string;
+  /**
+   * Maximum idle window between two stream events before the wrapper treats
+   * the underlying SSE as stalled and aborts it. Must be > 0.
+   */
+  idleTimeoutMs: number;
+}
+
+/**
+ * Default idle window used in production. Tuned to be far above normal
+ * delayed usage-only chunk gaps (sub-second) and far below the runtime's
+ * stuck-session recovery (~622s) so provider-owned termination wins.
+ */
+export const OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT = 30_000;
+
+function isOpencodeGoModel(model: unknown, providerId: string): boolean {
+  return Boolean(model) && typeof model === "object"
+    ? (model as { provider?: unknown }).provider === providerId
+    : false;
+}
+
+function combineAbortSignals(signals: (AbortSignal | undefined)[]): AbortSignal {
+  const present = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (present.length === 0) {
+    return new AbortController().signal;
+  }
+  if (present.length === 1) {
+    return present[0];
+  }
+  // Prefer the platform combiner when available; otherwise subscribe manually.
+  const anyFn = (AbortSignal as unknown as {
+    any?: (signals: AbortSignal[]) => AbortSignal;
+  }).any;
+  if (typeof anyFn === "function") {
+    return anyFn(present);
+  }
+  const controller = new AbortController();
+  const alreadyAborted = present.find((signal) => signal.aborted);
+  if (alreadyAborted) {
+    controller.abort((alreadyAborted as { reason?: unknown }).reason);
+    return controller.signal;
+  }
+  const unsubscribe: Array<() => void> = [];
+  for (const signal of present) {
+    const onAbort = () => controller.abort((signal as { reason?: unknown }).reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    unsubscribe.push(() => signal.removeEventListener("abort", onAbort));
+  }
+  return controller.signal;
+}
+
+function buildAbortedErrorEvent(partial: AssistantMessage | undefined): AssistantMessageEvent {
+  if (partial) {
+    return {
+      type: "error",
+      reason: "aborted",
+      error: {
+        ...partial,
+        stopReason: "aborted",
+        errorMessage: "opencode-go stream stalled; aborted at provider-owned SSE boundary",
+      },
+    };
+  }
+  return {
+    type: "error",
+    reason: "aborted",
+    error: synthesizeMinimalAssistantMessage(
+      "opencode-go stream stalled; aborted at provider-owned SSE boundary",
+      "aborted",
+    ),
+  };
+}
+
+function buildUnterminatedErrorEvent(
+  partial: AssistantMessage | undefined,
+): AssistantMessageEvent {
+  if (partial) {
+    return {
+      type: "error",
+      reason: "error",
+      error: {
+        ...partial,
+        stopReason: "error",
+        errorMessage: "opencode-go stream ended without a terminal event",
+      },
+    };
+  }
+  return {
+    type: "error",
+    reason: "error",
+    error: synthesizeMinimalAssistantMessage(
+      "opencode-go stream ended without a terminal event",
+      "error",
+    ),
+  };
+}
+
+function buildCaughtErrorEvent(
+  partial: AssistantMessage | undefined,
+  error: unknown,
+): AssistantMessageEvent {
+  const message = error instanceof Error ? error.message : String(error);
+  if (partial) {
+    return {
+      type: "error",
+      reason: "error",
+      error: {
+        ...partial,
+        stopReason: "error",
+        errorMessage: message,
+      },
+    };
+  }
+  return {
+    type: "error",
+    reason: "error",
+    error: synthesizeMinimalAssistantMessage(message, "error"),
+  };
+}
+
+function synthesizeMinimalAssistantMessage(
+  errorMessage: string,
+  stopReason: AssistantMessage["stopReason"],
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content: [],
+    api: "openai-completions",
+    provider: "opencode-go",
+    model: "",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason,
+    errorMessage,
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Wraps an opencode-go provider stream function so that an SSE socket that
+ * produces tokens and then silently stalls is aborted at the provider-owned
+ * raw boundary via the injected AbortSignal, instead of waiting for the much
+ * later shared runtime stuck-session recovery.
+ *
+ * Behavior:
+ * - Provider-scoped: only applies when `model.provider === options.provider`.
+ * - Idle-based: every event forwarded from the underlying stream refreshes
+ *   the idle timer; if no event arrives within `idleTimeoutMs`, the wrapper
+ *   calls `controller.abort()` on the AbortSignal injected into the
+ *   underlying call (so the OpenAI SDK request is genuinely interrupted, not
+ *   just the iterator) and pushes a terminal `error` event downstream.
+ * - Terminal-safe: when the underlying stream emits `done` or `error`, the
+ *   wrapper forwards the event, clears all timers, and ends the stream.
+ *
+ * The wrapper never shortens the natural end of a normal completion, because
+ * every event (including delayed usage-only deltas) refreshes the idle timer
+ * and a terminal event cancels it entirely.
+ */
+export function createOpencodeGoStalledStreamWrapper(
+  underlying: ProviderStreamFn,
+  options: OpencodeGoStalledStreamWrapperOptions,
+): ProviderStreamFn {
+  if (!options || options.idleTimeoutMs <= 0) {
+    throw new Error(
+      "createOpencodeGoStalledStreamWrapper requires idleTimeoutMs > 0",
+    );
+  }
+  const providerId = options.provider;
+  const idleTimeoutMs = options.idleTimeoutMs;
+
+  return (model, context, callOptions) => {
+    if (!isOpencodeGoModel(model, providerId)) {
+      return underlying(model, context, callOptions);
+    }
+
+    const controller = new AbortController();
+    const injectedSignal = combineAbortSignals([
+      (callOptions as { signal?: AbortSignal } | undefined)?.signal,
+      controller.signal,
+    ]);
+    const wrappedOptions = {
+      ...(callOptions ?? {}),
+      signal: injectedSignal,
+    };
+
+    const baseStreamResult = underlying(model, context, wrappedOptions);
+
+    const attach = (baseStream: AsyncIterable<AssistantMessageEvent>) => {
+      const output = createAssistantMessageEventStream();
+      let idleTimer: ReturnType<typeof setTimeout> | undefined;
+      let lastSeenPartial: AssistantMessage | undefined;
+      let settled = false;
+      let underlyingDone = false;
+
+      const clearIdleTimer = () => {
+        if (idleTimer !== undefined) {
+          clearTimeout(idleTimer);
+          idleTimer = undefined;
+        }
+      };
+
+      const armIdleTimer = () => {
+        clearIdleTimer();
+        idleTimer = setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearIdleTimer();
+          try {
+            controller.abort(new Error("opencode-go stream stalled"));
+          } catch {
+            // AbortController.abort never throws in spec; ignore defensively.
+          }
+          output.push(buildAbortedErrorEvent(lastSeenPartial));
+          output.end();
+        }, idleTimeoutMs);
+      };
+
+      const finishWith = (event: AssistantMessageEvent) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearIdleTimer();
+        output.push(event);
+        output.end(event.type === "done" ? (event as { message: AssistantMessage }).message : undefined);
+      };
+
+      const trackPartial = (event: AssistantMessageEvent) => {
+        const partial = (event as { partial?: AssistantMessage; message?: AssistantMessage }).partial
+          ?? (event as { message?: AssistantMessage }).message;
+        if (partial) {
+          lastSeenPartial = partial;
+        }
+      };
+
+      void (async () => {
+        try {
+          armIdleTimer();
+          for await (const event of baseStream) {
+            if (event.type === "done" || event.type === "error") {
+              trackPartial(event);
+              underlyingDone = true;
+              finishWith(event);
+              return;
+            }
+            trackPartial(event);
+            output.push(event);
+            // Refresh the idle window: any forward-progress (text delta,
+            // tool delta, thinking delta, usage-only chunk, etc.) means the
+            // underlying SSE is still alive.
+            armIdleTimer();
+          }
+          if (!underlyingDone && !settled) {
+            // Underlying iterator ended without an explicit terminal event.
+            // Surface it as an error so downstream consumers do not hang.
+            finishWith(buildUnterminatedErrorEvent(lastSeenPartial));
+          }
+        } catch (error) {
+          if (!settled) {
+            finishWith(buildCaughtErrorEvent(lastSeenPartial, error));
+          }
+        } finally {
+          clearIdleTimer();
+        }
+      })();
+
+      return output;
+    };
+
+    if (
+      baseStreamResult &&
+      typeof baseStreamResult === "object" &&
+      "then" in baseStreamResult
+    ) {
+      return Promise.resolve(baseStreamResult).then(attach) as ReturnType<ProviderStreamFn>;
+    }
+    return attach(baseStreamResult as AsyncIterable<AssistantMessageEvent>);
+  };
+}

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -199,7 +199,7 @@ export function createOpencodeGoStalledStreamWrapper(
       controller.signal,
     ]);
     const wrappedOptions = {
-      ...(callOptions ?? {}),
+      ...callOptions,
       signal: injectedSignal,
     };
 

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -196,7 +196,7 @@ function synthesizeMinimalAssistantMessage(
  * Behavior:
  * - Provider-scoped: only applies when `model.provider === options.provider`.
  * - Idle-based: the timer covers stream creation, first event delivery, and
- *   every gap between forwarded events; if no event arrives within
+ *   every gap after provider progress begins; if no event arrives within
  *   `idleTimeoutMs`, the wrapper calls `controller.abort()` on the AbortSignal
  *   injected into the underlying call (so the OpenAI SDK request is genuinely
  *   interrupted, not just the iterator) and pushes a terminal `error` event
@@ -205,8 +205,7 @@ function synthesizeMinimalAssistantMessage(
  *   wrapper forwards the event, clears all timers, and ends the stream.
  *
  * The wrapper never shortens the natural end of a normal completion, because
- * every event (including delayed usage-only deltas) refreshes the idle timer
- * and a terminal event cancels it entirely.
+ * provider progress refreshes the idle timer and a terminal event cancels it entirely.
  */
 export function createOpencodeGoStalledStreamWrapper(
   underlying: ProviderStreamFn,
@@ -349,7 +348,9 @@ export function createOpencodeGoStalledStreamWrapper(
           }
           trackPartial(event);
           output.push(event);
-          armIdleTimer();
+          if (event.type !== "start") {
+            armIdleTimer();
+          }
         }
       } catch (error) {
         if (!settled) {

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -18,6 +18,10 @@ export interface OpencodeGoStalledStreamWrapperOptions {
    * the underlying SSE as stalled and aborts it. Must be > 0.
    */
   idleTimeoutMs: number;
+  /**
+   * Maximum window for stream creation and first event delivery. Must be > 0.
+   */
+  firstEventTimeoutMs?: number;
 }
 
 /**
@@ -31,10 +35,23 @@ export interface OpencodeGoStalledStreamWrapperOptions {
  */
 export const OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT = 120_000;
 
+export const OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT = 300_000;
+
 function isOpencodeGoModel(model: unknown, providerId: string): boolean {
   return Boolean(model) && typeof model === "object"
     ? (model as { provider?: unknown }).provider === providerId
     : false;
+}
+
+function validTimeoutMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function resolveTimeoutMs(model: unknown, fallbackMs: number): number {
+  return Math.max(
+    validTimeoutMs((model as { requestTimeoutMs?: unknown })?.requestTimeoutMs) ?? 0,
+    fallbackMs,
+  );
 }
 
 function combineAbortSignals(signals: (AbortSignal | undefined)[]): {
@@ -198,8 +215,12 @@ export function createOpencodeGoStalledStreamWrapper(
   if (!options || options.idleTimeoutMs <= 0) {
     throw new Error("createOpencodeGoStalledStreamWrapper requires idleTimeoutMs > 0");
   }
+  if (options.firstEventTimeoutMs !== undefined && options.firstEventTimeoutMs <= 0) {
+    throw new Error("createOpencodeGoStalledStreamWrapper requires firstEventTimeoutMs > 0");
+  }
   const providerId = options.provider;
-  const idleTimeoutMs = options.idleTimeoutMs;
+  const idleTimeoutMsDefault = options.idleTimeoutMs;
+  const firstEventTimeoutMsDefault = options.firstEventTimeoutMs ?? options.idleTimeoutMs;
 
   return (model, context, callOptions) => {
     if (!isOpencodeGoModel(model, providerId)) {
@@ -207,6 +228,8 @@ export function createOpencodeGoStalledStreamWrapper(
     }
 
     const output = createAssistantMessageEventStream();
+    const idleTimeoutMs = resolveTimeoutMs(model, idleTimeoutMsDefault);
+    const firstEventTimeoutMs = resolveTimeoutMs(model, firstEventTimeoutMsDefault);
     const controller = new AbortController();
     const combinedSignal = combineAbortSignals([
       (callOptions as { signal?: AbortSignal } | undefined)?.signal,
@@ -264,11 +287,15 @@ export function createOpencodeGoStalledStreamWrapper(
       output.end();
     };
 
-    const armIdleTimer = () => {
+    const armTimer = (timeoutMs: number) => {
       clearIdleTimer();
-      idleTimer = setTimeout(abortStalledStream, idleTimeoutMs);
+      idleTimer = setTimeout(abortStalledStream, timeoutMs);
       idleTimer.unref?.();
     };
+
+    const armFirstEventTimer = () => armTimer(firstEventTimeoutMs);
+
+    const armIdleTimer = () => armTimer(idleTimeoutMs);
 
     const trackPartial = (event: AssistantMessageEvent) => {
       const partial =
@@ -286,7 +313,7 @@ export function createOpencodeGoStalledStreamWrapper(
       }
     };
 
-    armIdleTimer();
+    armFirstEventTimer();
     let baseStreamResult: ReturnType<ProviderStreamFn>;
     try {
       baseStreamResult = underlying(model, context, wrappedOptions);

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -6,6 +6,10 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { isOpencodeGoKimiNoReasoningModelId } from "./provider-catalog.js";
 import { stripOpencodeGoKimiReasoningPayload } from "./reasoning-sanitizer.js";
+import {
+  createOpencodeGoStalledStreamWrapper,
+  OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
+} from "./stream-termination.js";
 
 function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
@@ -46,6 +50,17 @@ export function createOpencodeGoWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): ProviderWrapStreamFnContext["streamFn"] {
+  if (!baseStreamFn) {
+    return undefined;
+  }
   const kimiWrapped = createOpencodeGoKimiNoReasoningWrapper(baseStreamFn) ?? baseStreamFn;
-  return createOpencodeGoDeepSeekV4Wrapper(kimiWrapped, thinkingLevel) ?? kimiWrapped;
+  const deepSeekWrapped =
+    createOpencodeGoDeepSeekV4Wrapper(kimiWrapped, thinkingLevel) ?? kimiWrapped;
+  // Outermost layer: provider-owned stalled SSE termination so the underlying
+  // OpenAI SDK request is aborted at the raw opencode-go boundary instead of
+  // waiting for the shared runtime stuck-session recovery.
+  return createOpencodeGoStalledStreamWrapper(deepSeekWrapped, {
+    provider: "opencode-go",
+    idleTimeoutMs: OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
+  });
 }

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -8,6 +8,7 @@ import { isOpencodeGoKimiNoReasoningModelId } from "./provider-catalog.js";
 import { stripOpencodeGoKimiReasoningPayload } from "./reasoning-sanitizer.js";
 import {
   createOpencodeGoStalledStreamWrapper,
+  OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT,
   OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
 } from "./stream-termination.js";
 
@@ -62,5 +63,6 @@ export function createOpencodeGoWrapper(
   return createOpencodeGoStalledStreamWrapper(deepSeekWrapped, {
     provider: "opencode-go",
     idleTimeoutMs: OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
+    firstEventTimeoutMs: OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT,
   });
 }

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1039,6 +1039,38 @@ describe("image dimension errors", () => {
 });
 
 describe("classifyAssistantFailoverReason", () => {
+  const opencodeGoStalledStreamError = {
+    role: "assistant" as const,
+    api: "openai-completions" as const,
+    provider: "opencode-go",
+    model: "deepseek-v4-flash",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "error" as const,
+    errorMessage: "opencode-go stream timed out after provider-owned SSE boundary stalled",
+    content: [],
+    timestamp: 0,
+  };
+
+  it("classifies opencode-go provider-owned stalled streams as timeout", () => {
+    expect(classifyAssistantFailoverReason(opencodeGoStalledStreamError)).toBe("timeout");
+  });
+
+  it("does not classify caller-aborted assistant messages as provider failover", () => {
+    expect(
+      classifyAssistantFailoverReason({
+        ...opencodeGoStalledStreamError,
+        stopReason: "aborted",
+      }),
+    ).toBeNull();
+  });
+
   it("uses structured assistant error bodies for model-not-found 400s", () => {
     expect(
       classifyAssistantFailoverReason({

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -668,6 +668,45 @@ describe("handleAssistantFailover", () => {
   });
 
   describe("fallback_model branch", () => {
+    it("throws timeout FailoverError for opencode-go provider-owned stalled streams", async () => {
+      const logDecision = vi.fn();
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "fallback_model", reason: "timeout" },
+          fallbackConfigured: true,
+          failoverReason: "timeout",
+          billingFailure: false,
+          lastAssistant: {
+            role: "assistant",
+            api: "openai-completions",
+            provider: "opencode-go",
+            model: "deepseek-v4-flash",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "error",
+            errorMessage: "opencode-go stream timed out after provider-owned SSE boundary stalled",
+            content: [],
+            timestamp: 0,
+          },
+          activeErrorContext: { provider: "opencode-go", model: "deepseek-v4-flash" },
+          provider: "opencode-go",
+          modelId: "deepseek-v4-flash",
+          logAssistantFailoverDecision: logDecision,
+        }),
+      );
+
+      const err = expectThrownFailoverError(outcome);
+      expect(err.reason).toBe("timeout");
+      expect(err.status).toBe(408);
+      expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 408 });
+    });
+
     it("still throws a FailoverError after the surface_error refactor", async () => {
       const logDecision = vi.fn();
       const outcome = await handleAssistantFailover(

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -1,6 +1,7 @@
 // Failover policy tests cover the embedded run decision table for retry,
 // profile rotation, fallback model escalation, and user-visible errors.
 import { describe, expect, it } from "vitest";
+import { classifyAssistantFailoverReason } from "../../embedded-agent-helpers.js";
 import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./failover-policy.js";
 
 describe("resolveRunFailoverDecision", () => {
@@ -262,6 +263,48 @@ describe("resolveRunFailoverDecision", () => {
       }),
     ).toEqual({
       action: "continue_normal",
+    });
+  });
+
+  it("falls back for opencode-go provider-owned stalled stream errors after rotation is exhausted", () => {
+    const assistantError = {
+      role: "assistant" as const,
+      api: "openai-completions" as const,
+      provider: "opencode-go",
+      model: "deepseek-v4-flash",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "error" as const,
+      errorMessage: "opencode-go stream timed out after provider-owned SSE boundary stalled",
+      content: [],
+      timestamp: 0,
+    };
+    const failoverReason = classifyAssistantFailoverReason(assistantError);
+
+    expect(failoverReason).toBe("timeout");
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: failoverReason !== null,
+        failoverReason,
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        profileRotated: true,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "timeout",
     });
   });
 


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes opencode-go streams that stop before a first upstream SSE event or between real provider progress events so cron jobs no longer wait for the late stuck-session abort path.
- Keeps the watchdog scoped to `model.provider === "opencode-go"` and to the provider-owned stream wrapper, rather than changing global runtime timeout behavior.
- Preserves the longer first-event window after the `openai-completions` transport emits its synthetic `start` event; only real provider progress switches the wrapper to the shorter idle timer.
- Ensures aborting the provider wrapper also releases the upstream async iterator and cleans fallback abort listeners.

Fix classification

- Root-cause fix at the opencode-go provider-owned raw SSE boundary. The source of truth for timer state is whether the wrapped provider stream has produced real provider progress, not whether the OpenAI-compatible transport has emitted its synthetic `start` event.

Root cause

- The failing source path is the raw opencode-go SSE boundary: the upstream provider call can remain open without delivering a first real chunk or terminal event, while cron-triggered runs may not have the shared runtime idle watchdog enabled.
- `openai-completions` emits `start` before processing real SSE chunks. Treating that synthetic event as provider progress caused the wrapper to replace the intended 300s first-event window with the 120s idle window, so a slow but valid first token could be aborted before real upstream progress arrived.

Why this is root-cause fix

- The fix changes the wrapper's timer lifecycle invariant at the source boundary: synthetic preamble events such as `start`, `text_start`, `thinking_start`, and `toolcall_start` are forwarded downstream but do not switch timer state; the idle timer begins only after real provider delta events.
- This preserves the provider-owned cancellation path for true stalls while removing the false-positive abort path introduced by counting synthetic transport bookkeeping as upstream provider progress.

Why does this matter now?

- Issue #93610 reports opencode-go cron runs reaching `model_call:stream_progress`, then sitting silent for roughly 10 minutes until stuck-session recovery aborts the run with `LLM request failed.` / `Request was aborted`.
- Cron runs can have the shared runtime idle watchdog disabled, so opencode-go needs its own raw-stream boundary guard without aborting legitimate slow first-token responses.

What is the intended outcome?

- This is a root-cause fix at the opencode-go provider-owned raw SSE boundary: a truly stalled opencode-go stream now produces a terminal provider error promptly at that boundary instead of leaving the gateway session open until stuck-session recovery.
- The source of truth for timer state is real provider progress, not the OpenAI-compatible transport's synthetic preamble events, so `start`/block-start events no longer shorten the first real provider-event window.
- Normal completions that continue to emit real progress, including delayed usage-only completion, still finish naturally.

What is intentionally out of scope?

- No changes to provider catalog, model routing, fallback policy, global agent timeout defaults, config schema, migrations, or non-opencode-go providers.
- No new retry/fallback path is introduced; the wrapper only terminates a hung opencode-go stream and lets existing caller error handling decide what happens next.
- No schema or config change is needed because existing `models.providers.opencode-go.timeoutSeconds` already reaches the model as `requestTimeoutMs` and is respected by this wrapper.

What does success look like?

- The wrapper aborts a pending stream-creation/TTFB stall.
- The wrapper gives first real provider-event delivery a longer window than inter-event idle gaps.
- The wrapper respects an explicit `models.providers.opencode-go.timeoutSeconds` value carried as `model.requestTimeoutMs`.
- The wrapper aborts and releases a stream that produced real progress and then stalls.
- The wrapper forwards natural `done` events without aborting.
- The fallback AbortSignal combiner removes listeners after completion and still propagates wrapper aborts.

What should reviewers focus on?

- Architecture / source-of-truth check: `extensions/opencode-go/stream-termination.ts` owns only the opencode-go raw provider stream watchdog contract; `openai-completions` transport events are downstream stream protocol events and are not the source of truth for upstream SSE progress.
- The timer lifecycle in `extensions/opencode-go/stream-termination.ts`: it starts before the upstream stream exists, keeps the first-event timer through synthetic preamble events, switches to the idle timer only after real provider delta progress, clears on terminal events, aborts the injected provider signal, calls `return()` on the upstream iterator, and removes fallback listeners.
- The public API/config/schema/provider-routing boundary is unchanged; this is not a canonical default, migration, or model-routing contract change.

<details>
<summary>Summary guidance</summary>

This PR description is the contributor's durable explanation of the change. Write it for human maintainers first; ClawSweeper and Barnacle use the same text to understand intent, proof, risk, and current review state.

Describe the intent and outcome in 2-5 bullets. Avoid restating the diff; reviewers and bots can read the changed files.

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

</details>

## Linked context

Which issue does this close?

Closes #93610

Which issues, PRs, or discussions are related?

Related #93965

Was this requested by a maintainer or owner?

No explicit maintainer request; this updates the existing PR after review identified that the previous timer could shorten the first-token window after an `openai-completions` synthetic `start` event.

<details>
<summary>Linked context guidance</summary>

Link the issue, PR, discussion, maintainer request, or owner request that explains why this PR should exist. Maintainer context helps reviewers and automation distinguish intended work from drive-by churn.

</details>

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: opencode-go stream stalls before the first upstream SSE event now terminate at the provider wrapper, while a synthetic `start` followed by a slow first real delta no longer triggers the shorter idle abort.
- Real environment tested: Linux OpenClaw checkout executing the patched opencode-go provider stream wrapper and plugin SDK stream contract with a live Node process.
- Exact steps or command run after this patch: ran a Node/tsx proof script that imports `extensions/opencode-go/stream-termination.ts`, wraps controlled opencode-go upstream streams, and exercises both no-first-event stall and synthetic-start/slow-first-delta behavior.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

  ```text
  OpenClaw opencode-go provider stream proof
  scenario=first-upstream-event-never-arrives
  provider_signal_aborted=true
  provider_abort_reason=opencode-go stream stalled
  upstream_iterator_return_calls=1
  downstream_terminal_event_type=error
  downstream_terminal_reason=aborted
  downstream_event_count=1
  scenario=synthetic-start-then-slow-first-delta
  provider_signal_aborted=false
  first_delta_arrived_after_idle_window=true
  downstream_saw_text_delta=true
  downstream_terminal_event_type=done
  downstream_event_count=3
  ```

- Observed result after fix: before any upstream SSE event arrived, the opencode-go wrapper aborted the signal passed to the provider stream, called `return()` on the upstream iterator once, and emitted one terminal downstream `error` event with reason `aborted`; after a synthetic `start`, a first real `text_delta` arriving after the idle window still completed normally with no provider abort.
- What was not tested: a live opencode-go provider outage was not forced against the public provider service.
- Proof limitations or environment constraints: the reported failure is intermittent and provider-side; this proof executes the real patched wrapper boundary in-process with controlled async upstream streams so the two timing cases are deterministic without relying on a flaky external provider.
- Before evidence (optional but encouraged): the new synthetic-start regression failed before the fix with `expected true to be false` at the `abortCalled` assertion after advancing past the idle timeout.

<details>
<summary>Real behavior proof guidance</summary>

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only.

Screenshots are encouraged even for CLI, console, text, or log changes. Terminal screenshots, copied live output, redacted runtime logs, recordings, and linked artifacts count.

If your environment cannot produce the ideal proof, explain that under `Proof limitations or environment constraints` so reviewers and ClawSweeper can direct the next step properly.

Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

</details>

## Tests and validation

Which commands did you run?

- `npx tsx <proof script>` against `extensions/opencode-go/stream-termination.ts` for no-first-event stall and synthetic-start/slow-first-delta behavior.
- `node scripts/run-vitest.mjs extensions/opencode-go/stream-termination.test.ts`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts`
- `git diff --check`

Focused test output:

```text
OpenClaw opencode-go provider stream proof
scenario=first-upstream-event-never-arrives
provider_signal_aborted=true
provider_abort_reason=opencode-go stream stalled
upstream_iterator_return_calls=1
downstream_terminal_event_type=error
downstream_terminal_reason=aborted
downstream_event_count=1
scenario=synthetic-start-then-slow-first-delta
provider_signal_aborted=false
first_delta_arrived_after_idle_window=true
downstream_saw_text_delta=true
downstream_terminal_event_type=done
downstream_event_count=3

[test] starting test/vitest/vitest.extension-misc.config.ts

 RUN  v4.1.8 [local path redacted]

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  23:44:34
   Duration  3.67s (transform 3.37s, setup 1.57s, import 937ms, tests 658ms, environment 0ms)

[test] passed 1 Vitest shard in 18.01s

[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.8 [local path redacted]

 Test Files  1 passed (1)
      Tests  76 passed (76)
   Start at  23:44:53
   Duration  3.68s (transform 3.39s, setup 1.45s, import 1.12s, tests 682ms, environment 0ms)

[test] passed 1 Vitest shard in 16.30s

git diff --check: pass
```

What regression coverage was added or updated?

- No-first-event stream aborts and releases the upstream iterator.
- First real provider-event delivery uses a longer timeout than the inter-event idle window.
- Synthetic `openai-completions` preamble events (`start` and block-start events) do not switch to the shorter idle timer before the first real delta.
- Explicit opencode-go provider `requestTimeoutMs` is honored above and below the wrapper defaults.
- Pending upstream stream promise aborts during stream creation.
- Post-progress stall still aborts at the raw provider boundary.
- Fallback AbortSignal listeners are removed after natural completion.
- Fallback combined signal still propagates wrapper abort.
- Normal delayed usage-only completion remains non-aborted.

What failed before this fix, if known?

- The synthetic preamble regression failed because the wrapper treated `text_start` as progress and aborted after the shorter idle timeout before the first real `text_delta` arrived.
- The explicit-timeout regression failed because a shorter `requestTimeoutMs` was widened to the wrapper default instead of preserving the operator ceiling.
- Earlier regressions covered by this PR failed for no-first-event abort, fallback listener cleanup, and fallback abort propagation.

If no test was added, why not?

N/A.

<details>
<summary>Testing guidance</summary>

List focused commands, not every incidental check. CI is useful support, but external PRs still need real behavior proof above when behavior changes.

</details>

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, network request cancellation timing changes for opencode-go streams only.

What is the highest-risk area?

Aborting an opencode-go request that is slow but still valid.

How is that risk mitigated?

The behavior is scoped to opencode-go, keeps the 120s window for inter-event idle gaps after real provider progress, gives first real provider-event delivery a longer 300s window even after synthetic preamble events, respects explicit `models.providers.opencode-go.timeoutSeconds` values, refreshes on forwarded real progress events, preserves natural `done` completion, and does not change local/global timeout contracts.

Patch quality notes

- Patch-quality warnings about timeout behavior are intentional: the change is the timer contract under review, and the regression suite now locks the false-abort case plus no-first-event abort, post-progress abort, explicit timeout, natural done, and fallback AbortSignal behavior.
- Test-only type escapes are limited to constructing plugin SDK `ProviderWrapStreamFnContext` inputs and synthetic stream events inside `extensions/opencode-go/stream-termination.test.ts`; production code does not add `any` escapes.
- The fallback AbortSignal tests are not a runtime fallback path for users; they cover the platform compatibility branch used only when `AbortSignal.any` is unavailable, so it does not mask provider errors or alter routing.

<details>
<summary>Risk guidance</summary>

Use this for author judgment that is not obvious from the diff. ClawSweeper can see touched files, but it cannot know which behavior you think is risky, why the risk is acceptable, or what mitigation reviewers should verify.

</details>

## Current review state

What is the next action?

Ready for maintainer/bot review after the updated branch and remote checks settle.

What is still waiting on author, maintainer, CI, or external proof?

- Normal remote PR checks after this branch update.
- The existing `status: ⏳ waiting on author` label should be re-evaluated after this update because the timer semantics and explicit-timeout findings now have focused regressions, passing focused tests, and behavior proof.

Which bot or reviewer comments were addressed?

- RF-001: the `status: ⏳ waiting on author` label remains page-visible until maintainers/bot update it; this branch update addresses the current author-side code, test, and proof work.
- RF-002: added regression coverage for explicit opencode-go timeout values below and above the wrapper defaults.
- RF-003/RF-006: opencode-go `requestTimeoutMs` is now honored directly, so shorter provider timeouts are no longer widened to the 120s/300s wrapper defaults.
- RF-004: the availability/compatibility risk is covered by focused tests for no-first-event abort, synthetic preamble before slow first delta, short/long explicit timeouts, post-progress stalls, natural completion, and fallback AbortSignal cleanup/abort propagation.
- RF-005: kept the existing provider-scoped approach and made the narrow mechanical repair at the timer source-of-truth boundary without changing global timeout behavior.
- RF-007: `node scripts/run-vitest.mjs extensions/opencode-go/stream-termination.test.ts` passed with 11 tests.
- RF-008: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts` passed with 76 tests.
- RF-009: `git diff --check` passed.
- Behavior proof: refreshed the opencode-go stream proof for no-first-event stall and synthetic-start/slow-first-delta behavior on the current head.

<details>
<summary>Review state guidance</summary>

Keep this as the durable state for review progress. If useful information appears in comments, fold the current next action or blocker back here so maintainers and ClawSweeper do not need to reconstruct state from comment history.

</details>
