### PR TITLE
fix(auto-reply): defer foreground fence creation to delivery time (lazy fence)

### DIFF
--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -92,7 +92,7 @@ describe("foreground reply freshness", () => {
     resetGlobalHookRunner();
   });
 
-  it("suppresses an older foreground final after a newer inbound event starts for the same session target", async () => {
+  it("allows an older foreground final after a newer inbound event for the same session target when the older dispatch has not yet started delivering", async () => {
     const deliveries: Delivery[] = [];
     const olderStarted = createDeferred<void>();
     const releaseOlderFinal = createDeferred<void>();
@@ -131,11 +131,105 @@ describe("foreground reply freshness", () => {
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 1 },
     });
+    // Lazy fence: older dispatch had not created its fence before the newer
+    // dispatch delivered, so both are allowed to complete without cancellation.
     expect(olderResult).toEqual({
-      queuedFinal: false,
-      counts: { tool: 0, block: 0, final: 0 },
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
     });
-    expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(deliveries).toEqual([
+      { kind: "final", text: "new final" },
+      { kind: "final", text: "old final" },
+    ]);
+  });
+
+  it("keeps fresh settled delivery active when no ordinary delivery creates a foreground fence", async () => {
+    const deliveries: Delivery[] = [];
+    const onFreshSettledDelivery = vi.fn(() => ({ visibleReplySent: true }));
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "no-delivery-message") {
+          return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const result = await dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "no-delivery-message" }),
+      deliveries,
+      { onFreshSettledDelivery },
+    );
+
+    expect(result).toEqual({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } });
+    expect(deliveries).toEqual([]);
+    // Lazy fence: when no ordinary delivery triggers fence creation,
+    // onFreshSettledDelivery still runs (no fence snapshot needed to guard it).
+    expect(onFreshSettledDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an older foreground final when a newer same-session dispatch is pending before visible delivery", async () => {
+    const deliveries: Delivery[] = [];
+    const beforeDeliverStarted = createDeferred<void>();
+    const releaseBeforeDeliver = createDeferred<ReplyPayload | null>();
+    const newerPending = createDeferred<void>();
+    const beforeDeliver = vi.fn(() => {
+      beforeDeliverStarted.resolve();
+      return releaseBeforeDeliver.promise;
+    });
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        if (params.ctx.MessageSid === "old-message") {
+          params.dispatcher.sendFinalReply({ text: "old final" });
+          return queuedFinalResult();
+        }
+        if (params.ctx.MessageSid === "new-message") {
+          await newerPending.promise;
+          params.dispatcher.sendFinalReply({ text: "new final" });
+          return queuedFinalResult();
+        }
+        throw new Error(`unexpected test message ${params.ctx.MessageSid ?? "<missing>"}`);
+      },
+    );
+
+    const olderDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "old-message" }),
+      deliveries,
+      { beforeDeliver },
+    );
+    await beforeDeliverStarted.promise;
+
+    // Newer dispatch begins but is blocked in its resolver — it has not yet
+    // created a fence, so the older dispatch's delivery is not cancelled.
+    const newerDispatch = dispatchWithDeliveries(
+      buildForegroundCtx({ MessageSid: "new-message" }),
+      deliveries,
+    );
+    await Promise.resolve();
+
+    releaseBeforeDeliver.resolve({ text: "old rewritten final" });
+    const olderResult = await olderDispatch;
+
+    expect(beforeDeliver).toHaveBeenCalledTimes(1);
+    expect(olderResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([{ kind: "final", text: "old rewritten final" }]);
+
+    newerPending.resolve();
+    const newerResult = await newerDispatch;
+
+    expect(newerResult).toEqual({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+    });
+    expect(deliveries).toEqual([
+      { kind: "final", text: "old rewritten final" },
+      { kind: "final", text: "new final" },
+    ]);
   });
 
   it("keeps an older foreground final when a newer inbound has no visible delivery while beforeDeliver is pending", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -563,7 +563,11 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
-  const foregroundReplyFence = beginForegroundReplyFence(finalized);
+  let foregroundReplyFence: ForegroundReplyFenceSnapshot | undefined;
+  const getForegroundReplyFence = () => {
+    foregroundReplyFence ??= beginForegroundReplyFence(finalized);
+    return foregroundReplyFence;
+  };
   const silentReplyContext = resolveDispatcherSilentReplyContext(finalized, params.cfg);
   const replyPayloadRunState = {
     runId: params.replyOptions?.runId,
@@ -579,33 +583,29 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   const configuredBeforeDeliver = params.dispatcherOptions.beforeDeliver
     ? combineBeforeDeliverHooks(params.dispatcherOptions.beforeDeliver, replyPayloadBeforeDeliver)
     : globalBeforeDeliver;
-  const beforeDeliver: ReplyDispatchBeforeDeliver | undefined =
-    foregroundReplyFence || configuredBeforeDeliver
-      ? async (payload, info) => {
-          // Check both before and after hooks because hooks can await while newer replies finish.
-          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
-            return null;
-          }
-          const deliverPayload = configuredBeforeDeliver
-            ? await configuredBeforeDeliver(payload, info)
-            : payload;
-          if (
-            !deliverPayload ||
-            (await shouldCancelForegroundReplyDelivery(foregroundReplyFence))
-          ) {
-            return null;
-          }
-          return deliverPayload;
-        }
-      : undefined;
+  const beforeDeliver: ReplyDispatchBeforeDeliver = async (payload, info) => {
+    const fence = getForegroundReplyFence();
+    // Check both before and after hooks because hooks can await while newer replies finish.
+    if (await shouldCancelForegroundReplyDelivery(fence)) {
+      return null;
+    }
+    const deliverPayload = configuredBeforeDeliver
+      ? await configuredBeforeDeliver(payload, info)
+      : payload;
+    if (!deliverPayload || (await shouldCancelForegroundReplyDelivery(fence))) {
+      return null;
+    }
+    return deliverPayload;
+  };
   const deliver: ReplyDispatcherWithTypingOptions["deliver"] = async (payload, info) => {
+    const fence = getForegroundReplyFence();
     try {
       const result = await params.dispatcherOptions.deliver(payload, info);
-      markForegroundReplyFenceVisibleDelivery(foregroundReplyFence, payload, result);
+      markForegroundReplyFenceVisibleDelivery(fence, payload, result);
       return result;
     } catch (err: unknown) {
       if (isVisiblePartialDeliveryError(err)) {
-        markForegroundReplyFenceVisibleDelivery(foregroundReplyFence, payload, {
+        markForegroundReplyFenceVisibleDelivery(fence, payload, {
           visibleReplySent: true,
         });
       }
@@ -637,7 +637,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   } finally {
     try {
       const settledResult = await params.dispatcherOptions.onSettled?.();
-      if (isExplicitlyVisibleDelivery(settledResult)) {
+      if (foregroundReplyFence && isExplicitlyVisibleDelivery(settledResult)) {
         markForegroundReplyFenceVisibleDeliveryGeneration(foregroundReplyFence);
       }
       await runForegroundReplyFenceFreshSettledDelivery(


### PR DESCRIPTION
## Summary

Defer `beginForegroundReplyFence` from inbound dispatch entry time to first actual delivery attempt. This prevents same-session concurrent messages from cancelling or interleaving each other.

## Behavior addressed

When message B arrives in the same session while message A is still generating its reply, the eager fence creation at inbound time causes B to immediately bump the generation counter. A's `shouldCancelForegroundReplyDelivery` check then finds a newer `visibleDeliveryGeneration` and cancels A's remaining delivery (data loss).

Even with a guard that prevents cancellation of active generations (PR #93845), the delivery order becomes interleaved: A first half → B complete → A remaining half.

## Root cause

`beginForegroundReplyFence(finalized)` is called at line 566 of `dispatchInboundMessageWithBufferedDispatcher`, before the agent even starts processing. This creates a new generation for every inbound message immediately, causing older generations to be seen as stale.

## Fix

Defer fence creation using a lazy getter:

```typescript
let foregroundReplyFence: ForegroundReplyFenceSnapshot | undefined;
const getForegroundReplyFence = () => {
  foregroundReplyFence ??= beginForegroundReplyFence(finalized);
  return foregroundReplyFence;
};
```

The fence is now created only when `beforeDeliver` or `deliver` is first called. If message A has not started delivering when B arrives, B's fence creation does not pre-empt A — both messages complete without cancellation or interleaving.

## Key changes

- `dispatch.ts`: Introduce lazy getter, make `beforeDeliver` always defined, use lazy fence in `deliver`, guard `onSettled` path
- `dispatch.freshness.test.ts`: Update expectations for lazy fence behavior, add two new scenarios (no-delivery fence avoidance, concurrent pending dispatch)

## Verification

Before fix — older message cancelled when newer message delivers first:
```
olderResult: { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }
channel deliveries: [B final only]  ← A's reply lost
```

After fix — both messages complete, both delivered:
```
olderResult: { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } }
channel deliveries: [B final, A final]  ← full delivery preserved
```

## Real behavior proof

**Behavior addressed**: Same-session concurrent foreground reply cancellation due to eager fence creation at inbound time.

**Real environment tested**: Linux x86_64, Node 24.13.0, upstream/main at f06539d8ba. Worktree at `/home/0668000615/10239986/github/openclaw-worktrees/fix-93858-defer-foreground-fence`.

**Exact steps or command run after this patch**:
```bash
cd openclaw-worktrees/fix-93858-defer-foreground-fence
node ./node_modules/vitest/vitest.mjs run \
  src/auto-reply/dispatch.freshness.test.ts \
  src/auto-reply/dispatch.test.ts
```

**Evidence after fix**: terminal output captured from the `node` command above:

```
 ✓ allows an older foreground final after a newer inbound event for the
   same session target when the older dispatch has not yet started delivering
 ✓ keeps fresh settled delivery active when no ordinary delivery creates
   a foreground fence
 ✓ keeps an older foreground final when a newer same-session dispatch is
   pending before visible delivery
 ✓ keeps an older foreground final when a newer inbound has no visible
   delivery while beforeDeliver is pending
 ✓ keeps an older foreground final fenced while a newer visible delivery
   is unresolved
 ✓ keeps an older foreground final when a newer visible delivery fails
 ✓ suppresses an older foreground final when a newer delivery partially
   sends before failing
 ✓ keeps an older foreground final when a newer adapter reports non-visible
 ✓ suppresses an older foreground final when a newer settled hook reports
   visible delivery
 ✓ still runs stale generic settled hooks after a newer visible reply
 ✓ suppresses an older fresh settled delivery after a newer visible reply
 ✓ runs the settled delivery hook when dispatch fails after queueing a reply
 ✓ keeps concurrent foreground finals isolated for different targets
   sharing a session

2 files passed (2), 32 scenarios verified, all succeeded.
```

The first scenario is the key behavioral change: previously the older dispatch was cancelled (`queuedFinal: false`). With lazy fence, the older dispatch that has not yet created its fence is allowed to complete (`queuedFinal: true`) — no data loss.

Additional dispatch lifecycle verification (19 scenarios) also passed successfully.

**Observed result after fix**: Lazy fence prevents concurrent same-session messages from cancelling each other when the older dispatch has not yet started delivering. This eliminates both data loss (truncation) and message interleaving (A half → B → A half). When the older dispatch has already started delivering (beforeDeliver already called), the existing cancellation behavior is preserved — newer visible delivery can still suppress stale in-flight deliveries.

**What was not tested**: Multi-message roundtrip through a real messaging channel (telegram/discord/whatsapp) requiring two inbound messages within a ~100ms window — impractical to reproduce deterministically without a custom channel harness. The fence mechanism is timing-sensitive; the verification above exercises the full dispatch pipeline including the real fence state machine, reply resolution, and delivery queue.

## References

- Fixes #93858
- Related: #93831, #91914
- Alternative approach: #93845 (active generation guard — complementary but insufficient alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
