### PR TITLE
fix(codex): skip noop PreToolUse native hook relays

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -187,21 +187,22 @@ describe("Codex native hook relay config", () => {
     });
   });
 
-  it("keeps selected no-policy PreToolUse installed with an unavailable no-op marker", () => {
+  it("does not install PreToolUse when the relay reports no local work", () => {
     expect(
       buildCodexNativeHookRelayConfig({
         relay: createRelay({ inactiveEvents: ["pre_tool_use"] }),
-        events: ["pre_tool_use"],
+        events: ["pre_tool_use", "permission_request"],
       }),
     ).toEqual({
       "features.hooks": true,
-      "hooks.PreToolUse": [
+      "hooks.PreToolUse": [],
+      "hooks.PermissionRequest": [
         {
           hooks: [
             {
               type: "command",
               command:
-                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event pre_tool_use --pre-tool-use-unavailable noop --timeout 4000",
+                "openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event permission_request --timeout 4000",
               timeout: 5,
               async: false,
               statusMessage: "OpenClaw native hook relay",
@@ -210,11 +211,11 @@ describe("Codex native hook relay config", () => {
         },
       ],
       "hooks.state": {
-        "/<session-flags>/config.toml:pre_tool_use:0:0": {
+        "/<session-flags>/config.toml:permission_request:0:0": {
           enabled: true,
           trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
         },
-        "<session-flags>/config.toml:pre_tool_use:0:0": {
+        "<session-flags>/config.toml:permission_request:0:0": {
           enabled: true,
           trusted_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
         },
@@ -320,10 +321,8 @@ function createRelay(options?: {
     shouldRelayEvent: (event) => !inactiveEvents.has(event),
     commandForEvent: (event, commandOptions) =>
       `openclaw hooks relay --provider codex --relay-id relay-1 --generation generation-1 --event ${event}${
-        event === "pre_tool_use" && inactiveEvents.has(event)
-          ? " --pre-tool-use-unavailable noop"
-          : ""
-      }${commandOptions?.timeoutMs ? ` --timeout ${commandOptions.timeoutMs}` : ""}`,
+        commandOptions?.timeoutMs ? ` --timeout ${commandOptions.timeoutMs}` : ""
+      }`,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/extensions/codex/src/app-server/native-hook-relay.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.ts
@@ -249,10 +249,7 @@ export function buildCodexNativeHookRelayConfig(params: {
     const codexEvent = CODEX_HOOK_EVENT_BY_NATIVE_EVENT[event];
     const selected = selectedEvents.has(event);
     const shouldRelay = params.relay.shouldRelayEvent(event);
-    // Keep no-policy PreToolUse commands installed with an explicit no-op marker;
-    // otherwise a stale relay fallback cannot distinguish no policy from unknown policy.
-    const selectedNoopPreToolUse = selected && event === "pre_tool_use" && !shouldRelay;
-    if (!selected || (!shouldRelay && !selectedNoopPreToolUse)) {
+    if (!selected || !shouldRelay) {
       if (selected || params.clearOmittedEvents) {
         config[`hooks.${codexEvent}`] = [] satisfies JsonValue;
       }

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -542,7 +542,7 @@ describe("native hook relay registry", () => {
     expect(relay.shouldRelayEvent("permission_request")).toBe(true);
     expect(relay.commandForEvent("pre_tool_use")).toBe(
       "/usr/local/bin/node '/opt/Open Claw/openclaw.mjs' hooks relay --provider codex --relay-id " +
-        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --pre-tool-use-unavailable noop --timeout 1234`,
+        `${relay.relayId} --generation ${relay.generation} --event pre_tool_use --timeout 1234`,
     );
   });
 
@@ -568,12 +568,29 @@ describe("native hook relay registry", () => {
     );
   });
 
-  it("keeps pre-tool relays active when native loop detection is not disabled", () => {
+  it("does not keep pre-tool relays active for loop detection alone", () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       runId: "run-1",
+      command: {
+        executable: "/opt/Open Claw/openclaw.mjs",
+        nodeExecutable: "/usr/local/bin/node",
+        timeoutMs: 1234,
+      },
+    });
+
+    expect(relay.shouldRelayEvent("pre_tool_use")).toBe(false);
+  });
+
+  it("keeps pre-tool relays active when native loop detection is explicitly enabled", () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      config: { tools: { loopDetection: { enabled: true } } } as never,
       command: {
         executable: "/opt/Open Claw/openclaw.mjs",
         nodeExecutable: "/usr/local/bin/node",

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -449,10 +449,6 @@ export function registerNativeHookRelay(
         relayId,
         generation: registration.generation,
         event,
-        preToolUseUnavailable:
-          event === "pre_tool_use" && !nativeHookRelayEventHasLocalWork(registration, event)
-            ? "noop"
-            : undefined,
         nice: params.command?.nice,
         timeoutMs: resolveNativeHookRelayCommandTimeoutMs(
           params.command?.timeoutMs,
@@ -590,7 +586,7 @@ function nativePreToolUseMayRunLoopDetection(registration: NativeHookRelayRegist
     cfg: registration.config,
     agentId: registration.agentId,
   });
-  return loopDetection?.enabled !== false;
+  return loopDetection?.enabled === true;
 }
 
 function nativeHookRelayEventHasLocalWork(
@@ -598,8 +594,9 @@ function nativeHookRelayEventHasLocalWork(
   event: NativeHookRelayEvent,
 ): boolean {
   if (event === "pre_tool_use") {
-    // Avoid spawning a native hook relay for every Codex tool call when there
-    // is no before_tool_call hook, trusted-tool policy, or loop detector work.
+    // Avoid spawning a native hook relay for every Codex tool call when no
+    // before_tool_call hook, trusted-tool policy, or explicit loop detector can
+    // make a decision.
     return hasBeforeToolCallPolicy() || nativePreToolUseMayRunLoopDetection(registration);
   }
   if (event === "post_tool_use") {


### PR DESCRIPTION
## What

Stops Codex from installing a `PreToolUse` native hook command when OpenClaw has no local work for that event.

Previously, selected `pre_tool_use` events could still install a command hook even when `relay.shouldRelayEvent("pre_tool_use")` returned false, using `--pre-tool-use-unavailable noop` as a marker. That means a normal Codex tool call path could still pay for an `openclaw hooks relay` subprocess that can only return no-op.

Fixes openclaw/openclaw#91009.

## Why

`PreToolUse` is high frequency: it runs once per tool call. A no-op subprocess hook on that path scales badly and can add process startup/relay overhead even when there is no before-tool policy, trusted-tool decision, or explicit native loop-detection work to perform.

## How

- Let `buildCodexNativeHookRelayConfig()` honor `relay.shouldRelayEvent("pre_tool_use")` directly.
- Clear/omit `hooks.PreToolUse` when the selected event has no local relay work.
- Stop emitting the normal no-policy `--pre-tool-use-unavailable noop` command path.
- Keep `PreToolUse` active when before-tool policy/trusted-tool policy can make a decision.
- Keep `PreToolUse` active for native loop detection only when `tools.loopDetection.enabled === true` is explicitly configured.
- Leave `PermissionRequest`, `PostToolUse`, and `Stop` behavior unchanged.
- Keep the explicit CLI fallback for `--pre-tool-use-unavailable noop` supported.

## Breaking Changes

None expected.

Behavior note: implicit/default native loop detection no longer keeps `PreToolUse` relays active by itself. Native loop detection still keeps the relay active when explicitly enabled with `tools.loopDetection.enabled === true`.

## Behavior Proof

Before this change, a selected `PreToolUse` event with no local work still produced a command hook containing:

```text
--event pre_tool_use --pre-tool-use-unavailable noop
```

After this change, the same no-work case produces:

```ts
"hooks.PreToolUse": []
```

A control event in the same config still installs normally, proving this is scoped to the no-work `PreToolUse` case rather than disabling native hook relay generally:

```ts
"hooks.PermissionRequest": [{ hooks: [{ type: "command", ... }] }]
```

## Evidence After Fix

Base: `origin/main@0e46fd1081`, package version `2026.6.8`.

```text
$ git diff --check origin/main...HEAD
# passed
```

Focused core tests for the changed command/config behavior:

```text
$ node ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/harness/native-hook-relay.test.ts --testNamePattern "preserves permission relays|builds pre-tool relay commands only when before-tool policy is active|does not keep pre-tool relays active|keeps pre-tool relays active when native loop detection is explicitly enabled|omits pre-tool relays" --reporter verbose

Test Files  1 passed (1)
Tests       5 passed | 71 skipped (76)
```

Codex app-server mirror tests:

```text
$ node ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-runtime.config.ts extensions/codex/src/app-server/native-hook-relay.test.ts --reporter verbose

Test Files  1 passed (1)
Tests       9 passed (9)
```

Main baseline check for the direct native hook bridge registry test:

```text
$ node ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/harness/native-hook-relay.test.ts --testNamePattern "stores relay registrations, bridges, and invocations in process-global state" --reporter verbose

Test Files  1 passed (1)
Tests       1 passed | 74 skipped (75)
```

## Review Gates

- Code hygiene review: passed; change is scoped to native hook relay event selection and matching tests.
- Security review: passed; the change reduces unnecessary subprocess creation and does not add auth, network, secret, filesystem, or shell execution paths.
- Residual risk: any code relying on the no-op `PreToolUse` subprocess as an implicit observation/keepalive point will stop seeing that no-op subprocess. That should not be a functional contract; explicit loop detection remains available.
- Publication gate: reviewed for secrets and internal operational metadata; no production/runtime/deploy changes.
