### PR TITLE
fix(reply): strip leaked current-message scaffolding and (no output) placeholders

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -514,6 +514,33 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
   });
 
+  it("preserves ordinary replies that begin with the priority-marker phrase", () => {
+    // A genuine reply that explains the marker must not be erased just because
+    // its first line starts with "Current message priority:". Only copied
+    // scaffolding — the phrase alongside a bracketed scaffold marker — is
+    // stripped. (#78177)
+    const prose = "Current message priority: high means the sender flagged the message as urgent.";
+    expect(sanitizeUserFacingText(prose)).toBe(prose);
+
+    const multiLine = [
+      "Current message priority: high",
+      "is how that runtime header is labeled, in case you were asking.",
+    ].join("\n");
+    expect(sanitizeUserFacingText(multiLine)).toBe(multiLine);
+  });
+
+  it("still strips a priority-marker line when it heads a copied scaffold block", () => {
+    const input = [
+      "Current message priority: high",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: ping",
+      "",
+      "Pong.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Pong.");
+  });
+
   it("suppresses standalone no-output placeholders without stripping inline mentions", () => {
     expect(sanitizeUserFacingText("(no output)")).toBe("");
     expect(sanitizeUserFacingText("Before\n(no output)\nAfter")).toBe("Before\nAfter");

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -541,6 +541,36 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Pong.");
   });
 
+  it("strips a CRLF copied scaffold block while preserving the genuine reply (#78177)", () => {
+    // Windows/CRLF line endings must still split the scaffold from the answer;
+    // before the CRLF-aware blank-line split the scaffold and the reply were a
+    // single block and the genuine reply was suppressed along with it.
+    const scaffolded = [
+      "Current message priority: high",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: ping",
+      "[from: Danny]",
+      "",
+      "Pong.",
+    ].join("\r\n");
+    expect(sanitizeUserFacingText(scaffolded)).toBe("Pong.");
+
+    const history = [
+      "[Chat messages since your last reply - for context]",
+      "[Telegram 2026-05-05T20:19:00Z] Danny: previous",
+      "",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: current",
+      "",
+      "Visible reply.",
+    ].join("\r\n");
+    expect(sanitizeUserFacingText(history)).toBe("Visible reply.");
+
+    // A CRLF reply that merely begins with the phrase (no bracketed marker) is kept.
+    const prose = ["Current message priority: high", "means the sender flagged it."].join("\r\n");
+    expect(sanitizeUserFacingText(prose)).toContain("means the sender flagged it.");
+  });
+
   it("suppresses standalone no-output placeholders without stripping inline mentions", () => {
     expect(sanitizeUserFacingText("(no output)")).toBe("");
     expect(sanitizeUserFacingText("Before\n(no output)\nAfter")).toBe("Before\nAfter");

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -487,6 +487,41 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Done. Clean answer only.");
   });
 
