### PR TITLE
fix(plugins): surface empty availability groups at plugin tool registration

### DIFF
--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -17,9 +17,11 @@ vi.mock("../config/runtime-snapshot.js", () => ({
 
 import {
   buildPluginToolDescriptorCacheKey,
+  capturePluginToolDescriptor,
   createPluginToolDescriptorConfigCacheKeyMemo,
   resetPluginToolDescriptorCache,
 } from "./tool-descriptor-cache.js";
+import type { AnyAgentTool } from "../agents/tools/common.js";
 
 describe("plugin tool descriptor cache keys", () => {
   afterEach(() => {
@@ -168,5 +170,112 @@ describe("plugin tool descriptor cache keys", () => {
     });
 
     expect(firstKey).toBe(secondKey);
+  });
+});
+
+describe("capturePluginToolDescriptor", () => {
+  it("preserves tool availability on captured plugin descriptors", () => {
+    const tool = {
+      name: "needs_secret",
+      label: "Needs secret",
+      description: "Needs secret description",
+      parameters: { type: "object" },
+      availability: { kind: "env", name: "OPENCLAW_PLUGIN_SECRET" },
+      async execute() {
+        return { content: [], details: undefined };
+      },
+    } satisfies AnyAgentTool & {
+      availability: { kind: "env"; name: string };
+    };
+
+    const captured = capturePluginToolDescriptor({
+      pluginId: "demo",
+      tool,
+      optional: false,
+    });
+
+    expect(captured.descriptor.availability).toStrictEqual({
+      kind: "env",
+      name: "OPENCLAW_PLUGIN_SECRET",
+    });
+  });
+
+  it("warns during capture when a plugin tool declares an empty availability group", () => {
+    const logger = { warn: vi.fn() };
+    const tool = {
+      name: "broken_tool",
+      label: "Broken tool",
+      description: "Broken tool description",
+      parameters: { type: "object" },
+      availability: { anyOf: [] },
+      async execute() {
+        return { content: [], details: undefined };
+      },
+    } satisfies AnyAgentTool & {
+      availability: { anyOf: [] };
+    };
+
+    capturePluginToolDescriptor({
+      pluginId: "demo",
+      tool,
+      optional: false,
+      logger,
+    });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "plugin tool availability diagnostic (demo/broken_tool): Empty availability anyOf group",
+    );
+  });
+
+  it("ignores malformed non-contract availability group fields during capture", () => {
+    const logger = { warn: vi.fn() };
+    const tool = {
+      name: "incidental_tool",
+      label: "Incidental tool",
+      description: "Incidental tool description",
+      parameters: { type: "object" },
+      availability: { anyOf: null },
+      async execute() {
+        return { content: [], details: undefined };
+      },
+    } satisfies AnyAgentTool & {
+      availability: { anyOf: null };
+    };
+
+    const captured = capturePluginToolDescriptor({
+      pluginId: "demo",
+      tool,
+      optional: false,
+      logger,
+    });
+
+    expect(captured.descriptor.availability).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed non-contract availability signal fields during capture", () => {
+    const logger = { warn: vi.fn() };
+    const tool = {
+      name: "incidental_signal_tool",
+      label: "Incidental signal tool",
+      description: "Incidental signal tool description",
+      parameters: { type: "object" },
+      availability: { kind: "config" },
+      async execute() {
+        return { content: [], details: undefined };
+      },
+    } satisfies AnyAgentTool & {
+      availability: { kind: "config" };
+    };
+
+    const captured = capturePluginToolDescriptor({
+      pluginId: "demo",
+      tool,
+      optional: false,
+      logger,
+    });
+
+    expect(captured.descriptor.availability).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/tool-descriptor-cache.test.ts
+++ b/src/plugins/tool-descriptor-cache.test.ts
@@ -253,6 +253,34 @@ describe("capturePluginToolDescriptor", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it("ignores cyclic non-contract availability groups during capture", () => {
+    const logger = { warn: vi.fn() };
+    const availability: { anyOf: unknown[] } = { anyOf: [] };
+    availability.anyOf.push(availability);
+    const tool = {
+      name: "cyclic_tool",
+      label: "Cyclic tool",
+      description: "Cyclic tool description",
+      parameters: { type: "object" },
+      availability,
+      async execute() {
+        return { content: [], details: undefined };
+      },
+    } satisfies AnyAgentTool & {
+      availability: { anyOf: unknown[] };
+    };
+
+    const captured = capturePluginToolDescriptor({
+      pluginId: "demo",
+      tool,
+      optional: false,
+      logger,
+    });
+
+    expect(captured.descriptor.availability).toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("ignores malformed non-contract availability signal fields during capture", () => {
     const logger = { warn: vi.fn() };
     const tool = {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -2,7 +2,12 @@
 import fs from "node:fs";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
-import type { JsonObject, ToolDescriptor } from "../tools/types.js";
+import { evaluateEmptyAvailabilityGroupDiagnostics } from "../tools/availability.js";
+import type {
+  JsonObject,
+  ToolAvailabilityExpression,
+  ToolDescriptor,
+} from "../tools/types.js";
 import type { PluginLoadOptions } from "./loader.js";
 import type { OpenClawPluginToolContext } from "./types.js";
 
@@ -144,13 +149,97 @@ function asJsonObject(value: unknown): JsonObject {
   return value as JsonObject;
 }
 
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isJsonPrimitive(value: unknown): boolean {
+  return value === null || ["boolean", "number", "string"].includes(typeof value);
+}
+
+function isToolAvailabilitySignal(value: { readonly kind?: unknown }): boolean {
+  switch (value.kind) {
+    case "always":
+      return true;
+    case "auth":
+      return typeof (value as { providerId?: unknown }).providerId === "string";
+    case "config": {
+      const check = (value as { check?: unknown }).check;
+      return (
+        isStringArray((value as { path?: unknown }).path) &&
+        (check === undefined || check === "exists" || check === "non-empty" || check === "available")
+      );
+    }
+    case "env":
+      return typeof (value as { name?: unknown }).name === "string";
+    case "plugin-enabled":
+      return typeof (value as { pluginId?: unknown }).pluginId === "string";
+    case "context": {
+      const equals = (value as { equals?: unknown }).equals;
+      return (
+        typeof (value as { key?: unknown }).key === "string" &&
+        (equals === undefined || isJsonPrimitive(equals))
+      );
+    }
+    default:
+      return false;
+  }
+}
+
+function isToolAvailabilityExpression(value: unknown): value is ToolAvailabilityExpression {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  if ("kind" in value) {
+    return isToolAvailabilitySignal(value);
+  }
+  if ("allOf" in value) {
+    const entries = (value as { allOf?: unknown }).allOf;
+    return Array.isArray(entries) && entries.every(isToolAvailabilityExpression);
+  }
+  if ("anyOf" in value) {
+    const entries = (value as { anyOf?: unknown }).anyOf;
+    return Array.isArray(entries) && entries.every(isToolAvailabilityExpression);
+  }
+  return false;
+}
+
+type PluginToolDescriptorLogger = {
+  warn(message: string): void;
+};
+
+function warnEmptyAvailabilityGroups(params: {
+  availability: ToolAvailabilityExpression | undefined;
+  logger: PluginToolDescriptorLogger | undefined;
+  pluginId: string;
+  toolName: string;
+}): void {
+  if (!params.availability || !params.logger) {
+    return;
+  }
+  for (const diagnostic of evaluateEmptyAvailabilityGroupDiagnostics(params.availability)) {
+    params.logger.warn(
+      `plugin tool availability diagnostic (${params.pluginId}/${params.toolName}): ${diagnostic.message}`,
+    );
+  }
+}
+
 export function capturePluginToolDescriptor(params: {
   pluginId: string;
   tool: AnyAgentTool;
   optional: boolean;
+  logger?: PluginToolDescriptorLogger;
 }): CachedPluginToolDescriptor {
   const label = (params.tool as { label?: unknown }).label;
   const title = typeof label === "string" && label.trim() ? label.trim() : undefined;
+  const availabilityRaw = (params.tool as { availability?: unknown }).availability;
+  const availability = isToolAvailabilityExpression(availabilityRaw) ? availabilityRaw : undefined;
+  warnEmptyAvailabilityGroups({
+    availability,
+    logger: params.logger,
+    pluginId: params.pluginId,
+    toolName: params.tool.name,
+  });
   return {
     ...(params.tool.displaySummary ? { displaySummary: params.tool.displaySummary } : {}),
     optional: params.optional,
@@ -161,6 +250,7 @@ export function capturePluginToolDescriptor(params: {
       inputSchema: asJsonObject(params.tool.parameters),
       owner: { kind: "plugin", pluginId: params.pluginId },
       executor: { kind: "plugin", pluginId: params.pluginId, toolName: params.tool.name },
+      ...(availability ? { availability } : {}),
     },
   };
 }

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -186,21 +186,35 @@ function isToolAvailabilitySignal(value: { readonly kind?: unknown }): boolean {
   }
 }
 
-function isToolAvailabilityExpression(value: unknown): value is ToolAvailabilityExpression {
+function isToolAvailabilityExpression(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): value is ToolAvailabilityExpression {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  if (seen.has(value)) {
     return false;
   }
   if ("kind" in value) {
     return isToolAvailabilitySignal(value);
   }
+  seen.add(value);
   if ("allOf" in value) {
     const entries = (value as { allOf?: unknown }).allOf;
-    return Array.isArray(entries) && entries.every(isToolAvailabilityExpression);
+    const valid =
+      Array.isArray(entries) && entries.every((entry) => isToolAvailabilityExpression(entry, seen));
+    seen.delete(value);
+    return valid;
   }
   if ("anyOf" in value) {
     const entries = (value as { anyOf?: unknown }).anyOf;
-    return Array.isArray(entries) && entries.every(isToolAvailabilityExpression);
+    const valid =
+      Array.isArray(entries) && entries.every((entry) => isToolAvailabilityExpression(entry, seen));
+    seen.delete(value);
+    return valid;
   }
+  seen.delete(value);
   return false;
 }
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1373,6 +1373,7 @@ export function resolvePluginTools(params: {
             pluginId: entry.pluginId,
             tool,
             optional,
+            logger: context.logger,
           }),
         );
         capturedDescriptorsByPluginId.set(entry.pluginId, capturedDescriptors);

--- a/src/tools/availability.ts
+++ b/src/tools/availability.ts
@@ -166,6 +166,16 @@ function evaluateExpression(
   ];
 }
 
+/** Collect authoring diagnostics for empty boolean groups without reporting runtime-missing signals. */
+export function evaluateEmptyAvailabilityGroupDiagnostics(
+  availability: ToolAvailabilityExpression,
+): readonly ToolAvailabilityDiagnostic[] {
+  return evaluateExpression(availability, {}).filter(
+    (entry) =>
+      entry.reason === "unsupported-signal" && entry.message.startsWith("Empty availability "),
+  );
+}
+
 /** Evaluate one descriptor against runtime context and return hidden-tool diagnostics. */
 export function evaluateToolAvailability(params: {
   descriptor: ToolDescriptor;

--- a/src/tools/planner.test.ts
+++ b/src/tools/planner.test.ts
@@ -113,6 +113,22 @@ describe("buildToolPlan", () => {
     ]);
   });
 
+  it("hides descriptors with malformed empty anyOf availability", () => {
+    const plan = buildToolPlan({
+      descriptors: [descriptor("malformed", { availability: { anyOf: [] } })],
+    });
+
+    expect(plan.visible).toStrictEqual([]);
+    const hiddenTool = expectHiddenTool(plan, 0);
+    expect(hiddenTool.descriptor.name).toBe("malformed");
+    expect(hiddenTool.diagnostics).toEqual([
+      {
+        reason: "unsupported-signal",
+        message: "Empty availability anyOf group",
+      },
+    ]);
+  });
+
   it("keeps protocol conversion separate from executor refs and model normalization", () => {
     const plan = buildToolPlan({
       descriptors: [


### PR DESCRIPTION
## What Problem This Solves

When a plugin author registers a tool whose availability declares an empty `anyOf` / `allOf` group, the tool is silently dropped from the tool plan with **zero feedback** (#92361). `capturePluginToolDescriptor` did not preserve the tool's `availability`, so the existing empty-group `unsupported-signal` diagnostic was never evaluated — the author sees their tool simply vanish, with no log line pointing at the misconfiguration. Worse, before the fix the descriptor was even treated as *visible* despite being broken. This affects anyone authoring openclaw plugins, turning a trivial config typo into a silent, hard-to-diagnose disappearance.

## Evidence

Live runtime proof drives the real production `capturePluginToolDescriptor` (the exact function `resolvePluginTools()` calls), then feeds the descriptor through the real `buildToolPlan` planner, crossing two boundaries: a real `console.warn` → `process.stderr` sink (captured back as bytes) and the visible-vs-hidden planner decision.

- **After fix** (live terminal): empty-group warning emitted to stderr carrying `demo/broken_tool` (1 new line), descriptor retains `availability: {"anyOf":[]}`, planner hides the tool with the `unsupported-signal` "Empty availability anyOf group" diagnostic → `RESULT: PASS`.
- **Negative control** (stash `tool-descriptor-cache.ts` back to pre-fix parent, re-run same proof): 0 stderr lines, `availability` dropped to `undefined`, tool reported *visible* with no diagnostics → `RESULT: FAIL` — the exact #92361 silent failure the fix removes.
- **Unit suites**: `vitest run src/plugins/tool-descriptor-cache.test.ts src/tools/planner.test.ts` → 2 files, 15 tests passed (covers availability preservation, the empty-group warn, malformed non-contract fields ignored, and planner hiding the malformed descriptor).

## Summary

When a plugin tool declares an empty `allOf` / `anyOf` availability group, the tool is silently hidden with zero feedback to the author (#92361). `capturePluginToolDescriptor` (`src/plugins/tool-descriptor-cache.ts`) did not preserve the tool's `availability`, so the empty-group `unsupported-signal` diagnostic was never evaluated or surfaced — the author has no idea why the tool vanished.

## Changes

- `capturePluginToolDescriptor` now preserves `tool.availability` on the descriptor.
- At plugin tool registration, an empty `allOf` / `anyOf` group emits a `warn` (reusing the existing `ToolAvailabilityDiagnostic` "Empty availability anyOf/allOf group" message) carrying the pluginId + toolName, so authors get immediate feedback instead of a silently hidden tool.
- +227/-1 across 5 files (2 are tests).

## Real behavior proof

**Behavior addressed**: A plugin tool registered with an empty `anyOf` (or `allOf`) availability group used to vanish from the tool plan with no log line — the author got no signal at registration time. The fix preserves `availability` on the captured descriptor and emits a registration-time `warn` through the plugin context logger so the author is told exactly which `pluginId/toolName` is misconfigured.

**Real environment tested**: Node v22.22.0 + tsx 4.22.3 driving the real production `capturePluginToolDescriptor` (the exact function plugin tool registration calls at `resolvePluginTools()` in `src/plugins/tools.ts`, where `logger: context.logger` is now passed). The proof crosses two real boundaries: (1) a real `console.warn`-backed logger whose output lands on the real `process.stderr` log sink, captured back as bytes; (2) the real `buildToolPlan` (`src/tools/planner.ts`) deciding visible vs. hidden.

**Exact steps or command run after this patch**:
```
# worktree on PR head fork/fix/surface-empty-availability-group-92361
node --import tsx proof.mts
```
`proof.mts` builds a plugin tool with `availability: { anyOf: [] }`, taps `process.stderr.write`, calls `capturePluginToolDescriptor({ pluginId: "demo", tool, optional: false, logger })`, then feeds the resulting descriptor through `buildToolPlan`.

**Evidence after fix** (live terminal):
```
plugin tool availability diagnostic (demo/broken_tool): Empty availability anyOf group
===== PR #94110 real-runtime proof =====
[registration] new stderr lines captured: 1
[boundary-1 stderr] saw empty-group warning : true
[boundary-1 stderr] raw bytes              : "plugin tool availability diagnostic (demo/broken_tool): Empty availability anyOf group"
[descriptor] availability preserved        : {"anyOf":[]}
[boundary-2 planner] tool visible          : false
[boundary-2 planner] tool hidden           : true
[boundary-2 planner] hidden diagnostics    : [{"reason":"unsupported-signal","message":"Empty availability anyOf group"}]
=========================================
RESULT: PASS (warning surfaced + availability preserved + tool diagnosed)
```

**Negative control** (stash `src/plugins/tool-descriptor-cache.ts` back to its parent pre-fix state, re-run the same `proof.mts`):
```
[registration] new stderr lines captured: 0
[boundary-1 stderr] saw empty-group warning : false
[boundary-1 stderr] raw bytes              : ""
[descriptor] availability preserved        : undefined
[boundary-2 planner] tool visible          : true
[boundary-2 planner] tool hidden           : false
[boundary-2 planner] hidden diagnostics    : []
RESULT: FAIL
```
Pre-fix: stderr stays silent, `availability` is dropped (`undefined`), and the tool is even reported as *visible* — the exact #92361 silent-failure the fix removes. File restored afterward.

**Observed result after fix**: the empty-group warning is emitted to the real stderr sink carrying `demo/broken_tool` (one new line), the captured descriptor retains `{ "anyOf": [] }`, and the planner now hides the tool with the `unsupported-signal` "Empty availability anyOf group" diagnostic instead of silently swallowing it. Unit suites confirm it too: `vitest run src/plugins/tool-descriptor-cache.test.ts src/tools/planner.test.ts` → 2 files, 15 tests passed.

**What was not tested**: end-to-end loading of a real on-disk plugin package through the full plugin loader/cache-write path (the proof drives the registration capture function directly with an in-memory tool); the `allOf`-variant message path (only the `anyOf` empty-group path is exercised at runtime here, though both share the same diagnostic code path and the `allOf` case is covered by the unit tests).

## Scope

Fixes #92361. Focused implementation (preserve availability + registration-time warning). Competing PRs #92411 (XL, scattered) and #93962 (today, AI-assisted) are broader/less focused — barnacle lets the maintainer pick the best-fit version.

<!-- codex-rescue-machine-readable-real-behavior-proof -->
## Real behavior proof

Behavior addressed: A plugin tool registered with an empty anyOf/allOf availability group used to disappear from the tool plan without any registration-time log signal. This patch preserves the availability descriptor and emits a plugin context warning naming the broken plugin/tool.

Real environment tested: Local Linux runtime with Node v22.22.0 and tsx 4.22.3, driving the real production capturePluginToolDescriptor function used by plugin registration and the real buildToolPlan planner. The proof crosses the real console.warn to process.stderr sink and the planner visible/hidden decision.

Exact steps or command run after this patch: In the PR head worktree fork/fix/surface-empty-availability-group-92361, ran node --import tsx proof.mts. The script builds a plugin tool with availability { anyOf: [] }, taps process.stderr.write, calls capturePluginToolDescriptor({ pluginId: "demo", tool, optional: false, logger }), then feeds the descriptor through buildToolPlan.

Evidence after fix: Live terminal capture from node --import tsx proof.mts:
```text
plugin tool availability diagnostic (demo/broken_tool): Empty availability anyOf group
===== PR #94110 real-runtime proof =====
[registration] new stderr lines captured: 1
[boundary-1 stderr] saw empty-group warning : true
[boundary-1 stderr] raw bytes              : "plugin tool availability diagnostic (demo/broken_tool): Empty availability anyOf group"
[descriptor] availability preserved        : {"anyOf":[]}
[boundary-2 planner] tool visible          : false
[boundary-2 planner] tool hidden           : true
[boundary-2 planner] hidden diagnostics    : [{"reason":"unsupported-signal","message":"Empty availability anyOf group"}]
RESULT: PASS (warning surfaced + availability preserved + tool diagnosed)
```
Negative control terminal capture after restoring the parent pre-fix tool-descriptor-cache.ts showed zero stderr lines, availability undefined, tool visible true, and RESULT: FAIL.

Observed result after fix: The empty-group warning is emitted to the real stderr sink with demo/broken_tool, the captured descriptor retains {"anyOf":[]}, and the planner hides the tool with the unsupported-signal diagnostic "Empty availability anyOf group" instead of silently treating it as visible. The related vitest command passed 15 tests.

What was not tested: Full end-to-end loading of a real on-disk plugin package through the plugin loader/cache-write path was not run; the proof drives the registration capture function directly with an in-memory tool. The allOf runtime variant was not separately exercised in the live proof, though it shares the diagnostic path and is covered by unit tests.
