### PR TITLE
fix(heartbeat): skip missing-file idle heartbeat

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1819,6 +1819,48 @@ tasks:
     }
   });
 
+  // Missing HEARTBEAT.md should skip only the default idle timer path.
+  it("skips default scheduled interval when HEARTBEAT.md is missing", async () => {
+    const tmpDir = await createCaseDir("openclaw-hb-missing-default");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const workspaceDir = path.join(tmpDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: workspaceDir } },
+      session: { store: storePath },
+    };
+
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [resolveMainSessionKey(cfg)]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+        },
+      }),
+    );
+
+    const replySpy = vi.fn().mockResolvedValue({ text: "should not be called" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      source: "interval",
+      intent: "scheduled",
+      reason: "interval",
+      deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+    });
+
+    expect(res).toEqual({ status: "skipped", reason: "missing-heartbeat-file" });
+    expect(replySpy).not.toHaveBeenCalled();
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+  });
+
   it("uses an internal-only cron prompt when heartbeat delivery target is none", async () => {
     const tmpDir = await createCaseDir("hb-cron-target-none");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -858,7 +858,34 @@ type HeartbeatWakePayloadFlags = {
   isWakePayload: boolean;
 };
 
-type HeartbeatSkipReason = "empty-heartbeat-file";
+type HeartbeatSkipReason = "empty-heartbeat-file" | "missing-heartbeat-file";
+
+// Returns true when the user explicitly configured heartbeat behavior.
+// Missing HEARTBEAT.md should not disable these runs because the heartbeat
+// - prompt can live in config instead of the workspace file.
+function hasExplicitHeartbeatConfigForAgent(cfg: OpenClawConfig, agentId: string): boolean {
+  if (cfg.agents?.defaults?.heartbeat) {
+    return true;
+  }
+
+  const resolvedAgentId = normalizeAgentId(agentId);
+  return (cfg.agents?.list ?? []).some(
+    (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
+  );
+}
+
+// Identifies the routine timer heartbeat with no event payload.
+// Missing HEARTBEAT.md skips only this idle path; manual, immediate, and
+// event-driven wakes must still run so queued work is not interrupted.
+function isDefaultScheduledIdleHeartbeat(params: {
+  source?: HeartbeatWakeSource;
+  intent?: HeartbeatWakeIntent;
+  reason?: string;
+}): boolean {
+  return (
+    params.source === "interval" && params.intent === "scheduled" && params.reason === "interval"
+  );
+}
 
 function buildCommitmentDeliveryKey(commitment: CommitmentRecord): string {
   return [
@@ -967,6 +994,7 @@ async function resolveHeartbeatPreflight(params: {
   forcedSessionKey?: string;
   reason?: string;
   source?: HeartbeatWakeSource;
+  intent?: HeartbeatWakeIntent;
   nowMs?: number;
 }): Promise<HeartbeatPreflight> {
   const wakeFlags = resolveHeartbeatWakePayloadFlags({
@@ -1061,11 +1089,21 @@ async function resolveHeartbeatPreflight(params: {
     };
   } catch (err: unknown) {
     if (hasErrnoCode(err, "ENOENT")) {
-      // Missing HEARTBEAT.md is intentional in some setups (for example, when
-      // heartbeat instructions live outside the file), so keep the run active.
-      // The heartbeat prompt already says "if it exists".
+      if (
+        dueCommitments.length === 0 &&
+        isDefaultScheduledIdleHeartbeat(params) &&
+        !hasExplicitHeartbeatConfigForAgent(params.cfg, params.agentId)
+      ) {
+        return {
+          ...basePreflight,
+          skipReason: "missing-heartbeat-file",
+          tasks: [],
+        };
+      }
+
       return basePreflight;
     }
+
     // For other read errors, proceed with heartbeat as before.
   }
 
@@ -1404,6 +1442,7 @@ export async function runHeartbeatOnce(opts: {
     forcedSessionKey: opts.sessionKey,
     source: opts.source,
     reason: opts.reason,
+    intent: opts.intent,
     nowMs: startedAt,
   });
   if (preflight.skipReason) {


### PR DESCRIPTION
## Summary

- Skip the default scheduled idle heartbeat when `HEARTBEAT.md` is missing and no heartbeat config is explicitly set.
- Preserve existing behavior for explicit heartbeat configuration, wake/event-triggered runs, queued cron/system events, due commitments, and non-`ENOENT` read errors.
- Add regression coverage proving the default missing-file idle path does not call the model or send outbound messages.
- Intentionally out of scope: docs changes, explicit heartbeat config behavior changes, event/immediate wake behavior changes, and broader activity/idle-timeout behavior.
- Reviewers should focus on whether the missing-file skip is limited to the safe idle timer path and does not suppress event-backed heartbeat work.

## Linked context

Closes #83143

Related #85225
Related #14051

Was this requested by a maintainer or owner?

No direct maintainer request. This follows the open issue and keeps the implementation narrower than the related open PR feedback by preserving explicit config and event-triggered runs.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Default scheduled idle heartbeat no longer calls the model when the agent workspace has no `HEARTBEAT.md`, no due commitments, and no explicit heartbeat config.
- Real environment tested: Local Linux checkout at `/home/devineni_monish/openclaw`, branch `feat/validating-heartbeat`.
- Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/heartbeat-runner.returns-default-unset.test.ts
```

- Evidence after fix:

```text
devineni_monish@openclawvm:~/openclaw$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/heartbeat-runner.returns-default-unset.test.ts
[test] starting test/vitest/vitest.infra.config.ts

 RUN  v4.1.7 /home/devineni_monish/openclaw

 ✓  infra  src/infra/heartbeat-runner.returns-default-unset.test.ts (40 tests) 750ms

 Test Files  1 passed (1)
      Tests  40 passed (40)
   Start at  23:46:23
   Duration  7.83s (transform 3.38s, setup 501ms, import 6.29s, tests 750ms, environment 0ms)

[test] passed 1 Vitest shard in 21.18s
```

- Observed result after fix: The heartbeat runner test file passes. The new missing-file default scheduled interval regression test verifies `runHeartbeatOnce` returns `skipped/missing-heartbeat-file`, does not call `getReplyFromConfig`, and does not send an outbound message. Existing coverage still verifies missing files run when heartbeat is explicitly configured, and wake/queued cron heartbeat paths still run.
- What was not tested: I did not run a live OpenClaw gateway idle soak against a real model provider or measure provider token usage.
- Proof limitations or environment constraints: This proof uses the repository heartbeat runner test harness on a local Linux checkout. I do not have a production OpenClaw gateway/model-provider setup available for live idle-token verification.
- Before evidence: Before the runtime fix, the new regression test failed because the missing-file default scheduled interval path returned `ran` instead of `skipped`. During test cleanup, an incorrect table expectation also failed because the explicit-config missing-file case was expected to skip; that table case was corrected to preserve explicit heartbeat behavior.

## Tests and validation

Which commands did you run?

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/heartbeat-runner.returns-default-unset.test.ts
git diff --check
```

What regression coverage was added or updated?

- Added coverage for the default scheduled missing-`HEARTBEAT.md` path with no explicit heartbeat config.
- Preserved existing coverage showing missing files still run for explicit heartbeat config.
- Preserved existing coverage showing wake and queued cron heartbeat paths still run.

What failed before this fix, if known?

- The new regression test failed before the runtime change because the missing-file default scheduled interval path still called the heartbeat runner instead of returning `skipped/missing-heartbeat-file`.

If no test was added, why not?

- A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Default scheduled idle heartbeats without `HEARTBEAT.md` and without explicit heartbeat config now skip instead of prompting the model.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The highest risk is accidentally suppressing event-backed heartbeat work when `HEARTBEAT.md` is missing.

How is that risk mitigated?

The skip is gated to `source: "interval"`, `intent: "scheduled"`, `reason: "interval"`, no due commitments, and no explicit heartbeat config. Existing tests continue to cover explicit heartbeat config, wake-triggered runs, queued cron events, and read-error behavior.

## Current review state

What is the next action?

Ready for maintainer review after CI runs.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI.
- Maintainers may still want stronger live gateway proof because this changes default heartbeat behavior.

Which bot or reviewer comments were addressed?

This PR is shaped around prior related feedback on #85225: it limits the missing-file skip to the default scheduled idle path and preserves explicit config/event-triggered behavior.

AI-assisted: yes. I used Codex to understand the issue, identify the problem scope, then I prepared the patch, validated the output using test cases and behaviour.
