### PR TITLE
fix(tailscale): pre-clean stale serve entries on gateway startup

### DIFF
--- a/src/gateway/server-tailscale.test.ts
+++ b/src/gateway/server-tailscale.test.ts
@@ -1,5 +1,6 @@
 // Tailscale exposure tests cover serve/funnel enablement, preserve-funnel mode,
-// hostname discovery, cleanup handles, and warning paths.
+// hostname discovery, cleanup handles, warning paths, and pre-cleanup of stale
+// serve entries on startup.
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -39,6 +40,82 @@ afterEach(() => {
 });
 
 describe("startGatewayTailscaleExposure preserveFunnel", () => {
+  it("pre-cleans stale serve routes before enabling", async () => {
+    const logTailscale = createLogger();
+
+    await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      port: 18789,
+      logTailscale,
+    });
+
+    // disableTailscaleServe must be called before enableTailscaleServe
+    expect(mocks.disableTailscaleServe).toHaveBeenCalled();
+    expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789);
+    const disableOrder = mocks.disableTailscaleServe.mock.invocationCallOrder[0];
+    const enableOrder = mocks.enableTailscaleServe.mock.invocationCallOrder[0];
+    expect(disableOrder).toBeLessThan(enableOrder);
+  });
+
+  it("pre-cleanup failure does not block serve enable", async () => {
+    const logTailscale = createLogger();
+    mocks.disableTailscaleServe.mockRejectedValueOnce(new Error("tailscale not running"));
+
+    await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      port: 18789,
+      logTailscale,
+    });
+
+    expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789);
+    // No serve failure logged since cleanup is best-effort
+    expect(logTailscale.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("serve failed"),
+    );
+  });
+
+  it("pre-cleans using serviceName when configured", async () => {
+    const logTailscale = createLogger();
+
+    await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      port: 18789,
+      serviceName: "svc:openclaw",
+      logTailscale,
+    });
+
+    expect(mocks.disableTailscaleServe).toHaveBeenCalledWith(undefined, "svc:openclaw");
+    expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789, undefined, "svc:openclaw");
+  });
+
+  it("does not pre-clean in funnel mode", async () => {
+    const logTailscale = createLogger();
+
+    await startGatewayTailscaleExposure({
+      tailscaleMode: "funnel",
+      port: 18789,
+      logTailscale,
+    });
+
+    expect(mocks.disableTailscaleServe).not.toHaveBeenCalled();
+    expect(mocks.enableTailscaleFunnel).toHaveBeenCalledWith(18789);
+  });
+
+  it("does not pre-clean when preserveFunnel skips serve", async () => {
+    const logTailscale = createLogger();
+    mocks.hasTailscaleFunnelRouteForPort.mockResolvedValue(true);
+
+    await startGatewayTailscaleExposure({
+      tailscaleMode: "serve",
+      port: 18789,
+      preserveFunnel: true,
+      logTailscale,
+    });
+
+    expect(mocks.disableTailscaleServe).not.toHaveBeenCalled();
+    expect(mocks.enableTailscaleServe).not.toHaveBeenCalled();
+  });
+
   it("calls enableTailscaleServe in serve mode when preserveFunnel is unset", async () => {
     const logTailscale = createLogger();
 
@@ -48,6 +125,7 @@ describe("startGatewayTailscaleExposure preserveFunnel", () => {
       logTailscale,
     });
 
+    expect(mocks.disableTailscaleServe).toHaveBeenCalled();
     expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789);
     expect(mocks.hasTailscaleFunnelRouteForPort).not.toHaveBeenCalled();
   });
@@ -102,6 +180,7 @@ describe("startGatewayTailscaleExposure preserveFunnel", () => {
     });
 
     expect(mocks.hasTailscaleFunnelRouteForPort).toHaveBeenCalledWith(18789);
+    expect(mocks.disableTailscaleServe).toHaveBeenCalled();
     expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789);
   });
 
@@ -117,6 +196,7 @@ describe("startGatewayTailscaleExposure preserveFunnel", () => {
       logTailscale,
     });
 
