### PR TITLE
fix(slack): keep agent identity on edited messages (#58737)

### DIFF
--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover actions.blocks plugin behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSlackEditTestClient } from "./blocks.test-helpers.js";
 
 const { editSlackMessage } = await import("./actions.js");
@@ -35,6 +35,76 @@ describe("editSlackMessage blocks", () => {
       text: "Shared a Block Kit message",
       blocks: [{ type: "divider" }],
     });
+  });
+
+  it("preserves custom username and icon_url on edit", async () => {
+    const client = createSlackEditTestClient();
+
+    await editSlackMessage("C123", "171234.567", "updated", {
+      token: "xoxb-test",
+      client,
+      identity: {
+        username: "OpenClaw Agent",
+        iconUrl: "https://example.com/avatar.png",
+      },
+    });
+
+    expect(client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        ts: "171234.567",
+        text: "updated",
+        username: "OpenClaw Agent",
+        icon_url: "https://example.com/avatar.png",
+      }),
+    );
+  });
+
+  it("forwards icon_emoji identity on edit (mutually exclusive with icon_url)", async () => {
+    const client = createSlackEditTestClient();
+
+    await editSlackMessage("C123", "171234.567", "updated", {
+      token: "xoxb-test",
+      client,
+      identity: {
+        username: "OpenClaw Agent",
+        iconEmoji: ":lobster:",
+      },
+    });
+
+    const [payload] = client.chat.update.mock.calls[0] as [Record<string, unknown>];
+    expect(payload).toMatchObject({
+      username: "OpenClaw Agent",
+      icon_emoji: ":lobster:",
+    });
+    expect(payload).not.toHaveProperty("icon_url");
+  });
+
+  it("retries the edit without identity when chat:write.customize scope is missing", async () => {
+    const scopeError = Object.assign(new Error("missing_scope"), {
+      data: { error: "missing_scope", needed: "chat:write.customize" },
+    });
+    const update = vi
+      .fn<(payload: Record<string, unknown>) => Promise<{ ok: boolean }>>()
+      .mockRejectedValueOnce(scopeError)
+      .mockResolvedValueOnce({ ok: true });
+    const client = { chat: { update } } as unknown as ReturnType<typeof createSlackEditTestClient>;
+
+    await editSlackMessage("C123", "171234.567", "updated", {
+      token: "xoxb-test",
+      client,
+      identity: { username: "OpenClaw Agent", iconUrl: "https://example.com/a.png" },
+    });
+
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        icon_url: "https://example.com/a.png",
+        username: "OpenClaw Agent",
+      }),
+    );
+    expect(update.mock.calls[1]?.[0]).not.toHaveProperty("icon_url");
+    expect(update.mock.calls[1]?.[0]).not.toHaveProperty("username");
   });
 
   it("uses image block text as edit fallback", async () => {

--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -107,6 +107,33 @@ describe("editSlackMessage blocks", () => {
     expect(update.mock.calls[1]?.[0]).not.toHaveProperty("username");
   });
 
+  it("retries the edit without identity when Slack rejects identity arguments", async () => {
+    const argumentError = Object.assign(new Error("invalid_arg_name"), {
+      data: { error: "invalid_arg_name" },
+    });
+    const update = vi
+      .fn<(payload: Record<string, unknown>) => Promise<{ ok: boolean }>>()
+      .mockRejectedValueOnce(argumentError)
+      .mockResolvedValueOnce({ ok: true });
+    const client = { chat: { update } } as unknown as ReturnType<typeof createSlackEditTestClient>;
+
+    await editSlackMessage("C123", "171234.567", "updated", {
+      token: "xoxb-test",
+      client,
+      identity: { username: "OpenClaw Agent", iconEmoji: ":lobster:" },
+    });
+
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        icon_emoji: ":lobster:",
+        username: "OpenClaw Agent",
+      }),
+    );
+    expect(update.mock.calls[1]?.[0]).not.toHaveProperty("icon_emoji");
+    expect(update.mock.calls[1]?.[0]).not.toHaveProperty("username");
+  });
+
   it("uses image block text as edit fallback", async () => {
     const client = createSlackEditTestClient();
 

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -10,7 +10,8 @@ import { createSlackWebClient, getSlackWriteClient } from "./client.js";
 import { buildSlackEditTextPayload } from "./edit-text.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
-import { sendMessageSlack } from "./send.js";
+import { hasCustomIdentity, isSlackCustomizeScopeError, sendMessageSlack } from "./send.js";
+import type { SlackSendIdentity } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
 export type SlackActionClientOpts = {
@@ -272,16 +273,57 @@ export async function editSlackMessage(
   channelId: string,
   messageId: string,
   content: string,
-  opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
+  opts: SlackActionClientOpts & {
+    blocks?: (Block | KnownBlock)[];
+    identity?: SlackSendIdentity;
+  } = {},
 ) {
   const client = await getClient(opts, "write");
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);
-  await client.chat.update({
+  const basePayload = {
     channel: channelId,
     ts: messageId,
     text: buildSlackEditTextPayload(content, blocks),
     ...(blocks ? { blocks } : {}),
-  });
+  };
+  const identity = opts.identity;
+  try {
+    // Slack honors username/icon_url/icon_emoji on chat.update at runtime, but the
+    // @slack/web-api ChatUpdateArguments type omits them, and icon_url/icon_emoji are
+    // mutually exclusive. Assemble each payload in a const so the extra identity
+    // fields reach the API without tripping object-literal excess-property checks.
+    if (identity?.iconUrl) {
+      const updatePayload = {
+        ...basePayload,
+        ...(identity.username ? { username: identity.username } : {}),
+        icon_url: identity.iconUrl,
+      };
+      await client.chat.update(updatePayload);
+      return;
+    }
+    if (identity?.iconEmoji) {
+      const updatePayload = {
+        ...basePayload,
+        ...(identity.username ? { username: identity.username } : {}),
+        icon_emoji: identity.iconEmoji,
+      };
+      await client.chat.update(updatePayload);
+      return;
+    }
+    const updatePayload = {
+      ...basePayload,
+      ...(identity?.username ? { username: identity.username } : {}),
+    };
+    await client.chat.update(updatePayload);
+  } catch (err) {
+    // Mirror the send path: if the workspace lacks chat:write.customize, retry the
+    // edit without custom identity so the message still updates with the bot identity.
+    if (!hasCustomIdentity(identity) || !isSlackCustomizeScopeError(err)) {
+      throw err;
+    }
+    logVerbose("slack edit: missing chat:write.customize, retrying without custom identity");
+    await client.chat.update(basePayload);
+  }
 }
 
 export async function deleteSlackMessage(

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -14,6 +14,20 @@ import { hasCustomIdentity, isSlackCustomizeScopeError, sendMessageSlack } from 
 import type { SlackSendIdentity } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
+type SlackWebApiError = Error & {
+  data?: {
+    error?: unknown;
+  };
+};
+
+function isSlackEditIdentityArgumentError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const code = (err as SlackWebApiError).data?.error;
+  return code === "invalid_arguments" || code === "invalid_arg_name";
+}
+
 export type SlackActionClientOpts = {
   cfg?: OpenClawConfig;
   accountId?: string;
@@ -316,12 +330,15 @@ export async function editSlackMessage(
     };
     await client.chat.update(updatePayload);
   } catch (err) {
-    // Mirror the send path: if the workspace lacks chat:write.customize, retry the
-    // edit without custom identity so the message still updates with the bot identity.
-    if (!hasCustomIdentity(identity) || !isSlackCustomizeScopeError(err)) {
+    // Mirror the send path: if custom authorship is unavailable or rejected, retry
+    // without identity so the message still updates with the bot identity.
+    if (
+      !hasCustomIdentity(identity) ||
+      (!isSlackCustomizeScopeError(err) && !isSlackEditIdentityArgumentError(err))
+    ) {
       throw err;
     }
-    logVerbose("slack edit: missing chat:write.customize, retrying without custom identity");
+    logVerbose("slack edit: custom identity unavailable, retrying without custom identity");
     await client.chat.update(basePayload);
   }
 }

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -88,6 +88,7 @@ export function createSlackDraftStream(params: {
           cfg: params.cfg,
           token: params.token,
           accountId: params.accountId,
+          identity: params.identity,
           ...(blocks ? { blocks } : {}),
         });
         return;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -1310,6 +1310,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             messageId,
             text: normalizeSlackOutboundText(trimmedFinalText),
             ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
+            ...(slackIdentity ? { identity: slackIdentity } : {}),
             threadTs: finalThreadTs,
           });
         } catch (err) {
@@ -1396,6 +1397,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             messageId: preview.messageId,
             text: edit.text,
             ...(edit.blocks?.length ? { blocks: edit.blocks } : {}),
+            ...(slackIdentity ? { identity: slackIdentity } : {}),
             threadTs: edit.threadTs,
           });
           if (!ttsSupplement) {

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.test.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.test.ts
@@ -33,6 +33,35 @@ describe("finalizeSlackPreviewEdit", () => {
     editSlackMessageMock.mockReset();
   });
 
+  it("forwards agent identity through to editSlackMessage", async () => {
+    editSlackMessageMock.mockResolvedValueOnce(undefined);
+    const client = createClient();
+
+    await finalizeSlackPreviewEdit({
+      client,
+      token: "xoxb-test",
+      channelId: "C123",
+      messageId: "171234.567",
+      text: "final answer",
+      identity: {
+        username: "OpenClaw Agent",
+        iconEmoji: ":lobster:",
+      },
+    });
+
+    expect(editSlackMessageMock).toHaveBeenCalledWith(
+      "C123",
+      "171234.567",
+      "final answer",
+      expect.objectContaining({
+        identity: {
+          username: "OpenClaw Agent",
+          iconEmoji: ":lobster:",
+        },
+      }),
+    );
+  });
+
   it("treats a thrown edit as success when history readback already matches", async () => {
     editSlackMessageMock.mockRejectedValueOnce(new Error("socket closed"));
     const client = createClient({

--- a/extensions/slack/src/monitor/message-handler/preview-finalize.ts
+++ b/extensions/slack/src/monitor/message-handler/preview-finalize.ts
@@ -4,6 +4,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { editSlackMessage } from "../../actions.js";
 import { buildSlackEditTextPayload } from "../../edit-text.js";
 import { normalizeSlackOutboundText } from "../../format.js";
+import type { SlackSendIdentity } from "../../send.js";
 
 type SlackReadbackMessage = {
   ts?: string;
@@ -98,12 +99,14 @@ export async function finalizeSlackPreviewEdit(params: {
   text: string;
   blocks?: (Block | KnownBlock)[];
   threadTs?: string;
+  identity?: SlackSendIdentity;
 }): Promise<void> {
   try {
     await editSlackMessage(params.channelId, params.messageId, params.text, {
       token: params.token,
       accountId: params.accountId,
       client: params.client,
+      identity: params.identity,
       ...(params.blocks?.length ? { blocks: params.blocks } : {}),
     });
   } catch (err) {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -129,7 +129,7 @@ type SlackWebApiError = Error & {
   data?: SlackWebApiErrorData;
 };
 
-function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
+export function hasCustomIdentity(identity?: SlackSendIdentity): boolean {
   return Boolean(identity?.username || identity?.iconUrl || identity?.iconEmoji);
 }
 
@@ -334,7 +334,7 @@ async function withSlackDnsRequestRetry<T>(operation: string, fn: () => Promise<
   throw new Error("unreachable Slack DNS retry loop exit");
 }
 
-function isSlackCustomizeScopeError(err: unknown): boolean {
+export function isSlackCustomizeScopeError(err: unknown): boolean {
   const data = getSlackWebApiErrorData(err);
   const code = normalizeLowercaseStringOrEmpty(normalizeSlackApiString(data?.error));
   if (code !== "missing_scope") {


### PR DESCRIPTION
## What Problem This Solves
Slack edits lost the custom agent identity used on the original message. Initial `chat.postMessage` calls carried `username` and icon fields, but edit/finalize paths updated the same message without those identity fields, so edited replies appeared to come from the default bot identity instead of the selected agent.

## Evidence
Focused proof from this maintenance cycle: the Slack action regression was updated so `chat.update` first tries the resolved identity fields and then retries without them only for Slack argument/scope rejections. The branch was committed as `d5129c62b6aadb624879b3b41ca8b64a19030f86`, pushed, and the review thread was answered with the exact focused verification command evidence.

---

## Summary
On current `main`, Slack messages posted with a custom agent identity (`username` + `icon_url`/`icon_emoji`) keep that identity on the initial `chat.postMessage`, but every edit path calls `chat.update` without forwarding identity. So when OpenClaw edits a message — after a tool call completes, during streaming preview updates, or on final-answer finalize — it reverts to the bot's default name and avatar, making it look like the wrong agent is replying. This PR forwards the resolved agent identity through the edit helper and its call sites, with the same missing-scope fallback the send path already uses.

## Root Cause
- `extensions/slack/src/actions.ts` (`editSlackMessage`): called `client.chat.update({ channel, ts, text, blocks })` and never accepted or forwarded `username`/`icon_url`/`icon_emoji`. The send path (`send.ts` `postSlackMessageBestEffort`) builds those identity fields, but the edit path dropped them.
- Execution path: `dispatch.ts` resolves `slackIdentity` -> draft-stream / preview-finalize edits -> `editSlackMessage` -> `chat.update` (identity lost here).

clawsweeper's review on #58737 reached the same conclusion: *"current main and the latest release still omit the configured Slack agent identity from the `chat.update` edit paths ... a narrow replacement repair lane is appropriate."*

## Changes
- `extensions/slack/src/actions.ts`: `editSlackMessage` accepts an optional `identity` and forwards `username` + `icon_url`/`icon_emoji` (mutually exclusive) on `chat.update`. Payloads are assembled in `const`s because `ChatUpdateArguments` does not type these runtime-honored fields. On a `chat:write.customize` missing-scope error it retries the edit without identity, mirroring the send path so edits still apply.
- `extensions/slack/src/send.ts`: export `hasCustomIdentity` and `isSlackCustomizeScopeError` for reuse by the edit fallback (no logic change).
- `extensions/slack/src/draft-stream.ts`: forward `identity` on the streaming edit call (send already forwarded it).
- `extensions/slack/src/monitor/message-handler/preview-finalize.ts`: accept and forward `identity` to `editSlackMessage`.
- `extensions/slack/src/monitor/message-handler/dispatch.ts`: pass the resolved `slackIdentity` to both `finalizeSlackPreviewEdit` call sites.

## Reproduction (before fix)
The new `editSlackMessage` identity tests fail against current `main` — `chat.update` is invoked without identity:

~~~text
FAIL  editSlackMessage blocks > preserves custom username and icon_url on edit
- Expected  { username: "OpenClaw Agent", icon_url: "https://example.com/avatar.png" }
+ Received  { channel: "C123", text: "updated", ts: "171234.567" }
FAIL  editSlackMessage blocks > retries the edit without identity when chat:write.customize scope is missing
  Error: missing_scope
Tests  3 failed | 8 passed (11)
~~~

## Verification (after fix)
~~~text
 ✓ extensions/slack/src/actions.blocks.test.ts (11 tests)
 ✓ extensions/slack/src/monitor/message-handler/preview-finalize.test.ts (6 tests)
 ✓ extensions/slack/src/draft-stream.test.ts (11 tests)
 Test Files  3 passed (3)
      Tests  28 passed (28)
~~~

## Test
- `pnpm test extensions/slack/src/actions.blocks.test.ts extensions/slack/src/monitor/message-handler/preview-finalize.test.ts extensions/slack/src/draft-stream.test.ts` — 28 passed
- `pnpm tsgo:extensions` — passed
- `pnpm tsgo:extensions:test` — passed

## Notes
- Scope: smallest complete fix threading identity through every agent-reply edit path. The approval-handler and block-action `chat.update` calls are intentionally left unchanged — those edit approval/interaction UI messages, not agent replies, so they should keep the bot identity.
- Compatibility: no config or public API surface change; `identity` is optional everywhere. A missing `chat:write.customize` scope degrades gracefully (edit applies with the bot identity), matching the send path.
- This follows clawsweeper's direction on #58737: *"land a narrow Slack-plugin fix that preserves agent identity through edit helper callers, keeps missing-scope fallback parity, and includes focused regression coverage."* The earlier fix PRs (#58800 and its sibling) are closed unmerged; this is the canonical replacement.

Closes #58737
