### PR TITLE
Fix sessions.list for literal per-agent store paths

### DIFF
--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -1373,4 +1373,86 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
       expect(store["agent:codex:acp-task"]).toBe(cachedStore["agent:codex:acp-task"]);
     });
   });
+
+  test("literal main-agent store paths still discover sibling agent stores (#54435)", async () => {
+    await withStateDirEnv("openclaw-literal-main-store-", async ({ stateDir }) => {
+      const customRoot = path.join(stateDir, "custom-state");
+      const mainDir = path.join(customRoot, "agents", "main", "sessions");
+      const codexDir = path.join(customRoot, "agents", "codex", "sessions");
+      fs.mkdirSync(mainDir, { recursive: true });
+      fs.mkdirSync(codexDir, { recursive: true });
+
+      const literalMainStorePath = path.join(mainDir, "sessions.json");
+      fs.writeFileSync(
+        literalMainStorePath,
+        JSON.stringify({
+          "agent:main:main": { sessionId: "s-main", updatedAt: 100 },
+        }),
+        "utf8",
+      );
+
+      fs.writeFileSync(
+        path.join(codexDir, "sessions.json"),
+        JSON.stringify({
+          "agent:codex:acp-task": { sessionId: "s-codex", updatedAt: 200 },
+        }),
+        "utf8",
+      );
+
+      const cfg = {
+        session: {
+          mainKey: "main",
+          store: literalMainStorePath,
+        },
+        agents: {
+          list: [{ id: "main", default: true }],
+        },
+      } as OpenClawConfig;
+
+      const { store } = loadCombinedSessionStoreForGateway(cfg);
+      expect(Object.keys(store).toSorted()).toEqual(["agent:codex:acp-task", "agent:main:main"]);
+    });
+  });
+
+  test("literal agent-layout store paths do not leak sessions from the default state dir", async () => {
+    await withStateDirEnv("openclaw-literal-scope-", async ({ stateDir }) => {
+      // Literal path under a custom root
+      const customRoot = path.join(stateDir, "custom-state");
+      const mainDir = path.join(customRoot, "agents", "main", "sessions");
+      fs.mkdirSync(mainDir, { recursive: true });
+      const literalMainStorePath = path.join(mainDir, "sessions.json");
+      fs.writeFileSync(
+        literalMainStorePath,
+        JSON.stringify({
+          "agent:main:main": { sessionId: "s-custom", updatedAt: 100 },
+        }),
+        "utf8",
+      );
+
+      // Sessions under the default state dir that should NOT leak in
+      const defaultAgentsDir = path.join(stateDir, "agents", "other", "sessions");
+      fs.mkdirSync(defaultAgentsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(defaultAgentsDir, "sessions.json"),
+        JSON.stringify({
+          "agent:other:leaked": { sessionId: "s-leaked", updatedAt: 300 },
+        }),
+        "utf8",
+      );
+
+      const cfg = {
+        session: {
+          mainKey: "main",
+          store: literalMainStorePath,
+        },
+        agents: {
+          list: [{ id: "main", default: true }],
+        },
+      } as OpenClawConfig;
+
+      const { store } = loadCombinedSessionStoreForGateway(cfg);
+      expect(Object.keys(store)).toEqual(["agent:main:main"]);
+      expect(store["agent:other:leaked"]).toBeUndefined();
+    });
+  });
 });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1,36 +1,23 @@
-// Session utility tests cover key parsing, store migration, agent/default rows,
-// model identity resolution, title derivation, and byte-capped row payloads.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, test, vi } from "vitest";
-import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
+import { afterEach, describe, expect, test } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadSessionStore, type SessionEntry } from "../config/sessions.js";
-import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
-import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
-  canonicalizeSpawnedByForAgent,
-  buildGatewaySessionRow,
   capArrayByJsonBytes,
   classifySessionKey,
   deriveSessionTitle,
-  getSessionDefaults,
   listAgentsForGateway,
   listSessionsFromStore,
-  listSessionsFromStoreAsync,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
   parseGroupKey,
   pruneLegacyStoreKeys,
-  resolveDeletedAgentIdFromSessionKey,
   resolveGatewayModelSupportsImages,
   resolveGatewaySessionStoreTarget,
-  resolveGatewaySessionStoreTargetWithStore,
-  resolveSessionDisplayModelIdentityRef,
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
   resolveSessionStoreKey,
@@ -64,197 +51,26 @@ function createSingleAgentAvatarConfig(workspace: string): OpenClawConfig {
 
 function createModelDefaultsConfig(params: {
   primary: string;
-  models?: Record<string, { agentRuntime?: { id: string } }>;
-  agentRuntime?: { id: string };
+  models?: Record<string, Record<string, never>>;
 }): OpenClawConfig {
   return {
     agents: {
       defaults: {
         model: { primary: params.primary },
-        models: {
-          ...params.models,
-          ...(params.agentRuntime
-            ? { [params.primary]: { agentRuntime: params.agentRuntime } }
-            : {}),
-        },
+        models: params.models,
       },
     },
   } as OpenClawConfig;
 }
 
-function requireString(value: string | undefined, label: string): string {
-  if (!value) {
-    throw new Error(`expected ${label}`);
-  }
-  return value;
-}
-
-function expectFields(value: unknown, expected: Record<string, unknown>): void {
-  if (!value || typeof value !== "object") {
-    throw new Error("expected fields object");
-  }
-  const record = value as Record<string, unknown>;
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    expect(record[key], key).toEqual(expectedValue);
-  }
-}
-
 describe("gateway session utils", () => {
   afterEach(() => {
     resetConfigRuntimeState();
-    resetPluginRuntimeStateForTest();
   });
 
   test("capArrayByJsonBytes trims from the front", () => {
     const res = capArrayByJsonBytes(["a", "b", "c"], 10);
     expect(res.items).toEqual(["b", "c"]);
-  });
-
-  test("session lists apply a bounded default and expose truncation metadata", async () => {
-    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
-    const store = Object.fromEntries(
-      Array.from({ length: 101 }, (_value, index) => [
-        `session-${index}`,
-        {
-          sessionId: `session-${index}`,
-          updatedAt: 1_000 - index,
-          modelProvider: "openai",
-          model: "gpt-5.4",
-        } satisfies SessionEntry,
-      ]),
-    );
-
-    const listed = await listSessionsFromStoreAsync({
-      cfg,
-      storePath: "",
-      store,
-      opts: {},
-    });
-
-    expect(listed.sessions).toHaveLength(100);
-    expect(listed.count).toBe(100);
-    expect(listed.totalCount).toBe(101);
-    expect(listed.limitApplied).toBe(100);
-    expect(listed.nextOffset).toBe(100);
-    expect(listed.hasMore).toBe(true);
-    expect(listed.sessions[0]?.key).toBe("session-0");
-    expect(listed.sessions.at(-1)?.key).toBe("session-99");
-  });
-
-  test("session lists honor explicit caller limits", () => {
-    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
-    const store = Object.fromEntries(
-      Array.from({ length: 5 }, (_value, index) => [
-        `session-${index}`,
-        {
-          sessionId: `session-${index}`,
-          updatedAt: 1_000 - index,
-        } satisfies SessionEntry,
-      ]),
-    );
-
-    const listed = listSessionsFromStore({
-      cfg,
-      storePath: "",
-      store,
-      opts: { limit: 3 },
-    });
-
-    expect(listed.sessions.map((session) => session.key)).toEqual([
-      "session-0",
-      "session-1",
-      "session-2",
-    ]);
-    expect(listed.count).toBe(3);
-    expect(listed.totalCount).toBe(5);
-    expect(listed.limitApplied).toBe(3);
-    expect(listed.nextOffset).toBe(3);
-    expect(listed.hasMore).toBe(true);
-  });
-
-  test("session lists page from an offset after filtering and sorting", () => {
-    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
-    const store = Object.fromEntries(
-      Array.from({ length: 6 }, (_value, index) => [
-        `session-${index}`,
-        {
-          sessionId: `session-${index}`,
-          updatedAt: 1_000 - index,
-          displayName: index === 5 ? "Different project" : `Project Alpha ${index}`,
-        } satisfies SessionEntry,
-      ]),
-    );
-
-    const listed = listSessionsFromStore({
-      cfg,
-      storePath: "",
-      store,
-      opts: { search: "alpha", limit: 2, offset: 2 },
-    });
-
-    expect(listed.sessions.map((session) => session.key)).toEqual(["session-2", "session-3"]);
-    expect(listed.count).toBe(2);
-    expect(listed.totalCount).toBe(5);
-    expect(listed.limitApplied).toBe(2);
-    expect(listed.offset).toBe(2);
-    expect(listed.nextOffset).toBe(4);
-    expect(listed.hasMore).toBe(true);
-  });
-
-  test("session list search includes direct-session origin display labels", () => {
-    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
-    const store = {
-      "agent:main:telegram:direct:42": {
-        chatType: "direct",
-        channel: "telegram",
-        origin: { label: "openclaw-tui" },
-        updatedAt: 2,
-      } as SessionEntry,
-      "agent:main:telegram:direct:99": {
-        chatType: "direct",
-        channel: "telegram",
-        origin: { label: "other-direct" },
-        updatedAt: 1,
-      } as SessionEntry,
-    };
-
-    const listed = listSessionsFromStore({
-      cfg,
-      storePath: "",
-      store,
-      opts: { search: "openclaw-tui" },
-    });
-
-    expect(listed.sessions.map((session) => session.key)).toEqual([
-      "agent:main:telegram:direct:42",
-    ]);
-    expect(listed.sessions[0]?.displayName).toBe("openclaw-tui");
-  });
-
-  test("session lists mark the final offset page without hasMore", () => {
-    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
-    const store = Object.fromEntries(
-      Array.from({ length: 5 }, (_value, index) => [
-        `session-${index}`,
-        {
-          sessionId: `session-${index}`,
-          updatedAt: 1_000 - index,
-        } satisfies SessionEntry,
-      ]),
-    );
-
-    const listed = listSessionsFromStore({
-      cfg,
-      storePath: "",
-      store,
-      opts: { limit: 2, offset: 4 },
-    });
-
-    expect(listed.sessions.map((session) => session.key)).toEqual(["session-4"]);
-    expect(listed.totalCount).toBe(5);
-    expect(listed.offset).toBe(4);
-    expect(listed.nextOffset).toBeNull();
-    expect(listed.hasMore).toBe(false);
   });
 
   test("parseGroupKey handles group keys", () => {
@@ -271,481 +87,6 @@ describe("gateway session utils", () => {
     expect(parseGroupKey("foo:bar")).toBeNull();
   });
 
-  test("session defaults include provider-owned thinking options", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.providers.push({
-      pluginId: "test",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "OpenAI Codex",
-        auth: [],
-        resolveThinkingProfile: ({ modelId }) => ({
-          levels: [
-            { id: "off" },
-            { id: "minimal" },
-            { id: "low" },
-            { id: "medium" },
-            { id: "adaptive" },
-            { id: "high" },
-            ...(modelId === "gpt-5.5" ? [{ id: "xhigh" as const }] : []),
-            { id: "max", label: "maximum" },
-          ],
-          defaultLevel: "adaptive",
-        }),
-      },
-    });
-    setActivePluginRegistry(registry);
-
-    const defaults = getSessionDefaults(createModelDefaultsConfig({ primary: "openai/gpt-5.5" }));
-
-    expectFields(defaults, {
-      modelProvider: "openai",
-      model: "gpt-5.5",
-      thinkingDefault: "adaptive",
-    });
-    const levelLabels = Object.fromEntries(
-      defaults.thinkingLevels?.map((level) => [level.id, level.label]) ?? [],
-    );
-    expectFields(levelLabels, {
-      adaptive: "adaptive",
-      xhigh: "xhigh",
-      max: "maximum",
-    });
-    expect(defaults.thinkingOptions).toContain("adaptive");
-    expect(defaults.thinkingOptions).toContain("xhigh");
-    expect(defaults.thinkingOptions).toContain("maximum");
-  });
-
-  test("session defaults and rows use catalog reasoning metadata for provider thinking options", () => {
-    const registry = createEmptyPluginRegistry();
-    registry.providers.push({
-      pluginId: "ollama",
-      source: "test",
-      provider: {
-        id: "ollama",
-        label: "Ollama",
-        auth: [],
-        resolveThinkingProfile: ({ reasoning }) => ({
-          levels:
-            reasoning === true
-              ? [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }]
-              : [{ id: "off" }],
-          defaultLevel: reasoning === true ? "medium" : "off",
-        }),
-      },
-    });
-    setActivePluginRegistry(registry);
-
-    const cfg = createModelDefaultsConfig({ primary: "ollama/qwen3:0.6b" });
-    const catalog = [
-      {
-        provider: "ollama",
-        id: "qwen3:0.6b",
-        name: "qwen3:0.6b",
-        reasoning: true,
-      },
-    ];
-
-    const defaults = getSessionDefaults(cfg, catalog);
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: {},
-      key: "main",
-      modelCatalog: catalog,
-    });
-
-    expect(defaults.thinkingLevels?.map((level) => level.id)).toEqual([
-      "off",
-      "low",
-      "medium",
-      "high",
-      "max",
-    ]);
-    expect(row.thinkingLevels?.map((level) => level.id)).toEqual([
-      "off",
-      "low",
-      "medium",
-      "high",
-      "max",
-    ]);
-    expect(defaults.thinkingDefault).toBe("medium");
-    expect(row.thinkingDefault).toBe("medium");
-  });
-
-  test("session rows ignore malformed compaction checkpoints", () => {
-    const row = buildGatewaySessionRow({
-      cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
-      storePath: "",
-      store: {},
-      key: "agent:main:main",
-      entry: {
-        sessionId: "session-1",
-        updatedAt: 1,
-        compactionCheckpoints: [
-          {
-            checkpointId: "checkpoint-older",
-            sessionKey: "agent:main:main",
-            sessionId: "session-1",
-            createdAt: 10,
-            reason: "manual",
-            preCompaction: { sessionId: "session-1" },
-            postCompaction: { sessionId: "session-1" },
-          },
-          null,
-          {
-            checkpointId: "",
-            createdAt: 30,
-            reason: "manual",
-          },
-          {
-            checkpointId: "checkpoint-bad-reason",
-            createdAt: 40,
-            reason: "bogus",
-          },
-          {
-            checkpointId: "checkpoint-newer",
-            sessionKey: "agent:main:main",
-            sessionId: "session-1",
-            createdAt: 50,
-            reason: "overflow-retry",
-            preCompaction: { sessionId: "session-1" },
-            postCompaction: { sessionId: "session-1" },
-          },
-        ],
-      } as unknown as SessionEntry,
-    });
-
-    expect(row.compactionCheckpointCount).toBe(2);
-    expect(row.latestCompactionCheckpoint).toEqual({
-      checkpointId: "checkpoint-newer",
-      createdAt: 50,
-      reason: "overflow-retry",
-    });
-  });
-
-  test("async session list reuses thinking metadata for lightweight rows", async () => {
-    const resolveThinkingProfile = vi.fn(() => ({
-      levels: [{ id: "off" as const }, { id: "medium" as const }],
-      defaultLevel: "medium" as const,
-    }));
-    const registry = createEmptyPluginRegistry();
-    registry.providers.push({
-      pluginId: "test",
-      source: "test",
-      provider: {
-        id: "openai",
-        label: "OpenAI Codex",
-        auth: [],
-        resolveThinkingProfile,
-      },
-    });
-    setActivePluginRegistry(registry);
-
-    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.5" });
-    const store = Object.fromEntries(
-      Array.from({ length: 5 }, (_value, index) => [
-        `session-${index}`,
-        {
-          sessionId: `session-${index}`,
-          modelProvider: "openai",
-          model: "gpt-5.5",
-          updatedAt: Date.now() - index,
-        } satisfies SessionEntry,
-      ]),
-    );
-
-    const result = await listSessionsFromStoreAsync({
-      cfg,
-      storePath: "",
-      store,
-      opts: {},
-    });
-
-    expect(result.sessions).toHaveLength(5);
-    const missingMediumLevelSessionIds = result.sessions
-      .filter((session) => !session.thinkingLevels?.some((level) => level.id === "medium"))
-      .map((session) => session.sessionId);
-    const missingMediumOptionSessionIds = result.sessions
-      .filter((session) => !session.thinkingOptions?.includes("medium"))
-      .map((session) => session.sessionId);
-
-    expect(missingMediumLevelSessionIds).toStrictEqual([]);
-    expect(missingMediumOptionSessionIds).toStrictEqual([]);
-    expect(result.sessions.map((session) => session.thinkingDefault)).toEqual(
-      Array.from({ length: result.sessions.length }, () => "medium"),
-    );
-    expect(resolveThinkingProfile).toHaveBeenCalled();
-  });
-
-  test("session list thinking cache preserves case-distinct model catalog entries", () => {
-    const cfg = createModelDefaultsConfig({ primary: "custom/CaseModel" });
-    const modelCatalog = [
-      {
-        provider: "custom",
-        id: "CaseModel",
-        name: "CaseModel",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
-      },
-      {
-        provider: "custom",
-        id: "casemodel",
-        name: "casemodel",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["low", "medium", "high"] },
-      },
-    ];
-    const result = listSessionsFromStore({
-      cfg,
-      storePath: "",
-      modelCatalog,
-      store: {
-        upper: {
-          sessionId: "upper",
-          modelProvider: "custom",
-          model: "CaseModel",
-          updatedAt: 2,
-        } satisfies SessionEntry,
-        lower: {
-          sessionId: "lower",
-          modelProvider: "custom",
-          model: "casemodel",
-          updatedAt: 1,
-        } satisfies SessionEntry,
-      },
-      opts: {},
-    });
-
-    const upper = result.sessions.find((session) => session.key === "upper");
-    const lower = result.sessions.find((session) => session.key === "lower");
-    expect(upper?.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
-    expect(lower?.thinkingLevels?.map((level) => level.id)).not.toContain("xhigh");
-  });
-
-  test("session defaults and rows expose xhigh from configured catalog compat", () => {
-    const cfg = createModelDefaultsConfig({ primary: "gmn/gpt-5.4" });
-    const catalog = [
-      {
-        provider: "gmn",
-        id: "gpt-5.4",
-        name: "GPT 5.4 via GMN",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
-      },
-    ];
-
-    const defaults = getSessionDefaults(cfg, catalog);
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: {},
-      key: "main",
-      modelCatalog: catalog,
-    });
-
-    expect(defaults.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
-    expect(row.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
-  });
-
-  test("session defaults and rows expose bundled startup-lazy provider thinking without catalog", () => {
-    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.5" });
-
-    const defaults = getSessionDefaults(cfg);
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: {},
-      key: "main",
-    });
-
-    expect(defaults.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
-    expect(row.thinkingLevels?.map((level) => level.id)).toContain("xhigh");
-  });
-
-  test("session defaults use configured thinking default", () => {
-    const defaults = getSessionDefaults({
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-5.5" },
-          thinkingDefault: "high",
-        },
-      },
-    } as OpenClawConfig);
-
-    expectFields(defaults, {
-      modelProvider: "openai",
-      model: "gpt-5.5",
-      thinkingDefault: "high",
-    });
-  });
-
-  test("session rows expose estimated context budget status", () => {
-    const row = buildGatewaySessionRow({
-      cfg: createModelDefaultsConfig({ primary: "anthropic/claude-sonnet-4.6" }),
-      storePath: "",
-      store: {},
-      key: "agent:main:main",
-      entry: {
-        sessionId: "session-1",
-        sessionFile: "/tmp/openclaw/agents/main/sessions/session-1.jsonl",
-        updatedAt: 1,
-        contextBudgetStatus: {
-          schemaVersion: 1,
-          source: "pre-prompt-estimate",
-          updatedAt: 2,
-          provider: "anthropic",
-          model: "claude-sonnet-4.6",
-          route: "compact_then_truncate",
-          shouldCompact: true,
-          estimatedPromptTokens: 640_000,
-          contextTokenBudget: 200_000,
-          promptBudgetBeforeReserve: 180_000,
-          reserveTokens: 20_000,
-          effectiveReserveTokens: 20_000,
-          remainingPromptBudgetTokens: 0,
-          overflowTokens: 460_000,
-          toolResultReducibleChars: 12_000,
-          messageCount: 42,
-          unwindowedMessageCount: 39,
-          sessionId: "session-1",
-        },
-      },
-    });
-
-    expect(row.contextBudgetStatus).toMatchObject({
-      provider: "anthropic",
-      model: "claude-sonnet-4.6",
-      estimatedPromptTokens: 640_000,
-      contextTokenBudget: 200_000,
-      sessionId: "session-1",
-    });
-  });
-
-  test("session rows preserve fresh zero-token usage", () => {
-    const row = buildGatewaySessionRow({
-      cfg: {} as OpenClawConfig,
-      storePath: "",
-      store: {},
-      key: "agent:main:main",
-      entry: {
-        sessionId: "fresh-zero-token-session",
-        updatedAt: 1,
-        totalTokens: 0,
-        totalTokensFresh: true,
-      },
-    });
-
-    expect(row.totalTokens).toBe(0);
-    expect(row.totalTokensFresh).toBe(true);
-  });
-
-  test("selected global rows read transcript usage from the selected agent", async () => {
-    await withStateDirEnv("session-utils-selected-global-usage-", async ({ stateDir }) => {
-      const sessionId = "selected-global-usage";
-      for (const [agentId, input] of [
-        ["main", 10],
-        ["work", 40],
-      ] as const) {
-        const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
-        fs.mkdirSync(sessionsDir, { recursive: true });
-        fs.writeFileSync(
-          path.join(sessionsDir, `${sessionId}.jsonl`),
-          [
-            JSON.stringify({ type: "session", version: 1, id: sessionId }),
-            JSON.stringify({
-              message: {
-                role: "assistant",
-                content: "done",
-                usage: { input, output: 2 },
-              },
-            }),
-          ].join("\n"),
-          "utf-8",
-        );
-      }
-
-      const row = buildGatewaySessionRow({
-        cfg: {
-          agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-        } as OpenClawConfig,
-        storePath: "",
-        store: {},
-        key: "global",
-        agentId: "work",
-        entry: { sessionId, updatedAt: 1 },
-      });
-
-      expect(row.totalTokens).toBe(40);
-    });
-  });
-
-  test("session rows use per-agent thinking default from config", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-5.5" },
-          thinkingDefault: "low",
-          models: {
-            "openai/gpt-5.5": {
-              params: { thinking: "max" },
-            },
-          },
-        },
-        list: [
-          {
-            id: "alpha",
-            default: true,
-            thinkingDefault: "high",
-          },
-        ],
-      },
-    } as OpenClawConfig;
-
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: {},
-      key: "agent:alpha:main",
-    });
-
-    expectFields(row, {
-      modelProvider: "openai",
-      model: "gpt-5.5",
-      thinkingDefault: "high",
-    });
-  });
-
-  test("session rows prefer per-model thinking over global default", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-5.5" },
-          thinkingDefault: "low",
-          models: {
-            "openai/gpt-5.5": {
-              params: { thinking: "max" },
-            },
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: {},
-      key: "main",
-    });
-
-    expectFields(row, {
-      modelProvider: "openai",
-      model: "gpt-5.5",
-      thinkingDefault: "max",
-    });
-  });
-
   test("classifySessionKey respects chat type + prefixes", () => {
     expect(classifySessionKey("global")).toBe("global");
     expect(classifySessionKey("unknown")).toBe("unknown");
@@ -753,60 +94,6 @@ describe("gateway session utils", () => {
     expect(classifySessionKey("main")).toBe("direct");
     const entry = { chatType: "group" } as SessionEntry;
     expect(classifySessionKey("main", entry)).toBe("group");
-  });
-
-  test("buildGatewaySessionRow displayName falls through to origin label for direct sessions", () => {
-    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
-    const entry = {
-      chatType: "direct",
-      channel: "telegram",
-      origin: { label: "openclaw-tui" },
-    } as SessionEntry;
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: { "agent:main:telegram:direct:42": entry },
-      key: "agent:main:telegram:direct:42",
-      entry,
-    });
-    expect(row.displayName).toBe("openclaw-tui");
-  });
-
-  test("buildGatewaySessionRow displayName uses group display name for group sessions", () => {
-    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
-    const entry = {
-      chatType: "group",
-      channel: "telegram",
-      subject: "Engineering",
-      origin: { label: "openclaw-tui" },
-    } as SessionEntry;
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: { "agent:main:telegram:group:99": entry },
-      key: "agent:main:telegram:group:99",
-      entry,
-    });
-    expect(row.displayName).toMatch(/^telegram:/);
-    expect(row.displayName).not.toBe("openclaw-tui");
-  });
-
-  test("buildGatewaySessionRow prefers entry.label over origin.label for direct sessions", () => {
-    const cfg = { agents: { list: [{ id: "main", default: true }] } } as OpenClawConfig;
-    const entry = {
-      chatType: "direct",
-      channel: "telegram",
-      label: "Alice",
-      origin: { label: "openclaw-tui" },
-    } as SessionEntry;
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath: "",
-      store: { "agent:main:telegram:direct:42": entry },
-      key: "agent:main:telegram:direct:42",
-      entry,
-    });
-    expect(row.displayName).toBe("Alice");
   });
 
   test("resolveSessionStoreKey maps main aliases to default agent main", () => {
@@ -818,136 +105,7 @@ describe("gateway session utils", () => {
     expect(resolveSessionStoreKey({ cfg, sessionKey: "work" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:main" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:ops:MAIN" })).toBe("agent:ops:work");
-    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:main:main" })).toBe("agent:ops:work");
-    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:main:work" })).toBe("agent:ops:work");
     expect(resolveSessionStoreKey({ cfg, sessionKey: "MAIN" })).toBe("agent:ops:work");
-  });
-
-  test("resolveSessionStoreKey preserves non-alias agent:main keys for deleted-agent checks", () => {
-    const cfg = {
-      session: { mainKey: "work" },
-      agents: { list: [{ id: "ops", default: true }] },
-    } as OpenClawConfig;
-    expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:main:discord:direct:u1" })).toBe(
-      "agent:main:discord:direct:u1",
-    );
-  });
-
-  test("resolveDeletedAgentIdFromSessionKey rejects non-alias main keys when main is absent", () => {
-    const cfg = {
-      session: { mainKey: "work" },
-      agents: { list: [{ id: "ops", default: true }] },
-    } as OpenClawConfig;
-    const legacyMainAlias = resolveSessionStoreKey({ cfg, sessionKey: "agent:main:main" });
-
-    expect(legacyMainAlias).toBe("agent:ops:work");
-    expect(resolveDeletedAgentIdFromSessionKey(cfg, legacyMainAlias)).toBeNull();
-    expect(resolveDeletedAgentIdFromSessionKey(cfg, "global")).toBeNull();
-    expect(resolveDeletedAgentIdFromSessionKey(cfg, "unknown")).toBeNull();
-    expect(resolveDeletedAgentIdFromSessionKey(cfg, "main")).toBeNull();
-    expect(resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:discord:direct:u1")).toBe("main");
-  });
-
-  test("resolveDeletedAgentIdFromSessionKey ignores confirmed ACP runtime session keys", () => {
-    const cfg = {
-      agents: { list: [{ id: "main", default: true }] },
-    } as OpenClawConfig;
-    const acpEntry = (agent: string, runtimeSessionName: string) =>
-      ({
-        acp: {
-          backend: "acpx",
-          agent,
-          runtimeSessionName,
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: 1,
-        },
-      }) as SessionEntry;
-    const claudeKey = "agent:claude:acp:11111111-1111-4111-8111-111111111111";
-    const cursorKey = "agent:cursor:acp:22222222-2222-4222-8222-222222222222";
-    expect(
-      resolveDeletedAgentIdFromSessionKey(cfg, claudeKey, acpEntry("claude", claudeKey)),
-    ).toBeNull();
-    expect(
-      resolveDeletedAgentIdFromSessionKey(cfg, cursorKey, acpEntry("cursor", cursorKey)),
-    ).toBeNull();
-  });
-
-  test("resolveDeletedAgentIdFromSessionKey rejects ACP-shaped bridge keys without ACP metadata", () => {
-    const cfg = {
-      agents: { list: [{ id: "main", default: true }] },
-    } as OpenClawConfig;
-
-    expect(
-      resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:acp:configured-bridge-without-meta", {
-        acp: undefined,
-        sessionId: "sess-configured-bridge",
-        updatedAt: 1,
-      }),
-    ).toBeNull();
-
-    expect(
-      resolveDeletedAgentIdFromSessionKey(
-        cfg,
-        "agent:deleted-agent:acp:bridge-session-without-runtime-meta",
-        { acp: undefined, sessionId: "sess-deleted-bridge", updatedAt: 1 },
-      ),
-    ).toBe("deleted-agent");
-  });
-
-  test("resolveDeletedAgentIdFromSessionKey repairs canonical ACP metadata aliases", async () => {
-    await withStateDirEnv("session-utils-acp-deleted-agent-repair-", async ({ stateDir }) => {
-      const storePath = path.join(stateDir, "agents", "claude", "sessions", "sessions.json");
-      const acpKey = "agent:claude:acp:55555555-5555-4555-8555-555555555555";
-      const legacyAcpKey = "agent:CLAUDE:acp:55555555-5555-4555-8555-555555555555";
-      const entry = {
-        sessionId: "sess-acp-repair",
-        updatedAt: 1,
-      } satisfies SessionEntry;
-      writeSessionStoreForTest(storePath, {
-        [acpKey]: entry,
-      });
-      writeAcpSessionMetaForMigration({
-        sessionKey: legacyAcpKey,
-        sessionId: "sess-acp-repair",
-        meta: {
-          backend: "acpx",
-          agent: "claude",
-          runtimeSessionName: legacyAcpKey,
-          mode: "oneshot",
-          state: "idle",
-          lastActivityAt: 1,
-        },
-      });
-      const cfg = {
-        session: {
-          store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
-        },
-        agents: { list: [{ id: "main", default: true }] },
-      } as OpenClawConfig;
-
-      expect(
-        resolveDeletedAgentIdFromSessionKey(cfg, acpKey, entry, {
-          acpMetadataSessionKey: acpKey,
-        }),
-      ).toBeNull();
-    });
-  });
-
-  test("resolveDeletedAgentIdFromSessionKey rejects deleted configured ACP binding owners", () => {
-    const cfg = {
-      agents: { list: [{ id: "main", default: true }] },
-    } as OpenClawConfig;
-
-    expect(
-      resolveDeletedAgentIdFromSessionKey(
-        cfg,
-        "agent:deleted-agent:acp:binding:discord:default:feedface",
-      ),
-    ).toBe("deleted-agent");
-    expect(
-      resolveDeletedAgentIdFromSessionKey(cfg, "agent:main:acp:binding:discord:default:feedface"),
-    ).toBeNull();
   });
 
   test("resolveSessionStoreKey canonicalizes bare keys to default agent", () => {
@@ -997,34 +155,6 @@ describe("gateway session utils", () => {
     );
   });
 
-  test("resolveSessionStoreKey preserves Signal group ids", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: { list: [{ id: "ops", default: true }] },
-    } as OpenClawConfig;
-    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
-    expect(resolveSessionStoreKey({ cfg, sessionKey: `Signal:Group:${mixedGroupId}` })).toBe(
-      `agent:ops:signal:group:${mixedGroupId}`,
-    );
-    expect(
-      resolveSessionStoreKey({ cfg, sessionKey: `Agent:Alpha:Signal:Group:${mixedGroupId}` }),
-    ).toBe(`agent:alpha:signal:group:${mixedGroupId}`);
-  });
-
-  test("canonicalizeSpawnedByForAgent preserves Signal group ids", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-    } as OpenClawConfig;
-    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
-
-    expect(canonicalizeSpawnedByForAgent(cfg, "ops", `Signal:Group:${mixedGroupId}`)).toBe(
-      `agent:ops:signal:group:${mixedGroupId}`,
-    );
-    expect(
-      canonicalizeSpawnedByForAgent(cfg, "ops", `Agent:Main:Signal:Group:${mixedGroupId}`),
-    ).toBe(`agent:main:signal:group:${mixedGroupId}`);
-  });
-
   test("resolveSessionStoreKey honors global scope", () => {
     const cfg = {
       session: { scope: "global", mainKey: "work" },
@@ -1049,8 +179,7 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "main" });
     expect(target.canonicalKey).toBe("agent:ops:main");
-    expect(target.storeKeys).toContain("agent:ops:main");
-    expect(target.storeKeys).toContain("main");
+    expect(target.storeKeys).toEqual(expect.arrayContaining(["agent:ops:main", "main"]));
     expect(target.storePath).toBe(path.resolve(storeTemplate.replace("{agentId}", "ops")));
   });
 
