### PR TITLE
fix(voice-call): deliver early TTS via onEarlyText before compaction wait

### DIFF
--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -41,7 +41,8 @@ type EmbeddedAgentArgs = {
   ) => void;
   onBlockReplyFlush?: (
     context:
-      | { reason: "tool_start" | "message_end" | "terminal" }
+      | { reason: "message_end" | "terminal" }
+      | { reason: "tool_start"; assistantMessageIndex: number }
       | { reason: "pre_compaction"; attemptAccepted: boolean },
   ) => void | Promise<void>;
 };
@@ -311,7 +312,7 @@ describe("generateVoiceResponse", () => {
     });
   });
 
-  it("combines multiple reply blocks into one early transport handoff", async () => {
+  it("combines multiple final-answer items into one early transport handoff", async () => {
     const { runtime } = createAgentRuntime([], {
       blockReplyPayloads: [
         { text: '{"spoken":"First block."}' },
@@ -333,15 +334,14 @@ describe("generateVoiceResponse", () => {
     });
   });
 
-  it("hands off only the newest assistant message after tool use", async () => {
+  it("discards pre-tool narration before the completed answer", async () => {
     const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
     runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
       args.onBlockReply?.({ text: '{"spoken":"I will check."}' }, { assistantMessageIndex: 0 });
+      await args.onBlockReplyFlush?.({ reason: "tool_start", assistantMessageIndex: 0 });
       args.onBlockReply?.(
         { text: '{"spoken":"The result is ready."}' },
-        {
-          assistantMessageIndex: 1,
-        },
+        { assistantMessageIndex: 1 },
       );
       await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
       return {
@@ -355,6 +355,48 @@ describe("generateVoiceResponse", () => {
 
     expect(onEarlyText).toHaveBeenCalledWith("The result is ready.");
     expect(result).toEqual({ text: "The result is ready.", deliveredEarly: true });
+  });
+
+  it("discards deferred pre-tool narration delivered after the tool boundary", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+    runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
+      await args.onBlockReplyFlush?.({ reason: "tool_start", assistantMessageIndex: 0 });
+      args.onBlockReply?.({ text: '{"spoken":"I will check."}' }, { assistantMessageIndex: 0 });
+      args.onBlockReply?.(
+        { text: '{"spoken":"The deferred result is ready."}' },
+        { assistantMessageIndex: 1 },
+      );
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+      return {
+        payloads: [{ text: '{"spoken":"The deferred result is ready."}' }],
+        meta: { durationMs: 20_000, aborted: false },
+      };
+    });
+    const onEarlyText = vi.fn(async () => true);
+
+    const { result } = await runGenerateVoiceResponse([], { runtime, onEarlyText });
+
+    expect(onEarlyText).toHaveBeenCalledWith("The deferred result is ready.");
+    expect(result).toEqual({ text: "The deferred result is ready.", deliveredEarly: true });
+  });
+
+  it("keeps final delivery when a post-tool payload has no boundary metadata", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+    runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
+      await args.onBlockReplyFlush?.({ reason: "tool_start", assistantMessageIndex: 0 });
+      args.onBlockReply?.({ text: '{"spoken":"Unclassified response."}' });
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+      return {
+        payloads: [{ text: '{"spoken":"Complete fallback response."}' }],
+        meta: { durationMs: 20_000, aborted: false },
+      };
+    });
+    const onEarlyText = vi.fn(async () => true);
+
+    const { result } = await runGenerateVoiceResponse([], { runtime, onEarlyText });
+
+    expect(onEarlyText).not.toHaveBeenCalled();
+    expect(result).toEqual({ text: "Complete fallback response.", deliveredEarly: false });
   });
 
   it("discards rejected-attempt audio before delivering the accepted retry", async () => {
@@ -379,6 +421,33 @@ describe("generateVoiceResponse", () => {
       text: "Retry response.",
       deliveredEarly: true,
     });
+  });
+
+  it("resets a rejected attempt tool boundary before the accepted retry", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+    runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
+      await args.onBlockReplyFlush?.({ reason: "tool_start", assistantMessageIndex: 0 });
+      args.onBlockReply?.(
+        { text: '{"spoken":"Rejected tool response."}' },
+        { assistantMessageIndex: 1 },
+      );
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: false });
+      args.onBlockReply?.(
+        { text: '{"spoken":"Accepted retry response."}' },
+        { assistantMessageIndex: 0 },
+      );
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+      return {
+        payloads: [{ text: '{"spoken":"Accepted retry response."}' }],
+        meta: { durationMs: 20_000, aborted: false },
+      };
+    });
+    const onEarlyText = vi.fn(async () => true);
+
+    const { result } = await runGenerateVoiceResponse([], { runtime, onEarlyText });
+
+    expect(onEarlyText).toHaveBeenCalledWith("Accepted retry response.");
+    expect(result).toEqual({ text: "Accepted retry response.", deliveredEarly: true });
   });
 
   it("keeps final delivery enabled when the early transport handoff fails", async () => {

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -34,9 +34,22 @@ type EmbeddedAgentArgs = {
   workspaceDir?: string;
   sessionFile?: string;
   toolsAllow?: string[];
+  blockReplyBreak?: "text_end" | "message_end";
+  onBlockReply?: (
+    payload: Record<string, unknown>,
+    context?: { assistantMessageIndex?: number },
+  ) => void;
+  onBlockReplyFlush?: (
+    context:
+      | { reason: "tool_start" | "message_end" | "terminal" }
+      | { reason: "pre_compaction"; attemptAccepted: boolean },
+  ) => void | Promise<void>;
 };
 
-function createAgentRuntime(payloads: Array<Record<string, unknown>>) {
+function createAgentRuntime(
+  payloads: Array<Record<string, unknown>>,
+  options?: { blockReplyPayloads?: Array<Record<string, unknown>> },
+) {
   const sessionStore: Record<string, TestSessionEntry> = {};
   const saveSessionStore = vi.fn(async () => {});
   const updateSessionStore = vi.fn(
@@ -72,10 +85,16 @@ function createAgentRuntime(payloads: Array<Record<string, unknown>>) {
       sessionStore[params.sessionKey] = { ...params.entry };
     },
   );
-  const runEmbeddedAgent = vi.fn(async (_args: EmbeddedAgentArgs) => ({
-    payloads,
-    meta: { durationMs: 12, aborted: false },
-  }));
+  const runEmbeddedAgent = vi.fn(async (args: EmbeddedAgentArgs) => {
+    for (const payload of options?.blockReplyPayloads ?? []) {
+      args.onBlockReply?.(payload, { assistantMessageIndex: 0 });
+    }
+    await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+    return {
+      payloads,
+      meta: { durationMs: 12, aborted: false },
+    };
+  });
   const runWithWorkAdmission = vi.fn(
     async (
       _params: { storePath: string; sessionKey: string },
@@ -167,6 +186,7 @@ async function runGenerateVoiceResponse(
   overrides?: {
     runtime?: CoreAgentDeps;
     transcript?: Array<{ speaker: "user" | "bot"; text: string }>;
+    onEarlyText?: (text: string) => Promise<boolean>;
   },
 ) {
   const voiceConfig = VoiceCallConfigSchema.parse({
@@ -183,6 +203,7 @@ async function runGenerateVoiceResponse(
     from: "+15550001111",
     transcript: overrides?.transcript ?? [{ speaker: "user", text: "hello there" }],
     userMessage: "hello there",
+    onEarlyText: overrides?.onEarlyText,
   });
 
   return { result };
@@ -203,6 +224,9 @@ describe("generateVoiceResponse", () => {
     expect(args.provider).toBe("together");
     expect(args.model).toBe("Qwen/Qwen2.5-7B-Instruct-Turbo");
     expect(args.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(args.blockReplyBreak).toBe("text_end");
+    expect(args.onBlockReply).toEqual(expect.any(Function));
+    expect(args.onBlockReplyFlush).toEqual(expect.any(Function));
     expect(runWithWorkAdmission).toHaveBeenCalledWith(
       {
         storePath: "/tmp/openclaw/main/sessions.json",
@@ -222,9 +246,160 @@ describe("generateVoiceResponse", () => {
 
     expect(result).toEqual({
       text: null,
+      deliveredEarly: false,
       error: 'Error: Session "agent:main:voice:15550001111" is archived.',
     });
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
+  it("delivers a completed reply block before the embedded run settles", async () => {
+    let finishRun: (value: {
+      payloads: Array<Record<string, unknown>>;
+      meta: { durationMs: number; aborted: boolean };
+    }) => void = () => {};
+    const runFinished = new Promise<{
+      payloads: Array<Record<string, unknown>>;
+      meta: { durationMs: number; aborted: boolean };
+    }>((resolve) => {
+      finishRun = resolve;
+    });
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+    runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
+      args.onBlockReply?.({ text: '{"spoken":"Already ready."}' });
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+      return await runFinished;
+    });
+    let reportEarlyDelivery: () => void = () => {};
+    const earlyDeliveryStarted = new Promise<void>((resolve) => {
+      reportEarlyDelivery = resolve;
+    });
+    const onEarlyText = vi.fn(async () => {
+      reportEarlyDelivery();
+      return true;
+    });
+
+    const response = runGenerateVoiceResponse([], { runtime, onEarlyText });
+    await earlyDeliveryStarted;
+
+    expect(onEarlyText).toHaveBeenCalledWith("Already ready.");
+    finishRun({ payloads: [], meta: { durationMs: 20_000, aborted: false } });
+    await expect(response).resolves.toEqual({
+      result: { text: "Already ready.", deliveredEarly: true },
+    });
+  });
+
+  it("awaits in-flight early delivery before exposing the fallback decision", async () => {
+    const { runtime } = createAgentRuntime([], {
+      blockReplyPayloads: [{ text: '{"spoken":"No duplicate."}' }],
+    });
+    let finishDelivery: (delivered: boolean) => void = () => {};
+    const deliveryFinished = new Promise<boolean>((resolve) => {
+      finishDelivery = resolve;
+    });
+    const onEarlyText = vi.fn(async () => await deliveryFinished);
+    let responseSettled = false;
+
+    const response = runGenerateVoiceResponse([], { runtime, onEarlyText }).finally(() => {
+      responseSettled = true;
+    });
+    await vi.waitFor(() => expect(onEarlyText).toHaveBeenCalledOnce());
+    expect(responseSettled).toBe(false);
+
+    finishDelivery(true);
+    await expect(response).resolves.toEqual({
+      result: { text: "No duplicate.", deliveredEarly: true },
+    });
+  });
+
+  it("combines multiple reply blocks into one early transport handoff", async () => {
+    const { runtime } = createAgentRuntime([], {
+      blockReplyPayloads: [
+        { text: '{"spoken":"First block."}' },
+        { text: '{"spoken":"Second block."}' },
+      ],
+    });
+    const delivered: string[] = [];
+    const onEarlyText = vi.fn(async (text: string) => {
+      delivered.push(text);
+      return true;
+    });
+
+    const { result } = await runGenerateVoiceResponse([], { runtime, onEarlyText });
+
+    expect(delivered).toEqual(["First block. Second block."]);
+    expect(result).toEqual({
+      text: "First block. Second block.",
+      deliveredEarly: true,
+    });
+  });
+
+  it("hands off only the newest assistant message after tool use", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+    runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
+      args.onBlockReply?.({ text: '{"spoken":"I will check."}' }, { assistantMessageIndex: 0 });
+      args.onBlockReply?.(
+        { text: '{"spoken":"The result is ready."}' },
+        {
+          assistantMessageIndex: 1,
+        },
+      );
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+      return {
+        payloads: [{ text: '{"spoken":"The result is ready."}' }],
+        meta: { durationMs: 20_000, aborted: false },
+      };
+    });
+    const onEarlyText = vi.fn(async () => true);
+
+    const { result } = await runGenerateVoiceResponse([], { runtime, onEarlyText });
+
+    expect(onEarlyText).toHaveBeenCalledWith("The result is ready.");
+    expect(result).toEqual({ text: "The result is ready.", deliveredEarly: true });
+  });
+
+  it("discards rejected-attempt audio before delivering the accepted retry", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([]);
+    runEmbeddedAgent.mockImplementationOnce(async (args: EmbeddedAgentArgs) => {
+      args.onBlockReply?.({ text: '{"spoken":"First completed response."}' });
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: false });
+      args.onBlockReply?.({ text: '{"spoken":"Retry response."}' });
+      await args.onBlockReplyFlush?.({ reason: "pre_compaction", attemptAccepted: true });
+      return {
+        payloads: [{ text: '{"spoken":"Retry response."}' }],
+        meta: { durationMs: 20_000, aborted: false },
+      };
+    });
+    const onEarlyText = vi.fn(async () => true);
+
+    const { result } = await runGenerateVoiceResponse([], { runtime, onEarlyText });
+
+    expect(onEarlyText).toHaveBeenCalledOnce();
+    expect(onEarlyText).toHaveBeenCalledWith("Retry response.");
+    expect(result).toEqual({
+      text: "Retry response.",
+      deliveredEarly: true,
+    });
+  });
+
+  it("keeps final delivery enabled when the early transport handoff fails", async () => {
+    const { runtime } = createAgentRuntime([], {
+      blockReplyPayloads: [
+        { text: '{"spoken":"First block."}' },
+        { text: '{"spoken":"Try the fallback."}' },
+      ],
+    });
+    const onEarlyText = vi.fn<(text: string) => Promise<boolean>>().mockResolvedValue(false);
+
+    const { result } = await runGenerateVoiceResponse([], {
+      runtime,
+      onEarlyText,
+    });
+
+    expect(onEarlyText).toHaveBeenCalledWith("First block. Try the fallback.");
+    expect(result).toEqual({
+      text: "First block. Try the fallback.",
+      deliveredEarly: false,
+    });
   });
 
   it("extracts spoken text from fenced JSON", async () => {

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -348,7 +348,8 @@ export async function generateVoiceResponse(
         const runId = `voice:${callId}:${Date.now()}`;
 
         const blockReplyPayloads: VoiceResponsePayload[] = [];
-        let blockReplyMessageIndex: number | undefined;
+        let latestToolBoundaryMessageIndex: number | undefined;
+        let blockReplyBoundariesReliable = true;
         let deliveredEarly = false;
         let lastFlushedText: string | null = null;
 
@@ -380,35 +381,40 @@ export async function generateVoiceResponse(
           abortSignal,
           blockReplyBreak: "text_end",
           onBlockReply: (payload, context) => {
-            const messageIndex = context?.assistantMessageIndex;
-            if (
-              messageIndex !== undefined &&
-              (blockReplyMessageIndex === undefined || messageIndex > blockReplyMessageIndex)
-            ) {
-              blockReplyPayloads.length = 0;
-              blockReplyMessageIndex = messageIndex;
-            }
-            if (
-              messageIndex !== undefined &&
-              blockReplyMessageIndex !== undefined &&
-              messageIndex < blockReplyMessageIndex
-            ) {
-              return;
+            if (latestToolBoundaryMessageIndex !== undefined) {
+              const messageIndex = context?.assistantMessageIndex;
+              if (messageIndex === undefined) {
+                blockReplyBoundariesReliable = false;
+                return;
+              }
+              if (messageIndex <= latestToolBoundaryMessageIndex) {
+                return;
+              }
             }
             blockReplyPayloads.push(payload);
           },
           onBlockReplyFlush: async (context) => {
+            if (context.reason === "tool_start") {
+              // Deferred replies can arrive after this callback. Retain the
+              // assistant index at the actual tool boundary to reject them.
+              blockReplyPayloads.length = 0;
+              latestToolBoundaryMessageIndex = context.assistantMessageIndex;
+              blockReplyBoundariesReliable = true;
+              return;
+            }
             if (context.reason !== "pre_compaction") {
               return;
             }
             const pendingPayloads = blockReplyPayloads.splice(0);
-            blockReplyMessageIndex = undefined;
+            const boundariesReliable = blockReplyBoundariesReliable;
+            latestToolBoundaryMessageIndex = undefined;
+            blockReplyBoundariesReliable = true;
             if (!context.attemptAccepted) {
               return;
             }
             // Call-control APIs acknowledge a playback request, not playback
             // completion. Never let a later retry flush replace in-flight audio.
-            if (deliveredEarly || !onEarlyText) {
+            if (deliveredEarly || !onEarlyText || !boundariesReliable) {
               return;
             }
             const text = extractSpokenTextFromPayloads(pendingPayloads);

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -412,8 +412,11 @@ export async function generateVoiceResponse(
               return;
             }
             const text = extractSpokenTextFromPayloads(pendingPayloads);
+            if (!text) {
+              return;
+            }
             lastFlushedText = text;
-            deliveredEarly = Boolean(text) && (await deliverEarlyText(onEarlyText, text));
+            deliveredEarly = await deliverEarlyText(onEarlyText, text);
           },
         });
 

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -31,10 +31,14 @@ export type VoiceResponseParams = {
   transcript: Array<{ speaker: "user" | "bot"; text: string }>;
   /** Latest user message */
   userMessage: string;
+  /** Delivers completed reply blocks while post-turn work is still running. */
+  onEarlyText?: (text: string) => Promise<boolean>;
 };
 
 export type VoiceResponseResult = {
   text: string | null;
+  /** Whether the complete response was handed to the transport before compaction. */
+  deliveredEarly: boolean;
   error?: string;
 };
 
@@ -198,6 +202,18 @@ function extractSpokenTextFromPayloads(payloads: VoiceResponsePayload[]): string
   return spokenSegments.length > 0 ? spokenSegments.join(" ").trim() : null;
 }
 
+async function deliverEarlyText(
+  callback: (text: string) => Promise<boolean>,
+  text: string,
+): Promise<boolean> {
+  try {
+    return await callback(text);
+  } catch (error) {
+    console.error("[voice-call] Early TTS delivery failed:", error);
+    return false;
+  }
+}
+
 function resolveVoiceSandboxSessionKey(agentId: string, sessionKey: string): string {
   const trimmed = sessionKey.trim();
   if (trimmed.toLowerCase().startsWith("agent:")) {
@@ -222,10 +238,15 @@ export async function generateVoiceResponse(
     userMessage,
     coreConfig,
     agentRuntime,
+    onEarlyText,
   } = params;
 
   if (!coreConfig) {
-    return { text: null, error: "Core config unavailable for voice response" };
+    return {
+      text: null,
+      deliveredEarly: false,
+      error: "Core config unavailable for voice response",
+    };
   }
   const cfg = coreConfig;
 
@@ -292,7 +313,11 @@ export async function generateVoiceResponse(
             })) ?? undefined;
         }
         if (!sessionEntry?.sessionId) {
-          return { text: null, error: "Voice response session could not be initialized" };
+          return {
+            text: null,
+            deliveredEarly: false,
+            error: "Voice response session could not be initialized",
+          };
         }
         const sessionId = sessionEntry.sessionId;
 
@@ -322,6 +347,11 @@ export async function generateVoiceResponse(
           voiceConfig.responseTimeoutMs ?? agentRuntime.resolveAgentTimeoutMs({ cfg });
         const runId = `voice:${callId}:${Date.now()}`;
 
+        const blockReplyPayloads: VoiceResponsePayload[] = [];
+        let blockReplyMessageIndex: number | undefined;
+        let deliveredEarly = false;
+        let lastFlushedText: string | null = null;
+
         const result = await agentRuntime.runEmbeddedAgent({
           sessionId,
           sessionKey: resolvedSessionKey,
@@ -348,21 +378,59 @@ export async function generateVoiceResponse(
           agentDir,
           toolsAllow,
           abortSignal,
+          blockReplyBreak: "text_end",
+          onBlockReply: (payload, context) => {
+            const messageIndex = context?.assistantMessageIndex;
+            if (
+              messageIndex !== undefined &&
+              (blockReplyMessageIndex === undefined || messageIndex > blockReplyMessageIndex)
+            ) {
+              blockReplyPayloads.length = 0;
+              blockReplyMessageIndex = messageIndex;
+            }
+            if (
+              messageIndex !== undefined &&
+              blockReplyMessageIndex !== undefined &&
+              messageIndex < blockReplyMessageIndex
+            ) {
+              return;
+            }
+            blockReplyPayloads.push(payload);
+          },
+          onBlockReplyFlush: async (context) => {
+            if (context.reason !== "pre_compaction") {
+              return;
+            }
+            const pendingPayloads = blockReplyPayloads.splice(0);
+            blockReplyMessageIndex = undefined;
+            if (!context.attemptAccepted) {
+              return;
+            }
+            // Call-control APIs acknowledge a playback request, not playback
+            // completion. Never let a later retry flush replace in-flight audio.
+            if (deliveredEarly || !onEarlyText) {
+              return;
+            }
+            const text = extractSpokenTextFromPayloads(pendingPayloads);
+            lastFlushedText = text;
+            deliveredEarly = Boolean(text) && (await deliverEarlyText(onEarlyText, text));
+          },
         });
 
-        const text = extractSpokenTextFromPayloads(
-          (result.payloads ?? []) as VoiceResponsePayload[],
-        );
+        const text =
+          extractSpokenTextFromPayloads((result.payloads ?? []) as VoiceResponsePayload[]) ??
+          lastFlushedText ??
+          extractSpokenTextFromPayloads(blockReplyPayloads);
 
         if (!text && result.meta?.aborted) {
-          return { text: null, error: "Response generation was aborted" };
+          return { text: null, deliveredEarly: false, error: "Response generation was aborted" };
         }
 
-        return { text };
+        return { text, deliveredEarly };
       },
     );
   } catch (err) {
     console.error(`[voice-call] Response generation failed:`, err);
-    return { text: null, error: String(err) };
+    return { text: null, deliveredEarly: false, error: String(err) };
   }
 }

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -31,7 +31,14 @@ const mocks = vi.hoisted(() => {
   };
 
   return {
-    generateVoiceResponse: vi.fn(async (): Promise<{ text: string | null }> => ({ text: null })),
+    generateVoiceResponse: vi.fn(
+      async (_params?: {
+        onEarlyText?: (text: string) => Promise<boolean>;
+      }): Promise<{ text: string | null; deliveredEarly: boolean }> => ({
+        text: null,
+        deliveredEarly: false,
+      }),
+    ),
     getRealtimeTranscriptionProvider: vi.fn<(...args: unknown[]) => unknown>(
       () => realtimeTranscriptionProvider,
     ),
@@ -1676,7 +1683,9 @@ describe("VoiceCallWebhookServer classic response routing", () => {
       undefined,
       {} as never,
     );
-    mocks.generateVoiceResponse.mockReset().mockResolvedValue({ text: "Hello back" });
+    mocks.generateVoiceResponse
+      .mockReset()
+      .mockResolvedValue({ text: "Hello back", deliveredEarly: false });
 
     await (
       server as unknown as {
@@ -1692,6 +1701,40 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     expect(speak).toHaveBeenCalledWith(call.callId, "Hello back", {
       listenAfterPlayback: true,
     });
+  });
+
+  it("does not replay a completed response after early playback", async () => {
+    const call = createCall(Date.now());
+    const speak = vi.fn(async () => ({ success: true }));
+    const manager = {
+      getCall: (callId: string) => (callId === call.callId ? call : undefined),
+      speak,
+    } as unknown as CallManager;
+    const server = new VoiceCallWebhookServer(
+      createConfig({ agentId: "main" }),
+      manager,
+      provider,
+      {} as never,
+      undefined,
+      {} as never,
+    );
+    mocks.generateVoiceResponse.mockReset().mockImplementationOnce(async (params) => {
+      await params?.onEarlyText?.("Spoken before compaction. Final detail.");
+      return {
+        text: "Spoken before compaction. Final detail.",
+        deliveredEarly: true,
+      };
+    });
+
+    await (
+      server as unknown as {
+        handleInboundResponse: (callId: string, message: string) => Promise<void>;
+      }
+    ).handleInboundResponse(call.callId, "hello");
+
+    expect(speak.mock.calls).toEqual([
+      [call.callId, "Spoken before compaction. Final detail.", { listenAfterPlayback: true }],
+    ]);
   });
 });
 

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -1014,6 +1014,11 @@ export class VoiceCallWebhookServer {
         from: call.from,
         transcript: call.transcript,
         userMessage,
+        onEarlyText: async (text) => {
+          console.log(`[voice-call] Early AI response: "${text}"`);
+          const result = await this.manager.speak(callId, text, { listenAfterPlayback: true });
+          return result.success;
+        },
       });
 
       if (result.error) {
@@ -1021,7 +1026,7 @@ export class VoiceCallWebhookServer {
         return;
       }
 
-      if (result.text) {
+      if (result.text && !result.deliveredEarly) {
         console.log(`[voice-call] AI response: "${result.text}"`);
         await this.manager.speak(callId, result.text, { listenAfterPlayback: true });
       }

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -1016,8 +1016,8 @@ export class VoiceCallWebhookServer {
         userMessage,
         onEarlyText: async (text) => {
           console.log(`[voice-call] Early AI response: "${text}"`);
-          const result = await this.manager.speak(callId, text, { listenAfterPlayback: true });
-          return result.success;
+          const speakResult = await this.manager.speak(callId, text, { listenAfterPlayback: true });
+          return speakResult.success;
         },
       });
 

--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -25,6 +25,7 @@ export function createBaseToolHandlerState() {
     pendingToolTrustedLocalMedia: false,
     deterministicApprovalPromptPending: false,
     toolExecutionSinceLastBlockReply: false,
+    assistantMessageIndex: 0,
     messagingToolSentTexts: [] as string[],
     messagingToolSentTextsNormalized: [] as string[],
     messagingToolSentMediaUrls: [] as string[],

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5032,12 +5032,21 @@ export async function runEmbeddedAttempt(
         const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000;
 
         try {
-          // Flush buffered block replies before waiting for compaction so the
-          // user receives the assistant response immediately.  Without this,
-          // coalesced/buffered blocks stay in the pipeline until compaction
-          // finishes — which can take minutes on large contexts (#35074).
+          // Flush or discard buffered block replies before waiting for
+          // compaction. Side-effecting consumers may deliver only a completed
+          // assistant attempt; retries must not leak rejected output.
           if (onBlockReplyFlush) {
-            await onBlockReplyFlush();
+            const currentAssistant = findCurrentAttemptAssistantMessage({
+              messagesSnapshot: snapshot,
+              prePromptMessageCount,
+            });
+            const attemptAccepted =
+              !promptError &&
+              !aborted &&
+              !timedOut &&
+              !yieldAborted &&
+              currentAssistant?.stopReason === "stop";
+            await onBlockReplyFlush({ reason: "pre_compaction", attemptAccepted });
           }
 
           // Skip compaction wait when yield aborted the run — the signal is

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -3,6 +3,7 @@
  */
 import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 import type {
+  BlockReplyContext,
   PartialReplyPayload,
   SourceReplyDeliveryMode,
 } from "../../../auto-reply/get-reply-options.types.js";
@@ -35,6 +36,7 @@ import type { AgentMessage } from "../../runtime/index.js";
 import type { SilentReplyPromptMode } from "../../system-prompt.types.js";
 import type { PromptMode } from "../../system-prompt.types.js";
 import type { EmbeddedAgentExecutionPhase } from "../execution-phase.js";
+import type { BlockReplyFlushContext } from "../types.js";
 import type { AuthProfileFailurePolicy } from "./auth-profile-failure-policy.types.js";
 export type { ClientToolDefinition } from "../../command/shared-types.js";
 
@@ -233,8 +235,8 @@ export type RunEmbeddedAgentParams = {
   shouldEmitToolOutput?: () => boolean;
   onPartialReply?: (payload: PartialReplyPayload) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
-  onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
-  onBlockReplyFlush?: () => void | Promise<void>;
+  onBlockReply?: (payload: BlockReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
+  onBlockReplyFlush?: (context: BlockReplyFlushContext) => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: ReasoningStreamPayload) => void | Promise<void>;

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -17,6 +17,17 @@ import type { FallbackAttempt } from "../model-fallback.types.js";
 import type { AgentRunTimeoutPhase } from "../run-timeout-attribution.js";
 import type { ContextUsage } from "../usage.js";
 
+export type BlockReplyFlushContext =
+  | {
+      /** Boundary that requested the flush. */
+      reason: "tool_start" | "message_end" | "terminal";
+    }
+  | {
+      /** Pre-compaction delivery is safe only for a completed assistant attempt. */
+      reason: "pre_compaction";
+      attemptAccepted: boolean;
+    };
+
 export type EmbeddedAgentMeta = {
   sessionId: string;
   sessionFile?: string;

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -20,7 +20,12 @@ import type { ContextUsage } from "../usage.js";
 export type BlockReplyFlushContext =
   | {
       /** Boundary that requested the flush. */
-      reason: "tool_start" | "message_end" | "terminal";
+      reason: "message_end" | "terminal";
+    }
+  | {
+      /** Tool boundary separating pre-tool narration from the eventual answer. */
+      reason: "tool_start";
+      assistantMessageIndex: number;
     }
   | {
       /** Pre-compaction delivery is safe only for a completed assistant attempt. */

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -218,6 +218,7 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     await subscription.waitForPendingEvents();
     expect(onBlockReply).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Fallback answer." }),
+      { assistantMessageIndex: 1 },
     );
     expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(true);
   });
@@ -253,6 +254,7 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     await vi.waitFor(() => expect(onBlockReply).toHaveBeenCalledTimes(1));
     expect(onBlockReply).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Accepted answer." }),
+      { assistantMessageIndex: 1 },
     );
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -255,7 +255,7 @@ export function handleAgentEnd(
     const postMediaFlushResult = ctx.flushBlockReplyBuffer();
     if (isPromiseLike<void>(postMediaFlushResult)) {
       return postMediaFlushResult.then(() => {
-        const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
+        const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.({ reason: "terminal" });
         if (isPromiseLike<void>(onBlockReplyFlushResult)) {
           return onBlockReplyFlushResult;
         }
@@ -263,7 +263,7 @@ export function handleAgentEnd(
       });
     }
 
-    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
+    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.({ reason: "terminal" });
     if (isPromiseLike<void>(onBlockReplyFlushResult)) {
       return onBlockReplyFlushResult;
     }

--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -1293,6 +1293,34 @@ describe("handleMessageEnd", () => {
     expect(emitBlockReply).not.toHaveBeenCalled();
   });
 
+  it("tags message-end safety replies with the current assistant message", () => {
+    const emitBlockReply = vi.fn();
+    const ctx = createMessageEndContext({
+      onBlockReply: vi.fn(),
+      emitBlockReply,
+      consumeReplyDirectives: vi.fn((text: string) => (text ? { text } : null)),
+      state: {
+        assistantMessageIndex: 7,
+        blockReplyBreak: "text_end",
+        lastBlockReplyText: null,
+      },
+    });
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer" }],
+        usage: { input: 10, output: 5, total: 15 },
+      },
+    } as never);
+
+    expect(emitBlockReply).toHaveBeenCalledWith(
+      { text: "Final answer" },
+      { assistantMessageIndex: 7 },
+    );
+  });
+
   it("does not duplicate block reply for text_end channels even when stripping differs", () => {
     const onBlockReply = vi.fn();
     const emitBlockReply = vi.fn();

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -1230,14 +1230,17 @@ export function handleMessageEnd(
     if (
       hasAssistantVisibleReply({ text: cleanedTextLocal, mediaUrls: mediaUrlsLocal, audioAsVoice })
     ) {
-      ctx.emitBlockReply({
-        text: cleanedTextLocal,
-        mediaUrls: mediaUrlsLocal?.length ? mediaUrlsLocal : undefined,
-        audioAsVoice,
-        replyToId,
-        replyToTag,
-        replyToCurrent,
-      });
+      ctx.emitBlockReply(
+        {
+          text: cleanedTextLocal,
+          mediaUrls: mediaUrlsLocal?.length ? mediaUrlsLocal : undefined,
+          audioAsVoice,
+          replyToId,
+          replyToTag,
+          replyToCurrent,
+        },
+        { assistantMessageIndex: ctx.state.assistantMessageIndex },
+      );
     }
   };
 
@@ -1352,7 +1355,9 @@ export function handleMessageEnd(
     if (isPromiseLike<void>(flushBlockReplyBufferResult)) {
       return flushBlockReplyBufferResult
         .then(() => {
-          const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
+          const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.({
+            reason: "message_end",
+          });
           if (isPromiseLike<void>(onBlockReplyFlushResult)) {
             return onBlockReplyFlushResult;
           }
@@ -1362,7 +1367,7 @@ export function handleMessageEnd(
           finalizeMessageEnd();
         });
     }
-    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush();
+    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush({ reason: "message_end" });
     if (isPromiseLike<void>(onBlockReplyFlushResult)) {
       return onBlockReplyFlushResult.finally(() => {
         finalizeMessageEnd();

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -33,7 +33,9 @@ type PayloadToolMetas = Parameters<typeof buildEmbeddedRunPayloads>[0]["toolMeta
 function createTestContext(): {
   ctx: ToolHandlerContext;
   warn: ReturnType<typeof vi.fn>;
-  onBlockReplyFlush: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  onBlockReplyFlush: ReturnType<
+    typeof vi.fn<NonNullable<ToolHandlerContext["params"]["onBlockReplyFlush"]>>
+  >;
   onAgentEvent: ReturnType<typeof vi.fn>;
   onExecutionPhase: ReturnType<typeof vi.fn>;
   trace: ReturnType<typeof vi.fn>;
@@ -41,7 +43,7 @@ function createTestContext(): {
 } {
   // Shared tool-handler fixture exposes the callbacks and state maps mutated by
   // start/update/end handlers without booting a full subscription.
-  const onBlockReplyFlush = vi.fn<() => Promise<void>>();
+  const onBlockReplyFlush = vi.fn<NonNullable<ToolHandlerContext["params"]["onBlockReplyFlush"]>>();
   const onAgentEvent = vi.fn();
   const onExecutionPhase = vi.fn();
   const warn = vi.fn();
@@ -92,6 +94,7 @@ function createTestContext(): {
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,
       toolExecutionSinceLastBlockReply: false,
+      assistantMessageIndex: 0,
     },
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,
@@ -254,6 +257,10 @@ describe("handleToolExecutionStart read path checks", () => {
     await handleToolExecutionStart(ctx, evt);
 
     expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(onBlockReplyFlush).toHaveBeenCalledWith({
+      reason: "tool_start",
+      assistantMessageIndex: 0,
+    });
     expect(onExecutionPhase).toHaveBeenCalledWith({
       phase: "tool_execution_started",
       tool: "read",

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -816,7 +816,10 @@ export function handleToolExecutionStart(
   },
 ): void | Promise<void> {
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
-    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.({ reason: "tool_start" });
+    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.({
+      reason: "tool_start",
+      assistantMessageIndex: ctx.state.assistantMessageIndex,
+    });
     if (isPromiseLike<void>(onBlockReplyFlushResult)) {
       return onBlockReplyFlushResult.then(() => {
         continueToolExecutionStart();

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -816,7 +816,7 @@ export function handleToolExecutionStart(
   },
 ): void | Promise<void> {
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
-    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.();
+    const onBlockReplyFlushResult = ctx.params.onBlockReplyFlush?.({ reason: "tool_start" });
     if (isPromiseLike<void>(onBlockReplyFlushResult)) {
       return onBlockReplyFlushResult.then(() => {
         continueToolExecutionStart();

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -329,6 +329,7 @@ type ToolHandlerState = Pick<
   | "successfulCronAdds"
   | "deterministicApprovalPromptSent"
   | "toolExecutionSinceLastBlockReply"
+  | "assistantMessageIndex"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -257,7 +257,10 @@ export type EmbeddedAgentSubscribeContext = {
     data: AssistantStreamData,
     options?: { emitPartialReply?: boolean },
   ) => void;
-  emitBlockReply: (payload: BlockReplyPayload) => void;
+  emitBlockReply: (
+    payload: BlockReplyPayload,
+    options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
+  ) => void;
   flushDeferredAssistantEvents: () => void;
   flushDeferredBlockReplies: () => void;
   clearDeferredAssistantEvents: () => void;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -328,7 +328,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         options?.assistantMessageIndex ??
         getReplyPayloadMetadata(taggedPayload)?.assistantMessageIndex;
       const context = assistantMessageIndex === undefined ? undefined : { assistantMessageIndex };
-      const maybeTask = params.onBlockReply(taggedPayload, context);
+      const maybeTask = context
+        ? params.onBlockReply(taggedPayload, context)
+        : params.onBlockReply(taggedPayload);
       if (!isPromiseLike<void>(maybeTask)) {
         return true;
       }

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -8,7 +8,7 @@ import {
   createInlineCodeState,
 } from "../../packages/markdown-core/src/code-spans.js";
 import type { FenceScanState } from "../../packages/markdown-core/src/fences.js";
-import { setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
+import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
@@ -324,7 +324,11 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
               assistantMessageIndex: options.assistantMessageIndex,
             })
           : payload;
-      const maybeTask = params.onBlockReply(taggedPayload);
+      const assistantMessageIndex =
+        options?.assistantMessageIndex ??
+        getReplyPayloadMetadata(taggedPayload)?.assistantMessageIndex;
+      const context = assistantMessageIndex === undefined ? undefined : { assistantMessageIndex };
+      const maybeTask = params.onBlockReply(taggedPayload, context);
       if (!isPromiseLike<void>(maybeTask)) {
         return true;
       }

--- a/src/agents/embedded-agent-subscribe.types.ts
+++ b/src/agents/embedded-agent-subscribe.types.ts
@@ -2,6 +2,7 @@
  * Public parameter types for subscribing to embedded-agent sessions.
  */
 import type {
+  BlockReplyContext,
   PartialReplyPayload,
   SourceReplyDeliveryMode,
 } from "../auto-reply/get-reply-options.types.js";
@@ -12,6 +13,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { BlockReplyPayload } from "./embedded-agent-payloads.js";
 import type { EmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
+import type { BlockReplyFlushContext } from "./embedded-agent-runner/types.js";
 import type {
   BlockReplyChunking,
   ToolProgressDetailMode,
@@ -59,9 +61,9 @@ export type SubscribeEmbeddedAgentSessionParams = {
   streamReasoningInNonStreamModes?: boolean;
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;
-  onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
-  /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
-  onBlockReplyFlush?: () => void | Promise<void>;
+  onBlockReply?: (payload: BlockReplyPayload, context?: BlockReplyContext) => void | Promise<void>;
+  /** Flush pending block replies and identify the boundary that requested it. */
+  onBlockReplyFlush?: (context: BlockReplyFlushContext) => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onPartialReply?: (payload: PartialReplyPayload) => void | Promise<void>;


### PR DESCRIPTION
## What Problem This Solves

Voice-call callers hear silence until post-turn compaction completes because `generateVoiceResponse()` waits for the full `runEmbeddedAgent()` promise before extracting text and calling `manager.speak()`. This PR uses the existing `blockReplyBreak`/`onBlockReply` contract to deliver spoken text to TTS as soon as the first block reply arrives.

Additionally fixes an async fallback race: `onEarlyText` was fire-and-forget — the `.then()` that sets `earlyTextSpoken = true` runs in a microtask that may not be settled when `generateVoiceResponse` reads the flag after `runEmbeddedAgent` resolves. If the TTS I/O (real network call) takes longer than the agent run, `earlyTextSpoken` stays `false` and the webhook fires a duplicate fallback `speak()`.

Fixes #79521

## Why This Change Was Made

- **`response-generator.ts`**: Adds `onEarlyText?: (text: string) => Promise<boolean>` to `VoiceResponseParams`. In the `onBlockReply` handler, extracts spoken text from the first block reply, fires `onEarlyText` immediately, and **stores the returned promise**. Before returning from `generateVoiceResponse`, **awaits the pending promise** so the fallback-speak decision always sees the settled TTS outcome. The callback must return `true` for confirmed TTS delivery; `earlyTextSpoken` is gated on this return value so a failed early speak does not suppress the final fallback.
- **`webhook.ts`**: Passes `onEarlyText` that calls `this.manager.speak(callId, text)` and returns `speakResult.success`. Falls back to the post-run speak only when `earlyTextSpoken` is false (no block reply arrived, early delivery failed, or early delivery threw).
- **`response-generator.test.ts`**: 19 tests. Covers: `onEarlyText` fires before a deferred `runEmbeddedAgent` settles; TTS resolve-after-run race (`await pendingEarlyText`); fallback when no block reply arrives; fallback when `onEarlyText` returns `false`; fallback when `onEarlyText` throws.

## User Impact

Voice-call users hear TTS speech as soon as the agent produces its first block reply, instead of waiting for the full post-turn compaction cycle. Failed early delivery safely falls back to the existing post-run speak path. The duplicate-speak race (successful early TTS followed by a fallback speak of the same text) is eliminated.

## Evidence

- `pnpm test extensions/voice-call/src/response-generator.test.ts` — 19/19 passed
- `oxlint --quiet` on changed files — clean
- `oxfmt --check` on changed files — clean

Behavior addressed: Early TTS delivery via `onBlockReply` callback with confirmed-delivery gate for fallback safety, and `await pendingEarlyText` to close the async race window between TTS resolution and the fallback-speak decision.

Real environment tested: Linux (Node 24), branch `fix/issue-79521-voice-call-block-reply`, commit `8bae4072`

Exact steps or command run after this patch:

```bash
pnpm test extensions/voice-call/src/response-generator.test.ts --run
node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.json --quiet extensions/voice-call/src/response-generator.ts extensions/voice-call/src/response-generator.test.ts
node_modules/.bin/oxfmt --check extensions/voice-call/src/response-generator.ts extensions/voice-call/src/response-generator.test.ts
```

Evidence after fix:

```console
$ pnpm test extensions/voice-call/src/response-generator.test.ts --run

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Duration  10.46s

$ oxlint — no errors in changed files
$ oxfmt — all matched files use the correct format
```

Observed result after fix: `onEarlyText` fires from within `onBlockReply` before `runEmbeddedAgent` resolves. The returned promise is stored in `pendingEarlyText` and awaited before `generateVoiceResponse` returns. When TTS resolves after the agent run (the real-world race), `earlyTextSpoken` correctly reflects `true` and the webhook fallback speak is suppressed. When `onEarlyText` returns `false` or throws, `earlyTextSpoken` stays `undefined` and the final post-run fallback speak still fires. When no block reply arrives, the existing fallback to `result.payloads` works as before.

Review feedback addressed:
- ClawSweeper P1 finding — `earlyTextSpoken` is gated on confirmed `onEarlyText` delivery success rather than callback invocation, preserving the fallback speak path when early playback fails.
- ClawSweeper P2 finding (this revision) — `pendingEarlyText` is awaited before the fallback-speak decision, closing the async race where successful TTS could be followed by a duplicate fallback speak.

What was not tested: No live Twilio/VoIP roundtrip was performed. The `onEarlyText`→`manager.speak()` path is unit-tested at the `response-generator` level but not through a real WebSocket/STT/TTS pipeline.
