### PR TITLE
fix(doctor): archive superseded plugin install indexes

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -2187,6 +2187,140 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("archives stale exact legacy npm install record when SQLite has newer authoritative metadata", async () => {
+    const root = await makeTempRoot();
+    await writeExistingPluginInstallIndex(root, {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord@2026.6.8",
+        resolvedName: "@openclaw/discord",
+        resolvedVersion: "2026.6.8",
+        resolvedSpec: "@openclaw/discord@2026.6.8",
+        integrity: "sha512-current",
+        installedAt: "2026-06-17T12:00:00.000Z",
+      },
+    });
+    const sourcePath = writeLegacyPluginInstallIndex(root, {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord@2026.6.8-beta.1",
+        version: "2026.6.8-beta.1",
+        resolvedName: "@openclaw/discord",
+        resolvedVersion: "2026.6.8-beta.1",
+        resolvedSpec: "@openclaw/discord@2026.6.8-beta.1",
+        installedAt: "2026-06-16T12:00:00.000Z",
+      },
+    });
+
+    const result = await runLegacyStateMigrationsForRoot(root);
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(fs.existsSync(sourcePath)).toBe(false);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(true);
+    await expect(readPersistedInstalledPluginIndex({ stateDir: root })).resolves.toMatchObject({
+      installRecords: {
+        discord: {
+          source: "npm",
+          spec: "@openclaw/discord@2026.6.8",
+          resolvedName: "@openclaw/discord",
+          resolvedVersion: "2026.6.8",
+          integrity: "sha512-current",
+        },
+      },
+    });
+  });
+
+  for (const fixture of [
+    {
+      label: "current spec names a different package",
+      currentPatch: { spec: "@vendor/discord@2026.6.8" },
+      legacyPatch: {},
+    },
+    {
+      label: "current version disagrees with its resolved version",
+      currentPatch: { version: "2026.6.7" },
+      legacyPatch: {},
+    },
+    {
+      label: "legacy resolved spec names a different package",
+      currentPatch: {},
+      legacyPatch: { resolvedSpec: "@vendor/discord@2026.6.8-beta.1" },
+    },
+    {
+      label: "legacy resolved version disagrees with its exact spec",
+      currentPatch: {},
+      legacyPatch: {
+        version: "2026.6.7-beta.1",
+        resolvedVersion: "2026.6.7-beta.1",
+      },
+    },
+  ] satisfies Array<{
+    label: string;
+    currentPatch: Partial<InstalledPluginInstallRecordInfo>;
+    legacyPatch: Partial<InstalledPluginInstallRecordInfo>;
+  }>) {
+    it(`keeps stale legacy npm install record when ${fixture.label}`, async () => {
+      const root = await makeTempRoot();
+      await writeExistingPluginInstallIndex(root, {
+        discord: {
+          source: "npm",
+          spec: "@openclaw/discord@2026.6.8",
+          resolvedName: "@openclaw/discord",
+          resolvedVersion: "2026.6.8",
+          resolvedSpec: "@openclaw/discord@2026.6.8",
+          ...fixture.currentPatch,
+        },
+      });
+      const sourcePath = writeLegacyPluginInstallIndex(root, {
+        discord: {
+          source: "npm",
+          spec: "@openclaw/discord@2026.6.8-beta.1",
+          version: "2026.6.8-beta.1",
+          resolvedName: "@openclaw/discord",
+          resolvedVersion: "2026.6.8-beta.1",
+          resolvedSpec: "@openclaw/discord@2026.6.8-beta.1",
+          ...fixture.legacyPatch,
+        },
+      });
+
+      const result = await runLegacyStateMigrationsForRoot(root);
+
+      expect(result.warnings).toStrictEqual([
+        "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: discord",
+      ]);
+      expect(fs.existsSync(sourcePath)).toBe(true);
+      expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+    });
+  }
+
+  it("keeps exact legacy npm install record when SQLite authoritative metadata is older", async () => {
+    const root = await makeTempRoot();
+    await writeExistingPluginInstallIndex(root, {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord@2026.6.8-beta.1",
+        resolvedName: "@openclaw/discord",
+        resolvedVersion: "2026.6.8-beta.1",
+        resolvedSpec: "@openclaw/discord@2026.6.8-beta.1",
+      },
+    });
+    const sourcePath = writeLegacyPluginInstallIndex(root, {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord@2026.6.8",
+        version: "2026.6.8",
+      },
+    });
+
+    const result = await runLegacyStateMigrationsForRoot(root);
+
+    expect(result.warnings).toStrictEqual([
+      "Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: discord",
+    ]);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.migrated`)).toBe(false);
+  });
+
   it("keeps exact legacy npm install record when SQLite lacks authoritative package identity", async () => {
     const root = await makeTempRoot();
     await writeExistingPluginInstallIndex(root, {

--- a/src/infra/state-migrations.ts
+++ b/src/infra/state-migrations.ts
@@ -71,10 +71,11 @@ import {
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
-import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
+import { compareOpenClawReleaseVersions, parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import { normalizeConversationRef } from "./outbound/session-binding-normalization.js";
 import type { SessionBindingRecord } from "./outbound/session-binding.types.js";
 import { isWithinDir } from "./path-safety.js";
+import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import {
   detectLegacyDebugProxyCaptureSidecar,
   migrateLegacyDebugProxyCaptureSidecar,
@@ -539,6 +540,75 @@ function readAuthoritativeCurrentNpmIdentity(
   return null;
 }
 
+function addRegistrySpecIdentityCandidates(params: {
+  record: InstalledPluginIndex["installRecords"][string];
+  key: string;
+  names: Set<string>;
+  versions: Set<string>;
+}): boolean {
+  const spec = readInstallRecordStringField(params.record, params.key);
+  if (!spec) {
+    return true;
+  }
+  const parsed = parseRegistryNpmSpec(spec);
+  if (!parsed) {
+    return false;
+  }
+  params.names.add(parsed.name);
+  if (parsed.selectorKind === "exact-version" && parsed.selector) {
+    params.versions.add(parsed.selector);
+  }
+  return true;
+}
+
+function collectNpmInstallRecordIdentityCandidates(
+  record: InstalledPluginIndex["installRecords"][string],
+): { names: Set<string>; versions: Set<string> } | null {
+  const names = new Set<string>();
+  const versions = new Set<string>();
+  const resolvedName = readInstallRecordStringField(record, "resolvedName");
+  const version = readInstallRecordStringField(record, "version");
+  const resolvedVersion = readInstallRecordStringField(record, "resolvedVersion");
+  if (resolvedName) {
+    names.add(resolvedName);
+  }
+  if (version) {
+    versions.add(version);
+  }
+  if (resolvedVersion) {
+    versions.add(resolvedVersion);
+  }
+  if (!addRegistrySpecIdentityCandidates({ record, key: "spec", names, versions })) {
+    return null;
+  }
+  if (!addRegistrySpecIdentityCandidates({ record, key: "resolvedSpec", names, versions })) {
+    return null;
+  }
+  return { names, versions };
+}
+
+function npmInstallRecordIdentityCandidatesAgreeWith(params: {
+  record: InstalledPluginIndex["installRecords"][string];
+  identity: { name: string; version: string };
+}): boolean {
+  const candidates = collectNpmInstallRecordIdentityCandidates(params.record);
+  return Boolean(
+    candidates &&
+    candidates.names.size === 1 &&
+    candidates.names.has(params.identity.name) &&
+    candidates.versions.size === 1 &&
+    candidates.versions.has(params.identity.version),
+  );
+}
+
+function compareNpmInstallRecordVersions(left: string, right: string): number | null {
+  const releaseCmp = compareOpenClawReleaseVersions(left, right);
+  if (releaseCmp !== null) {
+    return releaseCmp;
+  }
+  return compareComparableSemver(parseComparableSemver(left), parseComparableSemver(right));
+}
+
 function legacyNpmInstallRecordSupersededByCurrent(params: {
   currentRecord: InstalledPluginIndex["installRecords"][string];
   legacyRecord: InstalledPluginIndex["installRecords"][string];
@@ -553,12 +623,30 @@ function legacyNpmInstallRecordSupersededByCurrent(params: {
     return false;
   }
   const currentIdentity = readAuthoritativeCurrentNpmIdentity(currentRecord);
-  return Boolean(
-    currentIdentity &&
-    legacyParsedSpec.selector &&
-    currentIdentity.name === legacyParsedSpec.name &&
-    currentIdentity.version === legacyParsedSpec.selector,
+  const legacyIdentity =
+    legacyParsedSpec.selector !== undefined
+      ? { name: legacyParsedSpec.name, version: legacyParsedSpec.selector }
+      : null;
+  if (!currentIdentity || !legacyIdentity || currentIdentity.name !== legacyIdentity.name) {
+    return false;
+  }
+  if (
+    !npmInstallRecordIdentityCandidatesAgreeWith({
+      record: currentRecord,
+      identity: currentIdentity,
+    }) ||
+    !npmInstallRecordIdentityCandidatesAgreeWith({
+      record: legacyRecord,
+      identity: legacyIdentity,
+    })
+  ) {
+    return false;
+  }
+  const versionCmp = compareNpmInstallRecordVersions(
+    currentIdentity.version,
+    legacyIdentity.version,
   );
+  return versionCmp !== null && versionCmp >= 0;
 }
 
 function legacyInstallRecordCoveredByCurrent(


### PR DESCRIPTION
## Summary

- Archive a stale legacy `plugins/installs.json` record when shared SQLite has authoritative npm metadata for the same package at the same or newer version.
- Require every present npm identity field (`resolvedName`, `spec`, `resolvedSpec`, `version`, `resolvedVersion`) to agree before treating the legacy record as superseded.
- Preserve the existing warning/source-file path for true conflicts: older current metadata, package drift, version drift, malformed specs, or missing authoritative current identity.

## Linked context

Related #90418 and the prior closed attempts #90267 / #90474.

This PR intentionally keeps the scope to the older-version supersession shape and incorporates the key ClawSweeper feedback from #90474: do not trust the first matching identity field when other present npm fields disagree.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: after upgrades, stale legacy plugin install index records can keep producing `Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: ...` even when SQLite already has authoritative newer npm install metadata for the same package.
- Real environment tested: Windows source checkout on this branch, with isolated `OPENCLAW_HOME` and `OPENCLAW_STATE_DIR` under a temp directory. Shared SQLite installed-plugin index was seeded through the production `writePersistedInstalledPluginIndexSync` store API with current `discord` metadata at `@openclaw/discord@2026.6.8`; legacy `plugins/installs.json` was seeded with the same package pinned to older exact `@openclaw/discord@2026.6.8-beta.1`.
- Exact steps or command run after this patch:

```powershell
.\node_modules\.bin\tsx.cmd <temp proof script>
```

The temp proof script wrote the current SQLite record, wrote the stale legacy JSON, ran production `detectLegacyStateMigrations` + `runLegacyStateMigrations`, then printed changes, warnings, file state, and the final SQLite record.

- Evidence after fix:

```json
{
  "proofScope": "production legacy state migration entrypoint with isolated OPENCLAW_STATE_DIR",
  "changes": [
    "Archived plugin install index legacy source -> C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\openclaw-proof-plugin-index-9fff57967edf41d98509e58277bb993c\\state\\plugins\\installs.json.migrated"
  ],
  "warnings": [],
  "legacyExistsAfter": false,
  "archiveExistsAfter": true,
  "sqliteRecordAfter": {
    "source": "npm",
    "spec": "@openclaw/discord@2026.6.8",
    "resolvedName": "@openclaw/discord",
    "resolvedVersion": "2026.6.8",
    "resolvedSpec": "@openclaw/discord@2026.6.8",
    "integrity": "sha512-current",
    "installedAt": "2026-06-17T12:00:00.000Z"
  }
}
```

- Observed result after fix: The patched migration archived the stale beta legacy install index, emitted no warning, removed the live legacy source, created the `.migrated` archive, and preserved the current stable SQLite install record.
- What was not tested: A full packaged upgrade replay on macOS/Windows with gateway restart was not run. The proof above uses the real production migration entrypoint against isolated temp state; the focused regression tests cover both the safe archive case and the true-conflict cases.

## Tests and validation

```sh
node scripts/run-vitest.mjs src/commands/doctor-state-migrations.test.ts -t "legacy npm install record|legacy plugin install index when SQLite already has richer matching records"
.\node_modules\.bin\oxfmt.cmd --check --threads=1 src\infra\state-migrations.ts src\commands\doctor-state-migrations.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/state-migrations.ts src/commands/doctor-state-migrations.test.ts
git diff --check
```

Result: focused Vitest passed (`9 passed`, `67 skipped`); formatting, oxlint, and diff whitespace checks passed.

Regression coverage added:

- archives stale beta legacy metadata when current SQLite has stable authoritative metadata for the same official npm package;
- keeps the warning when current SQLite metadata is older than legacy metadata;
- keeps the warning when current package fields disagree;
- keeps the warning when current version fields disagree;
- keeps the warning when legacy resolved package fields disagree;
- keeps the warning when legacy version fields disagree.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A stale legacy install-index warning is cleared when the legacy npm record is provably superseded by current SQLite metadata.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes. This changes legacy plugin install-index migration behavior for a narrow superseded npm-record case.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

Incorrectly archiving a legacy install index that still contains meaningful conflicting metadata.

How is that risk mitigated?

The supersession path requires current authoritative identity plus unanimous agreement across all present npm package/version fields on both current and legacy records. Any malformed spec or identity disagreement returns to the existing conflict warning path.

## Current review state

Ready for CI and maintainer review. The main maintainer judgment is the compatibility policy for retiring stale legacy install-index records once the shared SQLite record is authoritative and newer.