### PR TITLE
fix(agents): exclude volatile output from failed exec hash so critica…

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -667,7 +667,39 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps changing empty-output exec failures below the global no-progress breaker", () => {
+    it("blocks repeated failed exec calls despite varying output text (#93917)", () => {
+      const state = createState();
+      const params = { command: "docker exec alist /opt/alist/alist admin set admin123" };
+
+      for (let index = 0; index < CRITICAL_THRESHOLD; index += 1) {
+        recordSuccessfulCall(
+          state,
+          "exec",
+          params,
+          {
+            content: [
+              { type: "text", text: `Connection refused at ${Date.now() + index}` },
+            ],
+            details: {
+              status: "failed",
+              exitCode: 1,
+              durationMs: 100 + index,
+              aggregated: `ssh: connect to host 172.17.0.2 port 22: Connection refused (${index})`,
+            },
+          },
+          index,
+        );
+      }
+
+      const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+      }
+    });
+
+    it("blocks varying-output failed exec calls at the global circuit breaker (#93917)", () => {
       const state = createState();
       const params = { command: "openclaw flaky-helper" };
 
@@ -692,8 +724,8 @@ describe("tool-loop-detection", () => {
       const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
-        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -210,12 +210,26 @@ function hashExecToolOutcome(details: Record<string, unknown>, text: string): st
     });
   }
 
-  if (status === "completed" || status === "failed") {
+  if (status === "completed") {
     return digestStable({
       status,
       exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
       timedOut: details.timedOut === true,
       output: nonEmptyStringField(details.aggregated) ?? text,
+    });
+  }
+
+  if (status === "failed") {
+    // Failed exec calls often produce output that varies between invocations
+    // (timestamps, connection state, etc.), which breaks noProgressStreak
+    // hashing and prevents the critical/circuit-breaker thresholds from ever
+    // firing.  Only hash the stable failure signals — status, exitCode, and
+    // timedOut — so repeated identical failures accumulate a streak regardless
+    // of volatile output text (#93917).
+    return digestStable({
+      status,
+      exitCode: typeof details.exitCode === "number" ? details.exitCode : null,
+      timedOut: details.timedOut === true,
     });
   }
 


### PR DESCRIPTION
Closing as duplicate per ClawSweeper review. The canonical fix is at #93964 which has the same touched-file diff.

@clawsweeper — closing this duplicate branch; the fix should continue in the canonical PR.