### PR TITLE
fix(outbound): reject reserved Telegram targets before directory/default fallback

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -737,6 +737,9 @@ outbound host generic and use the messaging adapter surface for provider rules:
   should be treated as `direct`, `group`, or `channel` before directory lookup.
 - `messaging.targetResolver.looksLikeId(raw, normalized)` tells core whether an
   input should skip straight to id-like resolution instead of directory search.
+- `messaging.targetResolver.reservedLiterals` lists bare words that are
+  channel/session references for that provider and must fail closed before
+  directory or default-target fallback.
 - `messaging.targetResolver.resolveTarget(...)` is the plugin fallback when
   core needs a final provider-owned resolution after normalization or after a
   directory miss.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -738,8 +738,9 @@ outbound host generic and use the messaging adapter surface for provider rules:
 - `messaging.targetResolver.looksLikeId(raw, normalized)` tells core whether an
   input should skip straight to id-like resolution instead of directory search.
 - `messaging.targetResolver.reservedLiterals` lists bare words that are
-  channel/session references for that provider and must fail closed before
-  directory or default-target fallback.
+  channel/session references for that provider. Resolution preserves configured
+  directory entries before rejecting reserved literals, then fails closed on a
+  directory miss.
 - `messaging.targetResolver.resolveTarget(...)` is the plugin fallback when
   core needs a final provider-owned resolution after normalization or after a
   directory miss.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -739,7 +739,7 @@ Write colocated tests in `src/channel.test.ts`:
     describeMessageTool and action discovery
   </Card>
   <Card title="Target resolution" icon="crosshair" href="/plugins/architecture-internals#channel-target-resolution">
