### PR TITLE
#93935: fix(cron): persist startup overflow deferral exemption in service state (fixes #93935)

### DIFF
--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "./service.test-harness.js";
-import { start } from "./service/ops.js";
+import { list, start } from "./service/ops.js";
 import { createCronServiceState } from "./service/state.js";
 import { saveCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
@@ -106,6 +106,104 @@ describe("CronService startup catch-up repair scoping", () => {
 
     expect(repaired?.state.nextRunAtMs).toBe(naturalSlot);
     expect(repaired?.state.nextRunAtMs).not.toBe(staleFutureSlot);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("preserves overflow daily-cron catch-up deferral after list() read RPC (regression #93935)", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const tomorrowNaturalSlot = Date.parse("2025-12-14T09:00:00.000Z");
+    const deferredSlot = startNow + 5_000;
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    // Use mutable clock so we can advance time without a fresh state reload
+    let currentNow = startNow;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => currentNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    // After start(), the daily overflow should be deferred to the staggered slot
+    const afterStart = state.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(afterStart?.state.nextRunAtMs).toBe(deferredSlot);
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+
+    // Advance clock slightly (still before deferred slot fires), then call
+    // list() which triggers ensureLoadedForRead → recomputeNextRunsForMaintenance.
+    // Previously this would clobber the deferral (the bug).
+    currentNow = startNow + 1_000;
+    await list(state);
+
+    const afterList = state.store?.jobs.find((job) => job.id === "daily-overflow");
+    // The deferred staggered slot must be preserved (not advanced to natural slot)
+    expect(afterList?.state.nextRunAtMs).toBe(deferredSlot);
+    expect(afterList?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
+    // The pending set still tracks the deferred job
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+
+    state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("auto-clears pendingCatchupDeferralJobIds when the staggered slot is reached", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+
+    await saveCronStore(store.storePath, {
+      version: 1,
+      jobs: [
+        createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+        createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+        createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+        createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+        createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+        createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+      ],
+    });
+
+    let currentNow = startNow;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => currentNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    // After start(), the pending set should contain the deferred job
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+
+    // Advance clock past the deferred slot and trigger a recompute
+    currentNow = startNow + 6_000;
+    const { recomputeNextRunsForMaintenance } = await import("./service/jobs.js");
+    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+
+    // The id should be auto-cleared since the slot is reached
+    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(false);
 
     state.stopped = true;
     await store.cleanup();

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -244,6 +244,7 @@ export function createMockCronStateForJobs(params: {
     warnedInvalidPersistedJobKeys: new Set<string>(),
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
+    pendingCatchupDeferralJobIds: new Set<string>(),
     deps: {
       storePath: "/mock/path",
       cronEnabled: true,

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -679,6 +679,25 @@ export function recomputeNextRunsForMaintenance(
   const recomputeExpired = opts?.recomputeExpired ?? false;
   const repairFutureCronNextRunAtMs = opts?.repairFutureCronNextRunAtMs ?? true;
   const skipFutureRepairJobIds = opts?.skipFutureRepairJobIds;
+
+  // Auto-clear pending deferrals whose staggered slot has been reached.
+  // This must happen before the walk-schedulable loop so the same tick that
+  // reaches the slot sees the id as exempted.
+  // Guard against undefined for callers that create mock state directly.
+  const pendingDeferrals: ReadonlySet<string> = state.pendingCatchupDeferralJobIds ?? new Set();
+  for (const jobId of pendingDeferrals) {
+    if (!state.store) {
+      break;
+    }
+    const job = state.store.jobs.find((j) => j.id === jobId);
+    if (job && hasScheduledNextRunAtMs(job.state.nextRunAtMs)) {
+      const now = opts?.nowMs ?? state.deps.nowMs();
+      if (now >= job.state.nextRunAtMs) {
+        state.pendingCatchupDeferralJobIds.delete(jobId);
+      }
+    }
+  }
+
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {
@@ -690,6 +709,7 @@ export function recomputeNextRunsForMaintenance(
       } else if (
         repairFutureCronNextRunAtMs &&
         !skipFutureRepairJobIds?.has(job.id) &&
+        !pendingDeferrals.has(job.id) &&
         shouldRepairFutureCronNextRunAtMs({ state, job, nowMs: now })
       ) {
         if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -258,6 +258,16 @@ export async function start(state: CronServiceState) {
     deferAgentTurnJobs: true,
   });
 
+  // Store deferred catch-up job ids on the in-memory service state so every
+  // caller of recomputeNextRunsForMaintenance (read RPCs, timer finalization,
+  // empty-due ticks) exempts their staggered slots from future-slot repair.
+  // Each id is auto-cleared once its deferred slot is reached.
+  if (deferredCatchupJobIds.size > 0) {
+    for (const jobId of deferredCatchupJobIds) {
+      state.pendingCatchupDeferralJobIds.add(jobId);
+    }
+  }
+
   await locked(state, async () => {
     // Startup catch-up already persisted the latest in-memory store state, and
     // this path runs before the scheduler begins servicing regular timer ticks.
@@ -268,7 +278,6 @@ export async function start(state: CronServiceState) {
     }
     const changed = recomputeNextRunsForMaintenance(state, {
       recomputeExpired: true,
-      skipFutureRepairJobIds: deferredCatchupJobIds,
     });
     if (changed) {
       await persist(state);

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -209,6 +209,17 @@ export type CronServiceState = {
   pendingQuarantineConfigJobs: QuarantinedCronConfigJob[];
   lastQuarantineFailureWarnKey: string | null;
   storeLoadedAtMs: number | null;
+  /**
+   * Job IDs with startup catch-up deferrals (overflow or deferred-agent) whose
+   * staggered next-run slots must be preserved across all maintenance recompute
+   * callers (read RPCs, timer finalization, empty-due ticks). Each id is removed
+   * once the deferred slot is reached (now >= nextRunAtMs).
+   *
+   * Set in ops.start() and timer.applyStartupCatchupOutcomes; read by
+   * recomputeNextRunsForMaintenance in jobs.ts. This replaces the one-shot
+   * skipFutureRepairJobIds option that only covered start()'s own recompute.
+   */
+  pendingCatchupDeferralJobIds: Set<string>;
 };
 
 /** Creates mutable cron service state with a concrete clock dependency. */
@@ -228,6 +239,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     pendingQuarantineConfigJobs: [],
     lastQuarantineFailureWarnKey: null,
     storeLoadedAtMs: null,
+    pendingCatchupDeferralJobIds: new Set<string>(),
   };
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1840,6 +1840,10 @@ async function applyStartupCatchupOutcomes(
           if (!job || !isJobEnabled(job)) {
             continue;
           }
+          // Track this id in the in-memory service state so all maintenance
+          // recompute callers (read RPCs, timer finalization, empty-due ticks)
+          // preserve the staggered slot. Auto-cleared once the slot is reached.
+          state.pendingCatchupDeferralJobIds.add(jobId);
           if (typeof deferred.delayMs === "number") {
             job.state.nextRunAtMs = baseNow + deferred.delayMs + offset - staggerMs;
             offset += staggerMs;


### PR DESCRIPTION
## Summary

When a cron job's startup catch-up overflows the per-restart budget (more than maxMissedJobsPerRestart jobs overdue), the overflow job is deferred to a near-future staggered slot (now + 5000ms). Before this fix, any read RPC (cron list/status), timer finalization after the first overflow job fires, or empty-due timer tick would silently advance the deferred slot to the job's natural next schedule time (e.g. tomorrow 09:00 for a daily "0 9 * * *" job), dropping the missed run for a full period.

## Root Cause

The merged #93810 fix scoped the future-slot repair exemption to a one-shot skipFutureRepairJobIds set passed only to start()'s second maintenance pass (src/cron/service/ops.ts:269). All other callers of recomputeNextRunsForMaintenance — ensureLoadedForRead (read RPCs at ops.ts:210), finalizeCompletedResults (timer.ts:1297), empty-due tick (timer.ts:1183) — ran with the default-enabled future-slot repair and no skip set, causing shouldRepairFutureCronNextRunAtMs (jobs.ts:197) to advance the staggered slot to its natural next time.

## Fix

- Add pendingCatchupDeferralJobIds: Set<string> to CronServiceState (state.ts)
- Populate it in ops.start() and timer.applyStartupCatchupOutcomes where deferred jobs are assigned staggered slots
- recomputeNextRunsForMaintenance always exempts ids in this set from future-slot repair, and auto-clears each id once its deferred slot is reached (now >= nextRunAtMs)
- 5 files changed, +145, −2

This replaces the one-shot skipFutureRepairJobIds option (preserved for backward compatibility) with a canonical in-memory state that covers all recompute callers.

## Real behavior proof

**Behavior or issue addressed:** Persist startup overflow catch-up deferral exemption in service state so all maintenance recompute callers preserve staggered slots.

**Real environment tested:**
- OS: Linux Linux 4.19.112-2.el8.x86_64
- Runtime: v24.13.1
- Branch: fix/issue-93935-deferral-clobber (based on origin/main 4ea1b4fc4a)
- Setup: OpenClaw cron service unit tests (real production code paths)

**Exact steps or command run after the patch:**
1. Seed store with 5 overdue hourly jobs + 1 daily overflow job
2. Call start() which defers the daily job to startNow + 5000
3. Simulate a client read RPC: call list() (which triggers ensureLoadedForRead → recomputeNextRunsForMaintenance)
4. Verify the daily job's nextRunAtMs is still the staggered deferral slot, not tomorrow 09:00
5. Advance clock past the staggered slot and verify the pending set is auto-cleared

**Evidence after fix:**

Test output from the regression test that directly reproduces the issue:
```
$ node scripts/run-vitest.mjs run src/cron/service.startup-overflow-clobber.test.ts
 RUN  v4.1.7

 Test Files  1 passed (1)
      Tests  4 passed (4)

 ✓ keeps the overflow daily-cron catch-up deferral after start()'s maintenance pass
 ✓ still repairs a stale future cron slot on start() when no jobs were deferred
 ✓ preserves overflow daily-cron catch-up deferral after list() read RPC (regression #93935)
 ✓ auto-clears pendingCatchupDeferralJobIds when the staggered slot is reached
```

**grep -n of key production code changes:**

```
$ grep -n "pendingCatchupDeferralJobIds" src/cron/service/state.ts
213:  pendingCatchupDeferralJobIds: Set<string>;
238:    pendingCatchupDeferralJobIds: new Set<string>(),

$ grep -n "pendingCatchupDeferralJobIds" src/cron/service/jobs.ts
685:  const pendingDeferrals: ReadonlySet<string> = state.pendingCatchupDeferralJobIds ?? new Set();
712:        !pendingDeferrals.has(job.id) &&

$ grep -n "pendingCatchupDeferralJobIds" src/cron/service/ops.ts
267:      state.pendingCatchupDeferralJobIds.add(jobId);

$ grep -n "pendingCatchupDeferralJobIds" src/cron/service/timer.ts
1844:          state.pendingCatchupDeferralJobIds.add(jobId);
```

**Full test suite evidence (no regressions):**
```
$ node scripts/run-vitest.mjs run src/cron/service/
 Test Files  14 passed (14)
      Tests  148 passed (148)
```

**Observed result after fix:**

Before fix (origin/main without patch):
- Overflow deferral set at startNow + 5000 by start()
- Plain cron list/status read RPC advances it to tomorrow 09:00
- Deferred missed run is dropped for a full period

After fix (with patch):
- Overflow deferral set at startNow + 5000 by start()
- Plain cron list/status read RPC preserves startNow + 5000
- Deferred missed run fires on the staggered catch-up tick
- pendingCatchupDeferralJobIds auto-clears once the slot is reached

**What was not tested:** The finalizeCompletedResults and empty-due-tick sibling paths are covered by identical call-site analysis (both use recomputeNextRunsForMaintenance(state) without skip set) but not independently driven end-to-end. Not run against a live multi-process gateway, only the in-process CronService.

Closes #93935
