### PR TITLE
fix(heartbeat): keep private final reply off-channel in message_tool mode

### DIFF
--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -445,6 +445,14 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
       // The private text must not reach the channel; run still completes.
       expect(result.status).toBe("ran");
       expect(sendTelegram).not.toHaveBeenCalled();
+
+      // The suppressed private text must not leak through the heartbeat event
+      // preview either (stored as lastHeartbeat, broadcast to gateway
+      // subscribers, and rendered in the Debug view).
+      const lastEvent = getLastHeartbeatEvent();
+      expect(lastEvent?.preview ?? "").not.toContain("private follow-ups");
+      expect(lastEvent?.preview ?? "").not.toContain("overnight logs");
+      expect(lastEvent?.preview).toBe("[private heartbeat reply suppressed]");
     });
   });
 

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -412,6 +412,42 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     ]);
   });
 
+  it("keeps a private final reply off-channel when message_tool mode is forced and the tool is not called", async () => {
+    // Regression for #94053: with visibleReplies="message_tool" the run forces
+    // the heartbeat response tool (sourceReplyDeliveryMode=message_tool_only).
+    // If the model returns plain final text WITHOUT calling heartbeat_respond,
+    // that text is private and must NOT be delivered to the channel.
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath, visibleReplies: "message_tool" });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      // Plain final text (no heartbeat_respond tool call). Includes HEARTBEAT_OK
+      // mid-string so edge-token stripping does not turn it into a quiet ack —
+      // this is the exact leak path described in the issue.
+      replySpy.mockResolvedValue({
+        text: "Reviewed the overnight logs and the deployment is HEARTBEAT_OK, but I noticed three private follow-ups I am tracking internally.",
+      });
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      // Confirm the run actually forced message_tool_only mode.
+      const calledOpts = replyOptions(replySpy);
+      expect(calledOpts.sourceReplyDeliveryMode).toBe("message_tool_only");
+      expect(calledOpts.forceHeartbeatTool).toBe(true);
+
+      // The private text must not reach the channel; run still completes.
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("keeps the legacy heartbeat ok prompt outside heartbeat response tool mode", async () => {
     await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createConfig({ tmpDir, storePath, visibleReplies: "automatic" });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -42,6 +42,7 @@ import {
   stripHeartbeatToken,
   type HeartbeatTask,
 } from "../auto-reply/heartbeat.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { replaceGenericExternalRunFailureText } from "../auto-reply/reply/agent-runner-failure-copy.js";
 import { resolveDefaultModel } from "../auto-reply/reply/directive-handling.defaults.js";
 import {
@@ -525,6 +526,26 @@ function shouldUseHeartbeatResponseToolPrompt(params: {
     return false;
   }
   return usesCodexHarness(params);
+}
+
+/**
+ * True only when the operator explicitly opted into message-tool visibility
+ * (messages.visibleReplies / groupChat.visibleReplies === "message_tool").
+ * This is the privacy contract: nothing user-facing should reach the channel
+ * unless the model surfaces it via the response/message tool. The Codex-harness
+ * default also forces the response tool, but that is a structural detail rather
+ * than a privacy opt-in, so plain-text fallback delivery stays allowed there.
+ */
+function isExplicitMessageToolVisibility(params: {
+  cfg: OpenClawConfig;
+  chatType?: ChatType;
+}): boolean {
+  const chatType = normalizeChatType(params.chatType);
+  const visibleReplies =
+    chatType === "group" || chatType === "channel"
+      ? (params.cfg.messages?.groupChat?.visibleReplies ?? params.cfg.messages?.visibleReplies)
+      : params.cfg.messages?.visibleReplies;
+  return visibleReplies === "message_tool";
 }
 
 function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
@@ -1841,6 +1862,62 @@ export async function runHeartbeatOnce(opts: {
       : [];
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
     const responsePrefix = resolveHeartbeatResponsePrefix();
+
+    // message_tool_only privacy guard (issue #94053): when the operator
+    // explicitly set visibleReplies="message_tool", the heartbeat run forces
+    // the heartbeat response tool and sourceReplyDeliveryMode=message_tool_only.
+    // The privacy contract is that nothing user-facing reaches the channel
+    // unless the model surfaces it via heartbeat_respond. If the model instead
+    // returns plain final text WITHOUT calling the tool, that text is private
+    // and must not leak — treat it as a silent heartbeat ack.
+    //
+    // Scope is intentionally limited to the explicit opt-in so the Codex-harness
+    // default (which also forces the tool, but expects plain-text fallback
+    // delivery) keeps its existing behavior. Two payloads are still allowed
+    // through to preserve current behavior:
+    //  - notices explicitly marked deliverDespiteSourceReplySuppression
+    //    (e.g. Codex runtime usage-limit / failure notices), and
+    //  - relayable exec-completion events.
+    const replyMarkedForDelivery =
+      Boolean(replyPayload) &&
+      getReplyPayloadMetadata(replyPayload as object)?.deliverDespiteSourceReplySuppression ===
+        true;
+    if (
+      usesHeartbeatResponseTool &&
+      isExplicitMessageToolVisibility({ cfg, chatType: delivery.chatType }) &&
+      !heartbeatToolResponse &&
+      replyPayload &&
+      hasOutboundReplyContent(replyPayload) &&
+      !replyMarkedForDelivery &&
+      !hasRelayableExecCompletion
+    ) {
+      await restoreHeartbeatUpdatedAt({
+        storePath,
+        sessionKey,
+        updatedAt: previousUpdatedAt,
+      });
+
+      const okSent = await maybeSendHeartbeatOk();
+      emitHeartbeatEvent({
+        status: "ok-token",
+        reason: opts.reason,
+        preview: replyPayload.text?.slice(0, 200) ?? "",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        silent: !okSent,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
+      });
+      await markCommitmentsStatus({
+        cfg,
+        ids: dueCommitmentIds,
+        status: "dismissed",
+        nowMs: startedAt,
+      });
+      await updateTaskTimestamps();
+      consumeInspectedSystemEvents();
+      return { status: "ran", durationMs: Date.now() - startedAt };
+    }
 
     if (heartbeatToolResponse && !heartbeatToolResponse.notify) {
       await restoreHeartbeatUpdatedAt({

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1898,10 +1898,15 @@ export async function runHeartbeatOnce(opts: {
       });
 
       const okSent = await maybeSendHeartbeatOk();
+      // Privacy: the suppressed final text must not leak through the heartbeat
+      // event preview either (heartbeat events are stored as lastHeartbeat,
+      // broadcast to gateway subscribers, returned by last-heartbeat, and
+      // rendered in the Debug view). Emit a metadata-only marker instead of the
+      // raw private reply text.
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
-        preview: replyPayload.text?.slice(0, 200) ?? "",
+        preview: "[private heartbeat reply suppressed]",
         durationMs: Date.now() - startedAt,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         accountId: delivery.accountId,


### PR DESCRIPTION
## Summary

- When `messages.visibleReplies: "message_tool"` is configured, a heartbeat that returns plain final text **without** calling `heartbeat_respond` no longer leaks that text to the channel.
- The no-tool-call fallback is now treated as a silent heartbeat ack, honoring the `message_tool_only` privacy contract.

## Motivation

Closes #94053.

With `visibleReplies: "message_tool"`, the heartbeat runner forces the heartbeat response tool and passes `sourceReplyDeliveryMode: "message_tool_only"` to the agent. The privacy contract is that nothing user-facing reaches the channel unless the model surfaces it via `heartbeat_respond`.

But if the model returned plain final text and did **not** call the tool, `heartbeatToolResponse` was `undefined` and the runner fell through to `normalizeHeartbeatReply()` → durable channel delivery. Any final text whose `HEARTBEAT_OK` token wasn't at an edge (so it survived stripping) was delivered to the Telegram DM/channel — exactly the leak in the issue's log:

```
[source-reply/private-final] agent produced a long private final reply without calling the configured delivery tool (message_tool_only); response kept private and not delivered to the source channel
[telegram] outbound send ok ... operation=sendMessage deliveryKind=text chunkCount=1
```

The first line says it was kept private; the second line shows it was sent anyway.

## Fix

After resolving the reply payload, if the run forces the response tool **and** the operator explicitly opted into `visibleReplies: "message_tool"`, and the model returned outbound text without a tool response, treat it as a silent heartbeat ack (restore `updatedAt`, optionally emit the OK token, mark commitments, return `ran`) instead of delivering the raw text.

Two payloads are still delivered to preserve existing behavior:
- notices explicitly marked `deliverDespiteSourceReplySuppression` (e.g. Codex runtime usage-limit / failure notices), and
- relayable exec-completion events.

Scope is intentionally limited to the **explicit** `message_tool` opt-in. The Codex-harness default also forces the response tool but expects plain-text fallback delivery, so its behavior is unchanged (verified by the existing tool-response and default-unset suites).

## Real behavior proof

- **Behavior addressed:** with `visibleReplies: "message_tool"`, a heartbeat whose final reply is plain text (no `heartbeat_respond` call) containing `HEARTBEAT_OK` mid-string was delivered to the Telegram channel. After the fix that private text is suppressed and the run still completes as a silent ack.
- **Real environment tested:** node v25.5.0 on macOS (Darwin arm64), this branch rebased on `openclaw/main`. The shipped `runHeartbeatOnce` from `src/infra/heartbeat-runner.ts` was driven directly via a standalone `tsx` script (no test framework / no mocking library) against a real on-disk session store under a temp dir; only the leaf Telegram send was a plain recorder so channel delivery could be observed.
- **Exact steps or command run after this patch:**
  1. Seed a real `sessions.json` with `lastChannel/lastProvider/lastTo` pointing at a Telegram group.
  2. Build a real config with `messages.visibleReplies: "message_tool"`.
  3. Provide a `getReplyFromConfig` that returns plain final text (no `heartbeat_respond` call) with `HEARTBEAT_OK` mid-string.
  4. `node_modules/.bin/tsx .tmp-heartbeat-proof.mts` → call `runHeartbeatOnce({ cfg, deps })` and record every Telegram send.
  5. Repeat with the source file reverted to `openclaw/main` to capture the pre-fix behavior.
- **Evidence after fix:** live captured stdout from the shipped runner (private text NOT delivered):

  ```
  === running SHIPPED runHeartbeatOnce with visibleReplies=message_tool ===
  [reply] sourceReplyDeliveryMode=message_tool_only forceHeartbeatTool=true
  [result] status=ran
  [observed] telegram sends recorded = 0
  PROOF: private final text was NOT delivered to the channel (leak suppressed).
  ```

- **Observed result after fix:** `runHeartbeatOnce` returned `status=ran` and the recorder captured **0** Telegram sends — the private text never reached the channel. Re-running the same script with `src/infra/heartbeat-runner.ts` reverted to `openclaw/main` reproduced the original leak live:

  ```
  === running SHIPPED runHeartbeatOnce with visibleReplies=message_tool ===
  [reply] sourceReplyDeliveryMode=message_tool_only forceHeartbeatTool=true
  [telegram] outbound send -> -1001234567890 :: "Reviewed the overnight logs and the deployment is HEARTBEAT_OK, but I noticed three private follow-ups I am tracking internally."
  [result] status=ran
  [observed] telegram sends recorded = 1
  LEAK: private text reached channel: [{"to":"-1001234567890","text":"..."}]
  ```

  So the same shipped code path leaks before the patch and is silent after it.
- **What was not tested:** delivery through a live Telegram API endpoint (the runner's channel-plugin send seam was exercised with a recorder rather than real credentials); the Codex-harness plain-text fallback path is intentionally unchanged and is covered by the existing default-unset and tool-response suites.

## Supplemental automated checks

- `npx vitest run src/infra/heartbeat-runner.tool-response.test.ts` — 16 passed (15 existing + 1 new regression asserting `sendTelegram` is not called in `message_tool_only` mode).
- `npx vitest run src/infra/heartbeat-runner.returns-default-unset.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-runner.skips-busy-session-lane.test.ts src/infra/heartbeat-runner.commitments.test.ts src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts src/infra/heartbeat-runner.scheduler.test.ts` — all pass (no regression in default / Codex-harness / commitment paths).
- `npx oxlint` + `npx oxfmt` on both changed files — clean.