@@ -1068,8 +197,9 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
     expect(target.canonicalKey).toBe("agent:ops:mysession");
-    expect(target.storeKeys).toContain("agent:ops:mysession");
-    expect(target.storeKeys).toContain("agent:ops:MySession");
+    expect(target.storeKeys).toEqual(
+      expect.arrayContaining(["agent:ops:mysession", "agent:ops:MySession"]),
+    );
     const store = JSON.parse(fs.readFileSync(storePath, "utf8"));
     const found = target.storeKeys.some((k) => Boolean(store[k]));
     expect(found).toBe(true);
@@ -1091,8 +221,9 @@ describe("gateway session utils", () => {
       agents: { list: [{ id: "ops", default: true }] },
     } as OpenClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:mysession" });
-    expect(target.storeKeys).toContain("agent:ops:mysession");
-    expect(target.storeKeys).toContain("agent:ops:MySession");
+    expect(target.storeKeys).toEqual(
+      expect.arrayContaining(["agent:ops:mysession", "agent:ops:MySession"]),
+    );
   });
 
   test("resolveGatewaySessionStoreTarget finds legacy main alias key when mainKey is customized", () => {
@@ -1109,7 +240,7 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
     const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:ops:main" });
     expect(target.canonicalKey).toBe("agent:ops:work");
-    expect(target.storeKeys).toContain("agent:ops:MAIN");
+    expect(target.storeKeys).toEqual(expect.arrayContaining(["agent:ops:MAIN"]));
   });
 
   test("resolveGatewaySessionStoreTarget preserves discovered store paths for non-round-tripping agent dirs", async () => {
@@ -1166,167 +297,6 @@ describe("gateway session utils", () => {
 
         expect(loaded.storePath).toBe(resolveSyncRealpath(retiredStorePath));
         expect(loaded.entry?.sessionId).toBe("sess-retired");
-      });
-    } finally {
-      resetConfigRuntimeState();
-    }
-  });
-
-  test("loadSessionEntry can borrow the cached store for read-only hot paths", async () => {
-    resetConfigRuntimeState();
-    try {
-      await withStateDirEnv("session-utils-load-entry-borrowed-", async ({ stateDir }) => {
-        const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-        fs.mkdirSync(sessionsDir, { recursive: true });
-        const storePath = path.join(sessionsDir, "sessions.json");
-        fs.writeFileSync(
-          storePath,
-          JSON.stringify({
-            "agent:main:main": { sessionId: "sess-main", updatedAt: 7 },
-          }),
-          "utf8",
-        );
-        const cfg = {
-          session: {
-            mainKey: "main",
-            store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
-          },
-          agents: { list: [{ id: "main", default: true }] },
-        } as OpenClawConfig;
-        setRuntimeConfigSnapshot(cfg, cfg);
-
-        const loaded = loadSessionEntry("agent:main:main", { clone: false });
-        const borrowedStore = loadSessionStore(loaded.storePath, { clone: false });
-
-        expect(loaded.entry).toBe(borrowedStore["agent:main:main"]);
-      });
-    } finally {
-      resetConfigRuntimeState();
-    }
-  });
-
-  test("resolveGatewaySessionStoreTargetWithStore returns the caller-provided store", async () => {
-    resetConfigRuntimeState();
-    try {
-      await withStateDirEnv("session-utils-target-store-", async ({ stateDir }) => {
-        const cfg = {
-          session: {
-            mainKey: "main",
-            store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
-          },
-          agents: { list: [{ id: "main", default: true }] },
-        } as OpenClawConfig;
-        const store: Record<string, SessionEntry> = {
-          "agent:main:main": { sessionId: "sess-main", updatedAt: 7 },
-        };
-
-        const target = resolveGatewaySessionStoreTargetWithStore({
-          cfg,
-          key: "agent:main:main",
-          store,
-        });
-
-        expect(target.store).toBe(store);
-        expect(target.storeKeys).toContain("agent:main:main");
-      });
-    } finally {
-      resetConfigRuntimeState();
-    }
-  });
-
-  test("loadSessionEntry preserves a listed deleted main session over the live default main", async () => {
-    resetConfigRuntimeState();
-    try {
-      await withStateDirEnv("session-utils-load-deleted-main-entry-", async ({ stateDir }) => {
-        const storeTemplate = path.join(
-          stateDir,
-          "agents",
-          "{agentId}",
-          "sessions",
-          "sessions.json",
-        );
-        const liveSessionsDir = path.join(stateDir, "agents", "ops", "sessions");
-        const deletedSessionsDir = path.join(stateDir, "agents", "main", "sessions");
-        fs.mkdirSync(liveSessionsDir, { recursive: true });
-        fs.mkdirSync(deletedSessionsDir, { recursive: true });
-        const liveStorePath = path.join(liveSessionsDir, "sessions.json");
-        const deletedStorePath = path.join(deletedSessionsDir, "sessions.json");
-        fs.writeFileSync(
-          liveStorePath,
-          JSON.stringify({
-            "agent:ops:main": { sessionId: "sess-live-default", updatedAt: 10 },
-          }),
-          "utf8",
-        );
-        fs.writeFileSync(
-          deletedStorePath,
-          JSON.stringify({
-            "agent:main:main": { sessionId: "sess-deleted-main", updatedAt: 20 },
-          }),
-          "utf8",
-        );
-        const cfg = {
-          session: { mainKey: "main", store: storeTemplate },
-          agents: { list: [{ id: "ops", default: true }] },
-        } as OpenClawConfig;
-        setRuntimeConfigSnapshot(cfg, cfg);
-
-        const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:main:main" });
-        const loaded = loadSessionEntry("agent:main:main");
-
-        expect(target.canonicalKey).toBe("agent:main:main");
-        expect(target.agentId).toBe("main");
-        expect(target.storePath).toBe(resolveSyncRealpath(deletedStorePath));
-        expect(loaded.canonicalKey).toBe("agent:main:main");
-        expect(loaded.storePath).toBe(resolveSyncRealpath(deletedStorePath));
-        expect(loaded.entry?.sessionId).toBe("sess-deleted-main");
-      });
-    } finally {
-      resetConfigRuntimeState();
-    }
-  });
-
-  test("loadSessionEntry resolves deleted main aliases when mainKey is customized", async () => {
-    resetConfigRuntimeState();
-    try {
-      await withStateDirEnv("session-utils-load-deleted-main-alias-", async ({ stateDir }) => {
-        const storeTemplate = path.join(
-          stateDir,
-          "agents",
-          "{agentId}",
-          "sessions",
-          "sessions.json",
-        );
-        const liveSessionsDir = path.join(stateDir, "agents", "ops", "sessions");
-        const deletedSessionsDir = path.join(stateDir, "agents", "main", "sessions");
-        fs.mkdirSync(liveSessionsDir, { recursive: true });
-        fs.mkdirSync(deletedSessionsDir, { recursive: true });
-        fs.writeFileSync(
-          path.join(liveSessionsDir, "sessions.json"),
-          JSON.stringify({
-            "agent:ops:work": { sessionId: "sess-live-default", updatedAt: 10 },
-          }),
-          "utf8",
-        );
-        const deletedStorePath = path.join(deletedSessionsDir, "sessions.json");
-        fs.writeFileSync(
-          deletedStorePath,
-          JSON.stringify({
-            "agent:main:main": { sessionId: "sess-deleted-main", updatedAt: 20 },
-          }),
-          "utf8",
-        );
-        const cfg = {
-          session: { mainKey: "work", store: storeTemplate },
-          agents: { list: [{ id: "ops", default: true }] },
-        } as OpenClawConfig;
-        setRuntimeConfigSnapshot(cfg, cfg);
-
-        const loaded = loadSessionEntry("agent:main:work");
-
-        expect(loaded.canonicalKey).toBe("agent:main:work");
-        expect(loaded.storePath).toBe(resolveSyncRealpath(deletedStorePath));
-        expect(loaded.entry?.sessionId).toBe("sess-deleted-main");
       });
     } finally {
       resetConfigRuntimeState();
@@ -1529,64 +499,6 @@ describe("gateway session utils", () => {
     );
   });
 
-  test("listAgentsForGateway falls back to identity.name when name is unset", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: {
-        list: [{ id: "main", default: true, identity: { name: "开发助手" } }],
-      },
-    } as OpenClawConfig;
-
-    const result = listAgentsForGateway(cfg);
-
-    expect(result.agents[0]).toMatchObject({
-      id: "main",
-      name: "开发助手",
-      identity: { name: "开发助手" },
-    });
-  });
-
-  test("listAgentsForGateway prefers explicit name over identity.name", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: {
-        list: [
-          {
-            id: "main",
-            default: true,
-            name: "Ops",
-            identity: { name: "开发助手" },
-          },
-        ],
-      },
-    } as OpenClawConfig;
-
-    const result = listAgentsForGateway(cfg);
-
-    expect(result.agents[0]).toMatchObject({
-      id: "main",
-      name: "Ops",
-      identity: { name: "开发助手" },
-    });
-  });
-
-  test("listAgentsForGateway leaves name unset when both configured and identity names are absent", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: {
-        list: [{ id: "main", default: true, identity: {} }],
-      },
-    } as OpenClawConfig;
-
-    const result = listAgentsForGateway(cfg);
-
-    expect(result.agents[0]).toMatchObject({
-      id: "main",
-      name: undefined,
-      identity: {},
-    });
-  });
-
   test("listAgentsForGateway keeps explicit agents.list scope over disk-only agents (scope boundary)", async () => {
     await withStateDirEnv("openclaw-agent-list-scope-", async ({ stateDir }) => {
       fs.mkdirSync(path.join(stateDir, "agents", "main"), { recursive: true });
@@ -1610,7 +522,7 @@ describe("gateway session utils", () => {
           workspace: "/tmp/default-workspace",
           model: {
             primary: "openai/gpt-5.4",
-            fallbacks: ["openai/gpt-5.4"],
+            fallbacks: ["openai-codex/gpt-5.4"],
           },
         },
         list: [{ id: "main", default: true }],
@@ -1618,47 +530,13 @@ describe("gateway session utils", () => {
     } as OpenClawConfig;
 
     const result = listAgentsForGateway(cfg);
-    expectFields(result.agents[0], {
+    expect(result.agents[0]).toMatchObject({
       id: "main",
       workspace: "/tmp/default-workspace",
-    });
-    expect(result.agents[0]?.model).toEqual({
-      primary: "openai/gpt-5.4",
-      fallbacks: ["openai/gpt-5.4"],
-    });
-    expect(result.agents[0]?.agentRuntime).toEqual({
-      id: "codex",
-      source: "implicit",
-    });
-  });
-
-  test("listAgentsForGateway reports explicit plugin runtime metadata", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            agentRuntime: { id: "codex" },
-            models: [],
-          },
-        },
+      model: {
+        primary: "openai/gpt-5.4",
+        fallbacks: ["openai-codex/gpt-5.4"],
       },
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-5.4" },
-        },
-        list: [{ id: "main", default: true }],
-      },
-    } as OpenClawConfig;
-
-    const result = listAgentsForGateway(cfg);
-    expectFields(result.agents[0], {
-      id: "main",
-    });
-    expect(result.agents[0]?.agentRuntime).toEqual({
-      id: "codex",
-      source: "provider",
     });
   });
 
