### PR TITLE
[codex] Soft-fail transient compaction spend backoff

### DIFF
--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -1359,7 +1359,7 @@ describe("runCliTurnCompactionLifecycle", () => {
           };
         },
       }),
-      createPreparedEmbeddedPiSettingsManager: async () => ({
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
         getCompactionReserveTokens: () => 200,
         getCompactionKeepRecentTokens: () => 0,
         applyOverrides: () => {},
@@ -1426,7 +1426,7 @@ describe("runCliTurnCompactionLifecycle", () => {
           throw err;
         },
       }),
-      createPreparedEmbeddedPiSettingsManager: async () => ({
+      createPreparedEmbeddedAgentSettingsManager: async () => ({
         getCompactionReserveTokens: () => 200,
         getCompactionKeepRecentTokens: () => 0,
         applyOverrides: () => {},

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -1328,6 +1328,141 @@ describe("runCliTurnCompactionLifecycle", () => {
     expect(calls).toEqual(["ensure", "resolve"]);
   });
 
+  it("soft-fails when context engine returns a spend-backoff reason, leaves session intact", async () => {
+    const sessionKey = "agent:main:cli";
+    const sessionId = "session-cli-backoff";
+    const sessionFile = path.join(tmpDir, "session-backoff.jsonl");
+    const storePath = path.join(tmpDir, "sessions-backoff.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => ({
+        ...buildContextEngine({ compactCalls: [] }),
+        async compact() {
+          return {
+            ok: false,
+            compacted: false,
+            reason:
+              "summary spend backoff open for compaction:agent:main:cli until 2099-01-01T00:00:00.000Z",
+          };
+        },
+      }),
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: vi.fn(),
+      recordCliCompactionInStore,
+    });
+
+    const result = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(result).toBe(sessionEntry);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+  });
+
+  it("soft-fails when context engine throws LcmSummarySpendLimitError, leaves session intact", async () => {
+    const sessionKey = "agent:main:cli";
+    const sessionId = "session-cli-backoff-throw";
+    const sessionFile = path.join(tmpDir, "session-backoff-throw.jsonl");
+    const storePath = path.join(tmpDir, "sessions-backoff-throw.json");
+    await writeSessionFile({ sessionFile, sessionId });
+
+    const sessionEntry: SessionEntry = {
+      sessionId,
+      updatedAt: Date.now(),
+      sessionFile,
+      contextTokens: 1_000,
+      totalTokens: 950,
+      totalTokensFresh: true,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const recordCliCompactionInStore = vi.fn();
+    setCliCompactionTestDeps({
+      resolveContextEngine: async () => ({
+        ...buildContextEngine({ compactCalls: [] }),
+        async compact() {
+          const err = new Error(
+            "summary spend backoff open for compaction:agent:main:cli until 2099-01-01T00:00:00.000Z",
+          );
+          err.name = "LcmSummarySpendLimitError";
+          throw err;
+        },
+      }),
+      createPreparedEmbeddedPiSettingsManager: async () => ({
+        getCompactionReserveTokens: () => 200,
+        getCompactionKeepRecentTokens: () => 0,
+        applyOverrides: () => {},
+      }),
+      shouldPreemptivelyCompactBeforePrompt: () => ({
+        route: "fits",
+        shouldCompact: false,
+        estimatedPromptTokens: 600,
+        promptBudgetBeforeReserve: 800,
+        overflowTokens: 0,
+        toolResultReducibleChars: 0,
+        effectiveReserveTokens: 200,
+      }),
+      resolveLiveToolResultMaxChars: () => 20_000,
+      runContextEngineMaintenance: vi.fn(),
+      recordCliCompactionInStore,
+    });
+
+    const result = await runCliTurnCompactionLifecycle({
+      cfg: {} as OpenClawConfig,
+      sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      workspaceDir: tmpDir,
+      agentDir: tmpDir,
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    expect(result).toBe(sessionEntry);
+    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+  });
+
   it("bounds a hung CLI context-engine compaction and leaves resume state intact", async () => {
     const sessionKey = "agent:main:cli";
     const sessionId = "session-cli-timeout";

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -92,6 +92,8 @@ type NativeHarnessCliCompactionOutcome = {
 type CliTranscriptCompactionOutcome = {
   compacted: boolean;
   failureReason?: string;
+  /** True when the failure is transient (e.g. spend-guard backoff) and the caller should soft-fail rather than throw. */
+  transient?: boolean;
 };
 type CliCompactionRuntimeContextParams = {
   sessionKey: string;
@@ -317,12 +319,13 @@ async function compactCliTranscript(params: {
       resolveCompactionTimeoutMs(params.cfg),
     );
   } catch (error) {
-    log.warn(
-      `CLI transcript compaction failed for ${params.provider}/${params.model}: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    const reason = error instanceof Error ? error.message : String(error);
+    const transient = error instanceof Error && error.name === "LcmSummarySpendLimitError";
+    log.warn(`CLI transcript compaction failed for ${params.provider}/${params.model}: ${reason}`);
     return {
       compacted: false,
-      failureReason: error instanceof Error ? error.message : String(error),
+      failureReason: reason,
+      ...(transient ? { transient: true } : {}),
     };
   }
 
@@ -334,12 +337,16 @@ async function compactCliTranscript(params: {
       );
       return { compacted: false };
     }
+    const transient =
+      typeof compactResult.reason === "string" &&
+      compactResult.reason.startsWith("summary spend backoff");
     log.warn(
       `CLI transcript compaction did not reduce context for ${params.provider}/${params.model}: ${reason}`,
     );
     return {
       compacted: false,
-      failureReason: compactResult.reason ?? "compaction did not reduce context",
+      failureReason: reason,
+      ...(transient ? { transient: true } : {}),
     };
   }
 
@@ -664,6 +671,12 @@ export async function runCliTurnCompactionLifecycle(params: {
     });
     compacted = contextOutcome.compacted;
     if (!compacted && contextOutcome.failureReason) {
+      if (contextOutcome.transient) {
+        log.warn(
+          `CLI transcript compaction deferred for ${params.provider}/${params.model}: ${contextOutcome.failureReason ?? "transient error"}`,
+        );
+        return params.sessionEntry;
+      }
       throw new Error(
         `CLI transcript compaction failed for ${params.provider}/${params.model}: ${
           contextOutcome.failureReason ?? "compaction did not reduce context"


### PR DESCRIPTION
## What changed

This makes CLI transcript compaction treat transient context-engine spend-backoff as a soft failure instead of throwing and aborting the turn.

## Why

When the context engine returns a temporary summary-spend backoff, the CLI compaction lifecycle currently reports a hard failure. That can bubble up as an unavailable turn even though the session should continue in degraded mode and retry compaction later.

## Details

- Marks `LcmSummarySpendLimitError` and `summary spend backoff...` compact results as transient.
- Returns the existing session entry for transient compaction deferrals instead of throwing.
- Preserves current below-target/no-op compaction behaviour on latest `main`.
- Adds regression coverage for both returned backoff reasons and thrown `LcmSummarySpendLimitError`.

## Real behavior proof

- Behavior or issue addressed: CLI turn compaction should not abort the turn when the selected context engine reports a temporary summary-spend backoff.
- Real environment tested: Local OpenClaw source checkout on macOS, PR head `db931fef3a34933d33518ad738856e491baad936`, running the production `runCliTurnCompactionLifecycle` path against file-backed OpenClaw session JSONL and session-store state.
- Exact steps or command run after this patch: Ran a local `pnpm exec tsx --eval ...` smoke that created a real session JSONL/store, invoked `runCliTurnCompactionLifecycle`, and fed the context-engine compact result shape observed from live runtime logs: `summary spend backoff open for compaction:agent:main:cli until ...`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[agents/cli-compaction] CLI transcript compaction did not reduce context for claude-cli/opus: summary spend backoff open for compaction:agent:main:cli until 2099-01-01T00:00:00.000Z
[agents/cli-compaction] CLI transcript compaction deferred for claude-cli/opus: summary spend backoff open for compaction:agent:main:cli until 2099-01-01T00:00:00.000Z
{
  "exit": "ok",
  "returnedSameSessionEntry": true,
  "compactCalls": 1,
  "recordCalls": 0,
  "sessionId": "real-proof-cli-backoff",
  "note": "spend-backoff deferral returned existing session entry without throwing"
}
```

- Observed result after fix: The CLI compaction lifecycle returned the existing session entry and exited successfully instead of throwing; no compaction-store rotation was recorded because the deferral was transient.
- What was not tested: A naturally occurring live summary-spend backoff from the production lossless-claw service during a real user turn was not forced, because that depends on the live summary-spend backoff window and would require waiting for or inducing the upstream quota condition.
- Proof limitations or environment constraints: This is a local source-run smoke against the production CLI compaction lifecycle with a real file-backed OpenClaw session, but the context-engine backoff result was injected to match the redacted live runtime error shape rather than generated by an actual exhausted production summary-spend window.
- Before evidence (optional but encouraged): Current main throws whenever context-engine CLI compaction returns a non-below-target failure reason; ClawSweeper also confirmed that source behaviour against main in its review.

## Verification

- `node scripts/test-projects.mjs src/agents/command/cli-compaction.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/command/cli-compaction.ts src/agents/command/cli-compaction.test.ts`
- `pnpm exec oxlint src/agents/command/cli-compaction.ts src/agents/command/cli-compaction.test.ts`
- `pnpm test src/agents/command/cli-compaction.test.ts`
- `git diff --check -- src/agents/command/cli-compaction.test.ts`
