### PR TITLE
fix(agents): classify generic "LLM request failed." as transient time…

### DIFF
--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -7,6 +7,7 @@ import {
   isOverloadedErrorMessage,
   isRateLimitErrorMessage,
   isServerErrorMessage,
+  isTimeoutErrorMessage,
 } from "./failover-matches.js";
 
 describe("Z.ai vendor error codes (#48988)", () => {
@@ -175,5 +176,37 @@ describe("server error status classification", () => {
 
   it("does not classify prefixed plain internal server error status prose", () => {
     expect(isServerErrorMessage("Proxy notice: Status: Internal Server Error")).toBe(false);
+  });
+});
+
+describe("generic assistant error text classification (#93931)", () => {
+  it("classifies the generic 'LLM request failed.' as a timeout (transient)", () => {
+    // The generic error text wraps provider availability failures (model not
+    // loaded, endpoint unreachable) that should engage retry/fallback.
+    expect(classifyFailoverReason("LLM request failed.")).toBe("timeout");
+  });
+
+  it("classifies lowercase 'llm request failed.' as a timeout", () => {
+    expect(classifyFailoverReason("llm request failed.")).toBe("timeout");
+  });
+
+  it("does NOT match 'LLM request failed:' variants as timeout via this pattern", () => {
+    // Variants with specific reasons should be classified by their own patterns,
+    // not by the generic LLM request failed match. The schema rejection variant
+    // is a format error, not a transient timeout.
+    expect(
+      isTimeoutErrorMessage(
+        "LLM request failed: provider rejected the request schema or tool payload.",
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match 'LLM request failed: connection refused' as timeout via this exact-match pattern", () => {
+    // The connection-refused variant is a sanitized user-facing string, not
+    // the raw error that cron/failover classifiers see. The exact-match regex
+    // /^llm request failed\.$/i should NOT match it because of the colon suffix.
+    expect(
+      isTimeoutErrorMessage("LLM request failed: connection refused by the provider endpoint."),
+    ).toBe(false);
   });
 });

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -184,6 +184,18 @@ const ERROR_PATTERNS = {
     // the configured fallback chain runs instead of surfacing the error.
     /^request failed$/i,
     /\brequest failed after repeated internal retries\b/i,
+    // The generic assistant error text "LLM request failed." is produced by
+    // formatUserFacingAssistantErrorText when the underlying provider error
+    // cannot be formatted into a specific category. For local providers (LM
+    // Studio, Ollama) this wraps connection/availability failures when the
+    // model is not loaded or the endpoint is unreachable. Without this match,
+    // cron retry and payload.fallbacks never engage because the error is not
+    // classified as any transient type (#93931).
+    // Use a strict exact-match regex so variants like
+    // "LLM request failed: provider rejected the request schema or tool payload."
+    // (a format/schema error, not transient) are NOT caught here — they
+    // fall through to their own pattern classifications.
+    /^llm request failed\.$/i,
   ],
   billing: [
     /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment/i,


### PR DESCRIPTION
## Summary

- `"LLM request failed."` (GENERIC_ASSISTANT_ERROR_TEXT) was not classified as any transient error type — `classifyFailoverReason` returned `null`, so `resolveCronExecutionRetryHint` returned `{ retryable: false }` and `payload.fallbacks` never engaged.
- Local providers (LM Studio, Ollama) produce this generic error when the model is not loaded or the endpoint is unreachable. Users who configured fallback chains expecting resilience got silent job failures instead.
- Fix: add `/^llm request failed\.$/i` as an exact-match regex in the timeout error patterns. Only the bare `"LLM request failed."` string matches; variants like `"LLM request failed: provider rejected the request schema or tool payload."` are not caught (they are format errors, not transient).
- Out of scope: no change to `"LLM request failed:"` variant classification, no change to cron `TRANSIENT_PATTERNS` regexes, no change to `formatUserFacingAssistantErrorText`.

## Change Type

- [x] Bug fix / [ ] Feature / [ ] Refactor / [ ] Docs / [ ] Security / [ ] Chore

## Scope

- [ ] Gateway / [ ] Skills / [ ] Auth / [ ] Memory / [x] Agents / [ ] Integrations / [ ] API / [ ] UI/UX / [ ] CI

## Linked context

Closes #93931

Thanks @hyphae-bot for the detailed root-cause analysis and production evidence.

## Real behavior proof

**Behavior addressed:** The generic assistant error text `LLM request failed.` now correctly classifies as a transient `timeout` error, enabling cron retry and `payload.fallbacks` to engage — previously `classifyFailoverReason` returned `null`, preventing any fallback or retry attempt.

**Environment tested:** Node 22.x on Linux (NewStartOS), tsx loader for production function verification.

**Steps run after the patch:** Called the actual patched `classifyFailoverReason` function from source via `node --import tsx`:

```bash
node --import tsx --no-warnings -e "
import { classifyFailoverReason } from './src/agents/embedded-agent-helpers/errors.js';
console.log('LLM request failed. ->', classifyFailoverReason('LLM request failed.'));
console.log('llm request failed. ->', classifyFailoverReason('llm request failed.'));
console.log('LLM request failed: provider rejected the request schema or tool payload. ->', classifyFailoverReason('LLM request failed: provider rejected the request schema or tool payload.'));
"
```

**Evidence after fix:**

```text
LLM request failed. -> timeout
llm request failed. -> timeout
LLM request failed: provider rejected the request schema or tool payload. -> null
```

Before the patch, `LLM request failed.` returned `null` (no transient classification):

```text
LLM request failed. -> null
```

**Observed result after the fix:** The generic `LLM request failed.` error now correctly classifies as `timeout` (transient), enabling `resolveCronExecutionRetryHint` to return `{ retryable: true, category: "timeout" }` when the `classifiedReason` is `timeout`. This allows cron retry and `payload.fallbacks` to engage for local provider availability failures. The `LLM request failed: provider rejected the request schema or tool payload.` variant remains unclassified by this pattern, preserving correct behavior for schema/format errors.

**Not tested:** Live gateway cron job execution with an actual LM Studio model-not-loaded failure; running the full vitest suite (native rolldown binding unavailable on this machine).

## Root Cause

- Root cause: `GENERIC_ASSISTANT_ERROR_TEXT = "LLM request failed."` did not match any pattern in `ERROR_PATTERNS.timeout` (or any other transient category) in `failover-matches.ts`. The classification chain in `classifyFailoverClassificationFromMessage` exhausted all pattern groups without a match and returned `null`.
- Missing detection/guardrail: no pattern existed for the exact generic assistant error wrapper string. The `timeout` pattern list had `/^request failed$/i` for a similar bare-string case (Cloudflare 502), but the `LLM`-prefixed variant was absent.

## Regression Test Plan

- Target test file: `src/agents/embedded-agent-helpers/failover-matches.test.ts`
- Scenario: verify that `classifyFailoverReason("LLM request failed.")` returns `"timeout"` and that `classifyFailoverReason("LLM request failed: provider rejected the request schema or tool payload.")` does NOT return `"timeout"`.
- Why this is the smallest reliable guardrail: the exact-match regex `/^llm request failed\.$/i` prevents false positives on variant strings — if the regex were a substring match instead, the schema rejection variant would be incorrectly classified as transient, causing unnecessary fallback attempts on permanent format errors.

## User-visible / Behavior Changes

Cron jobs with `payload.fallbacks` will now engage fallback models when the primary fails with `LLM request failed.` instead of failing outright with `fallbackUsed: false`. This is the intended fix — users who configured fallback chains for resilience will now see them work for local provider availability failures.

## Diagram

```text
Before: LLM request failed. -> classifyFailoverReason -> null -> resolveCronExecutionRetryHint -> retryable: false -> fallback skipped -> job fails
After:  LLM request failed. -> classifyFailoverReason -> timeout -> resolveCronExecutionRetryHint -> retryable: true -> fallback engages -> fallback model runs
```

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No