-    inferTargetChatType, looksLikeId, resolveTarget
+    inferTargetChatType, looksLikeId, reservedLiterals, resolveTarget
   </Card>
   <Card title="Runtime helpers" icon="settings" href="/plugins/sdk-runtime">
     TTS, STT, media, subagent via api.runtime

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -833,6 +833,7 @@ export const telegramPlugin = createChatChannelPlugin({
       targetResolver: {
         looksLikeId: looksLikeTelegramTargetId,
         hint: "<chatId>",
+        reservedLiterals: ["current", "self", "this", "me"],
       },
     },
     resolver: {

--- a/src/channels/plugins/contracts/test-helpers/surface-contract-suite.ts
+++ b/src/channels/plugins/contracts/test-helpers/surface-contract-suite.ts
@@ -92,6 +92,14 @@ export function expectChannelSurfaceContract(params: {
         expect(typeof messaging.targetResolver.hint).toBe("string");
         expect(messaging.targetResolver.hint.trim()).not.toBe("");
       }
+      if (messaging.targetResolver.reservedLiterals !== undefined) {
+        expect(Array.isArray(messaging.targetResolver.reservedLiterals)).toBe(true);
+        expect(
+          messaging.targetResolver.reservedLiterals.every(
+            (value) => typeof value === "string" && value.trim(),
+          ),
+        ).toBe(true);
+      }
       if (messaging.targetResolver.resolveTarget) {
         expect(typeof messaging.targetResolver.resolveTarget).toBe("function");
       }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -608,6 +608,8 @@ export type ChannelMessagingAdapter = {
   targetResolver?: {
     looksLikeId?: (raw: string, normalized?: string) => boolean;
     hint?: string;
+    /** Bare words that are command/session references for this channel, not literal destinations. */
+    reservedLiterals?: readonly string[];
     /**
      * Plugin-owned fallback for explicit/native targets or post-directory-miss
      * resolution. This should complement directory lookup, not duplicate it.

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -1,6 +1,9 @@
 // Isolated agent delivery target tests cover target resolution for cron runs.
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ChannelOutboundAdapter } from "../../channels/plugins/types.js";
+import type {
+  ChannelDirectoryEntry,
+  ChannelOutboundAdapter,
+} from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import {
@@ -739,6 +742,57 @@ describe("resolveDeliveryTarget", () => {
     expect(result.ok).toBe(true);
     expect(result.to).toBe("user:123");
     expect(result.threadId).toBeUndefined();
+  });
+
+  it("resolves cron reserved explicit targets through directory entries", async () => {
+    setMainSessionEntry(undefined);
+    const listGroups = vi.fn(async () => [
+      {
+        kind: "group",
+        id: "-1002458651455",
+        name: "current",
+        handle: "@current",
+      } satisfies ChannelDirectoryEntry,
+    ]);
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: {
+            ...createOutboundTestPlugin({
+              id: "telegram",
+              outbound: createStubOutbound("Telegram"),
+              capabilities: { chatTypes: ["direct", "group", "channel"] },
+              messaging: {
+                ...telegramMessagingForTest,
+                normalizeTarget: normalizeTelegramTargetForDeliveryTest,
+                targetResolver: {
+                  reservedLiterals: ["current", "self", "this", "me"],
+                  hint: "<chatId>",
+                },
+              },
+            }),
+            directory: { listGroups },
+          },
+        },
+      ]),
+    );
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "current",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("-1002458651455");
+    expect(result.threadId).toBeUndefined();
+    expect(listGroups).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: undefined,
+        query: "current",
+      }),
+    );
   });
 
   it("uses canonical route targets even when the route has no thread", async () => {

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { stripTargetProviderPrefix } from "../../infra/outbound/channel-target-prefix.js";
 import type { OutboundSessionRoute } from "../../infra/outbound/outbound-session.js";
+import { isReservedTargetLiteralError } from "../../infra/outbound/target-errors.js";
 import type { ResolvedMessagingTarget } from "../../infra/outbound/target-resolver.js";
 import { tryResolveLoadedOutboundTarget } from "../../infra/outbound/targets-loaded.js";
 import { resolveSessionDeliveryTarget } from "../../infra/outbound/targets-session.js";
@@ -349,7 +350,7 @@ export async function resolveDeliveryTarget(
     allowFrom: effectiveAllowFrom,
   });
   if (!docked.ok) {
-    if (!toCandidate || !docked.error.message.includes("Reserved target")) {
+    if (!toCandidate || !isReservedTargetLiteralError(docked.error)) {
       return {
         ok: false,
         channel,

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -349,17 +349,20 @@ export async function resolveDeliveryTarget(
     allowFrom: effectiveAllowFrom,
   });
   if (!docked.ok) {
-    return {
-      ok: false,
-      channel,
-      to: undefined,
-      accountId,
-      threadId: explicitThreadId,
-      mode,
-      error: docked.error,
-    };
+    if (!toCandidate || !docked.error.message.includes("Reserved target")) {
+      return {
+        ok: false,
+        channel,
+        to: undefined,
+        accountId,
+        threadId: explicitThreadId,
+        mode,
+        error: docked.error,
+      };
+    }
+  } else {
+    toCandidate = docked.to;
   }
-  toCandidate = docked.to;
   const targetResolution = await deliveryTargetRuntime.resolveChannelTargetForDelivery({
     cfg,
     channel,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -2300,7 +2300,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       let resolvedTo = deliveryPlan.resolvedTo;
       let effectivePlan = deliveryPlan;
       let deliveryDowngradeReason: string | null = null;
-      let deliveryTargetResolutionError: Error | undefined;
+      let deliveryTargetResolutionError: Error | undefined = deliveryPlan.targetResolutionError;
 
       if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
         const cfgResolved = cfgForAgent ?? cfg;
@@ -2326,6 +2326,27 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
           deliveryDowngradeReason = String(err);
         }
+      }
+
+      if (wantsDelivery && deliveryTargetResolutionError) {
+        if (!bestEffortDeliver) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, String(deliveryTargetResolutionError)),
+          );
+          return;
+        }
+        deliveryDowngradeReason = String(deliveryTargetResolutionError);
+        resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
+        deliveryTargetMode = undefined;
+        resolvedTo = undefined;
+        effectivePlan = {
+          ...deliveryPlan,
+          resolvedChannel,
+          resolvedTo,
+          deliveryTargetMode,
+        };
       }
 
       if (!resolvedTo && isDeliverableMessageChannel(resolvedChannel)) {

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -443,6 +443,55 @@ describe("agent delivery helpers", () => {
     expect(plan.targetResolutionError).toBe(reservedError);
   });
 
+  it("keeps directory-resolved reserved explicit targets when session-route canonicalization misses", async () => {
+    mocks.resolveOutboundChannelPlugin.mockReturnValue({
+      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
+    });
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: false,
+      error: new Error('Reserved target "current" for Telegram'),
+    });
+    mocks.resolveChannelTarget.mockResolvedValueOnce({
+      ok: true,
+      target: {
+        to: "telegram:-1002458651455",
+        kind: "group",
+        source: "directory",
+        resolutionSource: "directory",
+      },
+    });
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce(null);
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      currentSessionKey: "agent:main",
+      sessionEntry: undefined,
+      requestedChannel: "telegram",
+      explicitTo: "current",
+      accountId: "work",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveOutboundSessionRoute).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "telegram",
+      agentId: "agent",
+      accountId: "work",
+      target: "telegram:-1002458651455",
+      resolvedTarget: {
+        to: "telegram:-1002458651455",
+        kind: "group",
+        source: "directory",
+        resolutionSource: "directory",
+      },
+      currentSessionKey: "agent:main",
+      threadId: undefined,
+    });
+    expect(plan.resolvedTo).toBe("telegram:-1002458651455");
+    expect(plan.targetResolutionError).toBeUndefined();
+  });
+
   it("surfaces stored explicit target errors even when explicit validation is disabled", () => {
     const targetResolutionError = new Error('reserved target "current"');
 

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -313,6 +313,52 @@ describe("agent delivery helpers", () => {
     expect(plan.resolvedTo).toBe("1470130713209602050");
   });
 
+  it("carries explicit target resolution errors from session-route preparation", async () => {
+    const targetResolutionError = new Error('reserved target "current"');
+    mocks.resolveOutboundChannelPlugin.mockReturnValue({
+      messaging: { resolveOutboundSessionRoute: vi.fn() },
+    });
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: false,
+      error: targetResolutionError,
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      sessionEntry: undefined,
+      requestedChannel: "workspace",
+      explicitTo: "current",
+      accountId: undefined,
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
+    expect(plan.resolvedTo).toBe("current");
+    expect(plan.targetResolutionError).toBe(targetResolutionError);
+  });
+
+  it("surfaces stored explicit target errors even when explicit validation is disabled", () => {
+    const targetResolutionError = new Error('reserved target "current"');
+
+    const resolved = resolveAgentOutboundTarget({
+      cfg: {} as OpenClawConfig,
+      plan: {
+        baseDelivery: { mode: "explicit" },
+        resolvedChannel: "workspace",
+        resolvedTo: "current",
+        deliveryTargetMode: "explicit",
+        targetResolutionError,
+      },
+      targetMode: "explicit",
+      validateExplicitTarget: false,
+    });
+
+    expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
+    expect(resolved.resolvedTarget).toEqual({ ok: false, error: targetResolutionError });
+    expect(resolved.resolvedTo).toBeUndefined();
+  });
+
   it("falls back to the original plan when session-route canonicalization fails", async () => {
     mocks.resolveOutboundChannelPlugin.mockReturnValue({
       messaging: { resolveOutboundSessionRoute: vi.fn() },

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -313,14 +313,13 @@ describe("agent delivery helpers", () => {
     expect(plan.resolvedTo).toBe("1470130713209602050");
   });
 
-  it("carries explicit target resolution errors from session-route preparation", async () => {
-    const targetResolutionError = new Error('reserved target "current"');
+  it("defers reserved-literal errors to async session-route resolution", async () => {
     mocks.resolveOutboundChannelPlugin.mockReturnValue({
       messaging: { resolveOutboundSessionRoute: vi.fn() },
     });
     mocks.resolveOutboundTarget.mockReturnValueOnce({
       ok: false,
-      error: targetResolutionError,
+      error: new Error('Reserved target "current" for Telegram'),
     });
 
     const plan = await resolveAgentDeliveryPlanWithSessionRoute({
@@ -333,9 +332,12 @@ describe("agent delivery helpers", () => {
       wantsDelivery: true,
     });
 
-    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
+    // Reserved-literal errors do not block session route resolution; the
+    // async resolver (resolveMessagingTarget) does directory-first lookup
+    // before rejecting reserved literals.
+    expect(mocks.resolveOutboundSessionRoute).toHaveBeenCalled();
     expect(plan.resolvedTo).toBe("current");
-    expect(plan.targetResolutionError).toBe(targetResolutionError);
+    expect(plan.targetResolutionError).toBeUndefined();
   });
 
   it("surfaces stored explicit target errors even when explicit validation is disabled", () => {

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -4,6 +4,15 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   resolveOutboundChannelPlugin: vi.fn<() => unknown>(() => null),
+  resolveChannelTarget: vi.fn<() => Promise<unknown>>(async () => ({
+    ok: true,
+    target: {
+      to: "+1999",
+      kind: "group",
+      source: "normalized",
+      resolutionSource: "normalized",
+    },
+  })),
   resolveOutboundTarget: vi.fn<() => { ok: true; to: string } | { ok: false; error: Error }>(
     () => ({ ok: true, to: "+1999" }),
   ),
@@ -82,11 +91,16 @@ vi.mock("./outbound-session.js", () => ({
   resolveOutboundSessionRoute: mocks.resolveOutboundSessionRoute,
 }));
 
+vi.mock("./target-resolver.js", () => ({
+  resolveChannelTarget: mocks.resolveChannelTarget,
+}));
+
 vi.mock("../../utils/message-channel.js", () => ({
   INTERNAL_MESSAGE_CHANNEL: "webchat",
-  isDeliverableMessageChannel: (channel: string) => ["directchat", "workspace"].includes(channel),
+  isDeliverableMessageChannel: (channel: string) =>
+    ["directchat", "workspace", "telegram"].includes(channel),
   isGatewayMessageChannel: (channel: string) =>
-    ["directchat", "workspace", "webchat"].includes(channel),
+    ["directchat", "workspace", "telegram", "webchat"].includes(channel),
   normalizeMessageChannel: (value: string) => value.trim().toLowerCase(),
 }));
 
@@ -106,7 +120,18 @@ beforeAll(async () => {
 beforeEach(() => {
   mocks.resolveOutboundChannelPlugin.mockReset();
   mocks.resolveOutboundChannelPlugin.mockReturnValue(null);
-  mocks.resolveOutboundTarget.mockClear();
+  mocks.resolveChannelTarget.mockReset();
+  mocks.resolveChannelTarget.mockResolvedValue({
+    ok: true,
+    target: {
+      to: "+1999",
+      kind: "group",
+      source: "normalized",
+      resolutionSource: "normalized",
+    },
+  });
+  mocks.resolveOutboundTarget.mockReset();
+  mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "+1999" });
   mocks.resolveOutboundSessionRoute.mockReset();
   mocks.resolveOutboundSessionRoute.mockResolvedValue(null);
   mocks.resolveSessionDeliveryTarget.mockClear();
@@ -313,31 +338,109 @@ describe("agent delivery helpers", () => {
     expect(plan.resolvedTo).toBe("1470130713209602050");
   });
 
-  it("defers reserved-literal errors to async session-route resolution", async () => {
+  it("resolves reserved explicit targets through directory-capable resolution before session routing", async () => {
     mocks.resolveOutboundChannelPlugin.mockReturnValue({
-      messaging: { resolveOutboundSessionRoute: vi.fn() },
+      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
     });
     mocks.resolveOutboundTarget.mockReturnValueOnce({
       ok: false,
       error: new Error('Reserved target "current" for Telegram'),
+    });
+    mocks.resolveChannelTarget.mockResolvedValueOnce({
+      ok: true,
+      target: {
+        to: "telegram:-1002458651455",
+        kind: "group",
+        source: "directory",
+        resolutionSource: "directory",
+      },
+    });
+    mocks.resolveOutboundSessionRoute.mockResolvedValueOnce({
+      sessionKey: "agent:telegram:group:-1002458651455",
+      baseSessionKey: "agent:telegram:group:-1002458651455",
+      peer: { kind: "group", id: "-1002458651455" },
+      chatType: "group",
+      from: "telegram:group:-1002458651455",
+      to: "telegram:-1002458651455",
+    });
+
+    const plan = await resolveAgentDeliveryPlanWithSessionRoute({
+      cfg: {} as OpenClawConfig,
+      agentId: "agent",
+      currentSessionKey: "agent:main",
+      sessionEntry: undefined,
+      requestedChannel: "telegram",
+      explicitTo: "current",
+      accountId: "work",
+      wantsDelivery: true,
+    });
+
+    expect(mocks.resolveChannelTarget).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "telegram",
+      input: "current",
+      accountId: "work",
+      unknownTargetMode: "normalized",
+      plugin: {
+        messaging: { resolveOutboundSessionRoute: expect.any(Function), targetResolver: {} },
+      },
+    });
+    expect(mocks.resolveOutboundSessionRoute).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "telegram",
+      agentId: "agent",
+      accountId: "work",
+      target: "telegram:-1002458651455",
+      resolvedTarget: {
+        to: "telegram:-1002458651455",
+        kind: "group",
+        source: "directory",
+        resolutionSource: "directory",
+      },
+      currentSessionKey: "agent:main",
+      threadId: undefined,
+    });
+    expect(plan.resolvedTo).toBe("telegram:-1002458651455");
+    expect(plan.targetResolutionError).toBeUndefined();
+  });
+
+  it("keeps reserved explicit target errors when directory-capable resolution misses", async () => {
+    const reservedError = new Error('Reserved target "current" for Telegram');
+    mocks.resolveOutboundChannelPlugin.mockReturnValue({
+      messaging: { resolveOutboundSessionRoute: vi.fn(), targetResolver: {} },
+    });
+    mocks.resolveOutboundTarget.mockReturnValueOnce({
+      ok: false,
+      error: reservedError,
+    });
+    mocks.resolveChannelTarget.mockResolvedValueOnce({
+      ok: false,
+      error: reservedError,
     });
 
     const plan = await resolveAgentDeliveryPlanWithSessionRoute({
       cfg: {} as OpenClawConfig,
       agentId: "agent",
       sessionEntry: undefined,
-      requestedChannel: "workspace",
+      requestedChannel: "telegram",
       explicitTo: "current",
       accountId: undefined,
       wantsDelivery: true,
     });
 
-    // Reserved-literal errors do not block session route resolution; the
-    // async resolver (resolveMessagingTarget) does directory-first lookup
-    // before rejecting reserved literals.
-    expect(mocks.resolveOutboundSessionRoute).toHaveBeenCalled();
+    expect(mocks.resolveChannelTarget).toHaveBeenCalledWith({
+      cfg: {},
+      channel: "telegram",
+      input: "current",
+      accountId: undefined,
+      unknownTargetMode: "normalized",
+      plugin: {
+        messaging: { resolveOutboundSessionRoute: expect.any(Function), targetResolver: {} },
+      },
+    });
+    expect(mocks.resolveOutboundSessionRoute).not.toHaveBeenCalled();
     expect(plan.resolvedTo).toBe("current");
-    expect(plan.targetResolutionError).toBeUndefined();
+    expect(plan.targetResolutionError).toBe(reservedError);
   });
 
   it("surfaces stored explicit target errors even when explicit validation is disabled", () => {

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -163,9 +163,16 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     accountId: plan.resolvedAccountId,
     mode: plan.deliveryTargetMode ?? "explicit",
   });
-  if (!normalizedTarget.ok) {
+  // Reserved-literal errors are not fatal for explicit delivery: the async
+  // session-route resolver (resolveChannelTarget → resolveMessagingTarget)
+  // does directory-first lookup before rejecting reserved literals, so a
+  // configured directory entry named like a reserved word still resolves.
+  const isReservedLiteralError =
+    !normalizedTarget.ok && normalizedTarget.error.message.includes("Reserved target");
+  if (!normalizedTarget.ok && !isReservedLiteralError) {
     return { ...plan, targetResolutionError: normalizedTarget.error };
   }
+  const sessionRouteTarget = normalizedTarget.ok ? normalizedTarget.to : (plan.resolvedTo ?? "");
   const explicitThreadId =
     params.explicitThreadId != null && params.explicitThreadId !== ""
       ? params.explicitThreadId
@@ -177,7 +184,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
         channel: plan.resolvedChannel as ChannelId,
         agentId: params.agentId,
         accountId: plan.resolvedAccountId,
-        target: normalizedTarget.to,
+        target: sessionRouteTarget,
         currentSessionKey: params.currentSessionKey,
         threadId: plan.deliveryTargetMode === "explicit" ? explicitThreadId : plan.resolvedThreadId,
       });

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -212,6 +212,14 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     }
   })();
   if (!route) {
+    if (resolvedSessionRouteTarget) {
+      return {
+        ...plan,
+        resolvedTo: resolvedSessionRouteTarget.to,
+        resolvedThreadId:
+          plan.deliveryTargetMode === "explicit" ? explicitThreadId : plan.resolvedThreadId,
+      };
+    }
     return plan;
   }
   return {

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -15,6 +15,7 @@ import {
 } from "../../utils/message-channel.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveOutboundSessionRoute } from "./outbound-session.js";
+import { isReservedTargetLiteralError } from "./target-errors.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import type { OutboundTargetResolution } from "./targets.js";
 import {
@@ -174,7 +175,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   if (normalizedTarget.ok) {
     sessionRouteTarget = normalizedTarget.to;
   } else {
-    if (!normalizedTarget.error.message.includes("Reserved target")) {
+    if (!isReservedTargetLiteralError(normalizedTarget.error)) {
       return { ...plan, targetResolutionError: normalizedTarget.error };
     }
     const resolvedTarget = await resolveChannelTarget({

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -29,6 +29,7 @@ export type AgentDeliveryPlan = {
   resolvedAccountId?: string;
   resolvedThreadId?: string | number;
   deliveryTargetMode?: ChannelOutboundTargetMode;
+  targetResolutionError?: Error;
 };
 
 export function resolveAgentDeliveryPlan(params: {
@@ -163,7 +164,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     mode: plan.deliveryTargetMode ?? "explicit",
   });
   if (!normalizedTarget.ok) {
-    return plan;
+    return { ...plan, targetResolutionError: normalizedTarget.error };
   }
   const explicitThreadId =
     params.explicitThreadId != null && params.explicitThreadId !== ""
@@ -210,6 +211,13 @@ export function resolveAgentOutboundTarget(params: {
     params.targetMode ??
     params.plan.deliveryTargetMode ??
     (params.plan.resolvedTo ? "explicit" : "implicit");
+  if (params.plan.targetResolutionError) {
+    return {
+      resolvedTarget: { ok: false, error: params.plan.targetResolutionError },
+      resolvedTo: undefined,
+      targetMode,
+    };
+  }
   if (!isDeliverableMessageChannel(params.plan.resolvedChannel)) {
     return {
       resolvedTarget: null,

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -146,20 +146,21 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   },
 ): Promise<AgentDeliveryPlan> {
   const plan = resolveAgentDeliveryPlan(params);
-  const plugin =
-    params.wantsDelivery && plan.resolvedTo && isDeliverableMessageChannel(plan.resolvedChannel)
-      ? resolveOutboundChannelPlugin({
-          channel: plan.resolvedChannel,
-          cfg: params.cfg,
-          allowBootstrap: true,
-        })
-      : undefined;
+  const { resolvedChannel, resolvedTo } = plan;
+  if (!params.wantsDelivery || !resolvedTo || !isDeliverableMessageChannel(resolvedChannel)) {
+    return plan;
+  }
+  const plugin = resolveOutboundChannelPlugin({
+    channel: resolvedChannel,
+    cfg: params.cfg,
+    allowBootstrap: true,
+  });
   if (!plugin?.messaging?.resolveOutboundSessionRoute) {
     return plan;
   }
   const normalizedTarget = resolveOutboundTarget({
-    channel: plan.resolvedChannel,
-    to: plan.resolvedTo,
+    channel: resolvedChannel,
+    to: resolvedTo,
     cfg: params.cfg,
     accountId: plan.resolvedAccountId,
     mode: plan.deliveryTargetMode ?? "explicit",
@@ -174,8 +175,8 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     }
     const resolvedTarget = await resolveChannelTarget({
       cfg: params.cfg,
-      channel: plan.resolvedChannel as ChannelId,
-      input: plan.resolvedTo,
+      channel: resolvedChannel as ChannelId,
+      input: resolvedTo,
       accountId: plan.resolvedAccountId,
       unknownTargetMode: "normalized",
       plugin,
@@ -194,7 +195,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     try {
       return await resolveOutboundSessionRoute({
         cfg: params.cfg,
-        channel: plan.resolvedChannel as ChannelId,
+        channel: resolvedChannel as ChannelId,
         agentId: params.agentId,
         accountId: plan.resolvedAccountId,
         target: sessionRouteTarget,

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -15,6 +15,7 @@ import {
 } from "../../utils/message-channel.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { resolveOutboundSessionRoute } from "./outbound-session.js";
+import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import type { OutboundTargetResolution } from "./targets.js";
 import {
   resolveOutboundTarget,
@@ -156,6 +157,11 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   ) {
     return plan;
   }
+  const plugin = resolveOutboundChannelPlugin({
+    channel: plan.resolvedChannel,
+    cfg: params.cfg,
+    allowBootstrap: true,
+  });
   const normalizedTarget = resolveOutboundTarget({
     channel: plan.resolvedChannel,
     to: plan.resolvedTo,
@@ -163,16 +169,28 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
     accountId: plan.resolvedAccountId,
     mode: plan.deliveryTargetMode ?? "explicit",
   });
-  // Reserved-literal errors are not fatal for explicit delivery: the async
-  // session-route resolver (resolveChannelTarget → resolveMessagingTarget)
-  // does directory-first lookup before rejecting reserved literals, so a
-  // configured directory entry named like a reserved word still resolves.
-  const isReservedLiteralError =
-    !normalizedTarget.ok && normalizedTarget.error.message.includes("Reserved target");
-  if (!normalizedTarget.ok && !isReservedLiteralError) {
-    return { ...plan, targetResolutionError: normalizedTarget.error };
+  let sessionRouteTarget: string;
+  let resolvedSessionRouteTarget: ResolvedMessagingTarget | undefined;
+  if (normalizedTarget.ok) {
+    sessionRouteTarget = normalizedTarget.to;
+  } else {
+    if (!normalizedTarget.error.message.includes("Reserved target")) {
+      return { ...plan, targetResolutionError: normalizedTarget.error };
+    }
+    const resolvedTarget = await resolveChannelTarget({
+      cfg: params.cfg,
+      channel: plan.resolvedChannel as ChannelId,
+      input: plan.resolvedTo,
+      accountId: plan.resolvedAccountId,
+      unknownTargetMode: "normalized",
+      plugin,
+    });
+    if (!resolvedTarget.ok) {
+      return { ...plan, targetResolutionError: resolvedTarget.error };
+    }
+    sessionRouteTarget = resolvedTarget.target.to;
+    resolvedSessionRouteTarget = resolvedTarget.target;
   }
-  const sessionRouteTarget = normalizedTarget.ok ? normalizedTarget.to : (plan.resolvedTo ?? "");
   const explicitThreadId =
     params.explicitThreadId != null && params.explicitThreadId !== ""
       ? params.explicitThreadId
@@ -185,6 +203,7 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
         agentId: params.agentId,
         accountId: plan.resolvedAccountId,
         target: sessionRouteTarget,
+        ...(resolvedSessionRouteTarget ? { resolvedTarget: resolvedSessionRouteTarget } : {}),
         currentSessionKey: params.currentSessionKey,
         threadId: plan.deliveryTargetMode === "explicit" ? explicitThreadId : plan.resolvedThreadId,
       });

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -146,23 +146,17 @@ export async function resolveAgentDeliveryPlanWithSessionRoute(
   },
 ): Promise<AgentDeliveryPlan> {
   const plan = resolveAgentDeliveryPlan(params);
-  if (
-    !params.wantsDelivery ||
-    !plan.resolvedTo ||
-    !isDeliverableMessageChannel(plan.resolvedChannel) ||
-    !resolveOutboundChannelPlugin({
-      channel: plan.resolvedChannel,
-      cfg: params.cfg,
-      allowBootstrap: true,
-    })?.messaging?.resolveOutboundSessionRoute
-  ) {
+  const plugin =
+    params.wantsDelivery && plan.resolvedTo && isDeliverableMessageChannel(plan.resolvedChannel)
+      ? resolveOutboundChannelPlugin({
+          channel: plan.resolvedChannel,
+          cfg: params.cfg,
+          allowBootstrap: true,
+        })
+      : undefined;
+  if (!plugin?.messaging?.resolveOutboundSessionRoute) {
     return plan;
   }
-  const plugin = resolveOutboundChannelPlugin({
-    channel: plan.resolvedChannel,
-    cfg: params.cfg,
-    allowBootstrap: true,
-  });
   const normalizedTarget = resolveOutboundTarget({
     channel: plan.resolvedChannel,
     to: plan.resolvedTo,

--- a/src/infra/outbound/target-errors.test.ts
+++ b/src/infra/outbound/target-errors.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   ambiguousTargetError,
   ambiguousTargetMessage,
+  isReservedTargetLiteralError,
   missingTargetError,
   missingTargetMessage,
+  reservedTargetLiteralError,
   unknownTargetError,
   unknownTargetMessage,
 } from "./target-errors.js";
@@ -67,6 +69,15 @@ describe("target error helpers", () => {
   it("includes the hint in ambiguous target errors", () => {
     expect(ambiguousTargetError("Discord", "general", "Use channel:123").message).toContain(
       "Hint: Use channel:123",
+    );
+  });
+
+  it("identifies reserved target literal errors", () => {
+    expect(isReservedTargetLiteralError(reservedTargetLiteralError("Telegram", "current"))).toBe(
+      true,
+    );
+    expect(isReservedTargetLiteralError(new Error('Unknown target "current" for Telegram.'))).toBe(
+      false,
     );
   });
 });

--- a/src/infra/outbound/target-errors.ts
+++ b/src/infra/outbound/target-errors.ts
@@ -48,6 +48,10 @@ export function reservedTargetLiteralError(provider: string, raw: string, hint?:
   return new Error(reservedTargetLiteralMessage(provider, raw, hint));
 }
 
+export function isReservedTargetLiteralError(error: Error): boolean {
+  return error.message.includes("Reserved target");
+}
+
 function formatTargetHint(hint?: string, withLabel = false): string {
   const normalized = hint?.trim();
   if (!normalized) {

--- a/src/infra/outbound/target-errors.ts
+++ b/src/infra/outbound/target-errors.ts
@@ -40,6 +40,14 @@ export function unknownTargetError(provider: string, raw: string, hint?: string)
   return new Error(unknownTargetMessage(provider, raw, hint));
 }
 
+export function reservedTargetLiteralMessage(provider: string, raw: string, hint?: string): string {
+  return `Reserved target "${raw}" for ${provider} cannot be used as a literal destination. Provide an explicit id or handle.${formatTargetHint(hint, true)}`;
+}
+
+export function reservedTargetLiteralError(provider: string, raw: string, hint?: string): Error {
+  return new Error(reservedTargetLiteralMessage(provider, raw, hint));
+}
+
 function formatTargetHint(hint?: string, withLabel = false): string {
   const normalized = hint?.trim();
   if (!normalized) {

--- a/src/infra/outbound/target-normalization.ts
+++ b/src/infra/outbound/target-normalization.ts
@@ -32,6 +32,52 @@ function resolveChannelPluginForTargetRead(channelId: ChannelId): ChannelPlugin 
   return getLoadedChannelPluginForRead(channelId) ?? getChannelPlugin(channelId);
 }
 
+function normalizeTargetLiteral(value: string): string | undefined {
+  return normalizeOptionalLowercaseString(value);
+}
+
+function stripPluginTargetPrefix(raw: string, plugin: ChannelPlugin): string {
+  let target = raw.trim();
+  const prefixes = [plugin.id, ...(plugin.messaging?.targetPrefixes ?? [])]
+    .map((prefix) => normalizeTargetLiteral(String(prefix)))
+    .filter((prefix): prefix is string => Boolean(prefix));
+  while (target) {
+    const lowered = normalizeTargetLiteral(target) ?? "";
+    const prefix = prefixes.find((candidate) => lowered.startsWith(`${candidate}:`));
+    if (!prefix) {
+      return target;
+    }
+    target = target.slice(prefix.length + 1).trim();
+  }
+  return target;
+}
+
+export function resolveReservedTargetLiteral(params: {
+  raw?: string;
+  plugin?: ChannelPlugin;
+}): string | undefined {
+  const raw = normalizeOptionalString(params.raw);
+  const plugin = params.plugin;
+  const reservedLiterals = plugin?.messaging?.targetResolver?.reservedLiterals;
+  if (!raw || !plugin || !reservedLiterals?.length) {
+    return undefined;
+  }
+  const stripped = stripPluginTargetPrefix(raw, plugin);
+  if (!stripped || /^[@#]/.test(stripped) || /^(channel|group|user):/i.test(stripped)) {
+    return undefined;
+  }
+  const normalized = normalizeTargetLiteral(stripped);
+  if (!normalized) {
+    return undefined;
+  }
+  const reserved = new Set(
+    reservedLiterals
+      .map(normalizeTargetLiteral)
+      .filter((literal): literal is string => Boolean(literal)),
+  );
+  return reserved.has(normalized) ? normalized : undefined;
+}
+
 function resetTargetNormalizerCacheForTests(): void {
   targetNormalizerCacheByChannelId.clear();
 }
@@ -224,10 +270,15 @@ export function buildTargetResolverSignature(
     : "pinned";
   const resolver = plugin?.messaging?.targetResolver;
   const hint = resolver?.hint ?? "";
+  const reserved = (resolver?.reservedLiterals ?? [])
+    .map(normalizeTargetLiteral)
+    .filter((literal): literal is string => Boolean(literal))
+    .toSorted()
+    .join(",");
   const looksLike = resolver?.looksLikeId;
   // Function source is only a cheap invalidation hint; resolver behavior still belongs to the plugin.
   const source = looksLike ? looksLike.toString() : "";
-  return hashSignature(`${registryScope}|${hint}|${source}`);
+  return hashSignature(`${registryScope}|${hint}|${reserved}|${source}`);
 }
 
 function hashSignature(value: string): string {

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -130,7 +130,7 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroupsLive).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects plugin-reserved literal targets before directory lookup", async () => {
+  it("preserves configured directory entries before rejecting reserved literal targets", async () => {
     mocks.getChannelPlugin.mockReturnValue({
       ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
       directory: {
@@ -162,13 +162,47 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       input: "current",
     });
 
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target.to).toBe("-1002458651455");
+      expect(result.target.source).toBe("directory");
+    }
+    expect(mocks.listGroups).toHaveBeenCalled();
+    expect(mocks.resolveTarget).not.toHaveBeenCalled();
+  });
+
+  it("rejects reserved literal targets after directory miss", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        targetResolver: {
+          reservedLiterals: ["current", "self", "this", "me"],
+          hint: "<chatId>",
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    });
+    mocks.listGroups.mockResolvedValue([]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "current",
+    });
+
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.message).toContain('Reserved target "current"');
       expect(result.error.message).toContain("Telegram");
     }
-    expect(mocks.listGroups).not.toHaveBeenCalled();
-    expect(mocks.listGroupsLive).not.toHaveBeenCalled();
+    expect(mocks.listGroups).toHaveBeenCalled();
     expect(mocks.resolveTarget).not.toHaveBeenCalled();
   });
 

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -130,6 +130,48 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroupsLive).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects plugin-reserved literal targets before directory lookup", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        targetResolver: {
+          reservedLiterals: ["current", "self", "this", "me"],
+          hint: "<chatId>",
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    });
+    mocks.listGroups.mockResolvedValue([
+      {
+        kind: "group",
+        id: "-1002458651455",
+        name: "Current x jerry Channel",
+        handle: "@current",
+      } satisfies ChannelDirectoryEntry,
+    ]);
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "current",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('Reserved target "current"');
+      expect(result.error.message).toContain("Telegram");
+    }
+    expect(mocks.listGroups).not.toHaveBeenCalled();
+    expect(mocks.listGroupsLive).not.toHaveBeenCalled();
+    expect(mocks.resolveTarget).not.toHaveBeenCalled();
+  });
+
   it("does not reuse directory cache entries across prepared plugin runtimes", async () => {
     const firstListGroups = vi
       .fn()

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -171,6 +171,78 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.resolveTarget).not.toHaveBeenCalled();
   });
 
+  it("keeps reserved literals on the directory path before id-like plugin normalization", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        normalizeTarget: (raw: string) =>
+          raw === "current" || raw === "telegram:current" ? "telegram:@current" : raw,
+        targetResolver: {
+          looksLikeId: (raw: string) => raw === "current" || raw === "telegram:current",
+          reservedLiterals: ["current", "self", "this", "me"],
+          hint: "<chatId>",
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    });
+    mocks.listGroups.mockResolvedValueOnce([
+      { kind: "group", id: "room-1", name: "current" } satisfies ChannelDirectoryEntry,
+    ]);
+
+    const hit = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "current",
+    });
+
+    expect(hit.ok).toBe(true);
+    if (hit.ok) {
+      expect(hit.target.to).toBe("room-1");
+      expect(hit.target.source).toBe("directory");
+    }
+    expect(mocks.resolveTarget).not.toHaveBeenCalled();
+
+    resetDirectoryCache();
+    mocks.listGroups.mockResolvedValueOnce([
+      { kind: "group", id: "room-1", name: "current" } satisfies ChannelDirectoryEntry,
+    ]);
+
+    const prefixedHit = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "telegram:current",
+    });
+
+    expect(prefixedHit.ok).toBe(true);
+    if (prefixedHit.ok) {
+      expect(prefixedHit.target.to).toBe("room-1");
+      expect(prefixedHit.target.source).toBe("directory");
+    }
+
+    resetDirectoryCache();
+    mocks.listGroups.mockResolvedValueOnce([]);
+    mocks.listGroupsLive.mockResolvedValueOnce([]);
+
+    const miss = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "current",
+    });
+
+    expect(miss.ok).toBe(false);
+    if (!miss.ok) {
+      expect(miss.error.message).toContain('Reserved target "current"');
+      expect(miss.error.message).toContain("Telegram");
+    }
+    expect(mocks.resolveTarget).not.toHaveBeenCalled();
+  });
+
   it("rejects reserved literal targets after directory miss", async () => {
     mocks.getChannelPlugin.mockReturnValue({
       ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -132,7 +132,11 @@ describe("resolveMessagingTarget (directory fallback)", () => {
 
   it("preserves configured directory entries before rejecting reserved literal targets", async () => {
     mocks.getChannelPlugin.mockReturnValue({
-      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        label: "Telegram",
+        capabilities: { chatTypes: ["direct", "group", "channel"] },
+      }),
       directory: {
         listPeers: mocks.listPeers,
         listPeersLive: mocks.listPeersLive,
@@ -173,7 +177,11 @@ describe("resolveMessagingTarget (directory fallback)", () => {
 
   it("keeps reserved literals on the directory path before id-like plugin normalization", async () => {
     mocks.getChannelPlugin.mockReturnValue({
-      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        label: "Telegram",
+        capabilities: { chatTypes: ["direct", "group", "channel"] },
+      }),
       directory: {
         listPeers: mocks.listPeers,
         listPeersLive: mocks.listPeersLive,
@@ -245,7 +253,11 @@ describe("resolveMessagingTarget (directory fallback)", () => {
 
   it("rejects reserved literal targets after directory miss", async () => {
     mocks.getChannelPlugin.mockReturnValue({
-      ...createChannelTestPluginBase({ id: "telegram", label: "Telegram" }),
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        label: "Telegram",
+        capabilities: { chatTypes: ["direct", "group", "channel"] },
+      }),
       directory: {
         listPeers: mocks.listPeers,
         listPeersLive: mocks.listPeersLive,

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -290,6 +290,46 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.resolveTarget).not.toHaveBeenCalled();
   });
 
+  it("requires exact directory matches before preserving reserved literal targets", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        label: "Telegram",
+        capabilities: { chatTypes: ["direct", "group", "channel"] },
+      }),
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        targetResolver: {
+          reservedLiterals: ["current", "self", "this", "me"],
+          hint: "<chatId>",
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    });
+    mocks.listGroups.mockResolvedValue([
+      { kind: "group", id: "memes-room", name: "memes" } satisfies ChannelDirectoryEntry,
+    ]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "me",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('Reserved target "me"');
+      expect(result.error.message).toContain("Telegram");
+    }
+    expect(mocks.resolveTarget).not.toHaveBeenCalled();
+  });
+
   it("does not reuse directory cache entries across prepared plugin runtimes", async () => {
     const firstListGroups = vi
       .fn()

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -227,6 +227,7 @@ function matchesDirectoryEntry(params: {
   entry: ChannelDirectoryEntry;
   query: string;
   plugin?: ChannelPlugin;
+  exactOnly?: boolean;
 }): boolean {
   const query = normalizeQuery(params.query);
   if (!query) {
@@ -244,7 +245,9 @@ function matchesDirectoryEntry(params: {
     ? stripTargetPrefixes(params.entry.handle, params.channel, params.plugin)
     : "";
   const candidates = [id, name, handle].map((value) => normalizeQuery(value)).filter(Boolean);
-  return candidates.some((value) => value === query || value.includes(query));
+  return candidates.some((value) =>
+    params.exactOnly ? value === query : value === query || value.includes(query),
+  );
 }
 
 function resolveMatch(params: {
@@ -252,6 +255,7 @@ function resolveMatch(params: {
   entries: ChannelDirectoryEntry[];
   query: string;
   plugin?: ChannelPlugin;
+  exactOnly?: boolean;
 }) {
   const matches = params.entries.filter((entry) =>
     matchesDirectoryEntry({
@@ -259,6 +263,7 @@ function resolveMatch(params: {
       entry,
       query: params.query,
       plugin: params.plugin,
+      exactOnly: params.exactOnly,
     }),
   );
   if (matches.length === 0) {
@@ -462,7 +467,13 @@ export async function resolveMessagingTarget(params: {
     preferLiveOnMiss: true,
     plugin,
   });
-  const match = resolveMatch({ channel: params.channel, entries, query, plugin });
+  const match = resolveMatch({
+    channel: params.channel,
+    entries,
+    query,
+    plugin,
+    exactOnly: Boolean(reservedLiteral),
+  });
   if (match.kind === "single") {
     const entry = match.entry;
     return {

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -512,9 +512,7 @@ export async function resolveMessagingTarget(params: {
       candidates: match.entries,
     };
   }
-  // Directory miss: reject reserved literals before falling back to plugin
-  // resolution, so a bare reserved word without a matching directory entry
-  // does not accidentally resolve to a public channel or incorrect target.
+  // Directory misses are the fail-closed boundary for reserved literals.
   if (reservedLiteral) {
     return { ok: false, error: reservedTargetLiteralError(providerLabel, reservedLiteral, hint) };
   }

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -98,7 +98,7 @@ function normalizeQuery(value: string): string {
 
 function stripTargetPrefixes(value: string, channel?: ChannelId, plugin?: ChannelPlugin): string {
   const providerPrefixes = [channel, plugin?.id, ...(plugin?.messaging?.targetPrefixes ?? [])]
-    .map((prefix) => (prefix ? String(prefix).trim().toLowerCase() : ""))
+    .map((prefix) => prefix?.trim().toLowerCase() ?? "")
     .filter(Boolean);
   let target = value.trim();
   while (target) {

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -400,10 +400,6 @@ export async function resolveMessagingTarget(params: {
   const plugin = params.plugin ?? getChannelPlugin(params.channel);
   const providerLabel = plugin?.meta?.label ?? params.channel;
   const hint = plugin?.messaging?.targetResolver?.hint;
-  const reservedLiteral = resolveReservedTargetLiteral({ raw, plugin });
-  if (reservedLiteral) {
-    return { ok: false, error: reservedTargetLiteralError(providerLabel, reservedLiteral, hint) };
-  }
   const kind = detectTargetKind(params.channel, raw, params.preferredKind, plugin);
   const normalizedInput = resolveNormalizedTargetInput(params.channel, raw, plugin);
   const normalized = normalizedInput?.normalized ?? raw;
@@ -482,6 +478,13 @@ export async function resolveMessagingTarget(params: {
       error: ambiguousTargetError(providerLabel, raw, hint),
       candidates: match.entries,
     };
+  }
+  // Directory miss: reject reserved literals before falling back to plugin
+  // resolution, so a bare reserved word without a matching directory entry
+  // does not accidentally resolve to a public channel or incorrect target.
+  const reservedLiteral = resolveReservedTargetLiteral({ raw, plugin });
+  if (reservedLiteral) {
+    return { ok: false, error: reservedTargetLiteralError(providerLabel, reservedLiteral, hint) };
   }
   const resolvedFallbackTarget = asResolvedMessagingTarget(
     await maybeResolvePluginMessagingTarget({

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -96,9 +96,21 @@ function normalizeQuery(value: string): string {
   return normalizeLowercaseStringOrEmpty(value);
 }
 
-function stripTargetPrefixes(value: string): string {
-  return value
-    .replace(/^(channel|user):/i, "")
+function stripTargetPrefixes(value: string, channel?: ChannelId, plugin?: ChannelPlugin): string {
+  const providerPrefixes = [channel, plugin?.id, ...(plugin?.messaging?.targetPrefixes ?? [])]
+    .map((prefix) => (prefix ? String(prefix).trim().toLowerCase() : ""))
+    .filter(Boolean);
+  let target = value.trim();
+  while (target) {
+    const lowered = target.toLowerCase();
+    const prefix = providerPrefixes.find((candidate) => lowered.startsWith(`${candidate}:`));
+    if (!prefix) {
+      break;
+    }
+    target = target.slice(prefix.length + 1).trim();
+  }
+  return target
+    .replace(/^(channel|group|user):/i, "")
     .replace(/^[@#]/, "")
     .trim();
 }
@@ -222,9 +234,15 @@ function matchesDirectoryEntry(params: {
   }
   const id = stripTargetPrefixes(
     normalizeDirectoryEntryId(params.channel, params.entry, params.plugin),
+    params.channel,
+    params.plugin,
   );
-  const name = params.entry.name ? stripTargetPrefixes(params.entry.name) : "";
-  const handle = params.entry.handle ? stripTargetPrefixes(params.entry.handle) : "";
+  const name = params.entry.name
+    ? stripTargetPrefixes(params.entry.name, params.channel, params.plugin)
+    : "";
+  const handle = params.entry.handle
+    ? stripTargetPrefixes(params.entry.handle, params.channel, params.plugin)
+    : "";
   const candidates = [id, name, handle].map((value) => normalizeQuery(value)).filter(Boolean);
   return candidates.some((value) => value === query || value.includes(query));
 }
@@ -403,8 +421,10 @@ export async function resolveMessagingTarget(params: {
   const kind = detectTargetKind(params.channel, raw, params.preferredKind, plugin);
   const normalizedInput = resolveNormalizedTargetInput(params.channel, raw, plugin);
   const normalized = normalizedInput?.normalized ?? raw;
+  const reservedLiteral = resolveReservedTargetLiteral({ raw, plugin });
   if (
     normalizedInput &&
+    !reservedLiteral &&
     looksLikeTargetId({
       channel: params.channel,
       raw: normalizedInput.raw,
@@ -431,7 +451,7 @@ export async function resolveMessagingTarget(params: {
       kind,
     });
   }
-  const query = stripTargetPrefixes(raw);
+  const query = stripTargetPrefixes(raw, params.channel, plugin);
   const entries = await getDirectoryEntries({
     cfg: params.cfg,
     channel: params.channel,
@@ -450,7 +470,8 @@ export async function resolveMessagingTarget(params: {
       target: {
         to: normalizeDirectoryEntryId(params.channel, entry, plugin),
         kind,
-        display: entry.name ?? entry.handle ?? stripTargetPrefixes(entry.id),
+        display:
+          entry.name ?? entry.handle ?? stripTargetPrefixes(entry.id, params.channel, plugin),
         source: "directory",
         resolutionSource: "directory",
       },
@@ -466,7 +487,8 @@ export async function resolveMessagingTarget(params: {
           target: {
             to: normalizeDirectoryEntryId(params.channel, best, plugin),
             kind,
-            display: best.name ?? best.handle ?? stripTargetPrefixes(best.id),
+            display:
+              best.name ?? best.handle ?? stripTargetPrefixes(best.id, params.channel, plugin),
             source: "directory",
             resolutionSource: "directory",
           },
@@ -482,7 +504,6 @@ export async function resolveMessagingTarget(params: {
   // Directory miss: reject reserved literals before falling back to plugin
   // resolution, so a bare reserved word without a matching directory entry
   // does not accidentally resolve to a public channel or incorrect target.
-  const reservedLiteral = resolveReservedTargetLiteral({ raw, plugin });
   if (reservedLiteral) {
     return { ok: false, error: reservedTargetLiteralError(providerLabel, reservedLiteral, hint) };
   }

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -11,7 +11,11 @@ import type {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { buildDirectoryCacheKey, DirectoryCache } from "./directory-cache.js";
-import { ambiguousTargetError, unknownTargetError } from "./target-errors.js";
+import {
+  ambiguousTargetError,
+  reservedTargetLiteralError,
+  unknownTargetError,
+} from "./target-errors.js";
 import { maybeResolveIdLikeTarget, type ResolvedIdLikeTarget } from "./target-id-resolution.js";
 import {
   buildTargetResolverSignature,
@@ -20,6 +24,7 @@ import {
   normalizeChannelTargetInput,
   normalizeTargetForProvider,
   resolveNormalizedTargetInput,
+  resolveReservedTargetLiteral,
 } from "./target-normalization.js";
 
 /** Directory-backed destination kind used by outbound target resolution. */
@@ -395,6 +400,10 @@ export async function resolveMessagingTarget(params: {
   const plugin = params.plugin ?? getChannelPlugin(params.channel);
   const providerLabel = plugin?.meta?.label ?? params.channel;
   const hint = plugin?.messaging?.targetResolver?.hint;
+  const reservedLiteral = resolveReservedTargetLiteral({ raw, plugin });
+  if (reservedLiteral) {
+    return { ok: false, error: reservedTargetLiteralError(providerLabel, reservedLiteral, hint) };
+  }
   const kind = detectTargetKind(params.channel, raw, params.preferredKind, plugin);
   const normalizedInput = resolveNormalizedTargetInput(params.channel, raw, plugin);
   const normalized = normalizedInput?.normalized ?? raw;

--- a/src/infra/outbound/targets-resolve-shared.ts
+++ b/src/infra/outbound/targets-resolve-shared.ts
@@ -80,17 +80,24 @@ export function resolveOutboundTargetWithPlugin(params: {
   if (targetPrefixError) {
     return { ok: false, error: targetPrefixError };
   }
-  const hint = plugin.messaging?.targetResolver?.hint;
-  const reservedLiteral = resolveReservedTargetLiteral({ raw: effectiveTo, plugin });
-  if (reservedLiteral) {
-    return {
-      ok: false,
-      error: reservedTargetLiteralError(
-        plugin.meta.label ?? params.target.channel,
-        reservedLiteral,
-        hint,
-      ),
-    };
+  // Reserved-literal rejection is skipped for heartbeat mode so the
+  // async directory-capable resolver (resolveChannelTarget →
+  // resolveMessagingTarget) can do directory-first lookup before deciding.
+  // Rejecting here would suppress a heartbeat route to an existing directory
+  // entry whose name matches a reserved literal.
+  if (params.target.mode !== "heartbeat") {
+    const hint = plugin.messaging?.targetResolver?.hint;
+    const reservedLiteral = resolveReservedTargetLiteral({ raw: effectiveTo, plugin });
+    if (reservedLiteral) {
+      return {
+        ok: false,
+        error: reservedTargetLiteralError(
+          plugin.meta.label ?? params.target.channel,
+          reservedLiteral,
+          hint,
+        ),
+      };
+    }
   }
 
   const resolveTarget = plugin.outbound?.resolveTarget;

--- a/src/infra/outbound/targets-resolve-shared.ts
+++ b/src/infra/outbound/targets-resolve-shared.ts
@@ -80,13 +80,13 @@ export function resolveOutboundTargetWithPlugin(params: {
   if (targetPrefixError) {
     return { ok: false, error: targetPrefixError };
   }
+  const hint = plugin.messaging?.targetResolver?.hint;
   // Reserved-literal rejection is skipped for heartbeat mode so the
   // async directory-capable resolver (resolveChannelTarget →
   // resolveMessagingTarget) can do directory-first lookup before deciding.
   // Rejecting here would suppress a heartbeat route to an existing directory
   // entry whose name matches a reserved literal.
   if (params.target.mode !== "heartbeat") {
-    const hint = plugin.messaging?.targetResolver?.hint;
     const reservedLiteral = resolveReservedTargetLiteral({ raw: effectiveTo, plugin });
     if (reservedLiteral) {
       return {

--- a/src/infra/outbound/targets-resolve-shared.ts
+++ b/src/infra/outbound/targets-resolve-shared.ts
@@ -81,11 +81,7 @@ export function resolveOutboundTargetWithPlugin(params: {
     return { ok: false, error: targetPrefixError };
   }
   const hint = plugin.messaging?.targetResolver?.hint;
-  // Reserved-literal rejection is skipped for heartbeat mode so the
-  // async directory-capable resolver (resolveChannelTarget →
-  // resolveMessagingTarget) can do directory-first lookup before deciding.
-  // Rejecting here would suppress a heartbeat route to an existing directory
-  // entry whose name matches a reserved literal.
+  // Heartbeats defer reserved literals to the async resolver so directory hits can win.
   if (params.target.mode !== "heartbeat") {
     const reservedLiteral = resolveReservedTargetLiteral({ raw: effectiveTo, plugin });
     if (reservedLiteral) {

--- a/src/infra/outbound/targets-resolve-shared.ts
+++ b/src/infra/outbound/targets-resolve-shared.ts
@@ -8,7 +8,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel-constants.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { validateTargetProviderPrefix } from "./channel-target-prefix.js";
-import { missingTargetError } from "./target-errors.js";
+import { missingTargetError, reservedTargetLiteralError } from "./target-errors.js";
+import { resolveReservedTargetLiteral } from "./target-normalization.js";
 
 /**
  * Result of resolving a concrete outbound target for a channel send.
@@ -79,6 +80,18 @@ export function resolveOutboundTargetWithPlugin(params: {
   if (targetPrefixError) {
     return { ok: false, error: targetPrefixError };
   }
+  const hint = plugin.messaging?.targetResolver?.hint;
+  const reservedLiteral = resolveReservedTargetLiteral({ raw: effectiveTo, plugin });
+  if (reservedLiteral) {
+    return {
+      ok: false,
+      error: reservedTargetLiteralError(
+        plugin.meta.label ?? params.target.channel,
+        reservedLiteral,
+        hint,
+      ),
+    };
+  }
 
   const resolveTarget = plugin.outbound?.resolveTarget;
   if (resolveTarget) {
@@ -94,7 +107,6 @@ export function resolveOutboundTargetWithPlugin(params: {
   if (effectiveTo) {
     return { ok: true, to: effectiveTo };
   }
-  const hint = plugin.messaging?.targetResolver?.hint;
   return {
     ok: false,
     error: missingTargetError(plugin.meta.label ?? params.target.channel, hint),

--- a/src/infra/outbound/targets.shared-test.ts
+++ b/src/infra/outbound/targets.shared-test.ts
@@ -100,6 +100,73 @@ export function runResolveOutboundTargetCoreTests(): void {
       }
     });
 
+    it.each(["current", "telegram:current", "tg:self"])(
+      "rejects plugin-reserved literal target %s before direct outbound fallback",
+      (to) => {
+        setActivePluginRegistry(
+          createTargetsTestRegistry([
+            createTestChannelPlugin({
+              id: "telegram",
+              label: "Telegram",
+              outbound: {
+                deliveryMode: "direct",
+                sendText: async () => ({ channel: "telegram", messageId: "telegram-msg" }),
+              },
+              messaging: {
+                targetPrefixes: ["telegram", "tg"],
+                targetResolver: {
+                  reservedLiterals: ["current", "self", "this", "me"],
+                  hint: "<chatId>",
+                },
+              },
+            }),
+          ]),
+        );
+
+        const res = resolveOutboundTarget({
+          channel: "telegram",
+          to,
+          mode: "explicit",
+        });
+
+        expect(res.ok).toBe(false);
+        if (!res.ok) {
+          expect(res.error.message).toContain("Reserved target");
+          expect(res.error.message).toContain("Telegram");
+        }
+      },
+    );
+
+    it("allows explicit handles that include the provider handle marker", () => {
+      setActivePluginRegistry(
+        createTargetsTestRegistry([
+          createTestChannelPlugin({
+            id: "telegram",
+            label: "Telegram",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async () => ({ channel: "telegram", messageId: "telegram-msg" }),
+            },
+            messaging: {
+              targetPrefixes: ["telegram", "tg"],
+              targetResolver: {
+                reservedLiterals: ["current", "self", "this", "me"],
+                hint: "<chatId>",
+              },
+            },
+          }),
+        ]),
+      );
+
+      const res = resolveOutboundTarget({
+        channel: "telegram",
+        to: "telegram:@current",
+        mode: "explicit",
+      });
+
+      expect(res).toEqual({ ok: true, to: "telegram:@current" });
+    });
+
     it("uses the plugin hint when a channel has outbound support but no target resolver", () => {
       setActivePluginRegistry(
         createTargetsTestRegistry([

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -1194,6 +1194,117 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.reason).toBe("dm-blocked");
   });
 
+  it("resolves heartbeat reserved targets through directory before session routing", async () => {
+    const listGroups = vi
+      .fn()
+      .mockResolvedValue([{ kind: "group", id: "-1002458651455", name: "current" }]);
+    const listGroupsLive = vi.fn().mockResolvedValue([]);
+    setActivePluginRegistry(
+      createTargetsTestRegistry([
+        {
+          ...createTestChannelPlugin({
+            id: "telegram",
+            label: "Telegram",
+            outbound: {
+              deliveryMode: "direct",
+              resolveTarget: ({ to }) =>
+                to
+                  ? { ok: true as const, to: to.trim() }
+                  : { ok: false as const, error: new Error("target required") },
+            },
+            messaging: {
+              targetPrefixes: ["telegram", "tg"],
+              targetResolver: {
+                reservedLiterals: ["current", "self", "this", "me"],
+                hint: "<chatId>",
+              },
+              resolveOutboundSessionRoute: ({ target, resolvedTarget }) => ({
+                sessionKey: `main:telegram:group:${target}`,
+                baseSessionKey: `main:telegram:group:${target}`,
+                peer: { kind: resolvedTarget?.kind === "user" ? "direct" : "group", id: target },
+                chatType: resolvedTarget?.kind === "user" ? "direct" : "group",
+                from: `telegram:group:${target}`,
+                to: target,
+              }),
+            },
+          }),
+          directory: {
+            listGroups,
+            listGroupsLive,
+          },
+        },
+      ]),
+    );
+
+    const resolved = await resolveHeartbeatDeliveryTargetWithSessionRoute({
+      cfg: {},
+      agentId: "main",
+      heartbeat: {
+        target: "telegram",
+        to: "current",
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("-1002458651455");
+    expect(listGroups).toHaveBeenCalled();
+  });
+
+  it("fails closed when a heartbeat reserved target misses the directory", async () => {
+    const listGroups = vi.fn().mockResolvedValue([]);
+    const listGroupsLive = vi.fn().mockResolvedValue([]);
+    setActivePluginRegistry(
+      createTargetsTestRegistry([
+        {
+          ...createTestChannelPlugin({
+            id: "telegram",
+            label: "Telegram",
+            outbound: {
+              deliveryMode: "direct",
+              resolveTarget: ({ to }) =>
+                to
+                  ? { ok: true as const, to: to.trim() }
+                  : { ok: false as const, error: new Error("target required") },
+            },
+            messaging: {
+              targetPrefixes: ["telegram", "tg"],
+              targetResolver: {
+                reservedLiterals: ["current", "self", "this", "me"],
+                hint: "<chatId>",
+              },
+              resolveOutboundSessionRoute: ({ target }) => ({
+                sessionKey: `main:telegram:group:${target}`,
+                baseSessionKey: `main:telegram:group:${target}`,
+                peer: { kind: "group", id: target },
+                chatType: "group",
+                from: `telegram:group:${target}`,
+                to: target,
+              }),
+            },
+          }),
+          directory: {
+            listGroups,
+            listGroupsLive,
+          },
+        },
+      ]),
+    );
+
+    const resolved = await resolveHeartbeatDeliveryTargetWithSessionRoute({
+      cfg: {},
+      agentId: "main",
+      heartbeat: {
+        target: "telegram",
+        to: "current",
+      },
+    });
+
+    expect(resolved.channel).toBe("none");
+    expect(resolved.reason).toBe("no-target");
+    expect(listGroups).toHaveBeenCalled();
+    expect(listGroupsLive).toHaveBeenCalled();
+  });
+
   it("keeps heartbeat route canonicalization best-effort when target resolution fails", async () => {
     setActivePluginRegistry(
       createTargetsTestRegistry([

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -27,6 +27,7 @@ import {
   resolveOutboundChannelPlugin,
 } from "./channel-resolution.js";
 import { resolveOutboundSessionRoute } from "./outbound-session.js";
+import { isReservedTargetLiteralError } from "./target-errors.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import {
   resolveOutboundTargetWithPlugin,
@@ -361,7 +362,7 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
   })();
   if (targetResolution?.ok) {
     routeResolvedTarget = targetResolution.target;
-  } else if (targetResolution?.error.message.includes("Reserved target")) {
+  } else if (targetResolution && isReservedTargetLiteralError(targetResolution.error)) {
     return buildNoHeartbeatDeliveryTarget({
       reason: "no-target",
       accountId: delivery.accountId,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -361,6 +361,13 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
   })();
   if (targetResolution?.ok) {
     routeResolvedTarget = targetResolution.target;
+  } else if (targetResolution?.error.message.includes("Reserved target")) {
+    return buildNoHeartbeatDeliveryTarget({
+      reason: "no-target",
+      accountId: delivery.accountId,
+      lastChannel: delivery.lastChannel,
+      lastAccountId: delivery.lastAccountId,
+    });
   }
   if (routeResolvedTarget?.kind === "user" && heartbeat?.directPolicy === "block") {
     return buildNoHeartbeatDeliveryTarget({


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fixes Telegram outbound target resolution for provider-reserved words such as `current`, `self`, `this`, and `me`.
- A reserved word that is also a real configured Telegram group/channel target now resolves through the directory first, instead of being rejected before lookup.
- A reserved word with no directory match still fails closed before plugin/default fallback.
- Target validation and route-miss paths now keep only validated directory targets, so downstream delivery code cannot accidentally keep using the original unsafe input next to `targetResolutionError` or after route canonicalization misses.
- Isolated cron delivery now uses the same directory-first reserved-literal behavior before returning a reserved-target error.

Why does this matter now?

- The previous PR shape protected session-reference words, but it could break existing Telegram routes if a real configured group/channel was named or handled as one of those words.
- It also left delivery-path footguns: callers that did not check `targetResolutionError` first could still see the original unresolved target in `resolvedTo`, and isolated cron delivery could return the reserved-target error before the directory-aware resolver ran.
- The practical user impact is message-delivery correctness: real Telegram directory entries should remain routable, while missing reserved literals should not be treated as literal Telegram destinations.

What is the intended outcome?

- `current` resolves to a configured Telegram directory entry when that entry exists.
- `telegram:current` follows the same directory-first behavior as bare `current`.
- `current` fails closed with a reserved-target error when there is no matching Telegram directory entry.
- Gateway delivery planning uses the same directory-aware target result, failed target validation removes `resolvedTo`, and isolated cron delivery gives configured directory entries the same reserved-literal preservation before failing closed on misses.

What is intentionally out of scope?

- No Telegram schema, migration, permission, auth, or live-send behavior changes.
- No new public target syntax beyond using the already introduced plugin reserved-literal contract.
- No attempt to make bare reserved words literal Telegram usernames after a directory miss; users must use explicit handle/id syntax for literal destinations.
- No live Telegram network send in this proof environment.

What does success look like?

- Directory-backed Telegram targets named/handled as `current` keep working.
- Reserved words that are not directory entries remain blocked before fallback normalization.
- Delivery-plan error paths do not expose unsafe original inputs as resolved destinations.
- Focused regression tests and production-path resolver/gateway proof both pass on the current head.

What should reviewers focus on?

- The routing order in `resolveMessagingTarget`: directory matches are preserved before reserved-literal rejection, and reserved literals cannot continue to plugin/default fallback after a miss.
- The session-route preparation path in `resolveAgentDeliveryPlanWithSessionRoute`: it now uses the directory-aware resolver and clears `resolvedTo` on target-resolution errors.
- The compatibility boundary for Telegram users with literal reserved-word usernames: explicit handle/id syntax remains the intended path when there is no directory match.

Fix classification: root-cause compatibility and safety fix for Telegram outbound target resolution.

Root cause: reserved-literal rejection and session-route planning were split across sync outbound validation, the directory-aware resolver, gateway delivery planning, and isolated cron delivery. Core could not consistently distinguish a real Telegram directory entry named `current` from an unsafe session-reference literal, and route/error paths could keep raw reserved input after validation failed or route canonicalization missed.

Why this is the root cause: the resolver must first identify whether the input is a configured destination, then apply provider-reserved literal safety before plugin/default resolution; delivery planning and cron delivery must only expose destinations that have passed the directory-aware target owner.

Related PR scan: this is a repair/update to the existing PR #94107 for #91372. I did not open a competing PR; the remaining public-contract questions are disclosed below for maintainer review.

- Fix classification: Root-cause compatibility and safety fix for Telegram outbound target resolution.
- Root cause: Reserved-literal safety and delivery planning were split around the directory-aware resolver, so a configured Telegram destination named `current` could be rejected before lookup while directory misses or route misses could still leak raw reserved input across gateway or cron delivery paths.
- Why this is root-cause fix: `resolveMessagingTarget` is kept as the source of truth for configured destinations and reserved-literal misses. Directory lookup owns real destinations, reserved-literal rejection owns misses before plugin/default resolution, and gateway/cron delivery only keep validated targets after successful directory-aware resolution.
- Maintainer-ready confidence: High after `sync-main`, focused resolver/outbound validation, cron delivery validation, raw-channel-fetch boundary lint, and ClawSweeper commit review all passed on the current repair branch.
- What did NOT change: This PR does not change schema, migration, permission, auth, token, live-send, provider setup, public target syntax, or non-Telegram routing behavior.
- Architecture / source-of-truth check: Core target resolution remains the source-of-truth in `resolveMessagingTarget`; Telegram only declares its reserved literals/capabilities, and gateway/session-route delivery consumes the resolver result instead of duplicating destination ownership.
- Patch quality notes: Patch-quality warnings are test/body-risk guardrails, not runtime fallbacks: the `expect.any(Function)` shape assertion is confined to test fixtures, explicit `return undefined` keeps non-matching normalization branches clear, and fallback wording describes the old path being blocked rather than a new fallback being added.
- Related open PR scan: This updates my existing open PR #94107 for #91372 rather than opening a competing PR; the optional plugin `reservedLiterals` contract remains explicitly disclosed for maintainer review.
- Risk labels considered: message-delivery, session-state, and public plugin SDK contract.
- Risk explanation: The risky boundary is Telegram target routing order for provider-reserved words that may also be real configured directory destinations.
- Why acceptable: The change allows reserved words only after a concrete directory match; missing directory entries still fail closed before fallback/session-route handling, and focused resolver, outbound, Telegram target, and boundary lint checks pass.

## Linked context

Closes #91372

Related #94107

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram reserved targets like `current` should route to a real configured Telegram group/channel named or handled as `current`, but still fail closed when no directory entry exists.
- Real environment tested: production OpenClaw modules with the real Telegram plugin, config-backed Telegram groups, the production target resolver, and the gateway delivery-plan/session-route path.
- Exact steps or command run after this patch:

```bash
pnpm exec tsx <production-path proof script>
```

- Evidence after fix:

```json
{
  "proof": "telegram-current-directory-vs-reserved-miss",
  "registry": {
    "pluginId": "telegram",
    "channelId": "telegram",
    "source": "proof",
    "hasDirectory": true,
    "hasSessionRoute": true,
    "reservedLiterals": ["current", "self", "this", "me"]
  },
  "directoryHit": {
    "ok": true,
    "target": {
      "to": "telegram:@current",
      "kind": "group",
      "display": "current",
      "source": "directory",
      "resolutionSource": "directory"
    }
  },
  "prefixedHit": {
    "ok": true,
    "target": {
      "to": "telegram:@current",
      "kind": "group",
      "display": "current",
      "source": "directory",
      "resolutionSource": "directory"
    }
  },
  "reservedMiss": {
    "ok": false,
    "error": "Reserved target \"current\" for Telegram cannot be used as a literal destination. Provide an explicit id or handle. Hint: <chatId>"
  },
  "gatewayPlan": {
    "resolvedChannel": "telegram",
    "resolvedTo": "telegram:@current",
    "deliveryTargetMode": "explicit",
    "targetResolutionError": null
  },
  "heartbeatReservedMiss": {
    "channel": "none",
    "reason": "no-target"
  },
  "checks": {
    "directoryHitOk": true,
    "prefixedHitOk": true,
    "directoryMissFailClosed": true,
    "gatewayResolvedFromDirectory": true,
    "heartbeatReservedMissFailClosed": true
  }
}
```

- Observed result after fix: bare `current` and prefixed `telegram:current` both resolve through the Telegram directory when a config-backed directory entry exists; the same resolved target flows into gateway delivery planning as `telegram:@current`; a missing directory entry returns the reserved-target error instead of normalizing to an unintended literal destination; heartbeat delivery with missing `current` returns `channel: "none"` / `reason: "no-target"` before Telegram session-route canonicalization.
- What was not tested: no outbound Telegram message was sent to the public Telegram network.
- Proof limitations or environment constraints: this proof exercises the production Telegram plugin and OpenClaw resolver/delivery-plan path with config-backed directory data; it does not require or use a Telegram bot token.
- Before evidence: the production-path proof showed `current` being normalized as `telegram:@current` before directory/miss handling; after the resolver change, reserved literals stay on the directory-first path and fail closed only after a directory miss.

## Tests and validation

Which commands did you run?

```bash
pnpm exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/outbound/target-resolver.test.ts
pnpm exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/agent-delivery.test.ts src/infra/outbound/targets.test.ts src/infra/outbound/targets.shared-test.ts extensions/telegram/src/targets.test.ts
pnpm exec vitest run --config test/vitest/vitest.cron.config.ts src/cron/isolated-agent/delivery-target.test.ts
pnpm run lint:tmp:no-raw-channel-fetch
```

Result:

```text
Validation target-resolver-reserved-exact-only: pass
Test Files  1 passed (1)
Tests       13 passed (13)

Validation focused-outbound-cron-reserved-exact-only: pass
Test Files  4 passed (4)
Tests       113 passed (113)

Validation cron-delivery-reserved-exact-only: pass
Test Files  1 passed (1)
Tests       54 passed (54)

Validation no-raw-channel-fetch-reserved-exact-only: pass
$ node scripts/check-no-raw-channel-fetch.mjs
```

What regression coverage was added or updated?

- `target-resolver.test.ts` now covers directory-first resolution for both `current` and `telegram:current`, fail-closed behavior after a directory miss, and exact-only reserved-literal directory preservation so `me` does not match a substring-only directory entry such as `memes`.
- `agent-delivery.test.ts` now covers clearing `resolvedTo` when route preparation/target validation fails, preserving the stored target error, and preserving the directory-resolved target when session-route canonicalization itself cannot produce a route.
- `delivery-target.test.ts` now covers isolated cron delivery resolving a reserved explicit Telegram target through a configured directory entry before returning any reserved-target error.
- `targets.test.ts` now covers heartbeat delivery preserving directory hits for reserved literals and failing closed when a heartbeat reserved literal misses the directory.
- The shared direct outbound target tests stayed green, confirming direct fallback still rejects bare Telegram reserved literals instead of treating them as normal literal targets.

What failed before this fix, if known?

- `current` returned a reserved-target error before the resolver checked configured Telegram directory entries.
- A session-route target validation error could leave the original unsafe `resolvedTo` value visible next to `targetResolutionError`.
- Isolated cron delivery could return the sync reserved-target error before the directory-capable resolver preserved a configured Telegram directory entry named `current`.
- Reserved-literal directory preservation used the normal fuzzy directory match, so a reserved word like `me` could match a substring-only entry such as `memes` before the fail-closed reserved check ran.

If no test was added, why not?

- Tests were added/updated for the directory-first behavior, directory-miss fail-closed behavior, and delivery-plan error path.

Test guardrail rationale:

- The resolver tests protect both sides of the compatibility boundary: existing real Telegram directory entries keep routing, while missing reserved literals still stop before fallback.
- The delivery tests protect the safety boundary: failed target validation and route misses cannot leave a destination-shaped raw reserved literal for downstream code to reuse.
- The cron delivery test protects the scheduled/isolated delivery surface so it follows the same directory-first behavior as gateway delivery.
- The shared target tests protect direct outbound behavior so this repair does not accidentally re-enable reserved words as literal plugin/default destinations.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A real Telegram directory entry named/handled as `current`, `self`, `this`, or `me` can now be reached instead of being rejected before lookup; missing entries still fail closed.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No new network/auth/tool execution behavior. The safety posture is preserved for directory misses and strengthened on validation errors by clearing `resolvedTo`.

What is the highest-risk area?

Telegram target routing order for provider-reserved literals, especially compatibility between real directory entries and fail-closed reserved words.

How is that risk mitigated?

The resolver and delivery paths only allow reserved literals after an exact concrete directory match on id/name/handle after prefix stripping. If the directory does not contain an exact matching Telegram group/channel, the reserved literal still fails closed before plugin/default resolution. Gateway and cron delivery paths no longer expose the original unsafe target after validation failure or route canonicalization miss.

Scope boundary and patch quality notes:

- The word "fallback" in this PR refers to the existing plugin/default target-resolution stages, not to a silent mitigation path.
- The larger diff size comes from the existing PR's SDK contract/tests plus this repair's resolver/delivery regression coverage; this update stays within the existing PR scope and does not add a second feature.
- The public contract risk is the existing optional plugin reserved-literal field. This update narrows the behavior by preserving directory compatibility before applying that reserved-literal guard.

## Current review state

What is the next action?

Ready for maintainer review after the PR branch/body update and fresh checks.

What is still waiting on author, maintainer, CI, or external proof?

No known author-side code or test follow-up remains. The only proof limitation is that the production-path Telegram proof does not send a live Telegram network message. Maintainers still need to accept the existing SDK contract and compatibility choice for reserved Telegram literals.

Which bot or reviewer comments were addressed?

- RF-001 `triage: mock-only-proof`: addressed with production-path proof using the real Telegram plugin, production resolver, and gateway delivery-plan path; live Telegram network send remains disclosed as not tested.
- RF-002 real gateway/message-action or Telegram proof for `target: "current"`: addressed with current-head production-path proof showing directory hit for `current` and a fail-closed reserved error on directory miss.
- RF-003 real behavior proof request: addressed by replacing mock-only proof with production module proof and copied runtime output in this PR body.
- RF-004 new optional SDK field requires maintainer acceptance: disclosed as a maintainer contract decision; this repair does not expand that API further.
- RF-005 compatibility risk for bare Telegram reserved targets: addressed by preserving real directory matches before fail-closed rejection, and disclosed that literal non-directory destinations still need explicit handle/id syntax.
- RF-006 proof still helper/mock based: addressed with production Telegram plugin + resolver + gateway delivery-plan proof after the patch.
- RF-007 maintainer review needed for SDK field and compatibility choice: disclosed; author-side code/test/proof updates are complete, maintainer contract review remains.
- RF-008 explicit reserved targets reaching Telegram session routing: addressed by resolving reserved explicit targets through directory-capable target resolution before session-route planning, preserving a target-resolution error after directory miss instead of handing raw `current` to Telegram route parsing.
- RF-009 heartbeat reserved-target misses: addressed by making heartbeat session-route refinement stop delivery when directory-capable target resolution returns the reserved-target error after a directory miss.
- RF-010 `src/infra/outbound/targets.test.ts`: addressed with focused heartbeat coverage for both directory-hit routing and directory-miss fail-closed behavior.
- RF-011 resolver/agent-delivery/Telegram target tests: addressed by the current-head focused outbound and Telegram suite covering resolver, gateway delivery, direct outbound target fallback, and Telegram target behavior.
- RF-012 after-fix heartbeat proof: addressed with production-path Telegram proof showing `heartbeatReservedMiss` returns `channel: "none"` and `reason: "no-target"` for missing `current`.
- RF-013 latest proof/status signal: addressed by updating this PR body with current-head validation and the latest delivery-path, cron, and exact-match review fixes; proof remains `proof: sufficient`, while live Telegram Desktop proof is disclosed as optional maintainer-requested transport evidence.
- Latest delivery-path review finding: addressed by preserving a directory-resolved reserved target when session-route canonicalization misses, instead of returning raw `current`.
- Latest isolated cron review finding: addressed by letting cron delivery run directory-capable target resolution for reserved literals before returning a reserved-target error.
- Latest exact-match review finding: addressed by requiring reserved-literal directory preservation to match exact id/name/handle after prefix stripping, with regression coverage for `me` not matching `memes`.
