### PR TITLE
feat: route canonical provider models through ClawRouter

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e2a646aa93124c089fcfed3c3ef982c88d1fdd2170fcdec274446f3d02f20d2b  plugin-sdk-api-baseline.json
-f1762c7b4bbaea4a3ce47ab943daaa6ca3dbc58322cc5d39688da66b3d483a2d  plugin-sdk-api-baseline.jsonl
+defd142b57c2f9f83f61e21b10b939431e3612a2b3324c6ed629e0c93eb4285c  plugin-sdk-api-baseline.json
+35bb66ff25989e8cb8a0c8143f75c3f8ef3c745260bd456e7011b240f4d85ff8  plugin-sdk-api-baseline.jsonl

--- a/extensions/clawrouter/index.test.ts
+++ b/extensions/clawrouter/index.test.ts
@@ -1,0 +1,20 @@
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("ClawRouter plugin", () => {
+  it("registers a credential owner without a synthetic model catalog", () => {
+    const captured = capturePluginRegistration(plugin);
+    const provider = captured.providers[0];
+
+    expect(captured.modelCatalogProviders).toHaveLength(0);
+    expect(provider?.catalog).toBeUndefined();
+    expect(provider).toMatchObject({
+      id: "clawrouter",
+      label: "ClawRouter",
+      envVars: ["CLAWROUTER_API_KEY"],
+      routeModelTransport: expect.any(Function),
+      prepareModelTransportRoute: expect.any(Function),
+    });
+  });
+});

--- a/extensions/clawrouter/index.ts
+++ b/extensions/clawrouter/index.ts
@@ -1,0 +1,42 @@
+import { definePluginEntry, type ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { createClawRouterTransportRouter } from "./transport-router.js";
+
+const PROVIDER_ID = "clawrouter";
+const ENV_VAR = "CLAWROUTER_API_KEY";
+
+function buildApiKeyAuth(): ProviderAuthMethod {
+  return createProviderApiKeyAuthMethod({
+    providerId: PROVIDER_ID,
+    methodId: "api-key",
+    label: "ClawRouter proxy key",
+    hint: "Credential-scoped access to approved provider routes",
+    optionKey: "clawrouterApiKey",
+    flagName: "--clawrouter-api-key",
+    envVar: ENV_VAR,
+    promptMessage: "Enter ClawRouter proxy key",
+    wizard: {
+      choiceId: "clawrouter-api-key",
+      choiceLabel: "ClawRouter proxy key",
+      choiceHint: "Managed access to approved provider routes",
+      groupId: PROVIDER_ID,
+      groupLabel: "ClawRouter",
+      groupHint: "Managed provider access",
+    },
+  });
+}
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "ClawRouter",
+  description: "Routes canonical provider models through ClawRouter",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "ClawRouter",
+      envVars: [ENV_VAR],
+      auth: [buildApiKeyAuth()],
+      ...createClawRouterTransportRouter(),
+    });
+  },
+});

--- a/extensions/clawrouter/npm-shrinkwrap.json
+++ b/extensions/clawrouter/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/clawrouter-provider",
+  "version": "2026.6.17",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/clawrouter-provider",
+      "version": "2026.6.17"
+    }
+  }
+}

--- a/extensions/clawrouter/openclaw.plugin.json
+++ b/extensions/clawrouter/openclaw.plugin.json
@@ -1,0 +1,49 @@
+{
+  "id": "clawrouter",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": false,
+  "providers": ["clawrouter"],
+  "setup": {
+    "providers": [
+      {
+        "id": "clawrouter",
+        "envVars": ["CLAWROUTER_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "clawrouter",
+      "method": "api-key",
+      "choiceId": "clawrouter-api-key",
+      "choiceLabel": "ClawRouter proxy key",
+      "choiceHint": "Managed access to approved provider routes",
+      "groupId": "clawrouter",
+      "groupLabel": "ClawRouter",
+      "groupHint": "Managed provider access",
+      "optionKey": "clawrouterApiKey",
+      "cliFlag": "--clawrouter-api-key",
+      "cliOption": "--clawrouter-api-key <key>",
+      "cliDescription": "ClawRouter proxy key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string",
+        "description": "ClawRouter root URL. Defaults to the hosted ClawRouter endpoint."
+      },
+      "providers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Canonical providers to route. Omit or include '*' to route every catalog-approved provider."
+      }
+    }
+  }
+}

--- a/extensions/clawrouter/package.json
+++ b/extensions/clawrouter/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/clawrouter-provider",
+  "version": "2026.6.17",
+  "private": true,
+  "description": "OpenClaw ClawRouter transport routing plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/clawrouter/transport-router.test.ts
+++ b/extensions/clawrouter/transport-router.test.ts
@@ -1,0 +1,343 @@
+import type { ProviderRouteModelTransportContext } from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCachedLiveProviderModelRows: vi.fn(),
+  resolveApiKeyForProvider: vi.fn(),
+  resolveProviderAuthProfileOrder: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-catalog-live-runtime", () => ({
+  getCachedLiveProviderModelRows: mocks.getCachedLiveProviderModelRows,
+}));
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: mocks.resolveApiKeyForProvider,
+  resolveProviderAuthProfileOrder: mocks.resolveProviderAuthProfileOrder,
+}));
+
+import { createClawRouterTransportRouter } from "./transport-router.js";
+
+function buildContext(): ProviderRouteModelTransportContext {
+  return {
+    config: {
+      plugins: {
+        entries: {
+          clawrouter: {
+            enabled: true,
+            config: {
+              baseUrl: "https://router.example",
+            },
+          },
+        },
+      },
+    },
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-6",
+    model: {
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 32_768,
+    },
+  };
+}
+
+describe("ClawRouter transport router", () => {
+  beforeEach(() => {
+    mocks.resolveApiKeyForProvider.mockReset();
+    mocks.resolveProviderAuthProfileOrder.mockReset();
+    mocks.getCachedLiveProviderModelRows.mockReset();
+    mocks.resolveApiKeyForProvider.mockResolvedValue({
+      apiKey: "router-token",
+      mode: "api-key",
+    });
+    mocks.resolveProviderAuthProfileOrder.mockReturnValue([]);
+  });
+
+  it("routes an entitled canonical model without creating a ClawRouter model id", async () => {
+    mocks.getCachedLiveProviderModelRows.mockResolvedValue([
+      {
+        id: "anthropic",
+        openaiCompatible: false,
+        nativeBaseUrl: "/v1/native/anthropic",
+        routes: [
+          {
+            path: "/v1/messages",
+            methods: ["POST"],
+            requestFormat: "anthropic.messages",
+          },
+        ],
+        models: [
+          {
+            id: "anthropic/claude-sonnet-4-6",
+            upstream: "claude-sonnet-4-6-20260217",
+            capabilities: ["llm.messages"],
+          },
+        ],
+      },
+    ]);
+    const router = createClawRouterTransportRouter();
+    const ctx = buildContext();
+
+    await router.prepareModelTransportRoute?.(ctx);
+    const routed = router.routeModelTransport?.(ctx);
+
+    expect(routed).toMatchObject({
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      api: "anthropic-messages",
+      baseUrl: "https://router.example/v1/native/anthropic",
+      dispatch: {
+        authProvider: "clawrouter",
+        authHeader: "bearer",
+        forceOpenClawTransport: true,
+        upstreamModel: "claude-sonnet-4-6-20260217",
+      },
+    });
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith({
+      provider: "clawrouter",
+      cfg: ctx.config,
+    });
+    expect(mocks.getCachedLiveProviderModelRows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "https://router.example/v1/catalog",
+        apiKey: "router-token",
+      }),
+    );
+  });
+
+  it("fails closed when the catalog does not grant the canonical model", async () => {
+    mocks.getCachedLiveProviderModelRows.mockResolvedValue([]);
+    const router = createClawRouterTransportRouter();
+    const ctx = buildContext();
+
+    await router.prepareModelTransportRoute?.(ctx);
+
+    expect(router.routeModelTransport?.(ctx)).toBeUndefined();
+  });
+
+  it("clears an earlier profile route when the next profile lacks the grant", async () => {
+    mocks.getCachedLiveProviderModelRows.mockResolvedValueOnce([
+      {
+        id: "anthropic",
+        openaiCompatible: false,
+        nativeBaseUrl: "/v1/native/anthropic",
+        routes: [
+          {
+            path: "/v1/messages",
+            methods: ["POST"],
+            requestFormat: "anthropic.messages",
+          },
+        ],
+        models: [
+          {
+            id: "anthropic/claude-sonnet-4-6",
+            upstream: "claude-sonnet-4-6-20260217",
+            capabilities: ["llm.messages"],
+          },
+        ],
+      },
+    ]);
+    mocks.getCachedLiveProviderModelRows.mockResolvedValueOnce([]);
+    const router = createClawRouterTransportRouter();
+    const ctx = {
+      ...buildContext(),
+      authProfileId: "clawrouter:first",
+    };
+
+    await router.prepareModelTransportRoute?.(ctx);
+    expect(router.routeModelTransport?.(ctx)).toBeDefined();
+
+    ctx.authProfileId = "clawrouter:second";
+    await router.prepareModelTransportRoute?.(ctx);
+
+    expect(router.routeModelTransport?.(ctx)).toBeUndefined();
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenLastCalledWith({
+      provider: "clawrouter",
+      cfg: ctx.config,
+      profileId: "clawrouter:second",
+      lockedProfile: true,
+    });
+  });
+
+  it("keeps concurrently prepared profile routes isolated on a shared model", async () => {
+    mocks.resolveApiKeyForProvider.mockImplementation(async ({ profileId }) => ({
+      apiKey: profileId === "clawrouter:one" ? "token-one" : "token-two",
+      mode: "api-key",
+    }));
+    mocks.getCachedLiveProviderModelRows.mockImplementation(async ({ apiKey }) => [
+      {
+        id: "anthropic",
+        openaiCompatible: false,
+        nativeBaseUrl: "/v1/native/anthropic",
+        routes: [
+          {
+            path: "/v1/messages",
+            methods: ["POST"],
+            requestFormat: "anthropic.messages",
+          },
+        ],
+        models: [
+          {
+            id: "anthropic/claude-sonnet-4-6",
+            upstream:
+              apiKey === "token-one" ? "claude-sonnet-route-one" : "claude-sonnet-route-two",
+            capabilities: ["llm.messages"],
+          },
+        ],
+      },
+    ]);
+    const router = createClawRouterTransportRouter();
+    const sharedModel = buildContext().model;
+    const first = {
+      ...buildContext(),
+      model: sharedModel,
+      authProfileId: "clawrouter:one",
+    };
+    const second = {
+      ...buildContext(),
+      model: sharedModel,
+      authProfileId: "clawrouter:two",
+    };
+
+    await Promise.all([
+      router.prepareModelTransportRoute?.(first),
+      router.prepareModelTransportRoute?.(second),
+    ]);
+
+    expect(router.routeModelTransport?.(first)).toMatchObject({
+      dispatch: { upstreamModel: "claude-sonnet-route-one" },
+    });
+    expect(router.routeModelTransport?.(second)).toMatchObject({
+      dispatch: { upstreamModel: "claude-sonnet-route-two" },
+    });
+  });
+
+  it("uses the catalog upstream id for OpenAI-compatible dispatch", async () => {
+    mocks.getCachedLiveProviderModelRows.mockResolvedValue([
+      {
+        id: "openai",
+        openaiCompatible: true,
+        nativeBaseUrl: "/v1/native/openai",
+        routes: [],
+        models: [
+          {
+            id: "openai/gpt-5.5",
+            upstream: "gpt-5.5-20260617",
+            capabilities: ["llm.responses"],
+          },
+        ],
+      },
+    ]);
+    const router = createClawRouterTransportRouter();
+    const ctx = {
+      ...buildContext(),
+      provider: "openai",
+      modelId: "gpt-5.5",
+      model: {
+        ...buildContext().model,
+        provider: "openai",
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses" as const,
+        baseUrl: "https://api.openai.com/v1",
+      },
+    };
+
+    await router.prepareModelTransportRoute?.(ctx);
+    const routed = router.routeModelTransport?.(ctx);
+
+    expect(routed).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "openai-responses",
+      baseUrl: "https://router.example/v1",
+      dispatch: {
+        upstreamModel: "gpt-5.5-20260617",
+      },
+    });
+  });
+
+  it("uses an explicitly selected ClawRouter profile for catalog access", async () => {
+    mocks.getCachedLiveProviderModelRows.mockResolvedValue([]);
+    const router = createClawRouterTransportRouter();
+    const ctx = {
+      ...buildContext(),
+      authProfileId: "clawrouter:maintainer",
+    };
+
+    await router.prepareModelTransportRoute?.(ctx);
+
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenCalledWith({
+      provider: "clawrouter",
+      cfg: ctx.config,
+      profileId: "clawrouter:maintainer",
+      lockedProfile: true,
+    });
+  });
+
+  it("probes configured ClawRouter profiles before canonical auth can win", async () => {
+    mocks.resolveProviderAuthProfileOrder.mockReturnValue([
+      "clawrouter:denied",
+      "clawrouter:allowed",
+    ]);
+    mocks.resolveApiKeyForProvider.mockImplementation(async ({ profileId }) => ({
+      apiKey: profileId === "clawrouter:allowed" ? "allowed-token" : "denied-token",
+      mode: "api-key",
+    }));
+    mocks.getCachedLiveProviderModelRows.mockResolvedValueOnce([]);
+    mocks.getCachedLiveProviderModelRows.mockResolvedValueOnce([
+      {
+        id: "anthropic",
+        openaiCompatible: false,
+        nativeBaseUrl: "/v1/native/anthropic",
+        routes: [
+          {
+            path: "/v1/messages",
+            methods: ["POST"],
+            requestFormat: "anthropic.messages",
+          },
+        ],
+        models: [
+          {
+            id: "anthropic/claude-sonnet-4-6",
+            upstream: "claude-sonnet-4-6-20260217",
+            capabilities: ["llm.messages"],
+          },
+        ],
+      },
+    ]);
+    const router = createClawRouterTransportRouter();
+    const ctx = buildContext();
+
+    await router.prepareModelTransportRoute?.(ctx);
+
+    expect(mocks.resolveProviderAuthProfileOrder).toHaveBeenCalledWith({
+      provider: "clawrouter",
+      cfg: ctx.config,
+    });
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenNthCalledWith(1, {
+      provider: "clawrouter",
+      cfg: ctx.config,
+      profileId: "clawrouter:denied",
+      lockedProfile: true,
+    });
+    expect(mocks.resolveApiKeyForProvider).toHaveBeenNthCalledWith(2, {
+      provider: "clawrouter",
+      cfg: ctx.config,
+      profileId: "clawrouter:allowed",
+      lockedProfile: true,
+    });
+    expect(router.routeModelTransport?.(ctx)).toMatchObject({
+      dispatch: {
+        authProvider: "clawrouter",
+      },
+    });
+  });
+});

