### PR TITLE
Force manual compaction past empty kept-tail cuts

### DIFF
--- a/packages/agent-core/src/harness/agent-harness.ts
+++ b/packages/agent-core/src/harness/agent-harness.ts
@@ -825,7 +825,9 @@ export class CoreAgentHarness<
         throw new AgentHarnessError("auth", "No auth available for compaction");
       }
       const branchEntries = await this.session.getBranch();
-      const preparationResult = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS);
+      const preparationResult = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS, {
+        force: true,
+      });
       if (!preparationResult.ok) {
         throw preparationResult.error;
       }

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAssistantMessageEventStream } from "../../llm.js";
 import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
-import { generateSummary } from "./compaction.js";
+import { buildSessionContext } from "../session/session.js";
+import type { SessionTreeEntry } from "../types.js";
+import { DEFAULT_COMPACTION_SETTINGS, prepareCompaction, generateSummary } from "./compaction.js";
 
 describe("generateSummary thinking options", () => {
   it("maps explicit Fable off to low effort for compaction", async () => {
@@ -58,5 +60,121 @@ describe("generateSummary thinking options", () => {
 
     expect(result).toEqual({ ok: true, value: "summary" });
     expect(streamFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("prepareCompaction", () => {
+  function createHighUsageSmallTranscriptEntries(): SessionTreeEntry[] {
+    return [
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-06-17T08:45:00.000Z",
+        message: { role: "user", content: "What do you see in your history?", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        timestamp: "2026-06-17T08:45:10.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Stored." }],
+          api: "openai-responses",
+          provider: "openai",
+          model: "gpt-test",
+          usage: {
+            input: 625,
+            output: 6,
+            cacheRead: 172_928,
+            cacheWrite: 0,
+            totalTokens: 173_559,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: 2,
+        },
+      },
+    ];
+  }
+
+  it("skips automatic no-op summaries when usage is high but transcript text is below the kept-tail budget", () => {
+    const entries = createHighUsageSmallTranscriptEntries();
+
+    const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS);
+
+    expect(preparation).toEqual({ ok: true, value: undefined });
+  });
+
+  it("forces manual preparation when usage is high but transcript text is below the kept-tail budget", () => {
+    const entries = createHighUsageSmallTranscriptEntries();
+
+    const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS, { force: true });
+
+    expect(preparation).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        firstKeptEntryId: "assistant-1",
+        messagesToSummarize: entries.map((entry) =>
+          entry.type === "message" ? entry.message : undefined,
+        ),
+        tokensBefore: 173_559,
+        turnPrefixMessages: [],
+      }),
+    });
+  });
+
+  it("shows why the old empty-summary compaction replayed the whole transcript", () => {
+    const entries: SessionTreeEntry[] = [
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-06-17T08:45:00.000Z",
+        message: { role: "user", content: "What do you see in your history?", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        timestamp: "2026-06-17T08:45:10.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Stored." }],
+          api: "openai-responses",
+          provider: "openai",
+          model: "gpt-test",
+          usage: {
+            input: 625,
+            output: 6,
+            cacheRead: 172_928,
+            cacheWrite: 0,
+            totalTokens: 173_559,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: 2,
+        },
+      },
+    ];
+
+    const compactedContext = buildSessionContext([
+      ...entries,
+      {
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "assistant-1",
+        timestamp: "2026-06-17T08:45:20.000Z",
+        summary: "No prior conversation content provided.",
+        firstKeptEntryId: "user-1",
+        tokensBefore: 173_559,
+      },
+    ]);
+    expect(compactedContext.messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "user",
+      "assistant",
+    ]);
   });
 });

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -125,6 +125,84 @@ describe("prepareCompaction", () => {
     });
   });
 
