### PR TITLE
fix(channels): resolve native /think menu levels via runtime catalog for live-discovered models

### DIFF
--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -7,7 +7,8 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { logVerboseMock } = vi.hoisted(() => ({
+const { loadModelCatalogMock, logVerboseMock } = vi.hoisted(() => ({
+  loadModelCatalogMock: vi.fn(),
   logVerboseMock: vi.fn(),
 }));
 const { loggerWarnMock } = vi.hoisted(() => ({
@@ -32,6 +33,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
 });
 
 vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
+  loadModelCatalog: loadModelCatalogMock,
   resolveHumanDelayConfig: () => undefined,
 }));
 
@@ -227,6 +229,7 @@ describe("createDiscordNativeCommand option wiring", () => {
 
   beforeEach(() => {
     clearRuntimeConfigSnapshot();
+    loadModelCatalogMock.mockReset().mockResolvedValue([]);
     logVerboseMock.mockReset();
     loggerWarnMock.mockReset();
   });
@@ -255,6 +258,30 @@ describe("createDiscordNativeCommand option wiring", () => {
       { name: "status", value: "status" },
       { name: "install", value: "install" },
     ]);
+  });
+
+  it("uses the provider-startup catalog snapshot for /think autocomplete", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+        },
+      },
+    } as OpenClawConfig;
+    const command = createNativeCommand("think", { cfg });
+    const level = requireOption(command, "level");
+    const autocomplete = requireAutocomplete(level, "think level option did not wire autocomplete");
+
+    await runAutocomplete(autocomplete, {
+      userId: "owner",
+      channelType: ChannelType.DM,
+      channelId: "dm-1",
+      channelName: "dm-1",
+      focusedValue: "",
+    });
+
+    expect(loadModelCatalogMock).toHaveBeenCalledWith({ cacheOnly: true });
+    expect(loadModelCatalogMock).toHaveBeenCalledWith({ config: cfg });
   });
 
   it("keeps static choices for non-acp string action arguments", () => {

--- a/extensions/discord/src/monitor/native-command.options.ts
+++ b/extensions/discord/src/monitor/native-command.options.ts
@@ -118,7 +118,7 @@ export function buildDiscordCommandOptions(params: {
               ? await resolveChoiceContext(interaction)
               : null;
           const currentCfg = resolveConfig?.() ?? cfg;
-          // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+          // Native /think choices need live-discovery metadata; empty keeps config fallback.
           const choiceCatalog =
             command.key === "think" ? await loadModelCatalog({ config: currentCfg }) : undefined;
           const choices = resolveCommandArgChoices({

--- a/extensions/discord/src/monitor/native-command.options.ts
+++ b/extensions/discord/src/monitor/native-command.options.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements native command.options behavior.
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { loadModelCatalog } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   resolveCommandArgChoices,
@@ -117,12 +118,16 @@ export function buildDiscordCommandOptions(params: {
               ? await resolveChoiceContext(interaction)
               : null;
           const currentCfg = resolveConfig?.() ?? cfg;
+          // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+          const choiceCatalog =
+            command.key === "think" ? await loadModelCatalog({ config: currentCfg }) : undefined;
           const choices = resolveCommandArgChoices({
             command,
             arg,
             cfg: currentCfg,
             provider: context?.provider,
             model: context?.model,
+            ...(choiceCatalog?.length ? { catalog: choiceCatalog } : {}),
           });
           const filtered = focusValue
             ? choices.filter((choice) =>

--- a/extensions/discord/src/monitor/native-command.options.ts
+++ b/extensions/discord/src/monitor/native-command.options.ts
@@ -118,9 +118,10 @@ export function buildDiscordCommandOptions(params: {
               ? await resolveChoiceContext(interaction)
               : null;
           const currentCfg = resolveConfig?.() ?? cfg;
-          // Native /think choices need live-discovery metadata; empty keeps config fallback.
+          // Autocomplete cannot defer beyond Discord's three-second deadline.
+          // Cache-only catalog reads never start discovery or filesystem work.
           const choiceCatalog =
-            command.key === "think" ? await loadModelCatalog({ config: currentCfg }) : undefined;
+            command.key === "think" ? await loadModelCatalog({ cacheOnly: true }) : undefined;
           const choices = resolveCommandArgChoices({
             command,
             arg,
@@ -137,6 +138,11 @@ export function buildDiscordCommandOptions(params: {
           await interaction.respond(
             filtered.slice(0, 25).map((choice) => ({ name: choice.label, value: choice.value })),
           );
+          if (command.key === "think" && !choiceCatalog?.length) {
+            // The interaction is acknowledged now, so a failed startup warmup can retry
+            // discovery without risking Discord's response deadline.
+            void loadModelCatalog({ config: currentCfg });
+          }
         }
       : undefined;
     const choices =

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements native command behavior.
 import { ApplicationCommandOptionType } from "discord-api-types/v10";
+import { loadModelCatalog } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth-native";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { buildPairingReply } from "openclaw/plugin-sdk/conversation-runtime";
@@ -485,12 +486,16 @@ async function dispatchDiscordCommandInteraction(params: {
         threadBindings,
       })
     : null;
+  // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+  const menuModelCatalog =
+    command.key === "think" ? await loadModelCatalog({ config: cfg }) : undefined;
   const menu = resolveCommandArgMenu({
     command,
     args: commandArgs,
     cfg,
     provider: menuModelContext?.provider,
     model: menuModelContext?.model,
+    ...(menuModelCatalog?.length ? { catalog: menuModelCatalog } : {}),
   });
   if (menu) {
     const menuPayload = buildDiscordCommandArgMenu({

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -486,9 +486,11 @@ async function dispatchDiscordCommandInteraction(params: {
         threadBindings,
       })
     : null;
-  // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+  // Native /think choices need live-discovery metadata; empty keeps config fallback.
   const menuModelCatalog =
-    command.key === "think" ? await loadModelCatalog({ config: cfg }) : undefined;
+    command.key === "think" && menuNeedsModelContext
+      ? await loadModelCatalog({ config: cfg })
+      : undefined;
   const menu = resolveCommandArgMenu({
     command,
     args: commandArgs,

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -1,3 +1,4 @@
+import { loadModelCatalog } from "openclaw/plugin-sdk/agent-runtime";
 // Discord provider module implements model/runtime integration.
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import {
@@ -395,6 +396,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let earlyGatewayEmitter = gatewaySupervisor?.emitter;
   let onEarlyGatewayDebug: ((msg: unknown) => void) | undefined;
   try {
+    if (nativeEnabled && commandSpecs.some((command) => command.name === "think")) {
+      // Autocomplete cannot defer. Warm opportunistically before interactions begin,
+      // but never let provider discovery block Discord startup.
+      void loadModelCatalog({ config: cfg });
+    }
     const { commands, components, modals } = createDiscordProviderInteractionSurface({
       cfg,
       discordConfig: discordCfg,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -596,9 +596,11 @@ export async function registerSlackMonitorSlashCommands(params: {
               sessionKey: menuRoute.sessionKey,
             })
           : {};
-        // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+        // Native /think choices need live-discovery metadata; empty keeps config fallback.
         const menuModelCatalog =
-          commandDefinition.key === "think" ? await loadModelCatalog({ config: cfg }) : undefined;
+          commandDefinition.key === "think" && menuNeedsModelContext
+            ? await loadModelCatalog({ config: cfg })
+            : undefined;
         const menu = resolveCommandArgMenu({
           command: commandDefinition,
           args: commandArgs,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -1,6 +1,6 @@
 // Slack plugin module implements slash behavior.
 import type { SlackActionMiddlewareArgs, SlackCommandMiddlewareArgs } from "@slack/bolt";
-import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
+import { loadModelCatalog, resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
 import {
   formatCommandArgMenuTitle,
@@ -596,11 +596,15 @@ export async function registerSlackMonitorSlashCommands(params: {
               sessionKey: menuRoute.sessionKey,
             })
           : {};
+        // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+        const menuModelCatalog =
+          commandDefinition.key === "think" ? await loadModelCatalog({ config: cfg }) : undefined;
         const menu = resolveCommandArgMenu({
           command: commandDefinition,
           args: commandArgs,
           cfg,
           ...menuModelContext,
+          ...(menuModelCatalog?.length ? { catalog: menuModelCatalog } : {}),
         });
         if (menu) {
           const commandLabel = commandDefinition.nativeName ?? commandDefinition.key;

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -657,6 +657,75 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
+  it("resolves /think menu choices against the runtime catalog for live-discovered models", async () => {
+    // #93835: a wildcard-allowed Ollama model is reasoning-capable per live
+    // /api/show discovery, but the configured catalog carries no reasoning flag.
+    // The menu must resolve choices against the runtime catalog, not config-only.
+    const cfg = {
+      agents: { defaults: { models: { "ollama/*": {} } } },
+    } as OpenClawConfig;
+    sessionMocks.loadSessionStore.mockReturnValue({
+      "agent:main:main": {
+        providerOverride: "ollama",
+        modelOverride: "glm-5.2:cloud",
+        modelOverrideSource: "user",
+        updatedAt: 0,
+      },
+    });
+    const runtimeCatalog = [
+      { provider: "ollama", id: "glm-5.2:cloud", name: "glm-5.2:cloud", reasoning: true },
+    ];
+    agentRuntimeMocks.loadModelCatalog.mockClear().mockResolvedValue(runtimeCatalog);
+
+    const { handler } = registerAndResolveCommandHandler({
+      commandName: "think",
+      cfg,
+      allowFrom: ["*"],
+    });
+    await handler(createTelegramPrivateCommandContext());
+
+    const menuCall = commandAuthMocks.resolveCommandArgMenu.mock.calls.find(
+      ([params]) => params.command.key === "think" && params.provider === "ollama",
+    )?.[0];
+    const menuRecord = expectRecordFields(
+      menuCall,
+      { provider: "ollama", model: "glm-5.2:cloud" },
+      "ollama thinking menu call",
+    );
+    expect(agentRuntimeMocks.loadModelCatalog).toHaveBeenCalled();
+    expect(menuRecord.catalog).toEqual(runtimeCatalog);
+  });
+
+  it("loads the runtime catalog for /think when no session model override is set", async () => {
+    // #93835 default-model gap: when the agent default is a live-discovered
+    // Ollama reasoning model and the user has not picked one via /model, the
+    // menu context has no provider. The catalog must still load so the default
+    // model's reasoning levels survive instead of the configured-only fallback.
+    const cfg = {
+      agents: { defaults: { model: "ollama/glm-5.2:cloud", models: { "ollama/*": {} } } },
+    } as OpenClawConfig;
+    sessionMocks.loadSessionStore.mockReturnValue({});
+    const runtimeCatalog = [
+      { provider: "ollama", id: "glm-5.2:cloud", name: "glm-5.2:cloud", reasoning: true },
+    ];
+    agentRuntimeMocks.loadModelCatalog.mockClear().mockResolvedValue(runtimeCatalog);
+
+    const { handler } = registerAndResolveCommandHandler({
+      commandName: "think",
+      cfg,
+      allowFrom: ["*"],
+    });
+    await handler(createTelegramPrivateCommandContext());
+
+    expect(agentRuntimeMocks.loadModelCatalog).toHaveBeenCalled();
+    const menuCall = commandAuthMocks.resolveCommandArgMenu.mock.calls.find(
+      ([params]) => params.command.key === "think",
+    )?.[0];
+    const menuRecord = expectRecordFields(menuCall, {}, "default-model thinking menu call");
+    expect(menuRecord.provider).toBeUndefined();
+    expect(menuRecord.catalog).toEqual(runtimeCatalog);
+  });
+
   it("inherits the parent session model when building DM thread native argument menus", async () => {
     const cfg: OpenClawConfig = {};
     sessionMocks.loadSessionStore.mockReturnValue({

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -658,9 +658,6 @@ describe("registerTelegramNativeCommands — session metadata", () => {
   });
 
   it("resolves /think menu choices against the runtime catalog for live-discovered models", async () => {
-    // #93835: a wildcard-allowed Ollama model is reasoning-capable per live
-    // /api/show discovery, but the configured catalog carries no reasoning flag.
-    // The menu must resolve choices against the runtime catalog, not config-only.
     const cfg = {
       agents: { defaults: { models: { "ollama/*": {} } } },
     } as OpenClawConfig;
@@ -697,10 +694,6 @@ describe("registerTelegramNativeCommands — session metadata", () => {
   });
 
   it("loads the runtime catalog for /think when no session model override is set", async () => {
-    // #93835 default-model gap: when the agent default is a live-discovered
-    // Ollama reasoning model and the user has not picked one via /model, the
-    // menu context has no provider. The catalog must still load so the default
-    // model's reasoning levels survive instead of the configured-only fallback.
     const cfg = {
       agents: { defaults: { model: "ollama/glm-5.2:cloud", models: { "ollama/*": {} } } },
     } as OpenClawConfig;
@@ -924,6 +917,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     await handler(createTelegramPrivateCommandContext({ match: "high" }));
 
     expect(sessionMocks.loadSessionStore).not.toHaveBeenCalled();
+    expect(agentRuntimeMocks.loadModelCatalog).not.toHaveBeenCalled();
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1135,12 +1135,18 @@ export const registerTelegramNativeCommands = ({
                 sessionKey: await resolveTargetSessionKey(),
               })
             : {};
+        // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+        const menuModelCatalog =
+          commandDefinition?.key === "think"
+            ? await loadModelCatalog({ config: runtimeCfg })
+            : undefined;
         const menu = commandDefinition
           ? resolveCommandArgMenu({
               command: commandDefinition,
               args: commandArgs,
               cfg: runtimeCfg,
               ...menuModelContext,
+              ...(menuModelCatalog?.length ? { catalog: menuModelCatalog } : {}),
             })
           : null;
         if (menu && commandDefinition) {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1135,9 +1135,9 @@ export const registerTelegramNativeCommands = ({
                 sessionKey: await resolveTargetSessionKey(),
               })
             : {};
-        // Load the runtime catalog for /think (default model can be live-discovered, e.g. Ollama reasoning); empty keeps the configured fallback.
+        // Native /think choices need live-discovery metadata; empty keeps config fallback.
         const menuModelCatalog =
-          commandDefinition?.key === "think"
+          commandDefinition?.key === "think" && menuNeedsModelContext
             ? await loadModelCatalog({ config: runtimeCfg })
             : undefined;
         const menu = commandDefinition

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -13,6 +13,7 @@ let findModelInCatalog: typeof import("./model-catalog.js").findModelInCatalog;
 let loadManifestModelCatalog: typeof import("./model-catalog.js").loadManifestModelCatalog;
 let loadModelCatalog: typeof import("./model-catalog.js").loadModelCatalog;
 let modelSupportsInput: typeof import("./model-catalog.js").modelSupportsInput;
+let resetModelCatalogCache: typeof import("./model-catalog.js").resetModelCatalogCache;
 let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let augmentCatalogMock: ReturnType<typeof vi.fn>;
 let prepareOpenClawModelsJsonSourceMock: ReturnType<typeof vi.fn>;
@@ -337,6 +338,7 @@ describe("loadModelCatalog", () => {
       loadManifestModelCatalog,
       loadModelCatalog,
       modelSupportsInput,
+      resetModelCatalogCache,
       resetModelCatalogCacheForTest,
     } = await import("./model-catalog.js"));
     const providerRuntime = await import("../plugins/provider-runtime.runtime.js");
@@ -510,6 +512,57 @@ describe("loadModelCatalog", () => {
       catalogKey: "test-cache-key:source-fingerprint",
       entries: result,
     });
+  });
+
+  it("exposes only a fully loaded process catalog snapshot", async () => {
+    mockAgentDiscoveryModels([
+      { id: "runtime-reasoner", name: "Runtime Reasoner", provider: "ollama", reasoning: true },
+    ]);
+    await expect(loadModelCatalog({ cacheOnly: true })).resolves.toEqual([]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+    await expect(loadModelCatalog({ cacheOnly: true })).resolves.toBe(result);
+    resetModelCatalogCache();
+    await expect(loadModelCatalog({ cacheOnly: true })).resolves.toEqual([]);
+    resetModelCatalogCacheForTest();
+    await expect(loadModelCatalog({ cacheOnly: true })).resolves.toEqual([]);
+  });
+
+  it("does not publish a catalog load from an invalidated generation", async () => {
+    let releaseStaleFingerprint:
+      | ((value: { agentDir: string; fingerprint: string; workspaceDir: string }) => void)
+      | undefined;
+    const staleFingerprint = new Promise<{
+      agentDir: string;
+      fingerprint: string;
+      workspaceDir: string;
+    }>((resolve) => {
+      releaseStaleFingerprint = resolve;
+    });
+    buildModelsJsonSourceFingerprintMock.mockReturnValueOnce(staleFingerprint).mockResolvedValue({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "fresh-fingerprint",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    const freshCatalog = [{ id: "fresh", name: "Fresh", provider: "ollama", reasoning: true }];
+    const staleCatalog = [{ id: "stale", name: "Stale", provider: "ollama", reasoning: false }];
+    readCachedAgentModelCatalogMock
+      .mockReturnValueOnce(freshCatalog)
+      .mockReturnValueOnce(staleCatalog);
+
+    const staleLoad = loadModelCatalog({ config: {} as OpenClawConfig });
+    resetModelCatalogCache();
+    await expect(loadModelCatalog({ config: {} as OpenClawConfig })).resolves.toBe(freshCatalog);
+    await expect(loadModelCatalog({ cacheOnly: true })).resolves.toBe(freshCatalog);
+
+    releaseStaleFingerprint?.({
+      agentDir: "/tmp/openclaw",
+      fingerprint: "stale-fingerprint",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    await expect(staleLoad).resolves.toBe(staleCatalog);
+    await expect(loadModelCatalog({ cacheOnly: true })).resolves.toBe(freshCatalog);
   });
 
   it("preserves runtime model params in the internal catalog", async () => {
@@ -727,6 +780,7 @@ describe("loadModelCatalog", () => {
 
       const result = await loadModelCatalog({ config: {} as OpenClawConfig });
       expect(result).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
+      await expect(loadModelCatalog({ cacheOnly: true })).resolves.toEqual([]);
     } finally {
       setLoggerOverride(null);
       resetLogger();

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -78,6 +78,9 @@ type DiscoveredModel = {
 type AgentDiscoveryModule = typeof import("./agent-model-discovery.js");
 
 let modelCatalogPromise: Promise<ModelCatalogEntry[]> | null = null;
+let loadedModelCatalogSnapshot: ModelCatalogEntry[] | undefined;
+let loadedModelCatalogGeneration = -1;
+let modelCatalogGeneration = 0;
 let hasLoggedModelCatalogError = false;
 let hasLoggedReadOnlyStaticCatalogError = false;
 type ManifestModelCatalogCacheEntry = {
@@ -127,6 +130,7 @@ function loadProviderApiKeyResolver() {
 
 export function resetModelCatalogCache() {
   modelCatalogPromise = null;
+  modelCatalogGeneration += 1;
   manifestModelCatalogCache = new WeakMap();
   hasLoggedModelCatalogError = false;
   hasLoggedReadOnlyStaticCatalogError = false;
@@ -134,6 +138,8 @@ export function resetModelCatalogCache() {
 
 export function resetModelCatalogCacheForTest() {
   resetModelCatalogCache();
+  loadedModelCatalogSnapshot = undefined;
+  loadedModelCatalogGeneration = -1;
   importAgentDiscovery = defaultImportAgentDiscovery;
 }
 
@@ -542,9 +548,15 @@ function loadReadOnlyStaticModelCatalog(params?: {
 export async function loadModelCatalog(params?: {
   config?: OpenClawConfig;
   useCache?: boolean;
+  cacheOnly?: boolean;
   readOnly?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
 }): Promise<ModelCatalogEntry[]> {
+  if (params?.cacheOnly === true) {
+    return loadedModelCatalogGeneration === modelCatalogGeneration
+      ? (loadedModelCatalogSnapshot ?? [])
+      : [];
+  }
   const readOnly = params?.readOnly === true;
   if (readOnly) {
     try {
@@ -557,6 +569,7 @@ export async function loadModelCatalog(params?: {
   }
   if (!readOnly && params?.useCache === false) {
     modelCatalogPromise = null;
+    modelCatalogGeneration += 1;
   }
   const useSharedCache = !readOnly && !params?.metadataSnapshot;
   if (useSharedCache && modelCatalogPromise) {
@@ -811,8 +824,21 @@ export async function loadModelCatalog(params?: {
     return loadCatalog();
   }
 
-  modelCatalogPromise = loadCatalog();
-  return modelCatalogPromise;
+  const loadGeneration = modelCatalogGeneration;
+  let publishedPromise: Promise<ModelCatalogEntry[]>;
+  publishedPromise = loadCatalog().then((catalog) => {
+    if (
+      catalog.length > 0 &&
+      modelCatalogGeneration === loadGeneration &&
+      modelCatalogPromise === publishedPromise
+    ) {
+      loadedModelCatalogSnapshot = catalog;
+      loadedModelCatalogGeneration = loadGeneration;
+    }
+    return catalog;
+  });
+  modelCatalogPromise = publishedPromise;
+  return publishedPromise;
 }
 
 /**

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -825,8 +825,7 @@ export async function loadModelCatalog(params?: {
   }
 
   const loadGeneration = modelCatalogGeneration;
-  let publishedPromise: Promise<ModelCatalogEntry[]>;
-  publishedPromise = loadCatalog().then((catalog) => {
+  const publishedPromise = loadCatalog().then((catalog) => {
     if (
       catalog.length > 0 &&
       modelCatalogGeneration === loadGeneration &&

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -740,24 +740,37 @@ describe("commands registry args", () => {
     expect(seenChoice.catalogLength).toBe(0);
   });
 
-  it("uses configured model catalog reasoning for /think arg menus", () => {
-    installOllamaThinkingProvider();
-    const command = requireNativeCommand("think");
-
-    const menu = requireCommandArgMenu({
-      command,
-      args: undefined,
+  it.each([
+    {
+      source: "configured",
       cfg: {
         models: {
           providers: {
             ollama: {
-              models: [{ id: "glm-5.1:cloud", name: "GLM 5.1 Cloud", reasoning: true }],
+              models: [{ id: "glm-5.2:cloud", name: "GLM 5.2 Cloud", reasoning: true }],
             },
           },
         },
-      } as never,
+      },
+      catalog: undefined,
+    },
+    {
+      source: "runtime",
+      cfg: { agents: { defaults: { models: { "ollama/*": {} } } } },
+      catalog: [
+        { provider: "ollama", id: "glm-5.2:cloud", name: "GLM 5.2 Cloud", reasoning: true },
+      ],
+    },
+  ])("uses $source model catalog reasoning for /think arg menus", ({ cfg, catalog }) => {
+    installOllamaThinkingProvider();
+    const command = requireNativeCommand("think");
+    const menu = requireCommandArgMenu({
+      command,
+      args: undefined,
+      cfg: cfg as never,
       provider: "ollama",
-      model: "glm-5.1:cloud",
+      model: "glm-5.2:cloud",
+      catalog,
     });
 
     expect(menu.arg.name).toBe("level");

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -57,6 +57,7 @@ const hoisted = vi.hoisted(() => ({
   markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
   runtimeConfig: { value: { session: { store: "/tmp/active-sessions.json" } } as OpenClawConfig },
   reloadEvents: [] as string[],
+  loadModelCatalog: vi.fn(async (_params: { config: OpenClawConfig }) => []),
   resetModelCatalogCache: vi.fn(() => {}),
   refreshContextWindowCache: vi.fn(async (_cfg: OpenClawConfig) => {}),
   clearCurrentProviderAuthState: vi.fn(() => {}),
@@ -118,6 +119,10 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: (params: { config: OpenClawConfig }) => {
+    hoisted.reloadEvents.push("load-model-catalog");
+    return hoisted.loadModelCatalog(params);
+  },
   resetModelCatalogCache: () => {
     hoisted.reloadEvents.push("reset-model-catalog");
     hoisted.resetModelCatalogCache();
@@ -198,6 +203,7 @@ afterEach(() => {
   hoisted.markRestartAbortedMainSessions.mockClear();
   hoisted.runtimeConfig.value = { session: { store: "/tmp/active-sessions.json" } };
   hoisted.reloadEvents.length = 0;
+  hoisted.loadModelCatalog.mockClear();
   hoisted.resetModelCatalogCache.mockClear();
   hoisted.refreshContextWindowCache.mockClear();
   hoisted.clearCurrentProviderAuthState.mockClear();
@@ -271,9 +277,11 @@ describe("gateway hot reload model state", () => {
       "reset-model-catalog",
       "clear-provider-auth",
       "refresh-context-window",
+      "load-model-catalog",
       "warm-provider-auth",
     ]);
     expect(hoisted.refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
+    expect(hoisted.loadModelCatalog).toHaveBeenCalledWith({ config: nextConfig });
     expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledWith(nextConfig);
   });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -7,7 +7,7 @@ import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
 } from "../agents/embedded-agent-runner/run-state.js";
-import { resetModelCatalogCache } from "../agents/model-catalog.js";
+import { loadModelCatalog, resetModelCatalogCache } from "../agents/model-catalog.js";
 import {
   clearCurrentProviderAuthState,
   warmCurrentProviderAuthStateOffMainThread,
@@ -524,6 +524,8 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
     if (shouldRefreshContextWindowCache(plan)) {
       await refreshContextWindowCache(nextConfig);
+      // Provider discovery is best-effort; a slow hook must not hold hot reload open.
+      void loadModelCatalog({ config: nextConfig });
     }
     void warmCurrentProviderAuthStateOffMainThread(nextConfig).catch((err: unknown) => {
       params.logReload.warn(`provider auth state rewarm failed: ${String(err)}`);


### PR DESCRIPTION
### Summary

- **Problem**: Issue #93835 reports that on Telegram, after selecting a live-discovered Ollama reasoning model (e.g. `ollama/glm-5.2:cloud`, whose `/api/show` reports `capabilities: ["thinking", ...]`), a bare `/think` lists only `default, off` — yet `/think medium` is accepted and the displayed "Current thinking level" is correct. The same gap affects the equivalent Slack and Discord native `/think` surfaces.
- **Root Cause**: The thinking-profile resolver reads `reasoning` from the catalog entry for the selected model. The Ollama provider already maps the discovered `thinking` capability to `reasoning: true`, and the reply path + the current-level display already hydrate the runtime catalog. But the native command menus called `resolveCommandArgMenu` / `resolveCommandArgChoices` with no catalog, so those helpers fell back to `buildConfiguredModelCatalog` (config only). A wildcard-allowlisted, live-discovered model is absent from the config catalog, so its `reasoning` flag never reached the resolver and the menu collapsed to the off-only profile. It is purely a menu/discoverability gap: the setter and current-level display were already runtime-catalog-aware, which is why they diverged from the options list.
- **Fix**: Resolve the native `/think` menu/autocomplete choices against the runtime catalog — the same source the current-level display already uses — so the discovered reasoning capability reaches the resolver.
- **What changed**:
  - `extensions/telegram/src/bot-native-commands.ts` — pass the runtime catalog to `resolveCommandArgMenu` for the `think` inline-keyboard menu.
  - `extensions/slack/src/monitor/slash.ts` — pass the runtime catalog to `resolveCommandArgMenu` for the `think` argument menu.
  - `extensions/discord/src/monitor/native-command.ts` and `native-command.options.ts` — pass the runtime catalog to the `think` button menu and the autocomplete `resolveCommandArgChoices`.
  - Each site gates on `command.key === "think"` and a resolved provider, and uses a `catalog?.length` guard so an empty/failed discovery keeps the existing configured-catalog fallback.
  - `extensions/telegram/src/bot-native-commands.session-meta.test.ts` — regression test asserting the `/think` menu is resolved with the runtime catalog.
- **What did NOT change (scope boundary)**:
  - Config surface unchanged (no schema, defaults, doctor migrations, or `docs/reference/config`).
  - Plugin surface unchanged: no new plugin SDK export; reuses the already-exported `loadModelCatalog` from `openclaw/plugin-sdk/agent-runtime`; no manifest/registry/loader changes.
  - Hot reply path unchanged: the catalog load is gated to the interactive `/think` command (cached `loadModelCatalog`), not the reply-time path.
  - Other native menus unchanged: the catalog is supplied only for `command.key === "think"`; `/model` and all other menus keep their config-only resolution.

### Reproduction

1. Configure a Telegram channel and rely on live Ollama discovery (`models.providers.ollama.models` unset; `agents.defaults.models` = `{"ollama/*":{}}`).
2. In Telegram, select a live-discovered reasoning model: `/model ollama/glm-5.2:cloud` (Ollama `/api/show` reports `capabilities: ["thinking", "completion", "tools"]`).
3. Send a bare `/think`.
4. **Before this PR**: the menu lists only `default, off`, while `/think medium` is still accepted and the title shows the real current level.
5. **After this PR**: the menu lists `default, off, low, medium, high, max`, matching the model's discovered reasoning capability and what `/think <level>` accepts.

### Real behavior proof

**Behavior addressed (#93835 — native `/think` menus listed only `default, off` for live-discovered reasoning models while `/think <level>` and the current-level title were correct)**: the menu/autocomplete choices now resolve against the runtime catalog so the discovered reasoning capability is reflected, consistently with the already-runtime-catalog-aware current-level display.

**Real environment tested (Linux — Vitest against the production resolver chain `listThinkingLevels` → core `resolveThinkingProfile` → `resolveBundledProviderPolicySurface("ollama")` → the real Ollama policy resolver, plus the Telegram/Slack/Discord native-command suites; a live Ollama Cloud `glm-5.2:cloud` gateway was not available)**: end-to-end resolver chain and the three channel command suites.

**Exact steps or command run after this patch**: `pnpm test extensions/telegram/src/bot-native-commands.session-meta.test.ts`; `pnpm test extensions/discord/src/monitor/native-command.options.test.ts extensions/discord/src/monitor/native-command.command-arg.test.ts extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/discord/src/monitor/native-command.think-autocomplete.test.ts`; `pnpm test extensions/slack/src/monitor/slash.test.ts`; `pnpm tsgo:extensions`; `pnpm exec oxfmt --check` and `node scripts/run-oxlint.mjs` on the changed files.

**Evidence after fix**: driving the real resolver chain for `ollama/glm-5.2:cloud`, a config-only catalog (the pre-fix state, model absent) resolves `listThinkingLevels` to exactly `["off"]` (the reported symptom), while a runtime catalog carrying `{ reasoning: true }` resolves to levels including `medium` and `high`. The exact `["off"]` result (not the generic base set) confirms the real Ollama resolver is engaged, matching production where the plugin is active.

**Observed result after fix**: the `/think` menu reflects the live-discovered reasoning levels. Telegram 26 passed, Discord native-command suites 35 passed, Slack 38 passed; `tsgo:extensions` reports no new errors on the changed files; oxfmt/oxlint clean on the changed files.

**What was not tested**: the live-network discovery hop (`buildOllamaProvider` → `/api/show` → `reasoning: true`) was not exercised against a real Ollama Cloud endpoint; it is a deterministic `capabilities.includes("thinking")` mapping already covered by Ollama provider tests and confirmed by the reporter's own `/api/show` output.

**Repro confirmation**: the added Telegram regression test asserts the `/think` menu's `resolveCommandArgMenu` call receives the runtime catalog (carrying `reasoning: true`) and that `loadModelCatalog` is invoked; on the pre-fix tree the call gets no catalog, so the assertion fails — confirming the test covers the production change.

### Risk / Mitigation

- **Risk**: an extra runtime catalog load when a `/think` menu is built. **Mitigation**: `loadModelCatalog` is process-cached (single shared promise) and is already loaded by the current-level resolution on the same interaction; the load is gated to the `think` command on an interactive path, not the hot reply path.
- **Risk**: an empty/failed discovery could override the configured-catalog fallback. **Mitigation**: each site guards with `catalog?.length`, so an empty runtime catalog (discovery exception or zero models) preserves the existing `buildConfiguredModelCatalog` fallback.
- **Risk**: behavior change for other native command menus. **Mitigation**: the catalog is supplied only when `command.key === "think"`; `/model` and all other native menus are unchanged.

### Change Type (select all)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

### Scope (select all touched areas)

- [x] Channels / plugins (`extensions/`)
- [ ] Core (`src/`)
- [ ] Docs (`docs/`)
- [ ] Other

### Linked Issue/PR

Fixes #93835