--- a/extensions/clawrouter/transport-router.ts
+++ b/extensions/clawrouter/transport-router.ts
@@ -1,0 +1,332 @@
+import type { ProviderRouteModelTransportContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  resolveApiKeyForProvider,
+  resolveProviderAuthProfileOrder,
+} from "openclaw/plugin-sdk/provider-auth-runtime";
+import { getCachedLiveProviderModelRows } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+
+const PROVIDER_ID = "clawrouter";
+const DEFAULT_ROOT_URL = "https://clawrouter.openclaw.ai";
+const CATALOG_CACHE_TTL_MS = 60_000;
+
+type CatalogRoute = {
+  path: string;
+  requestFormat: string;
+  methods: string[];
+};
+
+type CatalogModel = {
+  id: string;
+  upstream: string;
+  capabilities: string[];
+};
+
+type CatalogProvider = {
+  id: string;
+  openaiCompatible: boolean;
+  nativeBaseUrl: string;
+  routes: CatalogRoute[];
+  models: CatalogModel[];
+};
+
+type ResolvedRoute = {
+  api: "openai-responses" | "openai-completions" | "anthropic-messages" | "google-generative-ai";
+  baseUrl: string;
+  upstreamModel?: string;
+};
+
+const DEFAULT_ROUTE_KEY = "";
+const preparedRoutes = new WeakMap<object, Map<string, ResolvedRoute>>();
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStrings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map(readString).filter((entry): entry is string => Boolean(entry))
+    : [];
+}
+
+function parseCatalog(catalogBody: unknown): CatalogProvider[] {
+  const providerRows = asRecord(catalogBody)?.providers;
+  if (!Array.isArray(providerRows)) {
+    throw new Error("ClawRouter catalog response must contain providers[]");
+  }
+  return providerRows.flatMap((providerValue): CatalogProvider[] => {
+    const row = asRecord(providerValue);
+    const id = readString(row?.id);
+    const nativeBaseUrl = readString(row?.nativeBaseUrl);
+    if (!id || !nativeBaseUrl || !nativeBaseUrl.startsWith("/v1/native/")) {
+      return [];
+    }
+    const routes = Array.isArray(row?.routes)
+      ? row.routes.flatMap((routeValue): CatalogRoute[] => {
+          const route = asRecord(routeValue);
+          const path = readString(route?.path);
+          const requestFormat = readString(route?.requestFormat);
+          return path && requestFormat
+            ? [
+                {
+                  path,
+                  requestFormat,
+                  methods: readStrings(route?.methods).map((method) => method.toUpperCase()),
+                },
+              ]
+            : [];
+        })
+      : [];
+    const models = Array.isArray(row?.models)
+      ? row.models.flatMap((modelValue): CatalogModel[] => {
+          const model = asRecord(modelValue);
+          const modelId = readString(model?.id);
+          const upstream = readString(model?.upstream);
+          return modelId && upstream
+            ? [{ id: modelId, upstream, capabilities: readStrings(model?.capabilities) }]
+            : [];
+        })
+      : [];
+    return [
+      { id, openaiCompatible: row?.openaiCompatible === true, nativeBaseUrl, routes, models },
+    ];
+  });
+}
+
+function normalizeRootUrl(value: string | undefined): string {
+  const root = (value?.trim() || DEFAULT_ROOT_URL).replace(/\/+$/, "");
+  return root.endsWith("/v1") ? root.slice(0, -3) : root;
+}
+
+function readPluginConfig(config: ProviderRouteModelTransportContext["config"]): {
+  baseUrl?: string;
+  providers?: string[];
+} {
+  const entry = asRecord(config?.plugins?.entries?.[PROVIDER_ID]);
+  const pluginConfig = asRecord(entry?.config);
+  return {
+    baseUrl: readString(pluginConfig?.baseUrl),
+    providers: readStrings(pluginConfig?.providers),
+  };
+}
+
+function isProviderEnabled(params: {
+  configured: string[];
+  canonicalProvider: string;
+  catalogProvider: string;
+}): boolean {
+  if (params.configured.length === 0 || params.configured.includes("*")) {
+    return true;
+  }
+  return (
+    params.configured.includes(params.canonicalProvider) ||
+    params.configured.includes(params.catalogProvider)
+  );
+}
+
+function hasCapability(model: CatalogModel, capability: string): boolean {
+  return model.capabilities.includes(capability);
+}
+
+function hasNativePostRoute(provider: CatalogProvider, requestFormat: string): boolean {
+  return provider.routes.some(
+    (route) => route.methods.includes("POST") && route.requestFormat === requestFormat,
+  );
+}
+
+function resolveGoogleBaseUrl(rootUrl: string, provider: CatalogProvider): string | undefined {
+  const googleRoute = provider.routes.find(
+    (candidate) =>
+      candidate.methods.includes("POST") &&
+      candidate.requestFormat === "google.generate_content" &&
+      candidate.path.includes(":streamGenerateContent"),
+  );
+  if (!googleRoute) {
+    return undefined;
+  }
+  const modelIndex = googleRoute.path.indexOf("/models/${model}");
+  return modelIndex > 0
+    ? `${rootUrl}${provider.nativeBaseUrl}${googleRoute.path.slice(0, modelIndex)}`
+    : undefined;
+}
+
+function buildRoute(params: {
+  rootUrl: string;
+  provider: CatalogProvider;
+  model: CatalogModel;
+}): ResolvedRoute | undefined {
+  if (params.provider.openaiCompatible && hasCapability(params.model, "llm.responses")) {
+    return {
+      api: "openai-responses",
+      baseUrl: `${params.rootUrl}/v1`,
+      upstreamModel: params.model.upstream,
+    };
+  }
+  if (params.provider.openaiCompatible && hasCapability(params.model, "llm.chat")) {
+    return {
+      api: "openai-completions",
+      baseUrl: `${params.rootUrl}/v1`,
+      upstreamModel: params.model.upstream,
+    };
+  }
+  if (
+    hasCapability(params.model, "llm.messages") &&
+    hasNativePostRoute(params.provider, "anthropic.messages")
+  ) {
+    return {
+      api: "anthropic-messages",
+      baseUrl: `${params.rootUrl}${params.provider.nativeBaseUrl}`,
+      upstreamModel: params.model.upstream,
+    };
+  }
+  if (hasCapability(params.model, "llm.stream")) {
+    const baseUrl = resolveGoogleBaseUrl(params.rootUrl, params.provider);
+    if (baseUrl) {
+      return {
+        api: "google-generative-ai",
+        baseUrl,
+        upstreamModel: params.model.upstream,
+      };
+    }
+  }
+  return undefined;
+}
+
+function resolveRoute(params: {
+  ctx: ProviderRouteModelTransportContext;
+  rootUrl: string;
+  providers: CatalogProvider[];
+  configuredProviders: string[];
+}): ResolvedRoute | undefined {
+  const modelRefs = new Set([params.ctx.model.id, `${params.ctx.provider}/${params.ctx.model.id}`]);
+  for (const provider of params.providers) {
+    if (
+      !isProviderEnabled({
+        configured: params.configuredProviders,
+        canonicalProvider: params.ctx.provider,
+        catalogProvider: provider.id,
+      })
+    ) {
+      continue;
+    }
+    const model = provider.models.find((candidate) => modelRefs.has(candidate.id));
+    if (model) {
+      return buildRoute({ rootUrl: params.rootUrl, provider, model });
+    }
+  }
+  return undefined;
+}
+
+async function prepareRoute(ctx: ProviderRouteModelTransportContext): Promise<void> {
+  // Catalog grants belong to a credential profile. A resolved catalog model can
+  // be shared across concurrent runs, so retain a separate route per profile.
+  const routes = preparedRoutes.get(ctx.model) ?? new Map<string, ResolvedRoute>();
+  preparedRoutes.set(ctx.model, routes);
+  const pluginConfig = readPluginConfig(ctx.config);
+  const rootUrl = normalizeRootUrl(pluginConfig.baseUrl);
+  const selectedProfileId = ctx.authProfileId?.startsWith(`${PROVIDER_ID}:`)
+    ? ctx.authProfileId
+    : undefined;
+  const preferredProfile = ctx.preferredProfile?.startsWith(`${PROVIDER_ID}:`)
+    ? ctx.preferredProfile
+    : undefined;
+  const profileCandidates = selectedProfileId
+    ? [selectedProfileId]
+    : [
+        ...resolveProviderAuthProfileOrder({
+          provider: PROVIDER_ID,
+          cfg: ctx.config,
+          ...(preferredProfile ? { preferredProfile } : {}),
+          ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+        }),
+        undefined,
+      ];
+  routes.delete(selectedProfileId ?? DEFAULT_ROUTE_KEY);
+
+  for (const profileId of new Set(profileCandidates)) {
+    const routeKey = profileId ?? DEFAULT_ROUTE_KEY;
+    routes.delete(routeKey);
+    try {
+      const auth = await resolveApiKeyForProvider({
+        provider: PROVIDER_ID,
+        cfg: ctx.config,
+        ...(ctx.agentDir ? { agentDir: ctx.agentDir } : {}),
+        ...(ctx.workspaceDir ? { workspaceDir: ctx.workspaceDir } : {}),
+        ...(profileId ? { profileId, lockedProfile: true } : {}),
+      });
+      const apiKey = auth.apiKey?.trim();
+      if (!apiKey) {
+        continue;
+      }
+      const catalogRows = await getCachedLiveProviderModelRows({
+        providerId: PROVIDER_ID,
+        endpoint: `${rootUrl}/v1/catalog`,
+        apiKey,
+        ttlMs: CATALOG_CACHE_TTL_MS,
+        shouldCacheRows: (candidateRows) => candidateRows.length > 0,
+        readRows: (body) => {
+          const providers = asRecord(body)?.providers;
+          return Array.isArray(providers) ? providers : [];
+        },
+        auditContext: "clawrouter-transport-routing",
+      });
+      const route = resolveRoute({
+        ctx,
+        rootUrl,
+        providers: parseCatalog({ providers: catalogRows }),
+        configuredProviders: pluginConfig.providers ?? [],
+      });
+      if (route) {
+        routes.set(routeKey, route);
+        if (!selectedProfileId) {
+          routes.set(DEFAULT_ROUTE_KEY, route);
+        }
+        return;
+      }
+    } catch {
+      // One unavailable credential must not block the next configured profile.
+    }
+  }
+}
+
+export function createClawRouterTransportRouter(): Pick<
+  ProviderPlugin,
+  "prepareModelTransportRoute" | "routeModelTransport"
+> {
+  return {
+    prepareModelTransportRoute: async (ctx) => {
+      try {
+        await prepareRoute(ctx);
+      } catch {
+        // Catalog routing is fail-closed: canonical provider dispatch remains intact.
+      }
+    },
+    routeModelTransport: (ctx) => {
+      const route = preparedRoutes
+        .get(ctx.model)
+        ?.get(
+          ctx.authProfileId?.startsWith(`${PROVIDER_ID}:`) ? ctx.authProfileId : DEFAULT_ROUTE_KEY,
+        );
+      if (!route) {
+        return undefined;
+      }
+      return {
+        ...ctx.model,
+        api: route.api,
+        baseUrl: route.baseUrl,
+        dispatch: {
+          authProvider: PROVIDER_ID,
+          authHeader: "bearer",
+          forceOpenClawTransport: true,
+          ...(route.upstreamModel ? { upstreamModel: route.upstreamModel } : {}),
+        },
+      };
+    },
+  };
+}

--- a/extensions/clawrouter/tsconfig.json
+++ b/extensions/clawrouter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -476,6 +476,37 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("thoughtSignature", "Y2FsbF9zaWdfMQ==");
   });
 
