### PR TITLE
fix(CLI) Markdown table columns misaligned with CJK characters on Telegram and Discord

### DIFF
--- a/src/markdown/ir.table-code.test.ts
+++ b/src/markdown/ir.table-code.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { markdownToIR } from "./ir.js";
+
+describe("markdownToIR tableMode code - style overlap", () => {
+  it("should not have overlapping styles when cell has bold text", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| **Bold** | Normal |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    // Check for overlapping styles
+    const codeBlockSpan = ir.styles.find((s) => s.style === "code_block");
+    const boldSpan = ir.styles.find((s) => s.style === "bold");
+
+    // Either:
+    // 1. There should be no bold spans in code mode (inner styles stripped), OR
+    // 2. If bold spans exist, they should not overlap with code_block span
+    if (codeBlockSpan && boldSpan) {
+      // Check for overlap
+      const overlaps = boldSpan.start < codeBlockSpan.end && boldSpan.end > codeBlockSpan.start;
+      // Overlapping styles are the bug - this should fail until fixed
+      expect(overlaps).toBe(false);
+    }
+  });
+
+  it("should not have overlapping styles when cell has italic text", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| *Italic* | Normal |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    const codeBlockSpan = ir.styles.find((s) => s.style === "code_block");
+    const italicSpan = ir.styles.find((s) => s.style === "italic");
+
+    if (codeBlockSpan && italicSpan) {
+      const overlaps = italicSpan.start < codeBlockSpan.end && italicSpan.end > codeBlockSpan.start;
+      expect(overlaps).toBe(false);
+    }
+  });
+
+  it("should not have overlapping styles when cell has inline code", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| \`code\` | Normal |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    const codeBlockSpan = ir.styles.find((s) => s.style === "code_block");
+    const codeSpan = ir.styles.find((s) => s.style === "code");
+
+    if (codeBlockSpan && codeSpan) {
+      const overlaps = codeSpan.start < codeBlockSpan.end && codeSpan.end > codeBlockSpan.start;
+      expect(overlaps).toBe(false);
+    }
+  });
+
+  it("should not have overlapping styles with multiple styled cells", () => {
+    const md = `
+| Name | Value |
+|------|-------|
+| **A** | *B* |
+| _C_ | ~~D~~ |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    const codeBlockSpan = ir.styles.find((s) => s.style === "code_block");
+    if (!codeBlockSpan) {
+      return;
+    }
+
+    // Check that no non-code_block style overlaps with code_block
+    for (const style of ir.styles) {
+      if (style.style === "code_block") {
+        continue;
+      }
+      const overlaps = style.start < codeBlockSpan.end && style.end > codeBlockSpan.start;
+      expect(overlaps).toBe(false);
+    }
+  });
+
+  it("pads code tables using display width for CJK cells", () => {
+    const md = `
+|          | Surge Ponte              | Tailscale           |
+|----------|--------------------------|---------------------|
+| 本质      | Surge 加密 Mesh 网络       | WireGuard VPN       |
+| 协调同步   | iCloud                   | 协调服务器            |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    expect(ir.text).toBe(
+      [
+        "|          | Surge Ponte          | Tailscale     |",
+        "| -------- | -------------------- | ------------- |",
+        "| 本质     | Surge 加密 Mesh 网络 | WireGuard VPN |",
+        "| 协调同步 | iCloud               | 协调服务器    |",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("pads code tables using grapheme width for emoji cells", () => {
+    const md = `
+| Icon | Label  |
+|------|--------|
+| 👨‍👩‍👧‍👦 | Family |
+| 📸   | Camera |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    expect(ir.text).toBe(
+      ["| Icon | Label  |", "| ---- | ------ |", "| 👨‍👩‍👧‍👦   | Family |", "| 📸   | Camera |", ""].join(
+        "\n",
+      ),
+    );
+  });
+
+  it("does not overestimate text-presentation symbols in code tables", () => {
+    const md = `
+| I | L |
+|---|---|
+| © | x |
+| A | y |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    expect(ir.text).toBe(["| I | L |", "| --- | --- |", "| © | x |", "| A | y |", ""].join("\n"));
+  });
+
+  it("does not widen partial emoji selector sequences in code tables", () => {
+    const md = `
+| I | L |
+|---|---|
+| 1️ | x |
+| A | y |
+`.trim();
+
+    const ir = markdownToIR(md, { tableMode: "code" });
+
+    expect(ir.text).toBe(["| I | L |", "| --- | --- |", "| 1️ | x |", "| A | y |", ""].join("\n"));
+  });
+});

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -1,0 +1,1084 @@
+import MarkdownIt from "markdown-it";
+import { chunkText } from "../auto-reply/chunk.js";
+import type { MarkdownTableMode } from "../config/types.base.js";
+
+type ListState = {
+  type: "bullet" | "ordered";
+  index: number;
+};
+
+type LinkState = {
+  href: string;
+  labelStart: number;
+};
+
+type RenderEnv = {
+  listStack: ListState[];
+};
+
+type MarkdownToken = {
+  type: string;
+  content?: string;
+  children?: MarkdownToken[];
+  attrs?: [string, string][];
+  attrGet?: (name: string) => string | null;
+};
+
+export type MarkdownStyle =
+  | "bold"
+  | "italic"
+  | "strikethrough"
+  | "code"
+  | "code_block"
+  | "spoiler"
+  | "blockquote";
+
+export type MarkdownStyleSpan = {
+  start: number;
+  end: number;
+  style: MarkdownStyle;
+};
+
+export type MarkdownLinkSpan = {
+  start: number;
+  end: number;
+  href: string;
+};
+
+export type MarkdownIR = {
+  text: string;
+  styles: MarkdownStyleSpan[];
+  links: MarkdownLinkSpan[];
+};
+
+type OpenStyle = {
+  style: MarkdownStyle;
+  start: number;
+};
+
+type RenderTarget = {
+  text: string;
+  styles: MarkdownStyleSpan[];
+  openStyles: OpenStyle[];
+  links: MarkdownLinkSpan[];
+  linkStack: LinkState[];
+};
+
+type TableCell = {
+  text: string;
+  styles: MarkdownStyleSpan[];
+  links: MarkdownLinkSpan[];
+};
+
+type TableState = {
+  headers: TableCell[];
+  rows: TableCell[][];
+  currentRow: TableCell[];
+  currentCell: RenderTarget | null;
+  inHeader: boolean;
+};
+
+type RenderState = RenderTarget & {
+  env: RenderEnv;
+  headingStyle: "none" | "bold";
+  blockquotePrefix: string;
+  enableSpoilers: boolean;
+  tableMode: MarkdownTableMode;
+  table: TableState | null;
+  hasTables: boolean;
+};
+
+export type MarkdownParseOptions = {
+  linkify?: boolean;
+  enableSpoilers?: boolean;
+  headingStyle?: "none" | "bold";
+  blockquotePrefix?: string;
+  autolink?: boolean;
+  /** How to render tables (off|bullets|code). Default: off. */
+  tableMode?: MarkdownTableMode;
+};
+
+function createMarkdownIt(options: MarkdownParseOptions): MarkdownIt {
+  const md = new MarkdownIt({
+    html: false,
+    linkify: options.linkify ?? true,
+    breaks: false,
+    typographer: false,
+  });
+  md.enable("strikethrough");
+  if (options.tableMode && options.tableMode !== "off") {
+    md.enable("table");
+  } else {
+    md.disable("table");
+  }
+  if (options.autolink === false) {
+    md.disable("autolink");
+  }
+  return md;
+}
+
+function getAttr(token: MarkdownToken, name: string): string | null {
+  if (token.attrGet) {
+    return token.attrGet(name);
+  }
+  if (token.attrs) {
+    for (const [key, value] of token.attrs) {
+      if (key === name) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function createTextToken(base: MarkdownToken, content: string): MarkdownToken {
+  return { ...base, type: "text", content, children: undefined };
+}
+
+function applySpoilerTokens(tokens: MarkdownToken[]): void {
+  for (const token of tokens) {
+    if (token.children && token.children.length > 0) {
+      token.children = injectSpoilersIntoInline(token.children);
+    }
+  }
+}
+
+function injectSpoilersIntoInline(tokens: MarkdownToken[]): MarkdownToken[] {
+  let totalDelims = 0;
+  for (const token of tokens) {
+    if (token.type !== "text") {
+      continue;
+    }
+    const content = token.content ?? "";
+    let i = 0;
+    while (i < content.length) {
+      const next = content.indexOf("||", i);
+      if (next === -1) {
+        break;
+      }
+      totalDelims += 1;
+      i = next + 2;
+    }
+  }
+
+  if (totalDelims < 2) {
+    return tokens;
+  }
+  const usableDelims = totalDelims - (totalDelims % 2);
+
+  const result: MarkdownToken[] = [];
+  const state = { spoilerOpen: false };
+  let consumedDelims = 0;
+
+  for (const token of tokens) {
+    if (token.type !== "text") {
+      result.push(token);
+      continue;
+    }
+
+    const content = token.content ?? "";
+    if (!content.includes("||")) {
+      result.push(token);
+      continue;
+    }
+
+    let index = 0;
+    while (index < content.length) {
+      const next = content.indexOf("||", index);
+      if (next === -1) {
+        if (index < content.length) {
+          result.push(createTextToken(token, content.slice(index)));
+        }
+        break;
+      }
+      if (consumedDelims >= usableDelims) {
+        result.push(createTextToken(token, content.slice(index)));
+        break;
+      }
+      if (next > index) {
+        result.push(createTextToken(token, content.slice(index, next)));
+      }
+      consumedDelims += 1;
+      state.spoilerOpen = !state.spoilerOpen;
+      result.push({
+        type: state.spoilerOpen ? "spoiler_open" : "spoiler_close",
+      });
+      index = next + 2;
+    }
+  }
+
+  return result;
+}
+
+function initRenderTarget(): RenderTarget {
+  return {
+    text: "",
+    styles: [],
+    openStyles: [],
+    links: [],
+    linkStack: [],
+  };
+}
+
+function resolveRenderTarget(state: RenderState): RenderTarget {
+  return state.table?.currentCell ?? state;
+}
+
+function appendText(state: RenderState, value: string) {
+  if (!value) {
+    return;
+  }
+  const target = resolveRenderTarget(state);
+  target.text += value;
+}
+
+function openStyle(state: RenderState, style: MarkdownStyle) {
+  const target = resolveRenderTarget(state);
+  target.openStyles.push({ style, start: target.text.length });
+}
+
+function closeStyle(state: RenderState, style: MarkdownStyle) {
+  const target = resolveRenderTarget(state);
+  for (let i = target.openStyles.length - 1; i >= 0; i -= 1) {
+    if (target.openStyles[i]?.style === style) {
+      const start = target.openStyles[i].start;
+      target.openStyles.splice(i, 1);
+      const end = target.text.length;
+      if (end > start) {
+        target.styles.push({ start, end, style });
+      }
+      return;
+    }
+  }
+}
+
+function appendParagraphSeparator(state: RenderState) {
+  if (state.env.listStack.length > 0) {
+    return;
+  }
+  if (state.table) {
+    return;
+  } // Don't add paragraph separators inside tables
+  state.text += "\n\n";
+}
+
+function appendListPrefix(state: RenderState) {
+  const stack = state.env.listStack;
+  const top = stack[stack.length - 1];
+  if (!top) {
+    return;
+  }
+  top.index += 1;
+  const indent = "  ".repeat(Math.max(0, stack.length - 1));
+  const prefix = top.type === "ordered" ? `${top.index}. ` : "• ";
+  state.text += `${indent}${prefix}`;
+}
+
+function renderInlineCode(state: RenderState, content: string) {
+  if (!content) {
+    return;
+  }
+  const target = resolveRenderTarget(state);
+  const start = target.text.length;
+  target.text += content;
+  target.styles.push({ start, end: start + content.length, style: "code" });
+}
+
+function renderCodeBlock(state: RenderState, content: string) {
+  let code = content ?? "";
+  if (!code.endsWith("\n")) {
+    code = `${code}\n`;
+  }
+  const target = resolveRenderTarget(state);
+  const start = target.text.length;
+  target.text += code;
+  target.styles.push({ start, end: start + code.length, style: "code_block" });
+  if (state.env.listStack.length === 0) {
+    target.text += "\n";
+  }
+}
+
+function handleLinkClose(state: RenderState) {
+  const target = resolveRenderTarget(state);
+  const link = target.linkStack.pop();
+  if (!link?.href) {
+    return;
+  }
+  const href = link.href.trim();
+  if (!href) {
+    return;
+  }
+  const start = link.labelStart;
+  const end = target.text.length;
+  if (end <= start) {
+    target.links.push({ start, end, href });
+    return;
+  }
+  target.links.push({ start, end, href });
+}
+
+function initTableState(): TableState {
+  return {
+    headers: [],
+    rows: [],
+    currentRow: [],
+    currentCell: null,
+    inHeader: false,
+  };
+}
+
+function finishTableCell(cell: RenderTarget): TableCell {
+  closeRemainingStyles(cell);
+  return {
+    text: cell.text,
+    styles: cell.styles,
+    links: cell.links,
+  };
+}
+
+function trimCell(cell: TableCell): TableCell {
+  const text = cell.text;
+  let start = 0;
+  let end = text.length;
+  while (start < end && /\s/.test(text[start] ?? "")) {
+    start += 1;
+  }
+  while (end > start && /\s/.test(text[end - 1] ?? "")) {
+    end -= 1;
+  }
+  if (start === 0 && end === text.length) {
+    return cell;
+  }
+  const trimmedText = text.slice(start, end);
+  const trimmedLength = trimmedText.length;
+  const trimmedStyles: MarkdownStyleSpan[] = [];
+  for (const span of cell.styles) {
+    const sliceStart = Math.max(0, span.start - start);
+    const sliceEnd = Math.min(trimmedLength, span.end - start);
+    if (sliceEnd > sliceStart) {
+      trimmedStyles.push({ start: sliceStart, end: sliceEnd, style: span.style });
+    }
+  }
+  const trimmedLinks: MarkdownLinkSpan[] = [];
+  for (const span of cell.links) {
+    const sliceStart = Math.max(0, span.start - start);
+    const sliceEnd = Math.min(trimmedLength, span.end - start);
+    if (sliceEnd > sliceStart) {
+      trimmedLinks.push({ start: sliceStart, end: sliceEnd, href: span.href });
+    }
+  }
+  return { text: trimmedText, styles: trimmedStyles, links: trimmedLinks };
+}
+
+function appendCell(state: RenderState, cell: TableCell) {
+  if (!cell.text) {
+    return;
+  }
+  const start = state.text.length;
+  state.text += cell.text;
+  for (const span of cell.styles) {
+    state.styles.push({
+      start: start + span.start,
+      end: start + span.end,
+      style: span.style,
+    });
+  }
+  for (const link of cell.links) {
+    state.links.push({
+      start: start + link.start,
+      end: start + link.end,
+      href: link.href,
+    });
+  }
+}
+
+function appendCellTextOnly(state: RenderState, cell: TableCell) {
+  if (!cell.text) {
+    return;
+  }
+  state.text += cell.text;
+  // Do not append styles - this is used for code blocks where inner styles would overlap
+}
+
+function appendTableBulletValue(
+  state: RenderState,
+  params: {
+    header?: TableCell;
+    value?: TableCell;
+    columnIndex: number;
+    includeColumnFallback: boolean;
+  },
+) {
+  const { header, value, columnIndex, includeColumnFallback } = params;
+  if (!value?.text) {
+    return;
+  }
+  state.text += "• ";
+  if (header?.text) {
+    appendCell(state, header);
+    state.text += ": ";
+  } else if (includeColumnFallback) {
+    state.text += `Column ${columnIndex}: `;
+  }
+  appendCell(state, value);
+  state.text += "\n";
+}
+
+function renderTableAsBullets(state: RenderState) {
+  if (!state.table) {
+    return;
+  }
+  const headers = state.table.headers.map(trimCell);
+  const rows = state.table.rows.map((row) => row.map(trimCell));
+
+  // If no headers or rows, skip
+  if (headers.length === 0 && rows.length === 0) {
+    return;
+  }
+
+  // Determine if first column should be used as row labels
+  // (common pattern: first column is category/feature name)
+  const useFirstColAsLabel = headers.length > 1 && rows.length > 0;
+
+  if (useFirstColAsLabel) {
+    // Format: each row becomes a section with header as row[0], then key:value pairs
+    for (const row of rows) {
+      if (row.length === 0) {
+        continue;
+      }
+
+      const rowLabel = row[0];
+      if (rowLabel?.text) {
+        const labelStart = state.text.length;
+        appendCell(state, rowLabel);
+        const labelEnd = state.text.length;
+        if (labelEnd > labelStart) {
+          state.styles.push({ start: labelStart, end: labelEnd, style: "bold" });
+        }
+        state.text += "\n";
+      }
+
+      // Add each column as a bullet point
+      for (let i = 1; i < row.length; i++) {
+        appendTableBulletValue(state, {
+          header: headers[i],
+          value: row[i],
+          columnIndex: i,
+          includeColumnFallback: true,
+        });
+      }
+      state.text += "\n";
+    }
+  } else {
+    // Simple table: just list headers and values
+    for (const row of rows) {
+      for (let i = 0; i < row.length; i++) {
+        appendTableBulletValue(state, {
+          header: headers[i],
+          value: row[i],
+          columnIndex: i,
+          includeColumnFallback: false,
+        });
+      }
+      state.text += "\n";
+    }
+  }
+}
+
+const codeTableGraphemeSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+const CODE_TABLE_EMOJI_PRESENTATION_RE = /\p{Emoji_Presentation}/u;
+const CODE_TABLE_EXTENDED_PICTOGRAPHIC_RE = /\p{Extended_Pictographic}/u;
+const CODE_TABLE_REGIONAL_INDICATOR_RE = /\p{Regional_Indicator}/u;
+const CODE_TABLE_KEYCAP_SEQUENCE_RE = /^(?:[#*0-9]\uFE0F?\u20E3)$/u;
+
+function splitCodeTableGraphemes(input: string): string[] {
+  if (!input) {
+    return [];
+  }
+  if (!codeTableGraphemeSegmenter) {
+    return Array.from(input);
+  }
+  try {
+    return Array.from(codeTableGraphemeSegmenter.segment(input), (segment) => segment.segment);
+  } catch {
+    return Array.from(input);
+  }
+}
+
+function isCodeTableZeroWidthCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    codePoint === 0x200d
+  );
+}
+
+function isCodeTableFullWidthCodePoint(codePoint: number): boolean {
+  if (codePoint < 0x1100) {
+    return false;
+  }
+  return (
+    codePoint <= 0x115f ||
+    codePoint === 0x2329 ||
+    codePoint === 0x232a ||
+    (codePoint >= 0x2e80 && codePoint <= 0x3247 && codePoint !== 0x303f) ||
+    (codePoint >= 0x3250 && codePoint <= 0x4dbf) ||
+    (codePoint >= 0x4e00 && codePoint <= 0xa4c6) ||
+    (codePoint >= 0xa960 && codePoint <= 0xa97c) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6b) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1aff0 && codePoint <= 0x1aff3) ||
+    (codePoint >= 0x1aff5 && codePoint <= 0x1affb) ||
+    (codePoint >= 0x1affd && codePoint <= 0x1affe) ||
+    (codePoint >= 0x1b000 && codePoint <= 0x1b2ff) ||
+    (codePoint >= 0x1f200 && codePoint <= 0x1f251) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  );
+}
+
+function isWideCodeTableEmoji(grapheme: string): boolean {
+  if (CODE_TABLE_KEYCAP_SEQUENCE_RE.test(grapheme)) {
+    return true;
+  }
+  if (CODE_TABLE_REGIONAL_INDICATOR_RE.test(grapheme)) {
+    return true;
+  }
+  if (CODE_TABLE_EMOJI_PRESENTATION_RE.test(grapheme)) {
+    return true;
+  }
+  if (!grapheme.includes("\u200d") && !grapheme.includes("\uFE0F")) {
+    return false;
+  }
+  return CODE_TABLE_EXTENDED_PICTOGRAPHIC_RE.test(grapheme);
+}
+
+function codeTableGraphemeWidth(grapheme: string): number {
+  if (!grapheme) {
+    return 0;
+  }
+  if (isWideCodeTableEmoji(grapheme)) {
+    return 2;
+  }
+
+  let sawPrintable = false;
+  for (const char of grapheme) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint == null) {
+      continue;
+    }
+    if (isCodeTableZeroWidthCodePoint(codePoint)) {
+      continue;
+    }
+    if (isCodeTableFullWidthCodePoint(codePoint)) {
+      return 2;
+    }
+    sawPrintable = true;
+  }
+  return sawPrintable ? 1 : 0;
+}
+
+// Code-mode tables need display-width padding so CJK and emoji cells stay aligned.
+function codeTableDisplayWidth(input: string): number {
+  return splitCodeTableGraphemes(input).reduce(
+    (sum, grapheme) => sum + codeTableGraphemeWidth(grapheme),
+    0,
+  );
+}
+
+function renderTableAsCode(state: RenderState) {
+  if (!state.table) {
+    return;
+  }
+  const headers = state.table.headers.map(trimCell);
+  const rows = state.table.rows.map((row) => row.map(trimCell));
+
+  const columnCount = Math.max(headers.length, ...rows.map((row) => row.length));
+  if (columnCount === 0) {
+    return;
+  }
+
+  const widths = Array.from({ length: columnCount }, () => 0);
+  const updateWidths = (cells: TableCell[]) => {
+    for (let i = 0; i < columnCount; i += 1) {
+      const cell = cells[i];
+      const width = codeTableDisplayWidth(cell?.text ?? "");
+      if (widths[i] < width) {
+        widths[i] = width;
+      }
+    }
+  };
+  updateWidths(headers);
+  for (const row of rows) {
+    updateWidths(row);
+  }
+
+  const codeStart = state.text.length;
+
+  const appendRow = (cells: TableCell[]) => {
+    state.text += "|";
+    for (let i = 0; i < columnCount; i += 1) {
+      state.text += " ";
+      const cell = cells[i];
+      if (cell) {
+        // Use text-only append to avoid overlapping styles with code_block
+        appendCellTextOnly(state, cell);
+      }
+      const pad = widths[i] - codeTableDisplayWidth(cell?.text ?? "");
+      if (pad > 0) {
+        state.text += " ".repeat(pad);
+      }
+      state.text += " |";
+    }
+    state.text += "\n";
+  };
+
+  const appendDivider = () => {
+    state.text += "|";
+    for (let i = 0; i < columnCount; i += 1) {
+      const dashCount = Math.max(3, widths[i]);
+      state.text += ` ${"-".repeat(dashCount)} |`;
+    }
+    state.text += "\n";
+  };
+
+  appendRow(headers);
+  appendDivider();
+  for (const row of rows) {
+    appendRow(row);
+  }
+
+  const codeEnd = state.text.length;
+  if (codeEnd > codeStart) {
+    state.styles.push({ start: codeStart, end: codeEnd, style: "code_block" });
+  }
+  if (state.env.listStack.length === 0) {
+    state.text += "\n";
+  }
+}
+
+function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
+  for (const token of tokens) {
+    switch (token.type) {
+      case "inline":
+        if (token.children) {
+          renderTokens(token.children, state);
+        }
+        break;
+      case "text":
+        appendText(state, token.content ?? "");
+        break;
+      case "em_open":
+        openStyle(state, "italic");
+        break;
+      case "em_close":
+        closeStyle(state, "italic");
+        break;
+      case "strong_open":
+        openStyle(state, "bold");
+        break;
+      case "strong_close":
+        closeStyle(state, "bold");
+        break;
+      case "s_open":
+        openStyle(state, "strikethrough");
+        break;
+      case "s_close":
+        closeStyle(state, "strikethrough");
+        break;
+      case "code_inline":
+        renderInlineCode(state, token.content ?? "");
+        break;
+      case "spoiler_open":
+        if (state.enableSpoilers) {
+          openStyle(state, "spoiler");
+        }
+        break;
+      case "spoiler_close":
+        if (state.enableSpoilers) {
+          closeStyle(state, "spoiler");
+        }
+        break;
+      case "link_open": {
+        const href = getAttr(token, "href") ?? "";
+        const target = resolveRenderTarget(state);
+        target.linkStack.push({ href, labelStart: target.text.length });
+        break;
+      }
+      case "link_close":
+        handleLinkClose(state);
+        break;
+      case "image":
+        appendText(state, token.content ?? "");
+        break;
+      case "softbreak":
+      case "hardbreak":
+        appendText(state, "\n");
+        break;
+      case "paragraph_close":
+        appendParagraphSeparator(state);
+        break;
+      case "heading_open":
+        if (state.headingStyle === "bold") {
+          openStyle(state, "bold");
+        }
+        break;
+      case "heading_close":
+        if (state.headingStyle === "bold") {
+          closeStyle(state, "bold");
+        }
+        appendParagraphSeparator(state);
+        break;
+      case "blockquote_open":
+        if (state.blockquotePrefix) {
+          state.text += state.blockquotePrefix;
+        }
+        openStyle(state, "blockquote");
+        break;
+      case "blockquote_close":
+        closeStyle(state, "blockquote");
+        break;
+      case "bullet_list_open":
+        // Add newline before nested list starts (so nested items appear on new line)
+        if (state.env.listStack.length > 0) {
+          state.text += "\n";
+        }
+        state.env.listStack.push({ type: "bullet", index: 0 });
+        break;
+      case "bullet_list_close":
+        state.env.listStack.pop();
+        if (state.env.listStack.length === 0) {
+          state.text += "\n";
+        }
+        break;
+      case "ordered_list_open": {
+        // Add newline before nested list starts (so nested items appear on new line)
+        if (state.env.listStack.length > 0) {
+          state.text += "\n";
+        }
+        const start = Number(getAttr(token, "start") ?? "1");
+        state.env.listStack.push({ type: "ordered", index: start - 1 });
+        break;
+      }
+      case "ordered_list_close":
+        state.env.listStack.pop();
+        if (state.env.listStack.length === 0) {
+          state.text += "\n";
+        }
+        break;
+      case "list_item_open":
+        appendListPrefix(state);
+        break;
+      case "list_item_close":
+        // Avoid double newlines (nested list's last item already added newline)
+        if (!state.text.endsWith("\n")) {
+          state.text += "\n";
+        }
+        break;
+      case "code_block":
+      case "fence":
+        renderCodeBlock(state, token.content ?? "");
+        break;
+      case "html_block":
+      case "html_inline":
+        appendText(state, token.content ?? "");
+        break;
+
+      // Table handling
+      case "table_open":
+        if (state.tableMode !== "off") {
+          state.table = initTableState();
+          state.hasTables = true;
+        }
+        break;
+      case "table_close":
+        if (state.table) {
+          if (state.tableMode === "bullets") {
+            renderTableAsBullets(state);
+          } else if (state.tableMode === "code") {
+            renderTableAsCode(state);
+          }
+        }
+        state.table = null;
+        break;
+      case "thead_open":
+        if (state.table) {
+          state.table.inHeader = true;
+        }
+        break;
+      case "thead_close":
+        if (state.table) {
+          state.table.inHeader = false;
+        }
+        break;
+      case "tbody_open":
+      case "tbody_close":
+        break;
+      case "tr_open":
+        if (state.table) {
+          state.table.currentRow = [];
+        }
+        break;
+      case "tr_close":
+        if (state.table) {
+          if (state.table.inHeader) {
+            state.table.headers = state.table.currentRow;
+          } else {
+            state.table.rows.push(state.table.currentRow);
+          }
+          state.table.currentRow = [];
+        }
+        break;
+      case "th_open":
+      case "td_open":
+        if (state.table) {
+          state.table.currentCell = initRenderTarget();
+        }
+        break;
+      case "th_close":
+      case "td_close":
+        if (state.table?.currentCell) {
+          state.table.currentRow.push(finishTableCell(state.table.currentCell));
+          state.table.currentCell = null;
+        }
+        break;
+
+      case "hr":
+        // Render as a visual separator
+        state.text += "───\n\n";
+        break;
+      default:
+        if (token.children) {
+          renderTokens(token.children, state);
+        }
+        break;
+    }
+  }
+}
+
+function closeRemainingStyles(target: RenderTarget) {
+  for (let i = target.openStyles.length - 1; i >= 0; i -= 1) {
+    const open = target.openStyles[i];
+    const end = target.text.length;
+    if (end > open.start) {
+      target.styles.push({
+        start: open.start,
+        end,
+        style: open.style,
+      });
+    }
+  }
+  target.openStyles = [];
+}
+
+function clampStyleSpans(spans: MarkdownStyleSpan[], maxLength: number): MarkdownStyleSpan[] {
+  const clamped: MarkdownStyleSpan[] = [];
+  for (const span of spans) {
+    const start = Math.max(0, Math.min(span.start, maxLength));
+    const end = Math.max(start, Math.min(span.end, maxLength));
+    if (end > start) {
+      clamped.push({ start, end, style: span.style });
+    }
+  }
+  return clamped;
+}
+
+function clampLinkSpans(spans: MarkdownLinkSpan[], maxLength: number): MarkdownLinkSpan[] {
+  const clamped: MarkdownLinkSpan[] = [];
+  for (const span of spans) {
+    const start = Math.max(0, Math.min(span.start, maxLength));
+    const end = Math.max(start, Math.min(span.end, maxLength));
+    if (end > start) {
+      clamped.push({ start, end, href: span.href });
+    }
+  }
+  return clamped;
+}
+
+function mergeStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
+  const sorted = [...spans].toSorted((a, b) => {
+    if (a.start !== b.start) {
+      return a.start - b.start;
+    }
+    if (a.end !== b.end) {
+      return a.end - b.end;
+    }
+    return a.style.localeCompare(b.style);
+  });
+
+  const merged: MarkdownStyleSpan[] = [];
+  for (const span of sorted) {
+    const prev = merged[merged.length - 1];
+    if (
+      prev &&
+      prev.style === span.style &&
+      // Blockquotes are container blocks. Adjacent blockquote spans should not merge or
+      // consecutive blockquotes can "style bleed" across the paragraph boundary.
+      (span.start < prev.end || (span.start === prev.end && span.style !== "blockquote"))
+    ) {
+      prev.end = Math.max(prev.end, span.end);
+      continue;
+    }
+    merged.push({ ...span });
+  }
+  return merged;
+}
+
+function resolveSliceBounds(
+  span: { start: number; end: number },
+  start: number,
+  end: number,
+): { start: number; end: number } | null {
+  const sliceStart = Math.max(span.start, start);
+  const sliceEnd = Math.min(span.end, end);
+  if (sliceEnd <= sliceStart) {
+    return null;
+  }
+  return { start: sliceStart, end: sliceEnd };
+}
+
+function sliceStyleSpans(
+  spans: MarkdownStyleSpan[],
+  start: number,
+  end: number,
+): MarkdownStyleSpan[] {
+  if (spans.length === 0) {
+    return [];
+  }
+  const sliced: MarkdownStyleSpan[] = [];
+  for (const span of spans) {
+    const bounds = resolveSliceBounds(span, start, end);
+    if (!bounds) {
+      continue;
+    }
+    sliced.push({
+      start: bounds.start - start,
+      end: bounds.end - start,
+      style: span.style,
+    });
+  }
+  return mergeStyleSpans(sliced);
+}
+
+function sliceLinkSpans(spans: MarkdownLinkSpan[], start: number, end: number): MarkdownLinkSpan[] {
+  if (spans.length === 0) {
+    return [];
+  }
+  const sliced: MarkdownLinkSpan[] = [];
+  for (const span of spans) {
+    const bounds = resolveSliceBounds(span, start, end);
+    if (!bounds) {
+      continue;
+    }
+    sliced.push({
+      start: bounds.start - start,
+      end: bounds.end - start,
+      href: span.href,
+    });
+  }
+  return sliced;
+}
+
+export function markdownToIR(markdown: string, options: MarkdownParseOptions = {}): MarkdownIR {
+  return markdownToIRWithMeta(markdown, options).ir;
+}
+
+export function markdownToIRWithMeta(
+  markdown: string,
+  options: MarkdownParseOptions = {},
+): { ir: MarkdownIR; hasTables: boolean } {
+  const env: RenderEnv = { listStack: [] };
+  const md = createMarkdownIt(options);
+  const tokens = md.parse(markdown ?? "", env as unknown as object);
+  if (options.enableSpoilers) {
+    applySpoilerTokens(tokens as MarkdownToken[]);
+  }
+
+  const tableMode = options.tableMode ?? "off";
+
+  const state: RenderState = {
+    text: "",
+    styles: [],
+    openStyles: [],
+    links: [],
+    linkStack: [],
+    env,
+    headingStyle: options.headingStyle ?? "none",
+    blockquotePrefix: options.blockquotePrefix ?? "",
+    enableSpoilers: options.enableSpoilers ?? false,
+    tableMode,
+    table: null,
+    hasTables: false,
+  };
+
+  renderTokens(tokens as MarkdownToken[], state);
+  closeRemainingStyles(state);
+
+  const trimmedText = state.text.trimEnd();
+  const trimmedLength = trimmedText.length;
+  let codeBlockEnd = 0;
+  for (const span of state.styles) {
+    if (span.style !== "code_block") {
+      continue;
+    }
+    if (span.end > codeBlockEnd) {
+      codeBlockEnd = span.end;
+    }
+  }
+  const finalLength = Math.max(trimmedLength, codeBlockEnd);
+  const finalText =
+    finalLength === state.text.length ? state.text : state.text.slice(0, finalLength);
+
+  return {
+    ir: {
+      text: finalText,
+      styles: mergeStyleSpans(clampStyleSpans(state.styles, finalLength)),
+      links: clampLinkSpans(state.links, finalLength),
+    },
+    hasTables: state.hasTables,
+  };
+}
+
+export function chunkMarkdownIR(ir: MarkdownIR, limit: number): MarkdownIR[] {
+  if (!ir.text) {
+    return [];
+  }
+  if (limit <= 0 || ir.text.length <= limit) {
+    return [ir];
+  }
+
+  const chunks = chunkText(ir.text, limit);
+  const results: MarkdownIR[] = [];
+  let cursor = 0;
+
+  chunks.forEach((chunk, index) => {
+    if (!chunk) {
+      return;
+    }
+    if (index > 0) {
+      while (cursor < ir.text.length && /\s/.test(ir.text[cursor] ?? "")) {
+        cursor += 1;
+      }
+    }
+    const start = cursor;
+    const end = Math.min(ir.text.length, start + chunk.length);
+    results.push({
+      text: chunk,
+      styles: sliceStyleSpans(ir.styles, start, end),
+      links: sliceLinkSpans(ir.links, start, end),
+    });
+    cursor = end;
+  });
+
+  return results;
+}

--- a/src/terminal/ansi.ts
+++ b/src/terminal/ansi.ts
@@ -1,0 +1,115 @@
+// Full CSI: ESC [ <params> <final byte> covers cursor movement, erase, and SGR.
+const ANSI_CSI_PATTERN = "\\x1b\\[[\\x20-\\x3f]*[\\x40-\\x7e]";
+// OSC-8 hyperlinks: ESC ] 8 ; ; url ST ... ESC ] 8 ; ; ST
+const OSC8_PATTERN = "\\x1b\\]8;;.*?\\x1b\\\\|\\x1b\\]8;;\\x1b\\\\";
+
+const ANSI_CSI_REGEX = new RegExp(ANSI_CSI_PATTERN, "g");
+const OSC8_REGEX = new RegExp(OSC8_PATTERN, "g");
+const graphemeSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+export function stripAnsi(input: string): string {
+  return input.replace(OSC8_REGEX, "").replace(ANSI_CSI_REGEX, "");
+}
+
+export function splitGraphemes(input: string): string[] {
+  if (!input) {
+    return [];
+  }
+  if (!graphemeSegmenter) {
+    return Array.from(input);
+  }
+  try {
+    return Array.from(graphemeSegmenter.segment(input), (segment) => segment.segment);
+  } catch {
+    return Array.from(input);
+  }
+}
+
+/**
+ * Sanitize a value for safe interpolation into log messages.
+ * Strips ANSI escape sequences, C0 control characters (U+0000–U+001F),
+ * and DEL (U+007F) to prevent log forging / terminal escape injection (CWE-117).
+ */
+export function sanitizeForLog(v: string): string {
+  let out = stripAnsi(v);
+  for (let c = 0; c <= 0x1f; c++) {
+    out = out.replaceAll(String.fromCharCode(c), "");
+  }
+  return out.replaceAll(String.fromCharCode(0x7f), "");
+}
+
+function isZeroWidthCodePoint(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0f) ||
+    codePoint === 0x200d
+  );
+}
+
+function isFullWidthCodePoint(codePoint: number): boolean {
+  if (codePoint < 0x1100) {
+    return false;
+  }
+  return (
+    codePoint <= 0x115f ||
+    codePoint === 0x2329 ||
+    codePoint === 0x232a ||
+    (codePoint >= 0x2e80 && codePoint <= 0x3247 && codePoint !== 0x303f) ||
+    (codePoint >= 0x3250 && codePoint <= 0x4dbf) ||
+    (codePoint >= 0x4e00 && codePoint <= 0xa4c6) ||
+    (codePoint >= 0xa960 && codePoint <= 0xa97c) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7a3) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe19) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe6b) ||
+    (codePoint >= 0xff01 && codePoint <= 0xff60) ||
+    (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
+    (codePoint >= 0x1aff0 && codePoint <= 0x1aff3) ||
+    (codePoint >= 0x1aff5 && codePoint <= 0x1affb) ||
+    (codePoint >= 0x1affd && codePoint <= 0x1affe) ||
+    (codePoint >= 0x1b000 && codePoint <= 0x1b2ff) ||
+    (codePoint >= 0x1f200 && codePoint <= 0x1f251) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  );
+}
+
+const emojiLikePattern = /[\p{Extended_Pictographic}\p{Regional_Indicator}\u20e3]/u;
+
+function graphemeWidth(grapheme: string): number {
+  if (!grapheme) {
+    return 0;
+  }
+  if (emojiLikePattern.test(grapheme)) {
+    return 2;
+  }
+
+  let sawPrintable = false;
+  for (const char of grapheme) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint == null) {
+      continue;
+    }
+    if (isZeroWidthCodePoint(codePoint)) {
+      continue;
+    }
+    if (isFullWidthCodePoint(codePoint)) {
+      return 2;
+    }
+    sawPrintable = true;
+  }
+  return sawPrintable ? 1 : 0;
+}
+
+export function visibleWidth(input: string): number {
+  return splitGraphemes(stripAnsi(input)).reduce(
+    (sum, grapheme) => sum + graphemeWidth(grapheme),
+    0,
+  );
+}


### PR DESCRIPTION
Closing: this cherry-pick re-adds 3 source files (src/markdown/ir.ts, src/terminal/ansi.ts, src/markdown/ir.table-code.test.ts) that were deliberately deleted from main during a refactor.

The CI checkout failed because the merge is unstable — these files reference imports that no longer exist in current main. The underlying code has been refactored and these files are no longer valid.

Recommendation: the upstream PR #55596 (March 2026) needs to be rewritten against the current architecture. A cherry-pick cannot bridge this refactor gap.

@clawsweeper — closing as unsalvageable.