### PR TITLE
fix(plugins): restore release package compatibility

### DIFF
--- a/extensions/feishu/src/client-import.test.ts
+++ b/extensions/feishu/src/client-import.test.ts
@@ -1,0 +1,30 @@
+// Feishu client module import behavior tests.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.doUnmock("@larksuiteoapi/node-sdk");
+  vi.doUnmock("@openclaw/proxyline");
+  vi.resetModules();
+});
+
+describe("Feishu client module", () => {
+  it("loads when the SDK has no default HTTP instance", async () => {
+    vi.doMock("@larksuiteoapi/node-sdk", () => ({
+      AppType: { SelfBuild: "self" },
+      Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
+      LoggerLevel: { info: "info" },
+      Client: vi.fn(),
+      WSClient: vi.fn(),
+      EventDispatcher: vi.fn(),
+      defaultHttpInstance: undefined,
+    }));
+    vi.doMock("@openclaw/proxyline", () => ({
+      createAmbientNodeProxyAgent: vi.fn(),
+      hasAmbientNodeProxyConfigured: vi.fn(() => false),
+    }));
+
+    await expect(import("./client.js")).resolves.toMatchObject({
+      createFeishuClient: expect.any(Function),
+    });
+  });
+});

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -387,6 +387,23 @@ describe("createFeishuClient HTTP timeout", () => {
     });
   });
 