+  it("strips leaked current-message scaffolding while preserving reply text", () => {
+    const input = [
+      "Current message priority: high",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: ping",
+      "[from: Danny]",
+      "",
+      "Pong.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Pong.");
+  });
+
+  it("strips copied history/current-message scaffolding blocks", () => {
+    const input = [
+      "[Chat messages since your last reply - for context]",
+      "[Telegram 2026-05-05T20:19:00Z] Danny: previous",
+      "",
+      "[Current message - respond to this]",
+      "[Telegram 2026-05-05T20:20:00Z] Danny: current",
+      "",
+      "Visible reply.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Visible reply.");
+  });
+
+  it("suppresses standalone no-output placeholders without stripping inline mentions", () => {
+    expect(sanitizeUserFacingText("(no output)")).toBe("");
+    expect(sanitizeUserFacingText("Before\n(no output)\nAfter")).toBe("Before\nAfter");
+    expect(sanitizeUserFacingText("The literal (no output) text is relevant.")).toBe(
+      "The literal (no output) text is relevant.",
+    );
+  });
+
   it("strips copied inbound metadata blocks from user-facing assistant text", () => {
     const input = [
       "Conversation info (untrusted metadata):",

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -73,6 +73,11 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE = /^[ \t]*\[tool calls omitted\][ \t]*$/i;
+const NO_OUTPUT_PLACEHOLDER_LINE_RE = /^[ \t]*\(no output\)[ \t]*$/i;
+const HISTORY_CONTEXT_MARKER_LINE_RE =
+  /^[ \t]*\[Chat messages since your last reply - for context\][ \t]*$/i;
+const CURRENT_MESSAGE_MARKER_LINE_RE = /^[ \t]*\[Current message - respond to this\][ \t]*$/i;
+const CURRENT_MESSAGE_PRIORITY_LINE_RE = /^[ \t]*Current message priority:[^\n]*$/i;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -364,7 +369,7 @@ function stripFinalTagsFromText(text: unknown): string {
   return stripFinalTags(normalized);
 }
 
-function stripToolCallsOmittedPlaceholderLines(text: string): string {
+function stripPlaceholderLines(text: string): string {
   let result = "";
   let start = 0;
   while (start < text.length) {
@@ -372,12 +377,62 @@ function stripToolCallsOmittedPlaceholderLines(text: string): string {
     const end = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const chunk = text.slice(start, end);
     const line = chunk.endsWith("\n") ? chunk.slice(0, -1).replace(/\r$/, "") : chunk;
-    if (!TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE.test(line)) {
+    if (
+      !TOOL_CALLS_OMITTED_PLACEHOLDER_LINE_RE.test(line) &&
+      !NO_OUTPUT_PLACEHOLDER_LINE_RE.test(line)
+    ) {
       result += chunk;
     }
     start = end;
   }
   return result;
+}
+
+/**
+ * Drop copied current-message/history scaffolding blocks (the
+ * "[Chat messages since your last reply - for context]" / "[Current message -
+ * respond to this]" / "Current message priority:" prompt headers and their
+ * indented payload) that can leak into a final reply when the model echoes its
+ * own input. Only standalone blocks whose first line is one of these markers
+ * are removed, so ordinary inline prose that happens to mention the phrase is
+ * preserved. (#78177)
+ */
+function stripCopiedCurrentMessageScaffolding(text: string): string {
+  const blocks = text.split(/(\n[ \t]*\n)/);
+  let changed = false;
+  const kept: string[] = [];
+
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    if (/^\n[ \t]*\n$/.test(block)) {
+      kept.push(block);
+      continue;
+    }
+
+    const firstLine = block.split(/\r?\n/, 1)[0] ?? "";
+    const shouldDrop =
+      HISTORY_CONTEXT_MARKER_LINE_RE.test(firstLine) ||
+      CURRENT_MESSAGE_PRIORITY_LINE_RE.test(firstLine) ||
+      CURRENT_MESSAGE_MARKER_LINE_RE.test(firstLine);
+    if (shouldDrop) {
+      changed = true;
+      if (/^\n[ \t]*\n$/.test(blocks[index + 1] ?? "")) {
+        index += 1;
+      }
+      continue;
+    }
+
+    kept.push(block);
+  }
+
+  if (!changed) {
+    return text;
+  }
+
+  return kept
+    .join("")
+    .replace(/^(?:[ \t]*\n)+/, "")
+    .replace(/(?:\n[ \t]*)+$/, "");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {
@@ -437,10 +492,11 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   // Replay repair may synthesize this placeholder to keep provider transcripts valid.
   // It is internal scaffolding, so drop standalone placeholder lines before delivery
   // while preserving ordinary inline mentions a user may be discussing.
-  const withoutPlaceholder = stripToolCallsOmittedPlaceholderLines(withoutToolCallXml);
+  const withoutPlaceholder = stripPlaceholderLines(withoutToolCallXml);
+  const withoutCurrentMessageScaffolding = stripCopiedCurrentMessageScaffolding(withoutPlaceholder);
   const withoutInternalTraceLines = errorContext
-    ? stripAssistantInternalTraceLines(withoutPlaceholder)
-    : withoutPlaceholder;
+    ? stripAssistantInternalTraceLines(withoutCurrentMessageScaffolding)
+    : withoutCurrentMessageScaffolding;
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(
     stripLegacyBracketToolCallBlocks(withoutInternalTraceLines),
   );

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -393,9 +393,10 @@ function stripPlaceholderLines(text: string): string {
  * "[Chat messages since your last reply - for context]" / "[Current message -
  * respond to this]" / "Current message priority:" prompt headers and their
  * indented payload) that can leak into a final reply when the model echoes its
- * own input. Only standalone blocks whose first line is one of these markers
- * are removed, so ordinary inline prose that happens to mention the phrase is
- * preserved. (#78177)
+ * own input. Only standalone blocks led by a bracketed marker (or a
+ * "Current message priority:" line that sits alongside one) are removed, so
+ * ordinary prose that merely mentions or starts with the phrase is preserved.
+ * (#78177)
  */
 function stripCopiedCurrentMessageScaffolding(text: string): string {
   const blocks = text.split(/(\n[ \t]*\n)/);
@@ -410,10 +411,21 @@ function stripCopiedCurrentMessageScaffolding(text: string): string {
     }
 
     const firstLine = block.split(/\r?\n/, 1)[0] ?? "";
+    // The bracketed "[Chat messages …]" / "[Current message - respond to this]"
+    // headers are unambiguous copied scaffolding. A plain-text "Current message
+    // priority:" line is not — it can legitimately begin a reply that explains
+    // the marker — so only treat it as scaffolding when the block also carries
+    // one of the bracketed markers, as real copied blocks always do. (#78177)
+    const blockHasBracketedScaffoldMarker = block
+      .split(/\r?\n/)
+      .some(
+        (line) =>
+          HISTORY_CONTEXT_MARKER_LINE_RE.test(line) || CURRENT_MESSAGE_MARKER_LINE_RE.test(line),
+      );
     const shouldDrop =
       HISTORY_CONTEXT_MARKER_LINE_RE.test(firstLine) ||
-      CURRENT_MESSAGE_PRIORITY_LINE_RE.test(firstLine) ||
-      CURRENT_MESSAGE_MARKER_LINE_RE.test(firstLine);
+      CURRENT_MESSAGE_MARKER_LINE_RE.test(firstLine) ||
+      (CURRENT_MESSAGE_PRIORITY_LINE_RE.test(firstLine) && blockHasBracketedScaffoldMarker);
     if (shouldDrop) {
       changed = true;
       if (/^\n[ \t]*\n$/.test(blocks[index + 1] ?? "")) {

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -399,13 +399,17 @@ function stripPlaceholderLines(text: string): string {
  * (#78177)
  */
 function stripCopiedCurrentMessageScaffolding(text: string): string {
-  const blocks = text.split(/(\n[ \t]*\n)/);
+  // Split on blank-line separators, matching both LF and CRLF so copied
+  // scaffolding that uses Windows line endings still parses as its own block
+  // (otherwise the scaffold and the genuine reply would be one droppable
+  // block and the real answer would be suppressed). (#78177)
+  const blocks = text.split(/(\r?\n[ \t]*\r?\n)/);
   let changed = false;
   const kept: string[] = [];
 
   for (let index = 0; index < blocks.length; index += 1) {
     const block = blocks[index];
-    if (/^\n[ \t]*\n$/.test(block)) {
+    if (/^\r?\n[ \t]*\r?\n$/.test(block)) {
       kept.push(block);
       continue;
     }
@@ -428,7 +432,7 @@ function stripCopiedCurrentMessageScaffolding(text: string): string {
       (CURRENT_MESSAGE_PRIORITY_LINE_RE.test(firstLine) && blockHasBracketedScaffoldMarker);
     if (shouldDrop) {
       changed = true;
-      if (/^\n[ \t]*\n$/.test(blocks[index + 1] ?? "")) {
+      if (/^\r?\n[ \t]*\r?\n$/.test(blocks[index + 1] ?? "")) {
         index += 1;
       }
       continue;
@@ -443,8 +447,8 @@ function stripCopiedCurrentMessageScaffolding(text: string): string {
 
   return kept
     .join("")
-    .replace(/^(?:[ \t]*\n)+/, "")
-    .replace(/(?:\n[ \t]*)+$/, "");
+    .replace(/^(?:[ \t]*\r?\n)+/, "")
+    .replace(/(?:\r?\n[ \t]*)+$/, "");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -20,7 +20,7 @@ import {
   type ResponsePrefixContext,
 } from "./response-prefix-template.js";
 
-export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat";
+export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat" | "empty-tool-output";
 
 export type NormalizeReplyOptions = {
   responsePrefix?: string;
@@ -101,6 +101,19 @@ export function normalizeReplyPayload(
   if (text && isInternalFormattingArtifact(text) && !hasContent("")) {
     opts.onSkip?.("silent");
     return null;
+  }
+
+  // A bare "(no output)" payload is internal tool scaffolding, never a real
+  // reply, so clear it before sanitization empties it to "".  Preserve any
+  // sendable non-text payload (media, presentation, interactive, channelData)
+  // via the existing content gate so those still deliver; only skip when
+  // nothing sendable remains. (#78177)
+  if (text?.trim().toLowerCase() === "(no output)") {
+    if (!hasContent("")) {
+      opts.onSkip?.("empty-tool-output");
+      return null;
+    }
+    text = "";
   }
 
   if (text) {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -149,6 +149,49 @@ describe("normalizeReplyPayload", () => {
     expect(reply.channelData).toEqual(payload.channelData);
   });
 
+  it("records empty-tool-output for bare no-output placeholders", () => {
+    const reasons: string[] = [];
+    const normalized = normalizeReplyPayload(
+      { text: "  (no output)\n" },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+
+    expect(normalized).toBeNull();
+    expect(reasons).toEqual(["empty-tool-output"]);
+  });
+
+  it("preserves non-text payloads when clearing bare no-output text", () => {
+    const reasons: string[] = [];
+    const mediaPayload = {
+      text: "  (no output)\n",
+      mediaUrl: "https://example.com/photo.jpg",
+    };
+
+    const normalizedMedia = normalizeReplyPayload(mediaPayload, {
+      onSkip: (reason) => reasons.push(reason),
+    });
+
+    const mediaReply = expectNormalizedReply(normalizedMedia);
+    expect(mediaReply.mediaUrl).toBe("https://example.com/photo.jpg");
+    expect(mediaReply.text ?? "").toBe("");
+    expect(reasons).toEqual([]);
+
+    const channelDataPayload = {
+      text: "(no output)",
+      channelData: {
+        line: {
+          flexMessage: { type: "bubble" },
+        },
+      },
+    };
+
+    const normalizedChannelData = normalizeReplyPayload(channelDataPayload);
+
+    const channelDataReply = expectNormalizedReply(normalizedChannelData);
+    expect(channelDataReply.channelData).toEqual(channelDataPayload.channelData);
+    expect(channelDataReply.text ?? "").toBe("");
+  });
+
   it("records skip reasons for silent, empty, and internal artifact payloads", () => {
     const cases = [
       { name: "silent", payload: { text: SILENT_REPLY_TOKEN }, reason: "silent" },


### PR DESCRIPTION
Fixes #78177.

## Summary
Final user-facing replies could surface internal scaffolding when the model echoed its own input back into the reply text:

- the prompt headers `[Chat messages since your last reply - for context]`, `[Current message - respond to this]`, and `Current message priority: …`
- bare `(no output)` tool placeholders

These are internal scaffolding, never intended for end users, but they were not consistently stripped before delivery.

## Root cause
`sanitizeUserFacingText()` already strips several internal-only artifacts (final tags, runtime context, inbound metadata, tool-call XML, `[tool calls omitted]` placeholder lines) but had no rule for the current-message/history scaffolding headers or for bare `(no output)` placeholders. On the reply path, `normalizeReplyPayload()` also had no early skip for a bare `(no output)` payload.

## Changes
- **`src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`**
  - `stripPlaceholderLines` (renamed from `stripToolCallsOmittedPlaceholderLines`) now also drops standalone `(no output)` lines, mirroring the existing `[tool calls omitted]` rule.
  - New `stripCopiedCurrentMessageScaffolding` removes copied scaffolding blocks. A block is dropped when its first line is a bracketed marker (`[Chat messages …]` / `[Current message - respond to this]`); a plain-text `Current message priority:` line only triggers a drop when the block **also** carries one of those bracketed markers — as real copied scaffolding always does. This keeps an ordinary reply that merely begins with the phrase (e.g. `Current message priority: high means …`) from being erased, consistent with the sanitizer's existing preserve-inline-mentions behavior.
- **`src/auto-reply/reply/normalize-reply.ts`**
  - A bare `(no output)` payload now clears the placeholder text and is skipped with the new `empty-tool-output` reason **only when no other sendable content remains**. When the payload still carries media, presentation, interactive, or channelData, that content is preserved and delivered (gated through the existing `hasContent("")` check), so non-text replies are not dropped.
- Regression tests added for the sanitizer (`embedded-agent-helpers.sanitizeuserfacingtext.test.ts`) and the normalizer (`reply-utils.test.ts`): coverage that a bare `(no output)` payload carrying media/channelData still delivers its non-text content, and that an ordinary reply beginning with `Current message priority:` is preserved while a copied scaffold block led by that line is still stripped.

All rules match standalone lines/blocks only, so text that merely mentions or starts with the literal strings inline is preserved — see the `"The literal (no output) text is relevant."` and `"Current message priority: high means …"` cases.

> This re-authors the approach from #78189 (which was closed only for an author PR-queue limit, not on review/design grounds) against current `main`: the helper moved from `pi-embedded-helpers/` to `embedded-agent-helpers/`, and the sanitize pipeline gained `stripAssistantInternalTraceLines` / `stripPlainTextToolCallBlocks` steps since then, so the change is rebased onto the current shape.

## Testing
- `node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts src/auto-reply/reply/reply-utils.test.ts` → **124 + 79 passing** (adds CRLF scaffold-splitting coverage) (including the new cases)
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental false` → clean
- `oxlint` and `oxfmt --check` on the changed files → clean

## AI-assisted disclosure
This PR was prepared with AI assistance. Per `CONTRIBUTING.md`, the automated tests/typecheck/lint above are supplemental. The real-behavior proof below is a direct run of the production functions at the current PR head; a live-channel recording can be added on request. `CHANGELOG.md` intentionally left untouched per the contributor guidelines.

## Real behavior proof

**Behavior or issue addressed:** Final user-facing replies could leak internal prompt scaffolding — `[Chat messages since your last reply - for context]`, `[Current message - respond to this]`, `Current message priority: ...` — and bare `(no output)` tool placeholders when the model echoed its own input back into the reply text (#78177). The fix must also (a) keep delivering non-text replies (media, presentation, interactive, channelData) whose visible text is only `(no output)`, (b) NOT erase an ordinary reply that merely begins with `Current message priority:` outside a copied scaffold block, and (c) strip copied scaffolding that uses CRLF / Windows line endings without dropping the genuine reply that follows it.

**Real environment tested:** Clean checkout at current PR head `48d42ac6` (this branch rebased onto current `main` `2f851ecfe9`) on Windows 11, Node `v24.13.0`; `git rev-parse HEAD` verified to equal `48d42ac657...` with no modified tracked files before the run. The shipped `sanitizeUserFacingText()` (`src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`) and `normalizeReplyPayload()` (`src/auto-reply/reply/normalize-reply.ts`) — the same functions the reply pipeline calls before delivery — were executed directly against the issue inputs, including CRLF variants and `(no output)` payloads carrying non-text content. This is a direct run of the production code paths at current head; it is not a full live-channel deployment (a maintainer can additionally request a live Telegram capture via Mantis if preferred).

**Exact steps or command run after this patch:** A short harness imports the real exported functions and prints input -> output for each case, then is run with the live command below:

```ts
import { sanitizeUserFacingText } from "./src/agents/embedded-agent-helpers/sanitize-user-facing-text.js";
import { normalizeReplyPayload } from "./src/auto-reply/reply/normalize-reply.js";
const show = (label, v) => console.log(label + ": " + JSON.stringify(v));
// sanitizeUserFacingText: LF and CRLF scaffold/history blocks, the (no output) line,
//   an inline (no output) mention, and ordinary prose that begins with the marker phrase.
// normalizeReplyPayload: bare (no output) text-only, (no output)+media, (no output)+channelData,
//   and an echoed-scaffolding reply.
```

Command: `node --import tsx repro-78177.mts`

**Evidence after fix:** Copied console output from `node --import tsx repro-78177.mts` at current head `48d42ac6`:

```text
=== sanitizeUserFacingText, LF inputs (current head 48d42ac6) ===
INPUT : "Current message priority: high\n[Current message - respond to this]\n[Telegram 2026-05-05T20:20:00Z] Danny: ping\n[from: Danny]\n\nPong."
OUTPUT: "Pong."

INPUT : "[Chat messages since your last reply - for context]\n[Telegram 2026-05-05T20:10:00Z] Danny: earlier\n\n[Current message - respond to this]\n[Telegram 2026-05-05T20:20:00Z] Danny: now\n\nVisible reply."
OUTPUT: "Visible reply."

INPUT : "Before\n(no output)\nAfter"
OUTPUT: "Before\nAfter"

INPUT : "The literal (no output) text is relevant."
OUTPUT: "The literal (no output) text is relevant."

INPUT : "Current message priority: high means this ticket is urgent, so I bumped it."
OUTPUT: "Current message priority: high means this ticket is urgent, so I bumped it."

=== sanitizeUserFacingText, CRLF inputs (Windows line endings) ===
INPUT : "Current message priority: high\r\n[Current message - respond to this]\r\n[Telegram 2026-05-05T20:20:00Z] Danny: ping\r\n[from: Danny]\r\n\r\nPong."
OUTPUT: "Pong."

INPUT : "[Chat messages since your last reply - for context]\r\n[Telegram] previous\r\n\r\n[Current message - respond to this]\r\n[Telegram] current\r\n\r\nVisible reply."
OUTPUT: "Visible reply."

INPUT : "Current message priority: high\r\nmeans the sender flagged it."
OUTPUT: "Current message priority: high\r\nmeans the sender flagged it."

=== normalizeReplyPayload (current head 48d42ac6) ===
CASE  : bare (no output), text only
INPUT : {"text":"  (no output)\n"}
RESULT: null (suppressed) reasons=["empty-tool-output"]

CASE  : (no output) + media
INPUT : {"text":"(no output)","mediaUrl":"https://example.com/photo.jpg"}
RESULT: {"text":"","mediaUrl":"https://example.com/photo.jpg"}

CASE  : (no output) + channelData
INPUT : {"text":"(no output)","channelData":{"line":{"flexMessage":{"type":"bubble"}}}}
RESULT: {"text":"","channelData":{"line":{"flexMessage":{"type":"bubble"}}}}

CASE  : scaffolding echoed into reply text
INPUT : {"text":"Current message priority: high\n[Current message - respond to this]\n[from: Danny]\n\nPong."}
RESULT: {"text":"Pong."}
```

**Observed result after fix:** At current head `48d42ac6`, `sanitizeUserFacingText` removes the `Current message priority:` / `[Current message - respond to this]` / `[Chat messages since your last reply - for context]` scaffolding blocks and standalone `(no output)` lines, returning only the genuine reply (`Pong.`, `Visible reply.`, `Before\nAfter`) for both LF and CRLF inputs. It preserves the inline-mention case (`The literal (no output) text is relevant.`) and ordinary prose that merely begins with the marker phrase (`Current message priority: high means ...`, including the CRLF variant). `normalizeReplyPayload` suppresses a bare `(no output)` text-only payload (skip reason `empty-tool-output`) but preserves and still delivers payloads carrying media or channelData (clearing only the placeholder text to `""`), and reduces an echoed-scaffolding reply to the genuine text (`Pong.`). The CRLF cases are the regression this revision fixes: previously a Windows-line-ending scaffold block was not split from the answer, so the genuine reply was dropped with it.

**What was not tested:** A full end-to-end delivery through a live messaging channel (for example a real Telegram bot) was not exercised; verification runs the production `sanitizeUserFacingText` and `normalizeReplyPayload` functions directly against the issue inputs at current head `48d42ac6`.