@@ -1669,7 +547,7 @@ describe("gateway session utils", () => {
         defaults: {
           model: {
             primary: "openai/gpt-5.4",
-            fallbacks: ["openai/gpt-5.4"],
+            fallbacks: ["openai-codex/gpt-5.4"],
           },
         },
         list: [
@@ -1689,56 +567,6 @@ describe("gateway session utils", () => {
     const ops = result.agents.find((agent) => agent.id === "ops");
     expect(ops?.model).toEqual({ primary: "anthropic/claude-opus-4-6" });
   });
-
-  test("listAgentsForGateway reports per-agent thinking defaults from the agent model", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: {
-        defaults: {
-          model: { primary: "minimax/MiniMax-M2.7" },
-          thinkingDefault: "off",
-        },
-        list: [
-          { id: "main", default: true },
-          {
-            id: "investment-master",
-            model: { primary: "deepseek/deepseek-v4-flash" },
-            thinkingDefault: "xhigh",
-          },
-        ],
-      },
-    } as OpenClawConfig;
-
-    const result = listAgentsForGateway(cfg);
-    const agent = result.agents.find((row) => row.id === "investment-master");
-
-    expect(agent?.model).toEqual({ primary: "deepseek/deepseek-v4-flash" });
-    expect(agent?.thinkingDefault).toBe("xhigh");
-    expect(agent?.thinkingLevels?.map((level) => level.id)).toEqual(
-      expect.arrayContaining(["off", "minimal", "low", "medium", "high", "xhigh"]),
-    );
-    expect(agent?.thinkingOptions).toEqual(agent?.thinkingLevels?.map((level) => level.label));
-  });
-
-  test("listAgentsForGateway uses the model catalog for per-agent thinking metadata", () => {
-    const cfg = {
-      session: { mainKey: "main" },
-      agents: {
-        defaults: {
-          model: { primary: "local/custom-reasoner" },
-        },
-        list: [{ id: "main", default: true }],
-      },
-    } as OpenClawConfig;
-
-    const result = listAgentsForGateway(cfg, [
-      { provider: "local", id: "custom-reasoner", name: "Custom Reasoner", reasoning: true },
-    ]);
-    const agent = result.agents.find((row) => row.id === "main");
-
-    expect(agent?.thinkingDefault).toBe("medium");
-    expect(agent?.thinkingLevels?.map((level) => level.id)).toContain("medium");
-  });
 });
 
 describe("resolveSessionModelRef", () => {
@@ -1750,7 +578,7 @@ describe("resolveSessionModelRef", () => {
     const resolved = resolveSessionModelRef(cfg, {
       sessionId: "s1",
       updatedAt: Date.now(),
-      modelProvider: "openai",
+      modelProvider: "openai-codex",
       model: "gpt-5.4",
       modelOverride: "claude-opus-4-6",
       providerOverride: "anthropic",
@@ -1785,25 +613,10 @@ describe("resolveSessionModelRef", () => {
     const resolved = resolveSessionModelRef(cfg, {
       sessionId: "s2",
       updatedAt: Date.now(),
-      modelOverride: "openai/gpt-5.4",
+      modelOverride: "openai-codex/gpt-5.4",
     });
 
-    expect(resolved).toEqual({ provider: "openai", model: "gpt-5.4" });
-  });
-
-  test("keeps nested model ids under the stored provider override", () => {
-    const cfg = createModelDefaultsConfig({
-      primary: "anthropic/claude-opus-4-6",
-    });
-
-    const resolved = resolveSessionModelRef(cfg, {
-      sessionId: "s-nested",
-      updatedAt: Date.now(),
-      providerOverride: "nvidia",
-      modelOverride: "moonshotai/kimi-k2.5",
-    });
-
-    expect(resolved).toEqual({ provider: "nvidia", model: "moonshotai/kimi-k2.5" });
+    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
   });
 
   test("preserves explicit wrapper providers for vendor-prefixed override models", () => {
@@ -1826,24 +639,9 @@ describe("resolveSessionModelRef", () => {
     });
   });
 
-  test("strips a duplicated provider prefix from stored overrides", () => {
-    const cfg = createModelDefaultsConfig({
-      primary: "anthropic/claude-opus-4-6",
-    });
-
-    const resolved = resolveSessionModelRef(cfg, {
-      sessionId: "s-qualified-override",
-      updatedAt: Date.now(),
-      providerOverride: "openai",
-      modelOverride: "openai/gpt-5.4",
-    });
-
-    expect(resolved).toEqual({ provider: "openai", model: "gpt-5.4" });
-  });
-
   test("falls back to resolved provider for unprefixed legacy runtime model", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
     });
 
     const resolved = resolveSessionModelRef(cfg, {
@@ -1861,7 +659,7 @@ describe("resolveSessionModelRef", () => {
 
   test("preserves provider from slash-prefixed model when modelProvider is missing", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
     });
 
     const resolved = resolveSessionModelRef(cfg, {
@@ -1876,185 +674,6 @@ describe("resolveSessionModelRef", () => {
 });
 
 describe("listSessionsFromStore selected model display", () => {
-  test("async list yields during bulk transcript title and last-message hydration", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-list-yield-"));
-    try {
-      const storePath = path.join(tmpDir, "sessions.json");
-      const store: Record<string, SessionEntry> = {};
-      const now = Date.now();
-      for (let i = 0; i < 11; i += 1) {
-        const sessionId = `sess-yield-${i}`;
-        store[`agent:main:${sessionId}`] = {
-          sessionId,
-          updatedAt: now - i,
-          modelProvider: "openai",
-          model: "gpt-5.4",
-          totalTokens: 1,
-          totalTokensFresh: true,
-          contextTokens: 1,
-          estimatedCostUsd: 0,
-        } as SessionEntry;
-        fs.writeFileSync(
-          path.join(tmpDir, `${sessionId}.jsonl`),
-          [
-            JSON.stringify({ type: "session", version: 1, id: sessionId }),
-            JSON.stringify({ message: { role: "user", content: `title ${i}` } }),
-            JSON.stringify({ message: { role: "assistant", content: `last ${i}` } }),
-          ].join("\n"),
-          "utf-8",
-        );
-      }
-
-      const params = {
-        cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
-        storePath,
-        store,
-        opts: { includeDerivedTitles: true, includeLastMessage: true, limit: 11 },
-      };
-      const expected = listSessionsFromStore(params);
-      const listedPromise = listSessionsFromStoreAsync(params);
-      let settled = false;
-      void listedPromise.then(() => {
-        settled = true;
-      });
-
-      await Promise.resolve();
-
-      expect(settled).toBe(false);
-      const listed = await listedPromise;
-      expect(listed.path).toBe(expected.path);
-      expect(listed.count).toBe(expected.count);
-      expect(listed.defaults).toEqual(expected.defaults);
-      expect(listed.sessions).toHaveLength(expected.sessions.length);
-      expectFields(listed.sessions[0], {
-        key: "agent:main:sess-yield-0",
-        derivedTitle: "title 0",
-        lastMessagePreview: "last 0",
-      });
-      expect(listed.sessions[0]?.agentRuntime).toEqual({ id: "codex", source: "implicit" });
-      expect(listed.sessions[0]?.thinkingLevel).toBeUndefined();
-      expect(listed.sessions[0]?.thinkingLevels?.length).toBeGreaterThan(0);
-      expect(listed.sessions[0]?.thinkingOptions?.length).toBeGreaterThan(0);
-      expect(listed.sessions[0]?.thinkingDefault).toBe("off");
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  test("caps transcript title and last-message hydration for bulk list responses", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-list-cap-"));
-    try {
-      const storePath = path.join(tmpDir, "sessions.json");
-      const store: Record<string, SessionEntry> = {};
-      const now = Date.now();
-      for (let i = 0; i < 101; i += 1) {
-        const sessionId = `sess-${i}`;
-        store[`agent:main:${sessionId}`] = {
-          sessionId,
-          updatedAt: now - i,
-          modelProvider: "openai",
-          model: "gpt-5.4",
-        } as SessionEntry;
-        if (i === 0 || i === 99 || i === 100) {
-          fs.writeFileSync(
-            path.join(tmpDir, `${sessionId}.jsonl`),
-            [
-              JSON.stringify({ type: "session", version: 1, id: sessionId }),
-              JSON.stringify({ message: { role: "user", content: `title ${i}` } }),
-              JSON.stringify({ message: { role: "assistant", content: `last ${i}` } }),
-            ].join("\n"),
-            "utf-8",
-          );
-        }
-      }
-
-      const result = await listSessionsFromStoreAsync({
-        cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
-        storePath,
-        store,
-        opts: { includeDerivedTitles: true, includeLastMessage: true, limit: 101 },
-      });
-
-      expect(result.sessions).toHaveLength(101);
-      expect(result.sessions[0]?.derivedTitle).toBe("title 0");
-      expect(result.sessions[0]?.lastMessagePreview).toBe("last 0");
-      expect(result.sessions[99]?.derivedTitle).toBe("title 99");
-      expect(result.sessions[99]?.lastMessagePreview).toBe("last 99");
-      expect(result.sessions[100]?.derivedTitle).toBeUndefined();
-      expect(result.sessions[100]?.lastMessagePreview).toBeUndefined();
-    } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  test("uses bounded top-N selection for small limited lists", () => {
-    const now = Date.now();
-    const store: Record<string, SessionEntry> = {
-      "agent:main:old": { sessionId: "old", updatedAt: now - 10_000 } as SessionEntry,
-      "agent:main:newest": { sessionId: "newest", updatedAt: now } as SessionEntry,
-      "agent:main:middle-a": { sessionId: "middle-a", updatedAt: now - 5_000 } as SessionEntry,
-      "agent:main:middle-b": { sessionId: "middle-b", updatedAt: now - 5_000 } as SessionEntry,
-      "agent:main:newer": { sessionId: "newer", updatedAt: now - 1_000 } as SessionEntry,
-    };
-    const result = listSessionsFromStore({
-      cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
-      storePath: "/tmp/sessions.json",
-      store,
-      opts: { limit: 4 },
-    });
-
-    expect(result.sessions.map((session) => session.key)).toEqual([
-      "agent:main:newest",
-      "agent:main:newer",
-      "agent:main:middle-a",
-      "agent:main:middle-b",
-    ]);
-  });
-
-  test("keeps the scoped global row when filtering by agent", () => {
-    const now = Date.now();
-    const result = listSessionsFromStore({
-      cfg: {
-        ...createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
-        agents: {
-          defaults: { model: { primary: "openai/gpt-5.4" } },
-          list: [
-            { id: "main", default: true, model: { primary: "openai/gpt-5.4" } },
-            { id: "work", model: { primary: "anthropic/claude-opus-4-6" } },
-          ],
-        },
-      } as OpenClawConfig,
-      storePath: "/tmp/sessions.json",
-      store: {
-        global: { sessionId: "global", updatedAt: now } as SessionEntry,
-        "agent:main:main": { sessionId: "main", updatedAt: now - 1 } as SessionEntry,
-        "agent:work:main": { sessionId: "work", updatedAt: now - 2 } as SessionEntry,
-      },
-      opts: { agentId: "work", includeGlobal: true, search: "global" },
-    });
-
-    expect(result.sessions.map((session) => session.key)).toEqual(["global"]);
-    expect(result.sessions[0]).toMatchObject({
-      modelProvider: "anthropic",
-      model: "claude-opus-4-6",
-    });
-  });
-
-  test("filters phantom agent store placeholder rows from session lists", () => {
-    const now = Date.now();
-    const result = listSessionsFromStore({
-      cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
-      storePath: "/tmp/sessions.json",
-      store: {
-        "agent:main:sessions": {} as SessionEntry,
-        "agent:main:main": { sessionId: "sess-main", updatedAt: now } as SessionEntry,
-      },
-      opts: {},
-    });
-
-    expect(result.sessions.map((session) => session.key)).toEqual(["agent:main:main"]);
-  });
-
   test("shows the selected override model even when a fallback runtime model exists", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",
@@ -2069,7 +688,7 @@ describe("listSessionsFromStore selected model display", () => {
           updatedAt: Date.now(),
           providerOverride: "anthropic",
           modelOverride: "claude-opus-4-6",
-          modelProvider: "openai",
+          modelProvider: "openai-codex",
           model: "gpt-5.4",
         } as SessionEntry,
       },
@@ -2079,166 +698,13 @@ describe("listSessionsFromStore selected model display", () => {
     expect(result.sessions[0]?.modelProvider).toBe("anthropic");
     expect(result.sessions[0]?.model).toBe("claude-opus-4-6");
   });
-
-  test("separates Claude CLI runtime metadata from canonical model identity", () => {
-    const cfg = createModelDefaultsConfig({
-      primary: "anthropic/claude-opus-4-7",
-      agentRuntime: { id: "claude-cli" },
-    });
-
-    const result = listSessionsFromStore({
-      cfg,
-      storePath: "/tmp/sessions.json",
-      store: {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          updatedAt: Date.now(),
-          modelProvider: "claude-cli",
-          model: "claude-opus-4-7",
-        } as SessionEntry,
-      },
-      opts: {},
-    });
-
-    expect(result.sessions[0]?.modelProvider).toBe("anthropic");
-    expect(result.sessions[0]?.model).toBe("claude-opus-4-7");
-    expect(result.sessions[0]?.agentRuntime).toEqual({
-      id: "claude-cli",
-      source: "model",
-    });
-  });
-
-  test("infers canonical provider for bare CLI models before default-provider fallback", () => {
-    const cfg = createModelDefaultsConfig({
-      primary: "openai/gpt-5.4",
-      models: {
-        "anthropic/claude-opus-4-7": {},
-      },
-      agentRuntime: { id: "claude-cli" },
-    });
-
-    const result = listSessionsFromStore({
-      cfg,
-      storePath: "/tmp/sessions.json",
-      store: {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          updatedAt: Date.now(),
-          modelProvider: "claude-cli",
-          model: "claude-opus-4-7",
-        } as SessionEntry,
-      },
-      opts: {},
-    });
-
-    expect(result.sessions[0]?.modelProvider).toBe("anthropic");
-    expect(result.sessions[0]?.model).toBe("claude-opus-4-7");
-  });
-
-  test("uses qualified selected defaults for rows without runtime model metadata", () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-5.4" },
-          models: {
-            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
-          },
-        },
-        list: [
-          { id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } },
-          {
-            id: "review",
-            model: { primary: "vercel-ai-gateway/anthropic/claude-haiku-4-5" },
-          },
-          { id: "alias", model: { primary: "anthropic/sonnet-4.6" } },
-        ],
-      },
-    } as OpenClawConfig;
-
-    const result = listSessionsFromStore({
-      cfg,
-      storePath: "/tmp/sessions.json",
-      store: {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          updatedAt: 2,
-        } as SessionEntry,
-        "agent:review:review": {
-          sessionId: "sess-review",
-          updatedAt: 1,
-        } as SessionEntry,
-        "agent:alias:alias": {
-          sessionId: "sess-alias",
-          updatedAt: 0,
-        } as SessionEntry,
-      },
-      opts: {},
-    });
-
-    expect(
-      result.sessions.map((session) => [session.key, session.modelProvider, session.model]),
-    ).toEqual([
-      ["agent:main:main", "anthropic", "claude-sonnet-4-6"],
-      ["agent:review:review", "vercel-ai-gateway", "anthropic/claude-haiku-4-5"],
-      ["agent:alias:alias", "anthropic", "claude-sonnet-4-6"],
-    ]);
-  });
-
-  test("uses persisted runtime model metadata before selected defaults", () => {
-    const cfg = {
-      agents: {
-        defaults: { model: { primary: "openai/gpt-5.4" } },
-        list: [{ id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } }],
-      },
-    } as OpenClawConfig;
-
-    const result = listSessionsFromStore({
-      cfg,
-      storePath: "/tmp/sessions.json",
-      store: {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          updatedAt: Date.now(),
-          modelProvider: "openai",
-          model: "gpt-5.5",
-        } as SessionEntry,
-      },
-      opts: {},
-    });
-
-    expect(result.sessions[0]?.modelProvider).toBe("openai");
-    expect(result.sessions[0]?.model).toBe("gpt-5.5");
-  });
-
-  test("uses complete model overrides without default-model fallback", () => {
-    const cfg = {
-      agents: {
-        defaults: { model: { primary: "openai/gpt-5.4" } },
-        list: [{ id: "main", model: { primary: "anthropic/claude-sonnet-4-6" } }],
-      },
-    } as OpenClawConfig;
-
-    const result = listSessionsFromStore({
-      cfg,
-      storePath: "/tmp/sessions.json",
-      store: {
-        "agent:main:main": {
-          sessionId: "sess-main",
-          updatedAt: Date.now(),
-          providerOverride: "anthropic",
-          modelOverride: "sonnet-4.6",
-        } as SessionEntry,
-      },
-      opts: {},
-    });
-
-    expect(result.sessions[0]?.modelProvider).toBe("anthropic");
-    expect(result.sessions[0]?.model).toBe("claude-sonnet-4-6");
-  });
 });
 
 describe("resolveSessionModelIdentityRef", () => {
-  const resolveLegacyIdentityRef = (cfg: OpenClawConfig, modelProvider?: string) =>
+  const resolveLegacyIdentityRef = (
+    cfg: OpenClawConfig,
+    modelProvider: string | undefined = undefined,
+  ) =>
     resolveSessionModelIdentityRef(cfg, {
       sessionId: "legacy-session",
       updatedAt: Date.now(),
@@ -2248,7 +714,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("does not inherit default provider for unprefixed legacy runtime model", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
     });
 
     const resolved = resolveLegacyIdentityRef(cfg);
@@ -2258,7 +724,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("infers provider from configured model allowlist when unambiguous", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
       models: {
         "anthropic/claude-sonnet-4-6": {},
       },
@@ -2271,7 +737,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("infers provider from configured provider catalogs when allowlist is absent", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
     });
     cfg.models = {
       providers: {
@@ -2293,7 +759,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("keeps provider unknown when configured models are ambiguous", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
       models: {
         "anthropic/claude-sonnet-4-6": {},
         "minimax/claude-sonnet-4-6": {},
@@ -2307,7 +773,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("keeps provider unknown when configured provider catalog matches are ambiguous", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
     });
     cfg.models = {
       providers: {
@@ -2332,7 +798,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("preserves provider from slash-prefixed runtime model", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
     });
 
     const resolved = resolveSessionModelIdentityRef(cfg, {
@@ -2347,7 +813,7 @@ describe("resolveSessionModelIdentityRef", () => {
 
   test("infers wrapper provider for slash-prefixed runtime model when allowlist match is unique", () => {
     const cfg = createModelDefaultsConfig({
-      primary: "google-gemini-cli/gemini-3.1-pro-preview",
+      primary: "google-gemini-cli/gemini-3-pro-preview",
       models: {
         "vercel-ai-gateway/anthropic/claude-sonnet-4-6": {},
       },
@@ -2364,43 +830,6 @@ describe("resolveSessionModelIdentityRef", () => {
       provider: "vercel-ai-gateway",
       model: "anthropic/claude-sonnet-4-6",
     });
-  });
-});
-
-describe("resolveSessionDisplayModelIdentityRef", () => {
-  test("canonicalizes CLI runtime provider to the selected model provider", () => {
-    const cfg = createModelDefaultsConfig({
-      primary: "anthropic/claude-opus-4-7",
-      agentRuntime: { id: "claude-cli" },
-    });
-
-    expect(
-      resolveSessionDisplayModelIdentityRef({
-        cfg,
-        agentId: "main",
-        provider: "claude-cli",
-        model: "claude-opus-4-7",
-      }),
-    ).toEqual({ provider: "anthropic", model: "claude-opus-4-7" });
-  });
-
-  test("prefers configured provider inference over default-provider parsing for bare CLI models", () => {
-    const cfg = createModelDefaultsConfig({
-      primary: "openai/gpt-5.4",
-      models: {
-        "anthropic/claude-opus-4-7": {},
-      },
-      agentRuntime: { id: "claude-cli" },
-    });
-
-    expect(
-      resolveSessionDisplayModelIdentityRef({
-        cfg,
-        agentId: "main",
-        provider: "claude-cli",
-        model: "claude-opus-4-7",
-      }),
-    ).toEqual({ provider: "anthropic", model: "claude-opus-4-7" });
   });
 });
 
@@ -2443,9 +872,10 @@ describe("deriveSessionTitle", () => {
     } as SessionEntry;
     const longMsg =
       "This is a very long message that exceeds sixty characters and should be truncated appropriately";
-    const result = requireString(deriveSessionTitle(entry, longMsg), "truncated session title");
-    expect(result.length).toBeLessThanOrEqual(60);
-    expect(result.endsWith("…")).toBe(true);
+    const result = deriveSessionTitle(entry, longMsg);
+    expect(result).toBeDefined();
+    expect(result!.length).toBeLessThanOrEqual(60);
+    expect(result!.endsWith("…")).toBe(true);
   });
 
   test("truncates at word boundary when possible", () => {
@@ -2454,9 +884,10 @@ describe("deriveSessionTitle", () => {
       updatedAt: Date.now(),
     } as SessionEntry;
     const longMsg = "This message has many words and should be truncated at a word boundary nicely";
-    const result = requireString(deriveSessionTitle(entry, longMsg), "word-boundary session title");
-    expect(result.endsWith("…")).toBe(true);
-    expect(result.includes("  ")).toBe(false);
+    const result = deriveSessionTitle(entry, longMsg);
+    expect(result).toBeDefined();
+    expect(result!.endsWith("…")).toBe(true);
+    expect(result!.includes("  ")).toBe(false);
   });
 
   test("falls back to sessionId prefix with date", () => {
@@ -2542,67 +973,5 @@ describe("resolveGatewayModelSupportsImages", () => {
         ],
       }),
     ).resolves.toBe(true);
-  });
-
-  test("matches catalog model ids case-insensitively for explicit providers", async () => {
-    await expect(
-      resolveGatewayModelSupportsImages({
-        model: "Qwen/Qwen3.5-35B-A3B",
-        provider: "modelscope",
-        loadGatewayModelCatalog: async () => [
-          {
-            id: "qwen/qwen3.5-35b-a3b",
-            name: "Qwen3.5 35B",
-            provider: "modelscope",
-            input: ["text", "image"],
-          },
-        ],
-      }),
-    ).resolves.toBe(true);
-  });
-
-  test("does not borrow image support from another provider when provider is explicit", async () => {
-    await expect(
-      resolveGatewayModelSupportsImages({
-        model: "gpt-4",
-        provider: "openai",
-        loadGatewayModelCatalog: async () => [
-          { id: "gpt-4", name: "GPT-4", provider: "other", input: ["text", "image"] },
-        ],
-      }),
-    ).resolves.toBe(false);
-  });
-
-  test("uses a unique providerless catalog match", async () => {
-    await expect(
-      resolveGatewayModelSupportsImages({
-        model: "Qwen/Qwen3.5-35B-A3B",
-        loadGatewayModelCatalog: async () => [
-          {
-            id: "qwen/qwen3.5-35b-a3b",
-            name: "Qwen3.5 35B",
-            provider: "modelscope",
-            input: ["text", "image"],
-          },
-        ],
-      }),
-    ).resolves.toBe(true);
-  });
-
-  test("fails closed on ambiguous providerless catalog matches", async () => {
-    await expect(
-      resolveGatewayModelSupportsImages({
-        model: "shared-vision",
-        loadGatewayModelCatalog: async () => [
-          { id: "shared-vision", name: "Shared Vision", provider: "first", input: ["text"] },
-          {
-            id: "shared-vision",
-            name: "Shared Vision",
-            provider: "second",
-            input: ["text", "image"],
-          },
-        ],
-      }),
-    ).resolves.toBe(false);
   });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,23 +1,6 @@
-// Gateway session listing and projection helpers.
-// Normalizes persisted session stores into UI/RPC rows without mutating state.
 import fs from "node:fs";
 import path from "node:path";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-  normalizeOptionalLowercaseString,
-} from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
-import {
-  readAcpSessionMeta,
-  readAcpSessionMetaForEntry,
-  repairAcpSessionMetaKeyForMigration,
-} from "../acp/runtime/session-meta.js";
-import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
-import {
-  listAgentIds,
-  resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
   resolveAgentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
@@ -25,63 +8,45 @@ import {
 } from "../agents/agent-scope.js";
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import {
-  findModelCatalogEntry,
-  modelSupportsInput,
-  type ModelCatalogEntry,
-} from "../agents/model-catalog.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
-  isCliProvider,
-  normalizeStoredOverrideModel,
   parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
   resolvePersistedSelectedModelRef,
-  resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import {
-  buildSubagentRunReadIndex,
-  countActiveDescendantRuns,
   getSessionDisplaySubagentRunByChildSessionKey,
   getSubagentSessionRuntimeMs,
   getSubagentSessionStartedAt,
-  isSubagentRunLive,
   listSubagentRunsForController,
   resolveSubagentSessionStatus,
 } from "../agents/subagent-registry-read.js";
-import {
-  RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS,
-  shouldKeepSubagentRunChildLink,
-} from "../agents/subagent-run-liveness.js";
-import { listThinkingLevelOptions } from "../auto-reply/thinking.js";
-import { getRuntimeConfig } from "../config/io.js";
+import { type OpenClawConfig, loadConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   buildGroupDisplayName,
-  getSessionStoreCacheVersion,
+  canonicalizeMainSessionAlias,
+  loadSessionStore,
   resolveAllAgentSessionStoreTargetsSync,
+  resolveAgentsDirFromSessionStorePath,
   resolveAgentMainSessionKey,
   resolveFreshSessionTotalTokens,
-  resolveSessionGoalDisplayState,
+  resolveMainSessionKey,
   resolveStorePath,
   type SessionEntry,
   type SessionStoreTarget,
   type SessionScope,
 } from "../config/sessions.js";
-import { listSessionEntries as listAccessorSessionEntries } from "../config/sessions/session-accessor.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
-import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
-import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
+import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import {
-  DEFAULT_AGENT_ID,
   normalizeAgentId,
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { isAcpSessionKey, isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
   isAvatarDataUrl,
@@ -90,58 +55,37 @@ import {
   isWorkspaceRelativeAvatarPath,
   resolveAvatarMime,
 } from "../shared/avatar-policy.js";
-import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared.js";
-import type { ModelCostConfig } from "../utils/usage-format.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
+import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import {
-  resolveSessionStoreAgentId,
-  resolveSessionStoreKey,
-  resolveStoredSessionKeyForAgentStore,
-} from "./session-store-key.js";
-import {
-  readRecentSessionUsageFromTranscript as readScopedRecentSessionUsageFromTranscript,
-  readSessionTitleFieldsFromTranscriptAsync as readScopedSessionTitleFieldsFromTranscriptAsync,
-  readSessionTitleFieldsFromTranscript as readScopedSessionTitleFieldsFromTranscript,
-} from "./session-transcript-readers.js";
+  readLatestSessionUsageFromTranscript,
+  readSessionTitleFieldsFromTranscript,
+} from "./session-utils.fs.js";
 import type {
   GatewayAgentRow,
   GatewaySessionRow,
   GatewaySessionsDefaults,
-  SessionRunStatus,
   SessionsListResult,
 } from "./session-utils.types.js";
 
 export {
   archiveFileOnDisk,
   archiveSessionTranscripts,
-  resolveSessionHistoryTranscriptPathAsync,
-  resolveSessionTranscriptCandidates,
-} from "./session-utils.fs.js";
-export {
   attachOpenClawTranscriptMeta,
   capArrayByJsonBytes,
   readFirstUserMessageFromTranscript,
-  readLatestSessionUsageFromTranscriptAsync,
-  readLatestRecentSessionUsageFromTranscriptAsync,
-  readRecentSessionUsageFromTranscriptAsync,
-  readRecentSessionMessagesAsync,
-  readRecentSessionMessagesWithStatsAsync,
-  readRecentSessionTranscriptLines,
-  readRecentSessionUsageFromTranscript,
-  readSessionMessageByIdAsync,
-  readSessionMessageCountAsync,
+  readLastMessagePreviewFromTranscript,
+  readLatestSessionUsageFromTranscript,
   readSessionTitleFieldsFromTranscript,
-  readSessionTitleFieldsFromTranscriptAsync,
   readSessionPreviewItemsFromTranscript,
-  readSessionMessagesAsync,
-  readSessionMessagesWithSourceAsync,
-  visitSessionMessagesAsync,
-} from "./session-transcript-readers.js";
-export type {
-  ReadSessionMessagesAsyncOptions,
-  SessionTranscriptReadScope,
-} from "./session-transcript-readers.js";
-export { canonicalizeSpawnedByForAgent, resolveSessionStoreKey } from "./session-store-key.js";
+  readSessionMessages,
+  resolveSessionTranscriptCandidates,
+} from "./session-utils.fs.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -187,9 +131,7 @@ function resolveIdentityAvatarUrl(
     return undefined;
   }
   try {
-    // Avatars can be workspace-relative, but projection must keep the file
-    // read inside the agent workspace and cap bytes before encoding.
-    const opened = openRootFileSync({
+    const opened = openBoundaryFileSync({
       absolutePath: resolvedCandidate,
       rootPath: workspaceRoot,
       rootRealPath: workspaceRoot,
@@ -277,93 +219,16 @@ function resolveNonNegativeNumber(value: number | null | undefined): number | un
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
-type SessionCompactionCheckpointEntry = NonNullable<SessionEntry["compactionCheckpoints"]>[number];
-
-function isProjectableCompactionCheckpoint(
-  value: unknown,
-): value is SessionCompactionCheckpointEntry {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  const checkpoint = value as {
-    checkpointId?: unknown;
-    createdAt?: unknown;
-    reason?: unknown;
-  };
-  return (
-    Boolean(normalizeOptionalString(checkpoint.checkpointId)) &&
-    typeof checkpoint.createdAt === "number" &&
-    Number.isFinite(checkpoint.createdAt) &&
-    (checkpoint.reason === "manual" ||
-      checkpoint.reason === "auto-threshold" ||
-      checkpoint.reason === "overflow-retry" ||
-      checkpoint.reason === "timeout-retry")
-  );
-}
-
-function resolveProjectableCompactionCheckpoints(
+function resolveLatestCompactionCheckpoint(
   entry?: Pick<SessionEntry, "compactionCheckpoints"> | null,
-): SessionCompactionCheckpointEntry[] {
+): NonNullable<SessionEntry["compactionCheckpoints"]>[number] | undefined {
   const checkpoints = entry?.compactionCheckpoints;
   if (!Array.isArray(checkpoints) || checkpoints.length === 0) {
-    return [];
+    return undefined;
   }
-  return checkpoints.filter(isProjectableCompactionCheckpoint);
-}
-
-function resolveLatestCompactionCheckpoint(
-  checkpoints: readonly SessionCompactionCheckpointEntry[],
-): SessionCompactionCheckpointEntry | undefined {
-  return checkpoints.reduce<SessionCompactionCheckpointEntry | undefined>(
-    (latest, checkpoint) =>
-      !latest || checkpoint.createdAt > latest.createdAt ? checkpoint : latest,
-    undefined,
+  return checkpoints.reduce((latest, checkpoint) =>
+    !latest || checkpoint.createdAt > latest.createdAt ? checkpoint : latest,
   );
-}
-
-function buildCompactionCheckpointPreview(
-  checkpoint: SessionCompactionCheckpointEntry | undefined,
-): GatewaySessionRow["latestCompactionCheckpoint"] {
-  if (!checkpoint) {
-    return undefined;
-  }
-  const checkpointId = normalizeOptionalString(checkpoint.checkpointId);
-  const createdAt = checkpoint.createdAt;
-  const reason = checkpoint.reason;
-  if (!checkpointId || typeof createdAt !== "number" || !Number.isFinite(createdAt)) {
-    return undefined;
-  }
-  if (
-    reason !== "manual" &&
-    reason !== "auto-threshold" &&
-    reason !== "overflow-retry" &&
-    reason !== "timeout-retry"
-  ) {
-    return undefined;
-  }
-  return {
-    checkpointId,
-    createdAt,
-    reason,
-  };
-}
-
-function resolveModelCostConfigCached(
-  provider: string | undefined,
-  model: string | undefined,
-  cfg: OpenClawConfig,
-  rowContext?: SessionListRowContext,
-): ModelCostConfig | undefined {
-  if (!rowContext) {
-    return resolveModelCostConfig({ provider, model, config: cfg });
-  }
-  const key = createSessionRowModelCacheKey(provider, model);
-  if (rowContext.modelCostConfigByModelRef.has(key)) {
-    return rowContext.modelCostConfigByModelRef.get(key);
-  }
-  const value = resolveModelCostConfig({ provider, model, config: cfg });
-  rowContext.modelCostConfigByModelRef.set(key, value);
-  return value;
 }
 
 function resolveEstimatedSessionCostUsd(params: {
@@ -375,7 +240,6 @@ function resolveEstimatedSessionCostUsd(params: {
     "estimatedCostUsd" | "inputTokens" | "outputTokens" | "cacheRead" | "cacheWrite"
   >;
   explicitCostUsd?: number;
-  rowContext?: SessionListRowContext;
 }): number | undefined {
   const explicitCostUsd = resolveNonNegativeNumber(
     params.explicitCostUsd ?? params.entry?.estimatedCostUsd,
@@ -395,12 +259,11 @@ function resolveEstimatedSessionCostUsd(params: {
   ) {
     return undefined;
   }
-  const cost = resolveModelCostConfigCached(
-    params.provider,
-    params.model,
-    params.cfg,
-    params.rowContext,
-  );
+  const cost = resolveModelCostConfig({
+    provider: params.provider,
+    model: params.model,
+    config: params.cfg,
+  });
   if (!cost) {
     return undefined;
   }
@@ -416,445 +279,47 @@ function resolveEstimatedSessionCostUsd(params: {
   return resolveNonNegativeNumber(estimated);
 }
 
-const STALE_STORE_ONLY_CHILD_LINK_MS = 60 * 60 * 1_000;
-const SINGLE_ROW_CONTEXT_CACHE_MAX_ENTRIES = 64;
-
-function isFinitePositiveTimestamp(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value) && value > 0;
-}
-
-function isTerminalSessionStatus(status: unknown): status is Exclude<SessionRunStatus, "running"> {
-  return status === "done" || status === "failed" || status === "killed" || status === "timeout";
-}
-
-function shouldKeepStoreOnlyChildLink(entry: SessionEntry, now: number): boolean {
-  if (isTerminalSessionStatus(entry.status) || isFinitePositiveTimestamp(entry.endedAt)) {
-    const endedAt = isFinitePositiveTimestamp(entry.endedAt) ? entry.endedAt : entry.updatedAt;
-    return (
-      isFinitePositiveTimestamp(endedAt) && now - endedAt <= RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS
-    );
-  }
-  if (entry.status === "running" || isFinitePositiveTimestamp(entry.startedAt)) {
-    return true;
-  }
-  // Store-only child links lack a live subagent registry entry. Keep recent
-  // unknown-state rows visible briefly so reloads do not hide fresh children.
-  return (
-    isFinitePositiveTimestamp(entry.updatedAt) &&
-    now - entry.updatedAt <= STALE_STORE_ONLY_CHILD_LINK_MS
-  );
-}
-
-type SessionListRowContext = {
-  subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
-  storeChildSessionsByKey: Map<string, string[]>;
-  selectedModelByOverrideRef: Map<string, ReturnType<typeof resolveSessionModelRef>>;
-  // Per-list memoization for deterministic resolvers that scale linearly with
-  // session count but only depend on (provider, model[, agentId]). Sessions
-  // in a single list typically share a small set of those tuples, so caching
-  // here collapses the work to O(unique tuples) per call.
-  thinkingMetadataByModelRef: Map<
-    string,
-    {
-      levels: ReturnType<typeof listThinkingLevelOptions>;
-      defaultLevel: ReturnType<typeof resolveGatewaySessionThinkingDefault>;
-    }
-  >;
-  displayModelIdentityByKey: Map<string, { provider?: string; model?: string }>;
-  modelCostConfigByModelRef: Map<string, ModelCostConfig | undefined>;
-};
-
-type SessionListRowContextProvider = () => SessionListRowContext;
-
-type SingleRowChildSessionCandidateCacheEntry = {
-  store: Record<string, SessionEntry>;
-  storeVersion: number;
-  childSessionCandidatesByParentKey: Map<string, string[]>;
-};
-
-export type GatewaySessionStoreTarget = {
-  agentId: string;
-  storePath: string;
-  canonicalKey: string;
-  storeKeys: string[];
-};
-
-export type GatewaySessionStoreTargetWithStore = GatewaySessionStoreTarget & {
-  store: Record<string, SessionEntry>;
-};
-
-const singleRowChildSessionCandidateCache = new Map<
-  string,
-  SingleRowChildSessionCandidateCacheEntry
->();
-
-function rememberSingleRowChildSessionCandidateCacheEntry(
-  storePath: string,
-  entry: SingleRowChildSessionCandidateCacheEntry,
-) {
-  if (singleRowChildSessionCandidateCache.has(storePath)) {
-    singleRowChildSessionCandidateCache.delete(storePath);
-  }
-  singleRowChildSessionCandidateCache.set(storePath, entry);
-  if (singleRowChildSessionCandidateCache.size <= SINGLE_ROW_CONTEXT_CACHE_MAX_ENTRIES) {
-    return;
-  }
-  const oldestKey = singleRowChildSessionCandidateCache.keys().next().value;
-  if (oldestKey) {
-    singleRowChildSessionCandidateCache.delete(oldestKey);
-  }
-}
-
-function buildStoreChildSessionCandidateIndex(
-  store: Record<string, SessionEntry> | null | undefined,
-): Map<string, string[]> {
-  const childSessionsByKey = new Map<string, string[]>();
-  if (!store) {
-    return childSessionsByKey;
-  }
-  for (const [key, entry] of Object.entries(store)) {
-    if (!entry) {
-      continue;
-    }
-    const parentKeys = [
-      normalizeOptionalString(entry.spawnedBy),
-      normalizeOptionalString(entry.parentSessionKey),
-    ].filter((value): value is string => Boolean(value) && value !== key);
-    for (const parentKey of parentKeys) {
-      addChildSessionKey(childSessionsByKey, parentKey, key);
-    }
-  }
-  return childSessionsByKey;
-}
-
-function getSingleRowChildSessionCandidates(params: {
-  storePath: string;
-  store: Record<string, SessionEntry> | null | undefined;
-}): Map<string, string[]> {
-  if (!params.store) {
-    return new Map();
-  }
-  const storeVersion = getSessionStoreCacheVersion(params.storePath);
-  const cached = singleRowChildSessionCandidateCache.get(params.storePath);
-  if (cached && cached.store === params.store && cached.storeVersion === storeVersion) {
-    return cached.childSessionCandidatesByParentKey;
-  }
-  const childSessionCandidatesByParentKey = buildStoreChildSessionCandidateIndex(params.store);
-  rememberSingleRowChildSessionCandidateCacheEntry(params.storePath, {
-    store: params.store,
-    storeVersion,
-    childSessionCandidatesByParentKey,
-  });
-  return childSessionCandidatesByParentKey;
-}
-
-function resolveRuntimeChildSessionKeys(
+function resolveChildSessionKeys(
   controllerSessionKey: string,
-  now = Date.now(),
-  subagentRuns?: SessionListRowContext["subagentRuns"],
+  store: Record<string, SessionEntry>,
 ): string[] | undefined {
   const childSessionKeys = new Set<string>();
-  const controllerKey = controllerSessionKey.trim();
-  const runs = subagentRuns
-    ? (subagentRuns.runsByControllerSessionKey.get(controllerKey) ?? [])
-    : listSubagentRunsForController(controllerSessionKey);
-  for (const entry of runs) {
+  for (const entry of listSubagentRunsForController(controllerSessionKey)) {
     const childSessionKey = normalizeOptionalString(entry.childSessionKey);
     if (!childSessionKey) {
       continue;
     }
-    const latest = subagentRuns
-      ? subagentRuns.getDisplaySubagentRun(childSessionKey)
-      : getSessionDisplaySubagentRunByChildSessionKey(childSessionKey);
-    if (!latest) {
-      continue;
-    }
+    const latest = getSessionDisplaySubagentRunByChildSessionKey(childSessionKey);
     const latestControllerSessionKey =
       normalizeOptionalString(latest?.controllerSessionKey) ||
       normalizeOptionalString(latest?.requesterSessionKey);
     if (latestControllerSessionKey !== controllerSessionKey) {
       continue;
     }
-    if (
-      !shouldKeepSubagentRunChildLink(latest, {
-        activeDescendants: subagentRuns
-          ? subagentRuns.countActiveDescendantRuns(childSessionKey)
-          : countActiveDescendantRuns(childSessionKey),
-        now,
-      })
-    ) {
-      continue;
-    }
     childSessionKeys.add(childSessionKey);
   }
-  const childSessions = Array.from(childSessionKeys);
-  return childSessions.length > 0 ? childSessions : undefined;
-}
-
-function addChildSessionKey(
-  childSessionsByKey: Map<string, string[]>,
-  parentKey: string,
-  childKey: string,
-) {
-  const current = childSessionsByKey.get(parentKey);
-  if (current) {
-    if (!current.includes(childKey)) {
-      current.push(childKey);
-    }
-    return;
-  }
-  childSessionsByKey.set(parentKey, [childKey]);
-}
-
-function buildStoreChildSessionIndex(
-  store: Record<string, SessionEntry>,
-  now = Date.now(),
-  subagentRuns?: SessionListRowContext["subagentRuns"],
-): Map<string, string[]> {
-  const childSessionsByKey = new Map<string, string[]>();
   for (const [key, entry] of Object.entries(store)) {
-    if (!entry) {
+    if (!entry || key === controllerSessionKey) {
       continue;
     }
-    const parentKeys = [
-      normalizeOptionalString(entry.spawnedBy),
-      normalizeOptionalString(entry.parentSessionKey),
-    ].filter((value): value is string => Boolean(value) && value !== key);
-    if (parentKeys.length === 0) {
+    const spawnedBy = normalizeOptionalString(entry.spawnedBy);
+    const parentSessionKey = normalizeOptionalString(entry.parentSessionKey);
+    if (spawnedBy !== controllerSessionKey && parentSessionKey !== controllerSessionKey) {
       continue;
     }
-    const latest = subagentRuns
-      ? subagentRuns.getDisplaySubagentRun(key)
-      : getSessionDisplaySubagentRunByChildSessionKey(key);
-    let latestControllerSessionKey: string | undefined;
-    if (latest) {
-      latestControllerSessionKey =
-        normalizeOptionalString(latest.controllerSessionKey) ||
-        normalizeOptionalString(latest.requesterSessionKey);
-      if (
-        !shouldKeepSubagentRunChildLink(latest, {
-          activeDescendants: subagentRuns
-            ? subagentRuns.countActiveDescendantRuns(key)
-            : countActiveDescendantRuns(key),
-          now,
-        })
-      ) {
-        continue;
-      }
-    } else if (!shouldKeepStoreOnlyChildLink(entry, now)) {
-      continue;
-    }
-    for (const parentKey of parentKeys) {
-      if (latestControllerSessionKey && latestControllerSessionKey !== parentKey) {
-        continue;
-      }
-      addChildSessionKey(childSessionsByKey, parentKey, key);
-    }
-  }
-  return childSessionsByKey;
-}
-
-function resolveStoreChildSessionKeysFromCandidates(params: {
-  store: Record<string, SessionEntry>;
-  key: string;
-  now: number;
-  candidates: ReadonlyMap<string, readonly string[]>;
-}): string[] | undefined {
-  const childSessionKeys: string[] = [];
-  for (const childKey of params.candidates.get(params.key) ?? []) {
-    const entry = params.store[childKey];
-    if (!entry) {
-      continue;
-    }
-    const latest = getSessionDisplaySubagentRunByChildSessionKey(childKey);
+    const latest = getSessionDisplaySubagentRunByChildSessionKey(key);
     if (latest) {
       const latestControllerSessionKey =
         normalizeOptionalString(latest.controllerSessionKey) ||
         normalizeOptionalString(latest.requesterSessionKey);
-      if (latestControllerSessionKey !== params.key) {
+      if (latestControllerSessionKey !== controllerSessionKey) {
         continue;
       }
-      if (
-        !shouldKeepSubagentRunChildLink(latest, {
-          activeDescendants: countActiveDescendantRuns(childKey),
-          now: params.now,
-        })
-      ) {
-        continue;
-      }
-      childSessionKeys.push(childKey);
-      continue;
     }
-    if (!shouldKeepStoreOnlyChildLink(entry, params.now)) {
-      continue;
-    }
-    childSessionKeys.push(childKey);
+    childSessionKeys.add(key);
   }
-  return childSessionKeys.length > 0 ? childSessionKeys : undefined;
-}
-
-function buildSessionListRowContext(params: {
-  store: Record<string, SessionEntry>;
-  now: number;
-}): SessionListRowContext {
-  const subagentRuns = buildSubagentRunReadIndex(params.now);
-  return buildSessionListRowContextFromParts({
-    subagentRuns,
-    storeChildSessionsByKey: buildStoreChildSessionIndex(params.store, params.now, subagentRuns),
-  });
-}
-
-function buildSessionListRowContextFromParts(params: {
-  subagentRuns: ReturnType<typeof buildSubagentRunReadIndex>;
-  storeChildSessionsByKey: Map<string, string[]>;
-}): SessionListRowContext {
-  return {
-    subagentRuns: params.subagentRuns,
-    storeChildSessionsByKey: params.storeChildSessionsByKey,
-    selectedModelByOverrideRef: new Map(),
-    thinkingMetadataByModelRef: new Map(),
-    displayModelIdentityByKey: new Map(),
-    modelCostConfigByModelRef: new Map(),
-  };
-}
-
-function buildSessionListRowMetadataContext(params: { now: number }): SessionListRowContext {
-  return buildSessionListRowContextFromParts({
-    subagentRuns: buildSubagentRunReadIndex(params.now),
-    storeChildSessionsByKey: new Map(),
-  });
-}
-
-function buildSingleRowStoreChildSessionsByKey(params: {
-  store: Record<string, SessionEntry>;
-  storePath: string;
-  key: string;
-  now: number;
-}): Map<string, string[]> {
-  const storeChildSessions = resolveStoreChildSessionKeysFromCandidates({
-    store: params.store,
-    key: params.key,
-    now: params.now,
-    candidates: getSingleRowChildSessionCandidates({
-      storePath: params.storePath,
-      store: params.store,
-    }),
-  });
-  return storeChildSessions ? new Map([[params.key, storeChildSessions]]) : new Map();
-}
-
-function createSessionRowModelCacheKey(provider: string | undefined, model: string | undefined) {
-  return `${normalizeLowercaseStringOrEmpty(provider)}\0${normalizeOptionalString(model) ?? ""}`;
-}
-
-function resolveSessionSelectedModelRef(params: {
-  cfg: OpenClawConfig;
-  entry?: SessionEntry;
-  agentId: string;
-  rowContext?: SessionListRowContext;
-  allowPluginNormalization?: boolean;
-}): ReturnType<typeof resolveSessionModelRef> | null {
-  const override = normalizeStoredOverrideModel({
-    providerOverride: params.entry?.providerOverride,
-    modelOverride: params.entry?.modelOverride,
-  });
-  if (!override.modelOverride) {
-    return null;
-  }
-  if (!params.rowContext) {
-    return resolveSessionModelRef(params.cfg, params.entry, params.agentId, {
-      allowPluginNormalization: params.allowPluginNormalization,
-    });
-  }
-  const key = [
-    normalizeAgentId(params.agentId),
-    override.providerOverride ?? "",
-    override.modelOverride,
-  ].join("\0");
-  const cached = params.rowContext.selectedModelByOverrideRef.get(key);
-  if (cached) {
-    return cached;
-  }
-  const selected = resolveSessionModelRef(params.cfg, params.entry, params.agentId, {
-    allowPluginNormalization: params.allowPluginNormalization,
-  });
-  params.rowContext.selectedModelByOverrideRef.set(key, selected);
-  return selected;
-}
-
-function resolveSessionRowThinkingMetadata(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  provider: string;
-  model: string;
-  modelCatalog?: ModelCatalogEntry[];
-  rowContext?: SessionListRowContext;
-}): {
-  levels: ReturnType<typeof listThinkingLevelOptions>;
-  defaultLevel: ReturnType<typeof resolveGatewaySessionThinkingDefault>;
-} {
-  if (!params.rowContext) {
-    return {
-      levels: listThinkingLevelOptions(params.provider, params.model, params.modelCatalog),
-      defaultLevel: resolveGatewaySessionThinkingDefault({
-        cfg: params.cfg,
-        provider: params.provider,
-        model: params.model,
-        agentId: params.agentId,
-        modelCatalog: params.modelCatalog,
-      }),
-    };
-  }
-  const key = `${normalizeAgentId(params.agentId)}\0${createSessionRowModelCacheKey(
-    params.provider,
-    params.model,
-  )}`;
-  const cached = params.rowContext.thinkingMetadataByModelRef.get(key);
-  if (cached) {
-    return cached;
-  }
-  const metadata = {
-    levels: listThinkingLevelOptions(params.provider, params.model, params.modelCatalog),
-    defaultLevel: resolveGatewaySessionThinkingDefault({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      agentId: params.agentId,
-      modelCatalog: params.modelCatalog,
-    }),
-  };
-  params.rowContext.thinkingMetadataByModelRef.set(key, metadata);
-  return metadata;
-}
-
-function mergeChildSessionKeys(
-  runtimeChildSessions: string[] | undefined,
-  storeChildSessions: string[] | undefined,
-): string[] | undefined {
-  if (!runtimeChildSessions?.length) {
-    return storeChildSessions?.length ? storeChildSessions : undefined;
-  }
-  if (!storeChildSessions?.length) {
-    return runtimeChildSessions;
-  }
-  return uniqueStrings([...runtimeChildSessions, ...storeChildSessions]);
-}
-
-function resolveChildSessionKeys(
-  controllerSessionKey: string,
-  store: Record<string, SessionEntry>,
-  now = Date.now(),
-  subagentRuns?: SessionListRowContext["subagentRuns"],
-): string[] | undefined {
-  const runtimeChildSessions = resolveRuntimeChildSessionKeys(
-    controllerSessionKey,
-    now,
-    subagentRuns,
-  );
-  const storeChildSessions = buildStoreChildSessionIndex(store, now, subagentRuns).get(
-    controllerSessionKey,
-  );
-  return mergeChildSessionKeys(runtimeChildSessions, storeChildSessions);
+  const childSessions = Array.from(childSessionKeys);
+  return childSessions.length > 0 ? childSessions : undefined;
 }
 
 function resolveTranscriptUsageFallback(params: {
@@ -864,9 +329,6 @@ function resolveTranscriptUsageFallback(params: {
   storePath: string;
   fallbackProvider?: string;
   fallbackModel?: string;
-  maxTranscriptBytes?: number;
-  rowContext?: SessionListRowContext;
-  agentId?: string;
 }): {
   estimatedCostUsd?: number;
   totalTokens?: number;
@@ -882,15 +344,12 @@ function resolveTranscriptUsageFallback(params: {
   const parsed = parseAgentSessionKey(params.key);
   const agentId = parsed?.agentId
     ? normalizeAgentId(parsed.agentId)
-    : normalizeAgentId(params.agentId ?? resolveDefaultAgentId(params.cfg));
-  const snapshot = readScopedRecentSessionUsageFromTranscript(
-    {
-      agentId,
-      sessionFile: entry.sessionFile,
-      sessionId: entry.sessionId,
-      storePath: params.storePath,
-    },
-    typeof params.maxTranscriptBytes === "number" ? params.maxTranscriptBytes : 256 * 1024,
+    : resolveDefaultAgentId(params.cfg);
+  const snapshot = readLatestSessionUsageFromTranscript(
+    entry.sessionId,
+    params.storePath,
+    entry.sessionFile,
+    agentId,
   );
   if (!snapshot) {
     return null;
@@ -915,7 +374,6 @@ function resolveTranscriptUsageFallback(params: {
       cacheRead: snapshot.cacheRead,
       cacheWrite: snapshot.cacheWrite,
     },
-    rowContext: params.rowContext,
   });
   return {
     modelProvider,
@@ -927,125 +385,43 @@ function resolveTranscriptUsageFallback(params: {
   };
 }
 
-function readAcpMetaForDeletedAgentCheck(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  entry?: Pick<SessionEntry, "acp" | "sessionId"> | null;
-  acpMetadataSessionKey?: string | null;
-}) {
-  if (params.entry?.acp) {
-    return params.entry.acp;
-  }
-
-  const acpMetadataSessionKey = normalizeOptionalString(params.acpMetadataSessionKey);
-  const directKeys = new Set<string>();
-  if (acpMetadataSessionKey) {
-    directKeys.add(acpMetadataSessionKey);
-  } else {
-    const acpMeta = readAcpSessionMeta({ sessionKey: params.sessionKey, cfg: params.cfg });
-    if (acpMeta) {
-      return acpMeta;
-    }
-  }
-  directKeys.add(params.sessionKey);
-
-  for (const directKey of directKeys) {
-    const acpMeta = readAcpSessionMetaForEntry({
-      sessionKey: directKey,
-      entry: params.entry ?? undefined,
-    });
-    if (acpMeta) {
-      return acpMeta;
-    }
-  }
-
-  repairAcpSessionMetaKeyForMigration({
-    sessionKey: params.sessionKey,
-    candidateSessionKeys: directKeys,
-    entry: params.entry ?? undefined,
-  });
-  return readAcpSessionMetaForEntry({
-    sessionKey: params.sessionKey,
-    entry: params.entry ?? undefined,
-  });
-}
-
-/**
- * Returns the owning agent id if the session key belongs to an agent that is no
- * longer present in config (deleted). Returns null for non-agent legacy/global
- * keys, confirmed ACP runtime session keys, or when the owning agent still
- * exists (#65524).
- */
-export function resolveDeletedAgentIdFromSessionKey(
-  cfg: OpenClawConfig,
-  sessionKey: string,
-  entry?: SessionEntry | null,
-  options?: { acpMetadataSessionKey?: string | null },
-): string | null {
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (!parsed) {
-    return null;
-  }
-  const agentId = normalizeAgentId(parsed.agentId);
-  if (listAgentIds(cfg).includes(agentId)) {
-    return null;
-  }
-  if (isAcpSessionKey(sessionKey) && !parsed.rest.startsWith("acp:binding:")) {
-    // Free ACP runtime keys use agent:<harnessId>:acp:<uuid>, but key shape is
-    // not proof: ACP bridge sessions can use ACP-shaped keys without SessionAcpMeta.
-    // Configured acp:binding keys stay owner-scoped even when ACP metadata exists.
-    const acpMeta = readAcpMetaForDeletedAgentCheck({
-      cfg,
-      sessionKey,
-      entry,
-      acpMetadataSessionKey: options?.acpMetadataSessionKey,
-    });
-    if (acpMeta) {
-      return null;
-    }
-  }
-  return agentId;
-}
-
-export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; clone?: boolean }) {
-  const cfg = getRuntimeConfig();
-  const key = normalizeOptionalString(sessionKey) ?? "";
-  const target = resolveGatewaySessionStoreTargetWithStore({
+export function loadSessionEntry(sessionKey: string) {
+  const cfg = loadConfig();
+  const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey });
+  const agentId = resolveSessionStoreAgentId(cfg, canonicalKey);
+  const { storePath, store } = resolveGatewaySessionStoreLookup({
     cfg,
-    key,
-    ...(opts?.clone === false ? { clone: false } : {}),
-    ...(opts?.agentId ? { agentId: opts.agentId } : {}),
+    key: normalizeOptionalString(sessionKey) ?? "",
+    canonicalKey,
+    agentId,
   });
-  const storePath = target.storePath;
-  const store = target.store;
-  const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
-  const legacyKey = freshestMatch?.key !== target.canonicalKey ? freshestMatch?.key : undefined;
-  return {
+  const target = resolveGatewaySessionStoreTarget({
     cfg,
-    storePath,
+    key: normalizeOptionalString(sessionKey) ?? "",
     store,
-    entry: freshestMatch?.entry,
-    canonicalKey: target.canonicalKey,
-    legacyKey,
-  };
+  });
+  const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
+  const legacyKey = freshestMatch?.key !== canonicalKey ? freshestMatch?.key : undefined;
+  return { cfg, storePath, store, entry: freshestMatch?.entry, canonicalKey, legacyKey };
 }
 
 export function resolveFreshestSessionStoreMatchFromStoreKeys(
   store: Record<string, SessionEntry>,
   storeKeys: string[],
 ): { key: string; entry: SessionEntry } | undefined {
-  let freshest: { key: string; entry: SessionEntry } | undefined;
-  for (const key of storeKeys) {
-    const entry = store[key];
-    if (!entry) {
-      continue;
-    }
-    const match = { key, entry };
-    if (!freshest || (match.entry.updatedAt ?? 0) > (freshest.entry.updatedAt ?? 0)) {
-      freshest = match;
-    }
+  const matches = storeKeys
+    .map((key) => {
+      const entry = store[key];
+      return entry ? { key, entry } : undefined;
+    })
+    .filter((match): match is { key: string; entry: SessionEntry } => match !== undefined);
+  if (matches.length === 0) {
+    return undefined;
   }
-  return freshest;
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  return [...matches].toSorted((a, b) => (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0))[0];
 }
 
 export function resolveFreshestSessionEntryFromStoreKeys(
@@ -1079,13 +455,9 @@ function findFreshestStoreMatch(
   if (matches.size === 0) {
     return undefined;
   }
-  let freshest: { entry: SessionEntry; key: string } | undefined;
-  for (const match of matches.values()) {
-    if (!freshest || (match.entry.updatedAt ?? 0) > (freshest.entry.updatedAt ?? 0)) {
-      freshest = match;
-    }
-  }
-  return freshest;
+  return [...matches.values()].toSorted(
+    (a, b) => (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0),
+  )[0];
 }
 
 /**
@@ -1117,7 +489,7 @@ export function pruneLegacyStoreKeys(params: {
 }) {
   const keysToDelete = new Set<string>();
   for (const candidate of params.candidates) {
-    const trimmed = normalizeOptionalString(candidate ?? "") ?? "";
+    const trimmed = normalizeOptionalString(String(candidate ?? "")) ?? "";
     if (!trimmed) {
       continue;
     }
@@ -1136,16 +508,14 @@ export function pruneLegacyStoreKeys(params: {
 }
 
 export function migrateAndPruneGatewaySessionStoreKey(params: {
-  cfg: OpenClawConfig;
+  cfg: ReturnType<typeof loadConfig>;
   key: string;
   store: Record<string, SessionEntry>;
-  agentId?: string;
 }) {
   const target = resolveGatewaySessionStoreTarget({
     cfg: params.cfg,
     key: params.key,
     store: params.store,
-    ...(params.agentId ? { agentId: params.agentId } : {}),
   });
   const primaryKey = target.canonicalKey;
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(
@@ -1196,18 +566,6 @@ export function parseGroupKey(
     }
   }
   return null;
-}
-
-function isGroupOrChannelDisplaySession(
-  entry: SessionEntry | undefined,
-  parsed: { kind?: "group" | "channel" } | null,
-): boolean {
-  return (
-    entry?.chatType === "group" ||
-    entry?.chatType === "channel" ||
-    parsed?.kind === "group" ||
-    parsed?.kind === "channel"
-  );
 }
 
 function isStorePathTemplate(store?: string): boolean {
@@ -1285,10 +643,7 @@ function resolveGatewayAgentModel(
   };
 }
 
-export function listAgentsForGateway(
-  cfg: OpenClawConfig,
-  modelCatalog?: ModelCatalogEntry[],
-): {
+export function listAgentsForGateway(cfg: OpenClawConfig): {
   defaultId: string;
   mainKey: string;
   scope: SessionScope;
@@ -1305,7 +660,6 @@ export function listAgentsForGateway(
     if (!entry?.id) {
       continue;
     }
-    const configuredName = normalizeOptionalString(entry.name);
     const identity = entry.identity
       ? {
           name: normalizeOptionalString(entry.identity.name),
@@ -1320,7 +674,7 @@ export function listAgentsForGateway(
         }
       : undefined;
     configuredById.set(normalizeAgentId(entry.id), {
-      name: configuredName ?? identity?.name,
+      name: normalizeOptionalString(entry.name),
       identity,
     });
   }
@@ -1339,40 +693,103 @@ export function listAgentsForGateway(
   const agents = agentIds.map((id) => {
     const meta = configuredById.get(id);
     const model = resolveGatewayAgentModel(cfg, id);
-    const resolvedModel = resolveDefaultModelForAgent({ cfg, agentId: id });
-    const thinkingLevels = listThinkingLevelOptions(
-      resolvedModel.provider,
-      resolvedModel.model,
-      modelCatalog,
-    );
-    return Object.assign(
-      {
-        id,
-        name: meta?.name,
-        identity: meta?.identity,
-        workspace: resolveAgentWorkspaceDir(cfg, id),
-        agentRuntime: resolveModelAgentRuntimeMetadata({
-          cfg,
-          agentId: id,
-          provider: resolvedModel.provider,
-          model: resolvedModel.model,
-          sessionKey: resolveAgentMainSessionKey({ cfg, agentId: id }),
-          acpRuntime: false,
-        }),
-        thinkingLevels,
-        thinkingOptions: thinkingLevels.map((level) => level.label),
-        thinkingDefault: resolveGatewaySessionThinkingDefault({
-          cfg,
-          provider: resolvedModel.provider,
-          model: resolvedModel.model,
-          agentId: id,
-          modelCatalog,
-        }),
-      },
-      model ? { model } : {},
-    );
+    return {
+      id,
+      name: meta?.name,
+      identity: meta?.identity,
+      workspace: resolveAgentWorkspaceDir(cfg, id),
+      ...(model ? { model } : {}),
+    };
   });
   return { defaultId, mainKey, scope, agents };
+}
+
+function canonicalizeSessionKeyForAgent(agentId: string, key: string): string {
+  const lowered = normalizeLowercaseStringOrEmpty(key);
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  if (lowered.startsWith("agent:")) {
+    return lowered;
+  }
+  return `agent:${normalizeAgentId(agentId)}:${lowered}`;
+}
+
+function resolveDefaultStoreAgentId(cfg: OpenClawConfig): string {
+  return normalizeAgentId(resolveDefaultAgentId(cfg));
+}
+
+export function resolveSessionStoreKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): string {
+  const raw = normalizeOptionalString(params.sessionKey) ?? "";
+  if (!raw) {
+    return raw;
+  }
+  const rawLower = normalizeLowercaseStringOrEmpty(raw);
+  if (rawLower === "global" || rawLower === "unknown") {
+    return rawLower;
+  }
+
+  const parsed = parseAgentSessionKey(raw);
+  if (parsed) {
+    const agentId = normalizeAgentId(parsed.agentId);
+    const lowered = normalizeLowercaseStringOrEmpty(raw);
+    const canonical = canonicalizeMainSessionAlias({
+      cfg: params.cfg,
+      agentId,
+      sessionKey: lowered,
+    });
+    if (canonical !== lowered) {
+      return canonical;
+    }
+    return lowered;
+  }
+
+  const lowered = normalizeLowercaseStringOrEmpty(raw);
+  const rawMainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (lowered === "main" || lowered === rawMainKey) {
+    return resolveMainSessionKey(params.cfg);
+  }
+  const agentId = resolveDefaultStoreAgentId(params.cfg);
+  return canonicalizeSessionKeyForAgent(agentId, lowered);
+}
+
+function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: string): string {
+  if (canonicalKey === "global" || canonicalKey === "unknown") {
+    return resolveDefaultStoreAgentId(cfg);
+  }
+  const parsed = parseAgentSessionKey(canonicalKey);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  return resolveDefaultStoreAgentId(cfg);
+}
+
+export function canonicalizeSpawnedByForAgent(
+  cfg: OpenClawConfig,
+  agentId: string,
+  spawnedBy?: string,
+): string | undefined {
+  const raw = normalizeOptionalString(spawnedBy) ?? "";
+  if (!raw) {
+    return undefined;
+  }
+  const lower = normalizeLowercaseStringOrEmpty(raw);
+  if (lower === "global" || lower === "unknown") {
+    return lower;
+  }
+  let result: string;
+  if (lower.startsWith("agent:")) {
+    result = lower;
+  } else {
+    result = `agent:${normalizeAgentId(agentId)}:${lower}`;
+  }
+  // Resolve main-alias references (e.g. agent:ops:main → configured main key).
+  const parsed = parseAgentSessionKey(result);
+  const resolvedAgent = parsed?.agentId ? normalizeAgentId(parsed.agentId) : agentId;
+  return canonicalizeMainSessionAlias({ cfg, agentId: resolvedAgent, sessionKey: result });
 }
 
 function buildGatewaySessionStoreScanTargets(params: {
@@ -1420,24 +837,11 @@ function resolveGatewaySessionStoreCandidates(
   return [...targets.values()];
 }
 
-function loadGatewaySessionLookupStore(
-  storePath: string,
-  clone: boolean | undefined,
-): Record<string, SessionEntry> {
-  return Object.fromEntries(
-    listAccessorSessionEntries({
-      ...(clone === false ? { clone: false } : {}),
-      storePath,
-    }).map(({ sessionKey, entry }) => [sessionKey, entry]),
-  );
-}
-
 function resolveGatewaySessionStoreLookup(params: {
   cfg: OpenClawConfig;
   key: string;
   canonicalKey: string;
   agentId: string;
-  clone?: boolean;
   initialStore?: Record<string, SessionEntry>;
 }): {
   storePath: string;
@@ -1450,9 +854,8 @@ function resolveGatewaySessionStoreLookup(params: {
     agentId: params.agentId,
     storePath: resolveStorePath(params.cfg.session?.store, { agentId: params.agentId }),
   };
-  const loadStore = (storePath: string) => loadGatewaySessionLookupStore(storePath, params.clone);
   let selectedStorePath = fallback.storePath;
-  let selectedStore = params.initialStore ?? loadStore(fallback.storePath);
+  let selectedStore = params.initialStore ?? loadSessionStore(fallback.storePath);
   let selectedMatch = findFreshestStoreMatch(selectedStore, ...scanTargets);
   let selectedUpdatedAt = selectedMatch?.entry.updatedAt ?? Number.NEGATIVE_INFINITY;
 
@@ -1461,7 +864,7 @@ function resolveGatewaySessionStoreLookup(params: {
     if (!candidate) {
       continue;
     }
-    const store = loadStore(candidate.storePath);
+    const store = loadSessionStore(candidate.storePath);
     const match = findFreshestStoreMatch(store, ...scanTargets);
     if (!match) {
       continue;
@@ -1484,120 +887,34 @@ function resolveGatewaySessionStoreLookup(params: {
   };
 }
 
-function resolveExplicitDeletedLegacyMainStoreTarget(params: {
+export function resolveGatewaySessionStoreTarget(params: {
   cfg: OpenClawConfig;
   key: string;
-  clone?: boolean;
-  scanLegacyKeys?: boolean;
-}): GatewaySessionStoreTargetWithStore | null {
-  const parsed = parseAgentSessionKey(params.key);
-  const legacyAgentId = normalizeAgentId(parsed?.agentId);
-  if (
-    !parsed ||
-    legacyAgentId !== DEFAULT_AGENT_ID ||
-    listAgentIds(params.cfg).includes(legacyAgentId)
-  ) {
-    return null;
-  }
-
-  // Only preserve agent:main:* when it is backed by a discovered deleted-main store.
-  // Shared-store legacy aliases should continue remapping to the configured default agent.
-  const canonicalKey = resolveStoredSessionKeyForAgentStore({
-    cfg: params.cfg,
-    agentId: legacyAgentId,
-    sessionKey: params.key,
-  });
-  const agentMainKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId: legacyAgentId });
-  const legacyAgentMainKey = `agent:${legacyAgentId}:main`;
-  const lookupSeeds = Array.from(
-    new Set([params.key, canonicalKey, agentMainKey, legacyAgentMainKey]),
-  );
-  let best:
-    | {
-        storePath: string;
-        store: Record<string, SessionEntry>;
-        match: { entry: SessionEntry; key: string };
-      }
-    | undefined;
-  for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg)) {
-    if (target.agentId !== legacyAgentId) {
-      continue;
-    }
-    const store = loadGatewaySessionLookupStore(target.storePath, params.clone);
-    const match = findFreshestStoreMatch(store, ...lookupSeeds);
-    if (!match) {
-      continue;
-    }
-    if (!best || (match.entry.updatedAt ?? 0) >= (best.match.entry.updatedAt ?? 0)) {
-      best = { storePath: target.storePath, store, match };
-    }
-  }
-  if (!best) {
-    return null;
-  }
-
-  const storeKeys = new Set<string>([canonicalKey]);
-  if (params.key !== canonicalKey) {
-    storeKeys.add(params.key);
-  }
-  storeKeys.add(best.match.key);
-  if (params.scanLegacyKeys !== false) {
-    for (const seed of lookupSeeds) {
-      storeKeys.add(seed);
-      for (const legacyKey of findStoreKeysIgnoreCase(best.store, seed)) {
-        storeKeys.add(legacyKey);
-      }
-    }
-  }
-  return {
-    agentId: legacyAgentId,
-    storePath: best.storePath,
-    canonicalKey,
-    storeKeys: Array.from(storeKeys),
-    store: best.store,
-  };
-}
-
-export function resolveGatewaySessionStoreTargetWithStore(params: {
-  cfg: OpenClawConfig;
-  key: string;
-  agentId?: string;
-  clone?: boolean;
   scanLegacyKeys?: boolean;
   store?: Record<string, SessionEntry>;
-}): GatewaySessionStoreTargetWithStore {
+}): {
+  agentId: string;
+  storePath: string;
+  canonicalKey: string;
+  storeKeys: string[];
+} {
   const key = normalizeOptionalString(params.key) ?? "";
-  const explicitDeletedMainTarget = resolveExplicitDeletedLegacyMainStoreTarget({
-    cfg: params.cfg,
-    key,
-    clone: params.clone,
-    scanLegacyKeys: params.scanLegacyKeys,
-  });
-  if (explicitDeletedMainTarget) {
-    return explicitDeletedMainTarget;
-  }
-
   const canonicalKey = resolveSessionStoreKey({
     cfg: params.cfg,
     sessionKey: key,
   });
-  const requestedAgentId = normalizeOptionalString(params.agentId);
-  const agentId =
-    canonicalKey === "global" && requestedAgentId
-      ? normalizeAgentId(requestedAgentId)
-      : resolveSessionStoreAgentId(params.cfg, canonicalKey);
+  const agentId = resolveSessionStoreAgentId(params.cfg, canonicalKey);
   const { storePath, store } = resolveGatewaySessionStoreLookup({
     cfg: params.cfg,
     key,
     canonicalKey,
     agentId,
-    clone: params.clone,
     initialStore: params.store,
   });
 
   if (canonicalKey === "global" || canonicalKey === "unknown") {
     const storeKeys = key && key !== canonicalKey ? [canonicalKey, key] : [key];
-    return { agentId, storePath, canonicalKey, storeKeys, store };
+    return { agentId, storePath, canonicalKey, storeKeys };
   }
 
   const storeKeys = new Set<string>();
@@ -1625,73 +942,130 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     storePath,
     canonicalKey,
     storeKeys: Array.from(storeKeys),
-    store,
   };
 }
 
-export function resolveGatewaySessionStoreTarget(params: {
+// Merge with existing entry based on latest timestamp to ensure data consistency and avoid overwriting with less complete data.
+function mergeSessionEntryIntoCombined(params: {
   cfg: OpenClawConfig;
-  key: string;
-  agentId?: string;
-  clone?: boolean;
-  scanLegacyKeys?: boolean;
-  store?: Record<string, SessionEntry>;
-}): GatewaySessionStoreTarget {
-  const { store: _store, ...target } = resolveGatewaySessionStoreTargetWithStore(params);
-  return target;
-}
-
-export { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
-
-export function resolveGatewaySessionThinkingDefault(params: {
-  cfg: OpenClawConfig;
-  provider: string;
-  model: string;
-  agentId?: string;
-  modelCatalog?: ModelCatalogEntry[];
+  combined: Record<string, SessionEntry>;
+  entry: SessionEntry;
+  agentId: string;
+  canonicalKey: string;
 }) {
-  const agentThinkingDefault = params.agentId
-    ? resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault
-    : undefined;
-  return (
-    agentThinkingDefault ??
-    resolveThinkingDefault({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      catalog: params.modelCatalog,
-    })
-  );
+  const { cfg, combined, entry, agentId, canonicalKey } = params;
+  const existing = combined[canonicalKey];
+
+  if (existing && (existing.updatedAt ?? 0) > (entry.updatedAt ?? 0)) {
+    combined[canonicalKey] = {
+      ...entry,
+      ...existing,
+      spawnedBy: canonicalizeSpawnedByForAgent(cfg, agentId, existing.spawnedBy ?? entry.spawnedBy),
+    };
+  } else {
+    combined[canonicalKey] = {
+      ...existing,
+      ...entry,
+      spawnedBy: canonicalizeSpawnedByForAgent(
+        cfg,
+        agentId,
+        entry.spawnedBy ?? existing?.spawnedBy,
+      ),
+    };
+  }
 }
 
-export function getSessionDefaults(
-  cfg: OpenClawConfig,
-  modelCatalog?: ModelCatalogEntry[],
-  options?: { allowPluginNormalization?: boolean },
-): GatewaySessionsDefaults {
+export function loadCombinedSessionStoreForGateway(cfg: OpenClawConfig): {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+} {
+  const storeConfig = cfg.session?.store;
+  const resolvedLiteralStorePath =
+    storeConfig && !isStorePathTemplate(storeConfig) ? resolveStorePath(storeConfig) : undefined;
+  const resolvedLiteralAgentsDir = resolvedLiteralStorePath
+    ? resolveAgentsDirFromSessionStorePath(resolvedLiteralStorePath)
+    : undefined;
+  if (resolvedLiteralStorePath && !resolvedLiteralAgentsDir) {
+    const defaultAgentId = normalizeAgentId(resolveDefaultAgentId(cfg));
+    const store = loadSessionStore(resolvedLiteralStorePath);
+    const combined: Record<string, SessionEntry> = {};
+    for (const [key, entry] of Object.entries(store)) {
+      const canonicalKey = canonicalizeSessionKeyForAgent(defaultAgentId, key);
+      mergeSessionEntryIntoCombined({
+        cfg,
+        combined,
+        entry,
+        agentId: defaultAgentId,
+        canonicalKey,
+      });
+    }
+    return { storePath: resolvedLiteralStorePath, store: combined };
+  }
+
+  const targets = resolveAllAgentSessionStoreTargetsSync(cfg);
+  // When the literal store path matches an agent-layout root, scope discovery to
+  // only that root so sessions from the default state directory are not pulled in.
+  // Use realpathSync to normalise symlinks (e.g. /var → /private/var on macOS)
+  // since target store paths are already realpath-resolved by the discovery layer.
+  const scopedTargets = resolvedLiteralAgentsDir
+    ? (() => {
+        let realLiteralAgentsDir: string;
+        try {
+          realLiteralAgentsDir = fs.realpathSync.native(resolvedLiteralAgentsDir);
+        } catch {
+          realLiteralAgentsDir = path.resolve(resolvedLiteralAgentsDir);
+        }
+        return targets.filter((t) => {
+          const tAgentsDir = resolveAgentsDirFromSessionStorePath(t.storePath);
+          if (!tAgentsDir) {
+            return false;
+          }
+          let realTAgentsDir: string;
+          try {
+            realTAgentsDir = fs.realpathSync.native(tAgentsDir);
+          } catch {
+            realTAgentsDir = path.resolve(tAgentsDir);
+          }
+          return realTAgentsDir === realLiteralAgentsDir;
+        });
+      })()
+    : targets;
+  const combined: Record<string, SessionEntry> = {};
+  for (const target of scopedTargets) {
+    const agentId = target.agentId;
+    const storePath = target.storePath;
+    const store = loadSessionStore(storePath);
+    for (const [key, entry] of Object.entries(store)) {
+      const canonicalKey = canonicalizeSessionKeyForAgent(agentId, key);
+      mergeSessionEntryIntoCombined({
+        cfg,
+        combined,
+        entry,
+        agentId,
+        canonicalKey,
+      });
+    }
+  }
+
+  const storePath =
+    typeof storeConfig === "string" && storeConfig.trim() ? storeConfig.trim() : "(multiple)";
+  return { storePath, store: combined };
+}
+
+export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults {
   const resolved = resolveConfiguredModelRef({
     cfg,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
-    allowPluginNormalization: options?.allowPluginNormalization,
   });
   const contextTokens =
     cfg.agents?.defaults?.contextTokens ??
     lookupContextTokens(resolved.model, { allowAsyncLoad: false }) ??
     DEFAULT_CONTEXT_TOKENS;
-  const thinkingLevels = listThinkingLevelOptions(resolved.provider, resolved.model, modelCatalog);
   return {
     modelProvider: resolved.provider ?? null,
     model: resolved.model ?? null,
     contextTokens: contextTokens ?? null,
-    thinkingLevels,
-    thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveGatewaySessionThinkingDefault({
-      cfg,
-      provider: resolved.provider,
-      model: resolved.model,
-      modelCatalog,
-    }),
   };
 }
 
@@ -1701,46 +1075,21 @@ export function resolveSessionModelRef(
     | SessionEntry
     | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
   agentId?: string,
-  options?: { allowPluginNormalization?: boolean },
 ): { provider: string; model: string } {
-  const normalizedOverride = normalizeStoredOverrideModel({
-    providerOverride: entry?.providerOverride,
-    modelOverride: entry?.modelOverride,
-  });
-  if (normalizedOverride.providerOverride && normalizedOverride.modelOverride) {
-    return resolvePersistedSelectedModelRef({
-      defaultProvider: normalizedOverride.providerOverride,
-      overrideProvider: normalizedOverride.providerOverride,
-      overrideModel: normalizedOverride.modelOverride,
-      allowPluginNormalization: options?.allowPluginNormalization,
-    })!;
-  }
-  const runtimeProvider = normalizeOptionalString(entry?.modelProvider);
-  const runtimeModel = normalizeOptionalString(entry?.model);
-  if (runtimeProvider && runtimeModel) {
-    return { provider: runtimeProvider, model: runtimeModel };
-  }
-
   const resolved = agentId
-    ? resolveDefaultModelForAgent({
-        cfg,
-        agentId,
-        allowPluginNormalization: options?.allowPluginNormalization,
-      })
+    ? resolveDefaultModelForAgent({ cfg, agentId })
     : resolveConfiguredModelRef({
         cfg,
         defaultProvider: DEFAULT_PROVIDER,
         defaultModel: DEFAULT_MODEL,
-        allowPluginNormalization: options?.allowPluginNormalization,
       });
 
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: resolved.provider || DEFAULT_PROVIDER,
-    runtimeProvider,
-    runtimeModel,
-    overrideProvider: normalizedOverride.providerOverride,
-    overrideModel: normalizedOverride.modelOverride,
-    allowPluginNormalization: options?.allowPluginNormalization,
+    runtimeProvider: entry?.modelProvider,
+    runtimeModel: entry?.model,
+    overrideProvider: entry?.providerOverride,
+    overrideModel: entry?.modelOverride,
   });
   if (persisted) {
     return persisted;
@@ -1749,7 +1098,7 @@ export function resolveSessionModelRef(
 }
 
 export async function resolveGatewayModelSupportsImages(params: {
-  loadGatewayModelCatalog: (params?: { readOnly?: boolean }) => Promise<ModelCatalogEntry[]>;
+  loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
   provider?: string;
   model?: string;
 }): Promise<boolean> {
@@ -1758,20 +1107,18 @@ export async function resolveGatewayModelSupportsImages(params: {
   }
 
   try {
-    const catalog = await params.loadGatewayModelCatalog({ readOnly: false });
-    const modelEntry = findModelCatalogEntry(catalog, {
-      provider: params.provider,
-      modelId: params.model,
-    });
-    const normalizedProvider = normalizeOptionalLowercaseString(
-      params.provider ?? modelEntry?.provider,
+    const catalog = await params.loadGatewayModelCatalog();
+    const modelEntry = catalog.find(
+      (entry) =>
+        entry.id === params.model && (!params.provider || entry.provider === params.provider),
     );
+    const normalizedProvider = normalizeOptionalLowercaseString(params.provider);
     const normalizedCandidates = [
       normalizeLowercaseStringOrEmpty(params.model),
       normalizeLowercaseStringOrEmpty(modelEntry?.name),
     ].filter(Boolean);
     if (modelEntry) {
-      if (modelSupportsInput(modelEntry, "image")) {
+      if (modelEntry.input?.includes("image")) {
         return true;
       }
       // Legacy safety shim for stale persisted Foundry rows that predate
@@ -1828,7 +1175,6 @@ export function resolveSessionModelIdentityRef(
     | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
   agentId?: string,
   fallbackModelRef?: string,
-  options?: { allowPluginNormalization?: boolean },
 ): { provider?: string; model: string } {
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
@@ -1844,9 +1190,7 @@ export function resolveSessionModelIdentityRef(
       return { provider: inferredProvider, model: runtimeModel };
     }
     if (runtimeModel.includes("/")) {
-      const parsedRuntime = parseModelRef(runtimeModel, DEFAULT_PROVIDER, {
-        allowPluginNormalization: options?.allowPluginNormalization,
-      });
+      const parsedRuntime = parseModelRef(runtimeModel, DEFAULT_PROVIDER);
       if (parsedRuntime) {
         return { provider: parsedRuntime.provider, model: parsedRuntime.model };
       }
@@ -1856,9 +1200,7 @@ export function resolveSessionModelIdentityRef(
   }
   const fallbackRef = fallbackModelRef?.trim();
   if (fallbackRef) {
-    const parsedFallback = parseModelRef(fallbackRef, DEFAULT_PROVIDER, {
-      allowPluginNormalization: options?.allowPluginNormalization,
-    });
+    const parsedFallback = parseModelRef(fallbackRef, DEFAULT_PROVIDER);
     if (parsedFallback) {
       return { provider: parsedFallback.provider, model: parsedFallback.model };
     }
@@ -1871,73 +1213,8 @@ export function resolveSessionModelIdentityRef(
     }
     return { model: fallbackRef };
   }
-  const resolved = resolveSessionModelRef(cfg, entry, agentId, {
-    allowPluginNormalization: options?.allowPluginNormalization,
-  });
+  const resolved = resolveSessionModelRef(cfg, entry, agentId);
   return { provider: resolved.provider, model: resolved.model };
-}
-
-function resolveSessionDisplayModelIdentityRefCached(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  provider?: string;
-  model?: string;
-  rowContext?: SessionListRowContext;
-}): { provider?: string; model?: string } {
-  const ctx = params.rowContext;
-  if (!ctx) {
-    return resolveSessionDisplayModelIdentityRef(params);
-  }
-  const key = `${params.agentId}\u0000${createSessionRowModelCacheKey(
-    params.provider,
-    params.model,
-  )}`;
-  const cached = ctx.displayModelIdentityByKey.get(key);
-  if (cached) {
-    return cached;
-  }
-  const value = resolveSessionDisplayModelIdentityRef(params);
-  ctx.displayModelIdentityByKey.set(key, value);
-  return value;
-}
-
-export function resolveSessionDisplayModelIdentityRef(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-  provider?: string;
-  model?: string;
-}): { provider?: string; model?: string } {
-  const provider = normalizeOptionalString(params.provider);
-  const model = normalizeOptionalString(params.model);
-  if (!provider || !model || !isCliProvider(provider, params.cfg)) {
-    return { provider, model };
-  }
-
-  const defaultRef = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
-  if (model.includes("/")) {
-    const parsedModel = parseModelRef(model, defaultRef.provider);
-    if (parsedModel && !isCliProvider(parsedModel.provider, params.cfg)) {
-      return parsedModel;
-    }
-  }
-
-  const inferredProvider = inferUniqueProviderFromConfiguredModels({
-    cfg: params.cfg,
-    model,
-  });
-  if (inferredProvider && !isCliProvider(inferredProvider, params.cfg)) {
-    return { provider: inferredProvider, model };
-  }
-
-  const parsedModel = parseModelRef(model, defaultRef.provider);
-  if (parsedModel && !isCliProvider(parsedModel.provider, params.cfg)) {
-    return parsedModel;
-  }
-
-  return {
-    provider: defaultRef.provider || provider,
-    model,
-  };
 }
 
 export function buildGatewaySessionRow(params: {
@@ -1946,20 +1223,11 @@ export function buildGatewaySessionRow(params: {
   store: Record<string, SessionEntry>;
   key: string;
   entry?: SessionEntry;
-  modelCatalog?: ModelCatalogEntry[];
   now?: number;
   includeDerivedTitles?: boolean;
   includeLastMessage?: boolean;
-  transcriptUsageMaxBytes?: number;
-  storeChildSessionsByKey?: Map<string, string[]>;
-  rowContext?: SessionListRowContext;
-  agentId?: string;
-  skipTranscriptUsageFallback?: boolean;
-  lightweightListRow?: boolean;
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
-  const lightweight = params.lightweightListRow === true;
-  const skipTranscriptUsage = params.skipTranscriptUsageFallback === true;
   const now = params.now ?? Date.now();
   const updatedAt = entry?.updatedAt ?? null;
   const parsed = parseGroupKey(key);
@@ -1970,10 +1238,9 @@ export function buildGatewaySessionRow(params: {
   const id = parsed?.id;
   const origin = entry?.origin;
   const originLabel = origin?.label;
-  const isGroupSession = isGroupOrChannelDisplaySession(entry, parsed);
   const displayName =
     entry?.displayName ??
-    (isGroupSession && channel
+    (channel
       ? buildGroupDisplayName({
           provider: channel,
           subject,
@@ -1987,92 +1254,38 @@ export function buildGatewaySessionRow(params: {
     originLabel;
   const deliveryFields = normalizeSessionDeliveryFields(entry);
   const parsedAgent = parseAgentSessionKey(key);
-  const sessionAgentId = normalizeAgentId(
-    parsedAgent?.agentId ?? params.agentId ?? resolveDefaultAgentId(cfg),
-  );
-  const rowContext = params.rowContext;
-  const subagentRun = rowContext
-    ? rowContext.subagentRuns.getDisplaySubagentRun(key)
-    : getSessionDisplaySubagentRunByChildSessionKey(key);
+  const sessionAgentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(cfg));
+  const subagentRun = getSessionDisplaySubagentRunByChildSessionKey(key);
   const subagentOwner =
     normalizeOptionalString(subagentRun?.controllerSessionKey) ||
     normalizeOptionalString(subagentRun?.requesterSessionKey);
-  const liveSubagentRunActive = isSubagentRunLive(subagentRun);
-  const persistedSessionStatus = entry?.status;
-  const persistedSessionEndedAt = entry?.endedAt;
-  const persistedSessionStartedAt = entry?.startedAt;
-  const persistedSessionRuntimeMs = entry?.runtimeMs;
-  const subagentRunState = subagentRun
-    ? liveSubagentRunActive
-      ? "active"
-      : typeof subagentRun.endedAt === "number" ||
-          persistedSessionStatus === "done" ||
-          persistedSessionStatus === "failed" ||
-          persistedSessionStatus === "killed" ||
-          persistedSessionStatus === "timeout" ||
-          typeof persistedSessionEndedAt === "number"
-        ? "historical"
-        : "interrupted"
-    : undefined;
-  const subagentStatus = subagentRun
-    ? liveSubagentRunActive
-      ? resolveSubagentSessionStatus(subagentRun)
-      : persistedSessionStatus === "running"
-        ? undefined
-        : (persistedSessionStatus ??
-          (typeof subagentRun.endedAt === "number"
-            ? resolveSubagentSessionStatus(subagentRun)
-            : undefined))
-    : undefined;
-  const subagentStartedAt = subagentRun
-    ? liveSubagentRunActive
-      ? getSubagentSessionStartedAt(subagentRun)
-      : (persistedSessionStartedAt ?? getSubagentSessionStartedAt(subagentRun))
-    : undefined;
-  const subagentEndedAt = subagentRun
-    ? liveSubagentRunActive
-      ? subagentRun.endedAt
-      : (persistedSessionEndedAt ?? subagentRun.endedAt)
-    : undefined;
-  const subagentRuntimeMs = subagentRun
-    ? liveSubagentRunActive
-      ? resolveSessionRuntimeMs(subagentRun, now)
-      : (persistedSessionRuntimeMs ??
-        (typeof subagentRun.endedAt === "number"
-          ? resolveSessionRuntimeMs(subagentRun, now)
-          : undefined))
-    : undefined;
-  const selectedModel = resolveSessionSelectedModelRef({
-    cfg,
-    entry,
-    agentId: sessionAgentId,
-    rowContext,
-    allowPluginNormalization: !lightweight,
-  });
+  const subagentStatus = subagentRun ? resolveSubagentSessionStatus(subagentRun) : undefined;
+  const subagentStartedAt = subagentRun ? getSubagentSessionStartedAt(subagentRun) : undefined;
+  const subagentEndedAt = subagentRun ? subagentRun.endedAt : undefined;
+  const subagentRuntimeMs = subagentRun ? resolveSessionRuntimeMs(subagentRun, now) : undefined;
+  const selectedModel = entry?.modelOverride?.trim()
+    ? resolveSessionModelRef(cfg, entry, sessionAgentId)
+    : null;
   const resolvedModel = resolveSessionModelIdentityRef(
     cfg,
     entry,
     sessionAgentId,
     subagentRun?.model,
-    { allowPluginNormalization: !lightweight },
   );
   const runtimeModelPresent =
     Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
-  const freshSessionTotalTokens = resolveNonNegativeNumber(resolveFreshSessionTotalTokens(entry));
-  const needsTranscriptTotalTokens = freshSessionTotalTokens === undefined;
+  const needsTranscriptTotalTokens =
+    resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined;
   const needsTranscriptContextTokens = resolvePositiveNumber(entry?.contextTokens) === undefined;
   const needsTranscriptEstimatedCostUsd =
-    !skipTranscriptUsage &&
     resolveEstimatedSessionCostUsd({
       cfg,
       provider: resolvedModel.provider,
       model: resolvedModel.model ?? DEFAULT_MODEL,
       entry,
-      rowContext,
     }) === undefined;
   const transcriptUsage =
-    !skipTranscriptUsage &&
-    (needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd)
+    needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd
       ? resolveTranscriptUsageFallback({
           cfg,
           key,
@@ -2080,9 +1293,6 @@ export function buildGatewaySessionRow(params: {
           storePath,
           fallbackProvider: resolvedModel.provider,
           fallbackModel: resolvedModel.model ?? DEFAULT_MODEL,
-          maxTranscriptBytes: params.transcriptUsageMaxBytes,
-          rowContext: params.rowContext,
-          agentId: sessionAgentId,
         })
       : null;
   const preferLiveSubagentModelIdentity =
@@ -2103,105 +1313,43 @@ export function buildGatewaySessionRow(params: {
     : resolvedModelIdentity;
   const { provider: modelProvider, model } = modelIdentity;
   const totalTokens =
-    freshSessionTotalTokens ?? resolveNonNegativeNumber(transcriptUsage?.totalTokens);
+    resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
+    resolvePositiveNumber(transcriptUsage?.totalTokens);
   const totalTokensFresh =
-    freshSessionTotalTokens !== undefined ||
-    (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0)
+    typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0
       ? true
       : transcriptUsage?.totalTokensFresh === true;
-  const goal = entry?.goal
-    ? resolveSessionGoalDisplayState(
-        {
-          goal: entry.goal,
-          totalTokens,
-          totalTokensFresh,
-        },
-        now,
-        // Session listing is read-only; stale goal baselines are adopted only
-        // by goal commands/tools that can persist the first fresh snapshot.
-        { adoptFreshBaseline: false },
-      )
-    : undefined;
-  const childSessions = params.storeChildSessionsByKey
-    ? mergeChildSessionKeys(
-        resolveRuntimeChildSessionKeys(key, now, rowContext?.subagentRuns),
-        params.storeChildSessionsByKey.get(key),
-      )
-    : resolveChildSessionKeys(key, store, now, rowContext?.subagentRuns);
-  const compactionCheckpoints = resolveProjectableCompactionCheckpoints(entry);
-  const compactionCheckpointCount = Array.isArray(entry?.compactionCheckpoints)
-    ? compactionCheckpoints.length
-    : undefined;
-  const latestCompactionCheckpoint = buildCompactionCheckpointPreview(
-    resolveLatestCompactionCheckpoint(compactionCheckpoints),
-  );
-  const selectedOrRuntimeModelProvider = selectedModel?.provider ?? modelProvider;
-  const selectedOrRuntimeModel = selectedModel?.model ?? model;
-  const rowModelIdentity = lightweight
-    ? { provider: selectedOrRuntimeModelProvider, model: selectedOrRuntimeModel }
-    : resolveSessionDisplayModelIdentityRefCached({
+  const childSessions = resolveChildSessionKeys(key, store);
+  const latestCompactionCheckpoint = resolveLatestCompactionCheckpoint(entry);
+  const estimatedCostUsd =
+    resolveEstimatedSessionCostUsd({
+      cfg,
+      provider: modelProvider,
+      model,
+      entry,
+    }) ?? resolveNonNegativeNumber(transcriptUsage?.estimatedCostUsd);
+  const contextTokens =
+    resolvePositiveNumber(entry?.contextTokens) ??
+    resolvePositiveNumber(transcriptUsage?.contextTokens) ??
+    resolvePositiveNumber(
+      resolveContextTokensForModel({
         cfg,
-        agentId: sessionAgentId,
-        provider: selectedOrRuntimeModelProvider,
-        model: selectedOrRuntimeModel,
-        rowContext: params.rowContext,
-      });
-  const rowModelProvider = rowModelIdentity.provider;
-  const rowModel = rowModelIdentity.model;
-  const acpSessionKey = resolveStoredSessionKeyForAgentStore({
-    cfg,
-    agentId: sessionAgentId,
-    sessionKey: key,
-  });
-  const acpMeta = readAcpSessionMeta({ sessionKey: acpSessionKey });
-  const agentRuntime = resolveModelAgentRuntimeMetadata({
-    cfg,
-    agentId: sessionAgentId,
-    provider: rowModelProvider,
-    model: rowModel,
-    sessionKey: acpSessionKey,
-    acpRuntime: acpMeta != null,
-    acpBackend: acpMeta?.backend,
-  });
-  const estimatedCostUsd = lightweight
-    ? resolveNonNegativeNumber(entry?.estimatedCostUsd)
-    : (resolveEstimatedSessionCostUsd({
-        cfg,
-        provider: rowModelProvider,
-        model: rowModel,
-        entry,
-        rowContext: params.rowContext,
-      }) ?? resolveNonNegativeNumber(transcriptUsage?.estimatedCostUsd));
-  const contextTokens = lightweight
-    ? (resolvePositiveNumber(entry?.contextTokens) ??
-      resolvePositiveNumber(
-        resolveContextTokensForModel({
-          cfg,
-          provider: rowModelProvider,
-          model: rowModel,
-          allowAsyncLoad: false,
-        }),
-      ))
-    : (resolvePositiveNumber(entry?.contextTokens) ??
-      resolvePositiveNumber(transcriptUsage?.contextTokens) ??
-      resolvePositiveNumber(
-        resolveContextTokensForModel({
-          cfg,
-          provider: rowModelProvider,
-          model: rowModel,
-          allowAsyncLoad: false,
-        }),
-      ));
+        provider: modelProvider,
+        model,
+        // Gateway/session listing is read-only; don't start async model discovery.
+        allowAsyncLoad: false,
+      }),
+    );
 
   let derivedTitle: string | undefined;
   let lastMessagePreview: string | undefined;
   if (entry?.sessionId && (params.includeDerivedTitles || params.includeLastMessage)) {
-    const fields = readScopedSessionTitleFieldsFromTranscript({
-      agentId: sessionAgentId,
-      sessionFile: entry.sessionFile,
-      sessionId: entry.sessionId,
+    const fields = readSessionTitleFieldsFromTranscript(
+      entry.sessionId,
       storePath,
-    });
+      entry.sessionFile,
+      sessionAgentId,
+    );
     if (params.includeDerivedTitles) {
       derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
     }
@@ -2210,26 +1358,10 @@ export function buildGatewaySessionRow(params: {
     }
   }
 
-  const thinkingProvider = rowModelProvider ?? DEFAULT_PROVIDER;
-  const thinkingModel = rowModel ?? DEFAULT_MODEL;
-  const thinkingMetadata = resolveSessionRowThinkingMetadata({
-    cfg,
-    agentId: sessionAgentId,
-    provider: thinkingProvider,
-    model: thinkingModel,
-    modelCatalog: params.modelCatalog,
-    rowContext,
-  });
-  const thinkingLevels = thinkingMetadata.levels;
-  const thinkingDefault = thinkingMetadata.defaultLevel;
-  const pluginExtensions =
-    !lightweight && entry ? projectPluginSessionExtensionsSync({ sessionKey: key, entry }) : [];
-
   return {
     key,
     spawnedBy: subagentOwner || entry?.spawnedBy,
     spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
-    spawnedCwd: entry?.spawnedCwd,
     forkedFromParent: entry?.forkedFromParent,
     spawnDepth: entry?.spawnDepth,
     subagentRole: entry?.subagentRole,
@@ -2250,12 +1382,8 @@ export function buildGatewaySessionRow(params: {
     systemSent: entry?.systemSent,
     abortedLastRun: entry?.abortedLastRun,
     thinkingLevel: entry?.thinkingLevel,
-    thinkingLevels,
-    thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault,
     fastMode: entry?.fastMode,
     verboseLevel: entry?.verboseLevel,
-    traceLevel: entry?.traceLevel,
     reasoningLevel: entry?.reasoningLevel,
     elevatedLevel: entry?.elevatedLevel,
     sendPolicy: entry?.sendPolicy,
@@ -2263,311 +1391,60 @@ export function buildGatewaySessionRow(params: {
     outputTokens: entry?.outputTokens,
     totalTokens,
     totalTokensFresh,
-    goal,
     estimatedCostUsd,
     status: subagentRun ? subagentStatus : entry?.status,
-    subagentRunState,
-    hasActiveSubagentRun: subagentRun ? liveSubagentRunActive : undefined,
     startedAt: subagentRun ? subagentStartedAt : entry?.startedAt,
     endedAt: subagentRun ? subagentEndedAt : entry?.endedAt,
     runtimeMs: subagentRun ? subagentRuntimeMs : entry?.runtimeMs,
     parentSessionKey: subagentOwner || entry?.parentSessionKey,
     childSessions,
     responseUsage: entry?.responseUsage,
-    modelProvider: rowModelProvider,
-    model: rowModel,
-    agentRuntime,
+    modelProvider: selectedModel?.provider ?? modelProvider,
+    model: selectedModel?.model ?? model,
     contextTokens,
-    contextBudgetStatus: entry?.contextBudgetStatus,
     deliveryContext: deliveryFields.deliveryContext,
     lastChannel: deliveryFields.lastChannel ?? entry?.lastChannel,
     lastTo: deliveryFields.lastTo ?? entry?.lastTo,
     lastAccountId: deliveryFields.lastAccountId ?? entry?.lastAccountId,
     lastThreadId: deliveryFields.lastThreadId ?? entry?.lastThreadId,
-    compactionCheckpointCount,
+    compactionCheckpointCount: entry?.compactionCheckpoints?.length,
     latestCompactionCheckpoint,
-    pluginExtensions: pluginExtensions.length > 0 ? pluginExtensions : undefined,
   };
-}
-
-function resolveSessionListSearchDisplayName(
-  key: string,
-  entry?: SessionEntry,
-): string | undefined {
-  if (entry?.displayName) {
-    return entry.displayName;
-  }
-  const parsed = parseGroupKey(key);
-  const channel = entry?.channel ?? parsed?.channel;
-  if (isGroupOrChannelDisplaySession(entry, parsed) && channel) {
-    return buildGroupDisplayName({
-      provider: channel,
-      subject: entry?.subject,
-      groupChannel: entry?.groupChannel,
-      space: entry?.space,
-      id: parsed?.id,
-      key,
-    });
-  }
-  return entry?.label ?? entry?.origin?.label;
-}
-
-function addSessionListSearchModelFields(
-  fields: Array<string | undefined>,
-  identity: { provider?: string; model?: string },
-) {
-  const provider = normalizeOptionalString(identity.provider);
-  const model = normalizeOptionalString(identity.model);
-  fields.push(provider, model);
-  if (provider && model) {
-    fields.push(`${provider}/${model}`);
-  }
-}
-
-function matchesSessionListSearch(fields: Array<string | undefined>, search: string): boolean {
-  return fields.some(
-    (field) => typeof field === "string" && normalizeLowercaseStringOrEmpty(field).includes(search),
-  );
-}
-
-function appendStoredSessionModelSearchFields(
-  fields: Array<string | undefined>,
-  entry?: SessionEntry,
-) {
-  const provider = normalizeOptionalString(entry?.modelProvider);
-  const model = normalizeOptionalString(entry?.model);
-  fields.push(provider, model);
-  if (provider && model) {
-    fields.push(`${provider}/${model}`);
-  }
-}
-
-function shouldResolveDerivedSessionModelSearchFields(search: string): boolean {
-  // Agent session-key searches are already covered by cheap key fields; do not
-  // hydrate model metadata for every non-matching row on hot TUI lookups.
-  return !search.startsWith("agent:");
-}
-
-function resolveSessionListRowContext(params: {
-  rowContext?: SessionListRowContext;
-  getRowContext?: SessionListRowContextProvider;
-}): SessionListRowContext | undefined {
-  return params.rowContext ?? params.getRowContext?.();
-}
-
-function resolveSessionListSearchModelFields(params: {
-  cfg: OpenClawConfig;
-  key: string;
-  entry?: SessionEntry;
-  rowContext?: SessionListRowContext;
-}): Array<string | undefined> {
-  const parsedAgent = parseAgentSessionKey(params.key);
-  const agentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(params.cfg));
-  const subagentRun = params.rowContext
-    ? params.rowContext.subagentRuns.getDisplaySubagentRun(params.key)
-    : getSessionDisplaySubagentRunByChildSessionKey(params.key);
-  const selectedModel = resolveSessionSelectedModelRef({
-    cfg: params.cfg,
-    entry: params.entry,
-    agentId,
-    rowContext: params.rowContext,
-    allowPluginNormalization: false,
-  });
-  const resolvedModel = resolveSessionModelIdentityRef(
-    params.cfg,
-    params.entry,
-    agentId,
-    subagentRun?.model,
-    { allowPluginNormalization: false },
-  );
-  const modelIdentity = {
-    provider: resolvedModel.provider,
-    model: resolvedModel.model ?? DEFAULT_MODEL,
-  };
-  const selectedOrRuntimeModelProvider = selectedModel?.provider ?? modelIdentity.provider;
-  const selectedOrRuntimeModel = selectedModel?.model ?? modelIdentity.model;
-  const displayModelIdentity = resolveSessionDisplayModelIdentityRefCached({
-    cfg: params.cfg,
-    agentId,
-    provider: selectedOrRuntimeModelProvider,
-    model: selectedOrRuntimeModel,
-    rowContext: params.rowContext,
-  });
-  const fields: Array<string | undefined> = [];
-  addSessionListSearchModelFields(fields, {
-    provider: params.entry?.modelProvider,
-    model: params.entry?.model,
-  });
-  addSessionListSearchModelFields(fields, resolvedModel);
-  if (selectedModel) {
-    addSessionListSearchModelFields(fields, selectedModel);
-  }
-  addSessionListSearchModelFields(fields, displayModelIdentity);
-  return fields;
 }
 
 export function loadGatewaySessionRow(
   sessionKey: string,
-  options?: {
-    agentId?: string;
-    includeDerivedTitles?: boolean;
-    includeLastMessage?: boolean;
-    now?: number;
-    transcriptUsageMaxBytes?: number;
-  },
+  options?: { includeDerivedTitles?: boolean; includeLastMessage?: boolean; now?: number },
 ): GatewaySessionRow | null {
-  const now = options?.now ?? Date.now();
-  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey, {
-    clone: false,
-    ...(options?.agentId ? { agentId: options.agentId } : {}),
-  });
+  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey);
   if (!entry) {
     return null;
   }
-  const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
-    storePath,
-    store,
-    key: canonicalKey,
-    now,
-  });
   return buildGatewaySessionRow({
     cfg,
     storePath,
     store,
     key: canonicalKey,
     entry,
-    now,
+    now: options?.now,
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
-    transcriptUsageMaxBytes: options?.transcriptUsageMaxBytes,
-    storeChildSessionsByKey,
-    ...(options?.agentId ? { agentId: options.agentId } : {}),
   });
 }
 
-export function buildGatewaySessionInfo(params: {
+export function listSessionsFromStore(params: {
   cfg: OpenClawConfig;
   storePath: string;
   store: Record<string, SessionEntry>;
-  key: string;
-  entry?: SessionEntry;
-  agentId?: string;
-  now?: number;
-  modelCatalog?: ModelCatalogEntry[];
-}): GatewaySessionRow {
-  const now = params.now ?? Date.now();
-  const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
-    storePath: params.storePath,
-    store: params.store,
-    key: params.key,
-    now,
-  });
-  return buildGatewaySessionRow({
-    cfg: params.cfg,
-    storePath: params.storePath,
-    store: params.store,
-    key: params.key,
-    entry: params.entry,
-    agentId: params.agentId,
-    modelCatalog: params.modelCatalog,
-    now,
-    storeChildSessionsByKey,
-    skipTranscriptUsageFallback: true,
-    lightweightListRow: true,
-  });
-}
+  opts: import("./protocol/index.js").SessionsListParams;
+}): SessionsListResult {
+  const { cfg, storePath, store, opts } = params;
+  const now = Date.now();
 
-/**
- * Number of session rows to build per batch before yielding to the event loop.
- * Keeps the main thread responsive during large session list operations while
- * avoiding excessive yielding overhead for small stores.
- */
-const SESSIONS_LIST_YIELD_BATCH_SIZE = 10;
-const SESSIONS_LIST_TOP_N_LIMIT = 200;
-const SESSIONS_LIST_DEFAULT_LIMIT = 100;
-
-type SessionEntryPair = [string, SessionEntry];
-type SessionEntrySelection = {
-  entries: SessionEntryPair[];
-  totalCount: number;
-  limitApplied?: number;
-  offset: number;
-  nextOffset: number | null;
-  hasMore: boolean;
-};
-
-function compareSessionEntryPairsByUpdatedAt(a: SessionEntryPair, b: SessionEntryPair): number {
-  return (b[1]?.updatedAt ?? 0) - (a[1]?.updatedAt ?? 0);
-}
-
-function resolveSessionsListLimit(
-  opts: SessionsListParams,
-  defaultLimit?: number,
-): number | undefined {
-  if (typeof opts.limit !== "number" || !Number.isFinite(opts.limit)) {
-    return defaultLimit;
-  }
-  return Math.max(1, Math.floor(opts.limit));
-}
-
-function resolveSessionsListOffset(opts: SessionsListParams): number {
-  if (typeof opts.offset !== "number" || !Number.isFinite(opts.offset)) {
-    return 0;
-  }
-  return Math.max(0, Math.floor(opts.offset));
-}
-
-function resolveSessionsListWindowLimit(limit: number | undefined, offset: number) {
-  if (limit === undefined) {
-    return undefined;
-  }
-  const windowLimit = offset + limit;
-  return Number.isFinite(windowLimit) ? Math.min(windowLimit, Number.MAX_SAFE_INTEGER) : undefined;
-}
-
-function selectNewestLimitedEntries(
-  entries: SessionEntryPair[],
-  limit: number,
-): SessionEntryPair[] {
-  const selected: SessionEntryPair[] = [];
-  for (const entry of entries) {
-    const insertAt = selected.findIndex(
-      (candidate) => compareSessionEntryPairsByUpdatedAt(entry, candidate) < 0,
-    );
-    if (insertAt >= 0) {
-      selected.splice(insertAt, 0, entry);
-      if (selected.length > limit) {
-        selected.pop();
-      }
-    } else if (selected.length < limit) {
-      selected.push(entry);
-    }
-  }
-  return selected;
-}
-
-function sortAndLimitSessionEntries(
-  entries: SessionEntryPair[],
-  limit: number | undefined,
-): SessionEntryPair[] {
-  if (limit !== undefined && limit <= SESSIONS_LIST_TOP_N_LIMIT) {
-    return selectNewestLimitedEntries(entries, limit);
-  }
-  const sorted = entries.toSorted(compareSessionEntryPairsByUpdatedAt);
-  return limit === undefined ? sorted : sorted.slice(0, limit);
-}
-
-function filterSessionEntries(params: {
-  cfg: OpenClawConfig;
-  store: Record<string, SessionEntry>;
-  opts: SessionsListParams;
-  now: number;
-  rowContext?: SessionListRowContext;
-  getRowContext?: SessionListRowContextProvider;
-}): SessionEntryPair[] {
-  const { cfg, store, opts, now } = params;
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
+  const includeDerivedTitles = opts.includeDerivedTitles === true;
+  const includeLastMessage = opts.includeLastMessage === true;
   const spawnedBy = typeof opts.spawnedBy === "string" ? opts.spawnedBy : "";
   const label = normalizeOptionalString(opts.label) ?? "";
   const agentId = typeof opts.agentId === "string" ? normalizeAgentId(opts.agentId) : "";
@@ -2577,7 +1454,7 @@ function filterSessionEntries(params: {
       ? Math.max(1, Math.floor(opts.activeMinutes))
       : undefined;
 
-  let entries = Object.entries(store)
+  let sessions = Object.entries(store)
     .filter(([key]) => {
       if (isCronRunSessionKey(key)) {
         return false;
@@ -2589,10 +1466,7 @@ function filterSessionEntries(params: {
         return false;
       }
       if (agentId) {
-        if (key === "global") {
-          return includeGlobal;
-        }
-        if (key === "unknown") {
+        if (key === "global" || key === "unknown") {
           return false;
         }
         const parsed = parseAgentSessionKey(key);
@@ -2604,337 +1478,65 @@ function filterSessionEntries(params: {
       return true;
     })
     .filter(([key, entry]) => {
-      if (isPhantomAgentStoreListEntry(key, entry)) {
-        return false;
-      }
       if (!spawnedBy) {
         return true;
       }
       if (key === "unknown" || key === "global") {
         return false;
       }
-      const filterRowContext = resolveSessionListRowContext(params);
-      const latest = filterRowContext
-        ? filterRowContext.subagentRuns.getDisplaySubagentRun(key)
-        : getSessionDisplaySubagentRunByChildSessionKey(key);
+      const latest = getSessionDisplaySubagentRunByChildSessionKey(key);
       if (latest) {
         const latestControllerSessionKey =
           normalizeOptionalString(latest.controllerSessionKey) ||
           normalizeOptionalString(latest.requesterSessionKey);
-        return (
-          latestControllerSessionKey === spawnedBy &&
-          shouldKeepSubagentRunChildLink(latest, {
-            activeDescendants: filterRowContext
-              ? filterRowContext.subagentRuns.countActiveDescendantRuns(key)
-              : countActiveDescendantRuns(key),
-            now,
-          })
-        );
+        return latestControllerSessionKey === spawnedBy;
       }
-      return (
-        shouldKeepStoreOnlyChildLink(entry, now) &&
-        (entry?.spawnedBy === spawnedBy || entry?.parentSessionKey === spawnedBy)
-      );
+      return entry?.spawnedBy === spawnedBy || entry?.parentSessionKey === spawnedBy;
     })
     .filter(([, entry]) => {
       if (!label) {
         return true;
       }
       return entry?.label === label;
-    });
+    })
+    .map(([key, entry]) =>
+      buildGatewaySessionRow({
+        cfg,
+        storePath,
+        store,
+        key,
+        entry,
+        now,
+        includeDerivedTitles,
+        includeLastMessage,
+      }),
+    )
+    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
 
   if (search) {
-    entries = entries.filter(([key, entry]) => {
-      const cheapFields = [
-        resolveSessionListSearchDisplayName(key, entry),
-        entry?.label,
-        entry?.subject,
-        entry?.sessionId,
-        key,
-      ];
-      appendStoredSessionModelSearchFields(cheapFields, entry);
-      if (matchesSessionListSearch(cheapFields, search)) {
-        return true;
-      }
-      if (!shouldResolveDerivedSessionModelSearchFields(search)) {
-        return false;
-      }
-      const searchRowContext = resolveSessionListRowContext(params);
-      return matchesSessionListSearch(
-        resolveSessionListSearchModelFields({
-          cfg,
-          key,
-          entry,
-          rowContext: searchRowContext,
-        }),
-        search,
+    sessions = sessions.filter((s) => {
+      const fields = [s.displayName, s.label, s.subject, s.sessionId, s.key];
+      return fields.some(
+        (f) => typeof f === "string" && normalizeLowercaseStringOrEmpty(f).includes(search),
       );
     });
   }
 
   if (activeMinutes !== undefined) {
     const cutoff = now - activeMinutes * 60_000;
-    entries = entries.filter(([, entry]) => (entry?.updatedAt ?? 0) >= cutoff);
+    sessions = sessions.filter((s) => (s.updatedAt ?? 0) >= cutoff);
   }
 
-  return entries;
-}
-
-function isPhantomAgentStoreListEntry(key: string, entry: SessionEntry | undefined): boolean {
-  const parsed = parseAgentSessionKey(key);
-  return (
-    parsed?.rest === "sessions" &&
-    !normalizeOptionalString(entry?.sessionId) &&
-    entry?.updatedAt == null
-  );
-}
-
-function selectSessionEntries(params: {
-  cfg: OpenClawConfig;
-  store: Record<string, SessionEntry>;
-  opts: SessionsListParams;
-  now: number;
-  rowContext?: SessionListRowContext;
-  getRowContext?: SessionListRowContextProvider;
-  defaultLimit?: number;
-}): SessionEntrySelection {
-  const filtered = filterSessionEntries(params);
-  const limit = resolveSessionsListLimit(params.opts, params.defaultLimit);
-  const offset = resolveSessionsListOffset(params.opts);
-  const windowLimit = resolveSessionsListWindowLimit(limit, offset);
-  const sortedWindow = sortAndLimitSessionEntries(filtered, windowLimit);
-  const entries =
-    limit === undefined ? sortedWindow.slice(offset) : sortedWindow.slice(offset, offset + limit);
-  const nextOffset = offset + entries.length;
-  const hasMore = nextOffset < filtered.length;
-  return {
-    entries,
-    totalCount: filtered.length,
-    limitApplied: limit,
-    offset,
-    nextOffset: hasMore ? nextOffset : null,
-    hasMore,
-  };
-}
-
-export function filterAndSortSessionEntries(params: {
-  cfg: OpenClawConfig;
-  store: Record<string, SessionEntry>;
-  opts: SessionsListParams;
-  now: number;
-  rowContext?: SessionListRowContext;
-  getRowContext?: SessionListRowContextProvider;
-}): [string, SessionEntry][] {
-  return selectSessionEntries(params).entries;
-}
-
-export function listSessionsFromStore(params: {
-  cfg: OpenClawConfig;
-  storePath: string;
-  store: Record<string, SessionEntry>;
-  modelCatalog?: ModelCatalogEntry[];
-  opts: SessionsListParams;
-}): SessionsListResult {
-  const { cfg, storePath, store, opts } = params;
-  const now = Date.now();
-  const sessionListTranscriptUsageMaxBytes = 64 * 1024;
-  const sessionListTranscriptFieldRows = 100;
-  let rowContext: SessionListRowContext | undefined;
-  const getRowContext = () => {
-    rowContext ??= buildSessionListRowContext({ store, now });
-    return rowContext;
-  };
-  const includeDerivedTitles = opts.includeDerivedTitles === true;
-  const includeLastMessage = opts.includeLastMessage === true;
-  const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
-
-  const selection = selectSessionEntries({
-    cfg,
-    store,
-    opts,
-    now,
-    getRowContext:
-      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
-        ? getRowContext
-        : undefined,
-    defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
-  });
-  const { entries, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;
-  const fullRowContext =
-    rowContext || hasSpawnedByFilter || entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE
-      ? getRowContext()
-      : undefined;
-  const sharedRowContext =
-    fullRowContext ??
-    (entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined);
-
-  const sessions = entries.map(([key, entry], index) => {
-    const includeTranscriptFields = index < sessionListTranscriptFieldRows;
-    const rowAgentId =
-      key === "global" && typeof opts.agentId === "string"
-        ? normalizeAgentId(opts.agentId)
-        : undefined;
-    const storeChildSessionsByKey =
-      fullRowContext?.storeChildSessionsByKey ??
-      buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
-    return buildGatewaySessionRow({
-      cfg,
-      storePath,
-      store,
-      key,
-      entry,
-      agentId: rowAgentId,
-      modelCatalog: params.modelCatalog,
-      now,
-      includeDerivedTitles: includeTranscriptFields && includeDerivedTitles,
-      includeLastMessage: includeTranscriptFields && includeLastMessage,
-      transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
-      storeChildSessionsByKey,
-      rowContext: sharedRowContext,
-    });
-  });
-
-  return {
-    ts: now,
-    path: storePath,
-    count: sessions.length,
-    totalCount,
-    limitApplied,
-    offset: offset > 0 ? offset : undefined,
-    nextOffset,
-    hasMore,
-    defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
-    sessions,
-  };
-}
-
-/**
- * Async version of listSessionsFromStore that yields to the event loop between
- * batches of session row builds. This prevents large session stores from
- * blocking the event loop during sessions.list requests.
- *
- * The synchronous file I/O in readSessionTitleFieldsFromTranscript (head/tail
- * reads for derived titles and last-message previews) is the dominant blocker.
- * By yielding every SESSIONS_LIST_YIELD_BATCH_SIZE rows, we keep the event
- * loop responsive for WebSocket heartbeats, channel I/O, and concurrent RPC.
- */
-export async function listSessionsFromStoreAsync(params: {
-  cfg: OpenClawConfig;
-  storePath: string;
-  store: Record<string, SessionEntry>;
-  modelCatalog?: ModelCatalogEntry[];
-  opts: SessionsListParams;
-}): Promise<SessionsListResult> {
-  // Pin the active plugin-registry workspace dir for the duration of this
-  // call so per-row metadata lookups use a stable memo key. Without this pin,
-  // concurrent agent turns / crons mutate the process-global workspace dir
-  // between rows, the memo never hits, and each row triggers a full
-  // loadPluginMetadataSnapshot scan (~100 ms).
-  return withPinnedActivePluginRegistryWorkspaceDir(async () => {
-  const { cfg, storePath, store, opts } = params;
-  const now = Date.now();
-  const sessionListTranscriptUsageMaxBytes = 64 * 1024;
-  const sessionListTranscriptFieldRows = 100;
-  let rowContext: SessionListRowContext | undefined;
-  const getRowContext = () => {
-    rowContext ??= buildSessionListRowContext({ store, now });
-    return rowContext;
-  };
-  const includeDerivedTitles = opts.includeDerivedTitles === true;
-  const includeLastMessage = opts.includeLastMessage === true;
-  const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
-
-  const selection = selectSessionEntries({
-    cfg,
-    store,
-    opts,
-    now,
-    getRowContext:
-      hasSpawnedByFilter || Boolean(normalizeOptionalString(opts.search))
-        ? getRowContext
-        : undefined,
-    defaultLimit: SESSIONS_LIST_DEFAULT_LIMIT,
-  });
-  const { entries, totalCount, limitApplied, offset, nextOffset, hasMore } = selection;
-  const fullRowContext =
-    rowContext || hasSpawnedByFilter || entries.length > SESSIONS_LIST_YIELD_BATCH_SIZE
-      ? getRowContext()
-      : undefined;
-  const sharedRowContext =
-    fullRowContext ??
-    (entries.length > 0 ? buildSessionListRowMetadataContext({ now }) : undefined);
-
-  const sessions: GatewaySessionRow[] = [];
-  for (let i = 0; i < entries.length; i++) {
-    const [key, entry] = entries[i];
-    const includeTranscriptFields = i < sessionListTranscriptFieldRows;
-    const rowAgentId =
-      key === "global" && typeof opts.agentId === "string"
-        ? normalizeAgentId(opts.agentId)
-        : undefined;
-    const storeChildSessionsByKey =
-      fullRowContext?.storeChildSessionsByKey ??
-      buildSingleRowStoreChildSessionsByKey({ store, storePath, key, now });
-    const row = buildGatewaySessionRow({
-      cfg,
-      storePath,
-      store,
-      key,
-      entry,
-      agentId: rowAgentId,
-      modelCatalog: params.modelCatalog,
-      now,
-      includeDerivedTitles: false,
-      includeLastMessage: false,
-      transcriptUsageMaxBytes: sessionListTranscriptUsageMaxBytes,
-      storeChildSessionsByKey,
-      rowContext: sharedRowContext,
-      skipTranscriptUsageFallback: true,
-      lightweightListRow: true,
-    });
-    if (
-      entry?.sessionId &&
-      includeTranscriptFields &&
-      (includeDerivedTitles || includeLastMessage)
-    ) {
-      const parsed = parseAgentSessionKey(key);
-      const sessionAgentId =
-        rowAgentId ??
-        (parsed?.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg));
-      const fields = await readScopedSessionTitleFieldsFromTranscriptAsync({
-        agentId: sessionAgentId,
-        sessionFile: entry.sessionFile,
-        sessionId: entry.sessionId,
-        storePath,
-      });
-      if (includeDerivedTitles) {
-        row.derivedTitle = deriveSessionTitle(entry, fields.firstUserMessage);
-      }
-      if (includeLastMessage && fields.lastMessagePreview) {
-        row.lastMessagePreview = fields.lastMessagePreview;
-      }
-    }
-    sessions.push(row);
-    // Yield to the event loop between batches so WebSocket heartbeats,
-    // channel I/O, and concurrent RPC calls are not starved.
-    if ((i + 1) % SESSIONS_LIST_YIELD_BATCH_SIZE === 0 && i + 1 < entries.length) {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-    }
+  if (typeof opts.limit === "number" && Number.isFinite(opts.limit)) {
+    const limit = Math.max(1, Math.floor(opts.limit));
+    sessions = sessions.slice(0, limit);
   }
 
   return {
     ts: now,
     path: storePath,
     count: sessions.length,
-    totalCount,
-    limitApplied,
-    offset: offset > 0 ? offset : undefined,
-    nextOffset,
-    hasMore,
-    defaults: getSessionDefaults(cfg, params.modelCatalog, { allowPluginNormalization: false }),
+    defaults: getSessionDefaults(cfg),
     sessions,
   };
-  });
 }


### PR DESCRIPTION
Closing: this cherry-pick of #54716 (April 2026) is too far diverged from current main (34 CI failures, +515/-3462 lines, gateway session code heavily refactored since).

The upstream PR is 2 months old and modifies core gateway session-utils.ts which has been substantially rewritten. A cherry-pick cannot resolve the semantic conflicts.

Recommendation: the upstream PR author should rebase onto latest main. This fork branch is beyond automatic repair.

@clawsweeper — closing as unsalvageable duplicate.