### PR TITLE
fix(tools): surface hidden-tool diagnostics via onHiddenDiagnostic callback

### DIFF
--- a/src/tools/availability.test.ts
+++ b/src/tools/availability.test.ts
@@ -236,6 +236,30 @@ describe("evaluateToolAvailability", () => {
     ).toEqual(["auth-missing", "env-missing", "config-missing", "plugin-disabled"]);
   });
 
+  it("returns unsupported-signal for non-array allOf instead of crashing", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      // Use a runtime cast to bypass the TS type system and simulate a
+      // malformed JS object that would otherwise crash on .flatMap().
+      availability: { allOf: "not-array" } as unknown as ToolDescriptor["availability"],
+    };
+
+    expect(
+      evaluateToolAvailability({ descriptor }).map((entry) => entry.reason),
+    ).toEqual(["unsupported-signal"]);
+  });
+
+  it("returns unsupported-signal for non-array anyOf instead of crashing", () => {
+    const descriptor: ToolDescriptor = {
+      ...baseDescriptor,
+      availability: { anyOf: 42 } as unknown as ToolDescriptor["availability"],
+    };
+
+    expect(
+      evaluateToolAvailability({ descriptor }).map((entry) => entry.reason),
+    ).toEqual(["unsupported-signal"]);
+  });
+
   it("surfaces an unsupported-signal sibling even when another anyOf branch is available", () => {
     const descriptor: ToolDescriptor = {
       ...baseDescriptor,

--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -130,7 +130,8 @@ function evaluateExpression(
     return diagnosticLocal ? [diagnosticLocal] : [];
   }
   if ("allOf" in expression) {
-    if (expression.allOf.length === 0) {
+    // Defensive guard: non-array values that bypass the TS type system must not crash .flatMap().
+    if (!Array.isArray(expression.allOf) || expression.allOf.length === 0) {
       return [
         {
           reason: "unsupported-signal",
@@ -141,7 +142,8 @@ function evaluateExpression(
     return expression.allOf.flatMap((entry) => evaluateExpression(entry, context));
   }
   if ("anyOf" in expression) {
-    if (expression.anyOf.length === 0) {
+    // Defensive guard: non-array values that bypass the TS type system must not crash .map().
+    if (!Array.isArray(expression.anyOf) || expression.anyOf.length === 0) {
       return [
         {
           reason: "unsupported-signal",

--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -4,7 +4,7 @@ import { ToolPlanContractError } from "./diagnostics.js";
 import { formatToolExecutorRef } from "./execution.js";
 import { buildToolPlan } from "./planner.js";
 import { toToolProtocolDescriptors } from "./protocol.js";
-import type { ToolDescriptor } from "./types.js";
+import type { ToolAvailabilityDiagnostic, ToolDescriptor } from "./types.js";
 
 function descriptor(name: string, overrides: Partial<ToolDescriptor> = {}): ToolDescriptor {
   return {
@@ -111,6 +111,49 @@ describe("buildToolPlan", () => {
         message: "Empty availability allOf group",
       },
     ]);
+  });
+
+  it("calls onHiddenDiagnostic for each diagnostic that hides a tool", () => {
+    const hiddenCalls: Array<{
+      descriptor: ToolDescriptor;
+      diagnostic: ToolAvailabilityDiagnostic;
+    }> = [];
+
+    buildToolPlan({
+      descriptors: [
+        descriptor("visible_tool"),
+        descriptor("hidden_tool", {
+          availability: { allOf: [] },
+        }),
+        descriptor("hidden_env", {
+          availability: { kind: "env", name: "MISSING_ENV" },
+        }),
+      ],
+      availability: { env: {} },
+      onHiddenDiagnostic: ({ descriptor: desc, diagnostic }) => {
+        hiddenCalls.push({ descriptor: desc, diagnostic });
+      },
+    });
+
+    // visible_tool should NOT trigger a callback.
+    expect(hiddenCalls.filter((call) => call.descriptor.name === "visible_tool")).toEqual([]);
+
+    // hidden_tool has one unsupported-signal diagnostic.
+    const hiddenMalformed = hiddenCalls.filter(
+      (call) => call.descriptor.name === "hidden_tool",
+    );
+    expect(hiddenMalformed).toHaveLength(1);
+    expect(hiddenMalformed[0].diagnostic).toEqual({
+      reason: "unsupported-signal",
+      message: "Empty availability allOf group",
+    });
+
+    // hidden_env has one env-missing diagnostic.
+    const hiddenEnvCalls = hiddenCalls.filter(
+      (call) => call.descriptor.name === "hidden_env",
+    );
+    expect(hiddenEnvCalls).toHaveLength(1);
+    expect(hiddenEnvCalls[0].diagnostic.reason).toBe("env-missing");
   });
 
   it("keeps protocol conversion separate from executor refs and model normalization", () => {

--- a/src/tools/planner.ts
+++ b/src/tools/planner.ts
@@ -50,6 +50,11 @@ export function buildToolPlan(options: BuildToolPlanOptions): ToolPlan {
     ];
     if (diagnostics.length > 0) {
       hidden.push({ descriptor, diagnostics });
+      if (options.onHiddenDiagnostic) {
+        for (const diagnostic of diagnostics) {
+          options.onHiddenDiagnostic({ descriptor, diagnostic });
+        }
+      }
       continue;
     }
     if (!descriptor.executor) {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -115,4 +115,9 @@ export type ToolPlan = {
 export type BuildToolPlanOptions = {
   readonly descriptors: readonly ToolDescriptor[];
   readonly availability?: ToolAvailabilityContext;
+  /** Called for each diagnostic that causes a tool to be hidden. */
+  readonly onHiddenDiagnostic?: (params: {
+    readonly descriptor: ToolDescriptor;
+    readonly diagnostic: ToolAvailabilityDiagnostic;
+  }) => void;
 };


### PR DESCRIPTION
## Summary

The tool planner (`buildToolPlan`) silently hid descriptors with malformed availability expressions (empty `allOf`/`anyOf` groups), because it had no mechanism to surface `unsupported-signal` diagnostics to callers. Tools were hidden with detailed diagnostics but no observable signal reached the developer.

## Root Cause

In `evaluateExpression` (`availability.ts`), empty `allOf`/`anyOf` arrays correctly produce `unsupported-signal` diagnostics, but `buildToolPlan` consumes them silently — it pushes descriptors into the `hidden[]` array with no callback, logger, or event emitter to notify callers.

Additionally, `evaluateExpression` calls `.flatMap()` / `.map()` on `allOf`/`anyOf` values without checking they are actually arrays — allowing a crash path if non-array values bypass the TS type system.

## Fix

This adds an optional `onHiddenDiagnostic` callback to `BuildToolPlanOptions`. The planner invokes it for each diagnostic that hides a tool, giving callers a channel to observe authoring errors without coupling the planner to a specific logging mechanism.

It also adds defensive `Array.isArray` guards in `evaluateExpression` before `.flatMap()` / `.map()` calls to prevent crashes on malformed non-array `allOf`/`anyOf` values.

- `src/tools/types.ts`: add `onHiddenDiagnostic` callback to `BuildToolPlanOptions`
- `src/tools/planner.ts`: invoke `onHiddenDiagnostic` for each diagnostic that hides a tool
- `src/tools/availability.ts`: add `Array.isArray` guards on `allOf`/`anyOf` before `.flatMap`/`.map`
- `src/tools/planner.test.ts`: verify callback behavior across 3 descriptors (visible, malformed, env-missing)
- `src/tools/availability.test.ts`: verify crash prevention for non-array `allOf` and `anyOf`

## Alternative approaches considered

| Approach | Verdict |
|----------|---------|
| `console.warn` in `evaluateToolAvailability` (PR #92368, closed) | ❌ Violates purity contract of the evaluator |
| Full `resolvePluginTools` integration + recursive validation + SDK exports (PR #92411, open) | ❌ Too broad (530 lines / 10 files) — mixes crash prevention, production wiring, and SDK surface into one change |
| Bounded callback + defensive checks (this PR) | ✅ Keeps evaluator pure, adds observable surface at the planner boundary, prevents crash, minimal scope (82 lines / 5 files) |

## Verification

```console
$ node scripts/run-vitest.mjs run src/tools/planner.test.ts src/tools/availability.test.ts

 ✓  unit  src/tools/availability.test.ts (11 tests) 171ms
 ✓  unit  src/tools/planner.test.ts (7 tests) 29ms
 Test Files  2 passed (2)
      Tests  18 passed (18)

$ node scripts/run-vitest.mjs run src/tools/

 Test Files  3 passed (3)
      Tests  20 passed (20)
```

Standalone crash-prevention proof:

```console
$ node --import tsx --no-warnings -e "import { evaluateToolAvailability } from './src/tools/availability.js'; ..."
Empty anyOf diagnostic: [{"reason":"unsupported-signal","message":"Empty availability anyOf group"}]
Non-array allOf (no crash): [{"reason":"unsupported-signal","message":"Empty availability allOf group"}]
Non-array anyOf (no crash): [{"reason":"unsupported-signal","message":"Empty availability anyOf group"}]
```

## Real behavior proof

**Behavior addressed:** Empty `allOf`/`anyOf` arrays in tool availability descriptors produce `unsupported-signal` diagnostics that were silently consumed by `buildToolPlan`. The planner had no mechanism to surface authoring errors to callers, and `evaluateExpression` could crash on non-array `allOf`/`anyOf` values that bypassed the TS type system.

**Real environment tested:** Linux, Node.js v22.19.0, OpenClaw upstream/main (`0842cb71eb`), branch `fix/92361-tool-availability-hidden-diagnostic`.

**Exact steps or command run after this patch:**

```bash
cd /home/0668000615/10239986/github/openclaw-worktrees/fix-92361-tool-availability-hidden-diagnostic
node scripts/run-vitest.mjs run src/tools/planner.test.ts src/tools/availability.test.ts
```

**Evidence after fix:**

```console
 ✓  unit  src/tools/availability.test.ts (11 tests) 171ms
 ✓  unit  src/tools/planner.test.ts (7 tests) 29ms
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

The `onHiddenDiagnostic` callback test verifies:
- Visible tools do NOT trigger any callback
- Hidden tools with `unsupported-signal` diagnostics trigger one callback per diagnostic
- Hidden tools with `env-missing` diagnostics trigger one callback per diagnostic
- Multiple hidden tools each produce their own callbacks

Crash-prevention proof:

```console
$ node --import tsx --no-warnings -e "
import { evaluateToolAvailability } from './src/tools/availability.js';
const d = { name:'t',description:'t',inputSchema:{type:'object'},owner:{kind:'core'},executor:{kind:'core',executorId:'t'},availability:{allOf:'not-array'}} as any;
const r = evaluateToolAvailability({ descriptor: d });
console.log(JSON.stringify(r));
"
[{"reason":"unsupported-signal","message":"Empty availability allOf group"}]
```

No crash — returns a diagnostic instead of throwing `.flatMap is not a function`.

**Observed result after fix:** `buildToolPlan` now calls `onHiddenDiagnostic` for each diagnostic that hides a tool, giving callers a channel to observe authoring errors. `evaluateExpression` returns `unsupported-signal` diagnostics for non-array `allOf`/`anyOf` values instead of crashing with `.flatMap is not a function`. All 18 direct tests and 20 total tools-directory tests pass.

**What was not tested:** Live gateway startup with a production caller wiring the `onHiddenDiagnostic` callback, because `buildToolPlan` has no production callers on current `main`. The callback contract is verified through unit tests; production wiring is a separate integration task.

## What this does NOT change

- `evaluateToolAvailability` and `evaluateExpression` remain pure and side-effect free
- The `ToolPlan.hidden` array still contains diagnostics (backward compatible)
- This PR does NOT wire `buildToolPlan` into `resolvePluginTools` — production integration is a separate concern

Closes #92361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
