### PR TITLE
feat(commands): switch gemini default model to gemini-3-flash-preview

### DIFF
--- a/extensions/google/onboard.ts
+++ b/extensions/google/onboard.ts
@@ -4,7 +4,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
 
-export const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
+export const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3-flash-preview";
 const RETIRED_GOOGLE_GEMINI_MODEL_REFS = new Set([
   "gemini-3-pro",
   "gemini-3-pro-preview",


### PR DESCRIPTION
## Summary

Switches the default Gemini model used during Google provider onboarding from `google/gemini-3.1-pro-preview` to `google/gemini-3-flash-preview`.

- Single-line change to `GOOGLE_GEMINI_DEFAULT_MODEL` in `extensions/google/onboard.ts`.
- This constant feeds the Google `gemini-api-key` auth method's `defaultModel` and `applyConfig` hook (`extensions/google/provider-registration.ts:56-58`), so onboarding/configuring the Google provider now selects the Flash preview as the agent default model primary.
- `gemini-3-flash-preview` is a real catalogued model (`extensions/google/provider-catalog.ts:57`) and is not in `RETIRED_GOOGLE_GEMINI_MODEL_REFS`, so it is not normalized away.
- Only the onboarding *default* changes; existing configs that pin a model are unaffected.

## Real behavior proof

**Behavior addressed:** New Google (Gemini API key) onboardings should select `google/gemini-3-flash-preview` as the agent default model instead of `google/gemini-3.1-pro-preview`.

**Real environment tested:** macOS (Darwin 25.5.0), Node 22, built CLI from this branch run against an isolated `OPENCLAW_HOME` sandbox (no mocks, no test harness).

**Exact steps or command run after this patch:**
```
$ OPENCLAW_HOME=/tmp/oc-proof-home node openclaw.mjs onboard \
    --non-interactive --accept-risk \
    --auth-choice gemini-api-key --gemini-api-key <redacted> \
    --skip-daemon --skip-channels --skip-ui --skip-health --skip-search --skip-skills --skip-hooks
$ jq '.agents.defaults.model' $OPENCLAW_HOME/.openclaw/openclaw.json
```

**Evidence after fix (live CLI output):**
```
Updated config: $OPENCLAW_HOME/.openclaw/openclaw.json
Workspace OK: $OPENCLAW_HOME/.openclaw/workspace
Sessions OK: $OPENCLAW_HOME/.openclaw/agents/main/sessions

$ jq '.agents.defaults.model' $OPENCLAW_HOME/.openclaw/openclaw.json
{
  "primary": "google/gemini-3-flash-preview"
}
```

**Observed result after fix:** The onboarding flow wrote `agents.defaults.model.primary = "google/gemini-3-flash-preview"` to the generated `openclaw.json`, confirming the new default is applied end-to-end through the real CLI. A throwaway/dummy API key was used; it was not persisted to the config file.

**What was not tested:** No live Gemini API call was made (key was a dummy; `--skip-health`). Vertex onboarding and interactive (prompted) onboarding were not exercised — the changed constant is shared by both paths but only the non-interactive Gemini-API-key path was run.

## CI note

`checks-node-core-fast` is failing on `test/scripts/plugin-sdk-surface-report.test.ts` ("deprecated export budget", `expected 1 to be +0`). This is **pre-existing on `main`** and unrelated to this one-line model-default change: the same test fails identically on a clean checkout of the PR base commit, and this PR touches no plugin-SDK export surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
