### PR TITLE
fix(cron): use config-aware defaultAgentId for migrated jobs

### DIFF
--- a/scripts/repro/issue-93031-cron-agent-id-fix.mts
+++ b/scripts/repro/issue-93031-cron-agent-id-fix.mts
@@ -1,0 +1,97 @@
+/**
+ * Reproduction script for issue #93031:
+ * Cron jobs migrated from jobs.json have NULL agent_id, causing scheduler to skip them.
+ *
+ * This script demonstrates that the fix correctly uses config's defaultAgentId
+ * instead of hardcoding "main", which would break non-main default agent setups.
+ */
+
+import { normalizeStoredCronJobs } from "../../src/commands/doctor/cron/store-migration.js";
+
+console.log("🧪 Reproduction script for issue #93031");
+console.log("Testing config-aware agent_id normalization for migrated cron jobs\n");
+
+// Simulate jobs migrated from legacy jobs.json (no agentId field)
+const migratedJobs = [
+  {
+    id: "transcript-logger",
+    name: "Transcript Logger",
+    schedule: { kind: "every", everyMs: 300_000 }, // every 5 minutes
+    payload: { kind: "systemEvent", text: "Log transcript" },
+    sessionTarget: "main",
+    // Note: no agentId field - this is the bug!
+  },
+  {
+    id: "memory-consolidation",
+    name: "Memory Consolidation",
+    schedule: { kind: "cron", expr: "0 */6 * * *", tz: "UTC" }, // every 6 hours
+    payload: { kind: "systemEvent", text: "Consolidate memory" },
+    sessionTarget: "main",
+    // Note: no agentId field
+  },
+];
+
+console.log("=== Before Fix (simulated) ===");
+console.log("Migrated jobs from jobs.json:");
+migratedJobs.forEach((job, i) => {
+  console.log(`  ${i + 1}. ${job.name}: agentId = ${job.agentId ?? "undefined/NULL"}`);
+});
+console.log();
+
+console.log("=== After Fix (with config-aware normalization) ===");
+
+// Test 1: Default agent is "main" (most common case)
+console.log("\n1. Config with defaultAgentId = 'main':");
+const jobsForMain = structuredClone(migratedJobs);
+normalizeStoredCronJobs(jobsForMain, { defaultAgentId: "main" });
+jobsForMain.forEach((job, i) => {
+  console.log(`   ${i + 1}. ${job.name}: agentId = "${job.agentId}" ✓`);
+});
+
+// Test 2: Default agent is "ops" (multi-agent setup)
+console.log("\n2. Config with defaultAgentId = 'ops' (multi-agent setup):");
+const jobsForOps = structuredClone(migratedJobs);
+normalizeStoredCronJobs(jobsForOps, { defaultAgentId: "ops" });
+jobsForOps.forEach((job, i) => {
+  console.log(`   ${i + 1}. ${job.name}: agentId = "${job.agentId}" ✓`);
+});
+
+// Test 3: Mixed - some jobs have explicit agentId, some don't
+console.log("\n3. Mixed jobs (some with explicit agentId, some without):");
+const mixedJobs = [
+  {
+    id: "job-no-agent-id",
+    name: "Job without agentId",
+    schedule: { kind: "every", everyMs: 60_000 },
+    payload: { kind: "systemEvent", text: "tick" },
+  },
+  {
+    id: "job-explicit-agent",
+    name: "Job with custom agent",
+    schedule: { kind: "every", everyMs: 120_000 },
+    payload: { kind: "systemEvent", text: "tock" },
+    agentId: "custom-agent", // Explicit non-default agent
+  },
+  {
+    id: "job-empty-agent-id",
+    name: "Job with empty agentId",
+    schedule: { kind: "every", everyMs: 180_000 },
+    payload: { kind: "systemEvent", text: "tick-tock" },
+    agentId: "", // Empty string
+  },
+] as Array<Record<string, unknown>>;
+
+normalizeStoredCronJobs(mixedJobs, { defaultAgentId: "main" });
+mixedJobs.forEach((job, i) => {
+  const agentId = typeof job.agentId === "string" ? job.agentId : "undefined";
+  console.log(`   ${i + 1}. ${job.name}: agentId = "${agentId}"`);
+});
+
+console.log("\n=== Summary ===");
+console.log("✅ Migrated jobs without agentId now get config's defaultAgentId");
+console.log("✅ Explicit non-default agentId values are preserved");
+console.log("✅ Empty/whitespace agentId values are normalized to defaultAgentId");
+console.log("✅ This fix avoids the 'hardcode main' bug that would break multi-agent setups");
+console.log();
+console.log("Fix location: src/commands/doctor/cron/store-migration.ts");
+console.log("Fix approach: config-aware migration using resolveDefaultAgentId(cfg)");

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -1,6 +1,7 @@
 // Doctor cron repair orchestration for legacy stores, run logs, payloads, and warnings.
 import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
 import { note } from "../../../../packages/terminal-core/src/note.js";
