### PR TITLE
fix(cron): preserve isolated success on delivery failure

### DIFF
--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1212,6 +1212,76 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("keeps the isolated run successful when post-run delivery fails", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    resolveCronPayloadOutcomeMock.mockReturnValue({
+      summary: "Final cron report",
+      outputText: "Final cron report",
+      synthesizedText: "Final cron report",
+      deliveryPayload: { text: "Final cron report" },
+      deliveryPayloads: [{ text: "Final cron report" }],
+      deliveryPayloadHasStructuredContent: false,
+      hasFatalErrorPayload: false,
+      hasFatalStructuredErrorPayload: false,
+      embeddedRunError: undefined,
+    });
+    dispatchCronDeliveryMock.mockImplementationOnce(
+      (params: {
+        withRunSession: (result: {
+          status: "error";
+          summary: string;
+          outputText: string;
+          error: string;
+          deliveryAttempted: true;
+        }) => unknown;
+      }) => ({
+        result: params.withRunSession({
+          status: "error",
+          summary: "Final cron report",
+          outputText: "Final cron report",
+          error: "Message failed",
+          deliveryAttempted: true,
+        }),
+        delivered: false,
+        deliveryAttempted: true,
+        summary: "Final cron report",
+        outputText: "Final cron report",
+        synthesizedText: "Final cron report",
+        deliveryPayloads: [{ text: "Final cron report" }],
+      }),
+    );
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob({
+        id: "delivery-failure-after-success",
+        name: "Delivery Failure After Success",
+      }),
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.error).toBe("Message failed");
+    expect(result.delivered).toBe(false);
+    expect(result.deliveryAttempted).toBe(true);
+    expectDeliveryFields(result.delivery, {
+      intended: { channel: "messagechat", to: "123", source: "explicit" },
+      resolved: { ok: true, channel: "messagechat", to: "123", source: "explicit" },
+      fallbackUsed: true,
+      delivered: false,
+    });
+    expect(result.diagnostics?.summary).toBe("Message failed");
+    expect(result.diagnostics?.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "delivery",
+          severity: "error",
+          message: "Message failed",
+        }),
+      ]),
+    );
+  });
+
   it("rewrites generic message provider to resolved channel in delivery trace", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1178,12 +1178,17 @@ async function finalizeCronRun(params: {
     delivered?: boolean;
     deliveryAttempted?: boolean;
     delivery?: CronDeliveryTrace;
-  }) =>
-    prepared.withRunSession({
+    deliveryError?: string;
+    deliveryDiagnostics?: RunCronAgentTurnResult["diagnostics"];
+  }) => {
+    const deliveryError = normalizeOptionalString(result?.deliveryError);
+    return prepared.withRunSession({
       status: hasFatalErrorPayload ? "error" : "ok",
       ...(hasFatalErrorPayload
         ? { error: embeddedRunError ?? "cron isolated run returned an error payload" }
-        : {}),
+        : deliveryError
+          ? { error: deliveryError }
+          : {}),
       summary,
       outputText,
       delivered: result?.delivered,
@@ -1192,14 +1197,16 @@ async function finalizeCronRun(params: {
       diagnostics: hasFatalErrorPayload
         ? mergeCronRunDiagnostics(
             agentDiagnostics,
+            result?.deliveryDiagnostics,
             createCronRunDiagnosticsFromError(
               "agent-run",
               embeddedRunError ?? "cron isolated run returned an error payload",
             ),
           )
-        : agentDiagnostics,
+        : mergeCronRunDiagnostics(agentDiagnostics, result?.deliveryDiagnostics),
       ...telemetry,
     });
+  };
   const failPendingPresentationWarningUnlessDelivered = (delivered?: boolean) => {
     if (pendingPresentationWarningError && delivered !== true) {
       hasFatalErrorPayload = true;
@@ -1295,13 +1302,26 @@ async function finalizeCronRun(params: {
     failPendingPresentationWarningUnlessDelivered(
       resultWithDeliveryMeta.delivered ?? deliveryResult.delivered,
     );
-    if (!hasFatalErrorPayload || deliveryResult.result.status !== "ok") {
+    if (!hasFatalErrorPayload) {
+      if (deliveryResult.result.status === "error" && !params.isAborted()) {
+        return resolveRunOutcome({
+          delivered: resultWithDeliveryMeta.delivered ?? deliveryResult.delivered,
+          deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
+          delivery: deliveryTrace,
+          deliveryError: deliveryResult.result.error,
+          deliveryDiagnostics: resultWithDeliveryMeta.diagnostics,
+        });
+      }
+      return resultWithDeliveryMeta;
+    }
+    if (deliveryResult.result.status !== "ok") {
       return resultWithDeliveryMeta;
     }
     return resolveRunOutcome({
       delivered: deliveryResult.result.delivered,
       deliveryAttempted: resultWithDeliveryMeta.deliveryAttempted,
       delivery: deliveryTrace,
+      deliveryDiagnostics: resultWithDeliveryMeta.diagnostics,
     });
   }
   summary = deliveryResult.summary;


### PR DESCRIPTION
## Summary

- Preserve successful isolated cron agent runs when the post-run delivery phase returns an error.
- Keep delivery failure metadata (`error`, `delivered`, `deliveryAttempted`, and diagnostics) so cron state can record `not-delivered` separately from agent execution status.
- Add a regression test for a successful final report followed by a delivery dispatcher failure.

Fixes #94058

## Root Cause

`finalizeCronRun` propagated a `dispatchCronDelivery` result with `status: "error"` directly when the agent payload itself was non-fatal. That collapsed delivery/finalization failures into the isolated agent execution result, so the outer scheduled run could report `status=error` even though the isolated session had ended successfully.

## Validation

- `node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service.persists-delivered-status.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`
- `pnpm exec oxfmt --check --threads=1 src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `git diff --check`

## Real behavior proof

- **Behavior addressed:** Scheduled isolated `agentTurn` jobs could produce a successful isolated session/final assistant message, but a post-run delivery error caused the outer cron run to persist `status=error`, making the success look like an agent failure.
- **Real environment tested:** Local macOS OpenClaw source checkout at head `291dc8e6896c8cced2df1b7e5f5b5da0e100904d`, with dependencies hydrated by `pnpm install --frozen-lockfile` and commands run from the repository root.
- **Exact steps or command run after this patch:** Ran the focused cron runner/service regression command, core typecheck, repo formatter check, and whitespace diff check listed in Validation after applying this patch.
- **Evidence after fix:** Terminal capture from the local OpenClaw source checkout after the patch:

  ```text
  $ node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.meta-error-status.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/cron/service.persists-delivered-status.test.ts
  [test] starting test/vitest/vitest.cron.config.ts

   RUN  v4.1.8 /Users/stellarfish/.openmeta/worktrees/openclaw__openclaw/openmeta__94058-cron-isolated-outcome

   Test Files  5 passed (5)
        Tests  155 passed (155)
     Start at  19:30:54
     Duration  15.08s (transform 1.90s, setup 299ms, import 3.94s, tests 10.65s, environment 0ms)

  [test] passed 1 Vitest shard in 47.11s

  $ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false
  # exited 0

  $ pnpm exec oxfmt --check --threads=1 src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.message-tool-policy.test.ts
  Checking formatting...

  All matched files use the correct format.
  Finished in 12ms on 2 files using 1 threads.

  $ git diff --check
  # exited 0
  ```

- **Observed result after fix:** The new regression path verifies `runCronIsolatedAgentTurn` keeps the isolated run result at `status: "ok"` when post-run delivery fails, while preserving `error: "Message failed"`, `delivered: false`, `deliveryAttempted: true`, and a `source: "delivery"` diagnostic so the outer cron service can record delivery failure separately.
- **What was not tested:** I did not run a live scheduled gateway/cron delivery against a real chat provider; the after-fix proof is local source-checkout terminal output plus focused runner/service regression coverage.
