### PR TITLE
[ai-assisted] fix(transcripts): persist session metadata atomically to prevent corruption

### DIFF
--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -56,4 +56,25 @@ describe("TranscriptsStore metadata persistence", () => {
       expect(session?.sessionId).toBe(baseSession.sessionId);
     });
   });
+
+  it("preserves tightened file and directory modes across an atomic rewrite", async () => {
+    await withTempDir({ prefix: "openclaw-transcripts-store-modes-" }, async (root) => {
+      const store = new TranscriptsStore(root);
+      await store.writeSession(baseSession);
+
+      const dir = store.sessionDir(baseSession);
+      const metadataPath = path.join(dir, "metadata.json");
+      await fs.chmod(metadataPath, 0o600);
+      await fs.chmod(dir, 0o700);
+
+      await store.updateStopped(baseSession.sessionId, "2026-06-17T11:00:00.000Z");
+
+      // The atomic rewrite must not broaden user-tightened permissions.
+      expect((await fs.stat(metadataPath)).mode & 0o777).toBe(0o600);
+      expect((await fs.stat(dir)).mode & 0o777).toBe(0o700);
+      // ...and the rewrite still landed.
+      const reread = await store.readSession(baseSession.sessionId);
+      expect(reread?.sessionId).toBe(baseSession.sessionId);
+    });
+  });
 });

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -1,0 +1,59 @@
+// Verifies transcript metadata is persisted atomically so an interrupted
+// in-place rewrite cannot leave the live session file truncated.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { TranscriptsStore } from "./store.js";
+
+const baseSession: TranscriptSessionDescriptor = {
+  sessionId: "session-atomic",
+  source: { providerId: "test" },
+  startedAt: "2026-06-17T10:00:00.000Z",
+};
+
+describe("TranscriptsStore metadata persistence", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps metadata.json readable when an in-place rewrite is interrupted", async () => {
+    await withTempDir({ prefix: "openclaw-transcripts-store-" }, async (root) => {
+      const store = new TranscriptsStore(root);
+      await store.writeSession(baseSession);
+
+      const metadataPath = path.join(store.sessionDir(baseSession), "metadata.json");
+
+      // Simulate a crash mid-write to the destination: a non-atomic writeFile
+      // truncates the live file before failing, an atomic stage+rename never
+      // touches it (the temp sibling is written instead).
+      const realWriteFile = fs.writeFile.bind(fs);
+      type WriteFileArgs = Parameters<typeof fs.writeFile>;
+      vi.spyOn(fs, "writeFile").mockImplementation((async (
+        file: WriteFileArgs[0],
+        data: WriteFileArgs[1],
+        options: WriteFileArgs[2],
+      ) => {
+        if (typeof file === "string" && path.resolve(file) === metadataPath) {
+          await realWriteFile(file, "{ truncated", options);
+          throw Object.assign(new Error("simulated crash"), { code: "EIO" });
+        }
+        return realWriteFile(file, data, options);
+      }) as typeof fs.writeFile);
+
+      await store.updateStopped(baseSession.sessionId, "2026-06-17T11:00:00.000Z").catch(() => {
+        // A surfaced write failure is acceptable; data loss is not.
+      });
+
+      vi.restoreAllMocks();
+
+      const session = await store.readSession(baseSession.sessionId);
+      expect(
+        session,
+        "metadata.json must remain readable after an interrupted rewrite",
+      ).toBeDefined();
+      expect(session?.sessionId).toBe(baseSession.sessionId);
+    });
+  });
+});

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -9,8 +9,32 @@ import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provide
 import type { TranscriptsSummary } from "./summary.js";
 import { renderTranscriptsMarkdown } from "./summary.js";
 
