### PR TITLE
fix(cli): setup --non-interactive health hints point to unsupported flags

### DIFF
--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -343,7 +343,7 @@ export async function runNonInteractiveLocalSetup(params: {
         hints: !opts.installDaemon
           ? [
               "Non-interactive local setup only waits for an already-running gateway unless you pass --install-daemon.",
-              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run with \`--install-daemon\`, or use \`--skip-health\`.`,
+              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, or use \`${formatCliCommand("openclaw onboard --non-interactive --accept-risk --install-daemon")}\` to install the daemon, or \`${formatCliCommand("openclaw onboard --non-interactive --accept-risk --skip-health")}\` to bypass the health check.`,
               process.platform === "win32"
                 ? "Native Windows managed gateway install tries Scheduled Tasks first and falls back to a per-user Startup-folder login item when task creation is denied."
                 : undefined,


### PR DESCRIPTION
> **AI-assisted PR.** Implemented and verified with Claude (Claude Code).

## Summary

- **What**: When `openclaw setup --non-interactive --accept-risk` fails on the gateway health check, it prints recovery hints referencing `--install-daemon` and `--skip-health` — but those flags are only registered on `openclaw onboard`, not on `openclaw setup`.
- **Root cause**: The health-failure hints in the non-interactive local onboarding code were written assuming the user invoked `onboard`, but they are also reachable via `setup --non-interactive`.
- **Fix**: Updated the health-failure hint to clearly reference `openclaw onboard --non-interactive --accept-risk --install-daemon` and `openclaw onboard --non-interactive --accept-risk --skip-health` so users know which command supports those flags.

Fixes #93947

## Real behavior proof (required for external PRs)

**Behavior addressed**:
Health-failure hints now correctly reference the `onboard` command instead of bare flags that don't exist on `setup`.

**Real environment tested**:
macOS 26.5.1 (arm64), Node.js runtime, openclaw main branch (be4c541176), unit test suite

**Exact steps or command run after this patch**:
```bash
node scripts/run-vitest.mjs src/commands/onboard-non-interactive.gateway.test.ts
```

**Before-fix evidence**:
After running `openclaw setup --non-interactive --accept-risk` with no running gateway, the hint was:
```
Gateway did not become reachable at ws://127.0.0.1:19099/.
Non-interactive local setup only waits for an already-running gateway unless you pass --install-daemon.
Fix: start `openclaw gateway run`, re-run with `--install-daemon`, or use `--skip-health`.
```
(But `setup` has neither `--install-daemon` nor `--skip-health`.)

**After-fix evidence**:
```
Gateway did not become reachable at ws://127.0.0.1:19099/.
Non-interactive local setup only waits for an already-running gateway unless you pass --install-daemon.
Fix: start `openclaw gateway run`, or use `openclaw onboard --non-interactive --accept-risk --install-daemon` to install the daemon, or `openclaw onboard --non-interactive --accept-risk --skip-health` to bypass the health check.
```

**Observed result after the fix**:
The health-failure hint text now correctly references the `onboard` command with the required `--non-interactive --accept-risk` flags, making it actionable for users who entered the wizard via `setup --non-interactive`.

**What was not tested**:
- Full end-to-end gateway health failure with actual gateway daemon (Docker/production environment)
- JSON output mode (the hints are the same, just delivered via JSON instead of stderr)

## Tests and validation

```
✓ src/commands/onboard-non-interactive.gateway.test.ts (16 tests)
✓ src/commands/onboard-non-interactive.gateway-health-auth.test.ts (4 tests)
✓ src/commands/onboard-non-interactive/local/daemon-install.test.ts (2 tests)
✓ src/commands/setup.test.ts (5 tests)
✓ src/cli/program/register.setup.test.ts (2 tests)
  Test Files  5 passed (5)
       Tests  29 passed (29)
```

## Risk / scope

- User-visible behavior change: Yes — the health-failure hint now shows the correct command surface
- Config/environment/migration change: No
- Security/credentials/network change: No
- Highest risk: None — purely a help text change
- Mitigation: All existing tests pass with the updated hint text
