### PR TITLE
fix(agents): keep lane timeout alive during long tool execution

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1401,6 +1401,13 @@ export async function runEmbeddedPiAgent(
           } else {
             parentAbortSignal?.addEventListener("abort", relayParentAbort, { once: true });
           }
+          // Keep the lane timeout alive during long tool execution (e.g. exec
+          // commands that run 5+ minutes). Without this heartbeat the sliding
+          // lane-task timeout window expires and kills the cron run even though
+          // the configured timeoutSeconds has not been reached.
+          const laneProgressInterval = setInterval(() => {
+            noteLaneTaskProgress();
+          }, 30_000);
           const rawAttempt = await runEmbeddedAttemptWithBackend({
             sessionId: activeSessionId,
             sessionKey: resolvedSessionKey,
@@ -1540,6 +1547,7 @@ export async function runEmbeddedPiAgent(
               throw postCompactionAbortError ?? err;
             })
             .finally(() => {
+              clearInterval(laneProgressInterval);
               parentAbortSignal?.removeEventListener?.("abort", relayParentAbort);
               if (postCompactionAbortController === attemptAbortController) {
                 postCompactionAbortController = undefined;


### PR DESCRIPTION
Superseded by upstream refactor in bb46b79d3c (refactor: internalize OpenClaw agent runtime #85341). The new embedded-agent-runner/run.ts has a more sophisticated lane progress heartbeat mechanism (startLaneProgressHeartbeat/stopLaneProgressHeartbeat with EMBEDDED_RUN_LANE_HEARTBEAT_MS).