### PR TITLE
fix: recover Telegram channel after stop timeout in health monitor

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -456,6 +456,34 @@ describe("channel-health-monitor", () => {
     monitor.stop();
   });
 
+  it("continues pending recovery on the next check without waiting for cooldown", async () => {
+    const account: Partial<ChannelAccountSnapshot> = disconnectedAccount(Date.now() - 300_000);
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: account,
+        },
+      },
+      {
+        startChannel: vi.fn(async () => {
+          account.running = false;
+          account.connected = false;
+          account.restartPending = true;
+          account.reconnectAttempts = 0;
+        }),
+      },
+    );
+    const monitor = await startAndRunCheck(manager);
+    expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+    await advanceHealthCheck();
+
+    expect(manager.stopChannel).toHaveBeenCalledTimes(1);
+    expect(manager.startChannel).toHaveBeenCalledTimes(2);
+    monitor.stop();
+  });
+
   it("caps at 3 health-monitor restarts per channel per hour", async () => {
     const manager = createSnapshotManager({
       discord: {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -145,12 +145,20 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             restartsThisHour: [],
           };
 
-          if (now - record.lastRestartAt <= cooldownMs) {
+          const continuingPendingRestart =
+            status.running !== true &&
+            status.restartPending === true &&
+            (status.reconnectAttempts ?? 0) === 0;
+
+          // A timed-out recovery stop uses the first start request to mark
+          // restartPending; the next monitor pass must finish that same recovery
+          // instead of waiting behind this monitor's fresh-restart cooldown.
+          if (!continuingPendingRestart && now - record.lastRestartAt <= cooldownMs) {
             continue;
           }
 
           pruneOldRestarts(record, now);
-          if (record.restartsThisHour.length >= maxRestartsPerHour) {
+          if (!continuingPendingRestart && record.restartsThisHour.length >= maxRestartsPerHour) {
             log.warn?.(
               `[${channelId}:${accountId}] health-monitor: hit ${maxRestartsPerHour} restarts/hour limit, skipping`,
             );
@@ -161,9 +169,11 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
           log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
 
-          record.lastRestartAt = now;
-          record.restartsThisHour.push({ at: now });
-          restartRecords.set(key, record);
+          if (!continuingPendingRestart) {
+            record.lastRestartAt = now;
+            record.restartsThisHour.push({ at: now });
+            restartRecords.set(key, record);
+          }
 
           try {
             if (status.running) {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -546,6 +546,47 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toBeNull();
   });
 
+  it("keeps the second recovery task running when the stale task rejects", async () => {
+    const releaseFirstTask = createDeferred();
+    let startCount = 0;
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      startCount += 1;
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      if (startCount === 1) {
+        await releaseFirstTask.promise;
+        throw new Error("late stale worker exit");
+      }
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+
+    releaseFirstTask.resolve();
+    await flushMicrotasks();
+
+    const account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account?.running).toBe(true);
+    expect(account?.restartPending).toBe(false);
+    expect(account?.lastError).toBeNull();
+    expect(hoisted.sleepWithAbort).not.toHaveBeenCalled();
+  });
+
   it("restarts immediately when recovery stop timeout settles with an error", async () => {
     const rejectFirstTask = createDeferred();
     let startCount = 0;

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -511,6 +511,41 @@ describe("server-channels auto restart", () => {
     expect(account?.lastError).toContain("channel stop timed out");
   });
 
+  it("resumes startup on the second recovery pass while the stale task is still pending", async () => {
+    const startAccount = vi.fn(async ({ abortSignal }: { abortSignal: AbortSignal }) => {
+      abortSignal.addEventListener("abort", () => {}, { once: true });
+      await new Promise<void>(() => {});
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const recoveryStopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID, {
+      manual: false,
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await recoveryStopTask;
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    let account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(1);
+    expect(account?.running).toBe(false);
+    expect(account?.restartPending).toBe(true);
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    account = manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account?.running).toBe(true);
+    expect(account?.restartPending).toBe(false);
+    expect(account?.reconnectAttempts).toBe(0);
+    expect(account?.lastError).toBeNull();
+  });
+
   it("restarts immediately when recovery stop timeout settles with an error", async () => {
     const rejectFirstTask = createDeferred();
     let startCount = 0;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -449,6 +449,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       tasks: accountIds.map((id) => async () => {
         const rKey = restartKey(channelId, id);
         if (store.tasks.has(id)) {
+          let clearedTimedOutRecoveryTask = false;
           if (recoveryStopTimedOut.has(rKey)) {
             if (!preserveManualStop) {
               manuallyStopped.delete(rKey);
@@ -465,6 +466,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               restartAttempts.delete(rKey);
               store.aborts.delete(id);
               store.tasks.delete(id);
+              clearedTimedOutRecoveryTask = true;
               setRuntime(channelId, id, {
                 accountId: id,
                 restartPending: false,
@@ -476,7 +478,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               return;
             }
           }
-          return;
+          if (!clearedTimedOutRecoveryTask) {
+            return;
+          }
         }
         const existingStart = store.starting.get(id);
         if (existingStart) {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -456,8 +456,25 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             if (manuallyStopped.has(rKey)) {
               return;
             }
-            recoveryStartRequested.add(rKey);
-            setRuntime(channelId, id, { accountId: id, restartPending: true });
+            // When a previous stop timed out and the health monitor is
+            // requesting recovery again, clean up the stuck task so the
+            // channel can actually restart instead of staying in limbo.
+            if (recoveryStartRequested.has(rKey)) {
+              recoveryStopTimedOut.delete(rKey);
+              recoveryStartRequested.delete(rKey);
+              restartAttempts.delete(rKey);
+              store.aborts.delete(id);
+              store.tasks.delete(id);
+              setRuntime(channelId, id, {
+                accountId: id,
+                restartPending: false,
+                reconnectAttempts: 0,
+              });
+            } else {
+              recoveryStartRequested.add(rKey);
+              setRuntime(channelId, id, { accountId: id, restartPending: true });
+              return;
+            }
           }
           return;
         }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -570,6 +570,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             return;
           }
 
+          let trackedPromise: Promise<unknown>;
+          const isCurrentTask = () => store.tasks.get(id) === trackedPromise;
           scopedChannelRuntime = await measureStartup(`channels.${channelId}.runtime`, async () =>
             createTaskScopedChannelRuntime({
               channelRuntime: await getChannelRuntime(),
@@ -628,7 +630,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   abortSignal: abort.signal,
                   log,
                   getStatus: () => getRuntime(channelId, id),
-                  setStatus: (next) => setRuntimeFromTaskStatus(channelId, id, next, abort.signal),
+                  setStatus: (next) =>
+                    isCurrentTask()
+                      ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
+                      : getRuntime(channelId, id),
                   ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
                 });
               const routeRegistry = getPluginHttpRouteRegistry?.();
@@ -641,9 +646,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             }
             await startAccountTask;
           });
-          const trackedPromise = task
+          // Recovery can replace a timed-out task before the old promise settles.
+          // Only the task that still owns the store slot may write lifecycle state.
+          trackedPromise = task
             .then(() => {
-              if (abort.signal.aborted || manuallyStopped.has(rKey)) {
+              if (abort.signal.aborted || manuallyStopped.has(rKey) || !isCurrentTask()) {
                 return;
               }
               const message = "channel exited without an error";
@@ -651,17 +658,26 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               log.error?.(`[${id}] ${message}`);
             })
             .catch((err: unknown) => {
+              if (!isCurrentTask()) {
+                return;
+              }
               const message = formatErrorMessage(err);
               setRuntime(channelId, id, { accountId: id, lastError: message });
               log.error?.(`[${id}] channel exited: ${message}`);
             })
             .then(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
+              if (!isCurrentTask()) {
+                return;
+              }
               setStoppedRuntime(channelId, id, {
                 lastStopAt: Date.now(),
               });
             })
             .then(async () => {
+              if (!isCurrentTask()) {
+                return;
+              }
               if (manuallyStopped.has(rKey)) {
                 recoveryStopTimedOut.delete(rKey);
                 recoveryStartRequested.delete(rKey);

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -570,8 +570,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             return;
           }
 
-          let trackedPromise: Promise<unknown>;
-          const isCurrentTask = () => store.tasks.get(id) === trackedPromise;
           scopedChannelRuntime = await measureStartup(`channels.${channelId}.runtime`, async () =>
             createTaskScopedChannelRuntime({
               channelRuntime: await getChannelRuntime(),
@@ -648,7 +646,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           });
           // Recovery can replace a timed-out task before the old promise settles.
           // Only the task that still owns the store slot may write lifecycle state.
-          trackedPromise = task
+          const trackedPromise = task
             .then(() => {
               if (abort.signal.aborted || manuallyStopped.has(rKey) || !isCurrentTask()) {
                 return;
@@ -768,6 +766,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 store.aborts.delete(id);
               }
             });
+          function isCurrentTask() {
+            return store.tasks.get(id) === trackedPromise;
+          }
           handedOffTask = true;
           store.tasks.set(id, trackedPromise);
         } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #94008 — When a Telegram channel stop times out during an API outage, the health monitor could never recover the channel because it set `restartPending` but never actually cleaned up the stuck task state. This left the channel in `stopped` state permanently until a manual gateway restart.

## Root Cause

In `startChannelInternal`, when `recoveryStopTimedOut` was set and `store.tasks.has(id)` was true, the code added `recoveryStartRequested` and set `restartPending: true` then returned immediately without starting the channel. The start was supposed to happen when the stuck stop eventually completed but if the stop never completed (channel torn down), the callback was never triggered and the channel stayed dead.

## Fix

When the health monitor retries recovery (i.e. `recoveryStartRequested` is already set), clean up the stuck task state and allow the channel to start normally instead of deferring indefinitely.

## Testing

- `src/gateway/channel-health-monitor.test.ts` — 136 tests passed
- Lint: clean (oxlint)

## Real behavior proof

**Behavior or issue addressed**: After Telegram API outage, health monitor permanently fails to restart channel stuck in stopped state.

**Real environment tested**: Windows 10 LTSC 2019, Node.js v24.14.0, OpenClaw worktree on main with fix applied.

**Exact steps or command run after this patch**:
```bash
npx oxlint --config .oxlintrc.json src/gateway/server-channels.ts
node scripts/run-vitest.mjs src/gateway/channel-health-monitor.test.ts
```

**Evidence after fix**:
```
Lint: no issues found
channel-health-monitor.test.ts: 136 tests passed (4 test files)
```

**Observed result after fix**: When health monitor retries recovery after a stuck stop, the stale task state is cleaned up allowing a fresh start.

**What was not tested**: Live Telegram API outage scenario (no Telegram bot available).
