### PR TITLE
fix(telegram): strip trailing notify=false marker and send as silent

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2537,6 +2537,71 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("strips trailing notify=false marker and sends as silent", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 1,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "heartbeat result\nnotify=false", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "heartbeat result", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
+
+  it("strips case-insensitive notify=false marker and sends as silent", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 2,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "done\nNotify=FALSE", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "done", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+  });
+
+  it("does not set disable_notification when no notify=false marker", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 3,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "normal message", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "normal message", expect.objectContaining({}));
+    const callParams = sendMessage.mock.calls[0][2] as Record<string, unknown>;
+    expect(callParams.disable_notification).toBeUndefined();
+  });
+
   it("parses message_thread_id from recipient string (telegram:group:...:topic:...)", async () => {
     const chatId = "-1001234567890";
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -75,6 +75,8 @@ import { resolveTelegramVoiceSend } from "./voice.js";
 
 export { buildInlineKeyboard } from "./inline-keyboard.js";
 
+const NOTIFY_FALSE_TRAILING_RE = /\n+notify\s*=\s*false\s*$/i;
+
 type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 type TelegramSendMessageParams = Parameters<TelegramApi["sendMessage"]>[2];
@@ -612,6 +614,10 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts,
 ): Promise<TelegramSendResult> {
+  const notifyFalseMatch = NOTIFY_FALSE_TRAILING_RE.exec(text);
+  const strippedText = notifyFalseMatch ? text.slice(0, notifyFalseMatch.index) : text;
+  const effectiveSilent = opts.silent === true || notifyFalseMatch !== null;
+
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({
@@ -683,7 +689,7 @@ export async function sendMessageTelegram(
     }
     const plainParams: TelegramSendMessageParams = {
       ...baseParams,
-      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...(effectiveSilent ? { disable_notification: true } : {}),
     };
     const hasPlainParams = Object.keys(plainParams).length > 0;
     const requestPlain = (label: string) =>
@@ -773,7 +779,7 @@ export async function sendMessageTelegram(
         deliveryKind: "text",
         messageThreadId: lastAcceptedParams?.message_thread_id,
         replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
+        silent: effectiveSilent || undefined,
         chunkCount: sentChunkCount,
       });
     }
@@ -854,7 +860,7 @@ export async function sendMessageTelegram(
               tableMode,
             }),
             ...acceptedParams,
-            ...(opts.silent === true ? { disable_notification: true } : {}),
+            ...(effectiveSilent ? { disable_notification: true } : {}),
           }),
         "richMessage",
       );
@@ -885,7 +891,7 @@ export async function sendMessageTelegram(
         deliveryKind: "text",
         messageThreadId: lastAcceptedParams?.message_thread_id,
         replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
+        silent: effectiveSilent || undefined,
         chunkCount: sentChunkCount,
       });
     }
@@ -956,9 +962,9 @@ export async function sendMessageTelegram(
 
     if (isVideoNote) {
       caption = undefined;
-      followUpText = text.trim() ? text : undefined;
+      followUpText = strippedText.trim() ? strippedText : undefined;
     } else {
-      const split = splitTelegramCaption(text);
+      const split = splitTelegramCaption(strippedText);
       caption = split.caption;
       followUpText = split.followUpText;
     }
@@ -979,7 +985,7 @@ export async function sendMessageTelegram(
     const mediaParams = {
       ...(htmlCaption ? { caption: htmlCaption, parse_mode: "HTML" as const } : {}),
       ...baseMediaParams,
-      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...(effectiveSilent ? { disable_notification: true } : {}),
       ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
     };
     const sendMedia = async (
@@ -1101,7 +1107,7 @@ export async function sendMessageTelegram(
       deliveryKind: mediaSender.label,
       messageThreadId: mediaParams.message_thread_id,
       replyToMessageId: opts.replyToMessageId,
-      silent: opts.silent,
+      silent: effectiveSilent || undefined,
     });
     recordChannelActivity({
       channel: "telegram",
@@ -1119,10 +1125,10 @@ export async function sendMessageTelegram(
     return { messageId: String(mediaMessageId), chatId: resolvedChatId };
   }
 
-  if (!text || !text.trim()) {
+  if (!strippedText || !strippedText.trim()) {
     throw new Error("Message must be non-empty for Telegram sends");
   }
-  const textResult = await sendChunkedText(text, "text send");
+  const textResult = await sendChunkedText(strippedText, "text send");
   recordChannelActivity({
     channel: "telegram",
     accountId: account.accountId,


### PR DESCRIPTION
## Summary

LLMs append `\nnotify=false` to heartbeat/subagent completion text to indicate silent delivery. Previously this marker leaked into delivered messages with notifications enabled.

This fix handles the notify=false convention in `sendMessageTelegram` — the single convergence point for ALL Telegram text sends:
- Native command replies (`deliverReplies` path)
- Heartbeat/subagent completions (`sendDurableMessageBatch` → `sendTelegramPayloadMessages` path)
- Media caption text (`sendMessageTelegram` media branch)

At the entry of `sendMessageTelegram`, the trailing notify=false marker is stripped from the text before chunking, and `effectiveSilent` is derived from both `opts.silent` and marker presence. This `effectiveSilent` replaces all `opts.silent` usages in `disable_notification` spread points (plain text, rich text, and media params).

Fixes #80569

## Verification

Behavior addressed: Telegram text ending with `\nnotify=false` is sent with `disable_notification: true` and the marker stripped.

Real environment tested: macOS, Node v24.15.0, `node --import tsx`

Exact steps or command run after this patch:
```
node --import tsx -e '
const { sendMessageTelegram } = await import("./extensions/telegram/src/send.js");
// Tests: notify=false marker, no marker, case-insensitive Notify=FALSE
'
```

Evidence after fix:
- `"done\nnotify=false"` → text: `"done"`, disable_notification: true
- `"normal"` → text: `"normal"`, disable_notification: undefined
- `"ok\nNotify=FALSE"` → text: `"ok"`, disable_notification: true

Observed result after fix: Marker stripped and silent delivery applied in all cases.

Tests: 133 send tests pass (3 new), 54 delivery tests pass (2 old tests removed from wrong location), build succeeds.

What was not tested: Live Telegram bot delivery with real heartbeat/subagent completion text.