### PR TITLE
fix(update): preserve local package overrides

### DIFF
--- a/src/infra/package-local-overrides.ts
+++ b/src/infra/package-local-overrides.ts
@@ -1,0 +1,1351 @@
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createAsyncLock } from "@openclaw/fs-safe/advanced";
+import { configureFsSafePython, getFsSafePythonConfig } from "@openclaw/fs-safe/config";
+import { resolveStateDir } from "../config/paths.js";
+import { formatErrorMessage } from "./errors.js";
+import { root as openFsRoot } from "./fs-safe.js";
+import {
+  collectPackageDistInventory,
+  isLegacyContentInventoryCompatVersion,
+  PACKAGE_DIST_CONTENT_INVENTORY_RELATIVE_PATH,
+  readPackageDistContentInventoryIfPresent,
+  type PackageDistContentInventoryEntry,
+} from "./package-dist-inventory.js";
+import { readPackageVersion } from "./package-json.js";
+
+type LocalPackageOverrideKind = "added" | "modified" | "deleted";
+type LocalPackageOverrideConflictReason =
+  | "target-changed"
+  | "target-exists"
+  | "target-missing"
+  | "target-hardlinked"
+  | "target-inspection-failed"
+  | "apply-failed"
+  | "rollback-failed";
+
+type LocalPackageOverrideChange = {
+  kind: LocalPackageOverrideKind;
+  path: string;
+  baseline?: PackageDistContentInventoryEntry;
+  dependencies?: string[];
+  savedPath?: string;
+  mode?: number;
+};
+
+export type LocalPackageOverridesResult = {
+  status: "none" | "preserved" | "applied" | "conflict" | "error";
+  added: number;
+  modified: number;
+  deleted: number;
+  applied: number;
+  conflicts: Array<{
+    path: string;
+    reason: LocalPackageOverrideConflictReason;
+  }>;
+  recoveryDir?: string;
+  warnings: string[];
+};
+
+export type LocalPackageOverridesPlan = {
+  packageRoot: string;
+  recoveryDir: string;
+  changes: LocalPackageOverrideChange[];
+  result: LocalPackageOverridesResult;
+};
+
+function emptyResult(status: LocalPackageOverridesResult["status"]): LocalPackageOverridesResult {
+  return {
+    status,
+    added: 0,
+    modified: 0,
+    deleted: 0,
+    applied: 0,
+    conflicts: [],
+    warnings: [],
+  };
+}
+
+async function packageRootExists(packageRoot: string): Promise<boolean> {
+  try {
+    await fs.lstat(packageRoot);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+type LocalOverridePackageRootIdentity = {
+  realPath: string;
+  device: bigint;
+  inode: bigint;
+};
+
+async function readLocalOverridePackageRootIdentity(
+  packageRoot: string,
+): Promise<LocalOverridePackageRootIdentity> {
+  const realPath = await fs.realpath(packageRoot);
+  const stats = await fs.stat(realPath, { bigint: true });
+  if (!stats.isDirectory()) {
+    throw new Error(`local override package root is not a directory: ${packageRoot}`);
+  }
+  return { realPath, device: stats.dev, inode: stats.ino };
+}
+
+function isSameLocalOverridePackageRoot(
+  left: LocalOverridePackageRootIdentity,
+  right: LocalOverridePackageRootIdentity,
+): boolean {
+  return (
+    left.realPath === right.realPath && left.device === right.device && left.inode === right.inode
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return ["ENOENT", "ENOTDIR", "not-found"].includes((error as NodeJS.ErrnoException).code ?? "");
+}
+
+type LocalPackageOverrideTargetProbe =
+  | { status: "missing" }
+  | { status: "blocked" }
+  | { status: "error" }
+  | {
+      status: "present";
+      hardlinked: boolean;
+      mode: number;
+      safeFile: boolean;
+    };
+
+async function probeLocalOverrideTarget(
+  targetPath: string,
+): Promise<LocalPackageOverrideTargetProbe> {
+  try {
+    const stats = await fs.lstat(targetPath, { bigint: true });
+    return {
+      status: "present",
+      hardlinked: stats.nlink > 1n,
+      mode: Number(stats.mode & 0o777n),
+      safeFile: stats.isFile() && !stats.isSymbolicLink(),
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return { status: "missing" };
+    }
+    if (code === "ENOTDIR") {
+      return { status: "blocked" };
+    }
+    return { status: "error" };
+  }
+}
+
+async function resolveLocalOverrideTopologyPath(
+  packageRoot: string,
+  realPackageRoot: string,
+  relativePath: string,
+): Promise<string> {
+  const segments = normalizeDistPath(relativePath).split("/");
+  for (
+    let existingSegmentCount = segments.length;
+    existingSegmentCount >= 0;
+    existingSegmentCount--
+  ) {
+    const existingPath = path.join(packageRoot, ...segments.slice(0, existingSegmentCount));
+    try {
+      const realExistingPath = await fs.realpath(existingPath);
+      const resolvedTopologyPath = path.resolve(
+        realExistingPath,
+        ...segments.slice(existingSegmentCount),
+      );
+      if (
+        resolvedTopologyPath === realPackageRoot ||
+        resolvedTopologyPath.startsWith(`${realPackageRoot}${path.sep}`)
+      ) {
+        return resolvedTopologyPath;
+      }
+      throw new Error(`local override topology escapes package root: ${relativePath}`);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`could not resolve local override topology for ${relativePath}`);
+}
+
+async function resolvePathTopology(targetPath: string): Promise<string> {
+  const missingSegments: string[] = [];
+  let currentPath = path.resolve(targetPath);
+  while (true) {
+    try {
+      return path.resolve(await fs.realpath(currentPath), ...missingSegments);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        throw error;
+      }
+      missingSegments.unshift(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
+async function assertRecoveryRootOutsidePackageRoot(
+  packageRoot: string,
+  recoveryRoot: string,
+): Promise<void> {
+  const [resolvedPackageRoot, resolvedRecoveryRoot] = await Promise.all([
+    resolvePathTopology(packageRoot),
+    resolvePathTopology(recoveryRoot),
+  ]);
+  if (
+    resolvedRecoveryRoot === resolvedPackageRoot ||
+    resolvedRecoveryRoot.startsWith(`${resolvedPackageRoot}${path.sep}`)
+  ) {
+    throw new Error(`local override recovery root must be outside package root: ${recoveryRoot}`);
+  }
+}
+
+function countChanges(changes: LocalPackageOverrideChange[]) {
+  return {
+    added: changes.filter((change) => change.kind === "added").length,
+    modified: changes.filter((change) => change.kind === "modified").length,
+    deleted: changes.filter((change) => change.kind === "deleted").length,
+  };
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, "/");
+}
+
+function normalizeDistPath(relativePath: string): string {
+  return normalizeRelativePath(path.posix.normalize(relativePath));
+}
+
+function resolveSafePackagePath(packageRoot: string, relativePath: string): string {
+  const normalized = normalizeDistPath(relativePath);
+  if (!normalized.startsWith("dist/") || normalized.includes("\0")) {
+    throw new Error(`unsafe local override path: ${relativePath}`);
+  }
+  const resolved = path.resolve(packageRoot, normalized);
+  const root = path.resolve(packageRoot);
+  if (resolved !== root && resolved.startsWith(`${root}${path.sep}`)) {
+    return resolved;
+  }
+  throw new Error(`local override path escapes package root: ${relativePath}`);
+}
+
+async function assertLocalOverrideMutationTopology(params: {
+  packageRoot: string;
+  realPackageRoot: string;
+  relativePath: string;
+}): Promise<void> {
+  const resolvedPath = await resolveLocalOverrideTopologyPath(
+    params.packageRoot,
+    params.realPackageRoot,
+    params.relativePath,
+  );
+  const expectedPath = path.resolve(params.realPackageRoot, normalizeDistPath(params.relativePath));
+  if (resolvedPath !== expectedPath) {
+    throw new Error(`local override topology changed: ${params.relativePath}`);
+  }
+}
+
+async function hashFileSha256(filePath: string): Promise<string> {
+  const content = await fs.readFile(filePath);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function buildLocalOverrideInventoryEntry(params: {
+  relativePath: string;
+  sourcePath: string;
+  mode?: number;
+}): Promise<PackageDistContentInventoryEntry> {
+  const content = await fs.readFile(params.sourcePath);
+  const stats = await fs.stat(params.sourcePath);
+  return {
+    path: params.relativePath,
+    sha256: createHash("sha256").update(content).digest("hex"),
+    mode: params.mode ?? normalizeFileMode(stats.mode),
+    size: content.length,
+  };
+}
+
+function normalizeFileMode(mode: number): number {
+  return mode & 0o777;
+}
+
+function fileModesHaveSameExecutableSemantics(left: number, right: number): boolean {
+  return (
+    process.platform === "win32" ||
+    Boolean(normalizeFileMode(left) & 0o111) === Boolean(normalizeFileMode(right) & 0o111)
+  );
+}
+
+function mergeLocalOverrideFileMode(targetMode: number, overrideMode: number): number {
+  return (normalizeFileMode(targetMode) & ~0o111) | (normalizeFileMode(overrideMode) & 0o111);
+}
+
+async function writeFileWithMode(
+  content: Buffer,
+  destination: string,
+  mode?: number,
+): Promise<void> {
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.writeFile(destination, content);
+  if (mode !== undefined && process.platform !== "win32") {
+    await fs.chmod(destination, mode);
+  }
+}
+
+type LocalOverridePackageRoot = Awaited<ReturnType<typeof openFsRoot>>;
+const withRequiredFsSafePythonLock = createAsyncLock();
+
+async function runWithRequiredFsSafePython<T>(operation: () => Promise<T>): Promise<T> {
+  return await withRequiredFsSafePythonLock(async () => {
+    const previousPythonConfig = getFsSafePythonConfig();
+    configureFsSafePython({ mode: "require" });
+    try {
+      return await operation();
+    } finally {
+      configureFsSafePython(previousPythonConfig);
+    }
+  });
+}
+
+class LocalOverrideRollbackError extends Error {
+  constructor(
+    readonly relativePath: string,
+    readonly action: string,
+    readonly rollbackError: unknown,
+  ) {
+    super(
+      `local override rollback failed for ${relativePath}: ${formatErrorMessage(rollbackError)}`,
+    );
+    this.name = "LocalOverrideRollbackError";
+  }
+}
+
+function createLocalOverrideMutationPath(relativePath: string, label: string): string {
+  const normalized = normalizeDistPath(relativePath);
+  return path.posix.join(
+    path.posix.dirname(normalized),
+    `.openclaw-override-${label}-${randomUUID()}.tmp`,
+  );
+}
+
+async function moveLocalOverrideTargetNoReplace(params: {
+  packageFs: LocalOverridePackageRoot;
+  sourcePath: string;
+  relativePath: string;
+}): Promise<void> {
+  if (process.platform === "win32") {
+    await params.packageFs.move(params.sourcePath, params.relativePath, { overwrite: false });
+    return;
+  }
+  // Executable override replay fails closed instead of using fs-safe's path-based
+  // Node fallback for the final no-clobber publish.
+  await runWithRequiredFsSafePython(() =>
+    params.packageFs.move(params.sourcePath, params.relativePath, { overwrite: false }),
+  );
+}
+
+async function writeRollbackBackup(params: {
+  backupPath: string;
+  content: Buffer;
+  mode: number;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(params.backupPath), { recursive: true });
+  await fs.writeFile(params.backupPath, params.content);
+  if (process.platform !== "win32") {
+    await fs.chmod(params.backupPath, params.mode);
+  }
+}
+
+async function publishLocalOverrideTarget(params: {
+  packageFs: LocalOverridePackageRoot;
+  sourcePath: string;
+  relativePath: string;
+  onPublished?: () => void;
+}): Promise<void> {
+  await assertLocalOverrideMutationTopology({
+    packageRoot: params.packageFs.rootDir,
+    realPackageRoot: params.packageFs.rootReal,
+    relativePath: params.sourcePath,
+  });
+  await assertLocalOverrideMutationTopology({
+    packageRoot: params.packageFs.rootDir,
+    realPackageRoot: params.packageFs.rootReal,
+    relativePath: params.relativePath,
+  });
+  await moveLocalOverrideTargetNoReplace(params);
+  params.onPublished?.();
+  await assertLocalOverrideMutationTopology({
+    packageRoot: params.packageFs.rootDir,
+    realPackageRoot: params.packageFs.rootReal,
+    relativePath: params.relativePath,
+  });
+}
+
+async function restoreMovedLocalOverrideTarget(params: {
+  packageFs: LocalOverridePackageRoot;
+  movedPath: string;
+  relativePath: string;
+}): Promise<void> {
+  await publishLocalOverrideTarget({
+    packageFs: params.packageFs,
+    sourcePath: params.movedPath,
+    relativePath: params.relativePath,
+  });
+}
+
+async function throwAfterRestoringMovedLocalOverrideTarget(params: {
+  packageFs: LocalOverridePackageRoot;
+  movedPath: string;
+  relativePath: string;
+  originalError: unknown;
+  removeMovedAfterFailedRestore: boolean;
+}): Promise<never> {
+  try {
+    await restoreMovedLocalOverrideTarget({
+      packageFs: params.packageFs,
+      movedPath: params.movedPath,
+      relativePath: params.relativePath,
+    });
+  } catch (rollbackError) {
+    if (params.removeMovedAfterFailedRestore) {
+      await params.packageFs.remove(params.movedPath).catch(() => undefined);
+    }
+    throw new LocalOverrideRollbackError(
+      params.relativePath,
+      "restore current target",
+      rollbackError,
+    );
+  }
+  throw params.originalError;
+}
+
+async function removeLocalOverrideCleanupPath(
+  packageFs: LocalOverridePackageRoot,
+  relativePath: string,
+): Promise<void> {
+  try {
+    await packageFs.remove(relativePath);
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+  }
+}
+
+async function moveExpectedLocalOverrideTarget(params: {
+  packageFs: LocalOverridePackageRoot;
+  relativePath: string;
+  expected: PackageDistContentInventoryEntry;
+}): Promise<{ movedPath: string; content: Buffer; mode: number }> {
+  const movedPath = createLocalOverrideMutationPath(params.relativePath, "previous");
+  let targetMoved = false;
+  try {
+    if (process.platform !== "win32") {
+      // Verify the required publish/restore backend before moving the target aside.
+      await runWithRequiredFsSafePython(() => params.packageFs.stat("."));
+    }
+    await params.packageFs.move(params.relativePath, movedPath);
+    targetMoved = true;
+    const moved = await params.packageFs.read(movedPath, {
+      hardlinks: "reject",
+      maxBytes: Number.POSITIVE_INFINITY,
+      symlinks: "reject",
+    });
+    const mode = normalizeFileMode(moved.stat.mode);
+    const sha256 = createHash("sha256").update(moved.buffer).digest("hex");
+    if (
+      sha256 !== params.expected.sha256 ||
+      !fileModesHaveSameExecutableSemantics(mode, params.expected.mode)
+    ) {
+      throw new Error(`local override target changed during mutation: ${params.relativePath}`);
+    }
+    return { movedPath, content: moved.buffer, mode };
+  } catch (error) {
+    if (targetMoved) {
+      await throwAfterRestoringMovedLocalOverrideTarget({
+        packageFs: params.packageFs,
+        movedPath,
+        relativePath: params.relativePath,
+        originalError: error,
+        removeMovedAfterFailedRestore: false,
+      });
+    }
+    throw error;
+  }
+}
+
+async function replaceLocalOverrideTarget(params: {
+  packageFs: LocalOverridePackageRoot;
+  relativePath: string;
+  sourcePath: string;
+  mode?: number;
+  expected?: PackageDistContentInventoryEntry;
+  backupPath?: string;
+  onCommitted?: (cleanupPaths: string[], backupMode?: number) => void;
+}): Promise<string[]> {
+  const temporaryPath = createLocalOverrideMutationPath(params.relativePath, "next");
+  let backupMode: number | undefined;
+  let backupWritten = false;
+  let committed = false;
+  let movedPath: string | undefined;
+  let replacementMode = params.mode;
+  try {
+    await params.packageFs.copyIn(temporaryPath, params.sourcePath, {
+      maxBytes: Number.POSITIVE_INFINITY,
+      mkdir: true,
+      mode: params.mode,
+      sourceHardlinks: "reject",
+    });
+    if (params.expected) {
+      if (!params.backupPath) {
+        throw new Error(`missing local override rollback path: ${params.relativePath}`);
+      }
+      const moved = await moveExpectedLocalOverrideTarget({
+        packageFs: params.packageFs,
+        relativePath: params.relativePath,
+        expected: params.expected,
+      });
+      movedPath = moved.movedPath;
+      backupMode = moved.mode;
+      if (replacementMode !== undefined) {
+        replacementMode = mergeLocalOverrideFileMode(moved.mode, replacementMode);
+      }
+      await writeRollbackBackup({
+        backupPath: params.backupPath,
+        content: moved.content,
+        mode: moved.mode,
+      });
+      backupWritten = true;
+    }
+    if (replacementMode !== undefined && process.platform !== "win32") {
+      const temporary = await params.packageFs.open(temporaryPath, {
+        hardlinks: "reject",
+        symlinks: "reject",
+      });
+      try {
+        await temporary.handle.chmod(replacementMode);
+      } finally {
+        await temporary.handle.close();
+      }
+    }
+    const cleanupPaths = [temporaryPath, ...(movedPath ? [movedPath] : [])];
+    await publishLocalOverrideTarget({
+      packageFs: params.packageFs,
+      sourcePath: temporaryPath,
+      relativePath: params.relativePath,
+      onPublished: () => {
+        committed = true;
+        params.onCommitted?.(cleanupPaths, backupMode);
+      },
+    });
+    return cleanupPaths;
+  } catch (error) {
+    if (movedPath && !committed) {
+      await throwAfterRestoringMovedLocalOverrideTarget({
+        packageFs: params.packageFs,
+        movedPath,
+        relativePath: params.relativePath,
+        originalError: error,
+        removeMovedAfterFailedRestore: backupWritten,
+      });
+    }
+    throw error;
+  } finally {
+    if (!committed) {
+      await removeLocalOverrideCleanupPath(params.packageFs, temporaryPath).catch(() => undefined);
+    }
+  }
+}
+
+async function deleteLocalOverrideTarget(params: {
+  packageFs: LocalOverridePackageRoot;
+  relativePath: string;
+  expected: PackageDistContentInventoryEntry;
+  backupPath: string;
+}): Promise<number> {
+  const moved = await moveExpectedLocalOverrideTarget({
+    packageFs: params.packageFs,
+    relativePath: params.relativePath,
+    expected: params.expected,
+  });
+  let backupWritten = false;
+  try {
+    await writeRollbackBackup({
+      backupPath: params.backupPath,
+      content: moved.content,
+      mode: moved.mode,
+    });
+    backupWritten = true;
+    await params.packageFs.remove(moved.movedPath);
+    return moved.mode;
+  } catch (error) {
+    return await throwAfterRestoringMovedLocalOverrideTarget({
+      packageFs: params.packageFs,
+      movedPath: moved.movedPath,
+      relativePath: params.relativePath,
+      originalError: error,
+      removeMovedAfterFailedRestore: backupWritten,
+    });
+  }
+}
+
+async function copyOverridePayload(params: {
+  packageFs: LocalOverridePackageRoot;
+  recoveryDir: string;
+  relativePath: string;
+}): Promise<{ savedPath: string; mode: number }> {
+  const source = await params.packageFs.read(params.relativePath, {
+    hardlinks: "allow",
+    maxBytes: Number.POSITIVE_INFINITY,
+    symlinks: "reject",
+  });
+  const mode = normalizeFileMode(source.stat.mode);
+  const savedPath = path.join(
+    params.recoveryDir,
+    "files",
+    normalizeRelativePath(params.relativePath),
+  );
+  await writeFileWithMode(source.buffer, savedPath, mode);
+  return { savedPath, mode };
+}
+
+const BEST_EFFORT_LOCAL_IMPORT_SPECIFIER_PATTERN =
+  /(?:import|export)\b\s*(?:[^'"]*?\bfrom\s*)?["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)|require\s*\(\s*["']([^"']+)["']\s*\)/gu;
+
+function resolveReferencedDistPath(params: {
+  fromPath: string;
+  specifier: string;
+  actualSet: Set<string>;
+}): string | null {
+  const specifierPath = params.specifier.split(/[?#]/u, 1)[0] ?? "";
+  if (!specifierPath.startsWith(".")) {
+    return null;
+  }
+  const basePath = normalizeDistPath(
+    path.posix.join(path.posix.dirname(params.fromPath), specifierPath),
+  );
+  const candidates = [
+    basePath,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.cjs`,
+    `${basePath}.json`,
+    path.posix.join(basePath, "index.js"),
+  ];
+  return candidates.find((candidate) => params.actualSet.has(candidate)) ?? null;
+}
+
+async function collectReferencedAddedOverridePaths(params: {
+  packageFs: LocalOverridePackageRoot;
+  changes: LocalPackageOverrideChange[];
+  actualSet: Set<string>;
+  baselineSet: Set<string>;
+}): Promise<{
+  addedPaths: string[];
+  dependenciesByChangePath: Map<string, string[]>;
+}> {
+  const addedPaths = new Set<string>();
+  const dependenciesByChangePath = new Map<string, Set<string>>();
+  const scannedPathsByRoot = new Set<string>();
+  const modifiedChangesByPath = new Map(
+    params.changes
+      .filter((change) => change.kind === "modified" && change.savedPath)
+      .map((change) => [change.path, change]),
+  );
+  const queue: Array<
+    | { path: string; rootPath: string; sourcePath: string }
+    | { path: string; rootPath: string; packageRelativePath: string }
+  > = [
+    ...params.changes
+      .filter((change) => change.kind === "modified" && change.savedPath)
+      .map((change) => ({
+        path: change.path,
+        rootPath: change.path,
+        sourcePath: change.savedPath as string,
+      })),
+    ...[...params.actualSet]
+      .filter((relativePath) => !params.baselineSet.has(relativePath))
+      .map((relativePath) => ({
+        path: relativePath,
+        rootPath: relativePath,
+        packageRelativePath: relativePath,
+      })),
+  ];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+    // Shared added files must be rescanned per override root so partial-conflict
+    // reapply keeps each clean importer with its full dependency closure.
+    const scanKey = `${current.rootPath}\0${current.path}`;
+    if (scannedPathsByRoot.has(scanKey)) {
+      continue;
+    }
+    scannedPathsByRoot.add(scanKey);
+    const source =
+      "packageRelativePath" in current
+        ? await params.packageFs
+            .readText(current.packageRelativePath, {
+              hardlinks: "allow",
+              maxBytes: Number.POSITIVE_INFINITY,
+              symlinks: "reject",
+            })
+            .catch(() => "")
+        : await fs.readFile(current.sourcePath, "utf8").catch(() => "");
+    for (const match of source.matchAll(BEST_EFFORT_LOCAL_IMPORT_SPECIFIER_PATTERN)) {
+      const specifier = match[1] ?? match[2] ?? match[3] ?? "";
+      const referencedPath = resolveReferencedDistPath({
+        fromPath: current.path,
+        specifier,
+        actualSet: params.actualSet,
+      });
+      if (!referencedPath) {
+        continue;
+      }
+      const referencedModifiedChange = modifiedChangesByPath.get(referencedPath);
+      if (params.baselineSet.has(referencedPath) && !referencedModifiedChange) {
+        continue;
+      }
+      const dependencies = dependenciesByChangePath.get(current.rootPath) ?? new Set<string>();
+      dependencies.add(referencedPath);
+      dependenciesByChangePath.set(current.rootPath, dependencies);
+      if (!params.baselineSet.has(referencedPath)) {
+        addedPaths.add(referencedPath);
+      }
+      const referencedScanKey = `${current.rootPath}\0${referencedPath}`;
+      if (!scannedPathsByRoot.has(referencedScanKey)) {
+        queue.push(
+          referencedModifiedChange?.savedPath
+            ? {
+                path: referencedPath,
+                rootPath: current.rootPath,
+                sourcePath: referencedModifiedChange.savedPath,
+              }
+            : {
+                path: referencedPath,
+                rootPath: current.rootPath,
+                packageRelativePath: referencedPath,
+              },
+        );
+      }
+    }
+  }
+
+  return {
+    addedPaths: [...addedPaths].toSorted((left, right) => left.localeCompare(right)),
+    dependenciesByChangePath: new Map(
+      [...dependenciesByChangePath].map(([changePath, dependencies]) => [
+        changePath,
+        [...dependencies].toSorted((left, right) => left.localeCompare(right)),
+      ]),
+    ),
+  };
+}
+
+export async function captureLocalPackageOverrides(params: {
+  packageRoot: string;
+  recordedPackageRoot?: string;
+}): Promise<LocalPackageOverridesPlan | null> {
+  if (!(await packageRootExists(params.packageRoot))) {
+    return null;
+  }
+  const baseline = await readPackageDistContentInventoryIfPresent(params.packageRoot);
+  if (baseline === null) {
+    const packageVersion = await readPackageVersion(params.packageRoot);
+    if (isLegacyContentInventoryCompatVersion(packageVersion)) {
+      return null;
+    }
+    throw new Error(
+      `missing package dist content inventory ${PACKAGE_DIST_CONTENT_INVENTORY_RELATIVE_PATH}`,
+    );
+  }
+  const packageFs = await openFsRoot(params.packageRoot, {
+    hardlinks: "reject",
+    nonBlockingRead: true,
+    symlinks: "reject",
+  });
+
+  const actualFiles = await collectPackageDistInventory(params.packageRoot, {
+    includeSourceMaps: true,
+  });
+  const actualSet = new Set(actualFiles);
+  const actualCaseFoldedSet = new Set(
+    actualFiles.map((relativePath) => relativePath.toLocaleLowerCase("en-US")),
+  );
+  const changes: LocalPackageOverrideChange[] = [];
+  let recoveryDir: string | null = null;
+  const ensureRecoveryDir = async () => {
+    if (!recoveryDir) {
+      const recoveryRoot = path.join(resolveStateDir(), "update-recovery");
+      await assertRecoveryRootOutsidePackageRoot(params.packageRoot, recoveryRoot);
+      if (params.recordedPackageRoot && params.recordedPackageRoot !== params.packageRoot) {
+        await assertRecoveryRootOutsidePackageRoot(params.recordedPackageRoot, recoveryRoot);
+      }
+      await fs.mkdir(recoveryRoot, { recursive: true, mode: 0o700 });
+      recoveryDir = await fs.mkdtemp(path.join(recoveryRoot, "openclaw-local-overrides-"));
+    }
+    return recoveryDir;
+  };
+
+  try {
+    const baselineSet = new Set(baseline.map((entry) => entry.path));
+    for (const entry of baseline) {
+      resolveSafePackagePath(params.packageRoot, entry.path);
+      let current;
+      try {
+        current = await packageFs.read(entry.path, {
+          hardlinks: "allow",
+          maxBytes: Number.POSITIVE_INFINITY,
+          symlinks: "reject",
+        });
+      } catch (error) {
+        if (!actualSet.has(entry.path) && isMissingPathError(error)) {
+          await ensureRecoveryDir();
+          changes.push({ kind: "deleted", path: entry.path, baseline: entry });
+          continue;
+        }
+        throw error;
+      }
+      if (!actualSet.has(entry.path)) {
+        if (!actualCaseFoldedSet.has(entry.path.toLocaleLowerCase("en-US"))) {
+          throw new Error(`package dist inventory changed during override capture: ${entry.path}`);
+        }
+        await ensureRecoveryDir();
+        changes.push({ kind: "deleted", path: entry.path, baseline: entry });
+        continue;
+      }
+      const currentMode = normalizeFileMode(current.stat.mode);
+      const currentSha = createHash("sha256").update(current.buffer).digest("hex");
+      if (
+        currentSha === entry.sha256 &&
+        fileModesHaveSameExecutableSemantics(currentMode, entry.mode)
+      ) {
+        continue;
+      }
+      const payload = await copyOverridePayload({
+        packageFs,
+        recoveryDir: await ensureRecoveryDir(),
+        relativePath: entry.path,
+      });
+      changes.push({
+        kind: "modified",
+        path: entry.path,
+        baseline: entry,
+        savedPath: payload.savedPath,
+        mode: payload.mode,
+      });
+    }
+    const referencedAdded = await collectReferencedAddedOverridePaths({
+      packageFs,
+      changes,
+      actualSet,
+      baselineSet,
+    });
+    for (const change of changes) {
+      if (change.kind === "modified") {
+        change.dependencies = referencedAdded.dependenciesByChangePath.get(change.path) ?? [];
+      }
+    }
+    const addedOverridePaths = new Set(referencedAdded.addedPaths);
+    for (const relativePath of actualFiles) {
+      if (!baselineSet.has(relativePath)) {
+        addedOverridePaths.add(relativePath);
+      }
+    }
+    for (const relativePath of [...addedOverridePaths].toSorted((left, right) =>
+      left.localeCompare(right),
+    )) {
+      const payload = await copyOverridePayload({
+        packageFs,
+        recoveryDir: await ensureRecoveryDir(),
+        relativePath,
+      });
+      changes.push({
+        kind: "added",
+        path: relativePath,
+        dependencies: referencedAdded.dependenciesByChangePath.get(relativePath) ?? [],
+        savedPath: payload.savedPath,
+        mode: payload.mode,
+      });
+    }
+
+    if (changes.length === 0) {
+      return null;
+    }
+    const finalRecoveryDir = await ensureRecoveryDir();
+
+    const counts = countChanges(changes);
+    const result: LocalPackageOverridesResult = {
+      status: "none",
+      ...counts,
+      applied: 0,
+      conflicts: [],
+      recoveryDir: finalRecoveryDir,
+      warnings: [],
+    };
+    await fs.writeFile(
+      path.join(finalRecoveryDir, "manifest.json"),
+      JSON.stringify(
+        { packageRoot: params.recordedPackageRoot ?? params.packageRoot, changes },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+    return {
+      packageRoot: params.recordedPackageRoot ?? params.packageRoot,
+      recoveryDir: finalRecoveryDir,
+      changes,
+      result,
+    };
+  } catch (error) {
+    if (recoveryDir) {
+      await fs.rm(recoveryDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    throw error;
+  }
+}
+
+function buildCurrentInventoryMap(entries: PackageDistContentInventoryEntry[] | null) {
+  return new Map((entries ?? []).map((entry) => [entry.path, entry]));
+}
+
+async function preflightLocalOverrides(params: {
+  packageRoot: string;
+  realPackageRoot: string;
+  plan: LocalPackageOverridesPlan;
+}): Promise<LocalPackageOverridesResult["conflicts"]> {
+  const nextInventory = buildCurrentInventoryMap(
+    await readPackageDistContentInventoryIfPresent(params.packageRoot),
+  );
+  const conflicts: LocalPackageOverridesResult["conflicts"] = [];
+  const targetProbes = new Map<string, LocalPackageOverrideTargetProbe>();
+  for (const change of params.plan.changes) {
+    const targetPath = resolveSafePackagePath(params.packageRoot, change.path);
+    const nextEntry = nextInventory.get(change.path);
+    const targetProbe = await probeLocalOverrideTarget(targetPath);
+    targetProbes.set(change.path, targetProbe);
+    if (targetProbe.status === "error") {
+      conflicts.push({ path: change.path, reason: "target-inspection-failed" });
+      continue;
+    }
+    if (change.kind === "added") {
+      if (nextEntry || targetProbe.status !== "missing") {
+        conflicts.push({ path: change.path, reason: "target-exists" });
+      }
+      continue;
+    }
+    if (!change.baseline) {
+      conflicts.push({ path: change.path, reason: "target-missing" });
+      continue;
+    }
+    if (targetProbe.status === "blocked") {
+      conflicts.push({ path: change.path, reason: "target-changed" });
+      continue;
+    }
+    if (!nextEntry || targetProbe.status === "missing") {
+      if (change.kind === "deleted" && targetProbe.status === "missing") {
+        continue;
+      }
+      conflicts.push({
+        path: change.path,
+        reason: nextEntry && targetProbe.status === "missing" ? "target-missing" : "target-changed",
+      });
+      continue;
+    }
+    if (!targetProbe.safeFile) {
+      conflicts.push({ path: change.path, reason: "target-changed" });
+      continue;
+    }
+    if (targetProbe.hardlinked) {
+      conflicts.push({ path: change.path, reason: "target-hardlinked" });
+      continue;
+    }
+    let targetSha: string;
+    try {
+      // Package verification runs earlier; rehash at replay preflight so later mutations fail closed.
+      targetSha = await hashFileSha256(targetPath);
+    } catch {
+      conflicts.push({ path: change.path, reason: "target-inspection-failed" });
+      continue;
+    }
+    if (
+      nextEntry.sha256 !== change.baseline.sha256 ||
+      targetSha !== nextEntry.sha256 ||
+      !fileModesHaveSameExecutableSemantics(nextEntry.mode, change.baseline.mode) ||
+      !fileModesHaveSameExecutableSemantics(targetProbe.mode, nextEntry.mode)
+    ) {
+      conflicts.push({ path: change.path, reason: "target-changed" });
+    }
+  }
+  const conflictingPaths = new Set(conflicts.map((conflict) => conflict.path));
+  if (conflictingPaths.size > 0) {
+    // Dependency discovery is best-effort, so any conflict makes the full plan fail closed.
+    for (const change of params.plan.changes) {
+      if (conflictingPaths.has(change.path)) {
+        continue;
+      }
+      conflicts.push({ path: change.path, reason: "target-changed" });
+      conflictingPaths.add(change.path);
+    }
+    return conflicts;
+  }
+  const topologyPaths = new Map<string, string>();
+  let topologyResolutionFailed = false;
+  for (const change of params.plan.changes) {
+    try {
+      topologyPaths.set(
+        change.path,
+        await resolveLocalOverrideTopologyPath(
+          params.packageRoot,
+          params.realPackageRoot,
+          change.path,
+        ),
+      );
+    } catch {
+      topologyResolutionFailed = true;
+    }
+  }
+  if (topologyResolutionFailed) {
+    for (const change of params.plan.changes) {
+      if (conflictingPaths.has(change.path)) {
+        continue;
+      }
+      conflicts.push({ path: change.path, reason: "target-inspection-failed" });
+    }
+    return conflicts;
+  }
+  const conflictPaths = new Set(conflicts.map((conflict) => conflict.path));
+  const pathsShareTopology = (left: string, right: string) => {
+    const normalizedLeft = topologyPaths.get(left);
+    const normalizedRight = topologyPaths.get(right);
+    if (!normalizedLeft || !normalizedRight) {
+      return false;
+    }
+    return (
+      normalizedLeft === normalizedRight ||
+      normalizedLeft.startsWith(`${normalizedRight}${path.sep}`) ||
+      normalizedRight.startsWith(`${normalizedLeft}${path.sep}`)
+    );
+  };
+  let propagatedConflict = true;
+  while (propagatedConflict) {
+    propagatedConflict = false;
+    for (const change of params.plan.changes) {
+      if (conflictPaths.has(change.path)) {
+        continue;
+      }
+      if (
+        [...conflictPaths].some((conflictPath) => pathsShareTopology(change.path, conflictPath))
+      ) {
+        conflicts.push({ path: change.path, reason: "target-changed" });
+        conflictPaths.add(change.path);
+        propagatedConflict = true;
+      }
+    }
+    for (const change of params.plan.changes) {
+      if (change.kind === "deleted" || conflictPaths.has(change.path)) {
+        continue;
+      }
+      if ((change.dependencies ?? []).some((dependency) => conflictPaths.has(dependency))) {
+        conflicts.push({ path: change.path, reason: "target-changed" });
+        conflictPaths.add(change.path);
+        propagatedConflict = true;
+      }
+    }
+    for (const change of params.plan.changes) {
+      if (change.kind !== "added" || conflictPaths.has(change.path)) {
+        continue;
+      }
+      const importers = params.plan.changes.filter(
+        (candidate) =>
+          candidate.kind !== "deleted" && (candidate.dependencies ?? []).includes(change.path),
+      );
+      if (importers.length > 0 && importers.every((importer) => conflictPaths.has(importer.path))) {
+        conflicts.push({ path: change.path, reason: "target-changed" });
+        conflictPaths.add(change.path);
+        propagatedConflict = true;
+      }
+    }
+    for (const change of params.plan.changes) {
+      if (change.kind !== "deleted" || conflictPaths.has(change.path)) {
+        continue;
+      }
+      if (conflictPaths.size > 0) {
+        conflicts.push({ path: change.path, reason: "target-changed" });
+        conflictPaths.add(change.path);
+        propagatedConflict = true;
+      }
+    }
+  }
+  return conflicts;
+}
+
+function localOverrideInspectionConflict(
+  plan: LocalPackageOverridesPlan,
+): LocalPackageOverridesResult {
+  return {
+    ...plan.result,
+    status: "conflict",
+    applied: 0,
+    conflicts: plan.changes.map((change) => ({
+      path: change.path,
+      reason: "target-inspection-failed" as const,
+    })),
+    warnings: [
+      "Local OpenClaw changes were preserved but not reapplied because the updated package could not be safely inspected.",
+    ],
+  };
+}
+
+export async function applyLocalPackageOverrides(params: {
+  packageRoot: string;
+  plan: LocalPackageOverridesPlan | null;
+  reapply: boolean;
+}): Promise<LocalPackageOverridesResult> {
+  if (!params.plan) {
+    return emptyResult("none");
+  }
+
+  if (!params.reapply) {
+    return {
+      ...params.plan.result,
+      status: "preserved",
+      applied: 0,
+      warnings: [
+        "Local OpenClaw changes were preserved in the recovery bundle and were not reapplied. Inspect the bundle and copy back trusted files manually, or run the update with --reapply-local-overrides when you want trusted edits replayed during that update.",
+      ],
+    };
+  }
+
+  const packageRootIdentity = await readLocalOverridePackageRootIdentity(params.packageRoot).catch(
+    () => null,
+  );
+  if (!packageRootIdentity) {
+    return localOverrideInspectionConflict(params.plan);
+  }
+  const conflicts = await preflightLocalOverrides({
+    packageRoot: params.packageRoot,
+    realPackageRoot: packageRootIdentity.realPath,
+    plan: params.plan,
+  }).catch(() => null);
+  if (!conflicts) {
+    return localOverrideInspectionConflict(params.plan);
+  }
+  const conflictPaths = new Set(conflicts.map((conflict) => conflict.path));
+  const changesToApply: LocalPackageOverrideChange[] = [];
+  for (const change of params.plan.changes) {
+    if (conflictPaths.has(change.path)) {
+      continue;
+    }
+    if (
+      change.kind === "deleted" &&
+      (await probeLocalOverrideTarget(resolveSafePackagePath(params.packageRoot, change.path)))
+        .status === "missing"
+    ) {
+      continue;
+    }
+    changesToApply.push(change);
+  }
+  if (changesToApply.length === 0) {
+    return {
+      ...params.plan.result,
+      status: conflicts.length > 0 ? "conflict" : "applied",
+      applied: 0,
+      conflicts,
+      warnings:
+        conflicts.length > 0
+          ? [
+              "Local OpenClaw changes were preserved but not reapplied because the update changed the same file(s).",
+            ]
+          : [],
+    };
+  }
+
+  let rollbackDir: string | null = null;
+  const rollbackEntries: Array<{
+    path: string;
+    applied?: PackageDistContentInventoryEntry;
+    backupPath?: string;
+    backupMode?: number;
+    cleanupPaths?: string[];
+  }> = [];
+  let applied = 0;
+  let preserveRollbackDir = false;
+  let packageFs: LocalOverridePackageRoot | undefined;
+  try {
+    packageFs = await openFsRoot(params.packageRoot, {
+      hardlinks: "reject",
+      mkdir: true,
+      symlinks: "reject",
+    });
+    const openedPackageRootIdentity = await readLocalOverridePackageRootIdentity(
+      packageFs.rootReal,
+    ).catch(() => null);
+    if (
+      !openedPackageRootIdentity ||
+      !isSameLocalOverridePackageRoot(packageRootIdentity, openedPackageRootIdentity)
+    ) {
+      return localOverrideInspectionConflict(params.plan);
+    }
+    rollbackDir = await fs.mkdtemp(path.join(params.plan.recoveryDir, "rollback-"));
+    for (const change of changesToApply) {
+      const backupPath = path.join(rollbackDir, change.path);
+
+      if (change.kind === "deleted") {
+        if (!change.baseline) {
+          throw new Error(`missing local override baseline for ${change.path}`);
+        }
+        const backupMode = await deleteLocalOverrideTarget({
+          packageFs,
+          relativePath: change.path,
+          expected: change.baseline,
+          backupPath,
+        });
+        rollbackEntries.push({ path: change.path, backupPath, backupMode });
+      } else {
+        if (!change.savedPath) {
+          throw new Error(`missing saved override payload for ${change.path}`);
+        }
+        const appliedEntry = await buildLocalOverrideInventoryEntry({
+          relativePath: change.path,
+          sourcePath: change.savedPath,
+          mode: change.mode,
+        });
+        const cleanupPaths = await replaceLocalOverrideTarget({
+          packageFs,
+          relativePath: change.path,
+          sourcePath: change.savedPath,
+          mode: change.mode,
+          expected: change.kind === "modified" ? change.baseline : undefined,
+          backupPath: change.kind === "modified" ? backupPath : undefined,
+          onCommitted: (committedCleanupPaths, backupMode) => {
+            rollbackEntries.push({
+              path: change.path,
+              applied: appliedEntry,
+              cleanupPaths: committedCleanupPaths,
+              ...(change.kind === "modified" ? { backupPath, backupMode } : {}),
+            });
+          },
+        });
+        while (cleanupPaths.length > 0) {
+          await removeLocalOverrideCleanupPath(packageFs, cleanupPaths[0]);
+          cleanupPaths.shift();
+        }
+      }
+      applied += 1;
+    }
+  } catch (applyError) {
+    const rollbackFailures = new Map<string, string[]>();
+    const recordRollbackFailure = (relativePath: string, action: string, error: unknown) => {
+      const messages = rollbackFailures.get(relativePath) ?? [];
+      messages.push(`${action}: ${formatErrorMessage(error)}`);
+      rollbackFailures.set(relativePath, messages);
+    };
+    if (applyError instanceof LocalOverrideRollbackError) {
+      recordRollbackFailure(applyError.relativePath, applyError.action, applyError.rollbackError);
+    }
+    for (const entry of rollbackEntries.toReversed()) {
+      if (entry.cleanupPaths && packageFs) {
+        for (const cleanupPath of entry.cleanupPaths) {
+          try {
+            await removeLocalOverrideCleanupPath(packageFs, cleanupPath);
+          } catch (error) {
+            recordRollbackFailure(entry.path, "remove mutation backup", error);
+          }
+        }
+      }
+      let removeError: unknown;
+      if (entry.applied && packageFs && rollbackDir) {
+        try {
+          await deleteLocalOverrideTarget({
+            packageFs,
+            relativePath: entry.path,
+            expected: entry.applied,
+            backupPath: path.join(rollbackDir, "applied", entry.path),
+          });
+        } catch (error) {
+          removeError = error;
+        }
+      }
+      if (removeError) {
+        recordRollbackFailure(entry.path, "remove partial target", removeError);
+      }
+      if (entry.backupPath && packageFs) {
+        try {
+          const cleanupPaths = await replaceLocalOverrideTarget({
+            packageFs,
+            relativePath: entry.path,
+            sourcePath: entry.backupPath,
+            mode: entry.backupMode,
+          });
+          for (const cleanupPath of cleanupPaths) {
+            await removeLocalOverrideCleanupPath(packageFs, cleanupPath);
+          }
+        } catch (error) {
+          recordRollbackFailure(entry.path, "restore original target", error);
+        }
+      }
+    }
+    preserveRollbackDir = rollbackFailures.size > 0;
+    const failureReasonByPath = new Map<string, LocalPackageOverrideConflictReason>(
+      changesToApply.map((change) => [change.path, "apply-failed"]),
+    );
+    for (const relativePath of rollbackFailures.keys()) {
+      failureReasonByPath.set(relativePath, "rollback-failed");
+    }
+    const rollbackWarnings = [...rollbackFailures].map(
+      ([relativePath, messages]) => `Rollback failed for ${relativePath}: ${messages.join("; ")}`,
+    );
+    return {
+      ...params.plan.result,
+      status: "error",
+      applied: 0,
+      conflicts: [...failureReasonByPath].map(([relativePath, reason]) => ({
+        path: relativePath,
+        reason,
+      })),
+      warnings: [
+        "Local OpenClaw changes were preserved but could not be reapplied.",
+        ...(rollbackFailures.size > 0
+          ? [
+              `Rollback could not fully restore ${rollbackFailures.size} installed file(s); the package may be partially modified. Inspect the preserved rollback data before retrying.`,
+              ...rollbackWarnings,
+            ]
+          : []),
+      ],
+    };
+  } finally {
+    if (rollbackDir && !preserveRollbackDir) {
+      await fs.rm(rollbackDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+
+  return {
+    ...params.plan.result,
+    status: conflicts.length > 0 ? "conflict" : "applied",
+    applied,
+    conflicts,
+    warnings:
+      conflicts.length > 0
+        ? [
+            "Local OpenClaw changes were preserved but not reapplied because the update changed the same file(s).",
+          ]
+        : [],
+  };
+}

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -1,9 +1,17 @@
 // Covers package update step orchestration.
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { configureFsSafePython, getFsSafePythonConfig } from "@openclaw/fs-safe/config";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { writePackageDistInventory } from "./package-dist-inventory.js";
+import {
+  applyLocalPackageOverrides,
+  captureLocalPackageOverrides,
+} from "./package-local-overrides.js";
 import {
   markPackagePostInstallDoctorAdvisory,
   runGlobalPackageUpdateSteps,
@@ -18,6 +26,25 @@ import {
   type CommandRunner,
   type ResolvedGlobalInstallTarget,
 } from "./update-global.js";
+
+const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+let packageUpdateTestStateDir = "";
+
+beforeAll(async () => {
+  packageUpdateTestStateDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "openclaw-package-update-state-"),
+  );
+  process.env.OPENCLAW_STATE_DIR = packageUpdateTestStateDir;
+});
+
+afterAll(async () => {
+  if (originalStateDir === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = originalStateDir;
+  }
+  await fs.rm(packageUpdateTestStateDir, { recursive: true, force: true });
+});
 
 async function writePackageRoot(packageRoot: string, version: string): Promise<void> {
   await fs.mkdir(path.join(packageRoot, "dist"), { recursive: true });
@@ -153,6 +180,895 @@ describe("markPackagePostInstallDoctorAdvisory", () => {
 });
 
 describe("runGlobalPackageUpdateSteps", () => {
+  it("rejects recovery roots inside the package being updated", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-recovery-root-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+      const priorStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = path.join(packageRoot, "state");
+      try {
+        await expect(captureLocalPackageOverrides({ packageRoot })).rejects.toThrow(
+          "local override recovery root must be outside package root",
+        );
+      } finally {
+        if (priorStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = priorStateDir;
+        }
+      }
+      await expectPathMissing(path.join(packageRoot, "state"));
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not capture override payloads through symlinked source ancestors",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-capture-symlink-ancestor-" },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const distPath = path.join(packageRoot, "dist");
+          const preservedDistPath = path.join(packageRoot, "preserved-dist");
+          const indexPath = path.join(distPath, "index.js");
+          const outsideRoot = path.join(base, "outside");
+          const outsideIndexPath = path.join(outsideRoot, "index.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+          await fs.mkdir(outsideRoot);
+          await fs.writeFile(outsideIndexPath, "export const outside = true;\n", "utf8");
+
+          let ancestorChanged = false;
+          __setFsSafeTestHooksForTest({
+            afterPreOpenLstat: async (filePath) => {
+              if (!ancestorChanged && path.basename(filePath) === path.basename(indexPath)) {
+                ancestorChanged = true;
+                await fs.rename(distPath, preservedDistPath);
+                await fs.symlink(outsideRoot, distPath, "dir");
+              }
+            },
+          });
+
+          try {
+            await expect(captureLocalPackageOverrides({ packageRoot })).rejects.toMatchObject({
+              code: expect.stringMatching(/outside-workspace|path-mismatch|symlink/),
+            });
+            expect(ancestorChanged).toBe(true);
+            await expect(fs.readFile(outsideIndexPath, "utf8")).resolves.toBe(
+              "export const outside = true;\n",
+            );
+          } finally {
+            __setFsSafeTestHooksForTest(undefined);
+          }
+        },
+      );
+    },
+  );
+
+  it("does not classify baseline files replaced by directories as deletions", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-capture-non-file-" },
+      async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.rm(indexPath);
+        await fs.mkdir(indexPath);
+
+        await expect(captureLocalPackageOverrides({ packageRoot })).rejects.toMatchObject({
+          code: "not-file",
+        });
+        expect((await fs.stat(indexPath)).isDirectory()).toBe(true);
+      },
+    );
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "opens override capture reads nonblocking so unsupported entries cannot stall capture",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-capture-nonblocking-" },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+          const openFlags: number[] = [];
+          __setFsSafeTestHooksForTest({
+            beforeOpen: (_filePath, flags) => {
+              openFlags.push(flags);
+            },
+          });
+
+          try {
+            await expect(captureLocalPackageOverrides({ packageRoot })).resolves.not.toBeNull();
+            expect(openFlags.length).toBeGreaterThan(0);
+            expect(openFlags.every((flags) => (flags & fsConstants.O_NONBLOCK) !== 0)).toBe(true);
+          } finally {
+            __setFsSafeTestHooksForTest(undefined);
+          }
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not move updated targets when required fs-safe Python is unavailable",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-no-python-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+
+        const previousPythonConfig = getFsSafePythonConfig();
+        configureFsSafePython({
+          mode: "off",
+          pythonPath: path.join(base, "missing-python"),
+        });
+        try {
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(result.status).toBe("error");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "apply-failed" }]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+          expect(
+            (await fs.readdir(path.dirname(indexPath))).filter((entry) =>
+              entry.startsWith(".openclaw-override-"),
+            ),
+          ).toEqual([]);
+        } finally {
+          configureFsSafePython(previousPythonConfig);
+        }
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not reapply added overrides through symlinked target ancestors",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-symlink-ancestor-" },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const outsideRoot = path.join(base, "outside");
+          const localAddedPath = path.join(packageRoot, "dist", "local", "added.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.mkdir(path.dirname(localAddedPath), { recursive: true });
+          await fs.writeFile(localAddedPath, "export const local = true;\n", "utf8");
+
+          const plan = await captureLocalPackageOverrides({ packageRoot });
+          expect(plan).not.toBeNull();
+          await fs.rm(path.join(packageRoot, "dist"), { recursive: true, force: true });
+          await fs.mkdir(outsideRoot, { recursive: true });
+          await fs.symlink(outsideRoot, path.join(packageRoot, "dist"), "dir");
+
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(result.status).toBe("conflict");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([
+            { path: "dist/local/added.js", reason: "target-inspection-failed" },
+          ]);
+          await expectPathMissing(path.join(outsideRoot, "local", "added.js"));
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not publish overrides when a target ancestor swaps at the final mutation boundary",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-publish-symlink-ancestor-" },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const distPath = path.join(packageRoot, "dist");
+          const preservedDistPath = path.join(packageRoot, "preserved-dist");
+          const localAddedPath = path.join(distPath, "local.js");
+          const outsideRoot = path.join(base, "outside");
+          const outsideAddedPath = path.join(outsideRoot, "local.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(localAddedPath, "export const local = true;\n", "utf8");
+
+          const plan = await captureLocalPackageOverrides({ packageRoot });
+          expect(plan).not.toBeNull();
+          await writePackageRoot(packageRoot, "2.0.0");
+          await fs.rm(localAddedPath);
+          await writePackageDistInventory(packageRoot);
+          await fs.mkdir(outsideRoot);
+
+          const realRealpath = fs.realpath.bind(fs);
+          let ancestorChanged = false;
+          const realpathSpy = vi
+            .spyOn(fs, "realpath")
+            .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+              const result = await realRealpath(...args);
+              const entries =
+                String(args[0]) === distPath
+                  ? await fs.readdir(distPath).catch(() => [] as string[])
+                  : [];
+              if (
+                !ancestorChanged &&
+                entries.some((entry) => entry.startsWith(".openclaw-override-next-"))
+              ) {
+                ancestorChanged = true;
+                await fs.rename(distPath, preservedDistPath);
+                await fs.symlink(outsideRoot, distPath, "dir");
+              }
+              return result;
+            });
+
+          try {
+            const result = await applyLocalPackageOverrides({
+              packageRoot,
+              plan,
+              reapply: true,
+            });
+
+            expect(ancestorChanged).toBe(true);
+            expect(result.status).toBe("error");
+            expect(result.applied).toBe(0);
+            await expectPathMissing(outsideAddedPath);
+          } finally {
+            realpathSpy.mockRestore();
+          }
+        },
+      );
+    },
+  );
+
+  it("does not reapply added overrides after the package root changes", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-root-swap-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const replacementRoot = path.join(base, "replacement");
+      const preservedRoot = path.join(base, "preserved");
+      const addedPath = path.join(packageRoot, "dist", "local.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(addedPath, "export const local = true;\n", "utf8");
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      await writePackageRoot(packageRoot, "2.0.0");
+      await fs.rm(addedPath);
+      await writePackageDistInventory(packageRoot);
+      await writePackageRoot(replacementRoot, "2.0.0");
+
+      const realRealpath = fs.realpath.bind(fs);
+      let rootChanged = false;
+      const realpathSpy = vi
+        .spyOn(fs, "realpath")
+        .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+          const result = await realRealpath(...args);
+          if (!rootChanged && String(args[0]) === path.join(packageRoot, "dist")) {
+            rootChanged = true;
+            await fs.rename(packageRoot, preservedRoot);
+            await fs.rename(replacementRoot, packageRoot);
+          }
+          return result;
+        });
+
+      try {
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(rootChanged).toBe(true);
+        expect(result.status).toBe("conflict");
+        expect(result.applied).toBe(0);
+        expect(result.conflicts).toEqual([
+          { path: "dist/local.js", reason: "target-inspection-failed" },
+        ]);
+        await expectPathMissing(path.join(packageRoot, "dist", "local.js"));
+        await expectPathMissing(path.join(preservedRoot, "dist", "local.js"));
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
+  });
+
+  it.runIf(process.platform !== "win32").each([
+    ["modified", "outside"],
+    ["deleted", "outside"],
+    ["added", "outside"],
+    ["modified", "inside"],
+    ["deleted", "inside"],
+    ["added", "inside"],
+  ] as const)(
+    "does not reapply %s overrides after a target ancestor becomes an %s symlink",
+    async (overrideKind, redirectKind) => {
+      await withTempDir(
+        {
+          prefix: `openclaw-package-update-local-symlink-race-${overrideKind}-${redirectKind}-`,
+        },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const redirectRoot =
+            redirectKind === "outside"
+              ? path.join(base, "outside")
+              : path.join(packageRoot, "redirect");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          const addedPath = path.join(packageRoot, "dist", "local.js");
+          const redirectIndexPath = path.join(redirectRoot, "index.js");
+          const redirectAddedPath = path.join(redirectRoot, "local.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          if (overrideKind === "modified") {
+            await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+          } else if (overrideKind === "deleted") {
+            await fs.rm(indexPath);
+          } else {
+            await fs.writeFile(addedPath, "export const local = true;\n", "utf8");
+          }
+
+          const plan = await captureLocalPackageOverrides({ packageRoot });
+          expect(plan).not.toBeNull();
+          await writePackageRoot(packageRoot, "2.0.0");
+          if (overrideKind === "added") {
+            await fs.rm(addedPath);
+            await writePackageDistInventory(packageRoot);
+          }
+          await fs.mkdir(redirectRoot, { recursive: true });
+          await fs.writeFile(redirectIndexPath, "export const redirect = true;\n", "utf8");
+
+          const realMkdtemp = fs.mkdtemp.bind(fs);
+          const mkdtempSpy = vi
+            .spyOn(fs, "mkdtemp")
+            .mockImplementation(async (prefixArg, options) => {
+              if (prefixArg.endsWith(`${path.sep}rollback-`)) {
+                await fs.rm(path.join(packageRoot, "dist"), { recursive: true, force: true });
+                await fs.symlink(redirectRoot, path.join(packageRoot, "dist"), "dir");
+              }
+              return await realMkdtemp(prefixArg, options);
+            });
+
+          try {
+            const result = await applyLocalPackageOverrides({
+              packageRoot,
+              plan,
+              reapply: true,
+            });
+
+            expect(result.status).toBe("error");
+            expect(result.applied).toBe(0);
+            await expect(fs.readFile(redirectIndexPath, "utf8")).resolves.toBe(
+              "export const redirect = true;\n",
+            );
+            await expectPathMissing(redirectAddedPath);
+          } finally {
+            mkdtempSpy.mockRestore();
+          }
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32").each(["modified", "deleted"] as const)(
+    "does not reapply %s overrides over upstream mode changes",
+    async (overrideKind) => {
+      await withTempDir(
+        { prefix: `openclaw-package-update-local-mode-${overrideKind}-` },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.chmod(indexPath, 0o644);
+          await writePackageDistInventory(packageRoot);
+          if (overrideKind === "modified") {
+            await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+          } else {
+            await fs.rm(indexPath);
+          }
+
+          const plan = await captureLocalPackageOverrides({ packageRoot });
+          expect(plan).not.toBeNull();
+          await fs.writeFile(indexPath, "export {};\n", "utf8");
+          await fs.chmod(indexPath, 0o755);
+          await writePackageDistInventory(packageRoot);
+
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(result.status).toBe("conflict");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "target-changed" }]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+          expect((await fs.stat(indexPath)).mode & 0o777).toBe(0o755);
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")("captures and reapplies mode-only overrides", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-mode-only-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.chmod(indexPath, 0o644);
+      await writePackageDistInventory(packageRoot);
+      await fs.chmod(indexPath, 0o755);
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      expect(plan?.result.modified).toBe(1);
+
+      await writePackageRoot(packageRoot, "2.0.0");
+      await fs.chmod(indexPath, 0o644);
+      await writePackageDistInventory(packageRoot);
+
+      const result = await applyLocalPackageOverrides({
+        packageRoot,
+        plan,
+        reapply: true,
+      });
+
+      expect(result.status).toBe("applied");
+      expect(result.applied).toBe(1);
+      await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+      expect((await fs.stat(indexPath)).mode & 0o777).toBe(0o755);
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "ignores non-executable mode normalization during capture",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-mode-normalized-" },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.chmod(indexPath, 0o644);
+          await writePackageDistInventory(packageRoot);
+          await fs.chmod(indexPath, 0o600);
+
+          await expect(captureLocalPackageOverrides({ packageRoot })).resolves.toBeNull();
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "reapplies byte overrides over non-executable mode normalization",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-mode-reapply-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.chmod(indexPath, 0o644);
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+        await fs.chmod(indexPath, 0o644);
+        await writePackageDistInventory(packageRoot);
+        await fs.chmod(indexPath, 0o600);
+
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(result.status).toBe("applied");
+        expect(result.applied).toBe(1);
+        expect(result.conflicts).toEqual([]);
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export const local = true;\n");
+        expect((await fs.stat(indexPath)).mode & 0o777).toBe(0o600);
+      });
+    },
+  );
+
+  it("captures and reapplies locally added source maps excluded from package files", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-source-map-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const sourceMapPath = path.join(packageRoot, "dist", "index.js.map");
+      const writePackageJson = async (version: string) => {
+        await fs.writeFile(
+          path.join(packageRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version, files: ["dist/", "!dist/**/*.map"] }),
+          "utf8",
+        );
+      };
+      await writePackageRoot(packageRoot, "1.0.0");
+      await writePackageJson("1.0.0");
+      await writePackageDistInventory(packageRoot);
+      await fs.writeFile(sourceMapPath, '{"version":3,"sources":["index.ts"]}\n', "utf8");
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      expect(plan?.result.added).toBe(1);
+
+      await writePackageRoot(packageRoot, "2.0.0");
+      await writePackageJson("2.0.0");
+      await fs.rm(sourceMapPath);
+      await writePackageDistInventory(packageRoot);
+
+      const result = await applyLocalPackageOverrides({
+        packageRoot,
+        plan,
+        reapply: true,
+      });
+
+      expect(result.status).toBe("applied");
+      expect(result.applied).toBe(1);
+      await expect(fs.readFile(sourceMapPath, "utf8")).resolves.toBe(
+        '{"version":3,"sources":["index.ts"]}\n',
+      );
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not reapply overrides after an unrecorded installed mode change",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-actual-mode-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.chmod(indexPath, 0o644);
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await fs.writeFile(indexPath, "export {};\n", "utf8");
+        await fs.chmod(indexPath, 0o644);
+        await writePackageDistInventory(packageRoot);
+        await fs.chmod(indexPath, 0o755);
+
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(result.status).toBe("conflict");
+        expect(result.applied).toBe(0);
+        expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "target-changed" }]);
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+        expect((await fs.stat(indexPath)).mode & 0o777).toBe(0o755);
+      });
+    },
+  );
+
+  it.each(["modified", "deleted"] as const)(
+    "does not reapply %s overrides after an unrecorded installed byte change",
+    async (overrideKind) => {
+      await withTempDir(
+        { prefix: `openclaw-package-update-local-actual-bytes-${overrideKind}-` },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          if (overrideKind === "modified") {
+            await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+          } else {
+            await fs.rm(indexPath);
+          }
+
+          const plan = await captureLocalPackageOverrides({ packageRoot });
+          expect(plan).not.toBeNull();
+          await fs.writeFile(indexPath, "export {};\n", "utf8");
+          await writePackageDistInventory(packageRoot);
+          await fs.writeFile(indexPath, "export const changedAfterVerify = true;\n", "utf8");
+
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(result.status).toBe("conflict");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "target-changed" }]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+            "export const changedAfterVerify = true;\n",
+          );
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not overwrite a modified target changed after replay preflight",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-late-replace-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+
+        const realMkdtemp = fs.mkdtemp.bind(fs);
+        let targetChanged = false;
+        const mkdtempSpy = vi
+          .spyOn(fs, "mkdtemp")
+          .mockImplementation(async (prefixArg, options) => {
+            const result = await realMkdtemp(prefixArg, options);
+            if (!targetChanged && prefixArg.endsWith(`${path.sep}rollback-`)) {
+              targetChanged = true;
+              await fs.writeFile(indexPath, "export const concurrent = true;\n", "utf8");
+            }
+            return result;
+          });
+
+        try {
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(targetChanged).toBe(true);
+          expect(result.status).toBe("error");
+          expect(result.applied).toBe(0);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+            "export const concurrent = true;\n",
+          );
+        } finally {
+          mkdtempSpy.mockRestore();
+        }
+      });
+    },
+  );
+
+  it("does not overwrite a target created at the final replacement boundary", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-final-replace-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      await writePackageRoot(packageRoot, "2.0.0");
+
+      const realRealpath = fs.realpath.bind(fs);
+      let targetChanged = false;
+      const realpathSpy = vi
+        .spyOn(fs, "realpath")
+        .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+          const result = await realRealpath(...args);
+          const entries =
+            String(args[0]) === path.dirname(indexPath)
+              ? await fs.readdir(path.dirname(indexPath)).catch(() => [] as string[])
+              : [];
+          if (
+            !targetChanged &&
+            entries.some((entry) => entry.startsWith(".openclaw-override-next-"))
+          ) {
+            targetChanged = true;
+            await fs.writeFile(indexPath, "export const concurrent = true;\n", "utf8");
+          }
+          return result;
+        });
+
+      try {
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(targetChanged).toBe(true);
+        expect(result.status).toBe("error");
+        expect(result.applied).toBe(0);
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+          "export const concurrent = true;\n",
+        );
+        expect(
+          (await fs.readdir(path.dirname(indexPath))).filter((entry) =>
+            entry.startsWith(".openclaw-override-"),
+          ),
+        ).toEqual([]);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
+  });
+
+  it("does not delete a target changed at the final deletion boundary", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-late-delete-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.rm(indexPath);
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      await writePackageRoot(packageRoot, "2.0.0");
+
+      let targetChanged = false;
+      __setFsSafeTestHooksForTest({
+        beforeRootFallbackMutation: async (operation, targetPath) => {
+          if (
+            !targetChanged &&
+            operation === "move" &&
+            path.basename(targetPath).startsWith(".openclaw-override-previous-")
+          ) {
+            targetChanged = true;
+            await fs.writeFile(indexPath, "export const concurrent = true;\n", "utf8");
+          }
+        },
+      });
+
+      try {
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(targetChanged).toBe(true);
+        expect(result.status).toBe("error");
+        expect(result.applied).toBe(0);
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+          "export const concurrent = true;\n",
+        );
+        expect(
+          (await fs.readdir(path.dirname(indexPath))).filter((entry) =>
+            entry.startsWith(".openclaw-override-"),
+          ),
+        ).toEqual([]);
+      } finally {
+        __setFsSafeTestHooksForTest(undefined);
+      }
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not mutate a redirect target when a deletion ancestor swaps at the mutation boundary",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-delete-topology-" },
+        async (base) => {
+          const packageRoot = path.join(base, "package");
+          const distPath = path.join(packageRoot, "dist");
+          const preservedDistPath = path.join(packageRoot, "preserved-dist");
+          const indexPath = path.join(distPath, "index.js");
+          const outsideRoot = path.join(base, "outside");
+          const outsideIndexPath = path.join(outsideRoot, "index.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.rm(indexPath);
+
+          const plan = await captureLocalPackageOverrides({ packageRoot });
+          expect(plan).not.toBeNull();
+          await writePackageRoot(packageRoot, "2.0.0");
+          await fs.mkdir(outsideRoot);
+          await fs.writeFile(outsideIndexPath, "export const outside = true;\n", "utf8");
+
+          let topologyChanged = false;
+          __setFsSafeTestHooksForTest({
+            beforeRootFallbackMutation: async (operation, targetPath) => {
+              if (
+                !topologyChanged &&
+                operation === "move" &&
+                path.basename(targetPath).startsWith(".openclaw-override-previous-")
+              ) {
+                topologyChanged = true;
+                await fs.rename(distPath, preservedDistPath);
+                await fs.symlink(outsideRoot, distPath, "dir");
+              }
+            },
+          });
+
+          try {
+            const result = await applyLocalPackageOverrides({
+              packageRoot,
+              plan,
+              reapply: true,
+            });
+
+            expect(topologyChanged).toBe(true);
+            expect(result.status).toBe("error");
+            expect(result.applied).toBe(0);
+            await expect(fs.readFile(outsideIndexPath, "utf8")).resolves.toBe(
+              "export const outside = true;\n",
+            );
+            await expect(
+              fs.readFile(path.join(preservedDistPath, "index.js"), "utf8"),
+            ).resolves.toBe("export {};\n");
+          } finally {
+            __setFsSafeTestHooksForTest(undefined);
+          }
+        },
+      );
+    },
+  );
+
+  it("treats deletions already satisfied by the updated package as a no-op", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-deleted-upstream-" },
+      async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.rm(indexPath);
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+        await fs.rm(indexPath);
+        await writePackageDistInventory(packageRoot);
+
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(result.status).toBe("applied");
+        expect(result.applied).toBe(0);
+        expect(result.conflicts).toEqual([]);
+        await expectPathMissing(indexPath);
+      },
+    );
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "reapplies overrides when Windows reports synthetic installed modes",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-windows-mode-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.chmod(indexPath, 0o644);
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await fs.writeFile(indexPath, "export {};\n", "utf8");
+        await fs.chmod(indexPath, 0o644);
+        await writePackageDistInventory(packageRoot);
+        await fs.chmod(indexPath, 0o666);
+
+        const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+        let result;
+        try {
+          result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+        } finally {
+          platformSpy.mockRestore();
+        }
+
+        expect(result.status).toBe("applied");
+        expect(result.applied).toBe(1);
+        expect(result.conflicts).toEqual([]);
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export const local = true;\n");
+      });
+    },
+  );
+
   it("installs npm updates into a clean staged prefix before swapping the global package", async () => {
     await withTempDir({ prefix: "openclaw-package-update-staged-" }, async (base) => {
       const prefix = path.join(base, "prefix");
@@ -207,6 +1123,7 @@ describe("runGlobalPackageUpdateSteps", () => {
         packageRoot,
         runCommand: createRootRunner(globalRoot),
         runStep,
+        reapplyLocalOverrides: true,
         timeoutMs: 1000,
       });
 
@@ -227,6 +1144,1935 @@ describe("runGlobalPackageUpdateSteps", () => {
         "../lib/node_modules/openclaw/dist/index.js",
       );
     });
+  });
+
+  it("reapplies local dist overrides created while a staged package is prepared", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-overrides-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          expect(prefixIndex).toBeGreaterThan(0);
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          await writePackageRoot(
+            path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+            "2.0.0",
+          );
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "import './local-helper.js?local';\nexport const local = true;\n",
+            "utf8",
+          );
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "local-helper.js"),
+            "export const helper = true;\n",
+            "utf8",
+          );
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("applied");
+      expect(result.localOverrides?.modified).toBe(1);
+      expect(result.localOverrides?.added).toBe(1);
+      expect(result.localOverrides?.applied).toBe(2);
+      expect(result.steps.map((step) => step.name)).toContain("local overrides");
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "import './local-helper.js?local';\nexport const local = true;\n",
+      );
+      await expect(
+        fs.readFile(path.join(packageRoot, "dist", "local-helper.js"), "utf8"),
+      ).resolves.toBe("export const helper = true;\n");
+    });
+  });
+
+  it("preserves local dist overrides created at the staged swap boundary", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-swap-boundary-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const lateOverridePath = path.join(packageRoot, "dist", "late-local.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      const realRename = fs.rename.bind(fs);
+      let lateOverrideCreated = false;
+      const renameSpy = vi
+        .spyOn(fs, "rename")
+        .mockImplementation(async (...args: Parameters<typeof fs.rename>) => {
+          if (!lateOverrideCreated && String(args[0]) === packageRoot) {
+            lateOverrideCreated = true;
+            await fs.writeFile(lateOverridePath, "export const late = true;\n", "utf8");
+          }
+          return await realRename(...args);
+        });
+
+      try {
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep: async ({ name, argv, cwd }) => {
+            const stagePrefix = argv[argv.indexOf("--prefix") + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            await writePackageRoot(
+              path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+              "2.0.0",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+          timeoutMs: 1000,
+        });
+
+        expect(lateOverrideCreated).toBe(true);
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("preserved");
+        expect(result.localOverrides?.added).toBe(1);
+        await expectPathMissing(lateOverridePath);
+        await expect(
+          fs.readFile(
+            path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "late-local.js"),
+            "utf8",
+          ),
+        ).resolves.toBe("export const late = true;\n");
+        await expect(
+          fs
+            .readFile(path.join(result.localOverrides?.recoveryDir ?? "", "manifest.json"), "utf8")
+            .then((contents) => JSON.parse(contents)),
+        ).resolves.toMatchObject({ packageRoot });
+      } finally {
+        renameSpy.mockRestore();
+      }
+    });
+  });
+
+  it("rejects staged recapture recovery roots inside the recorded live package path", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-swap-recovery-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const lateOverridePath = path.join(packageRoot, "dist", "late-local.js");
+      const stateDir = path.join(packageRoot, "state");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      const priorStateDir = process.env.OPENCLAW_STATE_DIR;
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      const realRename = fs.rename.bind(fs);
+      let lateOverrideCreated = false;
+      const renameSpy = vi
+        .spyOn(fs, "rename")
+        .mockImplementation(async (...args: Parameters<typeof fs.rename>) => {
+          if (!lateOverrideCreated && String(args[0]) === packageRoot) {
+            lateOverrideCreated = true;
+            await fs.writeFile(lateOverridePath, "export const late = true;\n", "utf8");
+          }
+          return await realRename(...args);
+        });
+
+      try {
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep: async ({ name, argv, cwd }) => {
+            const stagePrefix = argv[argv.indexOf("--prefix") + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            await writePackageRoot(
+              path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+              "2.0.0",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+          timeoutMs: 1000,
+        });
+
+        expect(lateOverrideCreated).toBe(true);
+        expect(result.failedStep?.name).toBe("local overrides");
+        expect(result.failedStep?.stderrTail).toContain(
+          "local override recovery root must be outside package root",
+        );
+        expect(result.afterVersion).toBe("1.0.0");
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain('"version":"1.0.0"');
+        await expect(fs.readFile(lateOverridePath, "utf8")).resolves.toBe(
+          "export const late = true;\n",
+        );
+        await expectPathMissing(stateDir);
+      } finally {
+        renameSpy.mockRestore();
+        if (priorStateDir === undefined) {
+          delete process.env.OPENCLAW_STATE_DIR;
+        } else {
+          process.env.OPENCLAW_STATE_DIR = priorStateDir;
+        }
+      }
+    });
+  });
+
+  it("preserves local dist overrides without reapplying by default", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-preserved-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "index.js"),
+        "export const local = true;\n",
+        "utf8",
+      );
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          expect(prefixIndex).toBeGreaterThan(0);
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          await writePackageRoot(
+            path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+            "2.0.0",
+          );
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("preserved");
+      expect(result.localOverrides?.modified).toBe(1);
+      expect(result.localOverrides?.applied).toBe(0);
+      expect(path.basename(result.localOverrides?.recoveryDir ?? "")).toMatch(
+        /^openclaw-local-overrides-/u,
+      );
+      expect(path.dirname(result.localOverrides?.recoveryDir ?? "")).toBe(
+        path.join(packageUpdateTestStateDir, "update-recovery"),
+      );
+      expect(result.localOverrides?.recoveryDir?.startsWith(globalRoot)).toBe(false);
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "export {};\n",
+      );
+      await expect(
+        fs.readFile(
+          path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+          "utf8",
+        ),
+      ).resolves.toBe("export const local = true;\n");
+    });
+  });
+
+  it("preserves standalone local added dist files without requiring importer changes", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-standalone-added-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "local-data.json"),
+          '{"local":true}\n',
+          "utf8",
+        );
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            await writePackageRoot(
+              path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+              "2.0.0",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("preserved");
+        expect(result.localOverrides?.added).toBe(1);
+        expect(result.localOverrides?.modified).toBe(0);
+        expect(result.localOverrides?.applied).toBe(0);
+        await expectPathMissing(path.join(packageRoot, "dist", "local-data.json"));
+        await expect(
+          fs.readFile(
+            path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "local-data.json"),
+            "utf8",
+          ),
+        ).resolves.toBe('{"local":true}\n');
+      },
+    );
+  });
+
+  it.each([
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper.js",
+      name: "spaced import",
+      source: 'import "./local-helper.js";\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper.js",
+      name: "minified import",
+      source: 'import"./local-helper.js";\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper.js",
+      name: "minified re-export",
+      source: 'export*from"./local-helper.js";\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper.js",
+      name: "commented dynamic import",
+      source: 'void import(/* webpackChunkName: "local" */ "./local-helper.js");\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper.js",
+      name: "template dynamic import",
+      source: "void import(`./local-helper.js`);\n",
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper/index.mjs",
+      name: "extensionless mjs index import",
+      source: 'import "./local-helper";\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper/index.cjs",
+      name: "extensionless cjs index import",
+      source: 'require("./local-helper");\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.js",
+      helperRelativePath: "dist/local-helper.js",
+      name: "plain runtime path string",
+      source: 'const helperPath = "./local-helper.js";\n',
+    },
+    {
+      featureRelativePath: "dist/local-feature.css",
+      helperRelativePath: "dist/local-font.woff2",
+      name: "CSS URL",
+      source: 'body { font-family: local; src: url("./local-font.woff2"); }\n',
+    },
+  ])(
+    "does not partially reapply standalone added dependency trees with $name",
+    async ({ featureRelativePath, helperRelativePath, source }) => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-standalone-tree-" },
+        async (base) => {
+          const prefix = path.join(base, "prefix");
+          const globalRoot = path.join(prefix, "lib", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          const featurePath = path.join(packageRoot, featureRelativePath);
+          const helperPath = path.join(packageRoot, helperRelativePath);
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.mkdir(path.dirname(featurePath), { recursive: true });
+          await fs.writeFile(featurePath, source, "utf8");
+          await fs.mkdir(path.dirname(helperPath), { recursive: true });
+          await fs.writeFile(helperPath, "export const local = true;\n", "utf8");
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+              const prefixIndex = argv.indexOf("--prefix");
+              const stagePrefix = argv[prefixIndex + 1];
+              if (!stagePrefix) {
+                throw new Error("missing staged prefix");
+              }
+              const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+              await writePackageRoot(stagedPackageRoot, "2.0.0");
+              const stagedHelperPath = path.join(stagedPackageRoot, helperRelativePath);
+              await fs.mkdir(path.dirname(stagedHelperPath), { recursive: true });
+              await fs.writeFile(stagedHelperPath, "export const upstream = true;\n", "utf8");
+              await writePackageDistInventory(stagedPackageRoot);
+              return {
+                name,
+                command: argv.join(" "),
+                cwd: cwd ?? process.cwd(),
+                durationMs: 1,
+                exitCode: 0,
+              };
+            },
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.localOverrides?.status).toBe("conflict");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: helperRelativePath, reason: "target-exists" },
+            { path: featureRelativePath, reason: "target-changed" },
+          ]);
+          await expectPathMissing(featurePath);
+          await expect(fs.readFile(helperPath, "utf8")).resolves.toBe(
+            "export const upstream = true;\n",
+          );
+        },
+      );
+    },
+  );
+
+  it("aborts staged updates before package-manager work when local override capture fails", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-staged-capture-fail-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "postinstall-content-inventory.json"),
+        "[",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "index.js"),
+        "export const local = true;\n",
+        "utf8",
+      );
+
+      const runStep = vi.fn();
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep?.name).toBe("local overrides");
+      expect(result.failedStep?.stderrTail).toContain("could not be inspected safely");
+      expect(result.afterVersion).toBeNull();
+      expect(result.localOverrides).toBeUndefined();
+      expect(result.steps.map((step) => step.name)).toEqual(["local overrides"]);
+      expect(runStep).not.toHaveBeenCalled();
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "export const local = true;\n",
+      );
+      await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
+        '"version":"1.0.0"',
+      );
+    });
+  });
+
+  it("reports the live version when staged override recapture fails before swap", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-staged-recapture-fail-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep: async ({ name, argv, cwd }) => {
+            const prefixIndex = argv.indexOf("--prefix");
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            await writePackageRoot(
+              path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+              "2.0.0",
+            );
+            await fs.writeFile(
+              path.join(packageRoot, "dist", "postinstall-content-inventory.json"),
+              "{ invalid json\n",
+              "utf8",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep?.name).toBe("local overrides");
+        expect(result.afterVersion).toBe("1.0.0");
+        expect(result.steps.map((step) => step.name)).not.toContain("global install swap");
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain('"version":"1.0.0"');
+      },
+    );
+  });
+
+  it("preserves local overrides without overwriting updated dist files", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-conflict-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "index.js"),
+        "export const local = true;\n",
+        "utf8",
+      );
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          expect(prefixIndex).toBeGreaterThan(0);
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "index.js"),
+            "export const upstream = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(stagedPackageRoot);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("conflict");
+      expect(result.localOverrides?.conflicts).toEqual([
+        { path: "dist/index.js", reason: "target-changed" },
+      ]);
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "export const upstream = true;\n",
+      );
+      await expect(
+        fs.readFile(
+          path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+          "utf8",
+        ),
+      ).resolves.toBe("export const local = true;\n");
+    });
+  });
+
+  it("does not reapply case-aliased delete and add changes independently", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-case-alias-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const originalPath = path.join(packageRoot, "dist", "index.js");
+      const renamedPath = path.join(packageRoot, "dist", "Index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.rename(originalPath, renamedPath);
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          await writePackageRoot(
+            path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+            "2.0.0",
+          );
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+      const realLstat = fs.lstat.bind(fs);
+      const lstatSpy = vi
+        .spyOn(fs, "lstat")
+        .mockImplementation(async (...args: Parameters<typeof fs.lstat>) => {
+          const targetPath = String(args[0]);
+          if (targetPath === originalPath || targetPath === renamedPath) {
+            const packageVersion = JSON.parse(
+              await fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+            ).version;
+            if (packageVersion === "2.0.0") {
+              const stats = await realLstat(originalPath, { bigint: true });
+              return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, {
+                ino: 0n,
+                ...(targetPath === renamedPath && process.platform === "win32" ? { dev: 0n } : {}),
+              }) as never;
+            }
+          }
+          return await realLstat(...args);
+        });
+      const realRealpath = fs.realpath.bind(fs);
+      const realpathSpy = vi
+        .spyOn(fs, "realpath")
+        .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+          if (String(args[0]) === renamedPath) {
+            const packageVersion = JSON.parse(
+              await fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+            ).version;
+            if (packageVersion === "2.0.0") {
+              return (await realRealpath(originalPath)) as never;
+            }
+          }
+          return await realRealpath(...args);
+        });
+
+      try {
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("conflict");
+        expect(result.localOverrides?.applied).toBe(0);
+        expect(
+          result.localOverrides?.conflicts.map((conflict) => conflict.path).toSorted(),
+        ).toEqual(["dist/Index.js", "dist/index.js"]);
+        await expect(fs.readFile(originalPath, "utf8")).resolves.toBe("export {};\n");
+      } finally {
+        lstatSpy.mockRestore();
+        realpathSpy.mockRestore();
+      }
+    });
+  });
+
+  it("rejects a baseline file replaced by a directory containing a nested override", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-added-enotdir-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const featurePath = path.join(packageRoot, "dist", "feature");
+      const localFeaturePath = path.join(featurePath, "local.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(featurePath, "export const baseline = true;\n", "utf8");
+      await writePackageDistInventory(packageRoot);
+      await fs.rm(featurePath);
+      await fs.mkdir(path.dirname(localFeaturePath), { recursive: true });
+      await fs.writeFile(localFeaturePath, "export const local = true;\n", "utf8");
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "feature"),
+            "export const baseline = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(stagedPackageRoot);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(runStep).not.toHaveBeenCalled();
+      expect(result.failedStep).toMatchObject({
+        name: "local overrides",
+        exitCode: 1,
+        stderrTail: expect.stringContaining("not a file"),
+      });
+      expect(result.localOverrides).toBeUndefined();
+      await expect(fs.readFile(localFeaturePath, "utf8")).resolves.toBe(
+        "export const local = true;\n",
+      );
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "does not reapply local overrides onto hardlinked updated files",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-hardlink-conflict-" },
+        async (base) => {
+          const prefix = path.join(base, "prefix");
+          const globalRoot = path.join(prefix, "lib", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          const stagedCache = path.join(base, "cache", "staged");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const local = true;\n",
+            "utf8",
+          );
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+              const prefixIndex = argv.indexOf("--prefix");
+              const stagePrefix = argv[prefixIndex + 1];
+              if (!stagePrefix) {
+                throw new Error("missing staged prefix");
+              }
+              const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+              await writePackageRoot(stagedPackageRoot, "2.0.0");
+              await addHardlinkedPackageFile(stagedPackageRoot, stagedCache);
+              return {
+                name,
+                command: argv.join(" "),
+                cwd: cwd ?? process.cwd(),
+                durationMs: 1,
+                exitCode: 0,
+              };
+            },
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.localOverrides?.status).toBe("conflict");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: "dist/index.js", reason: "target-hardlinked" },
+          ]);
+          await expect(
+            fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("export {};\n");
+          await expect(
+            fs.readFile(path.join(stagedCache, "openclaw-index.js"), "utf8"),
+          ).resolves.toBe("export {};\n");
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves deleted overrides when updated files are hardlinked",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-hardlink-delete-" },
+        async (base) => {
+          const prefix = path.join(base, "prefix");
+          const globalRoot = path.join(prefix, "lib", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          const stagedCache = path.join(base, "cache", "staged");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.rm(indexPath);
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+              const prefixIndex = argv.indexOf("--prefix");
+              const stagePrefix = argv[prefixIndex + 1];
+              if (!stagePrefix) {
+                throw new Error("missing staged prefix");
+              }
+              const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+              await writePackageRoot(stagedPackageRoot, "2.0.0");
+              await addHardlinkedPackageFile(stagedPackageRoot, stagedCache);
+              return {
+                name,
+                command: argv.join(" "),
+                cwd: cwd ?? process.cwd(),
+                durationMs: 1,
+                exitCode: 0,
+              };
+            },
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.localOverrides?.status).toBe("conflict");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: "dist/index.js", reason: "target-hardlinked" },
+          ]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+          await expect(
+            fs.readFile(path.join(stagedCache, "openclaw-index.js"), "utf8"),
+          ).resolves.toBe("export {};\n");
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves groups containing only deleted hardlinked overrides",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-hardlink-delete-group-" },
+        async (base) => {
+          const prefix = path.join(base, "prefix");
+          const globalRoot = path.join(prefix, "lib", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          const aliasPath = path.join(packageRoot, "dist", "index-alias.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.link(indexPath, aliasPath);
+          await writePackageDistInventory(packageRoot);
+          await fs.rm(indexPath);
+          await fs.rm(aliasPath);
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+              const prefixIndex = argv.indexOf("--prefix");
+              const stagePrefix = argv[prefixIndex + 1];
+              if (!stagePrefix) {
+                throw new Error("missing staged prefix");
+              }
+              const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+              const stagedIndexPath = path.join(stagedPackageRoot, "dist", "index.js");
+              await writePackageRoot(stagedPackageRoot, "2.0.0");
+              await fs.link(
+                stagedIndexPath,
+                path.join(stagedPackageRoot, "dist", "index-alias.js"),
+              );
+              await writePackageDistInventory(stagedPackageRoot);
+              return {
+                name,
+                command: argv.join(" "),
+                cwd: cwd ?? process.cwd(),
+                durationMs: 1,
+                exitCode: 0,
+              };
+            },
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.localOverrides?.status).toBe("conflict");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: "dist/index-alias.js", reason: "target-hardlinked" },
+            { path: "dist/index.js", reason: "target-hardlinked" },
+          ]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+          await expect(fs.readFile(aliasPath, "utf8")).resolves.toBe("export {};\n");
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves deletions when a hardlinked modification conflicts",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-hardlink-mixed-" },
+        async (base) => {
+          const prefix = path.join(base, "prefix");
+          const globalRoot = path.join(prefix, "lib", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          const indexPath = path.join(packageRoot, "dist", "index.js");
+          const aliasPath = path.join(packageRoot, "dist", "index-alias.js");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.link(indexPath, aliasPath);
+          await writePackageDistInventory(packageRoot);
+          await fs.rm(indexPath);
+          await fs.writeFile(aliasPath, "export const local = true;\n", "utf8");
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+              const prefixIndex = argv.indexOf("--prefix");
+              const stagePrefix = argv[prefixIndex + 1];
+              if (!stagePrefix) {
+                throw new Error("missing staged prefix");
+              }
+              const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+              const stagedIndexPath = path.join(stagedPackageRoot, "dist", "index.js");
+              await writePackageRoot(stagedPackageRoot, "2.0.0");
+              await fs.link(
+                stagedIndexPath,
+                path.join(stagedPackageRoot, "dist", "index-alias.js"),
+              );
+              await writePackageDistInventory(stagedPackageRoot);
+              return {
+                name,
+                command: argv.join(" "),
+                cwd: cwd ?? process.cwd(),
+                durationMs: 1,
+                exitCode: 0,
+              };
+            },
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.localOverrides?.status).toBe("conflict");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: "dist/index-alias.js", reason: "target-hardlinked" },
+            { path: "dist/index.js", reason: "target-hardlinked" },
+          ]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+          await expect(fs.readFile(aliasPath, "utf8")).resolves.toBe("export {};\n");
+        },
+      );
+    },
+  );
+
+  it("does not replay deletions when a modified override conflicts", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-import-delete-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      const helperPath = path.join(packageRoot, "dist", "helper.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(indexPath, 'import "./helper.js";\n', "utf8");
+      await fs.writeFile(helperPath, "export const helper = true;\n", "utf8");
+      await writePackageDistInventory(packageRoot);
+      await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+      await fs.rm(helperPath);
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+          const prefixIndex = argv.indexOf("--prefix");
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          const stagedIndexPath = path.join(stagedPackageRoot, "dist", "index.js");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            stagedIndexPath,
+            'import "./helper.js";\nexport const upstream = true;\n',
+            "utf8",
+          );
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "helper.js"),
+            "export const helper = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(stagedPackageRoot);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("conflict");
+      expect(result.localOverrides?.applied).toBe(0);
+      expect(result.localOverrides?.conflicts).toEqual([
+        { path: "dist/index.js", reason: "target-changed" },
+        { path: "dist/helper.js", reason: "target-changed" },
+      ]);
+      await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+        'import "./helper.js";\nexport const upstream = true;\n',
+      );
+      await expect(fs.readFile(helperPath, "utf8")).resolves.toBe("export const helper = true;\n");
+    });
+  });
+
+  it("does not replay deletions when an added override conflicts", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-added-delete-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const featurePath = path.join(packageRoot, "dist", "feature.js");
+      const helperPath = path.join(packageRoot, "dist", "helper.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(helperPath, "export const helper = true;\n", "utf8");
+      await writePackageDistInventory(packageRoot);
+      await fs.writeFile(featurePath, "export const local = true;\n", "utf8");
+      await fs.rm(helperPath);
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+          const prefixIndex = argv.indexOf("--prefix");
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "feature.js"),
+            'import "./helper.js";\n',
+            "utf8",
+          );
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "helper.js"),
+            "export const helper = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(stagedPackageRoot);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("conflict");
+      expect(result.localOverrides?.applied).toBe(0);
+      expect(result.localOverrides?.conflicts).toEqual([
+        { path: "dist/feature.js", reason: "target-exists" },
+        { path: "dist/helper.js", reason: "target-changed" },
+      ]);
+      await expect(fs.readFile(featurePath, "utf8")).resolves.toBe('import "./helper.js";\n');
+      await expect(fs.readFile(helperPath, "utf8")).resolves.toBe("export const helper = true;\n");
+    });
+  });
+
+  it("returns a structured conflict when updated target inspection fails", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-inspection-conflict-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const realLstat = fs.lstat.bind(fs);
+        const lstatSpy = vi
+          .spyOn(fs, "lstat")
+          .mockImplementation(async (...args: Parameters<typeof fs.lstat>) => {
+            if (String(args[0]) === indexPath) {
+              const packageVersion = JSON.parse(
+                await fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+              ).version;
+              if (packageVersion === "2.0.0") {
+                throw createFsError("EACCES", "target inspection failed");
+              }
+            }
+            return await realLstat(...args);
+          });
+
+        try {
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep: async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+              const prefixIndex = argv.indexOf("--prefix");
+              const stagePrefix = argv[prefixIndex + 1];
+              if (!stagePrefix) {
+                throw new Error("missing staged prefix");
+              }
+              await writePackageRoot(
+                path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+                "2.0.0",
+              );
+              return {
+                name,
+                command: argv.join(" "),
+                cwd: cwd ?? process.cwd(),
+                durationMs: 1,
+                exitCode: 0,
+              };
+            },
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.localOverrides?.status).toBe("conflict");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.recoveryDir).toBeDefined();
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: "dist/index.js", reason: "target-inspection-failed" },
+          ]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+        } finally {
+          lstatSpy.mockRestore();
+        }
+      },
+    );
+  });
+
+  it("returns a structured conflict when replay preflight fails", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-preflight-fail-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      await writePackageRoot(packageRoot, "2.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "postinstall-content-inventory.json"),
+        "{ invalid json\n",
+        "utf8",
+      );
+
+      const result = await applyLocalPackageOverrides({
+        packageRoot,
+        plan,
+        reapply: true,
+      });
+
+      expect(result.status).toBe("conflict");
+      expect(result.applied).toBe(0);
+      expect(result.recoveryDir).toBe(plan?.recoveryDir);
+      expect(result.conflicts).toEqual([
+        { path: "dist/index.js", reason: "target-inspection-failed" },
+      ]);
+      expect(result.warnings.join("\n")).toContain("could not be safely inspected");
+      await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+    });
+  });
+
+  it("aborts before package-manager work for unsafe inventory paths", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-inventory-path-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "postinstall-content-inventory.json"),
+        JSON.stringify(
+          [
+            {
+              path: "dist/../package.json",
+              sha256: "0".repeat(64),
+              mode: 0o644,
+              size: 2,
+            },
+          ],
+          null,
+          2,
+        ) + "\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(packageRoot, "package.json"),
+        JSON.stringify({ name: "openclaw", version: "1.0.0", local: true }),
+        "utf8",
+      );
+
+      const runStep = vi.fn();
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep?.name).toBe("local overrides");
+      expect(result.failedStep?.stderrTail).toContain("unsafe local override path");
+      expect(result.afterVersion).toBeNull();
+      expect(result.localOverrides).toBeUndefined();
+      expect(runStep).not.toHaveBeenCalled();
+      await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
+        '"version":"1.0.0"',
+      );
+      await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
+        '"local":true',
+      );
+    });
+  });
+
+  it("does not partially reapply clean overrides when another override conflicts", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-partial-conflict-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "extra.js"),
+          "export const extra = 1;\n",
+          "utf8",
+        );
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "export const localConflict = true;\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "extra.js"),
+          "export const localClean = true;\n",
+          "utf8",
+        );
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "extra.js"),
+              "export const extra = 1;\n",
+              "utf8",
+            );
+            await writePackageDistInventory(stagedPackageRoot);
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "index.js"),
+              "export const upstreamConflict = true;\n",
+              "utf8",
+            );
+            await writePackageDistInventory(stagedPackageRoot);
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("conflict");
+        expect(result.localOverrides?.applied).toBe(0);
+        expect(result.localOverrides?.conflicts).toEqual([
+          { path: "dist/index.js", reason: "target-changed" },
+          { path: "dist/extra.js", reason: "target-changed" },
+        ]);
+        await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+          "export const upstreamConflict = true;\n",
+        );
+        await expect(fs.readFile(path.join(packageRoot, "dist", "extra.js"), "utf8")).resolves.toBe(
+          "export const extra = 1;\n",
+        );
+      },
+    );
+  });
+
+  it("does not partially reapply shared added trees with incomplete dependency graphs", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-shared-dependency-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(path.join(packageRoot, "dist", "index.js"), "export {};\n", "utf8");
+        await fs.writeFile(path.join(packageRoot, "dist", "feature.js"), "export {};\n", "utf8");
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "import './shared.js';\nexport const localConflict = true;\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "feature.js"),
+          "import './shared.js';\nexport const localClean = true;\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "shared.js"),
+          "import './nested.js';\nexport const shared = true;\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "nested.js"),
+          "export const nested = true;\n",
+          "utf8",
+        );
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "index.js"),
+              "export const upstreamConflict = true;\n",
+              "utf8",
+            );
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "feature.js"),
+              "export {};\n",
+              "utf8",
+            );
+            await writePackageDistInventory(stagedPackageRoot);
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("conflict");
+        expect(result.localOverrides?.applied).toBe(0);
+        expect(result.localOverrides?.conflicts).toEqual([
+          { path: "dist/index.js", reason: "target-changed" },
+          { path: "dist/feature.js", reason: "target-changed" },
+          { path: "dist/nested.js", reason: "target-changed" },
+          { path: "dist/shared.js", reason: "target-changed" },
+        ]);
+        await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+          "export const upstreamConflict = true;\n",
+        );
+        await expect(
+          fs.readFile(path.join(packageRoot, "dist", "feature.js"), "utf8"),
+        ).resolves.toBe("export {};\n");
+        await expectPathMissing(path.join(packageRoot, "dist", "shared.js"));
+        await expectPathMissing(path.join(packageRoot, "dist", "nested.js"));
+      },
+    );
+  });
+
+  it("does not reapply modified importers when a modified dependency conflicts", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-modified-dependency-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(path.join(packageRoot, "dist", "index.js"), "export {};\n", "utf8");
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "helper.js"),
+          "export const helper = 1;\n",
+          "utf8",
+        );
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "import './helper.js';\nexport const localIndex = true;\n",
+          "utf8",
+        );
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "helper.js"),
+          "export const localHelper = true;\n",
+          "utf8",
+        );
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "index.js"),
+              "export {};\n",
+              "utf8",
+            );
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "helper.js"),
+              "export const upstreamHelper = true;\n",
+              "utf8",
+            );
+            await writePackageDistInventory(stagedPackageRoot);
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("conflict");
+        expect(result.localOverrides?.applied).toBe(0);
+        expect(result.localOverrides?.conflicts).toEqual([
+          { path: "dist/helper.js", reason: "target-changed" },
+          { path: "dist/index.js", reason: "target-changed" },
+        ]);
+        await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+          "export {};\n",
+        );
+        await expect(
+          fs.readFile(path.join(packageRoot, "dist", "helper.js"), "utf8"),
+        ).resolves.toBe("export const upstreamHelper = true;\n");
+      },
+    );
+  });
+
+  it("does not reapply added dependencies when every importer conflicts", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-importer-conflict-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "index.js"),
+        "import './local-helper.js';\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "local-helper.js"),
+        "export const local = true;\n",
+        "utf8",
+      );
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          expect(prefixIndex).toBeGreaterThan(0);
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "index.js"),
+            "export const upstream = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(stagedPackageRoot);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("conflict");
+      expect(result.localOverrides?.conflicts).toEqual([
+        { path: "dist/index.js", reason: "target-changed" },
+        { path: "dist/local-helper.js", reason: "target-changed" },
+      ]);
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "export const upstream = true;\n",
+      );
+      await expectPathMissing(path.join(packageRoot, "dist", "local-helper.js"));
+    });
+  });
+
+  it("preserves local added dist files without overwriting upstream additions", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-added-conflict-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "index.js"),
+        "import './local-helper.js';\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "local-helper.js"),
+        "export const local = true;\n",
+        "utf8",
+      );
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          expect(prefixIndex).toBeGreaterThan(0);
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(stagedPackageRoot, "dist", "local-helper.js"),
+            "export const upstream = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(stagedPackageRoot);
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        reapplyLocalOverrides: true,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.localOverrides?.status).toBe("conflict");
+      expect(result.localOverrides?.conflicts).toEqual([
+        { path: "dist/local-helper.js", reason: "target-exists" },
+        { path: "dist/index.js", reason: "target-changed" },
+      ]);
+      await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+        "export {};\n",
+      );
+      await expect(
+        fs.readFile(path.join(packageRoot, "dist", "local-helper.js"), "utf8"),
+      ).resolves.toBe("export const upstream = true;\n");
+      await expect(
+        fs.readFile(
+          path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "local-helper.js"),
+          "utf8",
+        ),
+      ).resolves.toBe("export const local = true;\n");
+    });
+  });
+
+  it("does not reapply deleted overrides when a legacy updated package lacks content inventory", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-deleted-no-content-inventory-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.rm(path.join(packageRoot, "dist", "index.js"));
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2026.6.6");
+            await fs.rm(path.join(stagedPackageRoot, "dist", "postinstall-content-inventory.json"));
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2026.6.6",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep).toBeNull();
+        expect(result.localOverrides?.status).toBe("conflict");
+        expect(result.localOverrides?.conflicts).toEqual([
+          { path: "dist/index.js", reason: "target-changed" },
+        ]);
+        await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+          "export {};\n",
+        );
+      },
+    );
+  });
+
+  it("rejects updated packages that require content inventory before package swap", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-missing-content-inventory-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "export const local = true;\n",
+          "utf8",
+        );
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2026.6.7");
+            await fs.rm(path.join(stagedPackageRoot, "dist", "postinstall-content-inventory.json"));
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2026.6.7",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep?.name).toBe("global install verify");
+        expect(result.failedStep?.stderrTail).toContain("missing package dist content inventory");
+        expect(result.steps.map((step) => step.name)).not.toContain("global install swap");
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain('"version":"1.0.0"');
+        expect(
+          (await fs.readdir(globalRoot)).filter((entry) =>
+            entry.startsWith("openclaw-local-overrides-"),
+          ),
+        ).toEqual([]);
+      },
+    );
+  });
+
+  it("rejects malformed staged content inventories before package swap", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-bad-content-inventory-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "postinstall-content-inventory.json"),
+              "{}\n",
+              "utf8",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep?.name).toBe("global install verify");
+        expect(result.failedStep?.stderrTail).toContain("Invalid package dist content inventory");
+        expect(result.steps.map((step) => step.name)).not.toContain("global install swap");
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain('"version":"1.0.0"');
+      },
+    );
   });
 
   it.runIf(process.platform !== "win32")(
@@ -683,7 +3529,10 @@ describe("runGlobalPackageUpdateSteps", () => {
       expect(result.steps.map((step) => step.name)).toEqual([
         "global update",
         "global install swap",
+        "local overrides",
       ]);
+      expect(result.localOverrides?.status).toBe("preserved");
+      expect(result.localOverrides?.added).toBe(1);
       await expectPathMissing(staleChunk);
     });
   });
@@ -696,6 +3545,17 @@ describe("runGlobalPackageUpdateSteps", () => {
         const globalRoot = path.join(globalDir, "5", "node_modules");
         const packageRoot = path.join(globalRoot, "openclaw");
         await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "export const installed = true;\n",
+          "utf8",
+        );
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "export const local = true;\n",
+          "utf8",
+        );
 
         const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
           if (name !== "global update") {
@@ -703,6 +3563,12 @@ describe("runGlobalPackageUpdateSteps", () => {
           }
           expect(argv).toEqual(["pnpm", "add", "-g", "--global-dir", globalDir, "openclaw@2.0.0"]);
           await writePackageRoot(packageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const updated = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(packageRoot);
           return {
             name,
             command: argv.join(" "),
@@ -724,11 +3590,993 @@ describe("runGlobalPackageUpdateSteps", () => {
 
         expect(result.failedStep).toBeNull();
         expect(result.afterVersion).toBe("2.0.0");
-        expect(result.steps.map((step) => step.name)).toEqual(["global update"]);
+        expect(result.localOverrides?.status).toBe("preserved");
+        expect(result.localOverrides?.modified).toBe(1);
+        expect(result.steps.map((step) => step.name)).toEqual(["global update", "local overrides"]);
+        await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+          "export const updated = true;\n",
+        );
+        await expect(
+          fs.readFile(
+            path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+            "utf8",
+          ),
+        ).resolves.toBe("export const local = true;\n");
       });
     } finally {
       platformSpy.mockRestore();
     }
+  });
+
+  it("aborts in-place updates before package-manager work when local override capture fails", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await withTempDir(
+        { prefix: "openclaw-package-update-in-place-capture-fail-" },
+        async (base) => {
+          const globalDir = path.join(base, "pnpm", "global");
+          const globalRoot = path.join(globalDir, "5", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "postinstall-content-inventory.json"),
+            "[",
+            "utf8",
+          );
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const local = true;\n",
+            "utf8",
+          );
+
+          const runStep = vi.fn();
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createPnpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep?.name).toBe("local overrides");
+          expect(result.failedStep?.stderrTail).toContain("could not be inspected safely");
+          expect(result.afterVersion).toBeNull();
+          expect(result.localOverrides).toBeUndefined();
+          expect(result.steps.map((step) => step.name)).toEqual(["local overrides"]);
+          expect(runStep).not.toHaveBeenCalled();
+          await expect(
+            fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("export const local = true;\n");
+          await expect(
+            fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+          ).resolves.toContain('"version":"1.0.0"');
+        },
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("aborts in-place updates when the installed package root cannot be inspected", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await withTempDir(
+        { prefix: "openclaw-package-update-in-place-root-inspection-fail-" },
+        async (base) => {
+          const globalDir = path.join(base, "pnpm", "global");
+          const globalRoot = path.join(globalDir, "5", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          await writePackageRoot(packageRoot, "2026.6.7");
+
+          const realLstat = fs.lstat.bind(fs);
+          const lstatSpy = vi
+            .spyOn(fs, "lstat")
+            .mockImplementation(async (...args: Parameters<typeof fs.lstat>) => {
+              if (String(args[0]) === packageRoot) {
+                throw createFsError("EACCES", "permission denied");
+              }
+              return await realLstat(...args);
+            });
+          const runStep = vi.fn();
+
+          try {
+            const result = await runGlobalPackageUpdateSteps({
+              installTarget: createPnpmTarget(globalRoot),
+              installSpec: "openclaw@2026.6.8",
+              packageName: "openclaw",
+              packageRoot,
+              runCommand: createRootRunner(globalRoot),
+              runStep,
+              timeoutMs: 1000,
+            });
+
+            expect(result.failedStep?.name).toBe("local overrides");
+            expect(result.failedStep?.stderrTail).toContain("permission denied");
+            expect(result.afterVersion).toBeNull();
+            expect(result.steps.map((step) => step.name)).toEqual(["local overrides"]);
+            expect(runStep).not.toHaveBeenCalled();
+          } finally {
+            lstatSpy.mockRestore();
+          }
+        },
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("aborts in-place updates before package-manager work when required inventory is missing", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await withTempDir(
+        { prefix: "openclaw-package-update-in-place-missing-inventory-" },
+        async (base) => {
+          const globalDir = path.join(base, "pnpm", "global");
+          const globalRoot = path.join(globalDir, "5", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          await writePackageRoot(packageRoot, "2026.6.7");
+          await fs.rm(path.join(packageRoot, "dist", "postinstall-content-inventory.json"));
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const local = true;\n",
+            "utf8",
+          );
+
+          const runStep = vi.fn();
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createPnpmTarget(globalRoot),
+            installSpec: "openclaw@2026.6.8",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep?.name).toBe("local overrides");
+          expect(result.failedStep?.stderrTail).toContain("missing package dist content inventory");
+          expect(result.afterVersion).toBeNull();
+          expect(result.localOverrides).toBeUndefined();
+          expect(result.steps.map((step) => step.name)).toEqual(["local overrides"]);
+          expect(runStep).not.toHaveBeenCalled();
+          await expect(
+            fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("export const local = true;\n");
+          await expect(
+            fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+          ).resolves.toContain('"version":"2026.6.7"');
+        },
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("allows in-place updates for already-published installed packages without content inventory", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await withTempDir(
+        { prefix: "openclaw-package-update-in-place-legacy-missing-inventory-" },
+        async (base) => {
+          const globalDir = path.join(base, "pnpm", "global");
+          const globalRoot = path.join(globalDir, "5", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          await writePackageRoot(packageRoot, "2026.6.8");
+          await fs.rm(path.join(packageRoot, "dist", "postinstall-content-inventory.json"));
+
+          const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+            await writePackageRoot(packageRoot, "2026.6.9");
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          });
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createPnpmTarget(globalRoot),
+            installSpec: "openclaw@2026.6.9",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep).toBeNull();
+          expect(result.afterVersion).toBe("2026.6.9");
+          expect(runStep).toHaveBeenCalledTimes(1);
+        },
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("prints preserved local override recovery when an in-place update command fails", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await withTempDir(
+        { prefix: "openclaw-package-update-in-place-command-fail-" },
+        async (base) => {
+          const globalDir = path.join(base, "pnpm", "global");
+          const globalRoot = path.join(globalDir, "5", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const local = true;\n",
+            "utf8",
+          );
+
+          const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            expect(argv).toEqual([
+              "pnpm",
+              "add",
+              "-g",
+              "--global-dir",
+              globalDir,
+              "openclaw@2.0.0",
+            ]);
+            await writePackageRoot(packageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(packageRoot, "dist", "index.js"),
+              "export const partial = true;\n",
+              "utf8",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 1,
+              stderrTail: "package manager failed after mutation",
+            };
+          });
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createPnpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep,
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep?.name).toBe("global update");
+          expect(result.localOverrides?.status).toBe("preserved");
+          expect(result.localOverrides?.modified).toBe(1);
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.steps.map((step) => step.name)).toEqual([
+            "global update",
+            "local overrides",
+          ]);
+          await expect(
+            fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8"),
+          ).resolves.toBe("export const partial = true;\n");
+          await expect(
+            fs.readFile(
+              path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+              "utf8",
+            ),
+          ).resolves.toBe("export const local = true;\n");
+        },
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("prints preserved local override recovery when an in-place update fails verification", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      await withTempDir(
+        { prefix: "openclaw-package-update-in-place-verify-fail-" },
+        async (base) => {
+          const globalDir = path.join(base, "pnpm", "global");
+          const globalRoot = path.join(globalDir, "5", "node_modules");
+          const packageRoot = path.join(globalRoot, "openclaw");
+          await writePackageRoot(packageRoot, "1.0.0");
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const installed = true;\n",
+            "utf8",
+          );
+          await writePackageDistInventory(packageRoot);
+          await fs.writeFile(
+            path.join(packageRoot, "dist", "index.js"),
+            "export const local = true;\n",
+            "utf8",
+          );
+
+          const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            expect(argv).toEqual([
+              "pnpm",
+              "add",
+              "-g",
+              "--global-dir",
+              globalDir,
+              "openclaw@2.0.0",
+            ]);
+            await writePackageRoot(packageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(packageRoot, "dist", "index.js"),
+              "export const updated = true;\n",
+              "utf8",
+            );
+            await fs.writeFile(
+              path.join(packageRoot, "dist", "postinstall-content-inventory.json"),
+              "[",
+              "utf8",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          });
+
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createPnpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep,
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep?.name).toBe("global install verify");
+          expect(result.localOverrides?.status).toBe("preserved");
+          expect(result.localOverrides?.modified).toBe(1);
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.steps.map((step) => step.name)).toEqual([
+            "global update",
+            "global install verify",
+            "local overrides",
+          ]);
+          await expect(
+            fs.readFile(
+              path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+              "utf8",
+            ),
+          ).resolves.toBe("export const local = true;\n");
+        },
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("reports local override errors when rollback setup fails", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-rollback-setup-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(
+        path.join(packageRoot, "dist", "index.js"),
+        "export const local = true;\n",
+        "utf8",
+      );
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          expect(prefixIndex).toBeGreaterThan(0);
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+      const realMkdtemp = fs.mkdtemp.bind(fs);
+      const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefixArg, options) => {
+        if (prefixArg.endsWith(`${path.sep}rollback-`)) {
+          throw createFsError("EACCES", "rollback setup failed");
+        }
+        return await realMkdtemp(prefixArg, options);
+      });
+
+      try {
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep?.name).toBe("local overrides");
+        expect(result.localOverrides?.status).toBe("error");
+        expect(result.localOverrides?.applied).toBe(0);
+        expect(result.localOverrides?.conflicts).toEqual([
+          { path: "dist/index.js", reason: "apply-failed" },
+        ]);
+        expect(result.steps.at(-1)?.name).toBe("local overrides");
+        expect(result.steps.at(-1)?.exitCode).toBe(1);
+        await expect(fs.readFile(path.join(packageRoot, "dist", "index.js"), "utf8")).resolves.toBe(
+          "export {};\n",
+        );
+        await expect(
+          fs.readFile(
+            path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+            "utf8",
+          ),
+        ).resolves.toBe("export const local = true;\n");
+      } finally {
+        mkdtempSpy.mockRestore();
+      }
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rolls back and reports override chmod failures",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-chmod-fail-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+
+        const realOpen = fs.open.bind(fs);
+        const openSpy = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+          const handle = await realOpen(...args);
+          if (path.basename(String(args[0])).startsWith(".openclaw-override-")) {
+            vi.spyOn(handle, "chmod").mockRejectedValueOnce(
+              createFsError("EACCES", "override chmod failed"),
+            );
+          }
+          return handle;
+        });
+
+        try {
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(result.status).toBe("error");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "apply-failed" }]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+        } finally {
+          openSpy.mockRestore();
+        }
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "restores fs-safe Python configuration after concurrent override applications",
+    async () => {
+      await withTempDir(
+        { prefix: "openclaw-package-update-local-concurrent-config-" },
+        async (base) => {
+          const previousPythonConfig = getFsSafePythonConfig();
+          configureFsSafePython({ mode: "off" });
+          try {
+            const prepared = await Promise.all(
+              ["first", "second"].map(async (name) => {
+                const packageRoot = path.join(base, name);
+                const indexPath = path.join(packageRoot, "dist", "index.js");
+                await writePackageRoot(packageRoot, "1.0.0");
+                await fs.writeFile(indexPath, `export const ${name} = true;\n`, "utf8");
+                const plan = await captureLocalPackageOverrides({ packageRoot });
+                await writePackageRoot(packageRoot, "2.0.0");
+                return { packageRoot, plan };
+              }),
+            );
+
+            const results = await Promise.all(
+              prepared.map(({ packageRoot, plan }) =>
+                applyLocalPackageOverrides({ packageRoot, plan, reapply: true }),
+              ),
+            );
+
+            expect(results.map((result) => result.status)).toEqual(["applied", "applied"]);
+            expect(getFsSafePythonConfig().mode).toBe("off");
+          } finally {
+            configureFsSafePython(previousPythonConfig);
+          }
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "restores updated deletion modes when a later override fails",
+    async () => {
+      await withTempDir({ prefix: "openclaw-package-update-local-delete-mode-" }, async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        const helperPath = path.join(packageRoot, "dist", "helper.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(helperPath, "export const helper = true;\n", "utf8");
+        await writePackageDistInventory(packageRoot);
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+        await fs.rm(helperPath);
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+        await fs.writeFile(helperPath, "export const helper = true;\n", "utf8");
+        await writePackageDistInventory(packageRoot);
+        await fs.chmod(helperPath, 0o600);
+
+        let previousMoveCount = 0;
+        __setFsSafeTestHooksForTest({
+          beforeRootFallbackMutation: (operation, targetPath) => {
+            if (
+              operation === "move" &&
+              path.basename(targetPath).startsWith(".openclaw-override-previous-")
+            ) {
+              previousMoveCount += 1;
+              if (previousMoveCount === 2) {
+                throw createFsError("EACCES", "later override failed");
+              }
+            }
+          },
+        });
+
+        try {
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(previousMoveCount).toBe(2);
+          expect(result.status).toBe("error");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([
+            { path: "dist/helper.js", reason: "apply-failed" },
+            { path: "dist/index.js", reason: "apply-failed" },
+          ]);
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+          await expect(fs.readFile(helperPath, "utf8")).resolves.toBe(
+            "export const helper = true;\n",
+          );
+          expect((await fs.stat(helperPath)).mode & 0o777).toBe(0o600);
+        } finally {
+          __setFsSafeTestHooksForTest(undefined);
+        }
+      });
+    },
+  );
+
+  it("rolls back published replacements when post-publish cleanup fails", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-cleanup-fail-" }, async (base) => {
+      const packageRoot = path.join(base, "package");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+      const plan = await captureLocalPackageOverrides({ packageRoot });
+      expect(plan).not.toBeNull();
+      await writePackageRoot(packageRoot, "2.0.0");
+      if (process.platform !== "win32") {
+        await fs.chmod(indexPath, 0o600);
+      }
+
+      let cleanupFailed = false;
+      __setFsSafeTestHooksForTest({
+        beforeRootFallbackMutation: (operation, targetPath) => {
+          if (
+            !cleanupFailed &&
+            operation === "remove" &&
+            targetPath.includes(`${path.sep}.openclaw-override-previous-`)
+          ) {
+            cleanupFailed = true;
+            throw createFsError("EACCES", "post-publish cleanup failed");
+          }
+        },
+      });
+
+      try {
+        const result = await applyLocalPackageOverrides({
+          packageRoot,
+          plan,
+          reapply: true,
+        });
+
+        expect(cleanupFailed).toBe(true);
+        expect(result.status).toBe("error");
+        expect(result.applied).toBe(0);
+        expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "apply-failed" }]);
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe("export {};\n");
+        if (process.platform !== "win32") {
+          expect((await fs.stat(indexPath)).mode & 0o777).toBe(0o600);
+        }
+        expect(
+          (await fs.readdir(path.dirname(indexPath))).filter((entry) =>
+            entry.startsWith(".openclaw-override-"),
+          ),
+        ).toEqual([]);
+      } finally {
+        __setFsSafeTestHooksForTest(undefined);
+      }
+    });
+  });
+
+  it("preserves rollback data when a current replacement cannot restore", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-current-restore-" },
+      async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+
+        let cleanupFailed = false;
+        __setFsSafeTestHooksForTest({
+          beforeRootFallbackMutation: async (operation, targetPath) => {
+            if (
+              !cleanupFailed &&
+              operation === "remove" &&
+              targetPath.includes(`${path.sep}.openclaw-override-previous-`)
+            ) {
+              cleanupFailed = true;
+              await fs.writeFile(indexPath, "export const concurrent = true;\n", "utf8");
+              throw createFsError("EIO", "replacement cleanup failed");
+            }
+          },
+        });
+
+        try {
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(cleanupFailed).toBe(true);
+          expect(result.status).toBe("error");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "rollback-failed" }]);
+          expect(result.warnings.join("\n")).toContain("Rollback failed for dist/index.js");
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+            "export const concurrent = true;\n",
+          );
+          const recoveryDir = result.recoveryDir ?? "";
+          const rollbackDir = (await fs.readdir(recoveryDir)).find((entry) =>
+            entry.startsWith("rollback-"),
+          );
+          expect(rollbackDir).toBeDefined();
+          await expect(
+            fs.readFile(path.join(recoveryDir, rollbackDir ?? "", "dist/index.js"), "utf8"),
+          ).resolves.toBe("export {};\n");
+        } finally {
+          __setFsSafeTestHooksForTest(undefined);
+        }
+      },
+    );
+  });
+
+  it("preserves rollback data when a current deletion cannot restore", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-current-delete-restore-" },
+      async (base) => {
+        const packageRoot = path.join(base, "package");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.rm(indexPath);
+
+        const plan = await captureLocalPackageOverrides({ packageRoot });
+        expect(plan).not.toBeNull();
+        await writePackageRoot(packageRoot, "2.0.0");
+
+        let deleteCleanupFailed = false;
+        __setFsSafeTestHooksForTest({
+          beforeRootFallbackMutation: async (operation, targetPath) => {
+            if (
+              !deleteCleanupFailed &&
+              operation === "remove" &&
+              targetPath.includes(`${path.sep}.openclaw-override-previous-`)
+            ) {
+              deleteCleanupFailed = true;
+              await fs.writeFile(indexPath, "export const concurrent = true;\n", "utf8");
+              throw createFsError("EIO", "deletion cleanup failed");
+            }
+          },
+        });
+
+        try {
+          const result = await applyLocalPackageOverrides({
+            packageRoot,
+            plan,
+            reapply: true,
+          });
+
+          expect(deleteCleanupFailed).toBe(true);
+          expect(result.status).toBe("error");
+          expect(result.applied).toBe(0);
+          expect(result.conflicts).toEqual([{ path: "dist/index.js", reason: "rollback-failed" }]);
+          expect(result.warnings.join("\n")).toContain("Rollback failed for dist/index.js");
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+            "export const concurrent = true;\n",
+          );
+          const recoveryDir = result.recoveryDir ?? "";
+          const rollbackDir = (await fs.readdir(recoveryDir)).find((entry) =>
+            entry.startsWith("rollback-"),
+          );
+          expect(rollbackDir).toBeDefined();
+          await expect(
+            fs.readFile(path.join(recoveryDir, rollbackDir ?? "", "dist/index.js"), "utf8"),
+          ).resolves.toBe("export {};\n");
+        } finally {
+          __setFsSafeTestHooksForTest(undefined);
+        }
+      },
+    );
+  });
+
+  it("reports and preserves rollback data when reapply rollback is incomplete", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-local-rollback-fail-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      const indexPath = path.join(packageRoot, "dist", "index.js");
+      const helperPath = path.join(packageRoot, "dist", "local-helper.js");
+      await writePackageRoot(packageRoot, "1.0.0");
+      await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+      await fs.writeFile(helperPath, "export const helper = true;\n", "utf8");
+
+      const runStep = vi.fn(
+        async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+          expect(timeoutMs).toBe(1000);
+          if (name !== "global update") {
+            throw new Error(`unexpected step ${name}`);
+          }
+          const prefixIndex = argv.indexOf("--prefix");
+          const stagePrefix = argv[prefixIndex + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          await writePackageRoot(
+            path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+            "2.0.0",
+          );
+          return {
+            name,
+            command: argv.join(" "),
+            cwd: cwd ?? process.cwd(),
+            durationMs: 1,
+            exitCode: 0,
+          };
+        },
+      );
+      const realRealpath = fs.realpath.bind(fs);
+      let applyFailureTriggered = false;
+      let rollbackRestoreBlocked = false;
+      const realpathSpy = vi
+        .spyOn(fs, "realpath")
+        .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+          const result = await realRealpath(...args);
+          if (String(args[0]) !== path.dirname(indexPath)) {
+            return result;
+          }
+          const entries = await fs.readdir(path.dirname(indexPath)).catch(() => [] as string[]);
+          if (!entries.some((entry) => entry.startsWith(".openclaw-override-next-"))) {
+            return result;
+          }
+          const indexContent = await fs.readFile(indexPath, "utf8").catch(() => null);
+          const helperExists = await fs
+            .access(helperPath)
+            .then(() => true)
+            .catch(() => false);
+          if (
+            !applyFailureTriggered &&
+            indexContent === "export const local = true;\n" &&
+            !helperExists
+          ) {
+            applyFailureTriggered = true;
+            await fs.writeFile(helperPath, "export const concurrent = true;\n", "utf8");
+          } else if (applyFailureTriggered && !rollbackRestoreBlocked && indexContent === null) {
+            rollbackRestoreBlocked = true;
+            await fs.writeFile(indexPath, "export const concurrent rollback = true;\n", "utf8");
+          }
+          return result;
+        });
+
+      try {
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          reapplyLocalOverrides: true,
+          timeoutMs: 1000,
+        });
+
+        expect(applyFailureTriggered).toBe(true);
+        expect(rollbackRestoreBlocked).toBe(true);
+        expect(result.failedStep?.name).toBe("local overrides");
+        expect(result.localOverrides?.status).toBe("error");
+        expect(result.localOverrides?.applied).toBe(0);
+        expect(result.localOverrides?.conflicts).toEqual([
+          { path: "dist/index.js", reason: "rollback-failed" },
+          { path: "dist/local-helper.js", reason: "apply-failed" },
+        ]);
+        expect(result.localOverrides?.warnings.join("\n")).toContain(
+          "package may be partially modified",
+        );
+        expect(result.localOverrides?.warnings.join("\n")).toContain(
+          "Rollback failed for dist/index.js",
+        );
+        await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+          "export const concurrent rollback = true;\n",
+        );
+        const rollbackDir = (await fs.readdir(result.localOverrides?.recoveryDir ?? "")).find(
+          (entry) => entry.startsWith("rollback-"),
+        );
+        expect(rollbackDir).toBeDefined();
+        await expect(
+          fs.readFile(
+            path.join(result.localOverrides?.recoveryDir ?? "", rollbackDir ?? "", "dist/index.js"),
+            "utf8",
+          ),
+        ).resolves.toBe("export {};\n");
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
+  });
+
+  it("preserves rollback data when a rollback target cannot be safely removed", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-local-rollback-remove-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        const indexPath = path.join(packageRoot, "dist", "index.js");
+        const helperPath = path.join(packageRoot, "dist", "local-helper.js");
+        await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(indexPath, "export const local = true;\n", "utf8");
+        await fs.writeFile(helperPath, "export const helper = true;\n", "utf8");
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            await writePackageRoot(
+              path.join(stagePrefix, "lib", "node_modules", "openclaw"),
+              "2.0.0",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+        const realRealpath = fs.realpath.bind(fs);
+        let applyFailureTriggered = false;
+        const realpathSpy = vi
+          .spyOn(fs, "realpath")
+          .mockImplementation(async (...args: Parameters<typeof fs.realpath>) => {
+            const result = await realRealpath(...args);
+            if (String(args[0]) !== path.dirname(indexPath)) {
+              return result;
+            }
+            const entries = await fs.readdir(path.dirname(indexPath)).catch(() => [] as string[]);
+            const indexContent = await fs.readFile(indexPath, "utf8").catch(() => null);
+            const helperExists = await fs
+              .access(helperPath)
+              .then(() => true)
+              .catch(() => false);
+            if (
+              !applyFailureTriggered &&
+              entries.some((entry) => entry.startsWith(".openclaw-override-next-")) &&
+              indexContent === "export const local = true;\n" &&
+              !helperExists
+            ) {
+              applyFailureTriggered = true;
+              await fs.writeFile(helperPath, "export const concurrent = true;\n", "utf8");
+            }
+            return result;
+          });
+        __setFsSafeTestHooksForTest({
+          beforeRootFallbackMutation: (operation, targetPath) => {
+            if (
+              applyFailureTriggered &&
+              operation === "remove" &&
+              targetPath.includes(`${path.sep}.openclaw-override-previous-`)
+            ) {
+              throw createFsError("EACCES", "rollback remove failed");
+            }
+          },
+        });
+
+        try {
+          const result = await runGlobalPackageUpdateSteps({
+            installTarget: createNpmTarget(globalRoot),
+            installSpec: "openclaw@2.0.0",
+            packageName: "openclaw",
+            packageRoot,
+            runCommand: createRootRunner(globalRoot),
+            runStep,
+            reapplyLocalOverrides: true,
+            timeoutMs: 1000,
+          });
+
+          expect(result.failedStep?.name).toBe("local overrides");
+          expect(result.localOverrides?.status).toBe("error");
+          expect(result.localOverrides?.applied).toBe(0);
+          expect(result.localOverrides?.conflicts).toEqual([
+            { path: "dist/index.js", reason: "rollback-failed" },
+            { path: "dist/local-helper.js", reason: "apply-failed" },
+          ]);
+          expect(result.localOverrides?.warnings.join("\n")).toContain(
+            "Rollback failed for dist/index.js: remove partial target",
+          );
+          await expect(fs.readFile(indexPath, "utf8")).resolves.toBe(
+            "export const local = true;\n",
+          );
+          const rollbackDir = (await fs.readdir(result.localOverrides?.recoveryDir ?? "")).find(
+            (entry) => entry.startsWith("rollback-"),
+          );
+          expect(rollbackDir).toBeDefined();
+        } finally {
+          realpathSpy.mockRestore();
+          __setFsSafeTestHooksForTest(undefined);
+        }
+      },
+    );
   });
 
   it("keeps a successful staged swap when old package cleanup hits a transient Windows native module error", async () => {
@@ -849,6 +4697,64 @@ describe("runGlobalPackageUpdateSteps", () => {
     });
   });
 
+  it("rejects stale staged content inventories before package swap", async () => {
+    await withTempDir(
+      { prefix: "openclaw-package-update-stale-content-inventory-" },
+      async (base) => {
+        const prefix = path.join(base, "prefix");
+        const globalRoot = path.join(prefix, "lib", "node_modules");
+        const packageRoot = path.join(globalRoot, "openclaw");
+        await writePackageRoot(packageRoot, "1.0.0");
+
+        const runStep = vi.fn(
+          async ({ name, argv, cwd, timeoutMs }): Promise<PackageUpdateStepResult> => {
+            expect(timeoutMs).toBe(1000);
+            if (name !== "global update") {
+              throw new Error(`unexpected step ${name}`);
+            }
+            const prefixIndex = argv.indexOf("--prefix");
+            expect(prefixIndex).toBeGreaterThan(0);
+            const stagePrefix = argv[prefixIndex + 1];
+            if (!stagePrefix) {
+              throw new Error("missing staged prefix");
+            }
+            const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+            await writePackageRoot(stagedPackageRoot, "2.0.0");
+            await fs.writeFile(
+              path.join(stagedPackageRoot, "dist", "index.js"),
+              "export const stale = true;\n",
+              "utf8",
+            );
+            return {
+              name,
+              command: argv.join(" "),
+              cwd: cwd ?? process.cwd(),
+              durationMs: 1,
+              exitCode: 0,
+            };
+          },
+        );
+
+        const result = await runGlobalPackageUpdateSteps({
+          installTarget: createNpmTarget(globalRoot),
+          installSpec: "openclaw@2.0.0",
+          packageName: "openclaw",
+          packageRoot,
+          runCommand: createRootRunner(globalRoot),
+          runStep,
+          timeoutMs: 1000,
+        });
+
+        expect(result.failedStep?.name).toBe("global install verify");
+        expect(result.failedStep?.stderrTail).toContain("expected packaged file hashes");
+        expect(result.steps.map((step) => step.name)).not.toContain("global install swap");
+        await expect(
+          fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
+        ).resolves.toContain('"version":"1.0.0"');
+      },
+    );
+  });
+
   it.runIf(process.platform !== "win32")(
     "restores the existing bin shim when staged shim replacement fails",
     async () => {
@@ -858,6 +4764,11 @@ describe("runGlobalPackageUpdateSteps", () => {
         const packageRoot = path.join(globalRoot, "openclaw");
         const targetShim = path.join(prefix, "bin", "openclaw");
         await writePackageRoot(packageRoot, "1.0.0");
+        await fs.writeFile(
+          path.join(packageRoot, "dist", "index.js"),
+          "export const local = true;\n",
+          "utf8",
+        );
         await fs.mkdir(path.dirname(targetShim), { recursive: true });
         await fs.writeFile(targetShim, "old shim\n", "utf8");
 
@@ -912,9 +4823,17 @@ describe("runGlobalPackageUpdateSteps", () => {
         expect(result.failedStep?.name).toBe("global install swap");
         expect(result.verifiedPackageRoot).toBe(packageRoot);
         expect(result.afterVersion).toBe("1.0.0");
+        expect(result.localOverrides?.status).toBe("preserved");
+        expect(result.localOverrides?.modified).toBe(1);
         await expect(
           fs.readFile(path.join(packageRoot, "package.json"), "utf8"),
         ).resolves.toContain('"version":"1.0.0"');
+        await expect(
+          fs.readFile(
+            path.join(result.localOverrides?.recoveryDir ?? "", "files", "dist", "index.js"),
+            "utf8",
+          ),
+        ).resolves.toBe("export const local = true;\n");
         await expect(fs.readFile(targetShim, "utf8")).resolves.toBe("old shim\n");
       });
     },


### PR DESCRIPTION
Cherry-picked from https://github.com/openclaw/openclaw/pull/89985

## Summary

fix(update): preserve local package overrides

Original PR: #89985 by upstream contributor
Original description:

## Summary

- Preserves local package overrides during package update flows, including standalone added `dist` files, and reports the recovery bundle when overrides are not reapplied.
- Keeps content-inventory validation strict for new tarballs while allowing already-published `2026.6.5` / `2026.6.5-beta.6` packages that predate `dist/postinstall-content-inventory.json`.
- Repairs the `main` merge conflict on `src/cli/update-cli.ts` and `src/infra/update-runner.ts`, then refreshes the branch to current `upstream/main`.
- Adds the missing zh-CN glossary entries needed for the docs check after the latest main merge.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm docs:list`
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH pnpm check:docs`
- `git diff --check upstream/main...HEAD && git diff --check`
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH ./node_modules/.bin/oxfmt --check --threads=1 src/infra/package-local-overrides.ts src/infra/package-update-steps.test.ts src/infra/update-runner.test.ts docs/.i18n/glossary.zh-CN.json`
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH TMPDIR=/tmp node scripts/run-vitest.mjs test/scripts/check-openclaw-package-tarball.test.ts test/scripts/postinstall-bundled-plugins.test.ts test/scripts/openclaw-cross-os-release-checks.test.ts src/infra/package-dist-inventory.test.ts src/infra/package-update-steps.test.ts src/infra/update-runner.test.ts src/cli/update-cli/progress.test.ts src/cli/update-cli.option-collisions.test.ts`
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH TMPDIR=/tmp node --import tsx --input-type=module` current-head local package override smoke
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --codex-bin /Users/jason/.codex/openclaw-pr-autopilot/bin/codex-persist-sessions --model codex=gpt-5.5 --thinking codex=high` clean after the accepted standalone-added-file finding was fixed.

## Real behavior proof

Behavior addressed: Package self-update preserves local packaged `dist` overrides, captures edits through the staged swap boundary, fails closed on unsafe replay topology and package metadata, and verifies content hashes plus executable semantics.

Real environment tested: Local macOS source checkout on current PR head `4451b9f3fedf5ea1e327101c768509bb9178d8e1`, Node `v24.14.0`, plus fresh Linux Blacksmith Testbox runs. The final smoke used real filesystem package roots and the real override capture/replay and content-inventory implementations through `node --import tsx`; the tarball regression creates and checks a real tar archive.

Exact steps or command run after this patch:

- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH node scripts/run-vitest.mjs src/infra/package-update-steps.test.ts src/infra/package-dist-inventory.test.ts test/scripts/check-openclaw-package-tarball.test.ts test/scripts/openclaw-cross-os-release-checks.test.ts --reporter=dot`
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH pnpm exec oxfmt --check --threads=1 ...` and `node scripts/run-oxlint.mjs ...` on the touched update/tarball files
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH pnpm tsgo:prod`
- `PATH=/Users/jason/.nvm/versions/node/v24.14.0/bin:$PATH pnpm check:test-types`

## Real Behavior Proof (Automated)

| 项目 | 值 |
|------|-----|
| 验证环境 | Linux x64, Node.js v24.13.1, pnpm 11.2.2 |
| 验证时间 | 2026-06-17 17:36 |
| 构建状态 | ✅ 通过 |
| 测试文件 | 2 个 |

### 测试结果

  - `src/cli/update-cli.test.ts`: Tests **144** passed
  - `src/cli/update-cli/progress.test.ts`: Tests **6** passed

### 变更文件
- docs/.i18n/glossary.zh-CN.json
- docs/cli/update.md
- scripts/check-openclaw-package-tarball.mjs
- scripts/lib/content-inventory-compat.d.mts
- scripts/lib/content-inventory-compat.mjs

### 验证步骤
1. `git pull` — 更新到最新 main
2. `pnpm build` — 构建项目
3. `pnpm test` — 运行关联测试

---
*🤖 由 [OpenClaw PR 自动化流水线](https://github.com/zhanxingxin1998/openclaw) 生成 | 原始 PR: #89985*
