### PR TITLE
feat(agents): trace compaction summarization model calls

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -16,6 +16,12 @@ import {
   resolveSessionCompactionCheckpointReason,
   type CapturedCompactionCheckpointSnapshot,
 } from "../../gateway/session-compaction-checkpoints.js";
+import { resolveDiagnosticModelContentCapturePolicy } from "../../infra/diagnostic-llm-content.js";
+import {
+  createDiagnosticTraceContext,
+  freezeDiagnosticTraceContext,
+  getActiveDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
@@ -161,6 +167,7 @@ import { readAgentModelContextTokens } from "./model-context-tokens.js";
 import { resolveModelAsync } from "./model.js";
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
+import { wrapStreamFnWithDiagnosticModelCallEvents } from "./run/attempt.model-diagnostic-events.js";
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt.thread-helpers.js";
 import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
 import {
@@ -531,6 +538,16 @@ async function compactEmbeddedAgentSessionDirectOnce(
   const attempt = params.attempt ?? 1;
   const maxAttempts = params.maxAttempts ?? 1;
   const runId = params.runId ?? params.sessionId;
+  // Parent compaction model-call spans to the active run/harness trace when one
+  // exists, otherwise start a fresh root. Compaction emits no intermediate span
+  // of its own (unlike the run lifecycle, which backs its run trace with a
+  // run.started span), so a child trace here would orphan the model call under a
+  // phantom parent. The :compaction: runId/callId already distinguishes the span.
+  const compactionModelCallTrace = freezeDiagnosticTraceContext(
+    getActiveDiagnosticTraceContext() ?? createDiagnosticTraceContext(),
+  );
+  const diagnosticCompactionRunId = `${runId}:compaction:${diagId}`;
+  let diagnosticModelCallSeq = 0;
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   ensureRuntimePluginsLoaded({
     config: params.config,
@@ -1305,6 +1322,23 @@ async function compactEmbeddedAgentSessionDirectOnce(
             senderUsername: params.senderUsername,
             senderE164: params.senderE164,
           });
+          session.agent.streamFn = wrapStreamFnWithDiagnosticModelCallEvents(
+            session.agent.streamFn,
+            {
+              runId: diagnosticCompactionRunId,
+              ...(params.sessionKey && { sessionKey: params.sessionKey }),
+              sessionId: params.sessionId,
+              provider,
+              model: modelId,
+              api: effectiveModel.api,
+              transport: session.agent.transport,
+              contextTokenBudget,
+              trace: compactionModelCallTrace,
+              contentCapture: resolveDiagnosticModelContentCapturePolicy(params.config),
+              nextCallId: () =>
+                `${diagnosticCompactionRunId}:model:${(diagnosticModelCallSeq += 1)}`,
+            },
+          );
 
           const prior = await sanitizeSessionHistory({
             messages: session.messages,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -520,6 +520,135 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(events[1]?.privateData.modelContent?.outputMessages).toEqual([assistant]);
   });
 
+  it("captures output and completes when callers only await stream.result()", async () => {
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "compaction summary" }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.4",
+      usage: { input: 11, output: 7, cacheRead: 0, cacheWrite: 0, totalTokens: 18 },
+      stopReason: "stop",
+      timestamp: 1,
+    };
+    const originalStream = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            throw new Error("result-only callers should not need stream iteration");
+          },
+        };
+      },
+      result: vi.fn(async () => assistant),
+    };
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => originalStream) as unknown as StreamFn,
+      {
+        runId: "run-compact",
+        sessionKey: "session-key",
+        sessionId: "session-id",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        contentCapture: {
+          inputMessages: true,
+          outputMessages: true,
+          toolInputs: false,
+          toolOutputs: false,
+          systemPrompt: true,
+          toolDefinitions: true,
+          anyModelContent: true,
+        },
+        nextCallId: () => "call-result-only",
+      },
+    );
+
+    const inputMessages = [{ role: "user", content: "summarize this transcript", timestamp: 1 }];
+    const events = await collectTrustedModelCallEvents(async () => {
+      const streamResult = wrapped(
+        {} as never,
+        {
+          systemPrompt: "summarize accurately",
+          messages: inputMessages,
+        } as never,
+        {},
+      ) as unknown as typeof originalStream;
+      expect(await streamResult.result()).toBe(assistant);
+    });
+
+    expect(originalStream.result).toHaveBeenCalledOnce();
+    expect(events.map(({ event }) => event.type)).toEqual([
+      "model.call.started",
+      "model.call.completed",
+    ]);
+    const completedEvent = getEvent(
+      events.map((entry) => entry.event),
+      1,
+    );
+    expect(completedEvent.type).toBe("model.call.completed");
+    expect(completedEvent.callId).toBe("call-result-only");
+    expect(completedEvent.responseStreamBytes).toBe(
+      Buffer.byteLength(JSON.stringify(assistant), "utf8"),
+    );
+    expect(events[1]?.privateData.modelContent?.inputMessages).toEqual(inputMessages);
+    expect(events[1]?.privateData.modelContent?.systemPrompt).toBe("summarize accurately");
+    expect(events[1]?.privateData.modelContent?.outputMessages).toEqual([assistant]);
+  });
+
+  it("closes the underlying iterator when result() completes before the consumer abandons it", async () => {
+    // Mirrors packages/agent-core/src/agent-loop.ts: iterate, await result() on
+    // the terminal event, then return (abandoning the iterator). The iterator's
+    // return() carries provider cleanup (idle-timeout abort listeners, readers),
+    // so it must still run even though result() emits the terminal event first.
+    let returnCalled = false;
+    const doneEvent = { type: "done", message: { role: "assistant", content: "ok" } };
+    const stream = {
+      [Symbol.asyncIterator]() {
+        let emitted = false;
+        return {
+          async next() {
+            if (!emitted) {
+              emitted = true;
+              return { value: doneEvent, done: false };
+            }
+            return { value: undefined, done: true };
+          },
+          async return() {
+            returnCalled = true;
+            return { value: undefined, done: true };
+          },
+        };
+      },
+      result: async () => doneEvent.message,
+    };
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream) as unknown as StreamFn,
+      {
+        runId: "run-cleanup",
+        provider: "openai",
+        model: "gpt-5.4",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-cleanup",
+      },
+    );
+
+    const events = await collectModelCallEvents(async () => {
+      const response = wrapped({} as never, {} as never, {} as never) as unknown as typeof stream;
+      for await (const event of response as AsyncIterable<{ type: string }>) {
+        if (event.type === "done") {
+          await (response as { result: () => Promise<unknown> }).result();
+          break;
+        }
+      }
+    });
+
+    expect(returnCalled).toBe(true);
+    expect(events.map((event) => event.type)).toEqual([
+      "model.call.started",
+      "model.call.completed",
+    ]);
+  });
+
   it("propagates the trusted model-call traceparent without mutating caller headers", async () => {
     async function* stream() {
       yield { type: "text", text: "ok" };

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -85,6 +85,7 @@ type ModelCallObservationState = {
   outputMessages?: unknown[];
   contentCapture?: DiagnosticModelContentCapturePolicy;
   lastStreamProgressAt?: number;
+  terminalEventEmitted?: boolean;
 };
 
 const MODEL_CALL_STREAM_PROGRESS_INTERVAL_MS = 30_000;
@@ -181,6 +182,23 @@ function observeOutputMessageContent(state: ModelCallObservationState, chunk: un
     chunk.type === "done" ? chunk.message : chunk.type === "error" ? chunk.error : undefined;
   if (message !== undefined) {
     state.outputMessages = [cloneDiagnosticContentValue(message)];
+  }
+}
+
+function observeResultMessageContent(
+  state: ModelCallObservationState,
+  startedAt: number,
+  result: unknown,
+): void {
+  state.timeToFirstByteMs ??= Math.max(0, Date.now() - startedAt);
+  if (state.contentCapture?.outputMessages && state.outputMessages === undefined) {
+    state.outputMessages = [cloneDiagnosticContentValue(result)];
+  }
+  if (state.responseStreamBytes === 0) {
+    const bytes = utf8JsonByteLength(result);
+    if (bytes !== undefined) {
+      state.responseStreamBytes = bytes;
+    }
   }
 }
 
@@ -419,6 +437,10 @@ function emitModelCallCompleted(
   startedAt: number,
   state: ModelCallObservationState,
 ): void {
+  if (state.terminalEventEmitted) {
+    return;
+  }
+  state.terminalEventEmitted = true;
   const durationMs = Date.now() - startedAt;
   const sizeTimingFields = modelCallSizeTimingFields(state);
   emitTrustedDiagnosticEventWithPrivateData(
@@ -443,6 +465,10 @@ function emitModelCallError(
   state: ModelCallObservationState,
   fields: ModelCallErrorFields,
 ): void {
+  if (state.terminalEventEmitted) {
+    return;
+  }
+  state.terminalEventEmitted = true;
   const durationMs = Date.now() - startedAt;
   const sizeTimingFields = modelCallSizeTimingFields(state);
   emitTrustedDiagnosticEventWithPrivateData(
@@ -548,31 +574,78 @@ async function* observeModelCallIterator<T>(
   startedAt: number,
   state: ModelCallObservationState,
 ): AsyncIterable<T> {
-  let terminalEmitted = false;
+  // Tracks whether the underlying iterator terminated on its own (done or threw).
+  // This is independent of state.terminalEventEmitted: result() can emit the
+  // terminal event first, but the abandoned iterator still needs return() cleanup.
+  let iteratorSettled = false;
   try {
     for (;;) {
       const next = await iterator.next();
       if (next.done) {
+        iteratorSettled = true;
         break;
       }
       observeResponseChunk(state, startedAt, next.value);
       maybeEmitModelCallStreamProgress(eventBase, state);
       yield next.value;
     }
-    terminalEmitted = true;
     emitModelCallCompleted(eventBase, startedAt, state);
   } catch (err) {
-    terminalEmitted = true;
+    iteratorSettled = true;
     emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
     throw err;
   } finally {
-    if (!terminalEmitted) {
-      // A consumer can stop reading before the provider emits done/error. Close
-      // the iterator best-effort and record the call as completed with observed bytes.
+    if (!iteratorSettled) {
+      // A consumer can stop reading before the provider emits done/error — e.g.
+      // the agent loop returns on the terminal event after awaiting result().
+      // Close the underlying iterator for provider cleanup (idle-timeout abort
+      // listeners, SSE readers) even when result() already emitted the terminal
+      // event; emitModelCallCompleted self-dedupes via state.terminalEventEmitted.
       await safeReturnIterator(iterator);
       emitModelCallCompleted(eventBase, startedAt, state);
     }
   }
+}
+
+function observeModelCallFinalResult<T>(
+  result: T,
+  eventBase: ModelCallEventBase,
+  startedAt: number,
+  state: ModelCallObservationState,
+): T {
+  observeResultMessageContent(state, startedAt, result);
+  emitModelCallCompleted(eventBase, startedAt, state);
+  return result;
+}
+
+function createObservedResultFunction(
+  stream: unknown,
+  eventBase: ModelCallEventBase,
+  startedAt: number,
+  state: ModelCallObservationState,
+): ((...args: unknown[]) => unknown) | undefined {
+  if (!isRecord(stream) || typeof stream.result !== "function") {
+    return undefined;
+  }
+  const resultFn = stream.result;
+  return (...args: unknown[]) => {
+    try {
+      const result = resultFn.apply(stream, args);
+      if (isPromiseLike(result)) {
+        return result.then(
+          (resolved) => observeModelCallFinalResult(resolved, eventBase, startedAt, state),
+          (err: unknown) => {
+            emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+            throw err;
+          },
+        );
+      }
+      return observeModelCallFinalResult(result, eventBase, startedAt, state);
+    } catch (err) {
+      emitModelCallError(eventBase, startedAt, state, modelCallErrorFields(err));
+      throw err;
+    }
+  };
 }
 
 function observeModelCallStream<T extends AsyncIterable<unknown>>(
@@ -584,6 +657,7 @@ function observeModelCallStream<T extends AsyncIterable<unknown>>(
 ): T {
   const observedIterator = () =>
     observeModelCallIterator(createIterator(), eventBase, startedAt, state)[Symbol.asyncIterator]();
+  const observedResult = createObservedResultFunction(stream, eventBase, startedAt, state);
   let hasNonConfigurableIterator;
   try {
     hasNonConfigurableIterator =
@@ -594,12 +668,16 @@ function observeModelCallStream<T extends AsyncIterable<unknown>>(
   if (hasNonConfigurableIterator) {
     return {
       [Symbol.asyncIterator]: observedIterator,
+      ...(observedResult ? { result: observedResult } : {}),
     } as T;
   }
   return new Proxy(stream, {
     get(target, property, receiver) {
       if (property === Symbol.asyncIterator) {
         return observedIterator;
+      }
+      if (property === "result" && observedResult) {
+        return observedResult;
       }
       const value = Reflect.get(target, property, receiver);
       return typeof value === "function" ? value.bind(target) : value;


### PR DESCRIPTION
## Summary

Compaction summarization consumes the model stream via `result()` only (no iteration — see [`compaction.ts`](packages/agent-core/src/harness/compaction/compaction.ts) and [`branch-summarization.ts`](packages/agent-core/src/harness/compaction/branch-summarization.ts)), so it never emitted `model.call.*` diagnostic spans. As a result, compaction LLM calls were invisible to OTEL/Phoenix tracing.

This PR:

1. **Observes `stream.result()`** in the diagnostic stream wrapper ([`attempt.model-diagnostic-events.ts`](src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts)) — previously only the async iterator was observed. `result()`-only consumers now get `model.call.started` / `model.call.completed` with request/response content, byte accounting, TTFB, and traceparent propagation.
2. **Wires the wrapper into the direct compaction path** ([`compact.ts`](src/agents/embedded-agent-runner/compact.ts)) on the freshly-created compaction session, so summarization calls are traced under a `…:compaction:…` runId/callId.

The other two changes below were folded in after an adversarial review of the initial tracing patch caught two correctness/quality issues.

### Fix 1 — iterator cleanup must not be gated on terminal-event dedup

Making `result()` a terminal-event emitter changed the **normal** agent-loop path too (the wrapper is applied unconditionally in [`attempt.ts`](src/agents/embedded-agent-runner/run/attempt.ts), independent of whether diagnostics are enabled). The agent loop awaits `response.result()` on the `done`/`error` event, then `return`s — abandoning the iterator ([`agent-loop.ts`](packages/agent-core/src/agent-loop.ts)). Once `result()` set `terminalEventEmitted`, the iterator's `finally` skipped `safeReturnIterator`, so the underlying iterator's `return()` was never called — leaking the idle-timeout wrapper's `abort` listener on the **long-lived run signal** (re-added every model call) and skipping provider reader/abort cleanup.

Fixed by tracking iterator settlement (`iteratorSettled`) separately from event dedup: `safeReturnIterator` runs whenever the consumer abandons the iterator, while `emitModelCallCompleted` self-dedupes via `terminalEventEmitted`.

### Fix 2 — compaction model-call span no longer orphaned

The first patch created `diagnosticTrace → compactionTrace` but emitted **no** span at that level (unlike the run lifecycle, which backs `runTrace` with a `run.started` event in [`lifecycle.ts`](src/agents/harness/lifecycle.ts)), so the compaction model-call span pointed at a phantom parent. There is no `compaction.*` diagnostic event type, so the model call now parents to the **active run/harness trace** (a real span) when one exists, or a fresh root otherwise. Also drops the redundant intermediate trace variable.

## Behavior

- **Before:** compaction summarization produced no `model.call` spans; normal model calls cleaned up the underlying iterator on completion.
- **After:** compaction summarization emits full `model.call` spans; normal model calls still clean up the underlying iterator (cleanup decoupled from the new `result()` terminal emission); compaction spans nest under the active run trace instead of a phantom parent.

> Note: the local OTEL/Phoenix enablement (sample rate, endpoint, content capture) lives in `~/.openclaw/openclaw.json` and is **not** part of this PR — this is the runtime tracing path only.

## Verification

Local (normal checkout, branch based on latest `origin/main`):

- `node scripts/run-vitest.mjs …/run/attempt.model-diagnostic-events.test.ts` → **15 passed** (13 existing + 2 new: result()-only capture, and abandon-after-`result()` cleanup).
- `node scripts/run-vitest.mjs …/compact.hooks.test.ts` → **69 passed**.
- `node scripts/run-vitest.mjs …/manual-compaction-boundary.test.ts …/compact-reasons.test.ts` → **11 + 5 passed**.
- `pnpm tsgo:core` and `pnpm tsgo:test:src` → clean.
- `oxlint` + `oxfmt --check` on the 3 files → clean.

The new regression test for Fix 1 was confirmed to **fail** against the pre-fix `!state.terminalEventEmitted` gate and **pass** with the `!iteratorSettled` decoupling.

### Proof gaps

- No live OTEL→Phoenix end-to-end assertion in CI (covered manually); the tracing fields themselves are asserted via the trusted diagnostic event tests.
- Broad/changed-lane and full-suite gates left to CI.
