### PR TITLE
fix(feishu): paginate drive list/info to resolve files beyond first page

### DIFF
--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -26,11 +26,18 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    page_size: Type.Optional(
+      Type.Integer({ minimum: 1, maximum: 200, description: "Page size (default 50)" }),
+    ),
+    page_token: Type.Optional(Type.String({ description: "Page token for fetching next page" })),
   }),
   Type.Object({
     action: Type.Literal("info"),
     file_token: Type.String({ description: "File or folder token" }),
     type: FileType,
+    folder_token: Type.Optional(
+      Type.String({ description: "Parent folder token to narrow the search scope" }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("create_folder"),

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -1237,4 +1237,201 @@ describe("registerFeishuDriveTools", () => {
       "block_id is only supported for docx comments",
     );
   });
+
+  it("paginates list action returning requested page", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    // Mock the Lark SDK client with drive.file.list
+    const listMock = vi.fn();
+    createFeishuToolClientMock.mockReturnValue({
+      request: requestMock,
+      drive: {
+        file: {
+          list: listMock,
+        },
+      },
+    });
+
+    // Return a single page with has_more=true
+    listMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: true,
+        next_page_token: "page2",
+        files: [{ token: "f1", name: "file1.txt", type: "file", url: "https://example.com/f1" }],
+      },
+    });
+
+    const result = await tool.execute("call-list", {
+      action: "list",
+      folder_token: "folder_1",
+      page_token: "page2",
+    });
+
+    const details = result.details as {
+      files?: Array<{ token?: string; name?: string }>;
+      has_more?: boolean;
+      next_page_token?: string;
+    };
+    expect(details.files).toHaveLength(1);
+    expect(details.files?.[0]?.token).toBe("f1");
+    expect(details.has_more).toBe(true);
+    expect(details.next_page_token).toBe("page2");
+    // Verify page_token was passed to the SDK
+    expect(listMock).toHaveBeenCalledWith({
+      params: { folder_token: "folder_1", page_token: "page2" },
+    });
+  });
+
+  it("paginates getFileInfo through multiple pages to find file", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    // Mock the Lark SDK client with drive.file.list
+    const listMock = vi.fn();
+    createFeishuToolClientMock.mockReturnValue({
+      request: requestMock,
+      drive: {
+        file: {
+          list: listMock,
+        },
+      },
+    });
+
+    // Page 1: has_more=true, target file not on this page
+    listMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: true,
+        next_page_token: "page2",
+        files: [
+          { token: "other", name: "other.txt", type: "file", url: "https://example.com/other" },
+        ],
+      },
+    });
+    // Page 2: has_more=true, target still not here
+    listMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: true,
+        next_page_token: "page3",
+        files: [
+          {
+            token: "another",
+            name: "another.txt",
+            type: "file",
+            url: "https://example.com/another",
+          },
+        ],
+      },
+    });
+    // Page 3: target file found
+    listMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        files: [
+          { token: "target", name: "target.txt", type: "file", url: "https://example.com/target" },
+        ],
+      },
+    });
+
+    const result = await tool.execute("call-info", {
+      action: "info",
+      file_token: "target",
+      type: "file",
+    });
+
+    const details = result.details as { token?: string; name?: string };
+    expect(details.token).toBe("target");
+    expect(details.name).toBe("target.txt");
+    expect(listMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws File not found after exhausting all pages", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+
+    // Mock the Lark SDK client with drive.file.list
+    const listMock = vi.fn();
+    createFeishuToolClientMock.mockReturnValue({
+      request: requestMock,
+      drive: {
+        file: {
+          list: listMock,
+        },
+      },
+    });
+
+    // Single page, file not found
+    listMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        files: [
+          { token: "other", name: "other.txt", type: "file", url: "https://example.com/other" },
+        ],
+      },
+    });
+
+    const result = await tool.execute("call-info-missing", {
+      action: "info",
+      file_token: "missing",
+      type: "file",
+    });
+
+    expect((result.details as { error?: string }).error).toContain("File not found: missing");
+  });
 });

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -328,12 +328,25 @@ async function getRootFolderToken(client: Lark.Client): Promise<string> {
   return token;
 }
 
-async function listFolder(client: Lark.Client, folderToken?: string) {
+async function listFolder(
+  client: Lark.Client,
+  folderToken?: string,
+  pageSize?: number,
+  pageToken?: string,
+) {
   // Filter out invalid folder_token values (empty, "0", etc.)
   const validFolderToken = folderToken && folderToken !== "0" ? folderToken : undefined;
-  const res = await client.drive.file.list({
-    params: validFolderToken ? { folder_token: validFolderToken } : {},
-  });
+  const params: Record<string, string | number | undefined> = {};
+  if (validFolderToken) {
+    params.folder_token = validFolderToken;
+  }
+  if (pageSize) {
+    params.page_size = pageSize;
+  }
+  if (pageToken) {
+    params.page_token = pageToken;
+  }
+  const res = await client.drive.file.list({ params });
   if (res.code !== 0) {
     throw new Error(res.msg);
   }
@@ -349,33 +362,44 @@ async function listFolder(client: Lark.Client, folderToken?: string) {
         modified_time: f.modified_time,
         owner_id: f.owner_id,
       })) ?? [],
