### PR TITLE
fix(feishu): paginate drive file list and info actions

### DIFF
--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -1,5 +1,8 @@
 // Feishu helper module supports drive schema behavior.
+import { optionalPositiveIntegerSchema } from "openclaw/plugin-sdk/channel-actions";
 import { Type, type Static } from "typebox";
+
+const DRIVE_PAGE_SIZE_MAX = 50;
 
 const FileType = Type.Union([
   Type.Literal("doc"),
@@ -26,6 +29,11 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    page_size: optionalPositiveIntegerSchema({
+      maximum: DRIVE_PAGE_SIZE_MAX,
+      description: "Page size (1-50, default 50)",
+    }),
+    page_token: Type.Optional(Type.String({ description: "Pagination token for next page" })),
   }),
   Type.Object({
     action: Type.Literal("info"),

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -109,6 +109,18 @@ function expectRequestCall(
 
 describe("registerFeishuDriveTools", () => {
   const requestMock = vi.fn();
+  const driveFileListMock = vi.fn();
+
+  function createMockClient() {
+    return {
+      request: requestMock,
+      drive: {
+        file: {
+          list: driveFileListMock,
+        },
+      },
+    };
+  }
 
   beforeAll(async () => {
     ({ registerFeishuDriveTools } = await import("./drive.js"));
@@ -136,9 +148,7 @@ describe("registerFeishuDriveTools", () => {
       bitable: false,
       base: false,
     });
-    createFeishuToolClientMock.mockReturnValue({
-      request: requestMock,
-    });
+    createFeishuToolClientMock.mockReturnValue(createMockClient());
     cleanupAmbientCommentTypingReactionMock.mockResolvedValue(false);
   });
 
@@ -1236,5 +1246,248 @@ describe("registerFeishuDriveTools", () => {
     expect((result.details as { error?: string }).error).toBe(
       "block_id is only supported for docx comments",
     );
+  });
+
+  it("list action returns files with pagination fields", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret",
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    driveFileListMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        files: [
+          { token: "f1", name: "file1", type: "file", url: "u1", created_time: "t1", modified_time: "t2", owner_id: "o1" },
+        ],
+        has_more: true,
+        next_page_token: "page2token",
+      },
+    });
+
+    const result = await tool.execute("call-list", {
+      action: "list",
+      folder_token: "folder_abc",
+    });
+    expect(driveFileListMock).toHaveBeenCalledTimes(1);
+    expect(driveFileListMock.mock.calls[0][0]).toEqual({
+      params: { folder_token: "folder_abc" },
+    });
+    const details = result.details as {
+      files?: Array<{ token?: string }>;
+      has_more?: boolean;
+      next_page_token?: string;
+    };
+    expect(details.files).toHaveLength(1);
+    expect(details.files?.[0]?.token).toBe("f1");
+    expect(details.has_more).toBe(true);
+    expect(details.next_page_token).toBe("page2token");
+  });
+
+  it("list action passes page_size and page_token to API", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret",
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    driveFileListMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        files: [
+          { token: "f2", name: "file2", type: "file", url: "u2", created_time: "t3", modified_time: "t4", owner_id: "o2" },
+        ],
+        has_more: false,
+        next_page_token: undefined,
+      },
+    });
+
+    const result = await tool.execute("call-list-page", {
+      action: "list",
+      folder_token: "folder_abc",
+      page_size: 20,
+      page_token: "page2token",
+    });
+    expect(driveFileListMock).toHaveBeenCalledTimes(1);
+    expect(driveFileListMock.mock.calls[0][0]).toEqual({
+      params: { folder_token: "folder_abc", page_size: "20", page_token: "page2token" },
+    });
+    const details = result.details as { files?: Array<{ token?: string }>; has_more?: boolean };
+    expect(details.files).toHaveLength(1);
+    expect(details.has_more).toBe(false);
+  });
+
+  it("info action follows has_more pagination to find file on page 2", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret",
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    driveFileListMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          files: [
+            { token: "f1", name: "file1", type: "file", url: "u1", created_time: "t1", modified_time: "t2", owner_id: "o1" },
+          ],
+          has_more: true,
+          next_page_token: "page2token",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          files: [
+            { token: "target_file", name: "target", type: "docx", url: "u3", created_time: "t5", modified_time: "t6", owner_id: "o3" },
+          ],
+          has_more: false,
+          next_page_token: undefined,
+        },
+      });
+
+    const result = await tool.execute("call-info-paginated", {
+      action: "info",
+      file_token: "target_file",
+      type: "docx",
+    });
+    expect(driveFileListMock).toHaveBeenCalledTimes(2);
+    expect(driveFileListMock.mock.calls[0][0]).toEqual({ params: {} });
+    expect(driveFileListMock.mock.calls[1][0]).toEqual({ params: { page_token: "page2token" } });
+    const details = result.details as {
+      token?: string;
+      name?: string;
+      type?: string;
+    };
+    expect(details.token).toBe("target_file");
+    expect(details.name).toBe("target");
+  });
+
+  it("info action throws File not found when file is absent across all pages", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret",
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    driveFileListMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        files: [
+          { token: "f1", name: "file1", type: "file", url: "u1", created_time: "t1", modified_time: "t2", owner_id: "o1" },
+        ],
+        has_more: false,
+        next_page_token: undefined,
+      },
+    });
+
+    const result = await tool.execute("call-info-missing", {
+      action: "info",
+      file_token: "nonexistent",
+      type: "file",
+    });
+    expect(driveFileListMock).toHaveBeenCalledTimes(1);
+    expect((result.details as { error?: string }).error).toBe("File not found: nonexistent");
+  });
+
+  it("info action finds file on first page without pagination", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret",
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    driveFileListMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        files: [
+          { token: "f1", name: "file1", type: "file", url: "u1", created_time: "t1", modified_time: "t2", owner_id: "o1" },
+          { token: "target_file", name: "target", type: "docx", url: "u3", created_time: "t5", modified_time: "t6", owner_id: "o3" },
+        ],
+        has_more: false,
+        next_page_token: undefined,
+      },
+    });
+
+    const result = await tool.execute("call-info-first-page", {
+      action: "info",
+      file_token: "target_file",
+      type: "docx",
+    });
+    expect(driveFileListMock).toHaveBeenCalledTimes(1);
+    const details = result.details as { token?: string; name?: string };
+    expect(details.token).toBe("target_file");
+    expect(details.name).toBe("target");
   });
 });

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -328,11 +328,25 @@ async function getRootFolderToken(client: Lark.Client): Promise<string> {
   return token;
 }
 