+  it("keeps Google API-key auth when authHeader has no injected bearer token", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: { parts: [{ text: "answer" }] },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({ authHeader: true }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "gemini-api-key" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+
+    await stream.result();
+
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    const headers = new Headers(requireRequestInit(guardedCall, "guarded fetch").headers);
+    expect(headers.get("x-goog-api-key")).toBe("gemini-api-key");
+  });
+
   it("strips redundant google provider prefixes from Gemini API model paths", async () => {
     guardedFetchMock.mockResolvedValueOnce(buildSseResponse([]));
 

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -775,7 +775,14 @@ function buildGoogleHeaders(
   apiKey: string | undefined,
   optionHeaders: Record<string, string> | undefined,
 ): Record<string, string> {
-  const authHeaders = apiKey ? parseGeminiAuth(apiKey).headers : undefined;
+  const hasBearerAuthorization = [model.headers, optionHeaders].some((headers) =>
+    Object.entries(headers ?? {}).some(
+      ([name, value]) =>
+        name.toLowerCase() === "authorization" && /^Bearer\s+\S+$/i.test(value.trim()),
+    ),
+  );
+  const authHeaders =
+    apiKey && !hasBearerAuthorization ? parseGeminiAuth(apiKey).headers : undefined;
   return (
     mergeTransportHeaders(
       {

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -578,6 +578,22 @@ export interface VercelGatewayRouting {
   order?: string[];
 }
 
+/**
+ * Late-bound request routing applied after a canonical provider/model has been
+ * selected. This keeps user-facing model identity separate from the endpoint,
+ * credential owner, and upstream model used for dispatch.
+ */
+export type ModelDispatchRoute = {
+  /** Provider whose credential should authorize the dispatched request. */
+  authProvider?: Provider;
+  /** Upstream model id used only while constructing the outbound request. */
+  upstreamModel?: string;
+  /** Send the resolved credential as an HTTP Bearer token. */
+  authHeader?: "bearer";
+  /** Bypass provider-owned stream selection and use OpenClaw's HTTP transport. */
+  forceOpenClawTransport?: boolean;
+};
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
   id: string;
@@ -611,6 +627,8 @@ export interface Model<TApi extends Api = Api> {
   headers?: Record<string, string>;
   /** Sends runtime credentials as Authorization: Bearer instead of provider-specific key headers. */
   authHeader?: boolean;
+  /** Late-bound request routing that preserves the selected provider/model identity. */
+  dispatch?: ModelDispatchRoute;
   /** Compatibility overrides for OpenAI-compatible APIs. If not set, auto-detected from baseUrl. */
   compat?: TApi extends "openai-completions"
     ? OpenAICompletionsCompat

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,6 +485,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/clawrouter:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/chutes:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -266,6 +266,55 @@ describe("anthropic transport stream", () => {
     expect(headers.get("X-Provider")).toBe("foundry");
   });
 
+  it("uses bearer auth for Microsoft Foundry static bearer headers", async () => {
+    const model = makeAnthropicTransportModel({
+      provider: "microsoft-foundry",
+      baseUrl: "https://example.services.ai.azure.com/anthropic",
+      headers: {
+        Authorization: "Bearer stale-foundry-token",
+        "x-api-key": "stale-resource-key",
+      },
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "entra-access-token",
+      } as AnthropicStreamOptions,
+    );
+
+    const headers = latestAnthropicRequestHeaders();
+    expect(headers.get("authorization")).toBe("Bearer entra-access-token");
+    expect(headers.get("x-api-key")).toBeNull();
+  });
+
+  it("preserves static bearer proxy headers alongside Anthropic API-key auth", async () => {
+    const model = makeAnthropicTransportModel({
+      provider: "custom-anthropic-proxy",
+      baseUrl: "https://anthropic-proxy.example/v1",
+      headers: {
+        Authorization: "Bearer proxy-token",
+      },
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const headers = latestAnthropicRequestHeaders();
+    expect(headers.get("authorization")).toBe("Bearer proxy-token");
+    expect(headers.get("x-api-key")).toBe("sk-ant-api");
+  });
+
   it("honors ANTHROPIC_BASE_URL when model base URL is blank", async () => {
     vi.stubEnv("ANTHROPIC_BASE_URL", " https://anthropic-proxy.example/v1 ");
 

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -252,22 +252,19 @@ function isAnthropicOAuthToken(apiKey: string): boolean {
 }
 
 function hasBearerAuthorizationHeader(headers?: Record<string, string>): boolean {
-  if (!headers) {
-    return false;
-  }
-  return Object.entries(headers).some(
+  return Object.entries(headers ?? {}).some(
     ([key, value]) => key.toLowerCase() === "authorization" && /^bearer\s+\S+/i.test(value.trim()),
   );
 }
 
-function usesFoundryBearerAuth(model: AnthropicTransportModel): boolean {
+function usesBearerAuthorization(model: AnthropicTransportModel): boolean {
   return (
-    model.provider === "microsoft-foundry" &&
-    (model.authHeader === true || hasBearerAuthorizationHeader(model.headers))
+    model.authHeader === true ||
+    (model.provider === "microsoft-foundry" && hasBearerAuthorizationHeader(model.headers))
   );
 }
 
-function omitFoundryBearerCredentialHeaders(
+function omitBearerCredentialHeaders(
   headers?: Record<string, string>,
 ): Record<string, string> | undefined {
   if (!headers) {
@@ -825,7 +822,7 @@ function createAnthropicTransportClient(params: {
       isOAuthToken: false,
     };
   }
-  if (usesFoundryBearerAuth(model)) {
+  if (usesBearerAuthorization(model)) {
     const betaFeatures = needsInterleavedBeta ? ["interleaved-thinking-2025-05-14"] : [];
     return {
       client: createAnthropicMessagesClient({
@@ -838,7 +835,7 @@ function createAnthropicTransportClient(params: {
             "anthropic-dangerous-direct-browser-access": "true",
             ...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
           },
-          omitFoundryBearerCredentialHeaders(model.headers),
+          omitBearerCredentialHeaders(model.headers),
           options?.headers,
         ),
         fetch,

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -481,6 +481,9 @@ describe("runBtwSideQuestion", () => {
       id: "claude-sonnet-4-6",
       api: "anthropic-messages",
     });
+    resolveModelAsyncMock.mockImplementation(async () => ({
+      model: resolveModelWithRegistryMock(),
+    }));
     ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
     ensureAuthProfileStoreWithoutExternalProfilesMock.mockReturnValue({ version: 1, profiles: {} });
     getApiKeyForModelMock.mockResolvedValue({ apiKey: "secret", mode: "api-key", source: "test" });
@@ -1175,6 +1178,58 @@ describe("runBtwSideQuestion", () => {
       baseUrl: "https://api.enterprise.githubcopilot.com",
     });
     expectRecordFields(streamOptions, { apiKey: "copilot-runtime-token" });
+  });
+
+  it("resolves dispatch-routed BTW models with the gateway credential owner", async () => {
+    resolveModelAsyncMock.mockResolvedValueOnce({
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+        baseUrl: "https://router.example/v1/native/anthropic",
+        dispatch: {
+          authProvider: "clawrouter",
+          authHeader: "bearer",
+          forceOpenClawTransport: true,
+          upstreamModel: "claude-sonnet-4-6-20260217",
+        },
+      },
+    });
+    getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "router-token",
+      mode: "api-key",
+      source: "profile:clawrouter:work",
+      profileId: "clawrouter:work",
+    });
+    requireApiKeyMock.mockReturnValue("router-token");
+    mockDoneAnswer("Routed answer.");
+
+    const result = await runSideQuestion();
+
+    expect(result).toEqual({ text: "Routed answer." });
+    expect(resolveModelAsyncMock).toHaveBeenCalledWith(
+      DEFAULT_PROVIDER,
+      DEFAULT_MODEL,
+      DEFAULT_AGENT_DIR,
+      expect.anything(),
+      expect.objectContaining({
+        authProfileId: "profile-1",
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
+    expectRecordFields(mockArg(getApiKeyForModelMock, 0, 0), {
+      profileId: undefined,
+      model: expect.objectContaining({
+        dispatch: expect.objectContaining({ authProvider: "clawrouter" }),
+      }),
+    });
+    expectRecordFields(mockArg(prepareProviderRuntimeAuthMock, 0, 0), {
+      provider: "clawrouter",
+      context: expect.objectContaining({
+        provider: "clawrouter",
+        apiKey: "router-token",
+      }),
+    });
   });
 
   it("uses the provider's stream fn when registered so provider URL construction runs (#68336)", async () => {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -27,7 +27,7 @@ import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./bt
 import { executePreparedCliRun } from "./cli-runner/execute.runtime.js";
 import { prepareCliRunContext } from "./cli-runner/prepare.runtime.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./embedded-agent-block-chunker.js";
-import { resolveModelWithRegistry } from "./embedded-agent-runner/model.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./embedded-agent-runner/runs.js";
 import { resolveEmbeddedAgentStreamFn } from "./embedded-agent-runner/stream-resolution.js";
 import {
@@ -45,6 +45,7 @@ import {
   getApiKeyForModel,
   requireApiKey,
 } from "./model-auth.js";
+import { resolveModelDispatchAuthProvider } from "./model-dispatch.js";
 import {
   isCliRuntimeAliasForProvider,
   resolveCliRuntimeExecutionProvider,
@@ -314,16 +315,6 @@ async function resolveRuntimeModel(params: {
   await ensureOpenClawModelsJson(params.cfg, params.agentDir, modelsOptions);
   const authStorage = discoverAuthStorage(params.agentDir);
   const modelRegistry = discoverModels(authStorage, params.agentDir, modelsOptions);
-  const model = resolveModelWithRegistry({
-    provider: params.provider,
-    modelId: params.model,
-    modelRegistry,
-    cfg: params.cfg,
-  });
-  if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.model}`);
-  }
-
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg: params.cfg,
     provider: params.provider,
@@ -345,8 +336,23 @@ async function resolveRuntimeModel(params: {
     storePath: params.storePath,
     isNewSession: params.isNewSession,
   });
+  const resolved = await resolveModelAsync(
+    params.provider,
+    params.model,
+    params.agentDir,
+    params.cfg,
+    {
+      authStorage,
+      modelRegistry,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...(authProfileId ? { authProfileId } : {}),
+    },
+  );
+  if (!resolved.model) {
+    throw new Error(resolved.error ?? `Unknown model: ${params.provider}/${params.model}`);
+  }
   return {
-    model,
+    model: resolved.model,
     authProfileId,
     authProfileIdSource: resolveReturnedAuthProfileSource(params.sessionEntry, authProfileId),
   };
@@ -639,26 +645,33 @@ export async function runBtwSideQuestion(
     storePath: params.storePath,
     isNewSession: params.isNewSession,
   });
+  const authProvider = resolveModelDispatchAuthProvider(model);
+  const routedAuthProfileId =
+    authProvider === model.provider || authProfileId?.startsWith(`${authProvider}:`)
+      ? authProfileId
+      : undefined;
+  const routedAuthProfileIdSource = routedAuthProfileId ? authProfileIdSource : undefined;
   let externalCliAuthScope = resolveExternalCliAuthOverlayScopeFromSelection({
-    provider: model.provider,
+    provider: authProvider,
     cfg: params.cfg,
     agentId: sessionAgentId,
     modelId: model.id,
     workspaceDir,
-    userLockedAuthProfileId: authProfileIdSource === "user" ? authProfileId : undefined,
+    userLockedAuthProfileId: routedAuthProfileIdSource === "user" ? routedAuthProfileId : undefined,
   });
   if (!externalCliAuthScope.providerIds) {
     const noExternalAuthStore = ensureAuthProfileStoreWithoutExternalProfiles(params.agentDir, {
       allowKeychainPrompt: false,
     });
     externalCliAuthScope = resolveExternalCliAuthOverlayScopeFromSelection({
-      provider: model.provider,
+      provider: authProvider,
       cfg: params.cfg,
       agentId: sessionAgentId,
       modelId: model.id,
       workspaceDir,
       store: noExternalAuthStore,
-      userLockedAuthProfileId: authProfileIdSource === "user" ? authProfileId : undefined,
+      userLockedAuthProfileId:
+        routedAuthProfileIdSource === "user" ? routedAuthProfileId : undefined,
     });
   }
   const authStore = externalCliAuthScope.providerIds
@@ -668,9 +681,9 @@ export async function runBtwSideQuestion(
       })
     : undefined;
   const effectiveAuthProfileId =
-    externalCliAuthScope.ignoreAutoPreferredProfile && authProfileIdSource !== "user"
+    externalCliAuthScope.ignoreAutoPreferredProfile && routedAuthProfileIdSource !== "user"
       ? undefined
-      : authProfileId;
+      : routedAuthProfileId;
   const apiKeyInfo = await getApiKeyForModel({
     model,
     cfg: params.cfg,
@@ -683,10 +696,10 @@ export async function runBtwSideQuestion(
   let apiKey =
     apiKeyInfo.mode === "aws-sdk" && !apiKeyInfo.apiKey
       ? undefined
-      : requireApiKey(apiKeyInfo, model.provider);
+      : requireApiKey(apiKeyInfo, authProvider);
   if (apiKey) {
     const preparedAuth = await prepareProviderRuntimeAuth({
-      provider: model.provider,
+      provider: authProvider,
       config: params.cfg,
       workspaceDir,
       env: process.env,
@@ -695,7 +708,7 @@ export async function runBtwSideQuestion(
         agentDir: params.agentDir,
         workspaceDir,
         env: process.env,
-        provider: model.provider,
+        provider: authProvider,
         modelId: model.id,
         model,
         apiKey,

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -43,13 +43,27 @@ export const resolveContextEngineMock = vi.fn(async () => ({
   compact: contextEngineCompactMock,
 }));
 export const resolveModelMock: Mock<
-  (provider?: string, modelId?: string, agentDir?: string, cfg?: unknown) => MockResolvedModel
-> = vi.fn((_provider?: string, _modelId?: string, _agentDir?: string, _cfg?: unknown) => ({
-  model: { provider: "openai", api: "responses", id: "fake", input: [] },
-  error: null,
-  authStorage: { setRuntimeApiKey: vi.fn() },
-  modelRegistry: {},
-}));
+  (
+    provider?: string,
+    modelId?: string,
+    agentDir?: string,
+    cfg?: unknown,
+    options?: unknown,
+  ) => MockResolvedModel
+> = vi.fn(
+  (
+    _provider?: string,
+    _modelId?: string,
+    _agentDir?: string,
+    _cfg?: unknown,
+    _options?: unknown,
+  ) => ({
+    model: { provider: "openai", api: "responses", id: "fake", input: [] },
+    error: null,
+    authStorage: { setRuntimeApiKey: vi.fn() },
+    modelRegistry: {},
+  }),
+);
 export const sessionCompactImpl = vi.fn(async () => ({
   summary: "summary",
   firstKeptEntryId: "entry-1",
@@ -859,8 +873,13 @@ export async function loadCompactHooksHarness(): Promise<{
     buildModelAliasLines: vi.fn(() => []),
     resolveModel: resolveModelMock,
     resolveModelAsync: vi.fn(
-      async (provider: string, modelId: string, agentDir?: string, cfg?: unknown) =>
-        resolveModelMock(provider, modelId, agentDir, cfg),
+      async (
+        provider: string,
+        modelId: string,
+        agentDir?: string,
+        cfg?: unknown,
+        options?: unknown,
+      ) => resolveModelMock(provider, modelId, agentDir, cfg, options),
     ),
   }));
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1780,6 +1780,23 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     });
   });
 
+  it("resolves compaction transport with the selected auth profile", async () => {
+    const result = await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        workspaceDir: "/tmp/compaction-workspace",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        authProfileId: "clawrouter:maintainer",
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expectRecordFields(mockCallArg(resolveModelMock, 0, 4), {
+      workspaceDir: "/tmp/compaction-workspace",
+      authProfileId: "clawrouter:maintainer",
+    });
+  });
+
   it("clamps caller context token budget before queued engine-owned compaction", async () => {
     resolveContextWindowInfoMock.mockReturnValueOnce({ tokens: 32_000 });
 

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -94,6 +94,7 @@ import {
   MissingProviderAuthError,
   resolveModelAuthMode,
 } from "../model-auth.js";
+import { resolveModelDispatchAuthProvider } from "../model-dispatch.js";
 import { isFallbackSummaryError, runWithModelFallback } from "../model-fallback.js";
 import { supportsModelTools } from "../model-tool-support.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
@@ -634,6 +635,10 @@ async function compactEmbeddedAgentSessionDirectOnce(
     modelId,
     agentDir,
     params.config,
+    {
+      workspaceDir: resolvedWorkspace,
+      authProfileId,
+    },
   );
   if (!model) {
     const reason = error ?? `Unknown model: ${runtimeProvider}/${modelId}`;
@@ -653,11 +658,11 @@ async function compactEmbeddedAgentSessionDirectOnce(
 
     if (!apiKeyInfo.apiKey) {
       if (apiKeyInfo.mode !== "aws-sdk") {
-        throw new MissingProviderAuthError(runtimeModel.provider, apiKeyInfo);
+        throw new MissingProviderAuthError(resolveModelDispatchAuthProvider(runtimeModel), apiKeyInfo);
       }
     } else {
       const preparedAuth = await prepareProviderRuntimeAuth({
-        provider: runtimeModel.provider,
+        provider: resolveModelDispatchAuthProvider(runtimeModel),
         config: params.config,
         workspaceDir: resolvedWorkspace,
         env: process.env,
@@ -666,7 +671,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           agentDir,
           workspaceDir: resolvedWorkspace,
           env: process.env,
-          provider: runtimeModel.provider,
+          provider: resolveModelDispatchAuthProvider(runtimeModel),
           modelId,
           model: runtimeModel,
           apiKey: apiKeyInfo.apiKey,
@@ -680,7 +685,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       if (!runtimeApiKey) {
         throw new Error(`Provider "${runtimeModel.provider}" runtime auth returned no apiKey.`);
       }
-      authStorage.setRuntimeApiKey(runtimeModel.provider, runtimeApiKey);
+      authStorage.setRuntimeApiKey(resolveModelDispatchAuthProvider(runtimeModel), runtimeApiKey);
     }
   } catch (err) {
     const reason = formatErrorMessage(err);

--- a/src/agents/embedded-agent-runner/extra-params.provider-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.provider-runtime.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLlmStreamSimpleMock } from "../../../test/helpers/agents/llm-stream-simple-mock.js";
 import type { Model } from "../../llm/types.js";
 import {
+  applyExtraParamsToAgent,
   testing as extraParamsTesting,
   resolveAgentTransportOverride,
   resolveExplicitSettingsTransport,
@@ -93,6 +94,34 @@ describe("extra-params: provider runtime handoff", () => {
     // this wire-format distinction.
     expect(payload.think).toBe(false);
     expect((payload.options as Record<string, unknown>).think).toBeUndefined();
+  });
+
+  it("does not apply canonical provider wrappers to forced gateway transport", () => {
+    const wrapProviderStreamFn = vi.fn(({ context }) => context.streamFn);
+    extraParamsTesting.setProviderRuntimeDepsForTest({ wrapProviderStreamFn });
+    const model = {
+      api: "openai-completions",
+      provider: "local-provider",
+      id: "local-model:9b",
+      dispatch: {
+        authProvider: "clawrouter",
+        forceOpenClawTransport: true,
+      },
+    } as unknown as Model<"openai-completions">;
+
+    applyExtraParamsToAgent(
+      { streamFn: vi.fn() },
+      undefined,
+      model.provider,
+      model.id,
+      undefined,
+      "off",
+      undefined,
+      undefined,
+      model,
+    );
+
+    expect(wrapProviderStreamFn).not.toHaveBeenCalled();
   });
 
   it("does not apply the plugin wrapper for other providers", () => {

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -34,6 +34,7 @@ import {
   wrapProviderStreamFn as wrapProviderStreamFnRuntime,
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { hasForcedOpenClawTransport } from "../model-dispatch.js";
 import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../model-max-tokens-params.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
@@ -1105,23 +1106,26 @@ export function applyExtraParamsToAgent(
         ...options.nativeWebSearchPolicyContext,
       })
     : undefined;
-  const pluginWrappedStreamFn = providerRuntimeDeps.wrapProviderStreamFn({
-    provider,
-    config: cfg,
-    context: {
-      config: cfg,
-      agentDir,
-      workspaceDir,
-      agentId,
-      nativeWebSearchAllowedByToolPolicy,
-      provider,
-      modelId,
-      extraParams: effectiveExtraParams,
-      thinkingLevel,
-      model,
-      streamFn: providerStreamBase,
-    },
-  });
+  const pluginWrappedStreamFn =
+    model && hasForcedOpenClawTransport(model)
+      ? undefined
+      : providerRuntimeDeps.wrapProviderStreamFn({
+          provider,
+          config: cfg,
+          context: {
+            config: cfg,
+            agentDir,
+            workspaceDir,
+            agentId,
+            nativeWebSearchAllowedByToolPolicy,
+            provider,
+            modelId,
+            extraParams: effectiveExtraParams,
+            thinkingLevel,
+            model,
+            streamFn: providerStreamBase,
+          },
+        });
   agent.streamFn = pluginWrappedStreamFn ?? providerStreamBase;
   // Apply caller/config extra params outside provider defaults so explicit runtime
   // transport values can override provider-added defaults.

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -278,6 +278,63 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0): Record<stri
 }
 
 describe("resolveModel", () => {
+  it("applies a prepared gateway transport route without changing canonical identity", async () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      templateModel: {
+        provider: "anthropic",
+        api: "anthropic-messages",
+        baseUrl: "https://api.anthropic.com",
+        ...makeModel("claude-sonnet-4-6"),
+      },
+    });
+    const prepareModelTransportRoutes = vi.fn(async () => {});
+    const applyModelTransportRoute = vi.fn(({ context }) => ({
+      ...context.model,
+      api: "openai-responses",
+      baseUrl: "https://router.example/v1",
+      dispatch: {
+        authProvider: "clawrouter",
+        forceOpenClawTransport: true,
+      },
+    }));
+    const runtimeHooks = {
+      ...createRuntimeHooks(),
+      prepareModelTransportRoutes,
+      applyModelTransportRoute,
+    };
+
+    const result = await resolveModelAsync("anthropic", "claude-sonnet-4-6", "/tmp/agent", undefined, {
+      authStorage: { mocked: true } as never,
+      modelRegistry: discoverModels({ mocked: true } as never, "/tmp/agent"),
+      authProfileId: "clawrouter:maintainer",
+      runtimeHooks,
+    });
+    const model = expectResolvedModel(result);
+
+    expect(prepareModelTransportRoutes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          provider: "anthropic",
+          modelId: "claude-sonnet-4-6",
+          authProfileId: "clawrouter:maintainer",
+        }),
+      }),
+    );
+    expect(applyModelTransportRoute).toHaveBeenCalledOnce();
+    expect(model).toMatchObject({
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      api: "openai-responses",
+      baseUrl: "https://router.example/v1",
+      dispatch: {
+        authProvider: "clawrouter",
+        forceOpenClawTransport: true,
+      },
+    });
+  });
+
   it("reuses agent discovery stores while the agent model files are unchanged", async () => {
     mockDiscoveredModel(discoverModels, {
       provider: "openai",

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -9,9 +9,11 @@ import type { ModelRegistry as CoreModelRegistry } from "../../llm/model-registr
 import type { Api, Model } from "../../llm/types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import {
+  applyModelTransportRoute,
   applyProviderResolvedTransportWithPlugin,
   buildProviderUnknownModelHintWithPlugin,
   normalizeProviderTransportWithPlugin,
+  prepareModelTransportRoutes,
   prepareProviderDynamicModel,
   runProviderDynamicModel,
   normalizeProviderResolvedModelWithPlugin,
@@ -61,6 +63,7 @@ import {
 } from "./model.static-catalog.js";
 
 type ProviderRuntimeHooks = {
+  applyModelTransportRoute?: (params: Parameters<typeof applyModelTransportRoute>[0]) => unknown;
   applyProviderResolvedTransportWithPlugin?: (
     params: Parameters<typeof applyProviderResolvedTransportWithPlugin>[0],
   ) => unknown;
@@ -69,6 +72,9 @@ type ProviderRuntimeHooks = {
   ) => string | undefined;
   prepareProviderDynamicModel: (
     params: Parameters<typeof prepareProviderDynamicModel>[0],
+  ) => Promise<void>;
+  prepareModelTransportRoutes?: (
+    params: Parameters<typeof prepareModelTransportRoutes>[0],
   ) => Promise<void>;
   runProviderDynamicModel: (params: Parameters<typeof runProviderDynamicModel>[0]) => unknown;
   shouldPreferProviderRuntimeResolvedModel?: (
@@ -88,7 +94,9 @@ type StaticCatalogFallbackModel = Model & {
 };
 
 const TARGET_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
+  applyModelTransportRoute,
   buildProviderUnknownModelHintWithPlugin,
+  prepareModelTransportRoutes,
   prepareProviderDynamicModel,
   runProviderDynamicModel,
   shouldPreferProviderRuntimeResolvedModel,
@@ -106,8 +114,10 @@ const DEFAULT_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
 };
 
 const STATIC_PROVIDER_RUNTIME_HOOKS: ProviderRuntimeHooks = {
+  applyModelTransportRoute: () => undefined,
   applyProviderResolvedTransportWithPlugin: () => undefined,
   buildProviderUnknownModelHintWithPlugin: () => undefined,
+  prepareModelTransportRoutes: async () => {},
   prepareProviderDynamicModel: async () => {},
   runProviderDynamicModel: () => undefined,
   normalizeProviderResolvedModelWithPlugin: () => undefined,
@@ -313,6 +323,71 @@ function normalizeResolvedModel(params: {
       model: fallbackTransportNormalized ?? pluginNormalized ?? normalizedInputModel,
     }),
   });
+}
+
+function applyResolvedModelTransportRoute(params: {
+  provider: string;
+  modelId: string;
+  model: Model;
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  authProfileId?: string;
+  preferredProfile?: string;
+  runtimeHooks: ProviderRuntimeHooks;
+}): Model {
+  const routed = params.runtimeHooks.applyModelTransportRoute?.({
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    context: {
+      config: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      provider: params.provider,
+      modelId: params.modelId,
+      model: params.model as ProviderRuntimeModel,
+      authProfileId: params.authProfileId,
+      preferredProfile: params.preferredProfile,
+    },
+  });
+  if (!routed || typeof routed !== "object") {
+    return params.model;
+  }
+  const candidate = routed as Model;
+  return {
+    ...candidate,
+    provider: params.model.provider,
+    id: params.model.id,
+    name: params.model.name,
+  };
+}
+
+async function prepareAndApplyResolvedModelTransportRoute(params: {
+  provider: string;
+  modelId: string;
+  model: Model;
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  authProfileId?: string;
+  preferredProfile?: string;
+  runtimeHooks: ProviderRuntimeHooks;
+}): Promise<Model> {
+  await params.runtimeHooks.prepareModelTransportRoutes?.({
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    context: {
+      config: params.cfg,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      provider: params.provider,
+      modelId: params.modelId,
+      model: params.model as ProviderRuntimeModel,
+      authProfileId: params.authProfileId,
+      preferredProfile: params.preferredProfile,
+    },
+  });
+  return applyResolvedModelTransportRoute(params);
 }
 
 function resolveProviderTransport(params: {
@@ -1608,7 +1683,21 @@ export function resolveModel(
     runtimeHooks,
   });
   if (model) {
-    return { model, authStorage, modelRegistry };
+    return {
+      model: applyResolvedModelTransportRoute({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        model,
+        cfg,
+        agentDir: resolvedAgentDir,
+        workspaceDir,
+        authProfileId: options?.authProfileId,
+        preferredProfile: options?.preferredProfile,
+        runtimeHooks,
+      }),
+      authStorage,
+      modelRegistry,
+    };
   }
 
   return {
@@ -1634,6 +1723,7 @@ export async function resolveModelAsync(
     authStorage?: AuthStorage;
     modelRegistry?: ModelRegistry;
     allowBundledStaticCatalogFallback?: boolean;
+    applyTransportRouting?: boolean;
     preferBundledStaticCatalogTransport?: boolean;
     retryTransientProviderRuntimeMiss?: boolean;
     runtimeHooks?: ProviderRuntimeHooks;
@@ -1693,7 +1783,24 @@ export async function resolveModelAsync(
       runtimeHooks,
     });
     if (suppressedRuntimeModel) {
-      return { model: suppressedRuntimeModel, authStorage, modelRegistry };
+      return {
+        model:
+          options?.applyTransportRouting === false
+            ? suppressedRuntimeModel
+            : await prepareAndApplyResolvedModelTransportRoute({
+                provider: normalizedRef.provider,
+                modelId: normalizedRef.model,
+                model: suppressedRuntimeModel,
+                cfg,
+                agentDir: resolvedAgentDir,
+                workspaceDir,
+                authProfileId: options?.authProfileId,
+                preferredProfile: options?.preferredProfile,
+                runtimeHooks,
+              }),
+        authStorage,
+        modelRegistry,
+      };
     }
     return {
       error: buildUnknownModelError({
@@ -1835,7 +1942,24 @@ export async function resolveModelAsync(
     }
   }
   if (model) {
-    return { model, authStorage, modelRegistry };
+    return {
+      model:
+        options?.applyTransportRouting === false
+          ? model
+          : await prepareAndApplyResolvedModelTransportRoute({
+              provider: normalizedRef.provider,
+              modelId: normalizedRef.model,
+              model,
+              cfg,
+              agentDir: resolvedAgentDir,
+              workspaceDir,
+              authProfileId: options?.authProfileId,
+              preferredProfile: options?.preferredProfile,
+              runtimeHooks,
+            }),
+      authStorage,
+      modelRegistry,
+    };
   }
 
   return {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -102,6 +102,7 @@ import {
   resolveAuthProfileOrder,
   shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
+import { resolveModelDispatchAuthProvider } from "../model-dispatch.js";
 import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
@@ -942,6 +943,7 @@ async function runEmbeddedAgentInternal(
             // first generating OpenClaw models.json. This keeps one-shot model runs from
             // blocking on unrelated provider discovery.
             skipAgentDiscovery: true,
+            applyTransportRouting: !pluginHarnessOwnsTransport,
             allowBundledStaticCatalogFallback: pluginHarnessOwnsTransport,
             preferBundledStaticCatalogTransport: pluginHarnessOwnsTransport,
             workspaceDir: resolvedWorkspace,
@@ -969,6 +971,7 @@ async function runEmbeddedAgentInternal(
             agentDir,
             params.config,
             {
+              applyTransportRouting: !pluginHarnessOwnsTransport,
               workspaceDir: resolvedWorkspace,
               authProfileId: params.authProfileId,
             },
@@ -1017,6 +1020,7 @@ async function runEmbeddedAgentInternal(
       });
       const ctxInfo = resolvedRuntimeModel.ctxInfo;
       let effectiveModel = resolvedRuntimeModel.effectiveModel;
+      const authProvider = resolveModelDispatchAuthProvider(effectiveModel);
       startupStages.mark("model-resolution");
       notifyExecutionPhase("model_resolution", { provider, model: modelId });
 
@@ -1028,7 +1032,7 @@ async function runEmbeddedAgentInternal(
         !pluginHarnessOwnsTransport &&
         provider === OPENAI_PROVIDER_ID &&
         effectiveModel.api === "openai-chatgpt-responses";
-      let piExternalCliAuthScope = pluginHarnessOwnsTransport
+      let piExternalCliAuthScope = pluginHarnessOwnsTransport || authProvider !== provider
         ? { ignoreAutoPreferredProfile: false }
         : openClawNativeCodexResponsesNeedsAuthBootstrap
           ? {
@@ -1167,7 +1171,7 @@ async function runEmbeddedAgentInternal(
                 workspaceDir: resolvedWorkspace,
               })
             : undefined;
-          const runProvider = resolveProviderIdForAuth(provider, {
+          const runProvider = resolveProviderIdForAuth(authProvider, {
             config: params.config,
             workspaceDir: resolvedWorkspace,
           });
@@ -1186,27 +1190,29 @@ async function runEmbeddedAgentInternal(
         const eligibility = resolveAuthProfileEligibility({
           cfg: params.config,
           store: authStore,
-          provider,
+          provider: authProvider,
           profileId: lockedProfileId,
         });
         if (!eligibility.eligible) {
-          throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+          throw new Error(
+            `Auth profile "${lockedProfileId}" is not configured for ${authProvider}.`,
+          );
         }
       }
-      const profileOrder = shouldPreferExplicitConfigApiKeyAuth(params.config, provider)
+      const profileOrder = shouldPreferExplicitConfigApiKeyAuth(params.config, authProvider)
         ? []
         : [
             ...new Set(
               listOpenAIAuthProfileProvidersForAgentRuntime({
-                provider,
+                provider: authProvider,
                 harnessRuntime: agentHarness.id,
                 agentHarnessId: agentHarness.id,
                 config: params.config,
-              }).flatMap((authProvider) =>
+              }).flatMap((profileProvider) =>
                 resolveAuthProfileOrder({
                   cfg: params.config,
                   store: authStore,
-                  provider: authProvider,
+                  provider: profileProvider,
                   preferredProfile: preferredProfileId,
                 }),
               ),
@@ -1215,14 +1221,14 @@ async function runEmbeddedAgentInternal(
       const providerPreferredProfileId = lockedProfileId
         ? undefined
         : resolveProviderAuthProfileId({
-            provider,
+            provider: authProvider,
             config: params.config,
             workspaceDir: resolvedWorkspace,
             context: {
               config: params.config,
               agentDir,
               workspaceDir: resolvedWorkspace,
-              provider,
+              provider: authProvider,
               modelId,
               preferredProfileId,
               lockedProfileId,
@@ -1296,6 +1302,41 @@ async function runEmbeddedAgentInternal(
       let lastProfileId: string | undefined;
       let runtimeAuthState: RuntimeAuthState | null = null;
       let runtimeAuthRefreshCancelled = false;
+      const refreshModelForAuthProfile = runtimeModel.dispatch
+        ? async (profileId?: string) => {
+            const refreshed = await resolveModelAsync(provider, modelId, agentDir, params.config, {
+              authStorage,
+              modelRegistry,
+              workspaceDir: resolvedWorkspace,
+              authProfileId: profileId,
+            });
+            if (!refreshed.model) {
+              throw new Error(
+                refreshed.error ?? `Unknown model: ${provider}/${modelId} for auth profile ${profileId}`,
+              );
+            }
+            runtimeModel = refreshed.model;
+            effectiveModel = resolveEffectiveRuntimeModel({
+              cfg: params.config,
+              provider,
+              contextConfigProvider: resolveContextConfigProviderForRuntime({
+                provider: modelConfigProvider,
+                runtimeId: agentHarness.id,
+                config: params.config,
+              }),
+              modelId,
+              runtimeModel,
+            }).effectiveModel;
+            if (
+              profileId?.split(":", 1)[0] === authProvider &&
+              resolveModelDispatchAuthProvider(runtimeModel) !== authProvider
+            ) {
+              throw new Error(
+                `Model ${provider}/${modelId} is not available for auth profile ${profileId}.`,
+              );
+            }
+          }
+        : undefined;
       const {
         advanceAuthProfile,
         initializeAuthProfile,
@@ -1313,7 +1354,7 @@ async function runEmbeddedAgentInternal(
         attemptedThinking,
         fallbackConfigured,
         allowTransientCooldownProbe: params.allowTransientCooldownProbe === true,
-        getProvider: () => provider,
+        getProvider: () => authProvider,
         getModelId: () => modelId,
         getRuntimeModel: () => runtimeModel,
         setRuntimeModel: (next) => {
@@ -1323,6 +1364,7 @@ async function runEmbeddedAgentInternal(
         setEffectiveModel: (next) => {
           effectiveModel = next;
         },
+        ...(refreshModelForAuthProfile ? { refreshModelForAuthProfile } : {}),
         getApiKeyInfo: () => apiKeyInfo,
         setApiKeyInfo: (next) => {
           apiKeyInfo = next;

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -99,6 +99,7 @@ function createMutableEmbeddedRunAuthController(params: {
   authStore?: AuthProfileStore;
   fallbackConfigured?: boolean;
   warn?: (message: string) => void;
+  refreshModelForAuthProfile?: (profileId?: string) => Promise<void>;
 }) {
   return createEmbeddedRunAuthController({
     config: undefined,
@@ -126,6 +127,9 @@ function createMutableEmbeddedRunAuthController(params: {
     setEffectiveModel: (next) => {
       params.harness.effectiveModel = next;
     },
+    ...(params.refreshModelForAuthProfile
+      ? { refreshModelForAuthProfile: params.refreshModelForAuthProfile }
+      : {}),
     getApiKeyInfo: () => params.harness.apiKeyInfo as never,
     setApiKeyInfo: (next) => {
       params.harness.apiKeyInfo = next;
@@ -451,6 +455,68 @@ describe("createEmbeddedRunAuthController", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("refreshes transport routing for every auth-profile candidate", async () => {
+    const harness = createMutableAuthControllerHarness();
+    const refreshModelForAuthProfile = vi.fn(async (profileId?: string) => {
+      harness.runtimeModel = {
+        ...harness.runtimeModel,
+        baseUrl: `https://${profileId}.router.example/v1`,
+      };
+      harness.effectiveModel = harness.runtimeModel;
+    });
+    const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+    mocks.getApiKeyForModel.mockImplementation(async ({ profileId }) => ({
+      apiKey: `${profileId}-token`,
+      mode: "api-key",
+      profileId,
+      source: "profile",
+    }));
+    mocks.prepareProviderRuntimeAuth.mockResolvedValue(undefined);
+    const controller = createMutableEmbeddedRunAuthController({
+      harness,
+      setRuntimeApiKey,
+      profileCandidates: ["clawrouter:first", "clawrouter:second"],
+      refreshModelForAuthProfile,
+    });
+
+    await controller.initializeAuthProfile();
+    await controller.advanceAuthProfile();
+
+    expect(refreshModelForAuthProfile).toHaveBeenNthCalledWith(1, "clawrouter:first");
+    expect(refreshModelForAuthProfile).toHaveBeenNthCalledWith(2, "clawrouter:second");
+    expect(harness.runtimeModel.baseUrl).toBe("https://clawrouter:second.router.example/v1");
+  });
+
+  it("skips a profile when route refresh rejects its credential", async () => {
+    const harness = createMutableAuthControllerHarness();
+    const refreshModelForAuthProfile = vi.fn(async (profileId?: string) => {
+      if (profileId === "clawrouter:denied") {
+        throw new Error(`Model is not available for auth profile ${profileId}.`);
+      }
+    });
+    const setRuntimeApiKey = vi.fn<(provider: string, apiKey: string) => void>();
+    mocks.getApiKeyForModel.mockResolvedValue({
+      apiKey: "allowed-token",
+      mode: "api-key",
+      profileId: "clawrouter:allowed",
+      source: "profile",
+    });
+    mocks.prepareProviderRuntimeAuth.mockResolvedValue(undefined);
+    const controller = createMutableEmbeddedRunAuthController({
+      harness,
+      setRuntimeApiKey,
+      profileCandidates: ["clawrouter:denied", "clawrouter:allowed"],
+      refreshModelForAuthProfile,
+    });
+
+    await controller.initializeAuthProfile();
+
+    expect(refreshModelForAuthProfile).toHaveBeenNthCalledWith(1, "clawrouter:denied");
+    expect(refreshModelForAuthProfile).toHaveBeenNthCalledWith(2, "clawrouter:allowed");
+    expect(mocks.getApiKeyForModel).toHaveBeenCalledTimes(1);
+    expect(setRuntimeApiKey).toHaveBeenCalledWith("custom-openai", "allowed-token");
   });
 
   describe("aws-sdk auth without explicit API key (IMDS / instance role)", () => {

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -24,6 +24,7 @@ import {
   MissingProviderAuthError,
   type ResolvedProviderAuth,
 } from "../../model-auth.js";
+import { resolveModelDispatchAuthProvider } from "../../model-dispatch.js";
 import {
   applyPreparedRuntimeAuthToModel,
   type ModelProviderRequestTransportOverrides,
@@ -72,6 +73,7 @@ export function createEmbeddedRunAuthController(params: {
   setRuntimeModel(next: Model): void;
   getEffectiveModel(): Model;
   setEffectiveModel(next: Model): void;
+  refreshModelForAuthProfile?(profileId?: string): Promise<void>;
   getApiKeyInfo(): ApiKeyInfo | null;
   setApiKeyInfo(next: ApiKeyInfo | null): void;
   getLastProfileId(): string | undefined;
@@ -119,7 +121,7 @@ export function createEmbeddedRunAuthController(params: {
     profileId?: string;
   }) =>
     prepareProviderRuntimeAuth({
-      provider: prepareParams.runtimeModel.provider,
+      provider: resolveModelDispatchAuthProvider(prepareParams.runtimeModel),
       config: params.config,
       workspaceDir: params.workspaceDir,
       env: process.env,
@@ -128,7 +130,7 @@ export function createEmbeddedRunAuthController(params: {
         agentDir: params.agentDir,
         workspaceDir: params.workspaceDir,
         env: process.env,
-        provider: prepareParams.runtimeModel.provider,
+        provider: resolveModelDispatchAuthProvider(prepareParams.runtimeModel),
         modelId: params.getModelId(),
         model: prepareParams.runtimeModel,
         apiKey: prepareParams.apiKey,
@@ -198,7 +200,10 @@ export function createEmbeddedRunAuthController(params: {
         );
         return;
       }
-      params.authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
+      params.authStorage.setRuntimeApiKey(
+        resolveModelDispatchAuthProvider(runtimeModel),
+        preparedAuth.apiKey,
+      );
       applyPreparedRuntimeRequestOverrides({ runtimeModel, preparedAuth });
       params.setRuntimeAuthState({
         ...activeRuntimeAuthState,
@@ -377,13 +382,14 @@ export function createEmbeddedRunAuthController(params: {
   };
 
   const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
+    await params.refreshModelForAuthProfile?.(candidate);
     const apiKeyInfo = await resolveApiKeyForCandidate(candidate);
     params.setApiKeyInfo(apiKeyInfo);
     const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
     if (!apiKeyInfo.apiKey) {
       if (apiKeyInfo.mode !== "aws-sdk") {
         const runtimeModel = params.getRuntimeModel();
-        throw new MissingProviderAuthError(runtimeModel.provider, apiKeyInfo);
+        throw new MissingProviderAuthError(resolveModelDispatchAuthProvider(runtimeModel), apiKeyInfo);
       }
       // AWS SDK auth via IMDS / instance role / ECS task role: no explicit API
       // key is available but the SDK default credential chain can resolve
@@ -404,7 +410,10 @@ export function createEmbeddedRunAuthController(params: {
         applyPreparedRuntimeRequestOverrides({ runtimeModel, preparedAuth: preparedAuth ?? {} });
         if (preparedAuth?.apiKey) {
           clearRuntimeAuthRefreshTimer();
-          params.authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
+          params.authStorage.setRuntimeApiKey(
+            resolveModelDispatchAuthProvider(runtimeModel),
+            preparedAuth.apiKey,
+          );
           params.setRuntimeAuthState({
             generation: nextRuntimeAuthGeneration(),
             sourceApiKey: AWS_SDK_AUTH_SENTINEL,
@@ -427,7 +436,10 @@ export function createEmbeddedRunAuthController(params: {
       // sentinel so OpenClaw runtime's hasConfiguredAuth() passes and the AWS SDK default
       // credential chain handles actual request signing.
       clearRuntimeAuthRefreshTimer();
-      params.authStorage.setRuntimeApiKey(runtimeModel.provider, AWS_SDK_AUTH_SENTINEL);
+      params.authStorage.setRuntimeApiKey(
+        resolveModelDispatchAuthProvider(runtimeModel),
+        AWS_SDK_AUTH_SENTINEL,
+      );
       params.setRuntimeAuthState(null);
       params.setLastProfileId(resolvedProfileId);
       return;
@@ -443,7 +455,10 @@ export function createEmbeddedRunAuthController(params: {
     applyPreparedRuntimeRequestOverrides({ runtimeModel, preparedAuth: preparedAuth ?? {} });
     if (preparedAuth?.apiKey) {
       clearRuntimeAuthRefreshTimer();
-      params.authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
+      params.authStorage.setRuntimeApiKey(
+        resolveModelDispatchAuthProvider(runtimeModel),
+        preparedAuth.apiKey,
+      );
       params.setRuntimeAuthState({
         generation: nextRuntimeAuthGeneration(),
         sourceApiKey: apiKeyInfo.apiKey,
@@ -458,7 +473,10 @@ export function createEmbeddedRunAuthController(params: {
     }
     if (!runtimeAuthHandled) {
       clearRuntimeAuthRefreshTimer();
-      params.authStorage.setRuntimeApiKey(runtimeModel.provider, apiKeyInfo.apiKey);
+      params.authStorage.setRuntimeApiKey(
+        resolveModelDispatchAuthProvider(runtimeModel),
+        apiKeyInfo.apiKey,
+      );
       params.setRuntimeAuthState(null);
     }
     params.setLastProfileId(apiKeyInfo.profileId);

--- a/src/agents/embedded-agent-runner/stream-resolution.ts
+++ b/src/agents/embedded-agent-runner/stream-resolution.ts
@@ -4,7 +4,14 @@
 import { getApiProvider } from "../../llm/api-registry.js";
 import { streamSimple } from "../../llm/stream.js";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
-import { createBoundaryAwareStreamFnForModel } from "../provider-transport-stream.js";
+import {
+  hasForcedOpenClawTransport,
+  resolveModelDispatchAuthProvider,
+} from "../model-dispatch.js";
+import {
+  createBoundaryAwareStreamFnForModel,
+  createDispatchRoutedStreamFnForModel,
+} from "../provider-transport-stream.js";
 import type { StreamFn } from "../runtime/index.js";
 import { stripSystemPromptCacheBoundary } from "../system-prompt-cache-boundary.js";
 import type { EmbeddedRunAttemptParams } from "./run/types.js";
@@ -75,6 +82,9 @@ export function describeEmbeddedAgentStreamStrategy(params: {
   model: EmbeddedRunAttemptParams["model"];
   resolvedApiKey?: string;
 }): string {
+  if (hasForcedOpenClawTransport(params.model)) {
+    return `dispatch-route:${params.model.api}`;
+  }
   if (params.providerStreamFn) {
     return "provider";
   }
@@ -126,13 +136,27 @@ export function resolveEmbeddedAgentStreamFn(params: {
   authProfileId?: string;
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
 }): StreamFn {
+  const authProvider = resolveModelDispatchAuthProvider(params.model);
+  if (hasForcedOpenClawTransport(params.model)) {
+    const dispatchStreamFn = createDispatchRoutedStreamFnForModel(params.model);
+    if (dispatchStreamFn) {
+      return wrapEmbeddedAgentStreamFn(dispatchStreamFn, {
+        runSignal: params.signal,
+        resolvedApiKey: params.resolvedApiKey,
+        authProfileId: params.authProfileId,
+        authStorage: params.authStorage,
+        providerId: authProvider,
+        promptCacheKey: params.promptCacheKey,
+      });
+    }
+  }
   if (params.providerStreamFn) {
     return wrapEmbeddedAgentStreamFn(params.providerStreamFn, {
       runSignal: params.signal,
       resolvedApiKey: params.resolvedApiKey,
       authProfileId: params.authProfileId,
       authStorage: params.authStorage,
-      providerId: params.model.provider,
+      providerId: authProvider,
       promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
         context.systemPrompt
@@ -159,7 +183,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
       resolvedApiKey: params.resolvedApiKey,
       authProfileId: params.authProfileId,
       authStorage: params.authStorage,
-      providerId: params.model.provider,
+      providerId: authProvider,
       sessionId: params.sessionId,
       promptCacheKey: params.promptCacheKey,
       transformContext: (context) =>
@@ -192,7 +216,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
         resolvedApiKey: params.resolvedApiKey,
         authProfileId: params.authProfileId,
         authStorage: params.authStorage,
-        providerId: params.model.provider,
+        providerId: authProvider,
         promptCacheKey: params.promptCacheKey,
       });
     }
@@ -207,7 +231,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
     resolvedApiKey: undefined,
     authProfileId: undefined,
     authStorage: undefined,
-    providerId: params.model.provider,
+    providerId: authProvider,
     promptCacheKey,
   });
 }

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -402,6 +402,35 @@ async function resolveDemoLocalApiKey(params: {
 }
 
 describe("getApiKeyForModel", () => {
+  it("resolves credentials from a model's dispatch auth provider", async () => {
+    const auth = await getApiKeyForModel({
+      model: {
+        ...testModelDefinition("claude-sonnet-4-6"),
+        provider: "anthropic",
+        api: "anthropic-messages",
+        dispatch: {
+          authProvider: "clawrouter",
+          forceOpenClawTransport: true,
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "clawrouter:default": {
+            type: "api_key",
+            provider: "clawrouter",
+            key: "router-key",
+          },
+        },
+      },
+    });
+
+    expect(auth).toMatchObject({
+      apiKey: "router-key",
+      profileId: "clawrouter:default",
+    });
+  });
+
   it("reads oauth auth-profiles entries from auth-profiles.json via explicit profile", async () => {
     await withOpenClawTestState(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1530,7 +1530,7 @@ export async function getApiKeyForModel(params: {
   credentialPrecedence?: ProviderCredentialPrecedence;
 }): Promise<ResolvedProviderAuth> {
   return resolveApiKeyForProvider({
-    provider: params.model.provider,
+    provider: params.model.dispatch?.authProvider ?? params.model.provider,
     cfg: params.cfg,
     profileId: params.profileId,
     preferredProfile: params.preferredProfile,

--- a/src/agents/model-dispatch.test.ts
+++ b/src/agents/model-dispatch.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { Model } from "../llm/types.js";
+import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
+import {
+  hasForcedOpenClawTransport,
+  prepareModelForDispatch,
+  restoreCanonicalModelIdentityForStream,
+  resolveModelDispatchAuthProvider,
+} from "./model-dispatch.js";
+
+function buildModel(): Model<"anthropic-messages"> {
+  return {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "https://router.example/v1/native/anthropic",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 32_768,
+    headers: {
+      Authorization: "Bearer stale-token",
+      "x-goog-api-key": "direct-google-key",
+      "api-key": "direct-azure-key",
+      "X-Request-ID": "request-1",
+    },
+    dispatch: {
+      authProvider: "clawrouter",
+      authHeader: "bearer",
+      forceOpenClawTransport: true,
+      upstreamModel: "claude-sonnet-4-6-20260217",
+    },
+  };
+}
+
+describe("model dispatch", () => {
+  it("preserves canonical identity while preparing only the outbound request", () => {
+    const model = buildModel();
+
+    expect(hasForcedOpenClawTransport(model)).toBe(true);
+    expect(resolveModelDispatchAuthProvider(model)).toBe("clawrouter");
+
+    const requestModel = prepareModelForDispatch(model, "router-token");
+
+    expect(model).toMatchObject({
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+      dispatch: { authProvider: "clawrouter" },
+    });
+    expect(requestModel).toMatchObject({
+      provider: "anthropic",
+      id: "claude-sonnet-4-6-20260217",
+      authHeader: true,
+      headers: {
+        Authorization: "Bearer router-token",
+        "X-Request-ID": "request-1",
+      },
+      dispatch: undefined,
+    });
+    expect(requestModel.headers).not.toHaveProperty("x-goog-api-key");
+    expect(requestModel.headers).not.toHaveProperty("api-key");
+  });
+
+  it("restores canonical identity in streamed and persisted assistant messages", async () => {
+    const stream = restoreCanonicalModelIdentityForStream(
+      createAssistantMessageEventStream(),
+      "claude-sonnet-4-6",
+    );
+    const upstreamMessage = {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "hello" }],
+      api: "anthropic-messages" as const,
+      provider: "anthropic",
+      model: "claude-sonnet-4-6-20260217",
+      responseModel: "claude-sonnet-4-6-20260217",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop" as const,
+      timestamp: 1,
+    };
+    stream.push({ type: "start", partial: upstreamMessage });
+    stream.push({ type: "done", reason: "stop", message: upstreamMessage });
+
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "start",
+        partial: expect.objectContaining({
+          model: "claude-sonnet-4-6",
+          responseModel: "claude-sonnet-4-6-20260217",
+        }),
+      }),
+      expect.objectContaining({
+        type: "done",
+        message: expect.objectContaining({
+          model: "claude-sonnet-4-6",
+          responseModel: "claude-sonnet-4-6-20260217",
+        }),
+      }),
+    ]);
+    await expect(stream.result()).resolves.toMatchObject({
+      model: "claude-sonnet-4-6",
+      responseModel: "claude-sonnet-4-6-20260217",
+    });
+  });
+});

--- a/src/agents/model-dispatch.ts
+++ b/src/agents/model-dispatch.ts
@@ -1,0 +1,129 @@
+import type {
+  AssistantMessage,
+  AssistantMessageEvent,
+  AssistantMessageEventStreamLike,
+  Model,
+} from "../llm/types.js";
+import type { MutableAssistantMessageEventStream } from "./stream-compat.js";
+import { createStreamIteratorWrapper } from "./stream-iterator-wrapper.js";
+
+export function hasForcedOpenClawTransport(model: Model): boolean {
+  return model.dispatch?.forceOpenClawTransport === true;
+}
+
+export function resolveModelDispatchAuthProvider(model: Model): string {
+  return model.dispatch?.authProvider ?? model.provider;
+}
+
+function withBearerAuthorization(
+  headers: Record<string, string> | undefined,
+  apiKey: string | undefined,
+): Record<string, string> | undefined {
+  const next: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (!isCredentialHeaderName(name)) {
+      next[name] = value;
+    }
+  }
+  if (apiKey?.trim()) {
+    next.Authorization = `Bearer ${apiKey}`;
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+function isCredentialHeaderName(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  return (
+    normalized === "authorization" ||
+    normalized === "proxy-authorization" ||
+    normalized === "api-key" ||
+    normalized === "x-api-key" ||
+    normalized === "x-goog-api-key" ||
+    normalized === "x-amz-security-token" ||
+    normalized === "x-amz-credential" ||
+    normalized === "x-auth-token" ||
+    normalized === "x-access-token" ||
+    normalized.endsWith("-api-key") ||
+    normalized.endsWith("-auth-token") ||
+    normalized.endsWith("-access-token")
+  );
+}
+
+/**
+ * Clones a canonical model for one outbound request. The route metadata never
+ * reaches provider payload construction and therefore cannot leak into an
+ * upstream provider's request body.
+ */
+export function prepareModelForDispatch(model: Model, apiKey?: string): Model {
+  const route = model.dispatch;
+  if (!route) {
+    return model;
+  }
+  const headers =
+    route.authHeader === "bearer" ? withBearerAuthorization(model.headers, apiKey) : model.headers;
+  return {
+    ...model,
+    ...(route.upstreamModel && route.upstreamModel !== model.id ? { id: route.upstreamModel } : {}),
+    ...(route.authHeader === "bearer" ? { authHeader: true } : {}),
+    ...(headers !== model.headers ? { headers } : {}),
+    dispatch: undefined,
+  };
+}
+
+function restoreCanonicalModelIdentity(
+  message: AssistantMessage,
+  canonicalModelId: string,
+): AssistantMessage {
+  return message.model === canonicalModelId ? message : { ...message, model: canonicalModelId };
+}
+
+function restoreCanonicalModelIdentityInEvent(
+  event: AssistantMessageEvent,
+  canonicalModelId: string,
+): AssistantMessageEvent {
+  const next = { ...event };
+  if ("partial" in next && next.partial) {
+    next.partial = restoreCanonicalModelIdentity(next.partial, canonicalModelId);
+  }
+  if ("message" in next && next.message) {
+    next.message = restoreCanonicalModelIdentity(next.message, canonicalModelId);
+  }
+  if ("error" in next && next.error) {
+    next.error = restoreCanonicalModelIdentity(next.error, canonicalModelId);
+  }
+  return next;
+}
+
+/**
+ * Keeps the selected model identity in emitted session messages while the
+ * provider transport receives a catalog-specific upstream model id.
+ */
+export function restoreCanonicalModelIdentityForStream<T extends AssistantMessageEventStreamLike>(
+  stream: T,
+  canonicalModelId: string,
+): T {
+  const mutableStream = stream as MutableAssistantMessageEventStream;
+  const originalResult = mutableStream.result.bind(mutableStream);
+  mutableStream.result = async () =>
+    restoreCanonicalModelIdentity(await originalResult(), canonicalModelId);
+
+  const originalAsyncIterator = mutableStream[Symbol.asyncIterator].bind(mutableStream);
+  (mutableStream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[
+    Symbol.asyncIterator
+  ] = function () {
+    const iterator = originalAsyncIterator();
+    return createStreamIteratorWrapper({
+      iterator,
+      next: async (streamIterator) => {
+        const result = await streamIterator.next();
+        return result.done
+          ? result
+          : {
+              done: false as const,
+              value: restoreCanonicalModelIdentityInEvent(result.value, canonicalModelId),
+            };
+      },
+    });
+  };
+  return mutableStream as T;
+}

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -7,7 +7,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Api, Model } from "../llm/types.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
-import { createTransportAwareStreamFnForModel } from "./provider-transport-stream.js";
+import { hasForcedOpenClawTransport } from "./model-dispatch.js";
+import {
+  createDispatchRoutedStreamFnForModel,
+  createTransportAwareStreamFnForModel,
+} from "./provider-transport-stream.js";
 import type { StreamFn } from "./runtime/index.js";
 
 /** Resolves and registers the stream function for a provider-backed model. */
@@ -20,6 +24,14 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   allowRuntimePluginLoad?: boolean;
 }): StreamFn | undefined {
   const streamFn =
+    (hasForcedOpenClawTransport(params.model)
+      ? createDispatchRoutedStreamFnForModel(params.model, {
+          cfg: params.cfg,
+          agentDir: params.agentDir,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+        })
+      : undefined) ??
     resolveProviderStreamFn({
       provider: params.model.provider,
       config: params.cfg,

--- a/src/agents/provider-transport-stream.ts
+++ b/src/agents/provider-transport-stream.ts
@@ -8,6 +8,10 @@ import type { Api, Model } from "../llm/types.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
 import {
+  prepareModelForDispatch,
+  restoreCanonicalModelIdentityForStream,
+} from "./model-dispatch.js";
+import {
   createAzureOpenAIResponsesTransportStreamFn,
   createOpenAICompletionsTransportStreamFn,
   createOpenAIResponsesTransportStreamFn,
@@ -40,6 +44,15 @@ type ProviderTransportStreamContext = {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 };
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
 
 function createProviderOwnedGoogleTransportStreamFn(
   model: Model,
@@ -143,6 +156,32 @@ export function createOpenClawTransportStreamFnForModel(
     return undefined;
   }
   return createSupportedTransportStreamFn(model, ctx);
+}
+
+/**
+ * Creates a forced OpenClaw transport that applies a late-bound dispatch route
+ * only after the resolved credential is available.
+ */
+export function createDispatchRoutedStreamFnForModel(
+  model: Model,
+  ctx?: ProviderTransportStreamContext,
+): StreamFn | undefined {
+  const inner = createOpenClawTransportStreamFnForModel(model, ctx);
+  if (!inner) {
+    return undefined;
+  }
+  return (requestModel, context, options) => {
+    const stream = inner(
+      prepareModelForDispatch({ ...requestModel, api: model.api }, options?.apiKey),
+      context,
+      options,
+    );
+    return isPromiseLike(stream)
+      ? Promise.resolve(stream).then((resolved) =>
+          restoreCanonicalModelIdentityForStream(resolved, requestModel.id),
+        )
+      : restoreCanonicalModelIdentityForStream(stream, requestModel.id);
+  };
 }
 
 export function createBoundaryAwareStreamFnForModel(

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -138,6 +138,36 @@ describe("prepareSimpleCompletionModel", () => {
     expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith("anthropic", "sk-test");
   });
 
+  it("always resolves models asynchronously so transport routes can prepare", async () => {
+    const asyncResolver = vi.fn().mockResolvedValue({
+      model: {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      modelResolver: asyncResolver,
+    });
+
+    expectPreparedModelResult(result);
+    expect(asyncResolver).toHaveBeenCalledWith(
+      "anthropic",
+      "claude-opus-4-6",
+      undefined,
+      undefined,
+      {},
+    );
+    expect(hoisted.resolveModelMock).not.toHaveBeenCalled();
+  });
+
   it("returns error when model resolution fails", async () => {
     hoisted.resolveModelMock.mockReturnValueOnce({
       error: "Unknown model: anthropic/missing-model",
@@ -437,6 +467,48 @@ describe("prepareSimpleCompletionModel", () => {
     expect(result.auth.apiKey).toBe("bedrock-runtime-token");
   });
 
+  it("uses the dispatch auth provider for runtime credentials", async () => {
+    hoisted.resolveModelAsyncMock.mockResolvedValueOnce({
+      model: {
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+        dispatch: {
+          authProvider: "clawrouter",
+          authHeader: "bearer",
+          forceOpenClawTransport: true,
+        },
+      },
+      authStorage: {
+        setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
+      },
+      modelRegistry: {},
+    });
+    hoisted.getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: "router-token",
+      source: "profile:clawrouter:work",
+      mode: "api-key",
+      profileId: "clawrouter:work",
+    });
+
+    const result = await prepareSimpleCompletionModel({
+      cfg: undefined,
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+    });
+
+    expectPreparedModelResult(result);
+    expect(hoisted.prepareProviderRuntimeAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "clawrouter",
+        context: expect.objectContaining({
+          provider: "clawrouter",
+          modelId: "claude-opus-4-6",
+        }),
+      }),
+    );
+    expect(hoisted.setRuntimeApiKeyMock).toHaveBeenCalledWith("clawrouter", "router-token");
+  });
+
   it("can skip agent model/auth discovery for config-scoped one-shot completions", async () => {
     hoisted.resolveModelAsyncMock.mockResolvedValueOnce({
       model: {
@@ -475,7 +547,7 @@ describe("prepareSimpleCompletionModel", () => {
     );
   });
 
-  it("can preserve asynchronous provider model discovery", async () => {
+  it("accepts the legacy async-resolution option without changing async routing", async () => {
     // Use a standalone mock so the default beforeEach delegation from
     // resolveModelAsyncMock → resolveModelMock does not pollute call
     // history. The point of the test is that when useAsyncModelResolution

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -15,7 +15,7 @@ import type {
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
 import { resolveAgentDir, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
 import { DEFAULT_PROVIDER } from "./defaults.js";
-import { resolveModel, resolveModelAsync } from "./embedded-agent-runner/model.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import {
   applyLocalNoAuthHeaderOverride,
@@ -23,6 +23,7 @@ import {
   getApiKeyForModel,
   type ResolvedProviderAuth,
 } from "./model-auth.js";
+import { resolveModelDispatchAuthProvider } from "./model-dispatch.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import {
   buildModelAliasIndex,
@@ -151,7 +152,8 @@ async function setRuntimeApiKeyForCompletion(params: {
   workspaceDir?: string;
   profileId?: string;
 }): Promise<CompletionRuntimeCredential> {
-  if (params.model.provider === "github-copilot") {
+  const authProvider = resolveModelDispatchAuthProvider(params.model);
+  if (authProvider === "github-copilot" && params.model.provider === "github-copilot") {
     const { resolveCopilotApiToken } = await import("./github-copilot-token.js");
     const copilotToken = await resolveCopilotApiToken({
       githubToken: params.apiKey,
@@ -163,7 +165,7 @@ async function setRuntimeApiKeyForCompletion(params: {
     };
   }
   const preparedAuth = await prepareProviderRuntimeAuth({
-    provider: params.model.provider,
+    provider: authProvider,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     env: process.env,
@@ -171,7 +173,7 @@ async function setRuntimeApiKeyForCompletion(params: {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
       env: process.env,
-      provider: params.model.provider,
+      provider: authProvider,
       modelId: params.model.id,
       model: params.model,
       apiKey: params.apiKey,
@@ -180,7 +182,7 @@ async function setRuntimeApiKeyForCompletion(params: {
     },
   });
   const runtimeApiKey = preparedAuth?.apiKey?.trim() || params.apiKey;
-  params.authStorage.setRuntimeApiKey(params.model.provider, runtimeApiKey);
+  params.authStorage.setRuntimeApiKey(authProvider, runtimeApiKey);
   return {
     apiKey: runtimeApiKey,
     model: applyPreparedRuntimeAuthToModel(params.model, preparedAuth),
@@ -203,30 +205,25 @@ export async function prepareSimpleCompletionModel(params: {
   preferredProfile?: string;
   allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
   allowBundledStaticCatalogFallback?: boolean;
+  /** @deprecated Model resolution is asynchronous so gateway route hooks can prepare requests. */
   useAsyncModelResolution?: boolean;
   skipAgentDiscovery?: boolean;
   modelResolver?: typeof resolveModelAsync;
 }): Promise<PreparedSimpleCompletionModel> {
-  const resolved =
-    params.useAsyncModelResolution || params.skipAgentDiscovery
-      ? await (params.modelResolver ?? resolveModelAsync)(
-          params.provider,
-          params.modelId,
-          params.agentDir,
-          params.cfg,
-          {
-            ...(params.allowBundledStaticCatalogFallback !== undefined
-              ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
-              : {}),
-            ...(params.skipAgentDiscovery ? { skipAgentDiscovery: true } : {}),
-            authProfileId: params.profileId,
-            preferredProfile: params.preferredProfile,
-          },
-        )
-      : resolveModel(params.provider, params.modelId, params.agentDir, params.cfg, {
-          authProfileId: params.profileId,
-          preferredProfile: params.preferredProfile,
-        });
+  const resolved = await (params.modelResolver ?? resolveModelAsync)(
+    params.provider,
+    params.modelId,
+    params.agentDir,
+    params.cfg,
+    {
+      ...(params.allowBundledStaticCatalogFallback !== undefined
+        ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
+        : {}),
+      ...(params.skipAgentDiscovery ? { skipAgentDiscovery: true } : {}),
+      authProfileId: params.profileId,
+      preferredProfile: params.preferredProfile,
+    },
+  );
   if (!resolved.model) {
     return {
       error: resolved.error ?? `Unknown model: ${params.provider}/${params.modelId}`,
@@ -256,7 +253,7 @@ export async function prepareSimpleCompletionModel(params: {
     })
   ) {
     return {
-      error: formatMissingAuthError(auth, resolved.model.provider),
+      error: formatMissingAuthError(auth, resolveModelDispatchAuthProvider(resolved.model)),
       auth,
     };
   }
@@ -295,6 +292,7 @@ export async function prepareSimpleCompletionModelForAgent(params: {
   preferredProfile?: string;
   allowMissingApiKeyModes?: ReadonlyArray<AllowedMissingApiKeyMode>;
   allowBundledStaticCatalogFallback?: boolean;
+  /** @deprecated Model resolution is asynchronous so gateway route hooks can prepare requests. */
   useAsyncModelResolution?: boolean;
   skipAgentDiscovery?: boolean;
   modelResolver?: typeof resolveModelAsync;

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -11,6 +11,7 @@ const ensureCustomApiRegistered = vi.fn();
 const resolveProviderStreamFn = vi.fn();
 const wrapProviderSimpleCompletionStreamFn = vi.fn();
 const buildTransportAwareSimpleStreamFn = vi.fn();
+const createDispatchRoutedStreamFnForModel = vi.fn();
 const createOpenClawTransportStreamFnForModel = vi.fn();
 const createTransportAwareStreamFnForModel = vi.fn();
 const prepareTransportAwareSimpleModel = vi.fn();
@@ -31,6 +32,7 @@ vi.mock("./google-simple-completion-stream.js", () => ({
 
 vi.mock("./provider-transport-stream.js", () => ({
   buildTransportAwareSimpleStreamFn,
+  createDispatchRoutedStreamFnForModel,
   createOpenClawTransportStreamFnForModel,
   createTransportAwareStreamFnForModel,
   prepareTransportAwareSimpleModel,
@@ -64,6 +66,7 @@ describe("prepareModelForSimpleCompletion", () => {
     resolveProviderStreamFn.mockReset();
     wrapProviderSimpleCompletionStreamFn.mockReset();
     buildTransportAwareSimpleStreamFn.mockReset();
+    createDispatchRoutedStreamFnForModel.mockReset();
     createOpenClawTransportStreamFnForModel.mockReset();
     createTransportAwareStreamFnForModel.mockReset();
     prepareTransportAwareSimpleModel.mockReset();
@@ -73,6 +76,7 @@ describe("prepareModelForSimpleCompletion", () => {
     resolveProviderStreamFn.mockReturnValue("ollama-stream");
     wrapProviderSimpleCompletionStreamFn.mockReturnValue(undefined);
     buildTransportAwareSimpleStreamFn.mockReturnValue(undefined);
+    createDispatchRoutedStreamFnForModel.mockReturnValue(undefined);
     createOpenClawTransportStreamFnForModel.mockReturnValue(undefined);
     createTransportAwareStreamFnForModel.mockReturnValue(undefined);
     prepareTransportAwareSimpleModel.mockImplementation((model) => model);
@@ -139,6 +143,42 @@ describe("prepareModelForSimpleCompletion", () => {
     expect(stream).toBe(sourceResult);
     expect(stream).not.toBeInstanceOf(Promise);
     expect(capturedApi).toBe(sourceApi);
+  });
+
+  it("forces dispatch-routed models through a custom OpenClaw transport alias", () => {
+    const model: Model<"anthropic-messages"> = {
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://router.example/v1/native/anthropic",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 32_768,
+      dispatch: {
+        authProvider: "clawrouter",
+        authHeader: "bearer",
+        forceOpenClawTransport: true,
+        upstreamModel: "claude-sonnet-4-6-20260217",
+      },
+    };
+    createDispatchRoutedStreamFnForModel.mockReturnValueOnce("dispatch-stream");
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(createDispatchRoutedStreamFnForModel).toHaveBeenCalledWith(model, { cfg: undefined });
+    expect(resolveProviderStreamFn).not.toHaveBeenCalled();
+    expect(wrapProviderSimpleCompletionStreamFn).not.toHaveBeenCalled();
+    expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
+      "openclaw-provider-simple:anthropic:claude-sonnet-4-6:anthropic-messages:https%3A%2F%2Frouter.example%2Fv1%2Fnative%2Fanthropic",
+      "dispatch-stream",
+    );
+    expect(result).toEqual({
+      ...model,
+      api: "openclaw-provider-simple:anthropic:claude-sonnet-4-6:anthropic-messages:https%3A%2F%2Frouter.example%2Fv1%2Fnative%2Fanthropic",
+    });
   });
 
   it("registers the configured Ollama transport and keeps the original api", () => {

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -10,9 +10,11 @@ import { wrapProviderSimpleCompletionStreamFn } from "../plugins/provider-runtim
 import { createAnthropicVertexStreamFnForModel } from "./anthropic-vertex-stream.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
 import { prepareGoogleSimpleCompletionModel } from "./google-simple-completion-stream.js";
+import { hasForcedOpenClawTransport } from "./model-dispatch.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import {
   buildTransportAwareSimpleStreamFn,
+  createDispatchRoutedStreamFnForModel,
   createOpenClawTransportStreamFnForModel,
   prepareTransportAwareSimpleModel,
   resolveTransportAwareSimpleApi,
@@ -124,11 +126,33 @@ function prepareCodexSimpleTransportModel<TApi extends Api>(
   };
 }
 
+function prepareForcedDispatchSimpleTransportModel<TApi extends Api>(
+  model: Model<TApi>,
+  cfg?: OpenClawConfig,
+): Model {
+  const streamFn = createDispatchRoutedStreamFnForModel(model, { cfg });
+  if (!streamFn) {
+    throw new Error(
+      `No OpenClaw transport is available for forced dispatch api "${model.api}".`,
+    );
+  }
+  const api = resolveProviderSimpleCompletionApi(model);
+  ensureCustomApiRegistered(api, streamFn);
+  return {
+    ...model,
+    api,
+  };
+}
+
 export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
   model: Model<TApi>;
   cfg?: OpenClawConfig;
 }): Model {
   const { model, cfg } = params;
+  if (hasForcedOpenClawTransport(model)) {
+    return prepareForcedDispatchSimpleTransportModel(model, cfg);
+  }
+
   // Only provider-owned custom APIs need runtime stream registration here.
   if (!getApiProvider(model.api) && registerProviderStreamForModel({ model, cfg })) {
     return applyProviderSimpleCompletionWrapper(model, cfg);

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -83,6 +83,34 @@ describe("Anthropic provider", () => {
     expect(config.defaultHeaders?.["cf-aig-authorization"]).toBe("Bearer gateway-token");
   });
 
+  it("preserves static bearer proxy headers alongside Anthropic API-key auth", async () => {
+    const model = makeAnthropicModel({
+      provider: "custom-anthropic-proxy",
+      baseUrl: "https://anthropic-proxy.example/v1",
+      headers: {
+        Authorization: "Bearer proxy-token",
+      },
+    });
+    const context = {
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    } satisfies Context;
+
+    streamAnthropic(model, context, {
+      apiKey: "sk-ant-provider",
+    });
+
+    await vi.waitFor(() => expect(anthropicMockState.configs).toHaveLength(1));
+    const config = anthropicMockState.configs[0] as {
+      apiKey?: string | null;
+      authToken?: string | null;
+      defaultHeaders?: Record<string, string | null>;
+    };
+
+    expect(config.apiKey).toBe("sk-ant-provider");
+    expect(config.authToken).toBeNull();
+    expect(config.defaultHeaders?.Authorization).toBe("Bearer proxy-token");
+  });
+
   it("uses bearer auth for Microsoft Foundry Anthropic requests", async () => {
     const model = makeAnthropicModel({
       provider: "microsoft-foundry",
@@ -112,6 +140,36 @@ describe("Anthropic provider", () => {
     expect(config.authToken).toBe("entra-access-token");
     expect(config.defaultHeaders?.Authorization).toBeUndefined();
     expect(config.defaultHeaders?.["api-key"]).toBeUndefined();
+    expect(config.defaultHeaders?.["x-api-key"]).toBeUndefined();
+  });
+
+  it("uses bearer auth for Microsoft Foundry static bearer headers", async () => {
+    const model = makeAnthropicModel({
+      provider: "microsoft-foundry",
+      baseUrl: "https://example.services.ai.azure.com/anthropic",
+      headers: {
+        Authorization: "Bearer stale-foundry-token",
+        "x-api-key": "stale-resource-key",
+      },
+    });
+    const context = {
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    } satisfies Context;
+
+    streamAnthropic(model, context, {
+      apiKey: "entra-access-token",
+    });
+
+    await vi.waitFor(() => expect(anthropicMockState.configs).toHaveLength(1));
+    const config = anthropicMockState.configs[0] as {
+      apiKey?: string | null;
+      authToken?: string | null;
+      defaultHeaders?: Record<string, string | null>;
+    };
+
+    expect(config.apiKey).toBeNull();
+    expect(config.authToken).toBe("entra-access-token");
+    expect(config.defaultHeaders?.Authorization).toBeUndefined();
     expect(config.defaultHeaders?.["x-api-key"]).toBeUndefined();
   });
 

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -260,22 +260,19 @@ function mergeHeaders(
 }
 
 function hasBearerAuthorizationHeader(headers?: Record<string, string>): boolean {
-  if (!headers) {
-    return false;
-  }
-  return Object.entries(headers).some(
+  return Object.entries(headers ?? {}).some(
     ([key, value]) => key.toLowerCase() === "authorization" && /^bearer\s+\S+/i.test(value.trim()),
   );
 }
 
-function usesFoundryBearerAuth(model: Model<"anthropic-messages">): boolean {
+function usesBearerAuthorization(model: Model<"anthropic-messages">): boolean {
   return (
-    model.provider === "microsoft-foundry" &&
-    (model.authHeader === true || hasBearerAuthorizationHeader(model.headers))
+    model.authHeader === true ||
+    (model.provider === "microsoft-foundry" && hasBearerAuthorizationHeader(model.headers))
   );
 }
 
-function omitFoundryBearerCredentialHeaders(
+function omitBearerCredentialHeaders(
   headers?: Record<string, string>,
 ): Record<string, string> | undefined {
   if (!headers) {
@@ -982,7 +979,7 @@ function createClient(
     return { client, isOAuthToken: false };
   }
 
-  if (usesFoundryBearerAuth(model)) {
+  if (usesBearerAuthorization(model)) {
     const client = new Anthropic({
       apiKey: null,
       authToken: apiKey,
@@ -994,7 +991,7 @@ function createClient(
           "anthropic-dangerous-direct-browser-access": "true",
           ...(betaFeatures.length > 0 ? { "anthropic-beta": betaFeatures.join(",") } : {}),
         },
-        omitFoundryBearerCredentialHeaders(model.headers),
+        omitBearerCredentialHeaders(model.headers),
         dynamicHeaders,
         optionsHeaders,
       ),

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -91,6 +91,8 @@ export type ProviderNormalizeModelIdContext =
   import("../plugins/types.js").ProviderNormalizeModelIdContext;
 export type ProviderNormalizeResolvedModelContext =
   import("../plugins/types.js").ProviderNormalizeResolvedModelContext;
+export type ProviderRouteModelTransportContext =
+  import("../plugins/types.js").ProviderRouteModelTransportContext;
 export type ProviderPrepareDynamicModelContext =
   import("../plugins/types.js").ProviderPrepareDynamicModelContext;
 export type ProviderPrepareExtraParamsContext =

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import { createServer } from "node:http";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolveAuthProfileOrder } from "../agents/auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { resolveApiKeyForProvider as resolveModelApiKeyForProvider } from "../agents/model-auth.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
@@ -66,6 +67,27 @@ export function resolveProviderAuthProfileMetadata(params: {
     profileId,
     ...(profile.type === "oauth" && profile.accountId ? { accountId: profile.accountId } : {}),
   };
+}
+
+/**
+ * Resolves usable provider profile ids in the same order as runtime auth failover.
+ */
+export function resolveProviderAuthProfileOrder(params: {
+  provider: string;
+  cfg?: OpenClawConfig;
+  preferredProfile?: string;
+  agentDir?: string;
+}): string[] {
+  const store = ensureAuthProfileStore(params.agentDir, {
+    config: params.cfg,
+    readOnly: true,
+  });
+  return resolveAuthProfileOrder({
+    cfg: params.cfg,
+    store,
+    provider: params.provider,
+    preferredProfile: params.preferredProfile,
+  });
 }
 
 // IdP-host allowlist for CORS echo on the loopback OAuth callback. Plugins

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -76,6 +76,7 @@ import type {
   ProviderNormalizeTransportContext,
   ProviderModernModelPolicyContext,
   ProviderPrepareDynamicModelContext,
+  ProviderRouteModelTransportContext,
   ProviderPreferRuntimeResolvedModelContext,
   ProviderPlugin,
   ProviderResolveExternalAuthProfilesContext,
@@ -172,6 +173,38 @@ export {
   wrapProviderSimpleCompletionStreamFn,
   wrapProviderStreamFn,
 };
+
+/**
+ * Warm generic late-bound model transport routes owned by enabled provider
+ * plugins. This deliberately does not use the selected model's provider
+ * owner: a credential gateway may route any canonical provider/model.
+ */
+export async function prepareModelTransportRoutes(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  context: ProviderRouteModelTransportContext;
+}): Promise<void> {
+  for (const plugin of resolveProviderPluginsForHooks(params)) {
+    await plugin.prepareModelTransportRoute?.(params.context);
+  }
+}
+
+/** Applies the first enabled generic model transport route that accepts the model. */
+export function applyModelTransportRoute(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  context: ProviderRouteModelTransportContext;
+}): ProviderRuntimeModel | undefined {
+  for (const plugin of resolveProviderPluginsForHooks(params)) {
+    const routed = plugin.routeModelTransport?.(params.context);
+    if (routed) {
+      return routed;
+    }
+  }
+  return undefined;
+}
 
 function resetExternalAuthFallbackWarningCacheForTest(): void {
   warnedExternalAuthFallbackPluginIds.clear();

--- a/src/plugins/runtime/runtime-model-auth.runtime.test.ts
+++ b/src/plugins/runtime/runtime-model-auth.runtime.test.ts
@@ -106,6 +106,42 @@ describe("runtime-model-auth.runtime", () => {
     });
   });
 
+  it("prepares runtime auth with the dispatch credential owner", async () => {
+    hoisted.getApiKeyForModel.mockResolvedValue({
+      apiKey: "router-token",
+      source: "profile:clawrouter:work",
+      mode: "api-key",
+      profileId: "clawrouter:work",
+    });
+    hoisted.prepareProviderRuntimeAuth.mockResolvedValue(undefined);
+    const model = {
+      ...MODEL,
+      id: "claude-sonnet-4-6",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      dispatch: {
+        authProvider: "clawrouter",
+        authHeader: "bearer",
+        forceOpenClawTransport: true,
+      },
+    };
+
+    await getRuntimeAuthForModel({
+      model: model as never,
+    });
+
+    expect(hoisted.prepareProviderRuntimeAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "clawrouter",
+        context: expect.objectContaining({
+          provider: "clawrouter",
+          modelId: "claude-sonnet-4-6",
+          model,
+        }),
+      }),
+    );
+  });
+
   it("skips provider preparation when raw auth does not expose an apiKey", async () => {
     hoisted.getApiKeyForModel.mockResolvedValue({
       source: "env:AWS_PROFILE",

--- a/src/plugins/runtime/runtime-model-auth.runtime.ts
+++ b/src/plugins/runtime/runtime-model-auth.runtime.ts
@@ -6,6 +6,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Model } from "../../llm/types.js";
 import { prepareProviderRuntimeAuth } from "../provider-runtime.runtime.js";
+import { resolveModelDispatchAuthProvider } from "../../agents/model-dispatch.js";
 import type { ResolvedProviderRuntimeAuth } from "./model-auth-types.js";
 
 export async function getApiKeyForModel(
@@ -29,6 +30,7 @@ export async function getRuntimeAuthForModel(params: {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
 }): Promise<ResolvedProviderRuntimeAuth> {
+  const authProvider = resolveModelDispatchAuthProvider(params.model);
   const resolvedAuth = await resolveModelApiKey({
     model: params.model,
     cfg: params.cfg,
@@ -40,7 +42,7 @@ export async function getRuntimeAuthForModel(params: {
   }
 
   const preparedAuth = await prepareProviderRuntimeAuth({
-    provider: params.model.provider,
+    provider: authProvider,
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     env: process.env,
@@ -48,7 +50,7 @@ export async function getRuntimeAuthForModel(params: {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
       env: process.env,
-      provider: params.model.provider,
+      provider: authProvider,
       modelId: params.model.id,
       model: params.model,
       apiKey: resolvedAuth.apiKey,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -553,6 +553,19 @@ export type ProviderNormalizeResolvedModelContext = {
 };
 
 /**
+ * Generic late-bound model transport routing.
+ *
+ * Unlike provider-owned normalization, this runs against every resolved
+ * canonical model. Credential/gateway plugins use it to replace only the
+ * dispatch transport while OpenClaw keeps the selected provider and model id
+ * for configuration, traces, and UI.
+ */
+export type ProviderRouteModelTransportContext = ProviderNormalizeResolvedModelContext & {
+  authProfileId?: string;
+  preferredProfile?: string;
+};
+
+/**
  * Provider-owned model-id normalization before config/runtime lookup.
  *
  * Use this for provider-specific alias cleanup that should stay with the
@@ -1344,6 +1357,22 @@ export type ProviderPlugin = {
    */
   normalizeResolvedModel?: (
     ctx: ProviderNormalizeResolvedModelContext,
+  ) => ProviderRuntimeModel | null | undefined;
+  /**
+   * Optional async cache warm-up for generic model transport routing.
+   *
+   * Use this for credential-scoped gateway discovery. It runs only during
+   * asynchronous model resolution and must not mutate the canonical model.
+   */
+  prepareModelTransportRoute?: (ctx: ProviderRouteModelTransportContext) => Promise<void>;
+  /**
+   * Optionally route a resolved canonical model through a different transport.
+   *
+   * Return a cloned model with dispatch metadata; retain the original
+   * `provider` and `id` so model selection and policy remain canonical.
+   */
+  routeModelTransport?: (
+    ctx: ProviderRouteModelTransportContext,
   ) => ProviderRuntimeModel | null | undefined;
   /**
    * Provider-owned model-id normalization.


### PR DESCRIPTION
## Summary

- adds generic plugin hooks for credential-scoped model transport routing
- adds a ClawRouter plugin that routes canonical provider models through the gateway without inventing `clawrouter/...` model IDs
- caches the gateway catalog per credential profile and preserves provider-specific request formats while rewriting only the outbound route and gateway authentication

## Why

ClawRouter should be an optional control-plane and proxy layer for normal provider configuration, not another model provider. A maintainer keeps using canonical models such as `openai/gpt-...` or `anthropic/claude-...`; selecting a ClawRouter credential profile controls whether that call is routed through the gateway.

## Impact

- provider credentials are stripped before gateway dispatch and replaced with the ClawRouter bearer credential
- direct, embedded, simple-completion, compaction, failover, and `/btw` paths resolve the same late transport route
- ClawRouter supports multiple credential profiles with independent catalog access
- response model identity remains canonical while the upstream gateway model alias is retained separately

## Validation

- 482 focused tests passed in Blacksmith Testbox
- autoreview clean
- formatting, lint, plugin SDK generation and export checks, import-boundary checks, and import-cycle checks passed
- full Testbox TypeScript build remains blocked by an unrelated missing `cross-spawn` declaration in `src/agents/utils/child-process.ts`

## Deployment status

Code only. No production ClawRouter configuration or deployment is included.

## Remaining risk

This branch is currently behind `main` and needs a rebase plus final merge validation before landing.
