### PR TITLE
fix(gateway.tls): reject empty/whitespace certPath and keyPath

### DIFF
--- a/src/config/zod-schema.tls.test.ts
+++ b/src/config/zod-schema.tls.test.ts
@@ -23,10 +23,25 @@ describe("gateway.tls schema", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("trims whitespace from a valid certPath", () => {
+  it("preserves exact bytes of a non-empty certPath (no silent trim)", () => {
     const res = validateConfigObject({
       gateway: { tls: { enabled: true, certPath: "  /etc/ssl/cert.pem  " } },
     });
     expect(res.ok).toBe(true);
+    if (res.ok) {
+      // Schema must validate without transforming the string; runtime path
+      // resolution owns normalization, so leading/trailing spaces are preserved.
+      expect(res.config.gateway?.tls?.certPath).toBe("  /etc/ssl/cert.pem  ");
+    }
+  });
+
+  it("preserves exact bytes of a non-empty keyPath (no silent trim)", () => {
+    const res = validateConfigObject({
+      gateway: { tls: { enabled: true, keyPath: "  /etc/ssl/private/server.key  " } },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.gateway?.tls?.keyPath).toBe("  /etc/ssl/private/server.key  ");
+    }
   });
 });

--- a/src/config/zod-schema.tls.test.ts
+++ b/src/config/zod-schema.tls.test.ts
@@ -1,0 +1,32 @@
+// Schema-level tests for gateway.tls certPath and keyPath validation.
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./validation.js";
+
+describe("gateway.tls schema", () => {
+  it("rejects empty certPath", () => {
+    const res = validateConfigObject({ gateway: { tls: { enabled: true, certPath: "" } } });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues[0]?.path).toMatch(/certPath/);
+    }
+  });
+
+  it("rejects whitespace-only keyPath", () => {
+    const res = validateConfigObject({ gateway: { tls: { enabled: true, keyPath: "   " } } });
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts a non-empty certPath", () => {
+    const res = validateConfigObject({
+      gateway: { tls: { enabled: true, certPath: "/etc/ssl/cert.pem" } },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("trims whitespace from a valid certPath", () => {
+    const res = validateConfigObject({
+      gateway: { tls: { enabled: true, certPath: "  /etc/ssl/cert.pem  " } },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1123,8 +1123,8 @@ export const OpenClawSchema = z
           .object({
             enabled: z.boolean().optional(),
             autoGenerate: z.boolean().optional(),
-            certPath: z.string().optional(),
-            keyPath: z.string().optional(),
+            certPath: z.string().trim().min(1).optional(),
+            keyPath: z.string().trim().min(1).optional(),
             caPath: z.string().optional(),
           })
           .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1123,8 +1123,18 @@ export const OpenClawSchema = z
           .object({
             enabled: z.boolean().optional(),
             autoGenerate: z.boolean().optional(),
-            certPath: z.string().trim().min(1).optional(),
-            keyPath: z.string().trim().min(1).optional(),
+            // Reject blank values without transforming the string. Trimming here would
+            // silently rewrite a legitimate filesystem path that contains leading or
+            // trailing spaces and persist the trimmed value into validated config;
+            // runtime path resolution (resolveUserPath) owns all normalization.
+            certPath: z
+              .string()
+              .optional()
+              .refine((v) => v === undefined || v.trim().length > 0, "certPath must not be blank"),
+            keyPath: z
+              .string()
+              .optional()
+              .refine((v) => v === undefined || v.trim().length > 0, "keyPath must not be blank"),
             caPath: z.string().optional(),
           })
           .optional(),

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -178,4 +178,18 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.keyPath).toBeTruthy();
     expect(result.keyPath).not.toBe("\t");
   });
+
+  it("does not fall back for non-empty paths with leading/trailing spaces", async () => {
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath: "  /etc/ssl/cert.pem  ",
+      keyPath: "  /etc/ssl/private/server.key  ",
+      autoGenerate: false,
+    });
+
+    // Non-empty paths are passed through verbatim; resolveUserPath owns
+    // normalization (it trims), so they must not fall back to default names.
+    expect(result.certPath).not.toContain("gateway-cert.pem");
+    expect(result.keyPath).not.toContain("gateway-key.pem");
+  });
 });

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -149,4 +149,33 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.keyPath).toBe(keyPath);
     expect(result.error).toContain("gateway tls: failed to load cert");
   });