+  it("anchors a forced boundary on the assistant tool call, not a trailing tool result", () => {
+    const entries: SessionTreeEntry[] = [
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: "2026-06-17T08:45:00.000Z",
+        message: { role: "user", content: "Read the notes file.", timestamp: 1 },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        timestamp: "2026-06-17T08:45:10.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call-1", name: "read_file", arguments: { path: "notes.md" } },
+          ],
+          api: "openai-responses",
+          provider: "openai",
+          model: "gpt-test",
+          usage: {
+            input: 625,
+            output: 6,
+            cacheRead: 172_928,
+            cacheWrite: 0,
+            totalTokens: 173_559,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "toolUse",
+          timestamp: 2,
+        },
+      },
+      {
+        type: "message",
+        id: "tool-1",
+        parentId: "assistant-1",
+        timestamp: "2026-06-17T08:45:11.000Z",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read_file",
+          content: [{ type: "text", text: "notes body" }],
+          isError: false,
+          timestamp: 3,
+        },
+      },
+    ];
+
+    const preparation = prepareCompaction(entries, DEFAULT_COMPACTION_SETTINGS, { force: true });
+
+    // Anchor must be the assistant that owns the tool call, never the trailing
+    // tool result, or the rebuilt context would replay an orphaned tool result.
+    expect(preparation).toEqual({
+      ok: true,
+      value: expect.objectContaining({ firstKeptEntryId: "assistant-1" }),
+    });
+
+    const compactedContext = buildSessionContext([
+      ...entries,
+      {
+        type: "compaction",
+        id: "compaction-1",
+        parentId: "tool-1",
+        timestamp: "2026-06-17T08:45:20.000Z",
+        summary: "Checkpoint of the file read.",
+        firstKeptEntryId: "assistant-1",
+        tokensBefore: 173_559,
+      },
+    ]);
+    expect(compactedContext.messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "assistant",
+      "toolResult",
+    ]);
+  });
+
   it("shows why the old empty-summary compaction replayed the whole transcript", () => {
     const entries: SessionTreeEntry[] = [
       {

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -626,10 +626,16 @@ export interface CompactionPreparation {
   settings: CompactionSettings;
 }
 
+export interface CompactionPreparationOptions {
+  /** Prepare a real summary even when the kept-tail heuristic would otherwise summarize nothing. */
+  force?: boolean;
+}
+
 /** Prepare session entries for compaction, or return undefined when compaction is not applicable. */
 export function prepareCompaction(
   pathEntries: SessionTreeEntry[],
   settings: CompactionSettings,
+  options: CompactionPreparationOptions = {},
 ): Result<CompactionPreparation | undefined, CompactionError> {
   if (pathEntries.length === 0 || pathEntries[pathEntries.length - 1].type === "compaction") {
     return ok(undefined);
@@ -685,6 +691,35 @@ export function prepareCompaction(
         turnPrefixMessages.push(msg);
       }
     }
+  }
+  if (messagesToSummarize.length === 0 && turnPrefixMessages.length === 0) {
+    if (options.force === true) {
+      const forcedMessagesToSummarize: AgentMessage[] = [];
+      for (let i = boundaryStart; i < boundaryEnd; i++) {
+        const msg = getMessageFromEntryForCompaction(pathEntries[i]);
+        if (msg) {
+          forcedMessagesToSummarize.push(msg);
+        }
+      }
+      if (forcedMessagesToSummarize.length > 0) {
+        const forcedFileOps = extractFileOperations(
+          forcedMessagesToSummarize,
+          pathEntries,
+          prevCompactionIndex,
+        );
+        return ok({
+          firstKeptEntryId: pathEntries[boundaryEnd - 1].id,
+          messagesToSummarize: forcedMessagesToSummarize,
+          turnPrefixMessages: [],
+          isSplitTurn: false,
+          tokensBefore,
+          previousSummary,
+          fileOps: forcedFileOps,
+          settings,
+        });
+      }
+    }
+    return ok(undefined);
   }
   const fileOps = extractFileOperations(messagesToSummarize, pathEntries, prevCompactionIndex);
   if (cutPoint.isSplitTurn) {

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -701,14 +701,20 @@ export function prepareCompaction(
           forcedMessagesToSummarize.push(msg);
         }
       }
-      if (forcedMessagesToSummarize.length > 0) {
+      // Anchor the kept tail on the last valid cut point, not the raw final entry.
+      // findValidCutPoints excludes tool results, so a forced boundary that is not
+      // collapsed to summary-only later never keeps an orphaned tool result.
+      const forcedCutPoints = findValidCutPoints(pathEntries, boundaryStart, boundaryEnd);
+      const forcedKeepIndex =
+        forcedCutPoints.length > 0 ? forcedCutPoints[forcedCutPoints.length - 1] : -1;
+      if (forcedMessagesToSummarize.length > 0 && forcedKeepIndex >= 0) {
         const forcedFileOps = extractFileOperations(
           forcedMessagesToSummarize,
           pathEntries,
           prevCompactionIndex,
         );
         return ok({
-          firstKeptEntryId: pathEntries[boundaryEnd - 1].id,
+          firstKeptEntryId: pathEntries[forcedKeepIndex].id,
           messagesToSummarize: forcedMessagesToSummarize,
           turnPrefixMessages: [],
           isSplitTurn: false,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -46,6 +46,7 @@ export {
   shouldCompact,
   type CompactionDetails,
   type CompactionPreparation,
+  type CompactionPreparationOptions,
   type CompactionResult,
   type CompactionSettings,
   type ContextUsageEstimate,

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -1920,7 +1920,9 @@ export class AgentSession {
     }
 
     const pathEntries = this.sessionManager.getBranch();
-    const preparation = unwrapCoreResult(prepareCompaction(pathEntries, options.settings));
+    const preparation = unwrapCoreResult(
+      prepareCompaction(pathEntries, options.settings, { force: isManual }),
+    );
     if (!preparation) {
       if (isManual) {
         const lastEntry = pathEntries[pathEntries.length - 1];

--- a/src/agents/sessions/compaction/compaction.ts
+++ b/src/agents/sessions/compaction/compaction.ts
@@ -21,6 +21,7 @@ import {
   openClawAgentCoreRuntime,
   type CompactionDetails,
   type CompactionPreparation,
+  type CompactionPreparationOptions,
   type CompactionResult,
   type CompactionSettings,
   type ContextUsageEstimate,
@@ -58,8 +59,9 @@ function unwrapCompactionResult<T>(result: Result<T, Error>): T {
 export function prepareCompaction(
   pathEntries: SessionEntry[],
   settings: CompactionSettings,
+  options?: CompactionPreparationOptions,
 ): CompactionPreparation | undefined {
-  return unwrapCompactionResult(prepareCompactionCore(pathEntries, settings));
+  return unwrapCompactionResult(prepareCompactionCore(pathEntries, settings, options));
 }
 
 /** Generates a compaction summary through the shared agent-core runtime. */


### PR DESCRIPTION
## Problem

Manual `/compact` failed to create a checkpoint when a session reported high context usage but held only a tiny transcript.

Context size is measured from provider usage (`usage.totalTokens`, which includes the cached system prompt and tool definitions), so it can read ~170k even when the actual conversation is just a couple of short messages. In that state the cut-point planner keeps the whole branch within the `keepRecentTokens` (20k) budget and selects **zero** older messages, so `prepareCompaction` returns `undefined`:

- **Automatic** compaction correctly skips — there is no old prefix worth summarizing yet.
- **Manual** `/compact` instead surfaced a confusing `Nothing to compact (session too small)`, even though the user explicitly asked for a checkpoint.

"0 messages to summarize" here means "the retained-tail heuristic found no old prefix to replace" — **not** "the session is empty".

## Fix

1. Add a `force` option to `prepareCompaction`. Manual session/harness compaction pass `force: true`; automatic does not. When the heuristic would summarize zero messages, the forced path summarizes the whole branch so `/compact` produces a real checkpoint.
2. The forced boundary anchors `firstKeptEntryId` on the last **valid cut point** (`findValidCutPoints`, which excludes tool results), not the raw final entry.

## Further context

- **Automatic behavior is unchanged.** Without `force`, the zero-message case still returns `undefined` → skip, so automatic compaction never writes empty no-op summaries.
- **The `force` path is narrowly scoped.** It only changes the zero-old-prefix case; every normal cut runs untouched. Truly empty / already-compacted sessions are still refused — the path proceeds only when there is at least one real message.
- **No content is lost.** The whole branch is summarized, so when manual compaction later collapses the boundary to summary-only (`hardenManualCompactionBoundary`), nothing is dropped silently.
- **The retained tail is always provider-valid.** Anchoring on a valid cut point — the same rule the normal path already trusts — keeps any trailing tool result paired with the assistant tool call that owns it, instead of replaying an orphaned tool result that providers reject. If no valid anchor exists, the path returns `undefined` rather than emitting an orphan.

## Tests
- `pnpm test packages/agent-core/src/harness/compaction/compaction.test.ts` — automatic skip, manual force, and the valid-anchor / no-orphan-tool-result regression
- `pnpm test src/agents/embedded-agent-runner/manual-compaction-boundary.test.ts`
- `pnpm test src/agents/embedded-agent-runner/compact.hooks.test.ts`
