### PR TITLE
Explain private-network exec failures

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -529,6 +529,60 @@ describe("buildExecExitOutcome", () => {
     expect(outcome.aggregated).toBe("done\n\n(Command exited with code 1)");
   });
 
+  it("annotates private-network connection failures on non-zero normal exits", () => {
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "exit",
+        exitCode: 7,
+        exitSignal: null,
+        durationMs: 123,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated:
+        "curl: (7) Failed to connect to 192.168.147.163 port 8686 after 3000 ms: Couldn't connect to server",
+      durationMs: 123,
+      timeoutSec: 30,
+      command: "curl -I http://192.168.147.163:8686/",
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") {
+      throw new Error(`Expected completed outcome, got ${outcome.status}`);
+    }
+    expect(outcome.aggregated).toContain("OpenClaw exec private-network diagnostic");
+    expect(outcome.aggregated).toContain("same macOS/Linux user");
+    expect(outcome.aggregated).toContain("exec runtime, sandbox, or process-scoped network policy");
+    expect(outcome.aggregated).toContain("exit code 7");
+  });
+
+  it("does not annotate public-network connection failures", () => {
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "exit",
+        exitCode: 7,
+        exitSignal: null,
+        durationMs: 123,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "curl: (7) Failed to connect to 203.0.113.10 port 8686",
+      durationMs: 123,
+      timeoutSec: 30,
+      command: "curl -I http://203.0.113.10:8686/",
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") {
+      throw new Error(`Expected completed outcome, got ${outcome.status}`);
+    }
+    expect(outcome.aggregated).not.toContain("OpenClaw exec private-network diagnostic");
+  });
+
   it("classifies timed out exits as failures with a reason", () => {
     const outcome = buildExecExitOutcome({
       exit: {
@@ -578,6 +632,33 @@ describe("buildExecExitOutcome", () => {
     expect(outcome.timedOut).toBe(true);
     expect(outcome.reason).toContain("background=true");
     expect(outcome.reason).toContain("Do not rely on shell backgrounding");
+  });
+
+  it("annotates private-network route failures on failed exits", () => {
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "manual-cancel",
+        exitCode: null,
+        exitSignal: "SIGTERM",
+        durationMs: 123,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "ssh: connect to host 192.168.147.163 port 22: No route to host",
+      durationMs: 123,
+      timeoutSec: 30,
+      command: "ssh -o ConnectTimeout=5 192.168.147.163 hostname",
+    });
+
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") {
+      throw new Error(`Expected failed outcome, got ${outcome.status}`);
+    }
+    expect(outcome.reason).toContain("OpenClaw exec private-network diagnostic");
+    expect(outcome.reason).toContain("same macOS/Linux user");
+    expect(outcome.reason).toContain("VPN/Network Extension filters");
   });
 });
 

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -660,6 +660,33 @@ describe("buildExecExitOutcome", () => {
     expect(outcome.reason).toContain("same macOS/Linux user");
     expect(outcome.reason).toContain("VPN/Network Extension filters");
   });
