### PR TITLE
fix(auto-reply): allow in-flight foreground reply to finish when newer generation delivers visible output

### DIFF
--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -167,7 +167,7 @@ async function shouldCancelForegroundReplyDelivery(
       return false;
     }
     if (state.visibleDeliveryGeneration > snapshot.generation) {
-      return true;
+      return !state.activeGenerations.has(snapshot.generation);
     }
     if (!hasNewerActiveForegroundReplyFenceGeneration(state, snapshot.generation)) {
       return false;


### PR DESCRIPTION
In foreground reply fence, when a newer generation produces visible delivery, the current code unconditionally cancels the older generation's delivery even if it's still actively sending output. This causes long in-flight replies to get truncated prematurely.

**Problem:**
When `state.visibleDeliveryGeneration > snapshot.generation`, the worker returns `true` unconditionally, cancelling the older in-flight reply even while it is still actively delivering content.

**Fix:**
Change the cancellation condition to only return `true` when the older generation is no longer active:
```diff
- if (state.visibleDeliveryGeneration > snapshot.generation) return true;
+ if (state.visibleDeliveryGeneration > snapshot.generation) return !state.activeGenerations.has(snapshot.generation);
```

This preserves the intent of the fence:
- If the older generation is already finished → cancel it (same as before)
- If the older generation is **still active/in-flight** → let it finish its remaining delivery

**Behavior table:**

| Scenario | Before (2026.6.8) | After |
|---|---|---|
| newer visible delivery, older generation ended | cancel | cancel |
| newer visible delivery, older generation still active | cancel | allow remaining delivery |

Fixes #93831

## Real behavior proof

**Behavior or issue addressed**: Fix foreground reply fence cancelling older in-flight reply when a newer generation produces visible delivery (issue #93831).

**Real environment tested**: TypeScript compilation + existing unit test suite on openclaw main branch at commit `f3d5f37b00` with Node.js v24.13.1 on Linux x64.

**Exact steps or command run after this patch**:
Applied the one-line change to `src/auto-reply/dispatch.ts`, then ran:
```
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast-fake-timers.config.ts --reporter=verbose
```

**Evidence after fix**:
The full test suite (149 tests across 10 test files) passes with the patch applied:
```
Test Files  10 passed (10)
     Tests  149 passed (149)
  Duration  11.58s
```

All existing auto-reply dispatch tests continue to pass with the modified logic. The diff itself is minimal and type-safe:
```diff
-      return true;
+      return !state.activeGenerations.has(snapshot.generation);
```

Code analysis of `activeGenerations`: The `beginForegroundReplyFence` function increments `activeGenerations` for the snapshot's generation, and `endForegroundReplyFence` decrements and deletes the entry when the generation completes. So `state.activeGenerations.has(snapshot.generation)` is `true` while the generation is still actively delivering, and `false` after it finishes. The change therefore only cancels the older reply when it has genuinely finished, not while it is still in-flight.

**Observed result after fix**:
- All 149 unit tests pass (no regressions)
- TypeScript compilation succeeds with no type errors
- Code logic verified: `activeGenerations` correctly tracks live dispatch generations throughout their lifecycle

**What was not tested**: Full end-to-end test with a running OpenClaw instance and real chat channels was not performed due to environment constraints. The fix relies on the existing dispatch lifecycle instrumentation (`activeGenerations` map) which is already exercised by the unit test suite.