### PR TITLE
fix(agents): isolate RTL lines on outbound assistant text

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -919,4 +919,43 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
       "🛠️ run git status",
     );
   });
+
+  // Regression for #68105: outbound delivery surfaces (Discord/Slack/Telegram/
+  // WhatsApp) receive assistant text without bidi isolation, so RTL lines that
+  // end with LTR punctuation render with the punctuation on the wrong visual
+  // side. The delivery profile now applies line-level RTL isolation; storage
+  // and runtime profiles still pass through unchanged so transcripts and
+  // internal inspection paths stay byte-for-byte with the model output.
+  describe("RTL bidi isolation on outbound delivery", () => {
+    const RLI = "\u2067";
+    const PDI = "\u2069";
+
+    it("wraps Hebrew lines on the delivery profile so trailing punctuation visually trails", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleText(input)).toBe(`${RLI}${input}${PDI}`);
+    });
+
+    it("wraps Arabic lines on the delivery profile and leaves LTR-only lines untouched", () => {
+      const input = ["مرحبا!", "Hello there.", "كيف حالك؟"].join("\n");
+      const expected = [`${RLI}مرحبا!${PDI}`, "Hello there.", `${RLI}كيف حالك؟${PDI}`].join("\n");
+      expect(sanitizeAssistantVisibleText(input)).toBe(expected);
+    });
+
+    it("does not wrap RTL lines on the history profile (transcript storage stays byte-clean)", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);
+    });
+
+    it("does not wrap RTL lines on the internal-scaffolding profile", () => {
+      const input = "שלום?";
+      expect(sanitizeAssistantVisibleTextWithProfile(input, "internal-scaffolding")).toBe(input);
+    });
+
+    it("is idempotent on the delivery profile (already-isolated text is not re-wrapped)", () => {
+      const input = "שלום?";
+      const once = sanitizeAssistantVisibleText(input);
+      const twice = sanitizeAssistantVisibleText(once);
+      expect(twice).toBe(once);
+    });
+  });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -8,6 +8,7 @@ import {
   type ReasoningTagMode,
   type ReasoningTagTrim,
 } from "./reasoning-tags.js";
+import { applyRtlIsolation } from "./rtl-isolation.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -815,6 +816,14 @@ type AssistantVisibleTextPipelineOptions = {
   reasoningMode: ReasoningTagMode;
   reasoningTrim: ReasoningTagTrim;
   stageOrder: "reasoning-first" | "reasoning-last";
+  /**
+   * Apply Unicode bidi isolation to RTL-script lines as the final stage so
+   * trailing LTR punctuation renders on the correct side on Discord/Slack/
+   * Telegram/WhatsApp. Only enabled for the delivery profile because history
+   * and internal-scaffolding pipelines feed transcript storage and runtime
+   * inspection paths that should stay byte-for-byte with the model output.
+   */
+  applyRtlIsolation?: boolean;
 };
 
 const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
@@ -827,6 +836,7 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
     reasoningMode: "strict",
     reasoningTrim: "both",
     stageOrder: "reasoning-last",
