### PR TITLE
fix(telegram): avoid Bot API 10.1 HTML tags in non-rich messages

### DIFF
--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -93,7 +93,7 @@ function normalizeTelegramDraftTransportPreview(
 ): TelegramDraftTransportPreview {
   if (preview.richMessage?.html) {
     return {
-      text: preview.richMessage.html,
+      text: renderTelegramHtmlText(preview.richMessage.html, { textMode: "html" }),
       parseMode: "HTML",
       plainText: preview.text,
     };

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -148,7 +148,7 @@ function preserveTelegramListBoundarySpacing(markdown: string): string {
 
 export function markdownToTelegramHtml(
   markdown: string,
-  options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
+  options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean; richMode?: boolean } = {},
 ): string {
   const tableMode = options.tableMode === "block" ? "code" : options.tableMode;
   const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
@@ -159,12 +159,24 @@ export function markdownToTelegramHtml(
     tableMode,
   });
   const html = renderTelegramHtml(ir);
-  const telegramHtml = preserveSupportedTelegramHtmlTags(html);
+  const supportedHtml = preserveSupportedTelegramHtmlTags(html);
+  // Bot API 10.1+ HTML features (e.g. <blockquote>, <h1>-<h6>) are not supported
+  // in regular sendMessage with parse_mode: "HTML". Telegram Web clients show
+  // "This message is not supported" when receiving these tags.
+  // Convert them to legacy-compatible <b> in non-rich mode.
+  const legacyHtml =
+    options.richMode === true
+      ? supportedHtml
+      : supportedHtml
+          .replace(/<blockquote>/g, "<b>")
+          .replace(/<\/blockquote>/g, "</b>")
+          .replace(/<h([1-6])>/g, "<b>")
+          .replace(/<\/h([1-6])>/g, "</b>");
   // Apply file reference wrapping if requested (for chunked rendering)
   if (options.wrapFileRefs !== false) {
-    return wrapFileReferencesInHtml(telegramHtml);
+    return wrapFileReferencesInHtml(legacyHtml);
   }
-  return telegramHtml;
+  return legacyHtml;
 }
 
 /**


### PR DESCRIPTION
## Summary

Telegram Web clients show `This message is not supported` when receiving messages containing Bot API 10.1+ HTML features like `<blockquote>` and headings, even when sent via regular `sendMessage` with `parse_mode=HTML`.

## Root Cause

OpenClaw's `markdownToTelegramHtml` emitted `<blockquote>` and heading tags unconditionally. The Bot API accepted these tags but Telegram Web could not render them.

## Changes

1. **markdownToTelegramHtml** - Added `richMode` option. Default (non-rich) replaces `<blockquote>` and headings with `<b>` for compatibility.
2. **normalizeTelegramDraftTransportPreview** - Rich message previews sanitized before standard HTML delivery.

Fixes #93794