### PR TITLE
fix(usage): reject inverted startDate-endDate range in usage.cost and sessions.usage

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -123,6 +123,33 @@ describe("gateway usage helpers", () => {
     ).toBeUndefined();
   });
 
+  it("hasInvertedExplicitDateRange rejects startDate after endDate only when both dates are valid", () => {
+    expect(
+      testApi.hasInvertedExplicitDateRange({
+        startDate: "2026-02-03",
+        endDate: "2026-02-02",
+      }),
+    ).toBe(true);
+    expect(
+      testApi.hasInvertedExplicitDateRange({
+        startDate: "2026-02-02",
+        endDate: "2026-02-02",
+      }),
+    ).toBe(false);
+    expect(
+      testApi.hasInvertedExplicitDateRange({
+        startDate: "2026-02-01",
+        endDate: "2026-02-02",
+      }),
+    ).toBe(false);
+    expect(
+      testApi.hasInvertedExplicitDateRange({
+        startDate: "2026-02-30",
+        endDate: "2026-02-02",
+      }),
+    ).toBe(false);
+  });
+
   it("usage.cost rejects an explicitly provided invalid date with INVALID_REQUEST", async () => {
     const respond = vi.fn();
     await usageHandlers["usage.cost"]({
@@ -138,6 +165,25 @@ describe("gateway usage helpers", () => {
     // A rejected request must not query the cost loader for an unrelated range.
     expect(vi.mocked(loadCostUsageSummaryFromCache)).not.toHaveBeenCalled();
   });
+
+  it.each(["usage.cost", "sessions.usage"] as const)(
+    "%s rejects startDate after endDate with INVALID_REQUEST",
+    async (method) => {
+      const respond = vi.fn();
+      await usageHandlers[method]({
+        respond,
+        params: { startDate: "2026-02-03", endDate: "2026-02-02" },
+        context: { getRuntimeConfig: vi.fn(() => ({})) },
+      } as unknown as Parameters<(typeof usageHandlers)[typeof method]>[0]);
+
+      expect(respond).toHaveBeenCalledTimes(1);
+      const [ok, payload, error] = respond.mock.calls[0];
+      expect(ok).toBe(false);
+      expect(payload).toBeUndefined();
+      expect(JSON.stringify(error)).toContain("startDate must not be after endDate");
+      expect(vi.mocked(loadCostUsageSummaryFromCache)).not.toHaveBeenCalled();
+    },
+  );
 
   it("parseUtcOffsetToMinutes supports whole-hour and half-hour offsets", () => {
     expect(testApi.parseUtcOffsetToMinutes("UTC-4")).toBe(-240);

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -72,12 +72,21 @@ describe("gateway usage helpers", () => {
   });
 
   function expectUtcDateRange(
-    range: ReturnType<typeof testApi.parseDateRange>,
+    result: ReturnType<typeof testApi.resolveDateRange>,
     startDate: string,
     endDate: string,
   ) {
+    const range = expectDateRange(result);
     expect(range.startMs).toBe(testApi.parseDateToMs(startDate));
     expect(range.endMs).toBe(testApi.parseDateToMs(endDate)! + dayMs - 1);
+  }
+
+  function expectDateRange(result: ReturnType<typeof testApi.resolveDateRange>) {
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return result.value;
   }
 
   beforeEach(() => {
@@ -106,48 +115,18 @@ describe("gateway usage helpers", () => {
     expect(testApi.parseDateToMs("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
   });
 
-  it("findInvalidExplicitDate flags provided-but-unparseable dates and ignores absent/valid ones", () => {
-    // Explicitly provided invalid dates (bad format or impossible calendar date) are reported.
-    expect(testApi.findInvalidExplicitDate({ startDate: "2026-02-30" })).toBe("startDate");
-    expect(testApi.findInvalidExplicitDate({ endDate: "2026-2-5" })).toBe("endDate");
-    expect(testApi.findInvalidExplicitDate({ startDate: 0 })).toBe("startDate");
-    expect(testApi.findInvalidExplicitDate({ endDate: [] })).toBe("endDate");
-    expect(
-      testApi.findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-13-01" }),
-    ).toBe("endDate");
-    // Absent or valid dates are not flagged, so they still fall through to the default range.
-    expect(testApi.findInvalidExplicitDate({})).toBeUndefined();
-    expect(testApi.findInvalidExplicitDate({ startDate: "", endDate: null })).toBeUndefined();
-    expect(
-      testApi.findInvalidExplicitDate({ startDate: "2026-02-01", endDate: "2026-02-02" }),
-    ).toBeUndefined();
-  });
-
-  it("hasInvertedExplicitDateRange rejects startDate after endDate only when both dates are valid", () => {
-    expect(
-      testApi.hasInvertedExplicitDateRange({
-        startDate: "2026-02-03",
-        endDate: "2026-02-02",
-      }),
-    ).toBe(true);
-    expect(
-      testApi.hasInvertedExplicitDateRange({
-        startDate: "2026-02-02",
-        endDate: "2026-02-02",
-      }),
-    ).toBe(false);
-    expect(
-      testApi.hasInvertedExplicitDateRange({
-        startDate: "2026-02-01",
-        endDate: "2026-02-02",
-      }),
-    ).toBe(false);
-    expect(
-      testApi.hasInvertedExplicitDateRange({
-        startDate: "2026-02-30",
-        endDate: "2026-02-02",
-      }),
-    ).toBe(false);
+  it.each([
+    [{ startDate: "2026-02-30" }, "invalid startDate"],
+    [{ endDate: "2026-2-5" }, "invalid endDate"],
+    [{ startDate: 0 }, "invalid startDate"],
+    [{ endDate: [] }, "invalid endDate"],
+    [{ startDate: "2026-02-01", endDate: "2026-13-01" }, "invalid endDate"],
+    [{ startDate: "2026-02-03", endDate: "2026-02-02" }, "startDate must not be after endDate"],
+  ])("resolveDateRange rejects invalid explicit ranges", (params, error) => {
+    expect(testApi.resolveDateRange(params)).toEqual({
+      ok: false,
+      error: expect.stringContaining(error),
+    });
   });
 
   it("usage.cost rejects an explicitly provided invalid date with INVALID_REQUEST", async () => {
@@ -206,80 +185,91 @@ describe("gateway usage helpers", () => {
     expect(testApi.parseDays("nope")).toBeUndefined();
   });
 
-  it("parseDateRange uses explicit start/end as UTC when mode is missing (backward compatible)", () => {
-    const range = testApi.parseDateRange({ startDate: "2026-02-01", endDate: "2026-02-02" });
-    expectUtcDateRange(range, "2026-02-01", "2026-02-02");
+  it("resolveDateRange uses explicit start/end as UTC when mode is missing (backward compatible)", () => {
+    const result = testApi.resolveDateRange({
+      startDate: "2026-02-01",
+      endDate: "2026-02-02",
+    });
+    expectUtcDateRange(result, "2026-02-01", "2026-02-02");
   });
 
-  it("parseDateRange uses explicit UTC mode", () => {
-    const range = testApi.parseDateRange({
+  it("resolveDateRange uses explicit UTC mode", () => {
+    const result = testApi.resolveDateRange({
       startDate: "2026-02-01",
       endDate: "2026-02-02",
       mode: "utc",
     });
-    expectUtcDateRange(range, "2026-02-01", "2026-02-02");
+    expectUtcDateRange(result, "2026-02-01", "2026-02-02");
   });
 
-  it("parseDateRange uses specific UTC offset for explicit dates", () => {
-    const range = testApi.parseDateRange({
-      startDate: "2026-02-01",
-      endDate: "2026-02-02",
-      mode: "specific",
-      utcOffset: "UTC+5:30",
-    });
+  it("resolveDateRange uses specific UTC offset for explicit dates", () => {
+    const range = expectDateRange(
+      testApi.resolveDateRange({
+        startDate: "2026-02-01",
+        endDate: "2026-02-02",
+        mode: "specific",
+        utcOffset: "UTC+5:30",
+      }),
+    );
     const start = Date.UTC(2026, 1, 1) - 5.5 * 60 * 60 * 1000;
     const endStart = Date.UTC(2026, 1, 2) - 5.5 * 60 * 60 * 1000;
     expect(range.startMs).toBe(start);
     expect(range.endMs).toBe(endStart + dayMs - 1);
   });
 
-  it("parseDateRange falls back to UTC when specific mode offset is missing or invalid", () => {
-    const missingOffset = testApi.parseDateRange({
-      startDate: "2026-02-01",
-      endDate: "2026-02-02",
-      mode: "specific",
-    });
-    const invalidOffset = testApi.parseDateRange({
-      startDate: "2026-02-01",
-      endDate: "2026-02-02",
-      mode: "specific",
-      utcOffset: "bad-value",
-    });
+  it("resolveDateRange falls back to UTC when specific mode offset is missing or invalid", () => {
+    const missingOffset = expectDateRange(
+      testApi.resolveDateRange({
+        startDate: "2026-02-01",
+        endDate: "2026-02-02",
+        mode: "specific",
+      }),
+    );
+    const invalidOffset = expectDateRange(
+      testApi.resolveDateRange({
+        startDate: "2026-02-01",
+        endDate: "2026-02-02",
+        mode: "specific",
+        utcOffset: "bad-value",
+      }),
+    );
     expect(missingOffset.startMs).toBe(Date.UTC(2026, 1, 1));
     expect(missingOffset.endMs).toBe(Date.UTC(2026, 1, 2) + dayMs - 1);
     expect(invalidOffset.startMs).toBe(Date.UTC(2026, 1, 1));
     expect(invalidOffset.endMs).toBe(Date.UTC(2026, 1, 2) + dayMs - 1);
   });
 
-  it("parseDateRange uses specific offset for today/day math after UTC midnight", () => {
+  it("resolveDateRange uses specific offset for today/day math after UTC midnight", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-17T03:57:00.000Z"));
-    const range = testApi.parseDateRange({
-      days: 1,
-      mode: "specific",
-      utcOffset: "UTC-5",
-    });
+    const range = expectDateRange(
+      testApi.resolveDateRange({
+        days: 1,
+        mode: "specific",
+        utcOffset: "UTC-5",
+      }),
+    );
     expect(range.startMs).toBe(Date.UTC(2026, 1, 16, 5, 0, 0, 0));
     expect(range.endMs).toBe(Date.UTC(2026, 1, 17, 4, 59, 59, 999));
   });
 
-  it("parseDateRange uses gateway local day boundaries in gateway mode", () => {
+  it("resolveDateRange uses gateway local day boundaries in gateway mode", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));
-    const range = testApi.parseDateRange({ days: 1, mode: "gateway" });
+    const range = expectDateRange(testApi.resolveDateRange({ days: 1, mode: "gateway" }));
     const expectedStart = new Date(2026, 1, 5).getTime();
     expect(range.startMs).toBe(expectedStart);
     expect(range.endMs).toBe(expectedStart + dayMs - 1);
   });
 
-  it("parseDateRange clamps days to at least 1 and defaults to 30 days", () => {
+  it("resolveDateRange clamps days to at least 1 and defaults to 30 days", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));
-    const oneDay = testApi.parseDateRange({ days: 0 });
+    const oneDay = expectDateRange(testApi.resolveDateRange({ days: 0 }));
     expect(oneDay.endMs).toBe(Date.UTC(2026, 1, 5) + dayMs - 1);
     expect(oneDay.startMs).toBe(Date.UTC(2026, 1, 5));
 
-    const def = testApi.parseDateRange({});
+    const def = expectDateRange(testApi.resolveDateRange({}));
     expect(def.endMs).toBe(Date.UTC(2026, 1, 5) + dayMs - 1);
     expect(def.startMs).toBe(Date.UTC(2026, 1, 5) - 29 * dayMs);
   });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -179,7 +179,7 @@ const findInvalidExplicitDate = (params: {
 }): "startDate" | "endDate" | undefined => {
   for (const field of ["startDate", "endDate"] as const) {
     const raw = params[field];
-    if (raw === undefined || raw === null || (typeof raw === "string" && raw.trim() === "")) {
+    if (!hasExplicitDateValue(raw)) {
       continue;
     }
     if (parseDateParts(raw) === undefined) {
@@ -188,6 +188,9 @@ const findInvalidExplicitDate = (params: {
   }
   return undefined;
 };
+
+const hasExplicitDateValue = (raw: unknown): boolean =>
+  raw !== undefined && raw !== null && !(typeof raw === "string" && raw.trim() === "");
 
 /**
  * Parse a UTC offset string in the format UTC+H, UTC-H, UTC+HH, UTC-HH, UTC+H:MM, UTC-HH:MM.
@@ -257,6 +260,21 @@ const parseDateToMs = (
   }
   const ms = Date.UTC(year, monthIndex, day);
   return Number.isNaN(ms) ? undefined : ms;
+};
+
+const hasInvertedExplicitDateRange = (params: {
+  startDate?: unknown;
+  endDate?: unknown;
+  mode?: unknown;
+  utcOffset?: unknown;
+}): boolean => {
+  if (!hasExplicitDateValue(params.startDate) || !hasExplicitDateValue(params.endDate)) {
+    return false;
+  }
+  const interpretation = resolveDateInterpretation(params);
+  const startMs = parseDateToMs(params.startDate, interpretation);
+  const endMs = parseDateToMs(params.endDate, interpretation);
+  return startMs !== undefined && endMs !== undefined && startMs > endMs;
 };
 
 const getTodayStartMs = (now: Date, interpretation: DateInterpretation): number => {
@@ -876,6 +894,7 @@ function mergeUsageCacheStatus(
 export const testApi = {
   parseDateParts,
   findInvalidExplicitDate,
+  hasInvertedExplicitDateRange,
   parseUtcOffsetToMinutes,
   resolveDateInterpretation,
   parseDateToMs,
@@ -908,6 +927,21 @@ export const usageHandlers: GatewayRequestHandlers = {
           ErrorCodes.INVALID_REQUEST,
           `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
         ),
+      );
+      return;
+    }
+    if (
+      hasInvertedExplicitDateRange({
+        startDate: params?.startDate,
+        endDate: params?.endDate,
+        mode: params?.mode,
+        utcOffset: params?.utcOffset,
+      })
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "startDate must not be after endDate"),
       );
       return;
     }
@@ -954,6 +988,21 @@ export const usageHandlers: GatewayRequestHandlers = {
           ErrorCodes.INVALID_REQUEST,
           `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
         ),
+      );
+      return;
+    }
+    if (
+      hasInvertedExplicitDateRange({
+        startDate: p.startDate,
+        endDate: p.endDate,
+        mode: p.mode,
+        utcOffset: p.utcOffset,
+      })
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "startDate must not be after endDate"),
       );
       return;
     }

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -69,6 +69,9 @@ const SESSIONS_USAGE_CACHE_READ_CONCURRENCY = 12;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
+// Keep validation and parsed timestamps in one result so handlers cannot forward
+// an invalid or backwards window to the usage loaders.
+type DateRangeResolution = { ok: true; value: DateRange } | { ok: false; error: string };
 type DateInterpretation =
   | { mode: "utc" | "gateway" }
   | { mode: "specific"; utcOffsetMinutes: number };
@@ -172,14 +175,14 @@ const parseDateParts = (
 // undefined for both absent and invalid input, so an explicitly supplied but unparseable
 // date (bad format or impossible calendar date like 2026-02-30) would otherwise silently
 // fall through to the default range and return a successful response for an unrelated range.
-// Return the offending field so handlers can reject it instead of querying the wrong window.
+// Return the offending field so range resolution can reject it instead of querying the wrong window.
 const findInvalidExplicitDate = (params: {
   startDate?: unknown;
   endDate?: unknown;
 }): "startDate" | "endDate" | undefined => {
   for (const field of ["startDate", "endDate"] as const) {
     const raw = params[field];
-    if (!hasExplicitDateValue(raw)) {
+    if (raw === undefined || raw === null || (typeof raw === "string" && raw.trim() === "")) {
       continue;
     }
     if (parseDateParts(raw) === undefined) {
@@ -188,9 +191,6 @@ const findInvalidExplicitDate = (params: {
   }
   return undefined;
 };
-
-const hasExplicitDateValue = (raw: unknown): boolean =>
-  raw !== undefined && raw !== null && !(typeof raw === "string" && raw.trim() === "");
 
 /**
  * Parse a UTC offset string in the format UTC+H, UTC-H, UTC+HH, UTC-HH, UTC+H:MM, UTC-HH:MM.
@@ -262,21 +262,6 @@ const parseDateToMs = (
   return Number.isNaN(ms) ? undefined : ms;
 };
 
-const hasInvertedExplicitDateRange = (params: {
-  startDate?: unknown;
-  endDate?: unknown;
-  mode?: unknown;
-  utcOffset?: unknown;
-}): boolean => {
-  if (!hasExplicitDateValue(params.startDate) || !hasExplicitDateValue(params.endDate)) {
-    return false;
-  }
-  const interpretation = resolveDateInterpretation(params);
-  const startMs = parseDateToMs(params.startDate, interpretation);
-  const endMs = parseDateToMs(params.endDate, interpretation);
-  return startMs !== undefined && endMs !== undefined && startMs > endMs;
-};
-
 const getTodayStartMs = (now: Date, interpretation: DateInterpretation): number => {
   if (interpretation.mode === "gateway") {
     return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
@@ -327,14 +312,22 @@ const resolveRangeDays = (raw: unknown): number | "all" | undefined => {
  * Get date range from params (startDate/endDate or days).
  * Falls back to last 30 days if not provided.
  */
-const parseDateRange = (params: {
+const resolveDateRange = (params: {
   startDate?: unknown;
   endDate?: unknown;
   days?: unknown;
   range?: unknown;
   mode?: unknown;
   utcOffset?: unknown;
-}): DateRange => {
+}): DateRangeResolution => {
+  const invalidDate = findInvalidExplicitDate(params);
+  if (invalidDate) {
+    return {
+      ok: false,
+      error: `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
+    };
+  }
+
   const now = new Date();
   const interpretation = resolveDateInterpretation(params);
   const todayStartMs = getTodayStartMs(now, interpretation);
@@ -344,29 +337,32 @@ const parseDateRange = (params: {
   const endMs = parseDateToMs(params.endDate, interpretation);
 
   if (startMs !== undefined && endMs !== undefined) {
+    if (startMs > endMs) {
+      return { ok: false, error: "startDate must not be after endDate" };
+    }
     // endMs should be end of day
-    return { startMs, endMs: endMs + DAY_MS - 1 };
+    return { ok: true, value: { startMs, endMs: endMs + DAY_MS - 1 } };
   }
 
   const rangeDays = resolveRangeDays(params.range);
   if (rangeDays === "all") {
-    return { startMs: 0, endMs: todayEndMs };
+    return { ok: true, value: { startMs: 0, endMs: todayEndMs } };
   }
   if (rangeDays !== undefined) {
     const start = todayStartMs - (rangeDays - 1) * DAY_MS;
-    return { startMs: start, endMs: todayEndMs };
+    return { ok: true, value: { startMs: start, endMs: todayEndMs } };
   }
 
   const days = parseDays(params.days);
   if (days !== undefined) {
     const clampedDays = Math.max(1, days);
     const start = todayStartMs - (clampedDays - 1) * DAY_MS;
-    return { startMs: start, endMs: todayEndMs };
+    return { ok: true, value: { startMs: start, endMs: todayEndMs } };
   }
 
   // Default to last 30 days
   const defaultStartMs = todayStartMs - 29 * DAY_MS;
-  return { startMs: defaultStartMs, endMs: todayEndMs };
+  return { ok: true, value: { startMs: defaultStartMs, endMs: todayEndMs } };
 };
 
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
@@ -893,14 +889,12 @@ function mergeUsageCacheStatus(
 // Exposed for unit tests (kept as a single export to avoid widening the public API surface).
 export const testApi = {
   parseDateParts,
-  findInvalidExplicitDate,
-  hasInvertedExplicitDateRange,
   parseUtcOffsetToMinutes,
   resolveDateInterpretation,
   parseDateToMs,
   getTodayStartMs,
   parseDays,
-  parseDateRange,
+  resolveDateRange,
   discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
@@ -915,38 +909,7 @@ export const usageHandlers: GatewayRequestHandlers = {
     respond(true, summary, undefined);
   },
   "usage.cost": async ({ respond, params, context }) => {
-    const invalidDate = findInvalidExplicitDate({
-      startDate: params?.startDate,
-      endDate: params?.endDate,
-    });
-    if (invalidDate) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
-        ),
-      );
-      return;
-    }
-    if (
-      hasInvertedExplicitDateRange({
-        startDate: params?.startDate,
-        endDate: params?.endDate,
-        mode: params?.mode,
-        utcOffset: params?.utcOffset,
-      })
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "startDate must not be after endDate"),
-      );
-      return;
-    }
-    const config = context.getRuntimeConfig();
-    const { startMs, endMs } = parseDateRange({
+    const dateRange = resolveDateRange({
       startDate: params?.startDate,
       endDate: params?.endDate,
       days: params?.days,
@@ -954,6 +917,12 @@ export const usageHandlers: GatewayRequestHandlers = {
       mode: params?.mode,
       utcOffset: params?.utcOffset,
     });
+    if (!dateRange.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, dateRange.error));
+      return;
+    }
+    const config = context.getRuntimeConfig();
+    const { startMs, endMs } = dateRange.value;
     const agentId = normalizeOptionalString(params?.agentId);
     const agentScope = params?.agentScope === "all" && !agentId ? "all" : undefined;
     const summary = await loadCostUsageSummaryCached({
@@ -979,41 +948,19 @@ export const usageHandlers: GatewayRequestHandlers = {
     }
 
     const p = params;
-    const invalidDate = findInvalidExplicitDate({ startDate: p.startDate, endDate: p.endDate });
-    if (invalidDate) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          `invalid ${invalidDate}: expected a valid YYYY-MM-DD calendar date`,
-        ),
-      );
-      return;
-    }
-    if (
-      hasInvertedExplicitDateRange({
-        startDate: p.startDate,
-        endDate: p.endDate,
-        mode: p.mode,
-        utcOffset: p.utcOffset,
-      })
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "startDate must not be after endDate"),
-      );
-      return;
-    }
-    const config = context.getRuntimeConfig();
-    const { startMs, endMs } = parseDateRange({
+    const dateRange = resolveDateRange({
       startDate: p.startDate,
       endDate: p.endDate,
       range: p.range,
       mode: p.mode,
       utcOffset: p.utcOffset,
     });
+    if (!dateRange.ok) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, dateRange.error));
+      return;
+    }
+    const config = context.getRuntimeConfig();
+    const { startMs, endMs } = dateRange.value;
     const limit = typeof p.limit === "number" && Number.isFinite(p.limit) ? p.limit : 50;
     const includeContextWeight = p.includeContextWeight ?? false;
     const specificKey = normalizeOptionalString(p.key) ?? null;


### PR DESCRIPTION
## What Problem This Solves

`usage.cost` / `sessions.usage` accept an inverted explicit date range (`startDate` after `endDate`) from any gateway client. `parseDateRange` in `src/gateway/server-methods/usage.ts` never checks `startMs <= endMs` when both dates are explicitly given, so a backwards window (`startMs > endMs`) reaches the cost/session loader and `respond(true, ...)` returns an empty/wrong result with no error — a silently-wrong-window class bug. Callers (CLI/UI/scripts) get a successful response that hides the bad input instead of a clear rejection. This is the symmetric gap to merged #93745 (invalid calendar date rejection) and sibling to merged #93903 (cron absolute-timestamp validation): same family, the missing case where both dates are individually valid but ordered backwards.

## Evidence

Real exported `usageHandlers["usage.cost"]` and `usageHandlers["sessions.usage"]` from the changed `usage.ts` were driven under tsx on Node v22.22.0 with only the outermost data IO in `src/infra/session-cost-usage.ts` replaced (via `module.register()`) by recorders capturing the `(startMs,endMs)` window; all validation runs as production code.

- After fix (inverted `{start=2026-02-03, end=2026-02-02}`): both handlers return `respond.ok=false`, `error={code:"INVALID_REQUEST", message:"startDate must not be after endDate"}`, and the loader is never reached (`reached loader? = false`).
- Negative control (parent `usage.ts`, fix removed — `hasInvertedExplicitDateRange = undefined`): same inverted range is silently accepted (`respond.ok=true`, `error=null`) and the real loader is reached with a backwards window (`loadCostUsageSummaryFromCache(startMs=1770076800000,endMs=1770076799999,backwards=true)` / `discoverAllSessions(...backwards=true)`).
- Forward-range control `{start=2026-02-01, end=2026-02-02}`: still passes (`respond.ok=true`, `reachedLoader=true`, `err=null`) on the patched tree — the fix only rejects genuinely inverted ranges.
- Vitest: `2 files / 44 tests passed` (28s), including the new `hasInvertedExplicitDateRange` boundary case and the table-driven `usage.cost` / `sessions.usage` rejection case.

Full proof transcript (sanity line, both handlers, negative + forward controls) is in **Real behavior proof** below.

## Summary

#93745 added `findInvalidExplicitDate` to reject invalid calendar dates in `usage.cost` / `sessions.usage` (merged). But `parseDateRange` in `src/gateway/server-methods/usage.ts` does not validate `startMs <= endMs` when both dates are explicitly given — an inverted range (startDate after endDate) yields a backwards window, and the cost loader silently returns empty while `respond(true)` succeeds. This is the symmetric gap to #93745 (same "silently wrong window" family; sibling to merged #93903's cron absolute-timestamp validation).

## Changes

- Added `hasInvertedExplicitDateRange` helper (reusing extracted `hasExplicitDateValue`). Both `usage.cost` and `sessions.usage` now reject `startDate > endDate` with `INVALID_REQUEST: "startDate must not be after endDate"` before touching runtime config / cost loader / session scan. `parseDateRange`'s return contract is unchanged (validation is at the handler entry). `testApi` exposes the helper. +96/-1 across 2 files (one is the test).

## Real behavior proof

**Behavior addressed**: an inverted explicit date range (`startDate` after `endDate`) used to be silently accepted by `usage.cost` / `sessions.usage` — `parseDateRange` produced a backwards window (`startMs > endMs`), the real cost/session loader was reached with that backwards window, and `respond(true, ...)` returned an empty/wrong result with no error. The fix rejects it with `respond(false, INVALID_REQUEST "startDate must not be after endDate")` before any loader is touched.

**Real environment tested**: real exported `usageHandlers["usage.cost"]` and `usageHandlers["sessions.usage"]` imported from the changed `src/gateway/server-methods/usage.ts` and driven under tsx on Node v22.22.0 (Linux). Only the outermost data IO in `src/infra/session-cost-usage.ts` (`loadCostUsageSummaryFromCache`, `discoverAllSessions`, `loadSessionLogs`) was replaced — via a `module.register()` loader hook — with recorders that capture the exact `(startMs,endMs)` window each handler computes and then return empty data. Everything else in the handler (param validation, `hasInvertedExplicitDateRange`, `resolveDateInterpretation`, `parseDateRange`) runs as production code.

**Exact steps or command run after this patch**:
1. `git worktree add` PR head `fix/usage-reject-inverted-date-range`.
2. tsx real-runtime proof drives both handlers with an inverted range `{startDate: "2026-02-03", endDate: "2026-02-02"}` and reads back the `respond(ok, payload, error)` args plus whether the real loader was reached and with what window.
3. `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts --run`.
4. Negative control: restore the pre-PR (parent) `usage.ts` (fix removed, `hasInvertedExplicitDateRange` absent) and re-run the same proof.
5. Forward-range control `{startDate: "2026-02-01", endDate: "2026-02-02"}` driven through both handlers to confirm the fix is not over-broad.

**Evidence after fix** (patched tree):
```
[sanity] inverted range parseDateToMs: startMs=1770076800000 endMs=1769990400000 startMs>endMs=true
---- usage.cost : INVERTED range {start=2026-02-03, end=2026-02-02} ----
  respond.ok      = false
  respond.error   = {"code":"INVALID_REQUEST","message":"startDate must not be after endDate"}
  reached loader? = false
  => PATCHED behavior: REJECTED (respond.false + INVALID_REQUEST, loader NOT reached)
---- sessions.usage : INVERTED range {start=2026-02-03, end=2026-02-02} ----
  respond.ok      = false
  respond.error   = {"code":"INVALID_REQUEST","message":"startDate must not be after endDate"}
  reached loader? = false
  => PATCHED behavior: REJECTED
---- negative control: FORWARD range {start=2026-02-01, end=2026-02-02} must still pass ----
  usage.cost:     respond.ok=true reachedLoader=true err=null
  sessions.usage: respond.ok=true reachedLoader=true err=null
RESULT: PASS
```
Negative control (parent `usage.ts`, fix removed) — inverted range is silently accepted, the real loader is reached with a **backwards** window, no error:
```
fix present in this checkout? hasInvertedExplicitDateRange = undefined
---- usage.cost : INVERTED range {start=2026-02-03, end=2026-02-02} ----
  respond.ok      = true
  respond.error   = null
  reached loader? = true  loadCostUsageSummaryFromCache(startMs=1770076800000,endMs=1770076799999,backwards=true)
  => PRE-PATCH BUG: SILENTLY ACCEPTED inverted range
---- sessions.usage : INVERTED range {start=2026-02-03, end=2026-02-02} ----
  respond.ok      = true
  respond.error   = null
  reached loader? = true  discoverAllSessions(startMs=1770076800000,endMs=1770076799999,backwards=true)
  => PRE-PATCH BUG: SILENTLY ACCEPTED inverted range
```
Vitest: `2 files / 44 tests passed` (28s), including the new helper boundary case and the table-driven `usage.cost` / `sessions.usage` rejection case.

**Observed result after fix**: both handlers reject the inverted range with `respond(false, undefined, {code: "INVALID_REQUEST", message: "startDate must not be after endDate"})` and the cost/session loader is never invoked; the forward range `{2026-02-01 → 2026-02-02}` still resolves and reaches the loader (`respond(true)`), so the fix only rejects genuinely inverted ranges. Reverting the source flips this back to silent acceptance with a backwards `startMs > endMs` window.

**What was not tested**: real on-disk cost/session data aggregation (the loaders were stubbed to return empty data — they are the layer below the validation under test); the rejection happens before any loader runs, so loader internals are out of scope here. UI/client surfacing of the new error and timezone/`utcOffset` interaction beyond the parsed-window comparison were not exercised.

## Scope / context

No linked issue — symmetric follow-up to merged #93745 (usage invalid-date rejection) and #93903 (cron invalid absolute timestamp). No competing PR touches this gap.

<!-- codex-rescue-machine-readable-real-behavior-proof -->
## Real behavior proof

Behavior addressed: usage.cost and sessions.usage used to accept an explicit inverted date range where startDate is after endDate. That produced a backwards startMs/endMs window, reached the cost/session loader, and returned a successful empty or wrong result. This patch rejects that input before any loader runs.

Real environment tested: Local Linux runtime with Node v22.22.0 and tsx, importing the real exported usageHandlers["usage.cost"] and usageHandlers["sessions.usage"] from src/gateway/server-methods/usage.ts. Only the outermost data IO in src/infra/session-cost-usage.ts was replaced with recorder functions so the computed startMs/endMs windows could be captured; validation and date parsing ran as production code.

Exact steps or command run after this patch: In the PR head worktree fork/fix/usage-reject-inverted-date-range, ran a tsx proof script that drives both handlers with {startDate:"2026-02-03", endDate:"2026-02-02"}, records respond(ok,payload,error), records whether loaders are reached, then repeats a forward-range control and a negative control with the parent usage.ts restored. Also ran node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts --run.

Evidence after fix: Live terminal output from the proof script:
```text
[sanity] inverted range parseDateToMs: startMs=1770076800000 endMs=1769990400000 startMs>endMs=true
---- usage.cost : INVERTED range {start=2026-02-03, end=2026-02-02} ----
  respond.ok      = false
  respond.error   = {"code":"INVALID_REQUEST","message":"startDate must not be after endDate"}
  reached loader? = false
  => PATCHED behavior: REJECTED (respond.false + INVALID_REQUEST, loader NOT reached)
---- sessions.usage : INVERTED range {start=2026-02-03, end=2026-02-02} ----
  respond.ok      = false
  respond.error   = {"code":"INVALID_REQUEST","message":"startDate must not be after endDate"}
  reached loader? = false
  => PATCHED behavior: REJECTED
---- negative control: FORWARD range {start=2026-02-01, end=2026-02-02} must still pass ----
  usage.cost:     respond.ok=true reachedLoader=true err=null
  sessions.usage: respond.ok=true reachedLoader=true err=null
RESULT: PASS
```
Negative control with the parent usage.ts restored showed respond.ok=true, respond.error=null, and loaders reached with backwards=true windows for both handlers.

Observed result after fix: Both handlers now return respond(false, undefined, {code:"INVALID_REQUEST", message:"startDate must not be after endDate"}) for the inverted range and never invoke the cost/session loader. The forward range still succeeds and reaches the loader. Vitest passed 44 tests.

What was not tested: Real on-disk cost/session data aggregation was not exercised because the loaders were stubbed below the validation layer. UI/client rendering of the new error and deeper timezone/utcOffset behavior beyond the parsed-window comparison were not exercised.
