### PR TITLE
fix(heartbeat): suppress raw reply delivery in message_tool_only mode

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -18,6 +18,7 @@ import { resolveModelRefFromString, type ModelRef } from "../agents/model-select
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
 import { formatReasoningMessage } from "../agents/pi-embedded-utils.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
 import {
   getHeartbeatToolNotificationText,
@@ -1857,8 +1858,20 @@ export async function runHeartbeatOnce(opts: {
       normalized.text = replacement.text;
       normalized.shouldSkip = false;
     }
+    // When message_tool_only mode is active and the heartbeat response tool was
+    // not called, suppress the raw reply to prevent private text from leaking to
+    // the channel (e.g. Telegram). The model must explicitly call the response
+    // tool with notify:true to send a visible reply.
+    // Error/failure notices that opt into source-suppression delivery (e.g.
+    // Codex usage limits) are still delivered.
+    const leakMessageToolOnlyReply =
+      usesHeartbeatResponseTool &&
+      !heartbeatToolResponse &&
+      replyPayload &&
+      !getReplyPayloadMetadata(replyPayload)?.deliverDespiteSourceReplySuppression;
     const shouldSkipMain =
-      normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion;
+      leakMessageToolOnlyReply ||
+      (normalized.shouldSkip && !normalized.hasMedia && !hasRelayableExecCompletion);
     if (shouldSkipMain && reasoningPayloads.length === 0) {
       await restoreHeartbeatUpdatedAt({
         storePath,


### PR DESCRIPTION
## Summary

- When `messages.visibleReplies` is set to `message_tool`, the heartbeat runner was delivering the raw agent reply text to the channel even when the heartbeat response tool was not called with `notify: true`.
- This leaked private model responses to the channel, bypassing the `message_tool_only` privacy mode.
- The fix suppresses raw reply delivery when the message_tool mode is active and the response tool was not called, while preserving error/failure notices that explicitly opt into source-suppression delivery (e.g. Codex usage limit warnings).

## Verification

- `node scripts/run-vitest.mjs run src/infra/heartbeat-runner.tool-response.test.ts` → **13/13 passed**

## Impact Assessment

- Scope: `src/infra/heartbeat-runner.ts` — adds a guard before the `shouldSkipMain` check
- Downstream: only affects heartbeat delivery when `visibleReplies: "message_tool"` is configured; error notices are still delivered via `deliverDespiteSourceReplySuppression`
- Edge cases: the check reads `getReplyPayloadMetadata` to allow error notices through; regular replies without the heartbeat tool invocation are suppressed
- Hard-coded values: none

## Real behavior proof

**Behavior addressed:** Heartbeat runner leaked private replies to Telegram in `message_tool_only` mode. After the fix, raw replies are suppressed unless the heartbeat response tool is called or the reply is an error notice.

**Environment tested:** Node 22.x on Linux, vitest test suite.

**Steps run after the patch:** Ran heartbeat tool response tests including the Codex failure notice scenario.

```bash
(cd /home/.../openclaw && node scripts/run-vitest.mjs run src/infra/heartbeat-runner.tool-response.test.ts)
```

**Evidence after fix:**

```text
Test Files  1 passed (1)
     Tests  13 passed (13)
```

**Observed result:** All 13 tests pass, including the Codex runtime failure notice delivery test which verifies error messages are still delivered in message_tool mode.

**Not tested:** Live Telegram bot with `visibleReplies: "message_tool"` configuration was not exercised.

Closes #94053
