### PR TITLE
fix(agent-runner): suppress stale tool-failed warning when Discord reply delivered via message tool

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -504,7 +504,7 @@ export function buildEmbeddedRunPayloads(params: {
                 : []
         ).filter((text) => !shouldSuppressRawErrorText(text));
 
-  let hasUserFacingAssistantReply = hasSourceReplyPayload;
+  let hasUserFacingAssistantReply = hasSourceReplyPayload || deliveredSourceReplyViaMessageTool;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);
   let hasUserFacingFailureAcknowledgement = false;
   for (const text of answerTexts) {


### PR DESCRIPTION
## Summary

- Discord source-channel turns that deliver the visible reply via `message(action=send)` can still append a stale tool-failed warning after the successful user-visible response
- The fix includes `deliveredSourceReplyViaMessageTool` in the `hasUserFacingAssistantReply` gate so that once a Discord reply has been delivered via the message tool, the turn is treated as having a user-facing assistant reply and stale tool-failure warnings are suppressed

## Real behavior proof

**Behavior addressed**: When `deliveredSourceReplyViaMessageTool` is true, the source reply was already delivered via a `message_tool_only` block, so agent-facing error warnings about failed tool calls should not be surfaced to the user.

**Real setup tested**:
- **Runtime**: node

**Exact steps or command run after fix**:

```bash
npx vitest run src/agents/embedded-agent-runner/run/payloads.test.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts
```

**After-fix evidence**:

```
Test Files  2 passed (2)
     Tests  90 passed (90)
```

All existing tests pass without modification. The fix adds `deliveredSourceReplyViaMessageTool` to the `hasUserFacingAssistantReply` condition at `payloads.ts:507`.

**Observed result after the fix**: `hasUserFacingAssistantReply` is now `true` when either `hasSourceReplyPayload` is set OR `deliveredSourceReplyViaMessageTool` is true, which matches the semantic intent — a reply was delivered to the user, so stale tool-failure warnings should be suppressed.

**What was not tested**: End-to-end Discord integration test (requires Discord bot credentials). The unit test suite covers the payload builder logic.

## Risk checklist

Did user-visible behavior change? (`Yes`)
- Discord source-channel turns that successfully deliver via message tool no longer show a misleading tool-failed warning after the successful reply

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- Very low — only affects the `hasUserFacingAssistantReply` boolean condition in payload building

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- CI pipeline verification

Which bot or reviewer comments were addressed?
- N/A (new PR)