### PR TITLE
fix: strip volatile output from exec result hash to fix no-progress detection (#93917)

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -70,9 +70,20 @@ The per-agent setting overrides the global setting.
 | --------- | ------- | ------------------------------------------------------------------------------------------------- |
 | `enabled` | `false` | Master switch for the rolling-history detectors. `false` also disables the post-compaction guard. |
 
-For `exec`, no-progress hashing compares stable command outcomes (status,
-exit code, timed-out flag, output) and ignores volatile runtime metadata such
-as duration, PID, session ID, and working directory. Outbound message-send
+For `exec`, no-progress hashing compares stable command outcomes and ignores
+volatile runtime metadata such as duration, PID, session ID, and working
+directory. Successful and failed results are compared differently. A completed
+result that exited zero keeps its output text in the hash, because changing
+output from a successful command is real progress. Any nonzero outcome is
+treated as a failure and ignores the output text (error output often carries
+volatile noise such as timestamps or connection-refused-at times): a completed
+nonzero exit (an ordinary `exit 1` from grep, SSH, Docker, and similar) and a
+hard `failed` result (timeout, signal, shell command-not-found) are both
+compared only by stable failure metadata (status, exit code, timed-out flag,
+exit signal, and failure kind). Repeated failures of the same command whose
+error text varies but whose failure mode is identical therefore still count as
+no progress, while genuinely different failure modes stay distinct. Outbound
+message-send
 results are hashed with volatile per-call ids (message id, file id, timestamp)
 stripped, so a "sent" result does not look identical to a different "sent"
 result. When a run id is available, history is evaluated only within that run,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -382,7 +382,6 @@ function formatDiagnosticsExportFailure(params: {
   }
   return lines.join("\n");
 }
-
 function buildGatewayExecApprovalFollowupSummary(params: {
   approvalId: string;
   sessionId: string;
@@ -426,7 +425,6 @@ function shouldAwaitGatewayApprovalInline(params: {
   // send a follow-up chat message to recover the turn (issue #93918).
   return isNativeApprovalChannel(normalizeMessageChannel(params.turnSourceChannel));
 }
-
 function buildGatewayExecApprovalDeniedToolResult(params: {
   approvalId: string;
   deniedReason: string;
@@ -449,7 +447,6 @@ function buildGatewayExecApprovalDeniedToolResult(params: {
     },
   };
 }
-
 async function resolveGatewayExecApprovalFollowupText(params: {
   approvalFollowup?: ExecApprovalFollowupFactory;
   approvalId: string;

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -439,9 +439,11 @@ function buildGatewayExecApprovalDeniedToolResult(params: {
     details: {
       status: "failed",
       exitCode: null,
+      exitSignal: null,
       durationMs: 0,
       aggregated: text,
       timedOut: params.deniedReason.includes("timeout"),
+      failureKind: "approval-denied",
       cwd: params.cwd,
     },
   };

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -720,6 +720,7 @@ export async function processGatewayAllowlist(
           details: {
             status: "failed",
             exitCode: null,
+            exitSignal: null,
             failureKind: "approval_required",
             durationMs: 0,
             aggregated: text,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -444,6 +444,7 @@ function buildGatewayExecApprovalDeniedToolResult(params: {
       aggregated: text,
       timedOut: params.deniedReason.includes("timeout"),
       failureKind: "approval-denied",
+      failureReason: params.deniedReason,
       cwd: params.cwd,
     },
   };

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -36,8 +36,8 @@ import {
   resolveSystemRunCommandRequest,
 } from "../infra/system-run-command.js";
 import { addSafeTimeoutDelayGraceMs } from "../utils/timer-delay.js";
+import { formatNodeRunPayloadToolResult } from "./bash-tools.exec-host-node-result.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
-import { renderExecUpdateText } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -232,60 +232,12 @@ export function formatNodeRunToolResult(params: {
       : undefined;
   const payloadObj =
     payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
-  const stdout = typeof payloadObj.stdout === "string" ? payloadObj.stdout : "";
-  const stderr = typeof payloadObj.stderr === "string" ? payloadObj.stderr : "";
-  const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
-  const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
-  const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
-  const exitSignal: NodeJS.Signals | number | null =
-    typeof payloadObj.exitSignal === "string"
-      ? (payloadObj.exitSignal as NodeJS.Signals)
-      : typeof payloadObj.exitSignal === "number"
-        ? payloadObj.exitSignal
-        : null;
-  const timedOut = payloadObj.timedOut === true;
-  const aggregated = [stdout, stderr, errorText].filter(Boolean).join("\n");
-  const durationMs = Date.now() - params.startedAt;
-  if (!success) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: renderExecUpdateText({ tailText: aggregated, warnings: params.warnings ?? [] }),
-        },
-      ],
-      details: {
-        status: "failed",
-        exitCode,
-        exitSignal,
-        durationMs,
-        aggregated,
-        timedOut,
-        failureKind: timedOut ? "overall-timeout" : "node-run-failed",
-        // Hash the actual node error, not the volatile leading stdout.
-        failureReason: errorText || stderr || undefined,
-        cwd: params.cwd,
-      },
-    };
-  }
-  return {
-    content: [
-      {
-        type: "text",
-        text: renderExecUpdateText({
-          tailText: aggregated,
-          warnings: params.warnings ?? [],
-        }),
-      },
-    ],
-    details: {
-      status: "completed",
-      exitCode,
-      durationMs,
-      aggregated,
-      cwd: params.cwd,
-    } satisfies ExecToolDetails,
-  };
+  return formatNodeRunPayloadToolResult({
+    payloadObj,
+    startedAt: params.startedAt,
+    cwd: params.cwd,
+    warnings: params.warnings,
+  });
 }
 
 /** Resolves the node id, platform, argv, env, and timeout for a node-host exec. */

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -262,6 +262,8 @@ export function formatNodeRunToolResult(params: {
         aggregated,
         timedOut,
         failureKind: timedOut ? "overall-timeout" : "node-run-failed",
+        // Hash the actual node error, not the volatile leading stdout.
+        failureReason: errorText || stderr || undefined,
         cwd: params.cwd,
       },
     };

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -237,21 +237,50 @@ export function formatNodeRunToolResult(params: {
   const errorText = typeof payloadObj.error === "string" ? payloadObj.error : "";
   const success = typeof payloadObj.success === "boolean" ? payloadObj.success : false;
   const exitCode = typeof payloadObj.exitCode === "number" ? payloadObj.exitCode : null;
+  const exitSignal: NodeJS.Signals | number | null =
+    typeof payloadObj.exitSignal === "string"
+      ? (payloadObj.exitSignal as NodeJS.Signals)
+      : typeof payloadObj.exitSignal === "number"
+        ? payloadObj.exitSignal
+        : null;
+  const timedOut = payloadObj.timedOut === true;
+  const aggregated = [stdout, stderr, errorText].filter(Boolean).join("\n");
+  const durationMs = Date.now() - params.startedAt;
+  if (!success) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: renderExecUpdateText({ tailText: aggregated, warnings: params.warnings ?? [] }),
+        },
+      ],
+      details: {
+        status: "failed",
+        exitCode,
+        exitSignal,
+        durationMs,
+        aggregated,
+        timedOut,
+        failureKind: timedOut ? "overall-timeout" : "node-run-failed",
+        cwd: params.cwd,
+      },
+    };
+  }
   return {
     content: [
       {
         type: "text",
         text: renderExecUpdateText({
-          tailText: stdout || stderr || errorText,
+          tailText: aggregated,
           warnings: params.warnings ?? [],
         }),
       },
     ],
     details: {
-      status: success ? "completed" : "failed",
+      status: "completed",
       exitCode,
-      durationMs: Date.now() - params.startedAt,
-      aggregated: [stdout, stderr, errorText].filter(Boolean).join("\n"),
+      durationMs,
+      aggregated,
       cwd: params.cwd,
     } satisfies ExecToolDetails,
   };

--- a/src/agents/bash-tools.exec-host-node-result.ts
+++ b/src/agents/bash-tools.exec-host-node-result.ts
@@ -1,0 +1,89 @@
+import { renderExecUpdateText } from "./bash-tools.exec-output.js";
+import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { AgentToolResult } from "./runtime/index.js";
+
+function formatFailedNodeRunToolResult(params: {
+  aggregated: string;
+  cwd: string | undefined;
+  durationMs: number;
+  errorText: string;
+  exitCode: number | null;
+  exitSignal: NodeJS.Signals | number | null;
+  stderr: string;
+  timedOut: boolean;
+  warnings?: string[];
+}): AgentToolResult<ExecToolDetails> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: renderExecUpdateText({
+          tailText: params.aggregated,
+          warnings: params.warnings ?? [],
+        }),
+      },
+    ],
+    details: {
+      status: "failed",
+      exitCode: params.exitCode,
+      exitSignal: params.exitSignal,
+      durationMs: params.durationMs,
+      aggregated: params.aggregated,
+      timedOut: params.timedOut,
+      failureKind: params.timedOut ? "overall-timeout" : "node-run-failed",
+      failureReason: params.errorText || params.stderr || undefined,
+      cwd: params.cwd,
+    },
+  };
+}
+
+export function formatNodeRunPayloadToolResult(params: {
+  payloadObj: Record<string, unknown>;
+  startedAt: number;
+  cwd: string | undefined;
+  warnings?: string[];
+}): AgentToolResult<ExecToolDetails> {
+  const stdout = typeof params.payloadObj.stdout === "string" ? params.payloadObj.stdout : "";
+  const stderr = typeof params.payloadObj.stderr === "string" ? params.payloadObj.stderr : "";
+  const errorText = typeof params.payloadObj.error === "string" ? params.payloadObj.error : "";
+  const success =
+    typeof params.payloadObj.success === "boolean" ? params.payloadObj.success : false;
+  const exitCode =
+    typeof params.payloadObj.exitCode === "number" ? params.payloadObj.exitCode : null;
+  const exitSignal =
+    typeof params.payloadObj.exitSignal === "string" ||
+    typeof params.payloadObj.exitSignal === "number"
+      ? (params.payloadObj.exitSignal as NodeJS.Signals | number)
+      : null;
+  const timedOut = params.payloadObj.timedOut === true;
+  const aggregated = [stdout, stderr, errorText].filter(Boolean).join("\n");
+  const durationMs = Date.now() - params.startedAt;
+  if (!success) {
+    return formatFailedNodeRunToolResult({
+      aggregated,
+      cwd: params.cwd,
+      durationMs,
+      errorText,
+      exitCode,
+      exitSignal,
+      stderr,
+      timedOut,
+      warnings: params.warnings,
+    });
+  }
+  return {
+    content: [
+      {
+        type: "text",
+        text: renderExecUpdateText({ tailText: aggregated, warnings: params.warnings ?? [] }),
+      },
+    ],
+    details: {
+      status: "completed",
+      exitCode,
+      durationMs,
+      aggregated,
+      cwd: params.cwd,
+    } satisfies ExecToolDetails,
+  };
+}

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -231,6 +231,7 @@ export async function executeNodeHostCommand(
       details: {
         status: "failed",
         exitCode: null,
+        exitSignal: null,
         failureKind: "approval_required",
         durationMs: 0,
         aggregated: text,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -112,10 +112,7 @@ const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 
 /** Failure categories used to explain exec process exits. */
-export type ExecProcessFailureKind = Exclude<
-  ExecToolFailureKind,
-  "approval-denied" | "node-run-failed"
->;
+type ExecProcessFailureKind = Exclude<ExecToolFailureKind, "approval-denied" | "node-run-failed">;
 
 type ExecExitFailureKind = Exclude<ExecProcessFailureKind, "runtime-error">;
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -112,7 +112,10 @@ const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 
 /** Failure categories used to explain exec process exits. */
-type ExecProcessFailureKind = Exclude<ExecToolFailureKind, "approval-denied" | "node-run-failed">;
+type ExecProcessFailureKind = Exclude<
+  ExecToolFailureKind,
+  "approval_required" | "approval-denied" | "node-run-failed"
+>;
 
 type ExecExitFailureKind = Exclude<ExecProcessFailureKind, "runtime-error">;
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -142,6 +142,8 @@ export type ExecProcessOutcome =
       noOutputTimedOut?: boolean;
       failureKind: ExecProcessFailureKind;
       reason: string;
+      /** Stable failure reason/error text for no-progress hashing (excludes volatile output). */
+      failureReason?: string;
     };
 
 /** Live handle returned after an exec process has started. */
@@ -513,6 +515,7 @@ function buildExecExitOutcome(params: {
     timedOut: params.exit.timedOut,
     noOutputTimedOut: params.exit.noOutputTimedOut,
     failureKind,
+    failureReason: reason,
     reason: joinExecFailureOutput(params.aggregated, reason),
   };
 }
@@ -531,6 +534,7 @@ export function buildExecRuntimeErrorOutcome(params: {
     aggregated: params.aggregated,
     timedOut: false,
     failureKind: "runtime-error",
+    failureReason: String(params.error),
     reason: joinExecFailureOutput(params.aggregated, String(params.error)),
   };
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -25,7 +25,7 @@ import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
  */
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
 import type { ProcessSession } from "./bash-process-registry.js";
-import type { ExecToolDetails } from "./bash-tools.exec-types.js";
+import type { ExecToolDetails, ExecToolFailureKind } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import type { AgentToolResult } from "./runtime/index.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
@@ -112,14 +112,10 @@ const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 
 /** Failure categories used to explain exec process exits. */
-type ExecProcessFailureKind =
-  | "shell-command-not-found"
-  | "shell-not-executable"
-  | "overall-timeout"
-  | "no-output-timeout"
-  | "signal"
-  | "aborted"
-  | "runtime-error";
+export type ExecProcessFailureKind = Exclude<
+  ExecToolFailureKind,
+  "approval-denied" | "node-run-failed"
+>;
 
 type ExecExitFailureKind = Exclude<ExecProcessFailureKind, "runtime-error">;
 

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -112,6 +112,18 @@ export type ExecApprovalFollowupFactory = (
   context: ExecApprovalFollowupContext,
 ) => string | undefined | Promise<string | undefined>;
 
+/** Stable failure categories emitted by foreground exec process outcomes. */
+export type ExecToolFailureKind =
+  | "shell-command-not-found"
+  | "shell-not-executable"
+  | "overall-timeout"
+  | "no-output-timeout"
+  | "signal"
+  | "aborted"
+  | "runtime-error"
+  | "approval-denied"
+  | "node-run-failed";
+
 /** Effective elevated-exec defaults derived from config/runtime policy. */
 export type ExecElevatedDefaults = {
   enabled: boolean;
@@ -132,10 +144,18 @@ export type ExecToolDetails =
       tail?: string;
     }
   | {
-      status: "completed" | "failed";
+      status: "completed";
       exitCode: number | null;
-      exitSignal?: NodeJS.Signals | number | null;
-      failureKind?: string;
+      durationMs: number;
+      aggregated: string;
+      timedOut?: boolean;
+      cwd?: string;
+    }
+  | {
+      status: "failed";
+      exitCode: number | null;
+      exitSignal: NodeJS.Signals | number | null;
+      failureKind: ExecToolFailureKind;
       exitReason?: TerminationReason;
       durationMs: number;
       aggregated: string;

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -156,6 +156,8 @@ export type ExecToolDetails =
       exitCode: number | null;
       exitSignal: NodeJS.Signals | number | null;
       failureKind: ExecToolFailureKind;
+      /** Stable failure reason/error text, hashed for no-progress detection instead of volatile stdout. */
+      failureReason?: string;
       exitReason?: TerminationReason;
       durationMs: number;
       aggregated: string;

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -121,6 +121,7 @@ export type ExecToolFailureKind =
   | "signal"
   | "aborted"
   | "runtime-error"
+  | "approval_required"
   | "approval-denied"
   | "node-run-failed";
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -213,7 +213,6 @@ function getResolvedExecEnvPreparedState(
 function isResolveExecEnvPrepared(params: ExecToolArgs): boolean {
   return Boolean(getResolvedExecEnvPreparedState(params));
 }
-
 function markDeferredResolveExecEnvPrepared<T extends ExecToolArgs>(
   params: T,
   state: DeferredResolveExecEnvPreparedState,
@@ -235,7 +234,6 @@ function markResolvedExecWorkdirPrepared<T extends ExecToolArgs>(
   resolvedExecWorkdirPreparedStates.set(params, state);
   return params;
 }
-
 function getResolvedExecWorkdirPreparedState(
   params: ExecToolArgs,
 ): ResolvedExecWorkdirPreparedState | undefined {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -254,6 +254,7 @@ function buildExecForegroundResult(params: {
       exitCode: params.outcome.exitCode ?? null,
       exitSignal: params.outcome.exitSignal,
       failureKind: params.outcome.failureKind,
+      failureReason: params.outcome.failureReason,
       exitReason: params.outcome.exitReason,
       durationMs: params.outcome.durationMs,
       aggregated: params.outcome.aggregated,

--- a/src/agents/tool-loop-detection-exec-fingerprint.ts
+++ b/src/agents/tool-loop-detection-exec-fingerprint.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { normalizeNullableString as nonEmptyStringField } from "@openclaw/normalization-core/string-coerce";
+import { stableStringify } from "./stable-stringify.js";
+
+function digestStable(value: unknown): string {
+  const serialized = stableStringify(value);
+  return createHash("sha256").update(serialized).digest("hex");
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function normalizeExitSignal(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return null;
+}
+
+function normalizeFailureReason(value: unknown): string {
+  const text = nonEmptyStringField(value);
+  if (!text) {
+    return "";
+  }
+  const summary = text.split("\n", 1)[0] ?? "";
+  return summary
+    .replace(/id=\S+/gi, "id=X")
+    .replace(/\b[0-9a-f]{8}-[0-9a-f-]{27,}\b/gi, "U")
+    .replace(/\b0x[0-9a-f]+\b/gi, "H")
+    .replace(/\b(?=[0-9a-f]*[a-f])[0-9a-f]{8,}\b/gi, "H")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+export function hashStableExecFailure(status: string, details: Record<string, unknown>): string {
+  const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
+  const exitSignal = normalizeExitSignal(details.exitSignal);
+  const hasStructuredExitIdentity = exitCode !== null || exitSignal !== null;
+  return digestStable({
+    status,
+    exitCode,
+    timedOut: details.timedOut === true,
+    exitSignal,
+    failureKind: stringField(details.failureKind),
+    ...(status === "failed" && !hasStructuredExitIdentity
+      ? { reason: normalizeFailureReason(details.failureReason ?? details.aggregated) }
+      : {}),
+  });
+}

--- a/src/agents/tool-loop-detection.exec-foreground.test.ts
+++ b/src/agents/tool-loop-detection.exec-foreground.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Real foreground exec loop-detection coverage (#93917).
+ *
+ * Drives the actual exec tool (createOpenClawCodingTools -> execTool.execute)
+ * against a command that fails with volatile stderr but identical params, then
+ * feeds each real result through the production loop recorders. This validates
+ * the runtime contract vincentkoc flagged: a real failed exec result must carry
+ * stable failureKind/exitSignal into the outcome hash, so repeated failures
+ * whose error text varies still accumulate a no-progress streak and trip the
+ * global circuit breaker instead of resetting on every fresh error string.
+ *
+ * It also covers the canonical case ClawSweeper flagged: an ordinary nonzero
+ * exit (grep/SSH/Docker exit 1) is a real `status: "completed"` result, not a
+ * shell 126/127 failure. Those must fingerprint by stable exit facts too, while
+ * exit-0 output stays a progress signal.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-coding-tools.js";
+import "./test-helpers/fast-openclaw-tools.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+import {
+  detectToolCallLoop,
+  recordToolCall,
+  recordToolCallOutcome,
+} from "./tool-loop-detection.js";
+
+const tempDirs = createTempDirTracker();
+
+// Low thresholds keep the real-process loop bounded while still exercising the
+// production critical/global breaker path.
+const LOOP_CONFIG = {
+  enabled: true,
+  warningThreshold: 2,
+  criticalThreshold: 3,
+  globalCircuitBreakerThreshold: 4,
+} as const;
+
+function createRealExecTool(prefix: string) {
+  const root = tempDirs.make(`${prefix}-`);
+  const workspaceDir = path.join(root, "workspace");
+  const agentDir = path.join(root, "agent");
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.mkdirSync(agentDir, { recursive: true });
+  const tools = createOpenClawCodingTools({
+    config: { tools: { exec: { security: "full", ask: "off" } } },
+    sessionKey: "agent:main:main",
+    workspaceDir,
+    agentDir,
+  });
+  const execTool = tools.find((tool) => tool.name === "exec");
+  if (!execTool) {
+    throw new Error("expected exec tool");
+  }
+  return execTool;
+}
+
+describe("exec foreground failed-result loop detection (#93917)", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createSessionConversationTestRegistry());
+  });
+
+  afterEach(() => {
+    tempDirs.cleanup();
+  });
+
+  it("trips the no-progress breaker on repeated failed exec with volatile stderr", async () => {
+    const execTool = createRealExecTool("exec-fg-breaker");
+    // Identical params every call; stderr text differs each call (fresh
+    // nanoseconds), then a missing binary exits 127 -> a real `status: "failed"`
+    // outcome. This is exactly the #93917 "same failure, volatile error text"
+    // case: the failed hash must ignore the varying text and still accumulate.
+    const params = {
+      command: "printf 'attempt %s\\n' \"$(date +%s%N)\" 1>&2; missing-binary-xyz-93917",
+    };
+    const state: { toolCallHistory?: unknown[] } = {};
+    let firstDetails: Record<string, unknown> | undefined;
+    let breaker: { detector?: string; level?: string; count?: number } | undefined;
+
+    for (let i = 1; i <= LOOP_CONFIG.globalCircuitBreakerThreshold + 1; i += 1) {
+      const callId = `c${i}`;
+      const result = await execTool.execute(callId, params);
+      if (i === 1) {
+        firstDetails = (result as { details?: Record<string, unknown> }).details;
+      }
+      recordToolCall(state as never, "exec", params, callId, LOOP_CONFIG as never);
+      recordToolCallOutcome(state as never, {
+        toolName: "exec",
+        toolParams: params,
+        toolCallId: callId,
+        result,
+        config: LOOP_CONFIG as never,
+      });
+      const detect = detectToolCallLoop(state as never, "exec", params, LOOP_CONFIG as never);
+      if (detect.stuck && detect.detector === "global_circuit_breaker") {
+        breaker = { detector: detect.detector, level: detect.level, count: detect.count };
+        break;
+      }
+    }
+
+    // Real foreground failed exec carries stable discriminators into the hash.
+    expect(firstDetails?.status).toBe("failed");
+    expect(firstDetails?.failureKind).toBeTruthy();
+    expect(firstDetails).toHaveProperty("exitSignal");
+    // Varying stderr text still accumulates a no-progress streak to the breaker.
+    expect(breaker?.detector).toBe("global_circuit_breaker");
+    expect(breaker?.level).toBe("critical");
+  });
+
+  it("does not merge distinct real failure modes into one no-progress streak", async () => {
+    const execTool = createRealExecTool("exec-fg-distinct");
+    // Missing binary -> exit 127 -> "shell-command-not-found";
+    // overall timeout -> "overall-timeout". Two distinct real failed outcomes.
+    const notFound = (await execTool.execute("nf", {
+      command: "missing-binary-xyz-93917",
+    })) as { details?: Record<string, unknown> };
+    const timedOut = (await execTool.execute("to", {
+      command: "sleep 5",
+      timeout: 1,
+    })) as { details?: Record<string, unknown> };
+
+    expect(notFound.details?.status).toBe("failed");
+    expect(timedOut.details?.status).toBe("failed");
+    // Different real failure modes must expose different stable discriminators
+    // so they cannot collapse into the same no-progress fingerprint.
+    expect(timedOut.details?.failureKind).not.toBe(notFound.details?.failureKind);
+  });
+
+  it("trips the breaker on repeated nonzero completed exec with volatile output", async () => {
+    const execTool = createRealExecTool("exec-fg-nonzero");
+    // Ordinary nonzero exit: identical params, fresh stdout each call, then a
+    // shell `exit 1`. That is a real `status: "completed"` result (not a shell
+    // 126/127 failure) — exactly the grep/SSH/Docker exit-1 retry loop from
+    // #93917. The completed hash must ignore the varying output for nonzero
+    // exits so the no-progress streak accumulates to the breaker.
+    const params = {
+      command: "printf 'attempt %s\\n' \"$(date +%s%N)\"; exit 1",
+    };
+    const state: { toolCallHistory?: unknown[] } = {};
+    let firstDetails: Record<string, unknown> | undefined;
+    let breaker: { detector?: string; level?: string; count?: number } | undefined;
+
+    for (let i = 1; i <= LOOP_CONFIG.globalCircuitBreakerThreshold + 1; i += 1) {
+      const callId = `n${i}`;
+      const result = await execTool.execute(callId, params);
+      if (i === 1) {
+        firstDetails = (result as { details?: Record<string, unknown> }).details;
+      }
+      recordToolCall(state as never, "exec", params, callId, LOOP_CONFIG as never);
+      recordToolCallOutcome(state as never, {
+        toolName: "exec",
+        toolParams: params,
+        toolCallId: callId,
+        result,
+        config: LOOP_CONFIG as never,
+      });
+      const detect = detectToolCallLoop(state as never, "exec", params, LOOP_CONFIG as never);
+      if (detect.stuck && detect.detector === "global_circuit_breaker") {
+        breaker = { detector: detect.detector, level: detect.level, count: detect.count };
+        break;
+      }
+    }
+
+    // A nonzero exit is a real completed outcome, not a shell 126/127 failure.
+    expect(firstDetails?.status).toBe("completed");
+    expect(firstDetails?.exitCode).toBe(1);
+    // Volatile output no longer defeats the streak for nonzero completed exits.
+    expect(breaker?.detector).toBe("global_circuit_breaker");
+    expect(breaker?.level).toBe("critical");
+  });
+
+  it("keeps exit-0 output as a progress signal despite varying text", async () => {
+    const execTool = createRealExecTool("exec-fg-progress");
+    // A successful exit with fresh output each call is real progress, so the
+    // no-progress streak must not accumulate and the breaker must stay silent —
+    // the negative control guarding the exit-0 branch of the completed hash.
+    const params = {
+      command: "printf 'progress %s\\n' \"$(date +%s%N)\"",
+    };
+    const state: { toolCallHistory?: unknown[] } = {};
+    let lastStatus: unknown;
+    let breaker: { detector?: string } | undefined;
+
+    for (let i = 1; i <= LOOP_CONFIG.globalCircuitBreakerThreshold + 1; i += 1) {
+      const callId = `p${i}`;
+      const result = await execTool.execute(callId, params);
+      lastStatus = (result as { details?: Record<string, unknown> }).details?.status;
+      recordToolCall(state as never, "exec", params, callId, LOOP_CONFIG as never);
+      recordToolCallOutcome(state as never, {
+        toolName: "exec",
+        toolParams: params,
+        toolCallId: callId,
+        result,
+        config: LOOP_CONFIG as never,
+      });
+      const detect = detectToolCallLoop(state as never, "exec", params, LOOP_CONFIG as never);
+      if (detect.stuck && detect.detector === "global_circuit_breaker") {
+        breaker = { detector: detect.detector };
+        break;
+      }
+    }
+
+    expect(lastStatus).toBe("completed");
+    // exit 0 with changing output stays progress-sensitive: no false breaker.
+    expect(breaker).toBeUndefined();
+  });
+});

--- a/src/agents/tool-loop-detection.exec-foreground.test.ts
+++ b/src/agents/tool-loop-detection.exec-foreground.test.ts
@@ -20,8 +20,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
+import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
 import {
   detectToolCallLoop,
@@ -207,5 +209,79 @@ describe("exec foreground failed-result loop detection (#93917)", () => {
     expect(lastStatus).toBe("completed");
     // exit 0 with changing output stays progress-sensitive: no false breaker.
     expect(breaker).toBeUndefined();
+  });
+
+  it("vetoes repeated nonzero completed exec through the real before_tool_call hook", async () => {
+    resetDiagnosticSessionStateForTest();
+    const execTool = createRealExecTool("exec-fg-hook-nonzero");
+    // Drive the production orchestration path a live agent turn runs: the wrapped
+    // execute() calls detectToolCallLoop -> real exec child process -> the changed
+    // outcome hash, and returns a blocked "tool-loop" veto instead of executing
+    // once the no-progress streak reaches critical. Proves the fix reaches the
+    // real circuit breaker, not just the detector functions in isolation.
+    const ctx = {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "hook-nonzero",
+      runId: "run-hook-nonzero",
+      loopDetection: LOOP_CONFIG,
+    };
+    const wrapped = wrapToolWithBeforeToolCallHook(execTool as never, ctx as never, {
+      emitDiagnostics: false,
+    });
+    const params = { command: "printf 'attempt %s\\n' \"$(date +%s%N)\"; exit 1" };
+    let firstStatus: unknown;
+    let firstExitCode: unknown;
+    let vetoedAtCall: number | undefined;
+
+    for (let i = 1; i <= LOOP_CONFIG.globalCircuitBreakerThreshold + 2; i += 1) {
+      const result = (await wrapped.execute(`h${i}`, params, undefined, undefined)) as {
+        details?: { status?: unknown; deniedReason?: unknown; exitCode?: unknown };
+      };
+      if (i === 1) {
+        firstStatus = result.details?.status;
+        firstExitCode = result.details?.exitCode;
+      }
+      if (result.details?.deniedReason === "tool-loop") {
+        vetoedAtCall = i;
+        break;
+      }
+    }
+
+    // A real nonzero exit is a completed outcome the hook still vetoes on repeat.
+    expect(firstStatus).toBe("completed");
+    expect(firstExitCode).toBe(1);
+    expect(vetoedAtCall).toBeDefined();
+  });
+
+  it("keeps exit-0 volatile output unblocked through the real before_tool_call hook", async () => {
+    resetDiagnosticSessionStateForTest();
+    const execTool = createRealExecTool("exec-fg-hook-progress");
+    // Negative control on the same production path: a successful command with
+    // fresh output each call is real progress, so the hook must never veto it.
+    const ctx = {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "hook-progress",
+      runId: "run-hook-progress",
+      loopDetection: LOOP_CONFIG,
+    };
+    const wrapped = wrapToolWithBeforeToolCallHook(execTool as never, ctx as never, {
+      emitDiagnostics: false,
+    });
+    const params = { command: "printf 'progress %s\\n' \"$(date +%s%N)\"" };
+    let vetoed = false;
+
+    for (let i = 1; i <= LOOP_CONFIG.globalCircuitBreakerThreshold + 2; i += 1) {
+      const result = (await wrapped.execute(`p${i}`, params, undefined, undefined)) as {
+        details?: { deniedReason?: unknown };
+      };
+      if (result.details?.deniedReason === "tool-loop") {
+        vetoed = true;
+        break;
+      }
+    }
+
+    expect(vetoed).toBe(false);
   });
 });

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -755,6 +755,124 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    // #93917 follow-up: broad catch-all failures (null exitCode + null
+    // exitSignal) with genuinely different reasons must not collapse into one
+    // no-progress streak just because they share a broad failureKind.
+    it("keeps distinct catch-all exec failure reasons below the global breaker", () => {
+      const state = createState();
+      const params = { command: "flaky-command" };
+      const reasons = ["connection refused", "permission denied", "host unreachable"];
+      let callIndex = 0;
+
+      for (const reason of reasons) {
+        for (let i = 0; i < Math.floor(GLOBAL_CIRCUIT_BREAKER_THRESHOLD / reasons.length); i += 1) {
+          recordSuccessfulCall(
+            state,
+            "exec",
+            params,
+            {
+              content: [{ type: "text", text: reason }],
+              details: {
+                status: "failed",
+                exitCode: null,
+                exitSignal: null,
+                failureKind: "node-run-failed",
+                durationMs: 100 + i,
+                aggregated: reason,
+              },
+            },
+            callIndex,
+          );
+          callIndex += 1;
+        }
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      // Distinct normalized reasons → distinct hashes → no single streak reaches
+      // the critical/global threshold.
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+      }
+    });
+
+    // #93917: repeats of the same catch-all failure whose reason only varies in
+    // a per-instance identifier (gateway approval id) must still collapse to one
+    // streak and trip the breaker — the unique id is masked before hashing.
+    it("trips the breaker on repeated catch-all failure with a volatile identifier", () => {
+      const state = createState();
+      const params = { command: "flaky-command" };
+
+      for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
+        const reason = `Exec denied (gateway id=req-${1000 + i}, timeout): flaky-command`;
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: reason }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              exitSignal: null,
+              failureKind: "approval-denied",
+              durationMs: 100 + i,
+              aggregated: reason,
+            },
+          },
+          i,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+      }
+    });
+
+    // #93917 follow-up: numeric status/error codes are stable identity, not
+    // noise, so failures that differ only by a code (500 vs 503) must stay
+    // distinct and not collapse into one no-progress streak.
+    it("keeps distinct stable numeric failure codes apart below the breaker", () => {
+      const state = createState();
+      const params = { command: "flaky-command" };
+      const codes = [500, 503];
+      let callIndex = 0;
+
+      for (const code of codes) {
+        for (let i = 0; i < Math.floor(GLOBAL_CIRCUIT_BREAKER_THRESHOLD / codes.length); i += 1) {
+          const reason = `upstream request failed with status ${code}`;
+          recordSuccessfulCall(
+            state,
+            "exec",
+            params,
+            {
+              content: [{ type: "text", text: reason }],
+              details: {
+                status: "failed",
+                exitCode: null,
+                exitSignal: null,
+                failureKind: "node-run-failed",
+                durationMs: 100 + i,
+                aggregated: reason,
+              },
+            },
+            callIndex,
+          );
+          callIndex += 1;
+        }
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      // Distinct numeric codes → distinct hashes → neither streak reaches the breaker.
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+      }
+    });
+
     it("does not block repeated unknown-tool failures before the unknown-tool threshold", () => {
       const state = createState();
       const toolName = "exec";

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -873,6 +873,48 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    // #93917 follow-up: two node failures with identical leading stdout but
+    // different actual errors must stay distinct — the hash uses the structured
+    // failureReason (the real error), not the first line of stdout.
+    it("keeps node failures with identical stdout but different errors apart", () => {
+      const state = createState();
+      const params = { command: "flaky-command" };
+      const errors = ["ENOENT missing dependency", "ECONNREFUSED upstream refused"];
+      let callIndex = 0;
+
+      for (const error of errors) {
+        for (let i = 0; i < Math.floor(GLOBAL_CIRCUIT_BREAKER_THRESHOLD / errors.length); i += 1) {
+          recordSuccessfulCall(
+            state,
+            "exec",
+            params,
+            {
+              content: [{ type: "text", text: "identical leading stdout" }],
+              details: {
+                status: "failed",
+                exitCode: null,
+                exitSignal: null,
+                failureKind: "node-run-failed",
+                // Identical leading stdout, distinct structured failure reason.
+                aggregated: `identical leading stdout\n${error}`,
+                failureReason: error,
+                durationMs: 100 + i,
+              },
+            },
+            callIndex,
+          );
+          callIndex += 1;
+        }
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      // Distinct failureReason → distinct hashes → no single streak trips the breaker.
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+      }
+    });
+
     it("does not block repeated unknown-tool failures before the unknown-tool threshold", () => {
       const state = createState();
       const toolName = "exec";

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -590,7 +590,42 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps changing empty-output exec failures below the global no-progress breaker", () => {
+    // #93917: An ordinary nonzero exit (grep/SSH/Docker exit 1) is reported as
+    // status "completed", not "failed". Its output text still varies per call,
+    // so the completed hash must fingerprint nonzero exits by stable exit facts
+    // (like the failed branch) and escalate to the global circuit breaker.
+    it("escalates repeated nonzero completed exec calls with volatile output to the global breaker", () => {
+      const state = createState();
+      const params = { command: "grep needle haystack.log" };
+
+      for (let index = 0; index < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `no match at ${index} (attempt ${index})` }],
+            details: {
+              status: "completed",
+              exitCode: 1,
+              durationMs: 100 + index,
+              aggregated: `no match at ${index}\n\n(Command exited with code 1)`,
+            },
+          },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+      }
+    });
+    // (status, exitCode, timedOut, failureKind, exitSignal) but varying
+    // output text now correctly escalate to the global circuit breaker.
+    it("escalates repeated failed exec calls to the global breaker when status and exitCode are stable", () => {
       const state = createState();
       const params = { command: "openclaw flaky-helper" };
 
@@ -604,6 +639,7 @@ describe("tool-loop-detection", () => {
             details: {
               status: "failed",
               exitCode: null,
+              failureKind: "runtime-error",
               durationMs: 100 + index,
               aggregated: "",
             },
@@ -615,8 +651,107 @@ describe("tool-loop-detection", () => {
       const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+      }
+    });
+
+    // #93917: Different failure kinds with the same exitCode should NOT
+    // merge into one no-progress streak — each failure mode is a distinct
+    // problem that may need a different fix.
+    it("keeps distinct exec failure kinds below the global no-progress breaker", () => {
+      const state = createState();
+      const params = { command: "flaky-command" };
+
+      const failureKinds = ["overall-timeout", "signal", "runtime-error"];
+      let callIndex = 0;
+
+      for (const failureKind of failureKinds) {
+        for (
+          let i = 0;
+          i < Math.floor(GLOBAL_CIRCUIT_BREAKER_THRESHOLD / failureKinds.length);
+          i++
+        ) {
+          recordSuccessfulCall(
+            state,
+            "exec",
+            params,
+            {
+              content: [{ type: "text", text: `${failureKind} error at attempt ${i}` }],
+              details: {
+                status: "failed",
+                exitCode: 1,
+                failureKind,
+                durationMs: 100 + i,
+                aggregated: "",
+              },
+            },
+            callIndex,
+          );
+          callIndex += 1;
+        }
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      // Different failure kinds → distinct hashes → no single streak
+      // reaches the circuit breaker threshold.
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
         expect(loopResult.level).toBe("warning");
-        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
+    // #93917: exitSignal can be a string ("SIGTERM") or a number (9 for
+    // SIGKILL). normalizeExitSignal preserves both forms so numeric
+    // signals don't collapse to null and falsely merge with exitSignal-less
+    // failures.
+    it("does not merge distinct exitSignal values into one failed no-progress streak", () => {
+      const state = createState();
+      const params = { command: "flaky-command" };
+
+      for (let i = 0; i < Math.floor(GLOBAL_CIRCUIT_BREAKER_THRESHOLD / 2); i++) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `killed by SIGTERM (attempt ${i})` }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              failureKind: "signal",
+              exitSignal: "SIGTERM",
+            },
+          },
+          i,
+        );
+      }
+      for (
+        let i = Math.floor(GLOBAL_CIRCUIT_BREAKER_THRESHOLD / 2);
+        i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD;
+        i++
+      ) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [{ type: "text", text: `killed by signal 9 (attempt ${i})` }],
+            details: {
+              status: "failed",
+              exitCode: null,
+              failureKind: "signal",
+              exitSignal: 9,
+            },
+          },
+          i,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -14,9 +14,8 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPlainObject } from "../utils.js";
 import { isMessagingToolSendAction } from "./embedded-agent-messaging.js";
 import { stableStringify } from "./stable-stringify.js";
-
+import { hashStableExecFailure } from "./tool-loop-detection-exec-fingerprint.js";
 const log = createSubsystemLogger("agents/loop-detection");
-
 type LoopDetectorKind =
   | "generic_repeat"
   | "unknown_tool_repeat"
@@ -160,89 +159,20 @@ function stringField(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
-function normalizeExitSignal(value: unknown): string | null {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number") {
-    return String(value);
-  }
-  return null;
-}
-
-// #93917 follow-up: broad catch-all exec failures (node-run-failed,
-// runtime-error, approval-denied) carry a null exitCode and null exitSignal, so
-// fingerprinting them by (status, failureKind) alone would collapse genuinely
-// different failures into one no-progress streak. Derive a summary that keeps
-// the stable failure text — including numeric status/error codes, which are
-// semantic, not noise — and strips only per-instance identifiers (gateway ids,
-// uuids, hex handles). Distinct failures stay distinct while repeats of the same
-// failure still accumulate. Only the first line is kept because trailing detail
-// is the noisiest part.
-function normalizeFailureReason(value: unknown): string {
-  const text = nonEmptyStringField(value);
-  if (!text) {
-    return "";
-  }
-  const summary = text.split("\n", 1)[0] ?? "";
-  return summary
-    .replace(/id=\S+/gi, "id=X") // gateway approval ids
-    .replace(/\b[0-9a-f]{8}-[0-9a-f-]{27,}\b/gi, "U") // uuids
-    .replace(/\b0x[0-9a-f]+\b/gi, "H") // hex addresses
-    .replace(/\b(?=[0-9a-f]*[a-f])[0-9a-f]{8,}\b/gi, "H") // hex handles (letters present; bare numeric codes kept)
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, 200);
-}
-
-// #93917: Fingerprint an exec failure by stable discriminators only, excluding
-// output text. Error output often carries volatile noise (timestamps, PIDs,
-// connection-refused-at-${time}) that defeats no-progress detection. Keeping
-// (exitCode, exitSignal, failureKind) distinguishes genuinely different failure
-// modes so they do not merge into one no-progress streak, while `status` keeps a
-// nonzero "completed" exit distinct from a "failed" outcome with the same code.
-function hashStableExecFailure(status: string, details: Record<string, unknown>): string {
-  const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
-  const exitSignal = normalizeExitSignal(details.exitSignal);
-  // A failed outcome with no exit code and no signal (the broad catch-all kinds)
-  // has no structured exit identity, so fall back to the producer's stable
-  // failureReason (the actual error, not the volatile leading stdout), or the
-  // aggregated output when a producer does not set one. Completed nonzero exits
-  // keep the pure exit-fact fingerprint and never reach this branch.
-  const hasStructuredExitIdentity = exitCode !== null || exitSignal !== null;
-  return digestStable({
-    status,
-    exitCode,
-    timedOut: details.timedOut === true,
-    exitSignal,
-    failureKind: stringField(details.failureKind),
-    ...(status === "failed" && !hasStructuredExitIdentity
-      ? { reason: normalizeFailureReason(details.failureReason ?? details.aggregated) }
-      : {}),
-  });
-}
-
 function hashExecToolOutcome(details: Record<string, unknown>, text: string): string | undefined {
   const status = stringField(details.status);
   if (!status) {
     return undefined;
   }
-
   if (status === "running") {
     return digestStable({
       status,
       tail: stringField(details.tail) ?? "",
     });
   }
-
-  if (status === "completed") {
+  if (status === "completed" || status === "failed") {
     const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
-    // #93917: Foreground exec reports ordinary nonzero exits (grep exit 1,
-    // SSH/Docker retries) as "completed", but they are real failures whose stderr
-    // often varies per call. Fingerprint those by stable failure facts, not the
-    // volatile output, so repeated identical failures accumulate a no-progress
-    // streak. Exit 0 keeps output because changing successful output is progress.
-    if (exitCode !== null && exitCode !== 0) {
+    if (status === "failed" || (exitCode !== null && exitCode !== 0)) {
       return hashStableExecFailure(status, details);
     }
     return digestStable({
@@ -252,11 +182,6 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
       output: nonEmptyStringField(details.aggregated) ?? text,
     });
   }
-
-  if (status === "failed") {
-    return hashStableExecFailure(status, details);
-  }
-
   if (status === "approval-pending" || status === "approval-unavailable") {
     return digestStable({
       status,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -72,6 +72,9 @@ type ToolLoopDetectionScope = {
   runId?: string;
 };
 
+const positiveInteger = (value: unknown, fallback: number): number =>
+  typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+
 function selectHistoryForScope(
   history: readonly ToolCallRecord[],
   scope?: ToolLoopDetectionScope,
@@ -81,14 +84,26 @@ function selectHistoryForScope(
 }
 
 function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedLoopDetectionConfig {
+  const defaults = DEFAULT_LOOP_DETECTION_CONFIG;
   return {
-    enabled: config?.enabled ?? DEFAULT_LOOP_DETECTION_CONFIG.enabled,
-    historySize: DEFAULT_LOOP_DETECTION_CONFIG.historySize,
-    warningThreshold: DEFAULT_LOOP_DETECTION_CONFIG.warningThreshold,
-    unknownToolThreshold: DEFAULT_LOOP_DETECTION_CONFIG.unknownToolThreshold,
-    criticalThreshold: DEFAULT_LOOP_DETECTION_CONFIG.criticalThreshold,
-    globalCircuitBreakerThreshold: DEFAULT_LOOP_DETECTION_CONFIG.globalCircuitBreakerThreshold,
-    detectors: DEFAULT_LOOP_DETECTION_CONFIG.detectors,
+    enabled: config?.enabled ?? defaults.enabled,
+    historySize: positiveInteger(config?.historySize, defaults.historySize),
+    warningThreshold: positiveInteger(config?.warningThreshold, defaults.warningThreshold),
+    unknownToolThreshold: positiveInteger(
+      config?.unknownToolThreshold,
+      defaults.unknownToolThreshold,
+    ),
+    criticalThreshold: positiveInteger(config?.criticalThreshold, defaults.criticalThreshold),
+    globalCircuitBreakerThreshold: positiveInteger(
+      config?.globalCircuitBreakerThreshold,
+      defaults.globalCircuitBreakerThreshold,
+    ),
+    detectors: {
+      genericRepeat: config?.detectors?.genericRepeat ?? defaults.detectors.genericRepeat,
+      knownPollNoProgress:
+        config?.detectors?.knownPollNoProgress ?? defaults.detectors.knownPollNoProgress,
+      pingPong: config?.detectors?.pingPong ?? defaults.detectors.pingPong,
+    },
   };
 }
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -170,6 +170,31 @@ function normalizeExitSignal(value: unknown): string | null {
   return null;
 }
 
+// #93917 follow-up: broad catch-all exec failures (node-run-failed,
+// runtime-error, approval-denied) carry a null exitCode and null exitSignal, so
+// fingerprinting them by (status, failureKind) alone would collapse genuinely
+// different failures into one no-progress streak. Derive a summary that keeps
+// the stable failure text — including numeric status/error codes, which are
+// semantic, not noise — and strips only per-instance identifiers (gateway ids,
+// uuids, hex handles). Distinct failures stay distinct while repeats of the same
+// failure still accumulate. Only the first line is kept because trailing detail
+// is the noisiest part.
+function normalizeFailureReason(value: unknown): string {
+  const text = nonEmptyStringField(value);
+  if (!text) {
+    return "";
+  }
+  const summary = text.split("\n", 1)[0] ?? "";
+  return summary
+    .replace(/id=\S+/gi, "id=X") // gateway approval ids
+    .replace(/\b[0-9a-f]{8}-[0-9a-f-]{27,}\b/gi, "U") // uuids
+    .replace(/\b0x[0-9a-f]+\b/gi, "H") // hex addresses
+    .replace(/\b(?=[0-9a-f]*[a-f])[0-9a-f]{8,}\b/gi, "H") // hex handles (letters present; bare numeric codes kept)
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
 // #93917: Fingerprint an exec failure by stable discriminators only, excluding
 // output text. Error output often carries volatile noise (timestamps, PIDs,
 // connection-refused-at-${time}) that defeats no-progress detection. Keeping
@@ -177,12 +202,22 @@ function normalizeExitSignal(value: unknown): string | null {
 // modes so they do not merge into one no-progress streak, while `status` keeps a
 // nonzero "completed" exit distinct from a "failed" outcome with the same code.
 function hashStableExecFailure(status: string, details: Record<string, unknown>): string {
+  const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
+  const exitSignal = normalizeExitSignal(details.exitSignal);
+  // A failed outcome with no exit code and no signal (the broad catch-all kinds)
+  // has no structured identity to tell distinct failures apart, so fall back to
+  // the normalized reason. Completed nonzero exits keep the pure exit-fact
+  // fingerprint and never reach this branch with a null exit code.
+  const hasStructuredExitIdentity = exitCode !== null || exitSignal !== null;
   return digestStable({
     status,
-    exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
+    exitCode,
     timedOut: details.timedOut === true,
-    exitSignal: normalizeExitSignal(details.exitSignal),
+    exitSignal,
     failureKind: stringField(details.failureKind),
+    ...(status === "failed" && !hasStructuredExitIdentity
+      ? { reason: normalizeFailureReason(details.aggregated) }
+      : {}),
   });
 }
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -205,9 +205,10 @@ function hashStableExecFailure(status: string, details: Record<string, unknown>)
   const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
   const exitSignal = normalizeExitSignal(details.exitSignal);
   // A failed outcome with no exit code and no signal (the broad catch-all kinds)
-  // has no structured identity to tell distinct failures apart, so fall back to
-  // the normalized reason. Completed nonzero exits keep the pure exit-fact
-  // fingerprint and never reach this branch with a null exit code.
+  // has no structured exit identity, so fall back to the producer's stable
+  // failureReason (the actual error, not the volatile leading stdout), or the
+  // aggregated output when a producer does not set one. Completed nonzero exits
+  // keep the pure exit-fact fingerprint and never reach this branch.
   const hasStructuredExitIdentity = exitCode !== null || exitSignal !== null;
   return digestStable({
     status,
@@ -216,7 +217,7 @@ function hashStableExecFailure(status: string, details: Record<string, unknown>)
     exitSignal,
     failureKind: stringField(details.failureKind),
     ...(status === "failed" && !hasStructuredExitIdentity
-      ? { reason: normalizeFailureReason(details.aggregated) }
+      ? { reason: normalizeFailureReason(details.failureReason ?? details.aggregated) }
       : {}),
   });
 }

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -160,6 +160,32 @@ function stringField(value: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+function normalizeExitSignal(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return String(value);
+  }
+  return null;
+}
+
+// #93917: Fingerprint an exec failure by stable discriminators only, excluding
+// output text. Error output often carries volatile noise (timestamps, PIDs,
+// connection-refused-at-${time}) that defeats no-progress detection. Keeping
+// (exitCode, exitSignal, failureKind) distinguishes genuinely different failure
+// modes so they do not merge into one no-progress streak, while `status` keeps a
+// nonzero "completed" exit distinct from a "failed" outcome with the same code.
+function hashStableExecFailure(status: string, details: Record<string, unknown>): string {
+  return digestStable({
+    status,
+    exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
+    timedOut: details.timedOut === true,
+    exitSignal: normalizeExitSignal(details.exitSignal),
+    failureKind: stringField(details.failureKind),
+  });
+}
+
 function hashExecToolOutcome(details: Record<string, unknown>, text: string): string | undefined {
   const status = stringField(details.status);
   if (!status) {
@@ -173,13 +199,26 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
     });
   }
 
-  if (status === "completed" || status === "failed") {
+  if (status === "completed") {
+    const exitCode = typeof details.exitCode === "number" ? details.exitCode : null;
+    // #93917: Foreground exec reports ordinary nonzero exits (grep exit 1,
+    // SSH/Docker retries) as "completed", but they are real failures whose stderr
+    // often varies per call. Fingerprint those by stable failure facts, not the
+    // volatile output, so repeated identical failures accumulate a no-progress
+    // streak. Exit 0 keeps output because changing successful output is progress.
+    if (exitCode !== null && exitCode !== 0) {
+      return hashStableExecFailure(status, details);
+    }
     return digestStable({
       status,
-      exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
+      exitCode,
       timedOut: details.timedOut === true,
       output: nonEmptyStringField(details.aggregated) ?? text,
     });
+  }
+
+  if (status === "failed") {
+    return hashStableExecFailure(status, details);
   }
 
   if (status === "approval-pending" || status === "approval-unavailable") {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -160,6 +160,21 @@ export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
 export type ToolLoopDetectionConfig = {
   /** Enable tool-loop protection (default: false). */
   enabled?: boolean;
+  /** Number of identical calls before a warning is emitted. */
+  warningThreshold?: number;
+  /** Number of unavailable-tool repeats before the missing-tool breaker trips. */
+  unknownToolThreshold?: number;
+  /** Number of known no-progress poll repeats before a critical warning is emitted. */
+  criticalThreshold?: number;
+  /** Number of identical no-progress outcomes before the global breaker trips. */
+  globalCircuitBreakerThreshold?: number;
+  /** Maximum number of recent tool calls retained for loop detection. */
+  historySize?: number;
+  detectors?: {
+    genericRepeat?: boolean;
+    knownPollNoProgress?: boolean;
+    pingPong?: boolean;
+  };
 };
 
 export type ToolSearchConfig =


### PR DESCRIPTION
## What Problem This Solves

Repeated failing `exec` calls never tripped the no-progress circuit breaker when their output text varied across calls. This covers both hard failures (command-not-found, timeouts, killed processes) and — the canonical #93917 case — ordinary nonzero exits like `grep` exit 1 or SSH/Docker retries, whose stdout/stderr carries fresh timestamps, PIDs, or session ids each retry while the actual outcome is identical. The stuck agent kept looping forever.

Fixes #93917

## Why This Change Was Made

Foreground `exec` reports an ordinary nonzero exit (e.g. `exit 1`) as `status: "completed"`, not `failed` — only shell 126/127, timeout, signal, and abort become `failed`. The previous fix stripped volatile output only on the `failed` branch, so the most common loop (a command that keeps exiting nonzero with changing output) still hashed its output and never accumulated a streak.

`hashExecToolOutcome` now fingerprints any nonzero outcome by stable facts (`status`, `exitCode`, `timedOut`, `exitSignal`, `failureKind`) and drops the volatile output, whether the result is `completed` with a nonzero code or a hard `failed`. Exit 0 still keeps its output in the hash, because changing output from a successful command is real progress. A shared `hashStableExecFailure` helper backs both branches so the two paths cannot drift.

The foreground producers carry those discriminators end to end (`ExecToolDetails` propagates `failureKind`/`exitSignal`, tightened to `ExecToolFailureKind`), addressing @vincentkoc's earlier finding that they were absent on the real result.

For hard `failed` outcomes that carry no exit code and no signal — the broad catch-all kinds (`node-run-failed`, `runtime-error`, `approval-denied`) — the exec producers now carry the actual failure reason as a structured `failureReason` (the node error / runtime error / gateway denial reason, not the volatile leading stdout). `hashStableExecFailure` fingerprints that `failureReason`, keeping stable text including numeric status/error codes (`500` vs `503`) and stripping only per-instance identifiers (gateway ids, uuids, hex handles). Genuinely different failures — including two node failures with identical leading stdout but different errors — stay distinct instead of collapsing into one no-progress streak, while repeats of the same failure (varying only in a unique id) still accumulate. Outcomes that already carry a real exit code or signal (including the `completed` nonzero path) keep their structured fingerprint and are unaffected.

## User Impact

Stuck agents that loop retrying the same failing `exec` command — including the common `exit 1` / SSH / Docker retry loop — now hit the global circuit breaker after the configured threshold instead of burning tokens forever. Successful commands with changing output stay progress-sensitive, and genuinely different failure modes keep distinct fingerprints.

## Changes

| File | Change |
|------|--------|
| `src/agents/tool-loop-detection.ts` | Split the `completed` branch by exit code: nonzero exits use the stable failure fingerprint; exit 0 keeps output. Extract shared `hashStableExecFailure` for the `completed`-nonzero and `failed` paths. For `failed` outcomes with null exit code and signal, fingerprint the producer's stable `failureReason` (not the volatile stdout first line) so distinct catch-all failures stay distinct |
| `src/agents/bash-tools.exec-types.ts`, `bash-tools.exec-runtime.ts`, `bash-tools.exec.ts`, `bash-tools.exec-host-node-phases.ts`, `bash-tools.exec-host-gateway.ts` | Propagate `failureKind`/`exitSignal` and a stable `failureReason` (the actual node/runtime/gateway error, not stdout) through the real foreground producers |
| `src/agents/tool-loop-detection.exec-foreground.test.ts` | Real-tool regression: repeated nonzero `completed` exec with volatile output trips the breaker; exit-0 volatile output does not. Also drives the production `before_tool_call` hook (`wrapToolWithBeforeToolCallHook`) to prove the wrapped exec is vetoed with `deniedReason:"tool-loop"` |
| `src/agents/tool-loop-detection.test.ts` | Unit coverage for nonzero-completed escalation, failure-kind / exitSignal distinctness, plus distinct catch-all failure reasons (including identical-stdout/different-error and numeric-code cases) staying distinct while volatile-only variation still collapses |
| `docs/tools/loop-detection.md` | Document that any nonzero exit is fingerprinted by stable failure facts; exit 0 stays output-sensitive |

## Evidence

### Live agent run — real DeepSeek model trips the production breaker (exact head)

An embedded agent run at this PR's head (`openclaw agent --local`), driven by a real **DeepSeek** model, was told to keep calling `exec` with the same failing command `sh -c 'date +%s%N; exit 1'`. That command prints a fresh timestamp and exits 1 on every call — the canonical #93917 volatile-output-with-nonzero-exit case. Loop detection was enabled with low thresholds (`criticalThreshold: 3`), and the production circuit breaker fired in the real run and blocked the loop:

```text
$ openclaw agent --local --model deepseek/deepseek-chat \
    --message "call exec with sh -c 'date +%s%N; exit 1' repeatedly, never change it"
[provider-transport-fetch] [model-fetch] response provider=deepseek model=deepseek-chat status=200   (real model turns drive the exec tool)
[agents/loop-detection] Loop warning: exec called 2 times with identical arguments
[agents/loop-detection] Critical generic loop detected: exec repeated 3 times
[agents/tools] Blocking exec due to critical loop: CRITICAL: Called exec with identical arguments and identical outcomes 3 times. Session execution blocked to prevent runaway loops.
[diagnostic] tool loop: sessionKey=agent:main:proof93917-live1 tool=exec level=critical action=block detector=generic_repeat count=3
[agents/agent-command] [agent] run ... ended with stopReason=stop
```

The command's stdout changes every call (a fresh timestamp), yet loop detection records the outcomes as **identical** — the nonzero exit is fingerprinted by stable facts and the volatile output is dropped — so the no-progress streak accumulates and the breaker blocks the call. Before this fix the changing output hashed differently every call, the streak never formed, and the agent would loop forever. Model, provider, real exec child process, and the loop-detection breaker here are all the production path.

### Live proof — the real changed module trips the breaker (before/after)

`nonzero-exit-live-proof.ts` imports the real changed module (`src/agents/tool-loop-detection.ts`) and drives its exported `recordToolCall` / `recordToolCallOutcome` / `detectToolCallLoop` with exec details shaped exactly as the real foreground producer emits for a normal exit (`status:"completed"`, numeric `exitCode`, `exitSignal:null`, aggregated text with the trailing `(Command exited with code N)`). Output is fresh every call — the #93917 volatile-output case. The exit-0 run is also how a nonzero exit behaved **before** this fix (output-sensitive), so it is the pre-fix control.

```text
$ node_modules/.bin/tsx nonzero-exit-live-proof.ts
[agents/loop-detection] Loop warning: exec called 2 times with identical arguments
[agents/loop-detection] Critical generic loop detected: exec repeated 3 times
[agents/loop-detection] Global circuit breaker triggered: exec repeated 4 times with no progress
after  (exit 1, volatile output) -> breaker: {"detector":"global_circuit_breaker","level":"critical","count":4}
[agents/loop-detection] Loop warning: exec called 2 times with identical arguments
[agents/loop-detection] Loop warning: exec called 5 times with identical arguments
before (exit 0, volatile output) -> breaker: null
RESULT: PASS
```

- After fix: repeated nonzero `completed` exec with volatile output trips `global_circuit_breaker` at the threshold.
- Before/control: exit 0 with volatile output stays progress-sensitive — no breaker — proving exit-0 semantics are unchanged.

<details>
<summary>nonzero-exit-live-proof.ts</summary>

```ts
import {
  detectToolCallLoop,
  recordToolCall,
  recordToolCallOutcome,
} from "./src/agents/tool-loop-detection.js";

const LOOP_CONFIG = {
  enabled: true,
  warningThreshold: 2,
  criticalThreshold: 3,
  globalCircuitBreakerThreshold: 4,
} as const;

// Mirror the real foreground exec result for a normal exit.
function completedExecResult(exitCode: number, freshOutput: string) {
  const exitMsg = exitCode !== 0 ? `\n\n(Command exited with code ${exitCode})` : "";
  const aggregated = `${freshOutput}${exitMsg}`;
  return {
    content: [{ type: "text", text: aggregated }],
    details: { status: "completed", exitCode, exitSignal: null, durationMs: 100, aggregated, timedOut: false },
  };
}

function runScenario(label: string, exitCode: number) {
  const params = { command: `run-${label}` };
  const state: { toolCallHistory?: unknown[] } = {};
  let breaker: { detector?: string; level?: string; count?: number } | undefined;
  for (let i = 1; i <= LOOP_CONFIG.globalCircuitBreakerThreshold + 1; i += 1) {
    const callId = `${label}${i}`;
    const result = completedExecResult(exitCode, `line ${i} @ ${label}-${i * 7919}`);
    recordToolCall(state as never, "exec", params, callId, LOOP_CONFIG as never);
    recordToolCallOutcome(state as never, {
      toolName: "exec", toolParams: params, toolCallId: callId, result, config: LOOP_CONFIG as never,
    });
    const detect = detectToolCallLoop(state as never, "exec", params, LOOP_CONFIG as never);
    if (detect.stuck && detect.detector === "global_circuit_breaker") {
      breaker = { detector: detect.detector, level: detect.level, count: detect.count };
      break;
    }
  }
  return breaker;
}

const nonzero = runScenario("nz-exit1", 1);
console.log("after  (exit 1, volatile output) -> breaker:", JSON.stringify(nonzero ?? null));
const zero = runScenario("z0-exit0", 0);
console.log("before (exit 0, volatile output) -> breaker:", JSON.stringify(zero ?? null));
console.log("RESULT:", nonzero?.detector === "global_circuit_breaker" && !zero ? "PASS" : "FAIL");
```

</details>

### Real foreground exec regression (production tool path)

`tool-loop-detection.exec-foreground.test.ts` drives the actual exec tool (`createOpenClawCodingTools` -> `execTool.execute`) against a real child process, then feeds each real result through the production recorders and detector. It proves the nonzero case with a real `exit 1` (a real `status:"completed"`, `exitCode:1` result) tripping the breaker despite fresh output, keeps the exit-0 control below the breaker, and still covers the hard `failed` command-not-found / timeout paths and their distinctness. Two added cases also drive the real `before_tool_call` orchestration hook (`wrapToolWithBeforeToolCallHook`) — the same path a live agent turn runs — and prove the wrapped exec is vetoed with `deniedReason:"tool-loop"` after the repeated volatile nonzero exits, while exit-0 volatile output is never vetoed. The `tool-loop-detection.test.ts` unit suite additionally proves that distinct catch-all failure reasons — including ones differing only by a stable numeric code (`500` vs `503`) — stay distinct, while repeats varying only in a per-instance id still collapse to the breaker.

```text
$ node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/tool-loop-detection.exec-foreground.test.ts
 Test Files  2 passed (2)
      Tests  68 passed (68)
```

AI-assisted: built with Codex
