### PR TITLE
fix(telegram): replace heading tags with <b> to fix text overlap on macOS desktop

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -208,7 +208,7 @@ describe("markdownToTelegramHtml", () => {
 
   it("preserves Markdown heading levels in rich HTML", () => {
     expect(markdownToTelegramRichHtml("# Title\n\n### Detail")).toBe(
-      "<h1>Title</h1>\n\n<h3>Detail</h3>",
+      "<b>Title</b>\n\n<b>Detail</b>",
     );
   });
 

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -82,12 +82,15 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       code_block: { open: buildTelegramCodeBlockOpen, close: "</code></pre>" },
       spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
       blockquote: { open: "<blockquote>", close: "</blockquote>" },
-      heading_1: { open: "<h1>", close: "</h1>" },
-      heading_2: { open: "<h2>", close: "</h2>" },
-      heading_3: { open: "<h3>", close: "</h3>" },
-      heading_4: { open: "<h4>", close: "</h4>" },
-      heading_5: { open: "<h5>", close: "</h5>" },
-      heading_6: { open: "<h6>", close: "</h6>" },
+      // Use <b> instead of <h1>-<h6> to avoid a Telegram macOS desktop
+      // rendering bug where heading tags cause overlapping text layers
+      // (GitHub issue #93804).
+      heading_1: { open: "<b>", close: "</b>" },
+      heading_2: { open: "<b>", close: "</b>" },
+      heading_3: { open: "<b>", close: "</b>" },
+      heading_4: { open: "<b>", close: "</b>" },
+      heading_5: { open: "<b>", close: "</b>" },
+      heading_6: { open: "<b>", close: "</b>" },
     },
     escapeText: escapeHtml,
     buildLink: buildTelegramLink,


### PR DESCRIPTION
## Summary

Telegram text overlap on macOS desktop caused by heading tags

## Changes

- `extensions/telegram/src/format.ts`: Replace heading tags with <b> tags for consistent rendering across Telegram clients.

## Real behavior proof

Behavior addressed: Telegram messages previously used <h3>/<h4> heading tags that render incorrectly (text overlap) on macOS desktop clients. Replaced with <b> tags for consistent formatting.

Real environment tested: ubuntu-24.04, Node 24, branch fix/issue-93804-telegram-keyboard-overlap.

Exact steps or command run after this patch:
  node scripts/test-projects.mjs extensions/telegram/src/format.test.ts

Evidence after fix:

```
$ node scripts/test-projects.mjs extensions/telegram/src/format.test.ts
 RUN  v4.1.8

 ✓ extensions/telegram/src/format.test.ts (45 tests)

 Test Files  1 passed (1)
      Tests  45 passed (45)
   Duration  1.31s
```

Observed result after fix: All 45 format tests pass, covering tag replacement, edge cases, and message structure preservation. No regressions.

What was not tested: End-to-end with real Telegram Bot token (requires platform-specific setup not available in this environment).

Closes: #93804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
