### PR TITLE
fix(agents): strip leaked truncation sentinels from final replies (#82121)

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -90,6 +90,11 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(crossLine)).toBe(crossLine);
   });
 
+  it("preserves standalone truncation marker examples inside fenced code (#82121)", () => {
+    const fenced = ["Example:", "```text", "...(truncated)...", "```"].join("\n");
+    expect(sanitizeUserFacingText(fenced)).toBe(fenced);
+  });
+
   it("strips a sentinel with mixed unicode/ascii ellipsis without a remnant (#82121)", () => {
     expect(sanitizeUserFacingText("...[truncated]\u2026")).toBe("");
     expect(sanitizeUserFacingText("Done.\n[... 0 more characters truncated]")).toBe("Done.");

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -47,6 +47,64 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
+  it("strips bracketed truncation sentinels from final replies (#82121)", () => {
+    expect(sanitizeUserFacingText("[... 5000 more characters truncated]")).toBe("");
+    expect(
+      sanitizeUserFacingText("Here is the result.\n[... 1000 more characters truncated]"),
+    ).toBe("Here is the result.");
+    expect(sanitizeUserFacingText("Answer.\n...[truncated]...")).toBe("Answer.");
+    expect(
+      sanitizeUserFacingText("Recent memory.\n...[additional startup memory truncated]..."),
+    ).toBe("Recent memory.");
+    expect(sanitizeUserFacingText("data \u2026[truncated]")).toBe("data");
+  });
+
+  it("strips parenthesized truncation sentinels from final replies (#82121)", () => {
+    expect(sanitizeUserFacingText("Partial tool output...(truncated)...")).toBe(
+      "Partial tool output",
+    );
+    expect(sanitizeUserFacingText("line1\n...(truncated)...\nline2")).toBe("line1\n\nline2");
+  });
+
+  it("preserves prose and code that merely mentions truncation (#82121)", () => {
+    const prose = "The response was truncated for brevity.";
+    expect(sanitizeUserFacingText(prose)).toBe(prose);
+    const code = "Use `arr.slice(0, n)` to get a truncated copy.";
+    expect(sanitizeUserFacingText(code)).toBe(code);
+    const link = "See the [docs](https://example.com) for details.";
+    expect(sanitizeUserFacingText(link)).toBe(link);
+    const bracketProse = "Status: [draft truncated by user]";
+    expect(sanitizeUserFacingText(bracketProse)).toBe(bracketProse);
+  });
+
+  it("preserves truncation markers embedded in code, JSON, and inline spans (#82121)", () => {
+    const inlineCode = "The literal marker is `...(truncated)...`.";
+    expect(sanitizeUserFacingText(inlineCode)).toBe(inlineCode);
+    const codeString = 'const s = "...(truncated)...";';
+    expect(sanitizeUserFacingText(codeString)).toBe(codeString);
+    const json = '{"message":"[... 5000 more characters truncated]","source":"fixture"}';
+    expect(sanitizeUserFacingText(json)).toBe(json);
+    const comment = "// output: [... response truncated by SDK]";
+    expect(sanitizeUserFacingText(comment)).toBe(comment);
+    const crossLine = "The excerpt continues...\n[quote truncated by editor]";
+    expect(sanitizeUserFacingText(crossLine)).toBe(crossLine);
+  });
+
+  it("strips a sentinel with mixed unicode/ascii ellipsis without a remnant (#82121)", () => {
+    expect(sanitizeUserFacingText("...[truncated]\u2026")).toBe("");
+    expect(sanitizeUserFacingText("Done.\n[... 0 more characters truncated]")).toBe("Done.");
+  });
+
+  it("matches truncation sentinels case-insensitively (#82121)", () => {
+    expect(sanitizeUserFacingText("...[TRUNCATED]...")).toBe("");
+    expect(sanitizeUserFacingText("Out.\n[... 12 MORE CHARACTERS TRUNCATED]")).toBe("Out.");
+  });
+
+  it("leaves whitespace-heavy non-sentinel text unchanged (#82121)", () => {
+    const big = `${" ".repeat(20_000)}not a sentinel`;
+    expect(sanitizeUserFacingText(big)).toBe(big);
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -12,6 +12,7 @@ import {
   sanitizeUserFacingText,
   stripThoughtSignatures,
 } from "./embedded-agent-helpers.js";
+import { formatContextLimitTruncationNotice } from "./embedded-agent-runner/context-truncation-notice.js";
 import {
   formatAgentInternalEventsForPrompt,
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
@@ -57,6 +58,17 @@ describe("sanitizeUserFacingText", () => {
       sanitizeUserFacingText("Recent memory.\n...[additional startup memory truncated]..."),
     ).toBe("Recent memory.");
     expect(sanitizeUserFacingText("data \u2026[truncated]")).toBe("data");
+  });
+
+  it("strips the live context-limit notice with the rerun hint (#82121)", () => {
+    // The real producer output, not a hand-typed copy — catches format drift.
+    expect(sanitizeUserFacingText(formatContextLimitTruncationNotice(5000))).toBe("");
+    expect(
+      sanitizeUserFacingText(`Here is the result.\n${formatContextLimitTruncationNotice(1234)}`),
+    ).toBe("Here is the result.");
+    // A differently-phrased hint is not the internal sentinel and must survive.
+    const differentHint = "[... 7 more characters truncated; see the log for details]";
+    expect(sanitizeUserFacingText(differentHint)).toBe(differentHint);
   });
 
   it("strips parenthesized truncation sentinels from final replies (#82121)", () => {

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -99,6 +99,30 @@ const RATE_LIMIT_SPECIFIC_HINT_RE =
 const MODEL_CAPACITY_ERROR_RE = /\b(?:selected\s+)?model\s+(?:is\s+)?at capacity\b/i;
 const NON_ERROR_PROVIDER_PAYLOAD_MAX_LENGTH = 16_384;
 const NON_ERROR_PROVIDER_PAYLOAD_PREFIX_RE = /^codex\s*error(?:\s+\d{3})?[:\s-]+/i;
+// Exact internal truncation sentinels emitted by tool-result, transcript,
+// startup-memory, and context-truncation helpers. Each alternative is a precise
+// shape (not a loose "contains truncated" match), and matching is anchored to a
+// standalone line or the very end of the reply, so prose/code/JSON that merely
+// mentions truncation — or a differently-phrased bracket like "[quote truncated
+// by editor]" — is never touched. The ellipsis may be "..." or the U+2026 glyph.
+const TRUNCATION_SENTINEL_CORE = [
+  "(?:\\.{3}|\\u2026)\\(truncated\\)(?:\\.{3}|\\u2026)",
+  "(?:\\.{3}|\\u2026)\\[additional startup memory truncated\\](?:\\.{3}|\\u2026)",
+  "(?:\\.{3}|\\u2026)\\[truncated\\](?:\\.{3}|\\u2026)",
+  "\\u2026\\[truncated\\]",
+  "\\[(?:\\.{3}|\\u2026) \\d+ more characters truncated\\]",
+].join("|");
+// Sentinel occupying a whole line (standalone). The leading `[ \t]*` is anchored
+// at `^` (per line), so it stays linear.
+const TRUNCATION_SENTINEL_LINE_RE = new RegExp(
+  `^[ \\t]*(?:${TRUNCATION_SENTINEL_CORE})[ \\t]*$`,
+  "gim",
+);
+// Sentinel trailing at the very end of the reply. No leading `[ \t]*` here: an
+// unanchored leading whitespace star would let the engine rescan long whitespace
+// runs on non-matching input (O(n^2)); the final trim in stripTruncationSentinels
+// already removes any space left in front of a stripped trailing sentinel.
+const TRUNCATION_SENTINEL_TRAILING_RE = new RegExp(`(?:${TRUNCATION_SENTINEL_CORE})[ \\t]*$`, "i");
 
 function extractProviderRateLimitMessage(raw: string): string | undefined {
   const withoutPrefix = raw.replace(ERROR_PREFIX_RE, "").trim();
@@ -389,6 +413,19 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
   return result;
 }
 
+function stripTruncationSentinels(text: string): string {
+  const stripped = text
+    .replace(TRUNCATION_SENTINEL_LINE_RE, "")
+    .replace(TRUNCATION_SENTINEL_TRAILING_RE, "");
+  if (stripped === text) {
+    return text;
+  }
+  // Only reached when a sentinel was removed: collapse the blank run a removed
+  // standalone line leaves behind and trim the trailing remnant. Sentinel-free
+  // input is returned byte-for-byte via the early return above.
+  return stripped.replace(/\n{3,}/g, "\n\n").replace(/[ \t\r\n]+$/, "");
+}
+
 function collapseConsecutiveDuplicateBlocks(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -446,7 +483,9 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // Replay repair may synthesize this placeholder to keep provider transcripts valid.
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
-  const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutToolCallXml);
+  const withoutPlaceholder = stripTruncationSentinels(
+    stripToolCallsOmittedPlaceholderLines(withoutToolCallXml),
+  );
   const withoutInternalTraceLines = errorContext
     ? stripAssistantInternalTraceLines(withoutPlaceholder)
     : withoutPlaceholder;

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -110,7 +110,10 @@ const TRUNCATION_SENTINEL_CORE = [
   "(?:\\.{3}|\\u2026)\\[additional startup memory truncated\\](?:\\.{3}|\\u2026)",
   "(?:\\.{3}|\\u2026)\\[truncated\\](?:\\.{3}|\\u2026)",
   "\\u2026\\[truncated\\]",
-  "\\[(?:\\.{3}|\\u2026) \\d+ more characters truncated\\]",
+  // formatContextLimitTruncationNotice() emits the "; rerun with narrower args
+  // if needed" hint; older bare "[... N more characters truncated]" payloads
+  // can still be replayed from stored sessions, so the hint stays optional.
+  "\\[(?:\\.{3}|\\u2026) \\d+ more characters truncated(?:; rerun with narrower args if needed)?\\]",
 ].join("|");
 // Sentinel trailing at the very end of the reply. No leading `[ \t]*` here: an
 // unanchored leading whitespace star would let the engine rescan long whitespace

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -112,17 +112,13 @@ const TRUNCATION_SENTINEL_CORE = [
   "\\u2026\\[truncated\\]",
   "\\[(?:\\.{3}|\\u2026) \\d+ more characters truncated\\]",
 ].join("|");
-// Sentinel occupying a whole line (standalone). The leading `[ \t]*` is anchored
-// at `^` (per line), so it stays linear.
-const TRUNCATION_SENTINEL_LINE_RE = new RegExp(
-  `^[ \\t]*(?:${TRUNCATION_SENTINEL_CORE})[ \\t]*$`,
-  "gim",
-);
 // Sentinel trailing at the very end of the reply. No leading `[ \t]*` here: an
 // unanchored leading whitespace star would let the engine rescan long whitespace
 // runs on non-matching input (O(n^2)); the final trim in stripTruncationSentinels
 // already removes any space left in front of a stripped trailing sentinel.
 const TRUNCATION_SENTINEL_TRAILING_RE = new RegExp(`(?:${TRUNCATION_SENTINEL_CORE})[ \\t]*$`, "i");
+const TRUNCATION_SENTINEL_TRIMMED_LINE_RE = new RegExp(`^(?:${TRUNCATION_SENTINEL_CORE})$`, "i");
+const MARKDOWN_FENCE_LINE_RE = /^[ \t]*(?:```|~~~)/;
 
 function extractProviderRateLimitMessage(raw: string): string | undefined {
   const withoutPrefix = raw.replace(ERROR_PREFIX_RE, "").trim();
@@ -414,9 +410,31 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
 }
 
 function stripTruncationSentinels(text: string): string {
-  const stripped = text
-    .replace(TRUNCATION_SENTINEL_LINE_RE, "")
-    .replace(TRUNCATION_SENTINEL_TRAILING_RE, "");
+  let stripped = "";
+  let inMarkdownFence = false;
+  let start = 0;
+
+  while (start < text.length) {
+    const newlineIndex = text.indexOf("\n", start);
+    const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
+    const chunk = text.slice(start, end);
+    const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
+
+    if (MARKDOWN_FENCE_LINE_RE.test(line)) {
+      inMarkdownFence = !inMarkdownFence;
+      stripped += chunk;
+    } else if (!inMarkdownFence && TRUNCATION_SENTINEL_TRIMMED_LINE_RE.test(line.trim())) {
+      stripped += chunk.endsWith("\n") ? "\n" : "";
+    } else {
+      stripped += chunk;
+    }
+
+    start = end;
+  }
+
+  if (!inMarkdownFence) {
+    stripped = stripped.replace(TRUNCATION_SENTINEL_TRAILING_RE, "");
+  }
   if (stripped === text) {
     return text;
   }


### PR DESCRIPTION
## What Problem This Solves
Internal truncation sentinels such as `...(truncated)...`, `[... N more characters truncated]` (with or without the live `; rerun with narrower args if needed` hint), `...[truncated]...`, `...[additional startup memory truncated]...`, and `…[truncated]` could leak into final user-facing assistant replies. The central sanitizer already strips other internal artifacts, but it did not recognize truncation markers, so users could receive implementation-only truncation text as if it were part of the answer.

## Why This Change Was Made
The root cause is in `src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`: `sanitizeUserFacingText()` had no truncation-sentinel stripping step. Producers such as tool-result context guards, tool-transcript truncation, startup context truncation, post-compaction context truncation, and `formatContextLimitTruncationNotice()` can emit these markers; if any marker reaches final reply text, the sanitizer previously passed it through unchanged.

This follows the conservative direction from clawsweeper's review on #82121: "Add a focused final-text sanitizer rule for standalone or trailing truncation sentinel lines, with regression tests that preserve inline prose and code examples; producer-only changes would leave other sentinel sources uncovered."

Per clawsweeper's producer-coverage finding on this PR, the sentinel set now also matches the live context-limit notice emitted by `formatContextLimitTruncationNotice()` — `[... N more characters truncated; rerun with narrower args if needed]` — with the hint as an optional suffix so older bare payloads replayed from stored sessions are still stripped. The regression asserts against the real producer output (imports `formatContextLimitTruncationNotice`), so future format drift breaks the test instead of silently un-covering the notice.

## User Impact
Final assistant replies no longer expose OpenClaw's internal truncation markers, including the live context-limit notice with the rerun hint. The sanitizer only strips a fixed set of precise sentinel shapes when they occupy a standalone line or trail at the very end of the reply, so normal prose, code snippets, JSON values, and unrelated bracketed text (e.g. a differently-phrased `[... 7 more characters truncated; see the log for details]`) remain byte-for-byte unchanged.

## Changes
- `src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`: adds `stripTruncationSentinels()` to the sanitizer pipeline before error-context classification; sentinel set covers the live rerun-hint notice variant.
- `src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts`: regression coverage for standalone/trailing sentinels, the live rerun-hint notice (asserted against the real producer function), and preservation of inline prose/code/JSON and differently-phrased brackets.

## Evidence
All proof below is from current head `4a08d7178d`, rebased on `upstream/main` (`99b24e7416`), run on Node v24.4.0 (previous rounds ran on a below-floor Node; that caveat is gone).

Real module behavior — the actual `sanitizeUserFacingText()` fed the actual `formatContextLimitTruncationNotice()` output via `tsx`:

```text
node v24.4.0
RAW FINAL REPLY  : "Here is the summary you asked for.\n[... 5000 more characters truncated; rerun with narrower args if needed]"
SANITIZED OUTPUT : "Here is the summary you asked for."
```

Negative control — with the test present but the source fix reverted, the new regression fails on the unpatched tree, confirming it guards this exact gap:

```text
× strips the live context-limit notice with the rerun hint (#82121) 9ms
Tests  1 failed | 126 passed (127)
```

After fix:

```text
Test Files  1 passed (1)
Tests       127 passed (127)
```

- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts` — 127 passed
- `pnpm exec oxlint <changed files>` — clean
- `pnpm exec oxfmt --check --threads=1 <changed files>` — "All matched files use the correct format"
- `pnpm tsgo` — passed
- Not run: `pnpm check:changed` delegates to the Blacksmith Testbox remote sandbox, which contributor machines cannot dispatch; the local lanes above cover lint, format, types, and the changed test file.

AI-assisted (Claude Code); I have reviewed and understand every line.

Closes #82121