-// Match a plain fs.writeFile's umask-derived mode so atomic writes keep permissions unchanged.
-const TRANSCRIPT_FILE_MODE = 0o666 & ~process.umask();
+// A new transcript artifact gets the umask-derived mode a plain fs.writeFile would use;
+// an existing artifact (and its parent directory) keeps the mode it already has, so an
+// atomic rewrite never broadens user-tightened permissions on private transcript data.
+const NEW_FILE_MODE = 0o666 & ~process.umask();
+const NEW_DIR_MODE = 0o777 & ~process.umask();
+
+async function existingMode(targetPath: string, fallback: number): Promise<number> {
+  try {
+    return (await fs.stat(targetPath)).mode & 0o777;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+// Atomic replace that preserves the existing file and parent-directory modes, falling
+// back to the umask default only for new artifacts (matching the old in-place writeFile).
+async function persistTranscriptArtifact(filePath: string, content: string): Promise<void> {
+  const [mode, dirMode] = await Promise.all([
+    existingMode(filePath, NEW_FILE_MODE),
+    existingMode(path.dirname(filePath), NEW_DIR_MODE),
+  ]);
+  await writeTextAtomic(filePath, content, { mode, dirMode });
+}
 
 /**
  * File-backed transcript session store.
@@ -134,12 +158,9 @@ export class TranscriptsStore {
   async writeSession(session: TranscriptSessionDescriptor): Promise<void> {
     const dir = this.sessionDir(session);
     await fs.mkdir(dir, { recursive: true });
-    await writeTextAtomic(
+    await persistTranscriptArtifact(
       path.join(dir, "metadata.json"),
       `${JSON.stringify(session, null, 2)}\n`,
-      {
-        mode: TRANSCRIPT_FILE_MODE,
-      },
     );
   }
 
@@ -255,10 +276,9 @@ export class TranscriptsStore {
     if (!session) {
       return;
     }
-    await writeTextAtomic(
+    await persistTranscriptArtifact(
       path.join(dir, "metadata.json"),
       `${JSON.stringify({ ...session, stoppedAt }, null, 2)}\n`,
-      { mode: TRANSCRIPT_FILE_MODE },
     );
   }
 
@@ -278,12 +298,13 @@ export class TranscriptsStore {
   /** Write summary JSON and markdown to a known directory. */
   async writeSummaryToDir(summary: TranscriptsSummary, dir: string): Promise<string> {
     await fs.mkdir(dir, { recursive: true });
-    await writeTextAtomic(path.join(dir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, {
-      mode: TRANSCRIPT_FILE_MODE,
-    });
+    await persistTranscriptArtifact(
+      path.join(dir, "summary.json"),
+      `${JSON.stringify(summary, null, 2)}\n`,
+    );
     const markdown = renderTranscriptsMarkdown(summary);
     const markdownPath = path.join(dir, "summary.md");
-    await writeTextAtomic(markdownPath, `${markdown}\n`, { mode: TRANSCRIPT_FILE_MODE });
+    await persistTranscriptArtifact(markdownPath, `${markdown}\n`);
     return markdownPath;
   }
 }

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -4,9 +4,13 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { writeTextAtomic } from "../infra/json-files.js";
 import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provider-types.js";
 import type { TranscriptsSummary } from "./summary.js";
 import { renderTranscriptsMarkdown } from "./summary.js";
+
+// Match a plain fs.writeFile's umask-derived mode so atomic writes keep permissions unchanged.
+const TRANSCRIPT_FILE_MODE = 0o666 & ~process.umask();
 
 /**
  * File-backed transcript session store.
@@ -130,7 +134,13 @@ export class TranscriptsStore {
   async writeSession(session: TranscriptSessionDescriptor): Promise<void> {
     const dir = this.sessionDir(session);
     await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(path.join(dir, "metadata.json"), `${JSON.stringify(session, null, 2)}\n`);
+    await writeTextAtomic(
+      path.join(dir, "metadata.json"),
+      `${JSON.stringify(session, null, 2)}\n`,
+      {
+        mode: TRANSCRIPT_FILE_MODE,
+      },
+    );
   }
 
   /** Read one session descriptor by session id or qualified date/id selector. */
@@ -245,9 +255,10 @@ export class TranscriptsStore {
     if (!session) {
       return;
     }
-    await fs.writeFile(
+    await writeTextAtomic(
       path.join(dir, "metadata.json"),
       `${JSON.stringify({ ...session, stoppedAt }, null, 2)}\n`,
+      { mode: TRANSCRIPT_FILE_MODE },
     );
   }
 
@@ -267,10 +278,12 @@ export class TranscriptsStore {
   /** Write summary JSON and markdown to a known directory. */
   async writeSummaryToDir(summary: TranscriptsSummary, dir: string): Promise<string> {
     await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(path.join(dir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+    await writeTextAtomic(path.join(dir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`, {
+      mode: TRANSCRIPT_FILE_MODE,
+    });
     const markdown = renderTranscriptsMarkdown(summary);
     const markdownPath = path.join(dir, "summary.md");
-    await fs.writeFile(markdownPath, `${markdown}\n`);
+    await writeTextAtomic(markdownPath, `${markdown}\n`, { mode: TRANSCRIPT_FILE_MODE });
     return markdownPath;
   }
 }


### PR DESCRIPTION
## Summary

- **Problem:** `TranscriptsStore` rewrote `metadata.json` and `summary.json` in place with a plain `fs.writeFile`, so a crash or `ENOSPC` mid-write truncates the live file.
- **Why it matters:** `metadata.json` is read back through a `readJsonFile` that re-throws on a non-`ENOENT` parse error, so a truncated file makes `readSession`/`findSessionDir` throw — the whole transcript session becomes unreadable, not just the in-flight update (`updateStopped` is the realistic trigger: it reads, then rewrites the same file).
- **What changed:** route every full-rewrite persistence site (`writeSession`, `updateStopped`, `writeSummaryToDir`) through the repo's existing `writeTextAtomic` stage-and-rename helper.
- **What did NOT change (scope boundary):** no change to read paths, the descriptor shape, or the append-only utterance JSONL (still `fs.appendFile`); file permissions are unchanged (mode is set to a plain `fs.writeFile`'s umask-derived value); no new dependency, no config/flag, no behavior change on the success path.

## Linked context

Which issue does this close?

Closes # — none; found by code review while sweeping in-place JSON rewrites for crash-durability.

Which issues, PRs, or discussions are related?

Related # N/A

Was this requested by a maintainer or owner?

No — proactive durability hardening, sent as an external `[ai-assisted]` contribution.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: a truncating crash during an in-place `metadata.json` rewrite leaves a corrupt file that makes the session unreadable on the next read.
- Real environment tested: Linux (Node 24), `pnpm install` from source at this branch's commit.
- Exact steps or command run after this patch: ran a small standalone script that drives the real `TranscriptsStore`, writes a session, then patches `fs.writeFile` to truncate-and-fail on the destination to emulate a crash mid-rewrite, and finally reads the session back: `node --import tsx run-transcripts-atomic-repro.mts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```
########## BEFORE this patch (in-place fs.writeFile) ##########
$ node --import tsx run-transcripts-atomic-repro.mts
updateStopped: threw (simulated crash)
metadata.json on disk: "{ truncated"
readSession after crash: THREW Expected property name or '}' in JSON at position 2 (line 1 column 3)

########## AFTER this patch (atomic stage+rename) ##########
$ node --import tsx run-transcripts-atomic-repro.mts
updateStopped: resolved
metadata.json on disk: "{\n  \"sessionId\": \"session-atomic\",\n  \"source\": {\n    \"providerId\": \"test\"\n  },\n  \"startedAt\": \"2026-06-17T10:00:00.000Z\",\n  \"stoppedAt\": \"2026-06-17T11:00:00.000Z\"\n}\n"
readSession after crash: OK sessionId=session-atomic
```

- Observed result after fix: running `node` against the real module shows the destination is never touched by the failed write — `metadata.json` keeps the full prior content (now with the applied `stoppedAt`), and `readSession` returns the session instead of throwing on corrupt content.
- What was not tested: no full gateway/daemon boot driving a live transcript provider; the change is confined to the file-persistence sites of `TranscriptsStore`.
- Proof limitations or environment constraints: the crash is emulated by forcing the destination write to truncate then fail; a real power-loss truncation is not reproducible in a sandbox.
- Before evidence (optional but encouraged): included inline in the same block above (the BEFORE run, with the fix reverted).

## Tests and validation

Which commands did you run?

`node scripts/run-vitest.mjs run src/transcripts/store.test.ts` and `pnpm exec oxfmt`/`oxlint` on the changed files.

What regression coverage was added or updated?

Added `src/transcripts/store.test.ts`: a fault-injection vitest that truncates `metadata.json` during an interrupted rewrite and asserts the session stays readable. It fails on the previous in-place write and passes with the atomic write.

What failed before this fix, if known?

With the prior code the new regression case fails — the corrupt `metadata.json` makes `readSession` throw a `SyntaxError`.

If no test was added, why not?

N/A — coverage added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) No — same files, same content, same permissions on the success path.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No.

What is the highest-risk area? The staged temp file (`<dir>/.fs-safe-replace.<pid>.<uuid>.tmp`) created next to each transcript artifact before the rename.

How is that risk mitigated? It reuses the repo's existing `writeTextAtomic` → `replaceFileAtomic` helper already used across the codebase (it fsyncs and cleans up its temp on failure); the file mode is set explicitly to match a plain `fs.writeFile` so permissions are unchanged; the append-only utterance JSONL is left untouched.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? CI run and maintainer review.

Which bot or reviewer comments were addressed? None yet — newly opened.
