### PR TITLE
fix(memory-lancedb): stop forwarding embedding dimensions upstream

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2440,10 +2440,322 @@ describe("memory plugin e2e", () => {
     }
   });
 
-  test("passes configured dimensions to OpenAI embeddings API", async () => {
+  test("sends OpenAI embedding dimensions upstream when accepted", async () => {
+    const embedding = Array.from({ length: 4 }, (_, index) => index + 1);
     const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
+      data: [{ embedding }],
     }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: memoryPluginWithMockedEmbeddings } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+            dimensions: 4,
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      memoryPluginWithMockedEmbeddings.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      if (!recallTool) {
+        throw new Error("memory_recall tool was not registered");
+      }
+      await recallTool.execute("test-call-dims", { query: "hello dimensions" });
+
+      expect(loadLanceDbModule).toHaveBeenCalledTimes(1);
+      expect(ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
+      expect(ensureGlobalUndiciEnvProxyDispatcher.mock.invocationCallOrder[0]).toBeLessThan(
+        embeddingsCreate.mock.invocationCallOrder[0],
+      );
+      expect(embeddingsCreate).toHaveBeenCalledWith({
+        model: "text-embedding-3-small",
+        input: "hello dimensions",
+        dimensions: 4,
+      });
+      expect(vectorSearch).toHaveBeenCalledWith([1, 2, 3, 4]);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("retries without OpenAI embedding dimensions and truncates locally when rejected", async () => {
+    const embedding = Array.from({ length: 8 }, (_, index) => index + 1);
+    const embeddingsCreate = vi.fn(async (body: unknown) => {
+      const request = body as Record<string, unknown>;
+      if (request.dimensions === 4) {
+        throw new Error("400 Extra inputs are not permitted: body.dimensions");
+      }
+      return {
+        data: [{ embedding }],
+      };
+    });
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: memoryPluginWithRejectedDimensions } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+            dimensions: 4,
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      memoryPluginWithRejectedDimensions.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      if (!recallTool) {
+        throw new Error("memory_recall tool was not registered");
+      }
+      await recallTool.execute("test-call-dims", { query: "hello dimensions" });
+
+      expect(loadLanceDbModule).toHaveBeenCalledTimes(1);
+      expect(ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledTimes(2);
+      expect(embeddingsCreate).toHaveBeenNthCalledWith(1, {
+        model: "text-embedding-3-small",
+        input: "hello dimensions",
+        dimensions: 4,
+      });
+      expect(embeddingsCreate).toHaveBeenNthCalledWith(2, {
+        model: "text-embedding-3-small",
+        input: "hello dimensions",
+      });
+      // Should search with the truncated vector [1, 2, 3, 4]
+      expect(vectorSearch).toHaveBeenCalledWith([1, 2, 3, 4]);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("retries without dimensions when provider rejects with tuple-style extra_forbidden error", async () => {
+    const embedding = Array.from({ length: 8 }, (_, index) => index + 1);
+    const embeddingsCreate = vi.fn(async (body: unknown) => {
+      const request = body as Record<string, unknown>;
+      if (request.dimensions === 4) {
+        throw new Error(
+          "422 Unprocessable Entity: [{'type': 'extra_forbidden', 'loc': ('body', 'dimensions'), 'msg': 'Extra inputs are not permitted'}]",
+        );
+      }
+      return {
+        data: [{ embedding }],
+      };
+    });
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: memoryPluginWithRejectedDimensions } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+            dimensions: 4,
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      memoryPluginWithRejectedDimensions.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      if (!recallTool) {
+        throw new Error("memory_recall tool was not registered");
+      }
+      await recallTool.execute("test-call-dims", { query: "hello dimensions tuple" });
+
+      expect(loadLanceDbModule).toHaveBeenCalledTimes(1);
+      expect(ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledTimes(2);
+      expect(embeddingsCreate).toHaveBeenNthCalledWith(1, {
+        model: "text-embedding-3-small",
+        input: "hello dimensions tuple",
+        dimensions: 4,
+      });
+      expect(embeddingsCreate).toHaveBeenNthCalledWith(2, {
+        model: "text-embedding-3-small",
+        input: "hello dimensions tuple",
+      });
+      // Should search with the truncated vector [1, 2, 3, 4]
+      expect(vectorSearch).toHaveBeenCalledWith([1, 2, 3, 4]);
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("returns unavailable when fallback embedding is shorter than the configured dimensions", async () => {
+    const embeddingsCreate = vi.fn(async (body: unknown) => {
+      const request = body as Record<string, unknown>;
+      if (request.dimensions === 4) {
+        throw new Error("400 Extra inputs are not permitted: body.dimensions");
+      }
+      return {
+        data: [{ embedding: [0.1, 0.2, 0.3] }],
+      };
+    });
     const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
@@ -2478,6 +2790,12 @@ describe("memory plugin e2e", () => {
     try {
       const { default: memoryPluginItem } = await import("./index.js");
       const registeredTools: any[] = [];
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
       const mockApi = {
         id: "memory-lancedb",
         name: "Memory (LanceDB)",
@@ -2487,19 +2805,14 @@ describe("memory plugin e2e", () => {
           embedding: {
             apiKey: OPENAI_API_KEY,
             model: "text-embedding-3-small",
-            dimensions: 1024,
+            dimensions: 4,
           },
           dbPath: getDbPath(),
           autoCapture: false,
           autoRecall: false,
         },
         runtime: {},
-        logger: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
+        logger,
         registerTool: (tool: any, opts: any) => {
           registeredTools.push({ tool, opts });
         },
@@ -2514,24 +2827,188 @@ describe("memory plugin e2e", () => {
       if (!recallTool) {
         throw new Error("memory_recall tool was not registered");
       }
-      await recallTool.execute("test-call-dims", { query: "hello dimensions" });
 
-      expect(loadLanceDbModule).toHaveBeenCalledTimes(1);
-      expect(ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
-      expect(ensureGlobalUndiciEnvProxyDispatcher.mock.invocationCallOrder[0]).toBeLessThan(
-        embeddingsCreate.mock.invocationCallOrder[0],
+      const result = await recallTool.execute("test-call-dims", { query: "hello dimensions" });
+
+      expect(result.details).toMatchObject({
+        count: 0,
+        disabled: true,
+        unavailable: true,
+        error:
+          "Embedding model text-embedding-3-small returned 3 dimensions, need at least 4 for local truncation",
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        "memory-lancedb: memory_recall failed: Embedding model text-embedding-3-small returned 3 dimensions, need at least 4 for local truncation; returning unavailable memory result",
       );
-      expect(embeddingsCreate).toHaveBeenCalledWith({
+      expect(embeddingsCreate).toHaveBeenNthCalledWith(1, {
         model: "text-embedding-3-small",
         input: "hello dimensions",
-        dimensions: 1024,
+        dimensions: 4,
       });
+      expect(embeddingsCreate).toHaveBeenNthCalledWith(2, {
+        model: "text-embedding-3-small",
+        input: "hello dimensions",
+      });
+      expect(result.content).toEqual([
+        { type: "text", text: "Memory recall is unavailable right now." },
+      ]);
+      expect(String(result.details.error)).toContain(
+        "Embedding model text-embedding-3-small returned 3 dimensions, need at least 4 for local truncation",
+      );
+      expect(vectorSearch).not.toHaveBeenCalled();
     } finally {
       vi.doUnmock("openclaw/plugin-sdk/runtime-env");
       vi.doUnmock("openai");
       vi.doUnmock("./lancedb-runtime.js");
       vi.resetModules();
     }
+  });
+
+  test("does not retry without dimensions when the provider rejects the dimension value", async () => {
+    const providerError =
+      "400 Unsupported dimensions value: 4 is not supported for model text-embedding-3-small";
+    const embeddingsCreate = vi.fn(async () => {
+      throw new Error(providerError);
+    });
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => 0),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: memoryPluginItem } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+            dimensions: 4,
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger,
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      memoryPluginItem.register(mockApi as any);
+      const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+      if (!recallTool) {
+        throw new Error("memory_recall tool was not registered");
+      }
+
+      const result = await recallTool.execute("test-call-dims", { query: "hello dimensions" });
+
+      expect(result.details).toMatchObject({
+        count: 0,
+        disabled: true,
+        unavailable: true,
+        error: providerError,
+      });
+      expect(logger.warn).toHaveBeenCalledWith(
+        `memory-lancedb: memory_recall failed: ${providerError}; returning unavailable memory result`,
+      );
+      expect(embeddingsCreate).toHaveBeenCalledOnce();
+      expect(embeddingsCreate).toHaveBeenCalledWith({
+        model: "text-embedding-3-small",
+        input: "hello dimensions",
+        dimensions: 4,
+      });
+      expect(ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
+      expect(result.content).toEqual([
+        { type: "text", text: "Memory recall is unavailable right now." },
+      ]);
+      expect(vectorSearch).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("rejects non-positive embedding dimensions before truncation", async () => {
+    const { default: memoryPluginWithInvalidDimensions } = await import("./index.js");
+    const registeredTools: any[] = [];
+    const mockApi = {
+      id: "memory-lancedb",
+      name: "Memory (LanceDB)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+          model: "text-embedding-3-small",
+          dimensions: 0,
+        },
+        dbPath: getDbPath(),
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      registerTool: (tool: any, opts: any) => {
+        registeredTools.push({ tool, opts });
+      },
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: vi.fn(),
+      resolvePath: (p: string) => p,
+    };
+
+    memoryPluginWithInvalidDimensions.register(mockApi as any);
+    const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+    expect(recallTool).toBeUndefined();
   });
 
   test("clears failed database initialization so later tool calls can retry", async () => {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -384,26 +384,116 @@ class OpenAiCompatibleEmbeddings implements Embeddings {
   }
 
   async embed(text: string, options?: { timeoutMs?: number }): Promise<number[]> {
+    if (
+      typeof this.dimensions === "number" &&
+      (!Number.isInteger(this.dimensions) || this.dimensions <= 0)
+    ) {
+      throw new Error("Embedding dimensions must be a positive integer");
+    }
+
+    try {
+      const response = await this.postEmbedding(text, { includeDimensions: true, options });
+      return normalizeEmbeddingVector(response.data?.[0]?.embedding);
+    } catch (error) {
+      if (typeof this.dimensions !== "number" || !isEmbeddingDimensionsRejectedError(error)) {
+        throw error;
+      }
+    }
+
+    const response = await this.postEmbedding(text, { includeDimensions: false, options });
+    const embedding = normalizeEmbeddingVector(response.data?.[0]?.embedding);
+    return this.trimEmbedding(embedding);
+  }
+
+  private async postEmbedding(
+    text: string,
+    request: {
+      includeDimensions: boolean;
+      options?: { timeoutMs?: number };
+    },
+  ): Promise<EmbeddingCreateResponse> {
     const params: Record<string, unknown> = {
       model: this.model,
       input: text,
+      ...(request.includeDimensions && typeof this.dimensions === "number"
+        ? { dimensions: this.dimensions }
+        : {}),
     };
-    if (this.dimensions) {
-      params.dimensions = this.dimensions;
-    }
+
     ensureGlobalUndiciEnvProxyDispatcher();
     // The OpenAI SDK's embeddings helper injects encoding_format=base64 when
     // omitted, then decodes the response. Several compatible providers either
     // reject encoding_format or always return float arrays, so use the generic
     // transport and normalize the response ourselves.
-    const response = await (
+    return await (
       await this.clientPromise
     ).post<EmbeddingCreateResponse>("/embeddings", {
       body: params,
-      ...(options?.timeoutMs ? { timeout: options.timeoutMs, maxRetries: 0 } : {}),
+      ...(request.options?.timeoutMs ? { timeout: request.options.timeoutMs, maxRetries: 0 } : {}),
     });
-    return normalizeEmbeddingVector(response.data?.[0]?.embedding);
   }
+
+  private trimEmbedding(embedding: number[]): number[] {
+    if (typeof this.dimensions !== "number") {
+      return embedding;
+    }
+    if (embedding.length < this.dimensions) {
+      throw new Error(
+        `Embedding model ${this.model} returned ${embedding.length} dimensions, need at least ${this.dimensions} for local truncation`,
+      );
+    }
+    return embedding.slice(0, this.dimensions);
+  }
+}
+
+function isEmbeddingDimensionsRejectedError(error: unknown): boolean {
+  const message = stringifyErrorLike(error).toLowerCase();
+  if (!mentionsEmbeddingDimensionsField(message)) {
+    return false;
+  }
+  return (
+    message.includes("extra_forbidden") ||
+    message.includes("extra inputs") ||
+    message.includes("not permitted") ||
+    message.includes("not allowed") ||
+    message.includes("unknown parameter") ||
+    message.includes("unknown field") ||
+    message.includes("unrecognized parameter") ||
+    message.includes("unrecognized field") ||
+    message.includes("unexpected parameter") ||
+    message.includes("unexpected field")
+  );
+}
+
+function mentionsEmbeddingDimensionsField(message: string): boolean {
+  return (
+    /\bbody\.dimensions\b/.test(message) ||
+    /\binput\.dimensions\b/.test(message) ||
+    /\bparam(?:eter)?\s*[:=]\s*["'`]?dimensions["'`]?\b/.test(message) ||
+    /\b(?:param(?:eter)?|field|argument)\s+["'`]?dimensions["'`]?\b/.test(message) ||
+    /\b["'`]?dimensions["'`]?\s+(?:param(?:eter)?|field|argument)\b/.test(message) ||
+    /(?:\(|\[)\s*['"](?:body|input)['"]\s*,\s*['"]dimensions['"]\s*(?:\)|\])/.test(message)
+  );
+}
+
+function stringifyErrorLike(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (!value || typeof value !== "object") {
+    return String(value);
+  }
+  const parts: string[] = value instanceof Error ? [value.message] : [];
+  const record = value as Record<string, unknown>;
+  for (const key of ["message", "type", "code", "param", "error"]) {
+    const item = record[key];
+    if (typeof item === "string" || typeof item === "number") {
+      parts.push(String(item));
+    } else if (item && typeof item === "object") {
+      parts.push(stringifyErrorLike(item));
+    }
+  }
+  return parts.join("\n");
 }
 
 class ProviderAdapterEmbeddings implements Embeddings {


### PR DESCRIPTION
Closing: 591 lines change exceeds cherry-pick safety threshold (>500 lines). The upstream PR #69707 modifies memory-lancedb core logic which has evolved significantly on main.

The cherry-pick introduces 579 additions across 2 files that touch core vector embedding handling. Semantic conflicts with current main are likely.

Recommendation: upstream PR author should rebase directly. This fork branch is too large for automated cherry-pick maintenance.