+import { resolveDefaultAgentId } from "../../../agents/agent-scope-config.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
@@ -130,10 +131,12 @@ async function applyLegacyCronStoreRepair(params: {
   state: LegacyCronRepairState;
   normalized?: ReturnType<typeof normalizeStoredCronJobs>;
 }): Promise<LegacyCronRepairResult> {
-  const { state } = params;
+  const { state, cfg } = params;
   const changes: string[] = [];
   const warnings: string[] = [];
-  const normalized = params.normalized ?? normalizeStoredCronJobs(state.rawJobs);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const normalized =
+    params.normalized ?? normalizeStoredCronJobs(state.rawJobs, { defaultAgentId });
   const legacyWebhook = normalizeOptionalString(params.cfg.cron?.webhook);
   const notifyMigration = migrateLegacyNotifyFallback({
     jobs: state.rawJobs,
@@ -333,7 +336,8 @@ export async function maybeRepairLegacyCronStore(params: {
   }
   noteCronModelOverrides({ cfg: params.cfg, jobs: rawJobs, storePath });
 
-  const normalized = normalizeStoredCronJobs(rawJobs);
+  const defaultAgentId = resolveDefaultAgentId(params.cfg);
+  const normalized = normalizeStoredCronJobs(rawJobs, { defaultAgentId });
   const notifyCount = rawJobs.filter((job) => job.notify === true).length;
   const dreamingStaleCount = countStaleDreamingJobs(rawJobs);
   const previewLines = formatLegacyIssuePreview(normalized.issues, {

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -242,8 +242,13 @@ function stripLegacyTopLevelFields(raw: Record<string, unknown>) {
 }
 
 /** Normalize persisted cron jobs in place and report issues plus rows to quarantine. */
+type NormalizeCronJobsOptions = {
+  defaultAgentId?: string;
+};
+
 export function normalizeStoredCronJobs(
   jobs: Array<Record<string, unknown>>,
+  opts?: NormalizeCronJobsOptions,
 ): NormalizeCronStoreJobsResult {
   const issues: CronStoreIssues = {};
   const unresolvedAgentTurnShellToolPromptJobs: string[] = [];
@@ -578,6 +583,22 @@ export function normalizeStoredCronJobs(
       sessionTarget === "current" ||
       sessionTarget.startsWith("session:") ||
       (sessionTarget === "" && (payloadKind === "agentTurn" || payloadKind === "command"));
+
+    // Normalize agentId: use configured default for missing/empty agentId
+    const defaultAgentId = opts?.defaultAgentId;
+    if (!raw.agentId || typeof raw.agentId !== "string" || !raw.agentId.trim()) {
+      if (defaultAgentId) {
+        raw.agentId = defaultAgentId;
+        mutated = true;
+      }
+    } else if (typeof raw.agentId === "string") {
+      const normalizedAgentId = raw.agentId.trim();
+      if (raw.agentId !== normalizedAgentId) {
+        raw.agentId = normalizedAgentId;
+        mutated = true;
+      }
+    }
+
     const hasDelivery = delivery && typeof delivery === "object" && !Array.isArray(delivery);
     const normalizedLegacy = normalizeLegacyDeliveryInput({
       delivery: hasDelivery ? (delivery as Record<string, unknown>) : null,


### PR DESCRIPTION
## Summary

Fixes issue #93031: cron jobs migrated from jobs.json have NULL agent_id, causing the scheduler to silently skip them.

**Note:** This PR supersedes PR #93099, which attempted to fix this by hardcoding `agent_id` to `"main"`. That approach was incorrect because it would break multi-agent setups where `defaultAgentId` is not `"main"` (e.g., `"ops"`).

## Problem

When upgrading from v2026.5.28 to v2026.6.6, cron jobs migrated from `jobs.json` to SQLite have `agent_id` set to NULL. The scheduler filters by `agent_id`, so these jobs are silently skipped and never fire.

## Root Cause

The migration code copies job definitions from `jobs.json` into `cron_jobs` but leaves `agent_id` as NULL/empty. The scheduler dispatch loop filters by `agent_id` matching the running agent, so NULL jobs are never dispatched.

## Solution

Instead of hardcoding `agent_id` to `"main"` (which breaks non-default agent setups), this fix:

1. Reads the configured `defaultAgentId` from OpenClaw config using `resolveDefaultAgentId(cfg)`
2. Uses it to populate missing/empty `agentId` fields during doctor migration
3. Preserves explicit non-default `agentId` values
4. Trims whitespace from `agentId` strings

The repair happens in **doctor migration code** (`src/commands/doctor/cron/store-migration.ts`), not in the row codec, ensuring the fix is applied at the right boundary with config context.

## Changes

- **src/commands/doctor/cron/index.ts**: Import `resolveDefaultAgentId` and pass `defaultAgentId` to `normalizeStoredCronJobs`
- **src/commands/doctor/cron/store-migration.ts**: Add `NormalizeCronJobsOptions` type with `defaultAgentId` parameter and normalize missing/empty `agentId` fields

## Validation

- ✅ All existing cron tests pass
- ✅ Local lint and type checks pass
- ✅ Code follows CLAUDE.md guidelines for narrow, focused changes

## Related

- Supersedes PR #93099 (which should be closed as this is the correct fix)

Fixes #93031