+    expect(mocks.disableTailscaleServe).toHaveBeenCalledWith(undefined, "svc:openclaw");
     expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789, undefined, "svc:openclaw");
     expect(logTailscale.info).toHaveBeenCalledWith(
       "serve enabled for svc:openclaw: https://openclaw.tailnet.ts.net/ (WS via wss://openclaw.tailnet.ts.net)",
@@ -124,7 +204,8 @@ describe("startGatewayTailscaleExposure preserveFunnel", () => {
 
     await cleanup?.();
 
-    expect(mocks.disableTailscaleServe).toHaveBeenCalledWith(undefined, "svc:openclaw");
+    // Called twice: once for pre-cleanup, once for shutdown cleanup
+    expect(mocks.disableTailscaleServe).toHaveBeenCalledTimes(2);
   });
 
   it("does not use serviceName in funnel mode", async () => {
@@ -165,6 +246,7 @@ describe("startGatewayTailscaleExposure preserveFunnel", () => {
       logTailscale,
     });
 
+    expect(mocks.disableTailscaleServe).toHaveBeenCalledWith(undefined, "svc:openclaw");
     expect(mocks.enableTailscaleServe).toHaveBeenCalledWith(18789, undefined, "svc:openclaw");
     expect(logTailscale.info).toHaveBeenCalledWith("serve enabled");
   });

--- a/src/gateway/server-tailscale.ts
+++ b/src/gateway/server-tailscale.ts
@@ -44,8 +44,21 @@ export async function startGatewayTailscaleExposure(params: {
         }
       }
       if (serviceName) {
+        // Best-effort pre-clean: remove stale serve entries from prior
+        // runs so tailscale serve (which is append-only) does not
+        // accumulate duplicate entries across gateway restarts.
+        try {
+          await disableTailscaleServe(undefined, serviceName);
+        } catch {
+          // pre-cleanup failure is non-fatal; serve enable proceeds either way
+        }
         await enableTailscaleServe(params.port, undefined, serviceName);
       } else {
+        try {
+          await disableTailscaleServe();
+        } catch {
+          // pre-cleanup failure is non-fatal; serve enable proceeds either way
+        }
         await enableTailscaleServe(params.port);
       }
     } else {


### PR DESCRIPTION
## Summary

On each gateway restart, `tailscale serve --bg --yes <port>` appends new entries without removing old ones. The `--service=<name>` path is especially affected because service registrations are append-only in the Tailscale control plane. After a few restarts, `tailscale serve status` shows duplicate entries causing `ERR_SSL_PROTOCOL_ERROR` or `ERR_CONNECTION_REFUSED`.

This PR adds best-effort pre-cleanup in `startGatewayTailscaleExposure` that calls `disableTailscaleServe` before `enableTailscaleServe`, reusing the existing shutdown cleanup logic.

## Root Cause

Three structural defects in `src/gateway/server-tailscale.ts`:

1. **No startup pre-cleanup**: `startGatewayTailscaleExposure` unconditionally calls `enableTailscaleServe` without checking or cleaning existing routes. `tailscale serve --bg --yes` is append-only.
2. **`resetOnExit` defaults to `false`**: The only cleanup mechanism (shutdown `disableTailscaleServe`) is opt-in. Most users never enable it.
3. **serviceName path highest risk**: `--service=<name>` registrations are append-only in Tailscale's service registry, accumulating duplicates on every restart.

### Solution Comparison

| Approach | Mechanism | Reuse | Risk | Score |
|----------|-----------|-------|------|-------|
| **A: Orchestration-level cleanup** ✅ | Call `disableTailscaleServe` before `enableTailscaleServe` in `startGatewayTailscaleExposure` | High — reuses existing `disableTailscaleServe` | Very low | **8.6/10** |
| B: Low-level auto-reset | Auto-reset inside `enableTailscaleServe` | Medium — changes function semantics | High — affects all callers | 6.1/10 |
| C: Serve + Funnel parity | Same as A plus funnel pre-cleanup | Medium — speculative | Medium | 8.0/10 |

**Selected: Approach A** — correct abstraction level (orchestration layer does lifecycle management), minimal change (+13 lines), lowest regression risk, reuses existing code.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/gateway/server-tailscale.ts` | Pre-cleanup try/catch before `enableTailscaleServe` | +13 |
| `src/gateway/server-tailscale.test.ts` | 5 new tests + 4 updated assertions | +84/-2 |

### Behavior

- **serve without serviceName**: `tailscale serve reset` → `tailscale serve <port>`
- **serve with serviceName**: `tailscale serve clear <name>` → `tailscale serve --service=<name> <port>`
- **preserveFunnel**: Unaffected (early return before pre-cleanup)
- **funnel mode**: Unaffected (separate code path)
- **Pre-cleanup failure**: Non-blocking (try-catch best-effort)

## Real behavior proof

**Behavior addressed**: Duplicate Tailscale serve entries accumulate on gateway restart because `tailscale serve --bg --yes <port>` is append-only and no pre-cleanup runs before adding new entries.

**Real environment tested**: Linux x64 (worktree), Node 22, vitest v4.1.8.

**Exact steps or command run after this patch**:
```console
$ node scripts/run-vitest.mjs src/gateway/server-tailscale.test.ts
[test] starting test/vitest/vitest.gateway.config.ts

 RUN  v4.1.8

 Test Files  2 passed (2)
      Tests  28 passed (28)
   Start at  18:42:48
   Duration  2.76s

[test] passed 1 Vitest shard in 19.66s

$ node scripts/run-vitest.mjs src/gateway/server-tailscale.test.ts \
    src/gateway/server-startup-post-attach.test.ts \
    src/infra/tailscale.test.ts
 Test Files  5 passed (5)
      Tests  165 passed (165)
```

**Evidence after fix**: All 28 tests pass including 5 new tests that verify: (a) `disableTailscaleServe` is called before `enableTailscaleServe` in serve mode, (b) pre-cleanup failure does not block serve enable, (c) `serviceName` is passed through to pre-cleanup, (d) funnel mode does not trigger serve pre-cleanup, (e) `preserveFunnel` skip path does not trigger pre-cleanup. Broader suite of 165 tests across related files all pass with no regressions.

**Observed result after fix**: The `startGatewayTailscaleExposure` function now calls `disableTailscaleServe` (best-effort) before `enableTailscaleServe`, ensuring stale serve entries from prior runs are cleaned up before new ones are added. The `invocationCallOrder` test proves the correct ordering.

**What was not tested**: End-to-end `tailscale serve status` verification on a real Tailscale-connected machine was not performed — this requires a Tailscale account with a configured tailnet. The logic of the `tailscale serve reset` and `tailscale serve clear <name>` commands is upstream Tailscale CLI behavior, not OpenClaw logic.

## Risks

1. `serve reset` clears all serve routes when not using `serviceName` — consistent with existing `resetOnExit` behavior.
2. First-run reset on old Tailscale versions may fail — catch block prevents blocking.
3. Startup latency: `disableTailscaleServe` has a 15s timeout, but typically completes in <1s.

Fixes #93936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>