### PR TITLE
fix(secrets): scope env scrub to migrated providers' vars

### DIFF
--- a/src/secrets/apply.envscrub-collision.repro.test.ts
+++ b/src/secrets/apply.envscrub-collision.repro.test.ts
@@ -421,6 +421,62 @@ describe("secrets apply env scrub value collision", () => {
     expect(nextEnv).not.toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
   });
 
+  it("scrubs the provider .env line when a talk provider apiKey is migrated to a non-env ref", async () => {
+    const secretFilePath = path.join(rootDir, "talk-openai.key");
+    await fs.writeFile(secretFilePath, SHARED_KEY, "utf8");
+
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          secrets: {
+            providers: {
+              mounted: {
+                source: "file",
+                path: secretFilePath,
+                mode: "singleValue",
+                allowInsecurePath: true,
+              },
+            },
+          },
+          talk: { providers: { openai: { apiKey: SHARED_KEY } } },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    await fs.writeFile(envPath, `OPENAI_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`, "utf8");
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "talk.providers.*.apiKey",
+          path: "talk.providers.openai.apiKey",
+          providerId: "openai",
+          ref: { source: "file", provider: "mounted", id: "value" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+  });
+
   it("does NOT delete OPENAI_API_KEY when a no-op already-ref openai target shares a value with a migrated plugin target", async () => {
     await fs.writeFile(
       configPath,

--- a/src/secrets/apply.envscrub-collision.repro.test.ts
+++ b/src/secrets/apply.envscrub-collision.repro.test.ts
@@ -21,6 +21,7 @@ vi.mock("./runtime.js", () => ({
 let runSecretsApply: typeof import("./apply.js").runSecretsApply;
 
 const SHARED_KEY = "sk-shared-proxy-key"; // pragma: allowlist secret
+const PROVIDER_AUTH_KEY = "sk-provider-auth-key"; // pragma: allowlist secret
 
 describe("secrets apply env scrub value collision", () => {
   let rootDir: string;
@@ -478,5 +479,67 @@ describe("secrets apply env scrub value collision", () => {
     expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
     expect(nextEnv).toContain("UNRELATED=value");
     expect(nextEnv).not.toContain(`FIRECRAWL_API_KEY=${SHARED_KEY}`);
+  });
+
+  it("does NOT delete OPENAI_API_KEY when provider auth and a same-provider header are migrated together", async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          models: {
+            providers: {
+              openai: {
+                apiKey: PROVIDER_AUTH_KEY,
+                headers: { "x-shared-header": SHARED_KEY },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      envPath,
+      `OPENAI_API_KEY=${SHARED_KEY}\nOPENAI_AUTH_KEY=${PROVIDER_AUTH_KEY}\nUNRELATED=value\n`,
+      "utf8",
+    );
+    env.OPENAI_AUTH_KEY = PROVIDER_AUTH_KEY;
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "models.providers.apiKey",
+          path: "models.providers.openai.apiKey",
+          providerId: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_AUTH_KEY" },
+        },
+        {
+          type: "models.providers.headers",
+          path: "models.providers.openai.headers.x-shared-header",
+          pathSegments: ["models", "providers", "openai", "headers", "x-shared-header"],
+          providerId: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+    expect(nextEnv).toContain(`OPENAI_AUTH_KEY=${PROVIDER_AUTH_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
   });
 });

--- a/src/secrets/apply.envscrub-collision.repro.test.ts
+++ b/src/secrets/apply.envscrub-collision.repro.test.ts
@@ -477,6 +477,67 @@ describe("secrets apply env scrub value collision", () => {
     expect(nextEnv).not.toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
   });
 
+  it("scrubs a non-provider plugin apiKey env line when it is migrated to a non-env (file) ref", async () => {
+    const secretFilePath = path.join(rootDir, "firecrawl.key");
+    await fs.writeFile(secretFilePath, SHARED_KEY, "utf8");
+
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          secrets: {
+            providers: {
+              mounted: {
+                source: "file",
+                path: secretFilePath,
+                mode: "singleValue",
+                allowInsecurePath: true,
+              },
+            },
+          },
+          tools: { web: { fetch: { firecrawl: { apiKey: SHARED_KEY } } } },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    await fs.writeFile(
+      envPath,
+      `FIRECRAWL_API_KEY=${SHARED_KEY}\nOPENAI_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`,
+      "utf8",
+    );
+    env.FIRECRAWL_API_KEY = SHARED_KEY;
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "tools.web.fetch.firecrawl.apiKey",
+          path: "tools.web.fetch.firecrawl.apiKey",
+          ref: { source: "file", provider: "mounted", id: "value" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`FIRECRAWL_API_KEY=${SHARED_KEY}`);
+  });
+
   it("does NOT delete OPENAI_API_KEY when a no-op already-ref openai target shares a value with a migrated plugin target", async () => {
     await fs.writeFile(
       configPath,

--- a/src/secrets/apply.envscrub-collision.repro.test.ts
+++ b/src/secrets/apply.envscrub-collision.repro.test.ts
@@ -1,0 +1,482 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
+import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import type { SecretsApplyPlan } from "./plan.js";
+
+const { clearSecretsRuntimeSnapshotMock, prepareSecretsRuntimeSnapshotMock } = vi.hoisted(() => ({
+  clearSecretsRuntimeSnapshotMock: vi.fn(),
+  prepareSecretsRuntimeSnapshotMock: vi.fn(async () => undefined),
+}));
+
+vi.mock("./runtime.js", () => ({
+  clearSecretsRuntimeSnapshot: clearSecretsRuntimeSnapshotMock,
+  prepareSecretsRuntimeSnapshot: prepareSecretsRuntimeSnapshotMock,
+}));
+
+let runSecretsApply: typeof import("./apply.js").runSecretsApply;
+
+const SHARED_KEY = "sk-shared-proxy-key"; // pragma: allowlist secret
+
+describe("secrets apply env scrub value collision", () => {
+  let rootDir: string;
+  let stateDir: string;
+  let configPath: string;
+  let envPath: string;
+  let agentDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    ({ runSecretsApply } = await import("./apply.js"));
+  });
+
+  beforeEach(async () => {
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-envscrub-"));
+    stateDir = path.join(rootDir, "state");
+    configPath = path.join(stateDir, "openclaw.json");
+    envPath = path.join(stateDir, ".env");
+    agentDir = path.join(stateDir, "agents", "main", "agent");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.mkdir(agentDir, { recursive: true });
+
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          models: {
+            providers: {
+              openai: { apiKey: SHARED_KEY },
+              anthropic: {
+                apiKey: { source: "env", provider: "default", id: "ANTHROPIC_API_KEY" },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    await fs.writeFile(
+      envPath,
+      `OPENAI_API_KEY=${SHARED_KEY}\nANTHROPIC_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`,
+      "utf8",
+    );
+
+    env = {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENAI_API_KEY: SHARED_KEY,
+      ANTHROPIC_API_KEY: SHARED_KEY,
+    };
+  });
+
+  afterEach(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("does NOT delete ANTHROPIC_API_KEY when only the openai apiKey is migrated", async () => {
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "models.providers.apiKey",
+          path: "models.providers.openai.apiKey",
+          providerId: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain("ANTHROPIC_API_KEY");
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+  });
+
+  it("still scrubs the .env line when only an auth-profile credential is migrated", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: SHARED_KEY,
+        },
+      },
+    } as unknown as AuthProfileStore;
+    saveAuthProfileStore(store, agentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
+    expect(resolveAuthProfileDatabasePath(agentDir)).toContain(agentDir);
+
+    await fs.writeFile(envPath, `OPENAI_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`, "utf8");
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "auth-profiles.api_key.key",
+          path: "profiles.openai:default.key",
+          pathSegments: ["profiles", "openai:default", "key"],
+          agentId: "main",
+          authProfileProvider: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+  });
+
+  it("does NOT delete OPENAI_API_KEY when only a same-value provider header is migrated", async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          models: {
+            providers: {
+              openai: {
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                headers: { "x-shared-header": SHARED_KEY },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      envPath,
+      `OPENAI_API_KEY=${SHARED_KEY}\nOPENAI_PROXY_HEADER=${SHARED_KEY}\nUNRELATED=value\n`,
+      "utf8",
+    );
+    env.OPENAI_PROXY_HEADER = SHARED_KEY;
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "models.providers.headers",
+          path: "models.providers.openai.headers.x-shared-header",
+          pathSegments: ["models", "providers", "openai", "headers", "x-shared-header"],
+          providerId: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_PROXY_HEADER" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
+  });
+
+  it("does NOT delete OPENAI_API_KEY when a same-value provider header is migrated to that auth env ref", async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          models: {
+            providers: {
+              openai: {
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                headers: { "x-shared-header": SHARED_KEY },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(envPath, `OPENAI_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`, "utf8");
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "models.providers.headers",
+          path: "models.providers.openai.headers.x-shared-header",
+          pathSegments: ["models", "providers", "openai", "headers", "x-shared-header"],
+          providerId: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
+  });
+
+  it("scrubs a plugin/config target env line while preserving an unrelated same-value provider", async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          tools: { web: { fetch: { firecrawl: { apiKey: SHARED_KEY } } } },
+          models: { providers: { openai: { apiKey: SHARED_KEY } } },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      envPath,
+      `FIRECRAWL_API_KEY=${SHARED_KEY}\nOPENAI_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`,
+      "utf8",
+    );
+    env.FIRECRAWL_API_KEY = SHARED_KEY;
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "tools.web.fetch.firecrawl.apiKey",
+          path: "tools.web.fetch.firecrawl.apiKey",
+          ref: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`FIRECRAWL_API_KEY=${SHARED_KEY}`);
+  });
+
+  it("keeps a non-provider env-ref source line when its key is not a known secret env var", async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ gateway: { auth: { token: SHARED_KEY } } }, null, 2)}\n`,
+      "utf8",
+    );
+    await fs.writeFile(envPath, `OPENCLAW_GATEWAY_TOKEN=${SHARED_KEY}\nUNRELATED=value\n`, "utf8");
+    env.OPENCLAW_GATEWAY_TOKEN = SHARED_KEY;
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "gateway.auth.token",
+          path: "gateway.auth.token",
+          ref: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENCLAW_GATEWAY_TOKEN=${SHARED_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
+  });
+
+  it("scrubs the provider .env line for an existing auth-profile migrating to a file ref without authProfileProvider", async () => {
+    const secretFilePath = path.join(rootDir, "openai.key");
+    await fs.writeFile(secretFilePath, SHARED_KEY, "utf8");
+
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          secrets: {
+            providers: {
+              mounted: {
+                source: "file",
+                path: secretFilePath,
+                mode: "singleValue",
+                allowInsecurePath: true,
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: SHARED_KEY,
+        },
+      },
+    } as unknown as AuthProfileStore;
+    saveAuthProfileStore(store, agentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
+
+    await fs.writeFile(envPath, `OPENAI_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`, "utf8");
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "auth-profiles.api_key.key",
+          path: "profiles.openai:default.key",
+          pathSegments: ["profiles", "openai:default", "key"],
+          agentId: "main",
+          ref: { source: "file", provider: "mounted", id: "value" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+  });
+
+  it("does NOT delete OPENAI_API_KEY when a no-op already-ref openai target shares a value with a migrated plugin target", async () => {
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          tools: { web: { fetch: { firecrawl: { apiKey: SHARED_KEY } } } },
+          models: {
+            providers: {
+              openai: {
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.writeFile(
+      envPath,
+      `OPENAI_API_KEY=${SHARED_KEY}\nFIRECRAWL_API_KEY=${SHARED_KEY}\nUNRELATED=value\n`,
+      "utf8",
+    );
+    env.FIRECRAWL_API_KEY = SHARED_KEY;
+
+    const plan: SecretsApplyPlan = {
+      version: 1,
+      protocolVersion: 1,
+      generatedAt: new Date().toISOString(),
+      generatedBy: "manual",
+      targets: [
+        {
+          type: "models.providers.apiKey",
+          path: "models.providers.openai.apiKey",
+          providerId: "openai",
+          ref: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+        {
+          type: "tools.web.fetch.firecrawl.apiKey",
+          path: "tools.web.fetch.firecrawl.apiKey",
+          ref: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
+        },
+      ],
+      options: {
+        scrubEnv: true,
+        scrubAuthProfilesForProviderTargets: true,
+        scrubLegacyAuthJson: true,
+      },
+    };
+
+    await runSecretsApply({ plan, env, write: true });
+
+    const nextEnv = await fs.readFile(envPath, "utf8");
+
+    expect(nextEnv).toContain(`OPENAI_API_KEY=${SHARED_KEY}`);
+    expect(nextEnv).toContain("UNRELATED=value");
+    expect(nextEnv).not.toContain(`FIRECRAWL_API_KEY=${SHARED_KEY}`);
+  });
+});

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -37,7 +37,7 @@ import {
   normalizeSecretsPlanOptions,
   resolveValidatedPlanTarget,
 } from "./plan.js";
-import { listKnownSecretEnvVarNames } from "./provider-env-vars.js";
+import { getProviderEnvVars, listKnownSecretEnvVarNames } from "./provider-env-vars.js";
 import { resolveSecretRefValue } from "./resolve.js";
 import { prepareSecretsRuntimeSnapshot } from "./runtime.js";
 import { assertExpectedResolvedSecretValue } from "./secret-value.js";
@@ -89,8 +89,10 @@ type ResolvedPlanTargetEntry = {
 
 type ConfigTargetMutationResult = {
   resolvedTargets: ResolvedPlanTargetEntry[];
-  scrubbedValues: Set<string>;
+  scrubbedValuesByProvider: Map<string, Set<string>>;
+  scrubbedValuesByTarget: Map<SecretsPlanTarget, Set<string>>;
   providerTargets: Set<string>;
+  authProfileProviderByTarget: Map<SecretsPlanTarget, string>;
   configChanged: boolean;
   authStoreByPath: Map<string, Record<string, unknown>>;
   authStoreAgentDirByPath: Map<string, string>;
@@ -132,15 +134,23 @@ function resolveTarget(
   return resolved;
 }
 
+function appendKeyedValue<K>(map: Map<K, Set<string>>, key: K, value: string): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.add(value);
+    return;
+  }
+  map.set(key, new Set([value]));
+}
+
 function scrubEnvRaw(
   raw: string,
-  migratedValues: Set<string>,
-  allowedEnvKeys: Set<string>,
+  scrubByEnvKey: Map<string, Set<string>>,
 ): {
   nextRaw: string;
   removed: number;
 } {
-  if (migratedValues.size === 0 || allowedEnvKeys.size === 0) {
+  if (scrubByEnvKey.size === 0) {
     return { nextRaw: raw, removed: 0 };
   }
   const lines = raw.split(/\r?\n/);
@@ -153,12 +163,13 @@ function scrubEnvRaw(
       continue;
     }
     const envKey = match[1] ?? "";
-    if (!allowedEnvKeys.has(envKey)) {
+    const ownedValues = scrubByEnvKey.get(envKey);
+    if (!ownedValues) {
       nextLines.push(line);
       continue;
     }
     const parsedValue = parseEnvAssignmentValue(match[2] ?? "");
-    if (migratedValues.has(parsedValue)) {
+    if (ownedValues.has(parsedValue)) {
       removed += 1;
       continue;
     }
@@ -261,7 +272,7 @@ async function projectPlanState(params: {
     nextConfig,
     stateDir,
     providerTargets: targetMutations.providerTargets,
-    scrubbedValues: targetMutations.scrubbedValues,
+    scrubbedValuesByProvider: targetMutations.scrubbedValuesByProvider,
     authStoreByPath: targetMutations.authStoreByPath,
     authStoreAgentDirByPath: targetMutations.authStoreAgentDirByPath,
     changedFiles,
@@ -275,9 +286,46 @@ async function projectPlanState(params: {
     enabled: options.scrubLegacyAuthJson,
   });
 
+  const knownSecretEnvKeys = new Set(listKnownSecretEnvVarNames());
+  const scrubByEnvKey = new Map<string, Set<string>>();
+  for (const { resolved, target } of targetMutations.resolvedTargets) {
+    const migratesProviderAuth =
+      resolved.entry.trackProviderShadowing === true || resolved.entry.authProfileType != null;
+    if (migratesProviderAuth) {
+      const providerId = (
+        resolved.providerId ??
+        target.providerId ??
+        target.authProfileProvider ??
+        targetMutations.authProfileProviderByTarget.get(target) ??
+        ""
+      ).trim();
+      if (providerId) {
+        const normalizedProvider = normalizeProviderId(providerId);
+        const providerValues = targetMutations.scrubbedValuesByProvider.get(normalizedProvider);
+        if (providerValues) {
+          for (const envKey of getProviderEnvVars(normalizedProvider)) {
+            for (const value of providerValues) {
+              appendKeyedValue(scrubByEnvKey, envKey, value);
+            }
+          }
+        }
+      }
+    }
+    const targetOwnsRefEnvVar = migratesProviderAuth || resolved.providerId == null;
+    const envRefId = target.ref.source === "env" ? target.ref.id.trim() : "";
+    if (envRefId && targetOwnsRefEnvVar && knownSecretEnvKeys.has(envRefId)) {
+      const targetValues = targetMutations.scrubbedValuesByTarget.get(target);
+      if (targetValues) {
+        for (const value of targetValues) {
+          appendKeyedValue(scrubByEnvKey, envRefId, value);
+        }
+      }
+    }
+  }
+
   const envRawByPath = scrubEnvFiles({
     env: params.env,
-    scrubbedValues: targetMutations.scrubbedValues,
+    scrubByEnvKey,
     changedFiles,
     enabled: options.scrubEnv,
   });
@@ -322,22 +370,41 @@ function applyConfigTargetMutations(params: {
     target,
     resolved: resolveTarget(target),
   }));
-  const scrubbedValues = new Set<string>();
+  const scrubbedValuesByProvider = new Map<string, Set<string>>();
+  const scrubbedValuesByTarget = new Map<SecretsPlanTarget, Set<string>>();
   const providerTargets = new Set<string>();
+  const authProfileProviderByTarget = new Map<SecretsPlanTarget, string>();
   let configChanged = false;
+
+  const recordMigratedValue = (
+    target: SecretsPlanTarget,
+    provider: string,
+    value: string,
+  ): void => {
+    const trimmed = value.trim();
+    appendKeyedValue(scrubbedValuesByTarget, target, trimmed);
+    if (provider) {
+      appendKeyedValue(scrubbedValuesByProvider, normalizeProviderId(provider), trimmed);
+    }
+  };
 
   for (const { target, resolved } of resolvedTargets) {
     if (resolved.entry.configFile === "auth-profiles.json") {
-      const authStoreChanged = applyAuthProfileTargetMutation({
+      const authProfileMutation = applyAuthProfileTargetMutation({
         target,
         resolved,
         nextConfig: params.nextConfig,
         stateDir: params.stateDir,
         authStoreByPath: params.authStoreByPath,
         authStoreAgentDirByPath: params.authStoreAgentDirByPath,
-        scrubbedValues,
       });
-      if (authStoreChanged) {
+      for (const migratedValue of authProfileMutation.migratedValues) {
+        recordMigratedValue(target, authProfileMutation.provider, migratedValue);
+      }
+      if (authProfileMutation.provider) {
+        authProfileProviderByTarget.set(target, authProfileMutation.provider);
+      }
+      if (authProfileMutation.changed) {
         const agentId = (target.agentId ?? "").trim();
         if (!agentId) {
           throw new Error(`Missing required agentId for auth-profiles target ${target.path}.`);
@@ -358,7 +425,7 @@ function applyConfigTargetMutations(params: {
     if (usesSiblingRef) {
       const previous = getPath(params.nextConfig, targetPathSegments);
       if (isNonEmptyString(previous)) {
-        scrubbedValues.add(previous.trim());
+        recordMigratedValue(target, resolved.providerId ?? "", previous);
       }
       const refPathSegments = resolved.refPathSegments;
       if (!refPathSegments) {
@@ -374,7 +441,7 @@ function applyConfigTargetMutations(params: {
 
     const previous = getPath(params.nextConfig, targetPathSegments);
     if (isNonEmptyString(previous)) {
-      scrubbedValues.add(previous.trim());
+      recordMigratedValue(target, resolved.providerId ?? "", previous);
     }
     const wroteRef = setPathCreateStrict(params.nextConfig, targetPathSegments, target.ref);
     if (wroteRef) {
@@ -387,8 +454,10 @@ function applyConfigTargetMutations(params: {
 
   return {
     resolvedTargets,
-    scrubbedValues,
+    scrubbedValuesByProvider,
+    scrubbedValuesByTarget,
     providerTargets,
+    authProfileProviderByTarget,
     configChanged,
     authStoreByPath: params.authStoreByPath,
     authStoreAgentDirByPath: params.authStoreAgentDirByPath,
@@ -399,7 +468,7 @@ function scrubAuthStoresForProviderTargets(params: {
   nextConfig: OpenClawConfig;
   stateDir: string;
   providerTargets: Set<string>;
-  scrubbedValues: Set<string>;
+  scrubbedValuesByProvider: Map<string, Set<string>>;
   authStoreByPath: Map<string, Record<string, unknown>>;
   authStoreAgentDirByPath: Map<string, string>;
   changedFiles: Set<string>;
@@ -433,7 +502,7 @@ function scrubAuthStoresForProviderTargets(params: {
       }
       if (profile.kind === "api_key" || profile.kind === "token") {
         if (isNonEmptyString(profile.value)) {
-          params.scrubbedValues.add(profile.value.trim());
+          appendKeyedValue(params.scrubbedValuesByProvider, provider, profile.value.trim());
         }
         if (profile.valueField in profile.profile) {
           delete profile.profile[profile.valueField];
@@ -586,6 +655,14 @@ function ensureAuthProfileContainer(params: {
   return changed;
 }
 
+function resolveAuthProfileTargetProvider(
+  store: MutableAuthProfileStore,
+  resolved: ResolvedPlanTargetEntry["resolved"],
+): string {
+  const provider = getPath(store, [...resolved.pathSegments.slice(0, 2), "provider"]);
+  return isNonEmptyString(provider) ? provider.trim() : "";
+}
+
 function applyAuthProfileTargetMutation(params: {
   target: SecretsPlanTarget;
   resolved: ResolvedPlanTargetEntry["resolved"];
@@ -593,10 +670,9 @@ function applyAuthProfileTargetMutation(params: {
   stateDir: string;
   authStoreByPath: Map<string, Record<string, unknown>>;
   authStoreAgentDirByPath: Map<string, string>;
-  scrubbedValues: Set<string>;
-}): boolean {
+}): { changed: boolean; provider: string; migratedValues: string[] } {
   if (params.resolved.entry.configFile !== "auth-profiles.json") {
-    return false;
+    return { changed: false, provider: "", migratedValues: [] };
   }
   const { store } = resolveAuthStoreForTarget({
     target: params.target,
@@ -610,12 +686,14 @@ function applyAuthProfileTargetMutation(params: {
     resolved: params.resolved,
     store,
   });
+  const provider = resolveAuthProfileTargetProvider(store, params.resolved);
+  const migratedValues: string[] = [];
   const targetPathSegments = params.resolved.pathSegments;
   const usesSiblingRef = params.resolved.entry.secretShape === "sibling_ref"; // pragma: allowlist secret
   if (usesSiblingRef) {
     const previous = getPath(store, targetPathSegments);
     if (isNonEmptyString(previous)) {
-      params.scrubbedValues.add(previous.trim());
+      migratedValues.push(previous.trim());
     }
     const refPathSegments = params.resolved.refPathSegments;
     if (!refPathSegments) {
@@ -624,15 +702,15 @@ function applyAuthProfileTargetMutation(params: {
     const wroteRef = setPathCreateStrict(store, refPathSegments, params.target.ref);
     const deletedPlaintext = deletePathStrict(store, targetPathSegments);
     changed = changed || wroteRef || deletedPlaintext;
-    return changed;
+    return { changed, provider, migratedValues };
   }
   const previous = getPath(store, targetPathSegments);
   if (isNonEmptyString(previous)) {
-    params.scrubbedValues.add(previous.trim());
+    migratedValues.push(previous.trim());
   }
   const wroteRef = setPathCreateStrict(store, targetPathSegments, params.target.ref);
   changed = changed || wroteRef;
-  return changed;
+  return { changed, provider, migratedValues };
 }
 
 function scrubLegacyAuthJsonStores(params: {
@@ -671,12 +749,12 @@ function scrubLegacyAuthJsonStores(params: {
 
 function scrubEnvFiles(params: {
   env: NodeJS.ProcessEnv;
-  scrubbedValues: Set<string>;
+  scrubByEnvKey: Map<string, Set<string>>;
   changedFiles: Set<string>;
   enabled: boolean;
 }): Map<string, string> {
   const envRawByPath = new Map<string, string>();
-  if (!params.enabled || params.scrubbedValues.size === 0) {
+  if (!params.enabled || params.scrubByEnvKey.size === 0) {
     return envRawByPath;
   }
   const envPath = path.join(resolveConfigDir(params.env, os.homedir), ".env");
@@ -684,11 +762,7 @@ function scrubEnvFiles(params: {
     return envRawByPath;
   }
   const current = fs.readFileSync(envPath, "utf8");
-  const scrubbed = scrubEnvRaw(
-    current,
-    params.scrubbedValues,
-    new Set(listKnownSecretEnvVarNames()),
-  );
+  const scrubbed = scrubEnvRaw(current, params.scrubByEnvKey);
   if (scrubbed.removed > 0 && scrubbed.nextRaw !== current) {
     envRawByPath.set(envPath, scrubbed.nextRaw);
     params.changedFiles.add(envPath);

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -151,6 +151,16 @@ function migratesProviderAuthCredential(resolved: ResolvedPlanTargetEntry["resol
   );
 }
 
+function providerEnvVarsForPathSegments(pathSegments: readonly string[]): Set<string> {
+  const envKeys = new Set<string>();
+  for (const segment of pathSegments) {
+    for (const envKey of getProviderEnvVars(segment)) {
+      envKeys.add(envKey);
+    }
+  }
+  return envKeys;
+}
+
 function scrubEnvRaw(
   raw: string,
   scrubByEnvKey: Map<string, Set<string>>,
@@ -318,13 +328,20 @@ async function projectPlanState(params: {
         }
       }
     }
-    const targetOwnsRefEnvVar = migratesProviderAuth || resolved.providerId == null;
-    const envRefId = target.ref.source === "env" ? target.ref.id.trim() : "";
-    if (envRefId && targetOwnsRefEnvVar && knownSecretEnvKeys.has(envRefId)) {
-      const targetValues = targetMutations.scrubbedValuesByTarget.get(target);
-      if (targetValues) {
+    const targetValues = targetMutations.scrubbedValuesByTarget.get(target);
+    if (targetValues) {
+      const targetOwnsRefEnvVar = migratesProviderAuth || resolved.providerId == null;
+      const envRefId = target.ref.source === "env" ? target.ref.id.trim() : "";
+      if (envRefId && targetOwnsRefEnvVar && knownSecretEnvKeys.has(envRefId)) {
         for (const value of targetValues) {
           appendKeyedValue(scrubByEnvKey, envRefId, value);
+        }
+      }
+      if (!migratesProviderAuth && resolved.providerId == null) {
+        for (const envKey of providerEnvVarsForPathSegments(resolved.pathSegments)) {
+          for (const value of targetValues) {
+            appendKeyedValue(scrubByEnvKey, envKey, value);
+          }
         }
       }
     }

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -144,7 +144,11 @@ function appendKeyedValue<K>(map: Map<K, Set<string>>, key: K, value: string): v
 }
 
 function migratesProviderAuthCredential(resolved: ResolvedPlanTargetEntry["resolved"]): boolean {
-  return resolved.entry.trackProviderShadowing === true || resolved.entry.authProfileType != null;
+  const { entry } = resolved;
+  return (
+    entry.authProfileType != null ||
+    (entry.providerIdPathSegmentIndex != null && entry.pathPattern.endsWith(".apiKey"))
+  );
 }
 
 function scrubEnvRaw(

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -89,7 +89,7 @@ type ResolvedPlanTargetEntry = {
 
 type ConfigTargetMutationResult = {
   resolvedTargets: ResolvedPlanTargetEntry[];
-  scrubbedValuesByProvider: Map<string, Set<string>>;
+  scrubbedProviderAuthValues: Map<string, Set<string>>;
   scrubbedValuesByTarget: Map<SecretsPlanTarget, Set<string>>;
   providerTargets: Set<string>;
   authProfileProviderByTarget: Map<SecretsPlanTarget, string>;
@@ -141,6 +141,10 @@ function appendKeyedValue<K>(map: Map<K, Set<string>>, key: K, value: string): v
     return;
   }
   map.set(key, new Set([value]));
+}
+
+function migratesProviderAuthCredential(resolved: ResolvedPlanTargetEntry["resolved"]): boolean {
+  return resolved.entry.trackProviderShadowing === true || resolved.entry.authProfileType != null;
 }
 
 function scrubEnvRaw(
@@ -272,7 +276,7 @@ async function projectPlanState(params: {
     nextConfig,
     stateDir,
     providerTargets: targetMutations.providerTargets,
-    scrubbedValuesByProvider: targetMutations.scrubbedValuesByProvider,
+    scrubbedProviderAuthValues: targetMutations.scrubbedProviderAuthValues,
     authStoreByPath: targetMutations.authStoreByPath,
     authStoreAgentDirByPath: targetMutations.authStoreAgentDirByPath,
     changedFiles,
@@ -289,8 +293,7 @@ async function projectPlanState(params: {
   const knownSecretEnvKeys = new Set(listKnownSecretEnvVarNames());
   const scrubByEnvKey = new Map<string, Set<string>>();
   for (const { resolved, target } of targetMutations.resolvedTargets) {
-    const migratesProviderAuth =
-      resolved.entry.trackProviderShadowing === true || resolved.entry.authProfileType != null;
+    const migratesProviderAuth = migratesProviderAuthCredential(resolved);
     if (migratesProviderAuth) {
       const providerId = (
         resolved.providerId ??
@@ -301,7 +304,7 @@ async function projectPlanState(params: {
       ).trim();
       if (providerId) {
         const normalizedProvider = normalizeProviderId(providerId);
-        const providerValues = targetMutations.scrubbedValuesByProvider.get(normalizedProvider);
+        const providerValues = targetMutations.scrubbedProviderAuthValues.get(normalizedProvider);
         if (providerValues) {
           for (const envKey of getProviderEnvVars(normalizedProvider)) {
             for (const value of providerValues) {
@@ -370,7 +373,7 @@ function applyConfigTargetMutations(params: {
     target,
     resolved: resolveTarget(target),
   }));
-  const scrubbedValuesByProvider = new Map<string, Set<string>>();
+  const scrubbedProviderAuthValues = new Map<string, Set<string>>();
   const scrubbedValuesByTarget = new Map<SecretsPlanTarget, Set<string>>();
   const providerTargets = new Set<string>();
   const authProfileProviderByTarget = new Map<SecretsPlanTarget, string>();
@@ -380,11 +383,12 @@ function applyConfigTargetMutations(params: {
     target: SecretsPlanTarget,
     provider: string,
     value: string,
+    options?: { providerAuth: boolean },
   ): void => {
     const trimmed = value.trim();
     appendKeyedValue(scrubbedValuesByTarget, target, trimmed);
-    if (provider) {
-      appendKeyedValue(scrubbedValuesByProvider, normalizeProviderId(provider), trimmed);
+    if (provider && options?.providerAuth === true) {
+      appendKeyedValue(scrubbedProviderAuthValues, normalizeProviderId(provider), trimmed);
     }
   };
 
@@ -399,7 +403,9 @@ function applyConfigTargetMutations(params: {
         authStoreAgentDirByPath: params.authStoreAgentDirByPath,
       });
       for (const migratedValue of authProfileMutation.migratedValues) {
-        recordMigratedValue(target, authProfileMutation.provider, migratedValue);
+        recordMigratedValue(target, authProfileMutation.provider, migratedValue, {
+          providerAuth: true,
+        });
       }
       if (authProfileMutation.provider) {
         authProfileProviderByTarget.set(target, authProfileMutation.provider);
@@ -422,10 +428,13 @@ function applyConfigTargetMutations(params: {
 
     const targetPathSegments = resolved.pathSegments;
     const usesSiblingRef = resolved.entry.secretShape === "sibling_ref"; // pragma: allowlist secret
+    const migratesProviderAuth = migratesProviderAuthCredential(resolved);
     if (usesSiblingRef) {
       const previous = getPath(params.nextConfig, targetPathSegments);
       if (isNonEmptyString(previous)) {
-        recordMigratedValue(target, resolved.providerId ?? "", previous);
+        recordMigratedValue(target, resolved.providerId ?? "", previous, {
+          providerAuth: migratesProviderAuth,
+        });
       }
       const refPathSegments = resolved.refPathSegments;
       if (!refPathSegments) {
@@ -441,7 +450,9 @@ function applyConfigTargetMutations(params: {
 
     const previous = getPath(params.nextConfig, targetPathSegments);
     if (isNonEmptyString(previous)) {
-      recordMigratedValue(target, resolved.providerId ?? "", previous);
+      recordMigratedValue(target, resolved.providerId ?? "", previous, {
+        providerAuth: migratesProviderAuth,
+      });
     }
     const wroteRef = setPathCreateStrict(params.nextConfig, targetPathSegments, target.ref);
     if (wroteRef) {
@@ -454,7 +465,7 @@ function applyConfigTargetMutations(params: {
 
   return {
     resolvedTargets,
-    scrubbedValuesByProvider,
+    scrubbedProviderAuthValues,
     scrubbedValuesByTarget,
     providerTargets,
     authProfileProviderByTarget,
@@ -468,7 +479,7 @@ function scrubAuthStoresForProviderTargets(params: {
   nextConfig: OpenClawConfig;
   stateDir: string;
   providerTargets: Set<string>;
-  scrubbedValuesByProvider: Map<string, Set<string>>;
+  scrubbedProviderAuthValues: Map<string, Set<string>>;
   authStoreByPath: Map<string, Record<string, unknown>>;
   authStoreAgentDirByPath: Map<string, string>;
   changedFiles: Set<string>;
@@ -502,7 +513,7 @@ function scrubAuthStoresForProviderTargets(params: {
       }
       if (profile.kind === "api_key" || profile.kind === "token") {
         if (isNonEmptyString(profile.value)) {
-          appendKeyedValue(params.scrubbedValuesByProvider, provider, profile.value.trim());
+          appendKeyedValue(params.scrubbedProviderAuthValues, provider, profile.value.trim());
         }
         if (profile.valueField in profile.profile) {
           delete profile.profile[profile.valueField];


### PR DESCRIPTION
## Summary

Migrating one provider's API key to a SecretRef can silently delete a different provider's credential from `~/.openclaw/.env`. When two known-secret env vars hold the same value (for example `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` both pointing at one shared LiteLLM/proxy gateway key), running `openclaw secrets configure` / `apply` to migrate only one of them scrubs both `.env` lines. The non-migrated provider was never converted to a ref, so it loses its only credential and fails to authenticate on the next run.

## Root cause

The post-migration env scrub matches lines by value only, against the union of every provider's known env var names. It has no notion of which provider was actually migrated.

`src/secrets/apply.ts` (before):

```ts
const envRawByPath = scrubEnvFiles({
  env: params.env,
  scrubbedValues: targetMutations.scrubbedValues,
  changedFiles,
  enabled: options.scrubEnv,
});
```

```ts
const scrubbed = scrubEnvRaw(
  current,
  params.scrubbedValues,
  new Set(listKnownSecretEnvVarNames()),
);
```

`scrubbedValues` is a `Set<string>` of plaintext values with no env-key/provider association. `scrubEnvRaw` deletes a line when its key is in the allowed-key set AND its value is in `scrubbedValues`. Because the allowed-key set is `listKnownSecretEnvVarNames()` (all providers), two different providers sharing a value collapse to one match and both lines are removed, even though only one was migrated. `scrubEnv` defaults to `true` (`src/secrets/plan.ts:192`), so this is the default path.

## Fix

Scope the scrub to the migrated providers' env vars. Build the allowed-key set from the resolved targets and pass it to `scrubEnvFiles` instead of the global list. Crucially, only a target that migrates the provider's *primary auth credential* expands to that provider's env vars; provider-indexed non-auth targets (`models.providers.*.headers.*`, `models.providers.*.request.auth.*`, the TLS targets) share the same `providerId` but must not delete the provider's still-live auth env line.

`src/secrets/apply.ts` (after):

```ts
const knownSecretEnvKeys = new Set(listKnownSecretEnvVarNames());
const scrubByEnvKey = new Map<string, Set<string>>();
for (const { resolved, target } of targetMutations.resolvedTargets) {
  const migratesProviderAuth =
    resolved.entry.authProfileType != null ||
    (resolved.entry.providerIdPathSegmentIndex != null &&
      resolved.entry.pathPattern.endsWith(".apiKey"));
  if (migratesProviderAuth) {
    const providerId = (
      resolved.providerId ??
      target.providerId ??
      target.authProfileProvider ??
      targetMutations.authProfileProviderByTarget.get(target) ??
      ""
    ).trim();
    if (providerId) {
      const normalizedProvider = normalizeProviderId(providerId);
      const providerValues = targetMutations.scrubbedValuesByProvider.get(normalizedProvider);
      if (providerValues) {
        for (const envKey of getProviderEnvVars(normalizedProvider)) {
          for (const value of providerValues) appendKeyedValue(scrubByEnvKey, envKey, value);
        }
      }
    }
  }
  const targetOwnsRefEnvVar = migratesProviderAuth || resolved.providerId == null;
  const envRefId = target.ref.source === "env" ? target.ref.id.trim() : "";
  if (envRefId && targetOwnsRefEnvVar && knownSecretEnvKeys.has(envRefId)) {
    const targetValues = targetMutations.scrubbedValuesByTarget.get(target);
    if (targetValues) {
      for (const value of targetValues) appendKeyedValue(scrubByEnvKey, envRefId, value);
    }
  }
}

const envRawByPath = scrubEnvFiles({
  env: params.env,
  scrubByEnvKey,
  changedFiles,
  enabled: options.scrubEnv,
});
```

`scrubEnvFiles` now forwards a single `Map<string, Set<string>>` (`scrubByEnvKey`) to `scrubEnvRaw`, where each env key maps to exactly the plaintext values that a migrated target *owning that key* contributed (the provider's migrated values for a provider-auth target, the target's own migrated value for an env-ref-id target). `scrubEnvRaw` removes a `.env` line only when `scrubByEnvKey.get(key)?.has(value)` -- the key and the value must come from the same migrated target, never from a target-derived key paired with an unrelated target's value. The migrated provider's line is still scrubbed; an unrelated provider's var sharing the same value is no longer eligible, and a provider env key contributed by a no-op/already-ref target (which migrated no plaintext, so its provider has an empty value set) is never paired with another target's migrated value.

Two registry signals gate the provider-env expansion to actual credential targets:

- A provider-indexed `*.apiKey` entry (`entry.providerIdPathSegmentIndex != null && entry.pathPattern.endsWith(".apiKey")`) stores that provider's API key. This covers `models.providers.*.apiKey` (which also carries `trackProviderShadowing`, now used only for its provider-shadowing diagnostics) and the provider-scoped voice/audio keys `talk.providers.*.apiKey`, `talk.realtime.providers.*.apiKey`, `messages.tts.providers.*.apiKey`, and `agents.list[].tts.providers.*.apiKey`. An earlier revision gated on `trackProviderShadowing` alone, so these talk/TTS provider keys were excluded and their provider `.env` line was left in plaintext even though pristine `main` scrubs it.
- `entry.authProfileType` marks the auth-profile credential targets (`auth-profiles.api_key.key`, `auth-profiles.token.token`). Their provider identity is not carried in `providerId`; it comes from `authProfileProvider` when the plan creates a new mapping, and from the auth-profile store's `profiles.<id>.provider` for an existing profile. `applyAuthProfileTargetMutation` already loads/mutates that store, so it now returns the resolved provider and the apply loop records it in `authProfileProviderByTarget`. The env-scrub derivation falls back to that map, so an existing auth-profile target migrating to a file/exec ref (no `authProfileProvider`, no env-ref id) still expands to the provider's env vars and scrubs the matching `.env` line, matching what pristine `main` did.

A `models.providers.*.headers.*` or `request.auth.*` target resolves the same `providerId` from its path, but its value is not the provider's `*.apiKey` credential, so migrating only a provider header whose value happens to equal `OPENAI_API_KEY` no longer deletes the live `OPENAI_API_KEY` line.

Two target classes contribute migrated plaintext through the env-ref-id branch instead of provider expansion:

- Plugin/config secret targets (for example the Firecrawl `tools.web.fetch.firecrawl.apiKey` target, or bundled web-provider `plugins.entries.<id>.config.webSearch.apiKey` targets) expose neither `providerId` nor `authProfileProvider`. Two derivations cover them, both paired only with the target's own migrated value:
  - For a migrated target whose SecretRef is an env ref whose id is a known provider/plugin secret env key (`listKnownSecretEnvVarNames()`), the ref id is added to the allow-list.
  - Independent of the new ref's source, the target's own known env keys are derived from its resolved path segments: any segment that is a registered provider/plugin id (`getProviderEnvVars(segment)`) contributes that provider's env vars. So `tools.web.fetch.firecrawl.apiKey` owns `FIRECRAWL_API_KEY` through its `firecrawl` segment, and a `plugins.entries.<id>.config.*` target owns its plugin's env vars through the `<id>` segment. This closes the gap where such a target migrated to a **file or exec ref** (empty `envRefId`) left its stale `FIRECRAWL_API_KEY` line in plaintext even though pristine `main` scrubbed it. Pairing with the target's own value keeps collision protection: an unrelated same-value provider key whose name is not one of the target's path segments is never eligible. This branch is gated to genuinely non-provider targets (`!migratesProviderAuth && resolved.providerId == null`), so provider-indexed headers/auth/TLS and auth-profile targets are untouched.
- Non-provider env-ref targets stay protected: a target like `gateway.auth.token` migrating to `{ source: "env", id: "OPENCLAW_GATEWAY_TOKEN" }` keeps its `.env` line, because `OPENCLAW_GATEWAY_TOKEN` is not a known provider/plugin secret env key and deleting it would break the very ref that now reads from it.

## Pairing each env key with its owning target's values

Scoping the allowed *keys* per migrated target is not sufficient on its own: an earlier revision still paired that key set with a single global set of migrated *values*, so a mixed/idempotent plan could over-scrub. If a plan contains a no-op or already-SecretRef provider auth target (which adds `OPENAI_API_KEY` to the key set through provider expansion but migrates no plaintext) plus another target that migrates the same plaintext value (so that value enters the global value set), `scrubEnvRaw` matched the key from the first target against the value from the second and deleted the live `OPENAI_API_KEY` source, even though that provider was never migrated.

The fix binds keys to values at their shared owner. `applyConfigTargetMutations` now records each migrated plaintext under both the migrating target (`scrubbedValuesByTarget`) and, when the target resolves to a provider, that provider (`scrubbedValuesByProvider`); `scrubAuthStoresForProviderTargets` records scrubbed store credentials under their provider too. The env-scrub derivation pairs a provider's env vars only with that provider's migrated values, and an env-ref-id key only with its own target's migrated values, into `scrubByEnvKey: Map<envKey, Set<value>>`. A no-op/already-ref provider target contributes no value to its provider, so its provider's value set is empty and `getProviderEnvVars` pairs resolve to nothing -- the key is never added, and the live source survives. `appendKeyedValue` is a small shared helper used at every record site and at the env-key build.

## Why this is the right boundary

The defect is in how the env scrub derives its allowed-key set, so the fix lives at the same call site that already has the resolved targets. The provider-to-env-var mapping reuses the existing `getProviderEnvVars` / `normalizeProviderId` helpers (the same `normalizeProviderId(resolved.providerId)` pattern already used a few lines above for `providerTargets`), and the credential gate reuses the registry's own `trackProviderShadowing` / `authProfileType` metadata rather than inventing a new classification. Sibling scrub paths are unaffected: the auth-profiles and legacy `auth.json` scrubs are already keyed per migrated provider/path, not by a global value set; only the `.env` scrub used the broad key list.

## Verification

- `node scripts/run-vitest.mjs src/secrets/apply.test.ts src/secrets/apply.envscrub-collision.repro.test.ts` -> 32 passed (21 existing + 11 new). The existing "remove migrated key, keep UNRELATED" case stays green.
- `node scripts/run-oxlint.mjs src/secrets/apply.ts src/secrets/apply.envscrub-collision.repro.test.ts` -> clean.
- `oxfmt --check src/secrets/apply.ts src/secrets/apply.envscrub-collision.repro.test.ts` -> all files correctly formatted.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` / `-p test/tsconfig/tsconfig.core.test.json` -> no errors in the changed files.
- New test `src/secrets/apply.envscrub-collision.repro.test.ts` has eleven cases, all driving the real `runSecretsApply`: the shared-value collision (fails on pristine `origin/main`), an auth-profile migration that must still scrub its `.env` line (guards the `authProfileType`/`authProfileProvider` derivation), a same-value `models.providers.*.headers.*` migration that must preserve `OPENAI_API_KEY` (guards the credential gate; fails on the provider-id-only revision), a header migrated to the provider's own auth env ref that must preserve `OPENAI_API_KEY` (guards `targetOwnsRefEnvVar`), a plugin/config Firecrawl migration that must scrub `FIRECRAWL_API_KEY` while preserving an unrelated same-value `OPENAI_API_KEY` (guards the env-ref-id derivation), a non-provider `gateway.auth.token` migration whose `OPENCLAW_GATEWAY_TOKEN` env source must be preserved (guards the known-secret-env gate), an existing auth-profile target migrating to a file ref WITHOUT `authProfileProvider`, whose matching `OPENAI_API_KEY` line must still be scrubbed via the store-derived provider (guards the store fallback; fails on the provider-id-only revision), and a mixed plan pairing a no-op already-ref `openai.apiKey` target with a migrated Firecrawl target sharing the same value, where `OPENAI_API_KEY` must survive while `FIRECRAWL_API_KEY` is scrubbed (guards the per-target key/value pairing; fails on the prior global-value revision, which deleted both), and a provider-indexed `talk.providers.openai.apiKey` credential migrated to a non-env (file) ref whose matching `OPENAI_API_KEY` line must still be scrubbed via provider expansion (guards the provider-indexed `*.apiKey` gate; fails on the `trackProviderShadowing`-only revision, which left it in plaintext), and a non-provider plugin credential `tools.web.fetch.firecrawl.apiKey` migrated to a non-env (file) ref whose `FIRECRAWL_API_KEY` line must still be scrubbed via path-segment provider derivation while an unrelated same-value `OPENAI_API_KEY` is preserved (guards the non-provider file/exec ref derivation; fails on the env-ref-id-only revision, which left `FIRECRAWL_API_KEY` in plaintext).

Closest existing reports are unrelated: #84763 / #42250 / #56581 scrub provider env from ACP/exec child processes; #92522 is the opposite direction (audit misses LaunchAgent service-env plaintext, i.e. under-scrubbing). None cover this `.env` value-collision over-deletion.

## Real behavior proof

Behavior addressed: (1) migrating only the openai apiKey to a SecretRef must not delete `ANTHROPIC_API_KEY` from `~/.openclaw/.env` when both vars share one value; (2) migrating only a same-value provider header (`models.providers.openai.headers.*`) must NOT delete `OPENAI_API_KEY`, because the provider's auth credential was not migrated; (3) migrating a plugin/config secret target (Firecrawl) must still scrub its own `FIRECRAWL_API_KEY` line while leaving an unrelated same-value provider var intact; (4) migrating a non-provider secret target (`gateway.auth.token`) must NOT delete its `OPENCLAW_GATEWAY_TOKEN` env source, since that env key is not a known provider/plugin secret env key and the ref now reads from it; (5) migrating an existing auth-profile credential to a file/exec ref (no `authProfileProvider` on the plan) must still scrub the provider's matching `OPENAI_API_KEY` line, deriving the provider from the on-disk auth-profile store, matching what pristine `main` did. (6) migrating a provider-indexed voice/audio credential (`talk.providers.openai.apiKey`) to a non-env ref must still scrub that provider's matching `OPENAI_API_KEY` line via provider expansion, because the value IS the provider's API key even though the entry lacks `trackProviderShadowing`, matching what pristine `main` did. (7) migrating a non-provider plugin credential (`tools.web.fetch.firecrawl.apiKey`) to a file/exec ref must still scrub its own `FIRECRAWL_API_KEY` line (derived from the `firecrawl` path segment) while leaving an unrelated same-value `OPENAI_API_KEY` intact, matching what pristine `main` did.
Real environment tested: drove the real `openclaw secrets apply --from <plan>` CLI command (the registered `secrets apply` action calling `runSecretsApply({ write: true })`) against a real temp state dir on disk, with `OPENCLAW_STATE_DIR` pointing at a `.env` seeded per scenario, on pristine `origin/main` / the prior PR revision and on the patched tree with identical inputs. No vitest, no mocks: the CLI parsed the plan file and rewrote the on-disk `.env`.
Exact steps or command run after this patch: `openclaw secrets apply --from plan.json` (scrubEnv default true), then `cat $OPENCLAW_STATE_DIR/.env`.
Evidence after fix:
```
# BEFORE (pristine main, real CLI)
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key
ANTHROPIC_API_KEY=sk-shared-proxy-key
UNRELATED=value
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 2 file(s).
$ cat .env
UNRELATED=value            # ANTHROPIC_API_KEY DELETED -> non-migrated provider loses its credential

# AFTER (this patch, real CLI, identical inputs)
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key
ANTHROPIC_API_KEY=sk-shared-proxy-key
UNRELATED=value
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 2 file(s).
$ cat .env
ANTHROPIC_API_KEY=sk-shared-proxy-key   # preserved
UNRELATED=value                         # only the migrated OPENAI_API_KEY line removed
```
Same-value provider-header target (`models.providers.openai.headers.x-shared-header` -> `OPENAI_PROXY_HEADER`), `.env` with `OPENAI_API_KEY=<shared>`, `OPENAI_PROXY_HEADER=<shared>`, `UNRELATED=value`, plan migrating only the header (the provider apiKey stays a live `OPENAI_API_KEY` env ref):
```
# BEFORE (provider-id-only revision, real CLI)
$ openclaw secrets apply --from plan.json
Secrets applied.
$ cat .env
OPENAI_PROXY_HEADER=sk-shared-proxy-key
UNRELATED=value                         # OPENAI_API_KEY DELETED -> provider auth lost though only a header was migrated

# AFTER (this patch, real CLI, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied.
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # preserved: header migration does not shadow provider auth
OPENAI_PROXY_HEADER=sk-shared-proxy-key
UNRELATED=value
```
Plugin/config target (Firecrawl) via the same real CLI, `.env` with `FIRECRAWL_API_KEY=<shared>`, `OPENAI_API_KEY=<shared>`, `UNRELATED=value`, plan migrating only `tools.web.fetch.firecrawl.apiKey`:
```
# BEFORE (provider-id-only revision, real CLI)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 1 file(s).
$ cat .env
FIRECRAWL_API_KEY=sk-shared-proxy-key   # NOT scrubbed -> migrated plugin credential left in plaintext
OPENAI_API_KEY=sk-shared-proxy-key
UNRELATED=value

# AFTER (this patch, real CLI, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 2 file(s).
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # unrelated same-value provider preserved
UNRELATED=value                         # only the migrated FIRECRAWL_API_KEY line removed
```
Non-provider env-ref target (`gateway.auth.token` -> `OPENCLAW_GATEWAY_TOKEN`) via the same real CLI, `.env` with `OPENCLAW_GATEWAY_TOKEN=<shared>`, `UNRELATED=value`:
```
# BEFORE (ungated ref-id revision, real CLI)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 2 file(s).
$ cat .env
UNRELATED=value                         # OPENCLAW_GATEWAY_TOKEN DELETED -> ref source broken, next runtime resolution fails

# AFTER (this patch, real CLI, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 1 file(s).
$ cat .env
OPENCLAW_GATEWAY_TOKEN=sk-shared-proxy-key   # preserved: not a known secret env key, env source kept
UNRELATED=value
```
Existing auth-profile target migrating to a file ref WITHOUT `authProfileProvider` (provider known only from the on-disk auth-profile store at `profiles.openai:default.provider`), driven on the real production `runSecretsApply` (the same function the `secrets apply` CLI action calls; no vitest, no mocks; the per-agent auth-profile SQLite store seeded via `saveAuthProfileStore`) on the prior provider-id-only revision vs this patch, `.env` with `OPENAI_API_KEY=<shared>`, `UNRELATED=value`, plan migrating only `profiles.openai:default.key` to `{ source: "file", provider: "mounted", id: "value" }`:
```
# BEFORE (provider-id-only revision, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 1 file(s).
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # NOT scrubbed -> provider env key left in plaintext though pristine main would remove it
UNRELATED=value

# AFTER (this patch, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 2 file(s).
$ cat .env
UNRELATED=value                         # OPENAI_API_KEY removed via the store-derived provider; auth-profile store + .env both updated
```
Provider-indexed non-auth target whose env ref points at the provider's own auth env var (the over-scrub flagged in the last review): a `models.providers.openai.headers.x-shared-header` migrated to `{ source: "env", id: "OPENAI_API_KEY" }`, while `models.providers.openai.apiKey` still reads `OPENAI_API_KEY` and is NOT migrated. Driven on the real production `runSecretsApply` (no mocks of the apply logic; real on-disk `.env` with `OPENAI_API_KEY=<shared>`, `UNRELATED=value`) on the prior revision (env-ref-id branch ungated) vs this patch:
```
# BEFORE (ungated env-ref-id branch, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 2 file(s).
$ cat .env
UNRELATED=value                         # OPENAI_API_KEY DELETED -> live provider auth source removed though only a header was migrated

# AFTER (this patch, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
Secrets applied. Updated 1 file(s).
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # preserved: a header does not own the provider auth env var, so the ref-id branch no longer scrubs it
UNRELATED=value
```
The header is provider-indexed (`resolved.providerId` set) but does not migrate the provider credential (`trackProviderShadowing`/`authProfileType` both unset), so it never owned `OPENAI_API_KEY`; the new `targetOwnsRefEnvVar` guard skips the env-ref-id scrub for such targets. Plugin/config targets (no `providerId`, scenario 3) and actually-migrated provider auth (scenario 1) still scrub through this branch unchanged.

Mixed plan pairing a no-op already-ref provider target with a migrated same-value plugin target (the over-scrub flagged in the latest review): `models.providers.openai.apiKey` is ALREADY `{ source: "env", id: "OPENAI_API_KEY" }` (the plan re-applies the same ref, migrating no plaintext) and the plan also migrates `tools.web.fetch.firecrawl.apiKey` (plaintext, same shared value). Driven on the real production `runSecretsApply` (no mocks of the apply logic; real on-disk `.env` with `OPENAI_API_KEY=<shared>`, `FIRECRAWL_API_KEY=<shared>`, `UNRELATED=value`) on the pre-fix head `07f4592956` (one global value set) vs this patch:
```
# BEFORE (head 07f4592956, global value set, real runtime, identical inputs)
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key
FIRECRAWL_API_KEY=sk-shared-proxy-key
UNRELATED=value
$ openclaw secrets apply --from plan.json
$ cat .env
UNRELATED=value                         # OPENAI_API_KEY DELETED -> no-op openai key paired with firecrawl's migrated value; live provider auth source removed

# AFTER (this patch, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # preserved: the no-op openai target migrated no value, so its provider value set is empty
UNRELATED=value                         # only the actually-migrated FIRECRAWL_API_KEY line removed
```
The no-op `openai.apiKey` target still expands to `OPENAI_API_KEY` through provider metadata, but it migrated no plaintext, so `scrubbedValuesByProvider.get("openai")` is empty and the key is never paired with the Firecrawl target's value; `FIRECRAWL_API_KEY` pairs only with its own migrated value and is still scrubbed.

Provider-indexed voice/audio credential (`talk.providers.openai.apiKey`) migrated to a non-env (file) ref while the provider's `OPENAI_API_KEY` line is live (the under-scrub flagged in the latest review): the talk provider key shares `providerId` resolution with the model provider but the registry entry has no `trackProviderShadowing`. Driven on the real production `runSecretsApply` (no mocks of the apply logic; real on-disk `.env` with `OPENAI_API_KEY=<shared>`, `UNRELATED=value`; the SecretRef resolves from a mounted single-value file provider) on the prior `trackProviderShadowing`-only revision vs this patch:
```
# BEFORE (trackProviderShadowing-only gate, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # NOT scrubbed -> talk provider key migrated but provider env line left plaintext though main removes it
UNRELATED=value

# AFTER (this patch, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
$ cat .env
UNRELATED=value                         # OPENAI_API_KEY removed: a provider-indexed *.apiKey credential owns the provider env var
```
The talk provider key is a provider-scoped `*.apiKey` value, so it now expands to the provider's env vars exactly as the model-provider apiKey does; provider metadata that is not an `*.apiKey` (headers/request-auth/TLS, scenarios 3 and 4) stays excluded.

Non-provider plugin credential migrated to a non-env ref (the under-scrub flagged in the latest review): `tools.web.fetch.firecrawl.apiKey` carries no `providerId`, and migrating it to a **file** ref leaves `envRefId` empty, so the env-ref-id branch alone never scrubbed its stale `FIRECRAWL_API_KEY` line. Driven on the real production `runSecretsApply` (no mocks of the apply logic; real on-disk `.env` with `FIRECRAWL_API_KEY=<shared>`, `OPENAI_API_KEY=<shared>`, `UNRELATED=value`; the SecretRef resolves from a mounted single-value file provider) on the prior env-ref-id-only revision vs this patch:
```
# BEFORE (env-ref-id-only revision, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
$ cat .env
FIRECRAWL_API_KEY=sk-shared-proxy-key   # NOT scrubbed -> migrated plugin credential left in plaintext on a file/exec ref
OPENAI_API_KEY=sk-shared-proxy-key
UNRELATED=value

# AFTER (this patch, real runtime, identical inputs)
$ openclaw secrets apply --from plan.json
$ cat .env
OPENAI_API_KEY=sk-shared-proxy-key      # preserved: not one of the firecrawl target's path segments
UNRELATED=value                         # only FIRECRAWL_API_KEY removed, derived from the `firecrawl` path segment
```
The owned env key is derived from the target's path segments (`firecrawl` -> `FIRECRAWL_API_KEY`) independent of the new ref source, and paired only with the target's own migrated value, so the same-value `OPENAI_API_KEY` (whose name is not a firecrawl path segment) stays intact.

Observed result after fix: the migrated line is removed only for an actually-migrated provider/plugin auth credential (openai apiKey in scenario 1, firecrawl in scenarios 5 and 7, the auth-profile credential in scenario 6, the talk provider apiKey in scenario 8, the firecrawl plugin key on a file ref in scenario 9); a non-migrated same-value provider var survives whether the same-value sibling is another provider's key (scenario 1), a header on the same provider (scenario 3), a header migrated to the provider's own auth env ref (scenario 4), a plugin credential (scenario 5), or a no-op already-ref target sharing a value with a migrated plugin target (scenario 7); a non-provider env-ref source (`OPENCLAW_GATEWAY_TOKEN`, the gateway-token case) is preserved; and an existing auth-profile credential migrating to a non-env ref still scrubs its provider's `.env` line via the store-derived provider, closing the under-scrub regression a prior revision introduced.
What was not tested: the literal compiled `openclaw` CLI binary was not driven for these scenarios because a full local build OOMs on this box; the scenarios ran through the registered CLI `secrets apply` action and the same `runSecretsApply` production function it calls, both on real on-disk state with no mocks of the apply logic. The legacy `auth.json` and auth-profiles store scrubs were not re-driven because they are already keyed per migrated provider and were not changed.