+
+  it("annotates hostname commands when stderr reports a private-network route failure", () => {
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "exit",
+        exitCode: 255,
+        exitSignal: null,
+        durationMs: 123,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "ssh: connect to host 192.168.147.163 port 22: No route to host",
+      durationMs: 123,
+      timeoutSec: 30,
+      command: "ssh -o ConnectTimeout=5 docker-arr hostname",
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") {
+      throw new Error(`Expected completed outcome, got ${outcome.status}`);
+    }
+    expect(outcome.aggregated).toContain("OpenClaw exec private-network diagnostic");
+    expect(outcome.aggregated).toContain("same macOS/Linux user");
+    expect(outcome.aggregated).toContain("exit code 255");
+  });
 });
 
 describe("runExecProcess POSIX command wrapper", () => {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -558,6 +558,33 @@ describe("buildExecExitOutcome", () => {
     expect(outcome.aggregated).toContain("exit code 7");
   });
 
+  it("does not annotate private-network-looking output on zero-exit normal exits", () => {
+    const outcome = buildExecExitOutcome({
+      exit: {
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 123,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      },
+      aggregated: "saved log line: ssh: connect to host 192.168.147.163 port 22: No route to host",
+      durationMs: 123,
+      timeoutSec: 30,
+      command: "printf '%s\n' 'ssh: connect to host 192.168.147.163 port 22: No route to host'",
+    });
+
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") {
+      throw new Error(`Expected completed outcome, got ${outcome.status}`);
+    }
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.aggregated).not.toContain("OpenClaw exec private-network diagnostic");
+    expect(outcome.aggregated).not.toContain("(Command exited with code");
+  });
+
   it("does not annotate public-network connection failures", () => {
     const outcome = buildExecExitOutcome({
       exit: {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -548,11 +548,15 @@ export function buildExecExitOutcome(params: {
     isNormalExit && !isShellFailure ? "completed" : "failed";
   if (status === "completed") {
     const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
-    const aggregated = appendPrivateNetworkExecDiagnostic({
-      command: params.command,
-      output: params.aggregated + exitMsg,
-      exitCode,
-    });
+    const output = params.aggregated + exitMsg;
+    const aggregated =
+      exitCode !== 0
+        ? appendPrivateNetworkExecDiagnostic({
+            command: params.command,
+            output,
+            exitCode,
+          })
+        : output;
     return {
       status: "completed",
       exitCode,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -426,6 +426,67 @@ function joinExecFailureOutput(aggregated: string, reason: string) {
   return aggregated ? `${aggregated}\n\n${reason}` : reason;
 }
 
+const PRIVATE_NETWORK_EXEC_DIAGNOSTIC = [
+  "OpenClaw exec private-network diagnostic: this command targets a private/internal address and failed with a network-looking error.",
+  "If the same macOS/Linux user can reach the target from an ordinary terminal, browser, or launchd/systemd user service, this may be an exec runtime, sandbox, or process-scoped network policy mismatch rather than a LAN outage.",
+  "Compare the same command from the user shell and check tools.exec.host/sandbox settings, elevated/runtime policy, and local VPN/Network Extension filters.",
+].join(" ");
+
+const NETWORK_FAILURE_PATTERNS = [
+  /\bno route to host\b/i,
+  /\bnetwork is unreachable\b/i,
+  /\bhost is down\b/i,
+  /\bfailed to connect\b/i,
+  /\bcould(?:n'?t| not) connect to server\b/i,
+  /\bconnection refused\b/i,
+  /\bconnection timed out\b/i,
+  /\boperation timed out\b/i,
+  /\bconnect\(\) failed\b/i,
+];
+
+const PRIVATE_HOST_PATTERNS = [
+  /\blocalhost\b/i,
+  /\b127(?:\.\d{1,3}){3}\b/,
+  /\b10(?:\.\d{1,3}){3}\b/,
+  /\b192\.168(?:\.\d{1,3}){2}\b/,
+  /\b172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}\b/,
+  /\b169\.254(?:\.\d{1,3}){2}\b/,
+  /\b::1\b/i,
+  /\bfc[0-9a-f]{2}:/i,
+  /\bfd[0-9a-f]{2}:/i,
+  /\bfe80:/i,
+];
+
+function commandTargetsPrivateNetwork(command: string | undefined): boolean {
+  if (!command?.trim()) {
+    return false;
+  }
+  return PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(command));
+}
+
+function outputLooksLikeNetworkFailure(output: string): boolean {
+  return NETWORK_FAILURE_PATTERNS.some((pattern) => pattern.test(output));
+}
+
+function appendPrivateNetworkExecDiagnostic(params: {
+  command?: string;
+  output: string;
+  exitCode: number | null;
+}): string {
+  if (!commandTargetsPrivateNetwork(params.command)) {
+    return params.output;
+  }
+  if (!outputLooksLikeNetworkFailure(params.output)) {
+    return params.output;
+  }
+  if (params.output.includes("OpenClaw exec private-network diagnostic:")) {
+    return params.output;
+  }
+  const codeText = typeof params.exitCode === "number" ? ` (exit code ${params.exitCode})` : "";
+  const diagnostic = `${PRIVATE_NETWORK_EXEC_DIAGNOSTIC}${codeText}`;
+  return params.output ? `${params.output}\n\n${diagnostic}` : diagnostic;
+}
+
 function classifyExecFailureKind(params: {
   exitReason: TerminationReason;
   exitCode: number;
@@ -478,6 +539,7 @@ export function buildExecExitOutcome(params: {
   aggregated: string;
   durationMs: number;
   timeoutSec: number | null | undefined;
+  command?: string;
 }): ExecProcessOutcome {
   const exitCode = params.exit.exitCode ?? 0;
   const isNormalExit = params.exit.reason === "exit";
@@ -486,12 +548,17 @@ export function buildExecExitOutcome(params: {
     isNormalExit && !isShellFailure ? "completed" : "failed";
   if (status === "completed") {
     const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
+    const aggregated = appendPrivateNetworkExecDiagnostic({
+      command: params.command,
+      output: params.aggregated + exitMsg,
+      exitCode,
+    });
     return {
       status: "completed",
       exitCode,
       exitSignal: params.exit.exitSignal,
       durationMs: params.durationMs,
-      aggregated: params.aggregated + exitMsg,
+      aggregated,
       timedOut: false,
     };
   }
@@ -506,6 +573,11 @@ export function buildExecExitOutcome(params: {
     exitSignal: params.exit.exitSignal,
     timeoutSec: params.timeoutSec,
   });
+  const failureReason = appendPrivateNetworkExecDiagnostic({
+    command: params.command,
+    output: joinExecFailureOutput(params.aggregated, reason),
+    exitCode: params.exit.exitCode ?? null,
+  });
   return {
     status: "failed",
     exitCode: params.exit.exitCode,
@@ -514,7 +586,7 @@ export function buildExecExitOutcome(params: {
     aggregated: params.aggregated,
     timedOut: params.exit.timedOut,
     failureKind,
-    reason: joinExecFailureOutput(params.aggregated, reason),
+    reason: failureReason,
   };
 }
 
@@ -908,6 +980,7 @@ export async function runExecProcess(opts: {
         aggregated: session.aggregated.trim(),
         durationMs,
         timeoutSec: opts.timeoutSec,
+        command: opts.command,
       });
 
       markExited(session, exit.exitCode, exit.exitSignal, outcome.status, exit.reason);

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -457,11 +457,11 @@ const PRIVATE_HOST_PATTERNS = [
   /\bfe80:/i,
 ];
 
-function commandTargetsPrivateNetwork(command: string | undefined): boolean {
-  if (!command?.trim()) {
+function textTargetsPrivateNetwork(text: string | undefined): boolean {
+  if (!text?.trim()) {
     return false;
   }
-  return PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(command));
+  return PRIVATE_HOST_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 function outputLooksLikeNetworkFailure(output: string): boolean {
@@ -473,7 +473,7 @@ function appendPrivateNetworkExecDiagnostic(params: {
   output: string;
   exitCode: number | null;
 }): string {
-  if (!commandTargetsPrivateNetwork(params.command)) {
+  if (!textTargetsPrivateNetwork(params.command) && !textTargetsPrivateNetwork(params.output)) {
     return params.output;
   }
   if (!outputLooksLikeNetworkFailure(params.output)) {


### PR DESCRIPTION
### Summary

- Adds a targeted exec diagnostic for private/internal network commands that fail with network-looking errors.
- Keeps existing exec/security behavior unchanged; this does not silently allow new private-LAN access.
- Covers the observed `curl` and hostname SSH/private-IP-in-stderr failure shapes from #94032.
- Avoids false positives for successful zero-exit commands whose output merely contains private-network-looking failure text.

### Why

When OpenClaw/Codex `exec` cannot reach a private-LAN target but the same user context can reach it from GUI Terminal, Browser, or a user service, the current output looks like a normal LAN outage. That sends operators toward switch/VPN/L2 debugging even when the failure may be an exec runtime, sandbox, or process-scoped policy mismatch.

This patch annotates that specific failed-command shape with a diagnostic that tells the operator to compare against a same-user shell and inspect exec host/sandbox/runtime policy and local VPN/Network Extension filters.

### Tests

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-runtime.test.ts`

### Real behavior proof

- **Behavior addressed:** Private/internal network-looking exec failures now include an explicit OpenClaw exec private-network diagnostic, while successful zero-exit output is left alone.
- **Real environment tested:** Mac mini OpenClaw/Codex shell context, PR-head worktree `/private/tmp/openclaw-pr94045-followup-20260621`, commit `184eb75babd0`.
- **Exact steps or command run after this patch:** Ran `runExecProcess` from PR head for these commands:

```sh
curl --connect-timeout 2 -I http://192.168.147.254:8686/
ssh -F /private/tmp/openclaw-pr94045-proof/ssh_config lan-proof-host hostname
printf "saved log line: ssh: connect to host 192.168.147.254 port 22: No route to host\n"
```

- **Evidence after fix:** Current-head exec runtime output:

```text
--- curl-private-ip ---
status=completed exitCode=7
curl: (7) Failed to connect to 192.168.147.254 port 8686 after 0 ms: Couldn't connect to server

(Command exited with code 7)

OpenClaw exec private-network diagnostic: this command targets a private/internal address and failed with a network-looking error. ... (exit code 7)

--- hostname-ssh-private-ip-stderr ---
status=completed exitCode=255
ssh: connect to host 192.168.147.254 port 22: Host is down

(Command exited with code 255)

OpenClaw exec private-network diagnostic: this command targets a private/internal address and failed with a network-looking error. ... (exit code 255)

--- zero-exit-private-looking-log ---
status=completed exitCode=0
saved log line: ssh: connect to host 192.168.147.254 port 22: No route to host
```

- **Observed result after fix:** Both failing private-network cases are annotated. The zero-exit command stays unannotated, which addresses the ClawSweeper false-positive finding.
- **What was not tested:** I did not deploy this branch into the production gateway or attempt to make private-LAN access succeed from exec. That is intentionally out of scope for this diagnostic-only patch.

Refs #94032