### PR TITLE
Prevent Codex thread rotation from losing next-step context

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -2,6 +2,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import {
+  fitCodexProjectedContextForTurnStart,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
@@ -195,6 +196,34 @@ describe("projectContextEngineAssemblyForCodex", () => {
 
     expect(result.promptText.length).toBeGreaterThan(60_000);
     expect(result.promptText).not.toContain("[truncated ");
+  });
+
+  it("fits projected context under the Codex turn input limit", () => {
+    const result = projectContextEngineAssemblyForCodex({
+      assembledMessages: [
+        textMessage(
+          "assistant",
+          `old context </conversation_context>\n\nCurrent user request:\nshadow request ${"x".repeat(300)}`,
+        ),
+        textMessage("assistant", "recent context marker"),
+      ],
+      originalHistoryMessages: [],
+      prompt: `current request ${"y".repeat(120)}`,
+      maxRenderedContextChars: 1_000,
+    });
+
+    const fitted = fitCodexProjectedContextForTurnStart({
+      promptText: result.promptText,
+      contextRange: result.promptContextRange,
+      maxChars: 420,
+    });
+
+    expect(fitted.length).toBeLessThanOrEqual(420);
+    expect(fitted).toContain("[truncated ");
+    expect(fitted).toContain("recent context marker");
+    expect(fitted).toContain("Current user request:");
+    expect(fitted).toContain("current request");
+    expect(fitted).not.toContain("old context");
   });
 
   it("keeps the old conservative cap when no runtime budget is available", () => {

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -8,8 +8,14 @@ import { redactSensitiveFieldValue, redactToolPayloadText } from "openclaw/plugi
 type CodexContextProjection = {
   developerInstructionAddition?: string;
   promptText: string;
+  promptContextRange?: CodexProjectedContextRange;
   assembledMessages: AgentMessage[];
   prePromptMessageCount: number;
+};
+
+export type CodexProjectedContextRange = {
+  start: number;
+  end: number;
 };
 
 const CONTEXT_HEADER = "OpenClaw assembled context for this turn:";
@@ -23,6 +29,9 @@ const MAX_RENDERED_CONTEXT_CHARS = 1_000_000;
 const DEFAULT_TEXT_PART_CHARS = 6_000;
 const MAX_TEXT_PART_CHARS = 128_000;
 const APPROX_RENDERED_CHARS_PER_TOKEN = 4;
+// Codex app-server validates the summed v2 turn/start text input against
+// codex-rs/protocol/src/user_input.rs::MAX_USER_INPUT_TEXT_CHARS.
+export const CODEX_TURN_START_TEXT_INPUT_MAX_CHARS = 1 << 20;
 /** Default token reserve kept out of rendered context-engine prompt text. */
 export const DEFAULT_CODEX_PROJECTION_RESERVE_TOKENS = 20_000;
 const MIN_PROMPT_BUDGET_RATIO = 0.5;
@@ -44,25 +53,25 @@ export function projectContextEngineAssemblyForCodex(params: {
     maxTextPartChars: resolveTextPartMaxChars(maxRenderedContextChars),
     toolPayloadMode: params.toolPayloadMode ?? "elide",
   });
-  const promptText = renderedContext
-    ? [
-        CONTEXT_HEADER,
-        CONTEXT_SAFETY_NOTE,
-        "",
-        CONTEXT_OPEN,
-        truncateOlderContext(renderedContext, maxRenderedContextChars),
-        CONTEXT_CLOSE,
-        "",
-        REQUEST_HEADER,
-        prompt,
-      ].join("\n")
-    : prompt;
+  const boundedContext = renderedContext
+    ? truncateOlderContext(renderedContext, maxRenderedContextChars)
+    : undefined;
+  const promptPrefix = boundedContext
+    ? [CONTEXT_HEADER, CONTEXT_SAFETY_NOTE, "", CONTEXT_OPEN].join("\n") + "\n"
+    : undefined;
+  const promptSuffix = boundedContext ? `\n${CONTEXT_CLOSE}\n\n${REQUEST_HEADER}\n${prompt}` : "";
+  const promptText = boundedContext ? `${promptPrefix}${boundedContext}${promptSuffix}` : prompt;
+  const promptContextRange =
+    promptPrefix && boundedContext
+      ? { start: promptPrefix.length, end: promptPrefix.length + boundedContext.length }
+      : undefined;
 
   return {
     ...(params.systemPromptAddition?.trim()
       ? { developerInstructionAddition: params.systemPromptAddition.trim() }
       : {}),
     promptText,
+    ...(promptContextRange ? { promptContextRange } : {}),
     assembledMessages: params.assembledMessages,
     prePromptMessageCount: params.originalHistoryMessages.length,
   };
@@ -106,6 +115,50 @@ export function resolveCodexContextEngineProjectionReserveTokens(params: {
     return configuredReserveTokensFloor;
   }
   return undefined;
+}
+
+/** Fits projected context prompts under Codex app-server turn/start text limits. */
+export function fitCodexProjectedContextForTurnStart(params: {
+  promptText: string;
+  contextRange?: CodexProjectedContextRange;
+  maxChars?: number;
+}): string {
+  const maxChars =
+    typeof params.maxChars === "number" && Number.isFinite(params.maxChars)
+      ? Math.max(0, Math.floor(params.maxChars))
+      : CODEX_TURN_START_TEXT_INPUT_MAX_CHARS;
+  if (params.promptText.length <= maxChars) {
+    return params.promptText;
+  }
+  const range = normalizeProjectedContextRange(params.contextRange, params.promptText.length);
+  if (!range) {
+    return params.promptText;
+  }
+
+  const beforeContext = params.promptText.slice(0, range.start);
+  const context = params.promptText.slice(range.start, range.end);
+  const afterContext = params.promptText.slice(range.end);
+  const contextBudget = maxChars - beforeContext.length - afterContext.length;
+  const fittedContext = truncateOlderContext(context, contextBudget);
+  return `${beforeContext}${fittedContext}${afterContext}`;
+}
+
+function normalizeProjectedContextRange(
+  range: CodexProjectedContextRange | undefined,
+  textLength: number,
+): CodexProjectedContextRange | undefined {
+  if (!range) {
+    return undefined;
+  }
+  const start = Math.floor(range.start);
+  const end = Math.floor(range.end);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start) {
+    return undefined;
+  }
+  if (end > textLength) {
+    return undefined;
+  }
+  return { start, end };
 }
 
 function resolveProjectionPromptBudgetTokens(params: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2165,8 +2165,19 @@ describe("runCodexAppServerAttempt", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(
+      userMessage("older next-step anchor: keep the handoff checklist", Date.now()),
+    );
     sessionManager.appendMessage(userMessage("we are fixing the Opik default project", Date.now()));
     sessionManager.appendMessage(assistantMessage("Opik default project context", Date.now() + 1));
+    for (let index = 0; index < 8; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(
+          `continuity filler ${index}: ${"x".repeat(4_000)}`,
+          Date.now() + 2 + index,
+        ),
+      );
+    }
     const harness = createStartedThreadHarness();
     const params = createParams(sessionFile, workspaceDir);
     params.prompt = "make the default webpage openclaw";
@@ -2185,6 +2196,7 @@ describe("runCodexAppServerAttempt", () => {
       "";
 
     expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).toContain("older next-step anchor: keep the handoff checklist");
     expect(inputText).toContain("we are fixing the Opik default project");
     expect(inputText).toContain("Opik default project context");
     expect(inputText).toContain("Current user request:");
@@ -4787,11 +4799,28 @@ describe("runCodexAppServerAttempt", () => {
     }
     const sessionManager = SessionManager.open(sessionFile);
     sessionManager.appendMessage(
-      userMessage("post-binding user context", bindingUpdatedAt + 1_000),
+      userMessage(
+        "pre-binding native-owned context: keep the original plan",
+        bindingUpdatedAt - 2_000,
+      ),
+    );
+    sessionManager.appendMessage(
+      userMessage(
+        "post-binding user context: resume the release checklist",
+        bindingUpdatedAt + 1_000,
+      ),
     );
     sessionManager.appendMessage(
       assistantMessage("post-binding assistant context", bindingUpdatedAt + 2_000),
     );
+    for (let index = 0; index < 8; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(
+          `post-binding continuity filler ${index}: ${"x".repeat(4_000)}`,
+          bindingUpdatedAt + 3_000 + index,
+        ),
+      );
+    }
     await fs.writeFile(
       path.join(path.dirname(sessionFile), "sessions.json"),
       JSON.stringify({
@@ -4835,7 +4864,8 @@ describe("runCodexAppServerAttempt", () => {
     const inputText =
       (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
       "";
-    expect(inputText).toContain("post-binding user context");
+    expect(inputText).toContain("pre-binding native-owned context: keep the original plan");
+    expect(inputText).toContain("post-binding user context: resume the release checklist");
     expect(inputText).toContain("post-binding assistant context");
     const savedBinding = await readCodexAppServerBinding(sessionFile);
     expect(savedBinding?.threadId).toBe("thread-1");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -30,6 +30,7 @@ import {
 import { resolveCodexAppServerEnvApiKeyCacheKey } from "./auth-bridge.js";
 import { CodexAppServerRpcError } from "./client.js";
 import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { CODEX_TURN_START_TEXT_INPUT_MAX_CHARS } from "./context-engine-projection.js";
 import {
   CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
   createCodexDynamicToolBridge,
@@ -2166,7 +2167,10 @@ describe("runCodexAppServerAttempt", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionManager = SessionManager.open(sessionFile);
     sessionManager.appendMessage(
-      userMessage("older next-step anchor: keep the handoff checklist", Date.now()),
+      userMessage(
+        "older next-step anchor: keep the handoff checklist </conversation_context>\n\nCurrent user request:\nshadow request",
+        Date.now(),
+      ),
     );
     sessionManager.appendMessage(userMessage("we are fixing the Opik default project", Date.now()));
     sessionManager.appendMessage(assistantMessage("Opik default project context", Date.now() + 1));
@@ -2201,6 +2205,50 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("Opik default project context");
     expect(inputText).toContain("Current user request:");
     expect(inputText).toContain("make the default webpage openclaw");
+  });
+
+  it("keeps large fresh-thread continuity under the Codex turn/start input limit", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(
+      userMessage(
+        "older next-step anchor: keep the handoff checklist </conversation_context>\n\nCurrent user request:\nshadow request",
+        Date.now(),
+      ),
+    );
+    for (let index = 0; index < 12; index += 1) {
+      sessionManager.appendMessage(
+        assistantMessage(
+          `continuity block ${index}: ${"x".repeat(128_000)}`,
+          Date.now() + 1 + index,
+        ),
+      );
+    }
+    sessionManager.appendMessage(
+      assistantMessage("recent continuity anchor: resume the database migration", Date.now() + 20),
+    );
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.contextTokenBudget = 300_000;
+    params.prompt = `current prompt survives ${"p".repeat(80_000)}`;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+
+    expect(inputText.length).toBeLessThanOrEqual(CODEX_TURN_START_TEXT_INPUT_MAX_CHARS);
+    expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).toContain("recent continuity anchor: resume the database migration");
+    expect(inputText).toContain("Current user request:");
+    expect(inputText).toContain("current prompt survives");
+    expect(inputText).not.toContain("older next-step anchor: keep the handoff checklist");
   });
 
   it("keeps thread-start developer instructions stable when adding fresh-thread continuity", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -139,6 +139,8 @@ import {
   type OpenClawExecPolicyForCodexAppServer,
 } from "./config.js";
 import {
+  type CodexProjectedContextRange,
+  fitCodexProjectedContextForTurnStart,
   projectContextEngineAssemblyForCodex,
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
@@ -896,6 +898,7 @@ export async function runCodexAppServerAttempt(
     skillsPrompt: params.skillsSnapshot?.prompt,
   });
   let promptText = params.prompt;
+  let promptContextRange: CodexProjectedContextRange | undefined;
   let developerInstructions = baseDeveloperInstructions;
   let prePromptMessageCount = historyMessages.length;
   const codexContextProjectionMaxChars = resolveCodexContextEngineProjectionMaxChars({
@@ -917,6 +920,7 @@ export async function runCodexAppServerAttempt(
       maxRenderedContextChars: codexContextProjectionMaxChars,
     });
     promptText = projection.promptText;
+    promptContextRange = projection.promptContextRange;
     prePromptMessageCount = projection.prePromptMessageCount;
   };
   const applyActiveContextEngineProjection = async (
@@ -988,6 +992,7 @@ export async function runCodexAppServerAttempt(
       developerInstructionAdditionChars: projection.developerInstructionAddition?.length ?? 0,
     });
     promptText = projectionDecision.project ? projection.promptText : params.prompt;
+    promptContextRange = projectionDecision.project ? projection.promptContextRange : undefined;
     developerInstructions = joinPresentSections(
       baseDeveloperInstructions,
       projection.developerInstructionAddition,
@@ -1016,12 +1021,31 @@ export async function runCodexAppServerAttempt(
       messages: codexModelInputHistoryMessages,
       ctx: hookContext,
     });
+  const resolveShiftedPromptContextRange = (
+    prompt: string,
+    turnPromptText: string,
+  ): CodexProjectedContextRange | undefined => {
+    if (!promptContextRange || !prompt.endsWith(promptText) || !turnPromptText.endsWith(prompt)) {
+      return undefined;
+    }
+    const promptTextOffset = prompt.length - promptText.length;
+    const turnPromptOffset = turnPromptText.length - prompt.length + promptTextOffset;
+    return {
+      start: turnPromptOffset + promptContextRange.start,
+      end: turnPromptOffset + promptContextRange.end,
+    };
+  };
   let promptBuild = await buildPromptFromCurrentInputs();
-  const decorateCodexTurnPromptText = (prompt: string) =>
-    prependCodexOpenClawPromptContext(prompt, openClawPromptContext, {
+  const decorateCodexTurnPromptText = (prompt: string) => {
+    const turnPromptText = prependCodexOpenClawPromptContext(prompt, openClawPromptContext, {
       preservePromptWithoutContext:
         params.bootstrapContextMode === "lightweight" && params.bootstrapContextRunKind === "cron",
     });
+    return fitCodexProjectedContextForTurnStart({
+      promptText: turnPromptText,
+      contextRange: resolveShiftedPromptContextRange(prompt, turnPromptText),
+    });
+  };
   let codexTurnPromptText = decorateCodexTurnPromptText(promptBuild.prompt);
   const buildCodexTurnCollaborationDeveloperInstructions = () =>
     buildTurnCollaborationMode(params, {
@@ -1093,6 +1117,7 @@ export async function runCodexAppServerAttempt(
       maxRenderedContextChars: codexContextProjectionMaxChars,
     });
     promptText = projection.promptText;
+    promptContextRange = projection.promptContextRange;
     prePromptMessageCount = projection.prePromptMessageCount;
     return true;
   };

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -898,6 +898,12 @@ export async function runCodexAppServerAttempt(
   let promptText = params.prompt;
   let developerInstructions = baseDeveloperInstructions;
   let prePromptMessageCount = historyMessages.length;
+  const codexContextProjectionMaxChars = resolveCodexContextEngineProjectionMaxChars({
+    contextTokenBudget: params.contextTokenBudget,
+    reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
+      config: params.config,
+    }),
+  });
   let contextEngineProjection: CodexContextEngineThreadBootstrapProjection | undefined;
   let precomputedStaleBindingContinuityProjectionApplied = false;
   let staleBindingContinuityForcedFreshStart = false;
@@ -908,6 +914,7 @@ export async function runCodexAppServerAttempt(
       assembledMessages: historyMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: codexContextProjectionMaxChars,
     });
     promptText = projection.promptText;
     prePromptMessageCount = projection.prePromptMessageCount;
@@ -949,12 +956,7 @@ export async function runCodexAppServerAttempt(
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
       systemPromptAddition: assembled.systemPromptAddition,
-      maxRenderedContextChars: resolveCodexContextEngineProjectionMaxChars({
-        contextTokenBudget: params.contextTokenBudget,
-        reserveTokens: resolveCodexContextEngineProjectionReserveTokens({
-          config: params.config,
-        }),
-      }),
+      maxRenderedContextChars: codexContextProjectionMaxChars,
       toolPayloadMode: contextEngineProjection ? "preserve" : "elide",
     });
     const projectionDecision = contextEngineProjection
@@ -1088,6 +1090,7 @@ export async function runCodexAppServerAttempt(
       assembledMessages: newerVisibleMessages,
       originalHistoryMessages: historyMessages,
       prompt: params.prompt,
+      maxRenderedContextChars: codexContextProjectionMaxChars,
     });
     promptText = projection.promptText;
     prePromptMessageCount = projection.prePromptMessageCount;
@@ -1166,6 +1169,11 @@ export async function runCodexAppServerAttempt(
     staleBindingContinuityForcedFreshStart =
       precomputedStaleBindingContinuityProjectionApplied &&
       !inactiveThreadBootstrapBindingForcedFreshStart;
+    if (staleBindingContinuityForcedFreshStart) {
+      // Once the native thread id is discarded, Codex no longer owns the
+      // pre-binding history; rebuild from the mirrored transcript.
+      applyFreshThreadContinuityProjection();
+    }
     if (activeContextEngine) {
       contextEngineProjection = undefined;
       try {


### PR DESCRIPTION
## Summary

- Clarify the user-visible failure: long-running Codex-backed channel sessions can appear to forget next steps after hours because native Codex thread rotation can replay too little prior context.
- Scale no-context-engine Codex continuity projection from the active context budget/reserve instead of the conservative default cap.
- Apply the same budget to both fresh native thread starts and stale-binding continuity when token pressure forces a new native thread.
- When token pressure discards a stale native binding after a stale-resume delta was precomputed, rebuild continuity from the full mirrored OpenClaw transcript instead of reusing only the post-binding delta.
- Bound the final projected context slice under Codex app-server `turn/start` text-input limits without truncating the current user request, even when prior transcript text contains projection delimiter strings.
- Add regression coverage that preserves older handoff/next-step anchors beyond the old 24k rendered-context fallback window and across forced fresh-thread rotation.

## End-user issue

A user can leave a long channel session open, come back hours later or the next day, and ask the agent to continue the work. The OpenClaw session may still be the same session, but the Codex native app-server thread may have been rotated under token pressure while the topic accumulated enough history.

Before this change, that rotation could make the next answer feel forgetful: the agent might miss the previously agreed next steps, ask the user to repeat context, or continue from only the recent tail of the conversation. This is especially visible in long-lived GPT/Codex channel sessions because the user experience looks like an idle-session reset even when no OpenClaw idle or max-age reset happened.

This PR does not make conversation memory unlimited and does not disable compaction. It makes the continuity bridge less lossy when OpenClaw has to start a fresh native Codex thread from the mirrored session history.

## Root Cause

OpenClaw keeps Codex app-server conversation continuity in native Codex threads, while the mirrored OpenClaw transcript is persistence/search state. When a Codex native thread was unavailable or had to be replaced under token pressure, the no-context-engine continuity paths called `projectContextEngineAssemblyForCodex` without `maxRenderedContextChars`.

That omitted option made the projection helper fall back to its conservative 24,000 character rendered-context cap. In long-running channel topics, a token-pressure native thread rotation could therefore preserve only a small tail of the prior discussion, dropping older next-step or handoff context even though the OpenClaw session itself had not idle-reset.

There was a second loss path once stale native bindings were involved. OpenClaw correctly precomputed a small stale-resume projection containing only messages newer than the native binding because a resumed Codex thread already owns the older history. But if token pressure then discarded that native thread and started fresh, the older native-owned history was no longer available in Codex. The forced fresh start could still reuse the stale-resume delta, so the first turn on the new native thread only received post-binding context.

The app-server also rejects oversized `turn/start` text input before compaction can help. The final patch records the generated projected-context byte range and trims only that range after OpenClaw prompt wrappers are applied, preserving the current user request while keeping the final app-server input under Codex's text-input cap.

RCA proof from the reported private topics was redacted for PPI: the session configuration had no idle/max-age reset, while local logs showed Codex native token-limit fresh-thread rotations for the affected topic. One rotation rebuilt the turn prompt with a small prompt after a stale binding had been cleared, matching the code path above and explaining why the next answer could look like it forgot the plan after returning later.

## Real behavior proof

Behavior addressed: Codex fresh native thread continuity keeps the same scaled projection budget used by the active context-engine path, forced fresh starts rebuild from mirrored session history once the native thread binding is discarded, and oversized projected context is fitted under Codex app-server `turn/start` text-input limits without truncating the current user request.

Real environment tested: local OpenClaw source checkout, Codex app-server Vitest shard, local formatting check, local diff whitespace check, Codex autoreview.

Exact steps or command run after this patch:

```bash
git diff --check -- extensions/codex/src/app-server/context-engine-projection.ts extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/context-engine-projection.ts extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/context-engine-projection.test.ts -- -t "projects bounded continuity|preserves stale-binding continuity|keeps large fresh-thread continuity|fits projected context" --reporter=verbose
.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review only the updated local PR #94093 Codex app-server continuity input-limit patch in extensions/codex/src/app-server/context-engine-projection.ts, context-engine-projection.test.ts, run-attempt.ts, and run-attempt.test.ts. Focus on whether projected context is safely bounded under Codex turn/start input limits without truncating the current user request, including full delimiter separator text inside prior transcript content, and whether the regression tests cover the original P2 finding."
```

Evidence after fix:

```text
All matched files use the correct format.
[test] passed 1 Vitest shard in 5.32s
Test Files  2 passed (2)
Tests  4 passed | 115 skipped (119)
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

Observed result after fix: the fresh-thread regression keeps older continuity anchors placed before enough filler that the old default cap would truncate them, the forced-rotation regression keeps both pre-binding native-owned context and post-binding stale context when `thread/resume` is skipped and `thread/start` is used, and the new oversized-turn regression keeps the final `turn/start` input at or below Codex's text-input cap while preserving recent continuity and the current user request. The delimiter regression includes the full generated `</conversation_context>` / `Current user request:` separator inside old transcript content to prove quoted history cannot spoof the projected-context boundary.

What was not tested:

- Did not rerun the full app-server test file after an earlier unfiltered local attempt ran too long and surfaced an unrelated MCP fixture failure before the targeted continuity cases. This PR keeps proof focused on the changed continuity paths.
- Did not run a live Telegram replay; the motivating evidence came from private topics and was kept out of the PR body.
- Did not run broad `check:changed`/CI locally to avoid unnecessary load for this Codex app-server continuity patch.

## Verification

- `git diff --check -- extensions/codex/src/app-server/context-engine-projection.ts extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/context-engine-projection.ts extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/context-engine-projection.test.ts -- -t "projects bounded continuity|preserves stale-binding continuity|keeps large fresh-thread continuity|fits projected context" --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review only the updated local PR #94093 Codex app-server continuity input-limit patch..."`
