### PR TITLE
[codex] Fix Telegram rich local Markdown link hrefs

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -218,6 +218,13 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramRichHtml("[user](tg://user?id=123)")).toBe(
       '<a href="tg://user?id=123">user</a>',
     );
+    expect(markdownToTelegramRichHtml("[support](mailto:user@example.com)")).toBe(
+      '<a href="mailto:user@example.com">support</a>',
+    );
+    expect(markdownToTelegramRichHtml("[call](tel:+123456789)")).toBe(
+      '<a href="tel:+123456789">call</a>',
+    );
+    expect(markdownToTelegramRichHtml("[back](#top)")).toBe('<a href="#top">back</a>');
   });
 
   it("preserves Markdown heading levels in rich HTML", () => {

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -212,6 +212,7 @@ describe("markdownToTelegramHtml", () => {
         "[scripts/yougile.py](/home/dankar/.openclaw/workspace-yougile/scripts/yougile.py#L41)",
       ),
     ).toBe("<code>scripts/yougile.py</code>");
+    expect(markdownToTelegramRichHtml("[config](./openclaw.json)")).toBe("config");
     expect(markdownToTelegramRichHtml("[docs](https://example.com/docs)")).toBe(
       '<a href="https://example.com/docs">docs</a>',
     );

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -206,6 +206,20 @@ describe("markdownToTelegramHtml", () => {
     ).toBe('<a href="https://example.com">docs</a>');
   });
 
+  it("keeps unsupported markdown link hrefs as visible text in rich HTML", () => {
+    expect(
+      markdownToTelegramRichHtml(
+        "[scripts/yougile.py](/home/dankar/.openclaw/workspace-yougile/scripts/yougile.py#L41)",
+      ),
+    ).toBe("<code>scripts/yougile.py</code>");
+    expect(markdownToTelegramRichHtml("[docs](https://example.com/docs)")).toBe(
+      '<a href="https://example.com/docs">docs</a>',
+    );
+    expect(markdownToTelegramRichHtml("[user](tg://user?id=123)")).toBe(
+      '<a href="tg://user?id=123">user</a>',
+    );
+  });
+
   it("preserves Markdown heading levels in rich HTML", () => {
     expect(markdownToTelegramRichHtml("# Title\n\n### Detail")).toBe(
       "<h1>Title</h1>\n\n<h3>Detail</h3>",

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -32,8 +32,8 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
-function isTelegramLinkHref(href: string): boolean {
-  return /^(?:https?:\/\/|tg:\/\/)/i.test(href);
+function isTelegramRichLinkHref(href: string): boolean {
+  return /^(?:https?:\/\/|tg:\/\/|mailto:|tel:|#)/i.test(href);
 }
 
 /**
@@ -57,7 +57,7 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
   }
   // Telegram rich links reject local or relative hrefs; keep the label visible
   // instead of letting one unsupported link drop the whole message.
-  if (!isTelegramLinkHref(href)) {
+  if (!isTelegramRichLinkHref(href)) {
     return null;
   }
   // Suppress auto-linkified file references (e.g. README.md → http://README.md)

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -32,6 +32,10 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
+function isTelegramLinkHref(href: string): boolean {
+  return /^(?:https?:\/\/|tg:\/\/)/i.test(href);
+}
+
 /**
  * File extensions that share TLDs and commonly appear in code/documentation.
  * These are wrapped in <code> tags to prevent Telegram from generating
@@ -49,6 +53,11 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
     return null;
   }
   if (link.start === link.end) {
+    return null;
+  }
+  // Telegram rich links reject local or relative hrefs; keep the label visible
+  // instead of letting one unsupported link drop the whole message.
+  if (!isTelegramLinkHref(href)) {
     return null;
   }
   // Suppress auto-linkified file references (e.g. README.md → http://README.md)

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1044,6 +1044,35 @@ describe("sendMessageTelegram", () => {
     expect(botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message.html).toBe(markdown);
   });
 
+  it.each([
+    {
+      name: "local path",
+      markdown:
+        "See [scripts/yougile.py](/home/user/.openclaw/workspace/scripts/yougile.py#L41) and [docs](https://example.com/docs)",
+      rejectedAnchor: '<a href="/home',
+      visibleLabel: "<code>scripts/yougile.py</code>",
+    },
+    {
+      name: "relative path",
+      markdown: "Edit [config](./openclaw.json) or see [docs](https://example.com/docs)",
+      rejectedAnchor: '<a href="./',
+      visibleLabel: "config",
+    },
+  ])("keeps rich delivery when a markdown link targets a $name", async (testCase) => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 48, chat: { id: "123" } });
+
+    await sendMessageTelegram("123", testCase.markdown, {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    const richHtml = String(botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message.html ?? "");
+    expect(richHtml).not.toContain(testCase.rejectedAnchor);
+    expect(richHtml).toContain(testCase.visibleLabel);
+    expect(richHtml).toContain('<a href="https://example.com/docs">docs</a>');
+  });
+
   it("renders complex markdown into HTML text", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
     const markdown = [


### PR DESCRIPTION
## Summary

Fixes #94117.

Telegram rich messages should not emit anchors for Markdown hrefs that Telegram rejects. This change keeps unsupported local or relative Markdown link hrefs as visible text while preserving clickable `http://`, `https://`, `tg://`, `mailto:`, `tel:`, and in-document `#...` links.

The observed production failure was a Telegram direct final reply containing a local-path Markdown link. Telegram rejected the entire `sendRichMessage` payload with `RICH_MESSAGE_URL_INVALID`, so the user saw transient progress messages but never received the final answer.

## What changed

- Add `isTelegramRichLinkHref()` in `extensions/telegram/src/format.ts`.
- Make `buildTelegramLink()` return no anchor for unsupported href schemes before producing Telegram rich HTML.
- Add a regression test covering a local-path Markdown href, plus supported `https://`, `tg://`, `mailto:`, `tel:`, and `#...` links.

## Validation

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts`
- `git diff --check`

## Real behavior proof

- **Behavior or issue addressed:** Telegram rich final replies containing local-path Markdown links, for example `[scripts/yougile.py](/home/dankar/.openclaw/workspace-yougile/scripts/yougile.py#L41)`, caused Telegram Bot API 10.1 `sendRichMessage` to reject the whole payload with `RICH_MESSAGE_URL_INVALID`.
- **Real environment tested:** A live OpenClaw Telegram direct conversation on the affected local OpenClaw workspace, plus the local PR checkout at `/home/dankar/.openclaw/workspace/tmp/openclaw-telegram-rich-url-fix`.
- **Exact steps or command run after this patch:** Applied the same link-filtering behavior to the affected local install, restarted the OpenClaw Telegram gateway, sent a Telegram final reply containing the local-path Markdown link shape and normal supported links, then ran `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts` in the PR checkout.
- **Evidence after fix:** Runtime log excerpt before the patch showed the real Telegram API failure:

```text
[telegram] richMessage failed: Call to 'sendRichMessage' failed! (400: Bad Request: RICH_MESSAGE_URL_INVALID)
[telegram] final reply failed: OutboundDeliveryError: Call to 'sendRichMessage' failed! (400: Bad Request: RICH_MESSAGE_URL_INVALID)
```

After the patch, the same local-path Markdown link shape rendered as visible code text instead of an `<a href="/home/...">` rich link. Supported links still render as anchors; current PR checkout output from the targeted test run:

```text
[test] starting test/vitest/vitest.extension-telegram.config.ts
Test Files  1 passed (1)
Tests  49 passed (49)
[test] passed 1 Vitest shard in 9.39s
```

- **Observed result after fix:** The live Telegram conversation received the final reply instead of losing it after progress messages, the gateway stayed active, and no new `RICH_MESSAGE_URL_INVALID` log entries appeared for the tested local-path Markdown link shape.
- **What was not tested:** Full Telegram Bot API matrix for every possible URI scheme; this patch intentionally preserves only schemes already supported by Telegram rich links here and strips local/relative href anchors.