+    applyRtlIsolation: true,
   },
   history: {
     finalTrim: "none",
@@ -896,11 +906,12 @@ function applyAssistantVisibleTextStagePipeline(
     return cleaned;
   };
 
-  if (options.stageOrder === "reasoning-first") {
-    return applyFinalTrim(stripNonReasoningStages(stripReasoning(text)));
-  }
+  const trimmed =
+    options.stageOrder === "reasoning-first"
+      ? applyFinalTrim(stripNonReasoningStages(stripReasoning(text)))
+      : applyFinalTrim(stripReasoning(stripNonReasoningStages(text)));
 
-  return applyFinalTrim(stripReasoning(stripNonReasoningStages(text)));
+  return options.applyRtlIsolation ? applyRtlIsolation(trimmed) : trimmed;
 }
 
 export function sanitizeAssistantVisibleTextWithProfile(

--- a/src/shared/text/rtl-isolation.test.ts
+++ b/src/shared/text/rtl-isolation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { RTL_ISOLATION_MARKERS, RTL_ISOLATION_REGEX, applyRtlIsolation } from "./rtl-isolation.js";
+
+const { start: RLI, end: PDI } = RTL_ISOLATION_MARKERS;
+
+describe("applyRtlIsolation", () => {
+  it("returns input unchanged when no RTL-script characters are present", () => {
+    expect(applyRtlIsolation("Hello, world!")).toBe("Hello, world!");
+  });
+
+  it("wraps a single Hebrew line so trailing LTR punctuation stays on the visual right", () => {
+    const input = "שלום?";
+    const expected = `${RLI}${input}${PDI}`;
+    expect(applyRtlIsolation(input)).toBe(expected);
+  });
+
+  it("wraps Arabic lines line-by-line and leaves LTR-only lines untouched", () => {
+    const input = ["مرحبا!", "English line.", "كيف حالك؟"].join("\n");
+    const expected = [`${RLI}مرحبا!${PDI}`, "English line.", `${RLI}كيف حالك؟${PDI}`].join("\n");
+    expect(applyRtlIsolation(input)).toBe(expected);
+  });
+
+  it("is idempotent: re-wrapping already-isolated text is a no-op", () => {
+    const input = "שלום?";
+    const once = applyRtlIsolation(input);
+    const twice = applyRtlIsolation(once);
+    expect(twice).toBe(once);
+  });
+
+  it("skips lines that already contain bidi control characters", () => {
+    const lineWithEmbed = `\u202aforced ltr שלום\u202c`;
+    expect(applyRtlIsolation(lineWithEmbed)).toBe(lineWithEmbed);
+  });
+
+  it("exposes the underlying regex and marker constants for downstream guards", () => {
+    expect(RTL_ISOLATION_REGEX.rtlScript.test("שלום")).toBe(true);
+    expect(RTL_ISOLATION_REGEX.bidiControl.test(RLI)).toBe(true);
+    expect(RLI).toBe("\u2067");
+    expect(PDI).toBe("\u2069");
+  });
+});

--- a/src/shared/text/rtl-isolation.ts
+++ b/src/shared/text/rtl-isolation.ts
@@ -1,0 +1,43 @@
+/**
+ * Wrap RTL-script lines in Unicode bidirectional isolate controls (FSI-style)
+ * so trailing LTR punctuation (".", "?", "!", parentheses, etc.) renders on
+ * the visually-correct side of the line on Discord, Slack, Telegram,
+ * WhatsApp, terminals, and any other surface that honors the bidi algorithm.
+ *
+ * Extracted from the TUI renderer so the same isolation can be applied to
+ * the canonical outbound assistant-visible text sanitizer (#68105). The
+ * line-level guard against existing bidi control characters keeps the
+ * function idempotent: re-wrapping already-isolated text is a no-op.
+ */
+
+const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
+const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
+const RTL_ISOLATE_START = "\u2067";
+const RTL_ISOLATE_END = "\u2069";
+
+function isolateRtlLine(line: string): string {
+  if (!RTL_SCRIPT_RE.test(line) || BIDI_CONTROL_RE.test(line)) {
+    return line;
+  }
+  return `${RTL_ISOLATE_START}${line}${RTL_ISOLATE_END}`;
+}
+
+export function applyRtlIsolation(text: string): string {
+  if (!RTL_SCRIPT_RE.test(text)) {
+    return text;
+  }
+  return text
+    .split("\n")
+    .map((line) => isolateRtlLine(line))
+    .join("\n");
+}
+
+export const RTL_ISOLATION_REGEX = {
+  rtlScript: RTL_SCRIPT_RE,
+  bidiControl: BIDI_CONTROL_RE,
+} as const;
+
+export const RTL_ISOLATION_MARKERS = {
+  start: RTL_ISOLATE_START,
+  end: RTL_ISOLATE_END,
+} as const;

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -5,6 +5,7 @@ import type { SessionGoal } from "../config/sessions/types.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
+import { applyRtlIsolation } from "../shared/text/rtl-isolation.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
 const REPLACEMENT_CHAR_RE = /\uFFFD/g;
@@ -18,11 +19,7 @@ const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
 const EDGE_PUNCTUATION_RE = /^[`"'([{<]+|[`"')\]}>.,:;!?]+$/g;
 const ALPHANUMERIC_RE = /[A-Za-z0-9]/;
 const TOKENISH_MIN_LENGTH = 24;
-const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const CJK_SCRIPT_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
-const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
-const RTL_ISOLATE_START = "\u2067";
-const RTL_ISOLATE_END = "\u2069";
 // Fenced code blocks (``` or ~~~). Lazy on content; tolerates info string after
 // the opening fence. Closing fence must sit on its own line.
 const FENCED_CODE_RE = /(```|~~~)[^\n]*\n[\s\S]*?\n\1[^\n]*/g;
@@ -170,23 +167,6 @@ function redactBinaryLikeLine(line: string): string {
     return "[binary data omitted]";
   }
   return line;
-}
-
-function isolateRtlLine(line: string): string {
-  if (!RTL_SCRIPT_RE.test(line) || BIDI_CONTROL_RE.test(line)) {
-    return line;
-  }
-  return `${RTL_ISOLATE_START}${line}${RTL_ISOLATE_END}`;
-}
-
-function applyRtlIsolation(text: string): string {
-  if (!RTL_SCRIPT_RE.test(text)) {
-    return text;
-  }
-  return text
-    .split("\n")
-    .map((line) => isolateRtlLine(line))
-    .join("\n");
 }
 
 export function sanitizeRenderableText(text: string): string {


### PR DESCRIPTION
Cherry-picked with proof from upstream.

## Real behavior proof

- **Behavior addressed**: fix(agents): isolate RTL lines on outbound assistant text
- **Real environment tested**: Linux x64, Node.js v24.13.1, pnpm 10.28.2, rebased onto latest main
- **Exact steps or command run after this patch**:
  1. Branch rebased onto latest origin/main
  2. pnpm build — verified
  3. CI checks triggered
- **Evidence after fix**: Build passes on latest main. Code CI checks pass.
- **Observed result after fix**: PR compiles and passes checks on current main.
- **What was not tested**: Live gateway runtime behavior.
- **Proof limitations or environment constraints**: Automated CI verification on Linux x64.

---
*Auto-maintained by PR pipeline*
