### PR TITLE
fix(secrets): forward BWS_SERVER_URL to the bws resolver for self-hosted Bitwarden (fixes #93851)

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -335,8 +335,9 @@ the config fields that accept SecretRefs.
     - `BWS_ACCESS_TOKEN` available to the Gateway service.
     - `PATH` passed to the resolver, or `BWS_BIN` set to the absolute `bws`
       binary path.
-    - Self-hosted Bitwarden only: `BWS_SERVER_URL` passed to the resolver so the
-      `bws` CLI targets your server instead of the public default.
+    - Self-hosted Bitwarden only: include `BWS_SERVER_URL` in `passEnv` so the exec
+      provider forwards it to the resolver; the resolver then passes it to the
+      `bws` CLI. Omit it for Bitwarden cloud.
 
     ```json5
     {
@@ -345,8 +346,7 @@ the config fields that accept SecretRefs.
           bws: {
             source: "exec",
             command: "/usr/local/bin/openclaw-bws-resolver.mjs",
-            // Add "BWS_SERVER_URL" for self-hosted Bitwarden instances.
-            passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN"],
+            passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN", "BWS_SERVER_URL"],
             jsonOnly: true,
           },
         },

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -335,6 +335,8 @@ the config fields that accept SecretRefs.
     - `BWS_ACCESS_TOKEN` available to the Gateway service.
     - `PATH` passed to the resolver, or `BWS_BIN` set to the absolute `bws`
       binary path.
+    - Self-hosted Bitwarden only: `BWS_SERVER_URL` passed to the resolver so the
+      `bws` CLI targets your server instead of the public default.
 
     ```json5
     {
@@ -343,6 +345,7 @@ the config fields that accept SecretRefs.
           bws: {
             source: "exec",
             command: "/usr/local/bin/openclaw-bws-resolver.mjs",
+            // Add "BWS_SERVER_URL" for self-hosted Bitwarden instances.
             passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN"],
             jsonOnly: true,
           },

--- a/scripts/secrets/openclaw-bws-resolver.mjs
+++ b/scripts/secrets/openclaw-bws-resolver.mjs
@@ -47,12 +47,18 @@ const main = async () => {
 
   const bwsBin =
     process.env.BWS_BIN && process.env.BWS_BIN.trim() ? process.env.BWS_BIN.trim() : "bws";
+  const bwsEnv = {
+    BWS_ACCESS_TOKEN: process.env.BWS_ACCESS_TOKEN,
+    PATH: process.env.PATH || "",
+  };
+  // Self-hosted Bitwarden needs the API base URL; forward it when present so the
+  // bws CLI targets the configured server instead of the public default.
+  if (process.env.BWS_SERVER_URL) {
+    bwsEnv.BWS_SERVER_URL = process.env.BWS_SERVER_URL;
+  }
   const raw = execFileSync(bwsBin, ["secret", "list"], {
     encoding: "utf8",
-    env: {
-      BWS_ACCESS_TOKEN: process.env.BWS_ACCESS_TOKEN,
-      PATH: process.env.PATH || "",
-    },
+    env: bwsEnv,
     maxBuffer: 1024 * 1024,
     timeout: 15_000,
   });

--- a/test/scripts/openclaw-bws-resolver.test.ts
+++ b/test/scripts/openclaw-bws-resolver.test.ts
@@ -1,10 +1,11 @@
-// Bitwarden resolver script tests cover parent-env forwarding to the bws CLI.
+// Bitwarden resolver tests cover exec passEnv forwarding and resolver-to-bws env handoff.
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { resolveSecretRefString } from "../../src/secrets/resolve.js";
 
 const resolverPath = fileURLToPath(
   new URL("../../scripts/secrets/openclaw-bws-resolver.mjs", import.meta.url),
@@ -14,13 +15,11 @@ const SECRET_ID = "openclaw/providers/openai/apiKey";
 
 /** Writes a fake `bws` CLI that records the env it received and emits one secret. */
 function writeFakeBws(dir: string, capturePath: string): string {
-  const bwsPath = path.join(dir, "fake-bws.cjs");
+  const bwsPath = path.join(dir, "fake-bws");
   const script = `#!/usr/bin/env node
-const fs = require("node:fs");
-fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({
-  BWS_SERVER_URL: process.env.BWS_SERVER_URL ?? null,
-}));
-process.stdout.write(JSON.stringify([{ key: ${JSON.stringify(SECRET_ID)}, value: "sk-test-value" }]));
+import fs from "node:fs";
+fs.writeFileSync(${JSON.stringify(capturePath)}, \`bws child saw BWS_SERVER_URL=\${process.env.BWS_SERVER_URL ?? "(unset)"}\\n\`);
+process.stdout.write(JSON.stringify([{ key: ${JSON.stringify(SECRET_ID)}, value: "sk-test-value" }]) + "\\n");
 `;
   fs.writeFileSync(bwsPath, script, { mode: 0o755 });
   return bwsPath;
@@ -41,7 +40,7 @@ describe("openclaw-bws-resolver", () => {
     }
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bws-resolver-"));
     try {
-      const capturePath = path.join(dir, "captured-env.json");
+      const capturePath = path.join(dir, "captured-env.txt");
       const bwsBin = writeFakeBws(dir, capturePath);
       const stdout = runResolver({
         PATH: process.env.PATH ?? "",
@@ -50,10 +49,8 @@ describe("openclaw-bws-resolver", () => {
         BWS_SERVER_URL: "https://pass.example.com",
       });
 
-      const captured = JSON.parse(fs.readFileSync(capturePath, "utf8")) as {
-        BWS_SERVER_URL: string | null;
-      };
-      expect(captured.BWS_SERVER_URL).toBe("https://pass.example.com");
+      const captured = fs.readFileSync(capturePath, "utf8");
+      expect(captured).toBe("bws child saw BWS_SERVER_URL=https://pass.example.com\n");
 
       const response = JSON.parse(stdout) as { values: Record<string, string> };
       expect(response.values[SECRET_ID]).toBe("sk-test-value");
@@ -68,7 +65,7 @@ describe("openclaw-bws-resolver", () => {
     }
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bws-resolver-"));
     try {
-      const capturePath = path.join(dir, "captured-env.json");
+      const capturePath = path.join(dir, "captured-env.txt");
       const bwsBin = writeFakeBws(dir, capturePath);
       runResolver({
         PATH: process.env.PATH ?? "",
@@ -76,10 +73,54 @@ describe("openclaw-bws-resolver", () => {
         BWS_BIN: bwsBin,
       });
 
-      const captured = JSON.parse(fs.readFileSync(capturePath, "utf8")) as {
-        BWS_SERVER_URL: string | null;
-      };
-      expect(captured.BWS_SERVER_URL).toBeNull();
+      const captured = fs.readFileSync(capturePath, "utf8");
+      expect(captured).toBe("bws child saw BWS_SERVER_URL=(unset)\n");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("exec provider passEnv forwards BWS_SERVER_URL through resolver to bws", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bws-exec-chain-"));
+    try {
+      const capturePath = path.join(dir, "bws-captured-env.txt");
+      const bwsBin = writeFakeBws(dir, capturePath);
+      const resolverCopy = path.join(dir, "openclaw-bws-resolver.mjs");
+      fs.copyFileSync(resolverPath, resolverCopy);
+      fs.chmodSync(resolverCopy, 0o700);
+
+      const resolved = await resolveSecretRefString(
+        { source: "exec", provider: "bws", id: SECRET_ID },
+        {
+          config: {
+            secrets: {
+              providers: {
+                bws: {
+                  source: "exec",
+                  command: resolverCopy,
+                  passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN", "BWS_SERVER_URL"],
+                  jsonOnly: true,
+                  allowInsecurePath: true,
+                },
+              },
+            },
+          },
+          env: {
+            PATH: `${dir}:${process.env.PATH ?? ""}`,
+            BWS_ACCESS_TOKEN: "demo-token",
+            BWS_BIN: bwsBin,
+            BWS_SERVER_URL: "https://pass.example.com",
+          },
+        },
+      );
+
+      expect(resolved).toBe("sk-test-value");
+      expect(fs.readFileSync(capturePath, "utf8")).toBe(
+        "bws child saw BWS_SERVER_URL=https://pass.example.com\n",
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/scripts/openclaw-bws-resolver.test.ts
+++ b/test/scripts/openclaw-bws-resolver.test.ts
@@ -1,0 +1,87 @@
+// Bitwarden resolver script tests cover parent-env forwarding to the bws CLI.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const resolverPath = fileURLToPath(
+  new URL("../../scripts/secrets/openclaw-bws-resolver.mjs", import.meta.url),
+);
+
+const SECRET_ID = "openclaw/providers/openai/apiKey";
+
+/** Writes a fake `bws` CLI that records the env it received and emits one secret. */
+function writeFakeBws(dir: string, capturePath: string): string {
+  const bwsPath = path.join(dir, "fake-bws.cjs");
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({
+  BWS_SERVER_URL: process.env.BWS_SERVER_URL ?? null,
+}));
+process.stdout.write(JSON.stringify([{ key: ${JSON.stringify(SECRET_ID)}, value: "sk-test-value" }]));
+`;
+  fs.writeFileSync(bwsPath, script, { mode: 0o755 });
+  return bwsPath;
+}
+
+function runResolver(env: NodeJS.ProcessEnv): string {
+  return execFileSync(process.execPath, [resolverPath], {
+    encoding: "utf8",
+    input: JSON.stringify({ protocolVersion: 1, ids: [SECRET_ID] }),
+    env,
+  });
+}
+
+describe("openclaw-bws-resolver", () => {
+  it("forwards BWS_SERVER_URL to the bws CLI for self-hosted instances", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bws-resolver-"));
+    try {
+      const capturePath = path.join(dir, "captured-env.json");
+      const bwsBin = writeFakeBws(dir, capturePath);
+      const stdout = runResolver({
+        PATH: process.env.PATH ?? "",
+        BWS_ACCESS_TOKEN: "token",
+        BWS_BIN: bwsBin,
+        BWS_SERVER_URL: "https://pass.example.com",
+      });
+
+      const captured = JSON.parse(fs.readFileSync(capturePath, "utf8")) as {
+        BWS_SERVER_URL: string | null;
+      };
+      expect(captured.BWS_SERVER_URL).toBe("https://pass.example.com");
+
+      const response = JSON.parse(stdout) as { values: Record<string, string> };
+      expect(response.values[SECRET_ID]).toBe("sk-test-value");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits BWS_SERVER_URL when it is absent from the parent env", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bws-resolver-"));
+    try {
+      const capturePath = path.join(dir, "captured-env.json");
+      const bwsBin = writeFakeBws(dir, capturePath);
+      runResolver({
+        PATH: process.env.PATH ?? "",
+        BWS_ACCESS_TOKEN: "token",
+        BWS_BIN: bwsBin,
+      });
+
+      const captured = JSON.parse(fs.readFileSync(capturePath, "utf8")) as {
+        BWS_SERVER_URL: string | null;
+      };
+      expect(captured.BWS_SERVER_URL).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #93851.
- Self-hosted Bitwarden Secrets Manager users hit `401 Unauthorized`: the bundled resolver `scripts/secrets/openclaw-bws-resolver.mjs` spawned the `bws` CLI with a hardcoded child env (`BWS_ACCESS_TOKEN`, `PATH`) only, so `BWS_SERVER_URL` was dropped even when listed in provider `passEnv`.
- The resolver now forwards `BWS_SERVER_URL` to the `bws` child process when it is present.
- Docs now include `BWS_SERVER_URL` in the Bitwarden `passEnv` example so the exec provider forwards it into the resolver process.
- Intentionally unchanged: the core exec secrets provider keeps its minimal-by-default child env; no core runtime, config, or schema changes.

## Why not change the core exec provider default

A previous version of this PR made the core exec provider inherit the full parent env by default. That approach was dropped because:

1. It violates the documented contract — `docs/gateway/secrets.md`: "exec child environment is minimal by default; pass required variables explicitly with `passEnv`" — and conflicts with the sibling `src/security/install-policy.ts` posture (`does not inherit PATH unless passEnv includes it`).
2. It would not even fix the bug alone. Even with the full env handed to the resolver, the bundled resolver re-spawns `bws` with its own hardcoded env subset, so `BWS_SERVER_URL` was still dropped at the second hop.

## Real behavior proof

Behavior addressed: self-hosted Bitwarden `401 Unauthorized` because `BWS_SERVER_URL` never reached the `bws` CLI through the documented exec-provider `passEnv` path.
Real environment tested: Linux, Node v22.22.0; exercised the actual OpenClaw exec provider (`resolveSecretRefString`) with the shipped Bitwarden resolver and a stand-in `bws` binary.
Exact steps or command run after this patch: called `resolveSecretRefString` via `node --import tsx` with `passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN", "BWS_SERVER_URL"]` and parent env `BWS_SERVER_URL=https://pass.example.com`.
Evidence after fix:

```
=========== exec provider passEnv -> resolver -> bws ===========
resolved secret: sk-live-demo-value
--- env captured by the bws child process ---
bws child saw BWS_SERVER_URL=https://pass.example.com
```

Observed result after fix: the exec provider forwarded `BWS_SERVER_URL` into the resolver process, the resolver forwarded it to the spawned `bws` child, and the requested secret resolved successfully.
What was not tested: a live self-hosted Bitwarden Secrets Manager server with a real `bws` binary and credentials.

## Tests and validation

- `node scripts/run-vitest.mjs test/scripts/openclaw-bws-resolver.test.ts` → 3 passed (resolver hop, absent-var hop, exec-provider full chain)
- `npx oxfmt --check scripts/secrets/openclaw-bws-resolver.mjs docs/gateway/secrets.md test/scripts/openclaw-bws-resolver.test.ts` → clean

## Risk checklist

Did user-visible behavior change? Yes — self-hosted `bws` setups work when `BWS_SERVER_URL` is listed in `passEnv` and set in the Gateway environment.
Did config, environment, or migration behavior change? Docs example adds `BWS_SERVER_URL` to `passEnv`; no schema change.
Did security, auth, secrets, network, or tool execution behavior change? Minimal — one named parent env var is forwarded through the existing explicit `passEnv` boundary; no full parent-env inheritance.
Highest-risk area: secrets resolver subprocess env.
Mitigation: forward only when present; documented explicit `passEnv` path; regression tests cover provider-to-resolver-to-bws handoff.

## Current review state

Next action: maintainer review.
Waiting on: ClawSweeper re-review after P1 fixes.
Bot comments addressed: added `BWS_SERVER_URL` to documented `passEnv`; added exec-provider full-chain proof and regression test.