+    has_more: res.data?.has_more ?? false,
     next_page_token: res.data?.next_page_token,
   };
 }
 
 async function getFileInfo(client: Lark.Client, fileToken: string, folderToken?: string) {
-  // Use list with folder_token to find file info
-  const res = await client.drive.file.list({
-    params: folderToken ? { folder_token: folderToken } : {},
-  });
-  if (res.code !== 0) {
-    throw new Error(res.msg);
-  }
+  // Use list with folder_token to find file info, paginating through all pages
+  let pageToken: string | undefined;
+  do {
+    const params: Record<string, string | undefined> = {};
+    if (folderToken) {
+      params.folder_token = folderToken;
+    }
+    if (pageToken) {
+      params.page_token = pageToken;
+    }
+    const res = await client.drive.file.list({ params });
+    if (res.code !== 0) {
+      throw new Error(res.msg);
+    }
 
-  const file = res.data?.files?.find((f) => f.token === fileToken);
-  if (!file) {
-    throw new Error(`File not found: ${fileToken}`);
-  }
+    const file = res.data?.files?.find((f) => f.token === fileToken);
+    if (file) {
+      return {
+        token: file.token,
+        name: file.name,
+        type: file.type,
+        url: file.url,
+        created_time: file.created_time,
+        modified_time: file.modified_time,
+        owner_id: file.owner_id,
+      };
+    }
 
-  return {
-    token: file.token,
-    name: file.name,
-    type: file.type,
-    url: file.url,
-    created_time: file.created_time,
-    modified_time: file.modified_time,
-    owner_id: file.owner_id,
-  };
+    pageToken = res.data?.has_more ? res.data?.next_page_token : undefined;
+  } while (pageToken);
+
+  throw new Error(`File not found: ${fileToken}`);
 }
 
 async function createFolder(client: Lark.Client, name: string, folderToken?: string) {
@@ -768,9 +792,11 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
             });
             switch (p.action) {
               case "list":
-                return jsonToolResult(await listFolder(client, p.folder_token));
+                return jsonToolResult(
+                  await listFolder(client, p.folder_token, p.page_size, p.page_token),
+                );
               case "info":
-                return jsonToolResult(await getFileInfo(client, p.file_token));
+                return jsonToolResult(await getFileInfo(client, p.file_token, p.folder_token));
               case "create_folder":
                 return jsonToolResult(await createFolder(client, p.name, p.folder_token));
               case "move":


### PR DESCRIPTION
## Summary

- Problem: `feishu_drive` `action: info` returns `File not found` for files past page 1, and `action: list` cannot retrieve pages beyond the first — both ignore the `has_more` / `next_page_token` cursor the Lark API returns.
- Why now: Any user with a Feishu drive folder containing more files than one API page (default 50) cannot access files beyond page 1 via the agent. This is a silent data-access bug.
- What changed:
  - `listFolder()` now accepts `page_size` and `page_token` params and returns `has_more` in the response
  - `getFileInfo()` now paginates through all pages when searching for a file by token, instead of only checking the first page
  - `list` action schema now accepts `page_size` and `page_token` for cursor-based pagination
  - `info` action schema now accepts `folder_token` to narrow the search scope
- What did NOT change: Comment pagination (`list_comments`, `list_comment_replies`) was already correct and untouched. No new dependencies added.
- Outcome: Files past page 1 are now accessible. `info` finds files on any page. `list` can be called with `page_token` to fetch subsequent pages.
- Reviewer focus: `drive.ts` changes to `listFolder` and `getFileInfo` functions, and `drive-schema.ts` schema additions.

## Linked context

Closes #93928

Was this requested by a maintainer?
- No, but the issue has clear reproduction steps and root cause analysis.

## Root Cause

- Root cause: `getFileInfo()` did a single `drive.file.list` call and only searched the first page results. `listFolder()` did not pass `page_token` to the Lark SDK and the schema exposed no cursor field.
- Missing detection / guardrail: No pagination tests for `list` or `info` actions. The sibling `list_comments` and `list_comment_replies` paths already paginated correctly (see `drive.ts:486-487`, `519-520`), making this the lone un-paginated lister in the plugin.

## Real behavior proof

- Behavior or issue addressed: `feishu_drive` `info` must find a file that lives past the first `drive.file.list` page instead of falsely reporting `File not found`. `list` must support cursor-based pagination.
- Real environment tested: Node v22.14.0, branch `fix/93928-drive-pagination-v2`, real `registerFeishuDriveTools` runtime with Lark SDK `drive.file.list` mocked.
- Exact steps or command run after this patch:
  ```bash
  node scripts/run-vitest.mjs test/vitest/vitest.extension-feishu.config.ts -- extensions/feishu/src/drive.test.ts
  ```
- Evidence after fix:
  ```text
  node scripts/run-vitest.mjs output:
  ✓ extension-feishu extensions/feishu/src/drive.test.ts (18 tests) 3340ms
  Test Files  1 passed (1)
       Tests  18 passed (18)
  ```
- Observed result after fix: All 18 tests pass after running node scripts/run-vitest.mjs, including 3 new pagination tests (list with page_token, info finding file on page 3, info throwing File not found after exhausting all pages).
- What was not tested: Not run against a live Feishu tenant; the proof drives the real plugin code path with the Lark `drive.file.list` response shape mocked rather than a live multi-page folder.
- Proof limitations or environment constraints: Mock-based test — does not verify against actual Feishu API pagination behavior.

## Tests and validation

Which commands did you run?
- `node scripts/run-vitest.mjs test/vitest/vitest.extension-feishu.config.ts -- extensions/feishu/src/drive.test.ts`

What regression coverage was added or updated?
- Added 3 new test cases:
  1. `paginates list action returning requested page` — verifies `page_token` is passed to SDK and `has_more`/`next_page_token` are returned
  2. `paginates getFileInfo through multiple pages to find file` — verifies 3-page pagination to find a file on page 3
  3. `throws File not found after exhausting all pages` — verifies error after single-page search with no match

What failed before this fix, if known?
- `info` action threw `File not found: <token>` for any file past page 1
- `list` action returned only page 1 with no way to fetch subsequent pages