### PR TITLE
fix(config): allow historyLimit: 0 in GroupChatSchema

### DIFF
--- a/src/config/zod-schema.core.test.ts
+++ b/src/config/zod-schema.core.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { GroupChatSchema } from "./zod-schema.core.js";
+
+describe("GroupChatSchema", () => {
+  it("accepts historyLimit: 0", () => {
+    const result = GroupChatSchema.unwrap().safeParse({ historyLimit: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a positive historyLimit", () => {
+    const result = GroupChatSchema.unwrap().safeParse({ historyLimit: 50 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a negative historyLimit", () => {
+    const result = GroupChatSchema.unwrap().safeParse({ historyLimit: -1 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -586,7 +586,7 @@ export const MentionPatternsPolicySchema = z
 export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),
-    historyLimit: z.number().int().positive().optional(),
+    historyLimit: z.number().int().min(0).optional(),
     unmentionedInbound: AmbientGroupInboundSchema.optional(),
     visibleReplies: VisibleRepliesSchema.optional(),
   })

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -448,6 +448,50 @@ describe("gateway config methods", () => {
     expect(after.payload?.hash).toBe(current.payload?.hash);
   });
 
+  it("accepts messages.groupChat.historyLimit: 0 through config.patch", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    let previousConfig: string | null = null;
+    try {
+      try {
+        previousConfig = await fs.readFile(configPath, "utf-8");
+      } catch (error) {
+        if ((error as { code?: string }).code !== "ENOENT") {
+          throw error;
+        }
+      }
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify({ messages: { groupChat: { historyLimit: 1 } } }, null, 2)}\n`,
+        "utf-8",
+      );
+      resetConfigRuntimeState();
+
+      const current = await rpcReq<{ hash?: string }>(requireWs(), "config.get", {});
+      expect(current.ok).toBe(true);
+      expect(typeof current.payload?.hash).toBe("string");
+
+      const res = await rpcReq<{
+        config?: { messages?: { groupChat?: { historyLimit?: number } } };
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ messages: { groupChat: { historyLimit: 0 } } }),
+        baseHash: current.payload?.hash,
+      });
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      expect(res.payload?.config?.messages?.groupChat?.historyLimit).toBe(0);
+    } finally {
+      if (previousConfig === null) {
+        await fs.rm(configPath, { force: true });
+      } else {
+        await fs.writeFile(configPath, previousConfig, "utf-8");
+      }
+      resetConfigRuntimeState();
+    }
+  });
+
   it("rejects config.patch when raw is null", async () => {
     const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
       raw: "null",


### PR DESCRIPTION
Closing per ClawSweeper review: duplicate of canonical PR #65359. The upstream PR already owns review and proof for this fix.

@clawsweeper — closing as requested.