### PR TITLE
fix(setup): point non-interactive health hints at onboard flags

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -783,7 +783,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           runtime,
         ),
       ).rejects.toThrow(
-        /only waits for an already-running gateway unless you pass --install-daemon[\s\S]*--skip-health/,
+        /only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`[\s\S]*openclaw onboard --install-daemon[\s\S]*openclaw onboard --skip-health/,
       );
     });
   }, 60_000);

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -342,8 +342,8 @@ export async function runNonInteractiveLocalSetup(params: {
         diagnostics,
         hints: !opts.installDaemon
           ? [
-              "Non-interactive local setup only waits for an already-running gateway unless you pass --install-daemon.",
-              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run with \`--install-daemon\`, or use \`--skip-health\`.`,
+              "Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.",
+              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run \`${formatCliCommand("openclaw onboard --install-daemon")}\`, or use \`${formatCliCommand("openclaw onboard --skip-health")}\`.`,
               process.platform === "win32"
                 ? "Native Windows managed gateway install tries Scheduled Tasks first and falls back to a per-user Startup-folder login item when task creation is denied."
                 : undefined,


### PR DESCRIPTION
## Summary
- Problem: `openclaw setup --non-interactive` prints recovery hints that mention `--install-daemon` and `--skip-health`, but those flags are only registered on `openclaw onboard`, not on `openclaw setup`.
- Solution: Update the non-interactive local health-failure hint to reference `openclaw onboard --install-daemon` and `openclaw onboard --skip-health`.
- What changed: `src/commands/onboard-non-interactive/local.ts` (health-failure hint text) and `src/commands/onboard-non-interactive.gateway.test.ts` (regression assertion).
- What did NOT change: CLI flag registration, health-check logic, or output formatting helpers.

Fixes #93947

## Real behavior proof
- **Behavior or issue addressed:** Users running `openclaw setup --non-interactive` and hitting a local gateway health failure were told to use flags that `setup` does not accept.
- **Real environment tested:** Linux x86_64, Node v22.22.0, local source checkout at upstream/main (e2fa4f396b).
- **Exact steps or command run after this patch:**
  ```bash
  pnpm build
  HOME=$(mktemp -d) node openclaw.mjs setup --non-interactive --accept-risk --mode local --workspace /tmp/oc-proof-workspace
  ```
- **Evidence after fix:** Terminal output shows the corrected hint:
  ```
  Gateway did not become reachable at ws://127.0.0.1:18789.
  Fix: run `openclaw doctor --fix`.
  Non-interactive local setup only waits for an already-running gateway unless you pass `--install-daemon` to `openclaw onboard`.
  Fix: start `openclaw gateway run`, re-run `openclaw onboard --install-daemon`, or use `openclaw onboard --skip-health`.
  ```
- **Observed result after fix:** The recovery hint no longer suggests unsupported `setup` flags; it points to `openclaw onboard --install-daemon` / `--skip-health`.
- **What was not tested:** macOS/Windows shell escaping; daemon-install failure path hint (unchanged).

## Regression Test Plan
- Coverage level: Unit test
- Target test file: `src/commands/onboard-non-interactive.gateway.test.ts`
- Scenario locked in: Local health failure without daemon install asserts that the hint references `openclaw onboard --install-daemon` and `openclaw onboard --skip-health`.
- Why this is the smallest reliable guardrail: It exercises the exact failure path and locks the corrected command surface in the user-facing message.

## Root Cause
- Root cause: The health-failure hint was written assuming the current command accepts `--install-daemon`/`--skip-health`. When invoked via `setup`, those flags are not registered, so the hint points to a non-existent CLI surface.
- Missing detection / guardrail: No test asserted the full command name in the hint, allowing the stale self-referential wording to persist.