-async function listFolder(client: Lark.Client, folderToken?: string) {
-  // Filter out invalid folder_token values (empty, "0", etc.)
+async function listFolder(
+  client: Lark.Client,
+  folderToken?: string,
+  pageSize?: number,
+  pageToken?: string,
+) {
   const validFolderToken = folderToken && folderToken !== "0" ? folderToken : undefined;
+  const params: Record<string, string | undefined> = {};
+  if (validFolderToken) {
+    params.folder_token = validFolderToken;
+  }
+  if (pageSize) {
+    params.page_size = String(Math.min(Math.max(Math.floor(pageSize), 1), 50));
+  }
+  if (pageToken) {
+    params.page_token = pageToken;
+  }
   const res = await client.drive.file.list({
-    params: validFolderToken ? { folder_token: validFolderToken } : {},
+    params,
   });
   if (res.code !== 0) {
     throw new Error(res.msg);
@@ -349,33 +363,44 @@ async function listFolder(client: Lark.Client, folderToken?: string) {
         modified_time: f.modified_time,
         owner_id: f.owner_id,
       })) ?? [],
+    has_more: res.data?.has_more ?? false,
     next_page_token: res.data?.next_page_token,
   };
 }
 
 async function getFileInfo(client: Lark.Client, fileToken: string, folderToken?: string) {
-  // Use list with folder_token to find file info
-  const res = await client.drive.file.list({
-    params: folderToken ? { folder_token: folderToken } : {},
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  let pageToken: string | undefined;
+  for (;;) {
+    const params: Record<string, string | undefined> = {};
+    if (folderToken) {
+      params.folder_token = folderToken;
+    }
+    if (pageToken) {
+      params.page_token = pageToken;
+    }
+    const res = await client.drive.file.list({ params });
+    if (res.code !== 0) {
+      throw new Error(res.msg);
+    }
 
-  const file = res.data?.files?.find((f) => f.token === fileToken);
-  if (!file) {
-    throw new Error(`File not found: ${fileToken}`);
-  }
+    const file = res.data?.files?.find((f) => f.token === fileToken);
+    if (file) {
+      return {
+        token: file.token,
+        name: file.name,
+        type: file.type,
+        url: file.url,
+        created_time: file.created_time,
+        modified_time: file.modified_time,
+        owner_id: file.owner_id,
+      };
+    }
 
-  return {
-    token: file.token,
-    name: file.name,
-    type: file.type,
-    url: file.url,
-    created_time: file.created_time,
-    modified_time: file.modified_time,
-    owner_id: file.owner_id,
-  };
+    if (!res.data?.has_more || !res.data?.next_page_token) {
+      throw new Error(`File not found: ${fileToken}`);
+    }
+    pageToken = res.data.next_page_token;
+  }
 }
 
 async function createFolder(client: Lark.Client, name: string, folderToken?: string) {
@@ -768,7 +793,9 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
             });
             switch (p.action) {
               case "list":
-                return jsonToolResult(await listFolder(client, p.folder_token));
+                return jsonToolResult(
+                  await listFolder(client, p.folder_token, p.page_size, p.page_token),
+                );
               case "info":
                 return jsonToolResult(await getFileInfo(client, p.file_token));
               case "create_folder":


### PR DESCRIPTION
## What changed

Feishu drive `list` and `info` actions now support pagination:

1. **`listFolder`** accepts `page_size` and `page_token` parameters, passes them to `client.drive.file.list`, and returns `has_more` alongside `next_page_token` so callers can page through the entire folder.
2. **`getFileInfo`** follows `has_more`/`next_page_token` pagination loops instead of searching only the first page and throwing `File not found` for files that live beyond page 1.
3. **`drive-schema.ts`** adds `page_size` and `page_token` to the `list` action schema (matching the wiki schema pattern), so the LLM can request subsequent pages.
4. **Tests** add 5 new regression tests covering: list with pagination fields, list with page_size/page_token passthrough, info follows pagination to page 2, info throws when absent across all pages, info finds file on first page without pagination.

## Why

Issue #93928 reports that `feishu_drive` `info` falsely returns `File not found` for files past the first API page, and `list` cannot retrieve any page after the first. Both surfaces ignore the `has_more`/`next_page_token` cursor the Lark API returns. This is the direct sibling of the wiki pagination fix (#37626), which paginated `wiki.spaceNode.list`/`wiki.space.list` but did not touch drive. The comment paths in the same plugin already paginate correctly (`list_comments`, `list_comment_replies` expose `page_size` + `page_token`).

## Real behavior proof

### Before fix
```
getFileInfo queried only page 1 (one list call) and threw "File not found: target";
list was never asked for page 2 despite has_more: true.
```

### After fix
```
Test Files  1 passed (1)
Tests       20 passed (20)

- getFileInfo drains has_more/next_page_token to page 2 (two list calls), finds and returns the file
- listFolder accepts and passes page_size/page_token, returns has_more
- Existing 15 drive.test.ts tests stay green; 5 new pagination tests added
```

**Evidence type**: Terminal output (vitest run)

**Setup**: OpenClaw checkout at commit 87bdaef0dba, Node.js v22.22.0, Linux x64

Fixes #93928