+
+  it("falls back to default paths when certPath and keyPath are empty strings", async () => {
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath: "",
+      keyPath: "",
+      autoGenerate: false,
+    });
+
+    // Empty paths must not reach downstream — they must be replaced with defaults.
+    expect(result.certPath).toBeTruthy();
+    expect(result.certPath).not.toBe("");
+    expect(result.keyPath).toBeTruthy();
+    expect(result.keyPath).not.toBe("");
+  });
+
+  it("falls back to default paths when certPath and keyPath are whitespace-only", async () => {
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath: "   ",
+      keyPath: "\t",
+      autoGenerate: false,
+    });
+
+    expect(result.certPath).toBeTruthy();
+    expect(result.certPath).not.toBe("   ");
+    expect(result.keyPath).toBeTruthy();
+    expect(result.keyPath).not.toBe("\t");
+  });
 });

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -80,14 +80,18 @@ export async function loadGatewayTlsRuntime(
 
   const autoGenerate = cfg.autoGenerate !== false;
   const baseDir = path.join(CONFIG_DIR, "gateway", "tls");
+  // Only blank/whitespace values fall back to the default. Any non-empty path is
+  // passed through verbatim so resolveUserPath owns all normalization (it trims
+  // and expands ~); trimming here would duplicate it and silently rewrite paths
+  // that contain leading/trailing spaces.
   const certPath = resolveUserPath(
     typeof cfg.certPath === "string" && cfg.certPath.trim()
-      ? cfg.certPath.trim()
+      ? cfg.certPath
       : path.join(baseDir, "gateway-cert.pem"),
   );
   const keyPath = resolveUserPath(
     typeof cfg.keyPath === "string" && cfg.keyPath.trim()
-      ? cfg.keyPath.trim()
+      ? cfg.keyPath
       : path.join(baseDir, "gateway-key.pem"),
   );
   const caPath = cfg.caPath ? resolveUserPath(cfg.caPath) : undefined;

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -62,12 +62,8 @@ async function generateSelfSignedCert(params: {
     "-subj",
     "/CN=openclaw-gateway",
   ]);
-  await fs.chmod(params.keyPath, 0o600).catch((err: unknown) => {
-    throw new Error(`failed to chmod key file ${params.keyPath}: ${String(err)}`);
-  });
-  await fs.chmod(params.certPath, 0o600).catch((err: unknown) => {
-    throw new Error(`failed to chmod cert file ${params.certPath}: ${String(err)}`);
-  });
+  await fs.chmod(params.keyPath, 0o600).catch(() => {});
+  await fs.chmod(params.certPath, 0o600).catch(() => {});
   params.log?.info?.(
     `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
   );

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -62,10 +62,10 @@ async function generateSelfSignedCert(params: {
     "-subj",
     "/CN=openclaw-gateway",
   ]);
-  await fs.chmod(params.keyPath, 0o600).catch((err) => {
+  await fs.chmod(params.keyPath, 0o600).catch((err: unknown) => {
     throw new Error(`failed to chmod key file ${params.keyPath}: ${String(err)}`);
   });
-  await fs.chmod(params.certPath, 0o600).catch((err) => {
+  await fs.chmod(params.certPath, 0o600).catch((err: unknown) => {
     throw new Error(`failed to chmod cert file ${params.certPath}: ${String(err)}`);
   });
   params.log?.info?.(

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -62,8 +62,12 @@ async function generateSelfSignedCert(params: {
     "-subj",
     "/CN=openclaw-gateway",
   ]);
-  await fs.chmod(params.keyPath, 0o600).catch(() => {});
-  await fs.chmod(params.certPath, 0o600).catch(() => {});
+  await fs.chmod(params.keyPath, 0o600).catch((err) => {
+    throw new Error(`failed to chmod key file ${params.keyPath}: ${String(err)}`);
+  });
+  await fs.chmod(params.certPath, 0o600).catch((err) => {
+    throw new Error(`failed to chmod cert file ${params.certPath}: ${String(err)}`);
+  });
   params.log?.info?.(
     `gateway tls: generated self-signed cert at ${shortenHomeInString(params.certPath)}`,
   );
@@ -80,8 +84,16 @@ export async function loadGatewayTlsRuntime(
 
   const autoGenerate = cfg.autoGenerate !== false;
   const baseDir = path.join(CONFIG_DIR, "gateway", "tls");
-  const certPath = resolveUserPath(cfg.certPath ?? path.join(baseDir, "gateway-cert.pem"));
-  const keyPath = resolveUserPath(cfg.keyPath ?? path.join(baseDir, "gateway-key.pem"));
+  const certPath = resolveUserPath(
+    typeof cfg.certPath === "string" && cfg.certPath.trim()
+      ? cfg.certPath.trim()
+      : path.join(baseDir, "gateway-cert.pem"),
+  );
+  const keyPath = resolveUserPath(
+    typeof cfg.keyPath === "string" && cfg.keyPath.trim()
+      ? cfg.keyPath.trim()
+      : path.join(baseDir, "gateway-key.pem"),
+  );
   const caPath = cfg.caPath ? resolveUserPath(cfg.caPath) : undefined;
 
   const hasCert = await pathExists(certPath);


### PR DESCRIPTION
## Summary

`gateway.tls.certPath` and `gateway.tls.keyPath` accepted `""` and whitespace-only strings (`z.string().optional()` with no blank guard), and the runtime fallback `cfg.certPath ?? default` only triggered on `null`/`undefined`, so empty strings reached `generateSelfSignedCert` and produced a cryptic openssl `-out ""` error. Sibling `caPath` already guarded against this via a truthy check.

This PR rejects blank paths and defaults them at runtime — **without trimming non-empty path bytes**. An earlier draft used `z.string().trim().min(1)` plus a runtime `.trim()`, which silently rewrote validated config data and duplicated `resolveUserPath` (which already trims and expands `~` in `resolveHomeRelativePath`); that compatibility risk was flagged as `merge-risk: compatibility` and is resolved here.

Two changes:

1. **Schema** (`src/config/zod-schema.ts`): `certPath`/`keyPath` use `z.string().optional().refine(v => v === undefined || v.trim().length > 0)` — reject blank values, never transform the string. Non-empty paths keep their exact bytes in validated config.
2. **Runtime** (`src/infra/tls/gateway.ts`): blank/whitespace values fall back to the default path; any non-empty value is passed verbatim to `resolveUserPath`, which owns all normalization (trim + `~` expansion). Aligns with the existing `caPath` truthy-check pattern.

## Linked context

N/A (no existing issue)

## Real behavior proof

- **Behavior or issue addressed:** Blank `certPath`/`keyPath` reached openssl with a cryptic error; the earlier `trim()` approach silently rewrote legitimate non-empty filesystem paths (compatibility risk).
- **Real environment tested:** Node 24.14, Linux x86_64, checkout of `openclaw/openclaw` at `c5b952ec1f` on branch `fix/gateway-tls-reject-empty-cert-key-path`.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx /tmp/verify-gateway-tls-paths.mjs
  ```
  Imports `validateConfigObject` and `loadGatewayTlsRuntime` from the patched source; verifies schema rejection, exact-byte preservation, and runtime fallback.
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```
  === schema layer (validateConfigObject) ===
  [PASS] empty certPath rejected -> ok=false
  [PASS] whitespace-only certPath rejected -> ok=false
  [PASS] tab-only keyPath rejected -> ok=false
  [PASS] certPath preserves exact bytes -> got="  /etc/ssl/cert.pem  "
  [PASS] keyPath preserves exact bytes -> got="  /etc/ssl/private/server.key  "

  === runtime layer (loadGatewayTlsRuntime) ===
  [PASS] empty certPath falls back -> certPath=~/.openclaw/gateway/tls/gateway-cert.pem
  [PASS] empty keyPath falls back -> keyPath=~/.openclaw/gateway/tls/gateway-key.pem
  [PASS] whitespace-only certPath falls back -> certPath=~/.openclaw/gateway/tls/gateway-cert.pem
  [PASS] whitespace-only keyPath falls back -> keyPath=~/.openclaw/gateway/tls/gateway-key.pem
  [PASS] spaced non-empty certPath does not fall back -> certPath=/etc/ssl/cert.pem
  [PASS] spaced non-empty keyPath does not fall back -> keyPath=/etc/ssl/private/server.key

  ALL PASS
  ```

  `~/.openclaw` is the resolved CONFIG_DIR. Non-empty paths with surrounding spaces resolve to the trimmed absolute path via `resolveUserPath` (which owns normalization), not the default name.
- **Observed result after fix:** Blank/whitespace `certPath`/`keyPath` reject at the schema and fall back to the default at runtime. Non-empty paths — including ones with leading/trailing spaces — keep exact bytes in validated config and are normalized once by `resolveUserPath`.
- **What was not tested:** End-to-end openssl execution with real certificate generation (covered by the existing `loadGatewayTlsRuntime` tests).

## Tests and validation

```
$ node scripts/run-vitest.mjs src/config/zod-schema.tls.test.ts src/infra/tls/gateway.test.ts
Test Files  2 passed (2)
Tests       12 passed (12)

$ pnpm build
exit 0 (built successfully)
```

## Risk checklist

- [x] User-visible behavior? **Yes** — blank/whitespace `certPath`/`keyPath` reject/default instead of a cryptic openssl error; non-empty paths unchanged (no silent trim).
- [x] Configuration? **Yes** — blank values are now rejected by schema validation. Backwards-compatible: blank paths previously silently broke; non-empty paths (incl. surrounding spaces) behave identically.
- [x] Security? **No**
- [x] Plugins/providers? **No**
- [x] Docs? **No**
- [x] Backwards-compatible? **Yes** — all previously-valid non-empty paths work identically with bytes preserved; only blank values (which previously caused obscure failures) now reject/default.
