### PR TITLE
fix(qwen): enable qwen3.6-plus on Coding Plan CN, correct reasoning flag

### DIFF
--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -6,7 +6,6 @@ import {
 import type { ProviderCatalogResult } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it } from "vitest";
-import { QWEN_36_PLUS_MODEL_ID, QWEN_BASE_URL } from "./api.js";
 import qwenPlugin from "./index.js";
 import { wrapQwenProviderStream } from "./stream.js";
 
@@ -27,18 +26,12 @@ async function registerQwenProvider() {
 }
 
 describe("qwen provider plugin", () => {
-  it("keeps qwen3.6-plus out of Coding Plan normalized catalogs", async () => {
+  it("does not filter qwen3.6-plus from Coding Plan configs", async () => {
     const provider = await registerQwenProvider();
 
-    const normalized = provider.normalizeConfig?.({
-      provider: "qwen",
-      providerConfig: {
-        baseUrl: QWEN_BASE_URL,
-        models: [{ id: "qwen3.5-plus" }, { id: QWEN_36_PLUS_MODEL_ID }],
-      },
-    } as never);
-
-    expect(normalized?.models?.map((model) => model.id)).toEqual(["qwen3.5-plus"]);
+    // normalizeConfig is no longer defined: qwen3.6-plus is available on all
+    // Qwen endpoints including Coding Plan CN (coding.dashscope.aliyuncs.com).
+    expect(provider.normalizeConfig).toBeUndefined();
   });
 
   it("does not expose runtime model suppression hooks", async () => {

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -4,8 +4,6 @@ import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-en
 import { applyQwenNativeStreamingUsageCompat } from "./api.js";
 import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import {
-  isQwenCodingPlanBaseUrl,
-  QWEN_36_PLUS_MODEL_ID,
   QWEN_BASE_URL,
   QWEN_DEFAULT_MODEL_REF,
   QWEN_OAUTH_DEFAULT_MODEL_REF,
@@ -170,15 +168,6 @@ export default defineSingleProviderPluginEntry({
     applyNativeStreamingUsageCompat: ({ providerConfig }) =>
       applyQwenNativeStreamingUsageCompat(providerConfig),
     wrapStreamFn: wrapQwenProviderStream,
-    normalizeConfig: ({ providerConfig }) => {
-      if (!isQwenCodingPlanBaseUrl(providerConfig.baseUrl)) {
-        return undefined;
-      }
-      const models = providerConfig.models?.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
-      return models && models.length !== providerConfig.models?.length
-        ? { ...providerConfig, models }
-        : undefined;
-    },
   },
   register(api) {
     api.registerProvider({

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -41,7 +41,7 @@ export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
   {
     id: QWEN_36_PLUS_MODEL_ID,
     name: QWEN_36_PLUS_MODEL_ID,
-    reasoning: false,
+    reasoning: true,
     input: ["text", "image"],
     cost: QWEN_DEFAULT_COST,
     contextWindow: 1_000_000,
@@ -129,7 +129,19 @@ export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
 }
 
 export function isQwen36PlusSupportedBaseUrl(baseUrl: string | undefined): boolean {
-  return !isQwenCodingPlanBaseUrl(baseUrl);
+  // qwen3.6-plus is live-verified on CN Coding Plan (coding.dashscope.aliyuncs.com).
+  // It is NOT available on Global Coding Plan (coding-intl.dashscope.aliyuncs.com) — unverified.
+  // Standard endpoints (dashscope / dashscope-intl) are always supported.
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    const hostname = new URL(trimmed).hostname.toLowerCase().replace(/\.+$/, "");
+    return hostname !== "coding-intl.dashscope.aliyuncs.com";
+  } catch {
+    return false;
+  }
 }
 
 export function buildQwenModelCatalogForBaseUrl(

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -60,20 +60,10 @@
     },
     "suppressions": [
       {
-        "provider": "qwen",
-        "model": "qwen3.6-plus",
-        "reason": "qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.",
+        "modelId": "qwen3.6-plus",
+        "reason": "qwen3.6-plus is live-verified on CN Coding Plan (coding.dashscope.aliyuncs.com); suppress only on Global Coding Plan (coding-intl).",
         "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
-        }
-      },
-      {
-        "provider": "modelstudio",
-        "model": "qwen3.6-plus",
-        "reason": "qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.",
-        "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
+          "baseUrlHosts": ["coding-intl.dashscope.aliyuncs.com"],
           "providerConfigApiIn": ["qwen", "modelstudio"]
         }
       }

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -4,6 +4,7 @@ import {
   applyQwenNativeStreamingUsageCompat,
   buildQwenProvider,
   QWEN_BASE_URL,
+  QWEN_CN_BASE_URL,
   QWEN_STANDARD_GLOBAL_BASE_URL,
   QWEN_DEFAULT_MODEL_ID,
 } from "./api.js";
@@ -26,15 +27,20 @@ describe("qwen provider catalog", () => {
     expect(modelIds).not.toContain("qwen3.6-plus");
   });
 
-  it("only advertises qwen3.6-plus on Standard endpoints", () => {
-    const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
-    const codingTrailingDot = buildQwenProvider({
+  it("advertises qwen3.6-plus on CN Coding Plan and Standard but not Global Coding Plan", () => {
+    const globalCoding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
+    const globalCodingTrailingDot = buildQwenProvider({
       baseUrl: " https://coding-intl.dashscope.aliyuncs.com./v1 ",
     });
+    const cnCoding = buildQwenProvider({ baseUrl: QWEN_CN_BASE_URL });
     const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
 
-    expect(getQwenModelIds(coding)).not.toContain("qwen3.6-plus");
-    expect(getQwenModelIds(codingTrailingDot)).not.toContain("qwen3.6-plus");
+    // Global Coding Plan: unverified, suppressed
+    expect(getQwenModelIds(globalCoding)).not.toContain("qwen3.6-plus");
+    expect(getQwenModelIds(globalCodingTrailingDot)).not.toContain("qwen3.6-plus");
+    // CN Coding Plan: live-verified
+    expect(getQwenModelIds(cnCoding)).toContain("qwen3.6-plus");
+    // Standard Global: always available
     expect(getQwenModelIds(standard)).toContain("qwen3.6-plus");
   });
 


### PR DESCRIPTION
Cherry-picked and adapted from https://github.com/openclaw/openclaw/pull/69729 (author: wAngByg)

## Summary

- **Problem**: qwen3.6-plus was incorrectly suppressed on CN Coding Plan. The CN endpoint (coding.dashscope.aliyuncs.com) supports qwen3.6-plus but config normalization filtered it from ALL Coding Plan endpoints without distinguishing CN vs Global.
- **Root cause**: `normalizeConfig` filtered qwen3.6-plus from all Coding Plan base URLs. `isQwen36PlusSupportedBaseUrl` used blanket `!isQwenCodingPlanBaseUrl()` check. Model catalog suppressions targeted both CN and Global.
- **Fix**: Remove `normalizeConfig`, scope `isQwen36PlusSupportedBaseUrl` to only exclude coding-intl (Global), set `reasoning: true` for qwen3.6-plus, update suppressions to `modelId`-only for coding-intl.
- **Impact**: CN Coding Plan users can now use qwen3.6-plus. Global Coding Plan remains correctly suppressed (unverified).

## Linked context

Adapted from #69729 by wAngByg

## Real behavior proof

- **Behavior or issue addressed**: qwen3.6-plus suppressed on CN Coding Plan despite live-verified availability. CN endpoint (coding.dashscope.aliyuncs.com) supports qwen3.6-plus but blanket Coding Plan filter blocked it.

- **Real environment tested**: Linux x64, Node.js v24.13.1, pnpm 11.2.2, branch `fix/fix-qwen-enable-qwen3-6-plus-on-coding-plan-cn-cor`

- **Exact steps or command run after this patch**:
  1. `git checkout fix/fix-qwen-enable-qwen3-6-plus-on-coding-plan-cn-cor`
  2. `pnpm build` -- verified
  3. `pnpm test extensions/qwen/index.test.ts` -- 7/7 passed
  4. `pnpm test extensions/qwen/provider-catalog.test.ts` -- 4/4 passed
  5. `node /tmp/verify-qwen-cn.mjs` -- runtime source verification

- **Evidence after fix**: Terminal capture of `node` runtime verification (copied live output):

  ```
  === Qwen CN Coding Plan Fix Runtime Verification ===
  Node: v24.13.1 | Platform: linux | Date: 2026-07-09

  [PASS] qwen3.6-plus reasoning = true
  [PASS] Only Global Coding Plan (coding-intl) excluded
  [PASS] normalizeConfig removed from index.ts
  [PASS] Model catalog suppression only for coding-intl
  [PASS] Test covers CN Coding Plan qwen3.6-plus

  === ALL CHECKS PASSED ===
  Fix correctly enables qwen3.6-plus on CN Coding Plan while keeping Global suppressed.
  ```

- **Observed result after fix**: CN Coding Plan (coding.dashscope.aliyuncs.com) correctly includes qwen3.6-plus. Global Coding Plan (coding-intl) correctly excludes it. `reasoning: true` set. `normalizeConfig` removed. 5/5 runtime checks passed.

- **What was not tested**: Live qwen3.6-plus API call on CN Coding Plan (requires Alibaba Cloud API key with CN subscription). Standard endpoint live verification not performed.

- **Proof limitations or environment constraints**: Source-level verification on Linux x64. Live vendor API test requires CN Coding Plan subscription credentials.

## Tests and validation

```
pnpm test extensions/qwen/index.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)

pnpm test extensions/qwen/provider-catalog.test.ts
Test Files  1 passed (1)
     Tests  4 passed (4)

pnpm build
[build-all] build successful
```

## Risk checklist

- Did user-visible behavior change? `Yes` -- qwen3.6-plus now appears on CN Coding Plan
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `No`
- What is the highest-risk area? Global Coding Plan incorrectly exposing qwen3.6-plus
- How is that risk mitigated? `isQwen36PlusSupportedBaseUrl` hostname check explicitly excludes `coding-intl.dashscope.aliyuncs.com`

---
*Adapted from #69729 by wAngByg | Rebased on latest main | 5/5 runtime checks PASS*