+  it("rejects client creation when the SDK default HTTP instance is unavailable", () => {
+    setFeishuClientRuntimeForTest({
+      sdk: {
+        defaultHttpInstance: undefined as never,
+      },
+    });
+
+    expect(() =>
+      createFeishuClient({
+        appId: "app-default-http",
+        appSecret: "secret-default-http", // pragma: allowlist secret
+        accountId: "default-http-instance",
+      }),
+    ).toThrow("Feishu SDK default HTTP instance is unavailable");
+    expect(clientCtorMock).not.toHaveBeenCalled();
+  });
+
   it("evicts client cache when SDK is replaced via setFeishuClientRuntimeForTest (#83911)", () => {
     const ctorCountA = clientCtorMock.mock.calls.length;
 

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -67,12 +67,14 @@ let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
 // If a future SDK version adds more interceptors, the upgrade will need
 // compatibility verification regardless.
 {
-  const inst = Lark.defaultHttpInstance as {
-    interceptors?: {
-      request: { handlers: unknown[]; use: (fn: (req: unknown) => unknown) => void };
-    };
-  };
-  if (inst.interceptors?.request) {
+  const inst = Lark.defaultHttpInstance as
+    | {
+        interceptors?: {
+          request: { handlers: unknown[]; use: (fn: (req: unknown) => unknown) => void };
+        };
+      }
+    | undefined;
+  if (inst?.interceptors?.request) {
     inst.interceptors.request.handlers = [];
     inst.interceptors.request.use((req: unknown) => {
       const r = req as { headers?: Record<string, string> };
@@ -119,9 +121,10 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
  * but injects a default request timeout and User-Agent header to prevent
  * indefinite hangs and set a standardized User-Agent per OAPI best practices.
  */
-function createTimeoutHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
-  const base: FeishuHttpInstanceLike = feishuClientSdk.defaultHttpInstance;
-
+function createTimeoutHttpInstance(
+  base: FeishuHttpInstanceLike,
+  defaultTimeoutMs: number,
+): Lark.HttpInstance {
   function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
     return { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
   }
@@ -175,13 +178,19 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
     return cached.client;
   }
 
-  // Create new client with timeout-aware HTTP instance
+  const defaultHttpInstance = feishuClientSdk.defaultHttpInstance as
+    | FeishuHttpInstanceLike
+    | undefined;
+  if (!defaultHttpInstance) {
+    throw new Error("Feishu SDK default HTTP instance is unavailable");
+  }
+
   const client = new feishuClientSdk.Client({
     appId,
     appSecret,
     appType: feishuClientSdk.AppType.SelfBuild,
     domain: resolveDomain(domain),
-    httpInstance: createTimeoutHttpInstance(defaultHttpTimeoutMs),
+    httpInstance: createTimeoutHttpInstance(defaultHttpInstance, defaultHttpTimeoutMs),
   });
 
   // Cache it

--- a/extensions/matrix/npm-shrinkwrap.json
+++ b/extensions/matrix/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@openclaw/matrix",
       "version": "2026.6.8",
       "dependencies": {
-        "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.0",
+        "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0",
         "@matrix-org/matrix-sdk-crypto-wasm": "18.3.0",
         "fake-indexeddb": "6.2.5",
         "markdown-it": "14.2.0",
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@matrix-org/matrix-sdk-crypto-nodejs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.6.0.tgz",
-      "integrity": "sha512-AndGryzkDtFbaDyPBAQ2B4pUhaA/q4HJf3wgiGpPa/70DsdY1Z3R5Wn9yp+56CeHOpk61mNHz/8WDPlzrZDSJw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.4.0.tgz",
+      "integrity": "sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -56,7 +56,7 @@
         "node-downloader-helper": "^2.1.9"
       },
       "engines": {
-        "node": ">= 24"
+        "node": ">= 22"
       }
     },
     "node_modules/@matrix-org/matrix-sdk-crypto-wasm": {

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -8,7 +8,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.0",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0",
     "@matrix-org/matrix-sdk-crypto-wasm": "18.3.0",
     "fake-indexeddb": "6.2.5",
     "markdown-it": "14.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,8 +957,8 @@ importers:
   extensions/matrix:
     dependencies:
       '@matrix-org/matrix-sdk-crypto-nodejs':
-        specifier: 0.6.0
-        version: 0.6.0
+        specifier: 0.4.0
+        version: 0.4.0
       '@matrix-org/matrix-sdk-crypto-wasm':
         specifier: 18.3.0
         version: 18.3.0
@@ -2926,9 +2926,9 @@ packages:
   '@lydell/node-pty@1.2.0-beta.12':
     resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
 
-  '@matrix-org/matrix-sdk-crypto-nodejs@0.6.0':
-    resolution: {integrity: sha512-AndGryzkDtFbaDyPBAQ2B4pUhaA/q4HJf3wgiGpPa/70DsdY1Z3R5Wn9yp+56CeHOpk61mNHz/8WDPlzrZDSJw==}
-    engines: {node: '>= 24'}
+  '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
+    resolution: {integrity: sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==}
+    engines: {node: '>= 22'}
 
   '@matrix-org/matrix-sdk-crypto-wasm@18.3.0':
     resolution: {integrity: sha512-9a4feyt8QLysARu7PHKaRWT+wcCd+IYH074LXp9QK5WqfN4zUXueRhiSSMNT18Bm+8q3sBR/4zxDxOSDR0M8Kg==}
@@ -8873,7 +8873,7 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
       '@lydell/node-pty-win32-x64': 1.2.0-beta.12
 
-  '@matrix-org/matrix-sdk-crypto-nodejs@0.6.0':
+  '@matrix-org/matrix-sdk-crypto-nodejs@0.4.0':
     dependencies:
       https-proxy-agent: 7.0.6
       node-downloader-helper: 2.1.11


### PR DESCRIPTION
## Summary

- Restore the Matrix native crypto package to `0.4.0`, the last release line that supports OpenClaw's Node 22 floor.
- Keep Feishu package inspection importable when an adapter omits the SDK HTTP singleton, while rejecting real client creation before the required timeout wrapper could be lost.
- Regenerate the published Matrix npm shrinkwrap from the workspace lockfile.

Out of scope: publishing the next OpenClaw npm release and updating downstream artifact repositories.

Review focus: the Lark SDK contract guarantees its production HTTP singleton; the guarded import is for inspection/adaptor shapes only, and client creation remains fail-closed to preserve request timeouts.

## Linked context

Related: organization Dependabot remediation for published OpenClaw plugin artifacts.

Requested by an OpenClaw maintainer during the security-alert sweep.

## Real behavior proof

- Behavior addressed: Matrix package installation remains usable on the supported Node 22 runtime; Feishu artifact inspection no longer crashes during module import when the SDK singleton is absent.
- Real environment tested: Blacksmith Testbox Linux.
- Exact steps or command run after this patch:
  - `corepack pnpm tsgo:extensions`
  - `node scripts/run-vitest.mjs extensions/feishu/src/client-import.test.ts extensions/feishu/src/client.test.ts extensions/matrix/src/matrix/sdk/crypto-node.runtime.test.ts`
  - `node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/matrix --check`
  - `corepack pnpm build`
  - `npm exec --yes --package=node@22.19.0 -- node -e 'require("@matrix-org/matrix-sdk-crypto-nodejs"); console.log(process.version)'`
- Evidence after fix: Testbox `tbx_01kva4j9na88zry6w0dqx83jv6` passed the extension typecheck, 20 focused tests, shrinkwrap verification, and build. The Node 22 native-binding check printed `v22.19.0`.
- Observed result after fix: the Matrix 0.4.0 native binding installs and loads under Node 22.19.0; Feishu imports in the missing-singleton inspection shape, while real client creation fails clearly instead of silently dropping timeouts.
- What was not tested: live Feishu API calls, which require tenant credentials.
- Proof limitations or environment constraints: the broad changed gate was attempted on the stale base and stopped on an upstream MCP typecheck failure; the branch was then rebased to current `main`, and the touched extension/type/build paths were rerun in Testbox.

## Tests and validation

- Fresh Codex autoreview: clean on `ad02a6226e`.
- Testbox `tbx_01kva4j9na88zry6w0dqx83jv6`: extension typecheck, focused Feishu/Matrix tests, generated shrinkwrap check, build, and Node 22 native-binding load.

## Risk checklist

- Did user-visible behavior change? Yes. Matrix npm installs again support Node 22; Feishu's unsupported SDK inspection shape now fails explicitly at client creation.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- What is the highest-risk area? Matrix native package resolution and Feishu HTTP initialization.
- How is that risk mitigated? Generated shrinkwrap validation, Node 22 native module loading, targeted tests, extension typecheck, build, and fresh autoreview.

## Current review state

Ready for maintainer merge. No remaining author work.
