### PR TITLE
feat(discord): send up to 10 file attachments per message (#24196)

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -359,8 +359,11 @@ The `/model` and `/models` slash commands open an interactive model picker with 
 File attachments:
 
 - `file` blocks must point to an attachment reference (`attachment://<filename>`)
-- Provide the attachment via `media`/`path`/`filePath` (single file); use `media-gallery` for multiple files
+- Provide the matching component attachment via `media`/`path`/`filePath`
+- Use `media-gallery` when the component itself should render multiple media items
 - Use `filename` to override the upload name when it should match the attachment reference
+
+For normal Discord message sends without component `file` blocks, pass ordered attachments via `mediaUrls`. OpenClaw sends up to 10 Discord file attachments in one message and splits additional files into follow-up messages.
 
 Modal forms:
 

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -302,6 +302,40 @@ describe("handleDiscordMessageAction", () => {
     });
   });
 
+  it("forwards ordered mediaUrls on sends", async () => {
+    const cfg = discordConfig();
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        to: "channel:123",
+        message: "gallery",
+        mediaUrls: ["file:///tmp/one.png", "file:///tmp/two.png"],
+      },
+      cfg,
+    });
+
+    expectDiscordActionCall({
+      payload: {
+        action: "sendMessage",
+        accountId: undefined,
+        to: "channel:123",
+        content: "gallery",
+        mediaUrl: undefined,
+        mediaUrls: ["file:///tmp/one.png", "file:///tmp/two.png"],
+        filename: undefined,
+        replyTo: undefined,
+        components: undefined,
+        embeds: undefined,
+        asVoice: false,
+        silent: false,
+        __sessionKey: undefined,
+        __agentId: undefined,
+      },
+      cfg,
+      options: defaultActionOptions(),
+    });
+  });
+
   it("forwards threadName on sends", async () => {
     const cfg = discordConfig();
     await handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -105,8 +105,9 @@ export async function handleDiscordMessageAction(
       readStringParam(params, "media", { trim: false }) ??
       readStringParam(params, "path", { trim: false }) ??
       readStringParam(params, "filePath", { trim: false });
+    const mediaUrls = readStringArrayParam(params, "mediaUrls");
     const content = readStringParam(params, "message", {
-      required: !asVoice && !hasComponents && !mediaUrl,
+      required: !asVoice && !hasComponents && !mediaUrl && !mediaUrls?.length,
       allowEmpty: true,
     });
     const filename = readStringParam(params, "filename");
@@ -126,6 +127,7 @@ export async function handleDiscordMessageAction(
         content: content ?? "",
         ...(threadName ? { threadName } : {}),
         mediaUrl: mediaUrl ?? undefined,
+        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
         filename: filename ?? undefined,
         replyTo: replyTo ?? undefined,
         components,

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -219,8 +219,9 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         readStringParam(ctx.params, "mediaUrl", { trim: false }) ??
         readStringParam(ctx.params, "path", { trim: false }) ??
         readStringParam(ctx.params, "filePath", { trim: false });
+      const mediaUrls = readStringArrayParam(ctx.params, "mediaUrls");
       const content = readStringParam(ctx.params, "content", {
-        required: !asVoice && !componentSpec && !components && !mediaUrl,
+        required: !asVoice && !componentSpec && !components && !mediaUrl && !mediaUrls?.length,
         allowEmpty: true,
       });
       const filename = readStringParam(ctx.params, "filename");
@@ -300,6 +301,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         ...ctx.withOpts(),
         mediaAccess: ctx.options?.mediaAccess,
         mediaUrl,
+        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
         filename: filename ?? undefined,
         mediaLocalRoots: ctx.options?.mediaLocalRoots,
         mediaReadFile: ctx.options?.mediaReadFile,

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -1276,6 +1276,30 @@ describe("handleDiscordMessagingAction", () => {
     expect(sendOptions.mediaLocalRoots).toEqual(["/tmp/agent-root"]);
   });
 
+  it("forwards ordered mediaUrls into sendMessageDiscord", async () => {
+    sendMessageDiscord.mockClear();
+    await handleMessagingAction(
+      "sendMessage",
+      {
+        to: "channel:123",
+        content: "gallery",
+        mediaUrls: ["/tmp/one.png", "/tmp/two.png"],
+      },
+      enableAllActions,
+      DISCORD_TEST_CFG,
+      { mediaLocalRoots: ["/tmp/agent-root"] },
+    );
+
+    expect(sendMessageDiscord).toHaveBeenCalledTimes(1);
+    const call = mockCall(sendMessageDiscord, "sendMessageDiscord");
+    const sendOptions = mockObjectArg(sendMessageDiscord, "sendMessageDiscord", 0, 2);
+    expect(call[0]).toBe("channel:123");
+    expect(call[1]).toBe("gallery");
+    expect(sendOptions.mediaUrls).toEqual(["/tmp/one.png", "/tmp/two.png"]);
+    expect(sendOptions.mediaUrl).toBeUndefined();
+    expect(sendOptions.mediaLocalRoots).toEqual(["/tmp/agent-root"]);
+  });
+
   it("ignores empty components objects for regular media sends", async () => {
     sendMessageDiscord.mockClear();
     sendDiscordComponentMessage.mockClear();

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -361,6 +361,45 @@ describe("discordOutbound", () => {
     });
   });
 
+  it("batches normal media payloads through one native Discord send", async () => {
+    const result = await discordOutbound.sendPayload?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "",
+      payload: {
+        text: "gallery",
+        mediaUrls: ["https://example.com/one.png", "https://example.com/two.png"],
+      },
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToMode: "first",
+      mediaLocalRoots: ["/tmp/media"],
+      formatting: {
+        maxLinesPerMessage: 3,
+      },
+    });
+
+    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    const call = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord");
+    expect(call[0]).toBe("channel:123456");
+    expect(call[1]).toBe("gallery");
+    const options = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2);
+    expect(options.mediaUrls).toEqual([
+      "https://example.com/one.png",
+      "https://example.com/two.png",
+    ]);
+    expect(options.mediaUrl).toBeUndefined();
+    expect(options.mediaLocalRoots).toEqual(["/tmp/media"]);
+    expect(options.accountId).toBe("default");
+    expect(options.replyTo).toBe("reply-1");
+    expect(options.maxLinesPerMessage).toBe(3);
+    expect(result).toEqual({
+      channel: "discord",
+      messageId: "msg-1",
+      channelId: "ch-1",
+    });
+  });
+
   it("keeps replyToId on every internal audioAsVoice send when replyToMode is all", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},

--- a/extensions/discord/src/outbound-payload.contract.test.ts
+++ b/extensions/discord/src/outbound-payload.contract.test.ts
@@ -45,6 +45,7 @@ describe("Discord outbound payload contract", () => {
   installChannelOutboundPayloadContractSuite({
     channel: "discord",
     chunking: { mode: "split", longTextLength: 3000, maxChunkLength: 2000 },
+    multiMediaMode: "native-batch",
     createHarness: createDiscordHarness,
   });
 });

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -9,6 +9,7 @@ import {
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isLikelyDiscordVideoMedia } from "./media-detection.js";
 import { normalizeDiscordApprovalPayload } from "./outbound-approval.js";
 import {
   resolveDiscordComponentSpec,
@@ -71,6 +72,40 @@ function resolveDiscordMediaDeliveryOptions(
   };
 }
 
+function shouldPreserveDiscordVideoCaptionSplit(params: {
+  text: string;
+  mediaUrls: readonly string[];
+}): boolean {
+  return Boolean(params.text.trim()) && params.mediaUrls.some(isLikelyDiscordVideoMedia);
+}
+
+async function sendDiscordMediaBatchPayload(params: {
+  ctx: DiscordOutboundPayloadContext;
+  sendContext: DiscordPayloadSendContext;
+  text: string;
+  mediaUrls: readonly string[];
+  components?: DiscordSendComponents;
+  embeds?: DiscordSendEmbeds;
+  filename?: string;
+}) {
+  return await params.sendContext.withRetry(
+    async () =>
+      await params.sendContext.send(params.sendContext.target, params.text, {
+        verbose: false,
+        ...(params.mediaUrls.length === 1
+          ? { mediaUrl: params.mediaUrls[0] }
+          : { mediaUrls: [...params.mediaUrls] }),
+        mediaAccess: params.ctx.mediaAccess,
+        mediaLocalRoots: params.ctx.mediaLocalRoots,
+        mediaReadFile: params.ctx.mediaReadFile,
+        components: params.components,
+        embeds: params.embeds,
+        filename: params.filename,
+        ...resolveDiscordFormattedDeliveryOptions(params.ctx, params.sendContext),
+      }),
+  );
+}
+
 export async function sendDiscordOutboundPayload(params: {
   ctx: DiscordOutboundPayloadContext;
   fallbackAdapter: ChannelOutboundAdapter;
@@ -129,6 +164,21 @@ export async function sendDiscordOutboundPayload(params: {
       : undefined;
     const filename = normalizeOptionalString(discordData.filename);
     if (nativeComponents || embeds?.length || filename) {
+      if (
+        mediaUrls.length > 0 &&
+        !shouldPreserveDiscordVideoCaptionSplit({ text: payload.text ?? "", mediaUrls })
+      ) {
+        const result = await sendDiscordMediaBatchPayload({
+          ctx,
+          sendContext,
+          text: payload.text ?? "",
+          mediaUrls,
+          components: nativeComponents,
+          embeds,
+          filename,
+        });
+        return attachChannelToResult("discord", result);
+      }
       const result = await sendPayloadMediaSequenceOrFallback({
         text: payload.text ?? "",
         mediaUrls,
@@ -155,6 +205,18 @@ export async function sendDiscordOutboundPayload(params: {
                 filename: isFirst ? filename : undefined,
               }),
           ),
+      });
+      return attachChannelToResult("discord", result);
+    }
+    if (
+      mediaUrls.length > 0 &&
+      !shouldPreserveDiscordVideoCaptionSplit({ text: payload.text ?? "", mediaUrls })
+    ) {
+      const result = await sendDiscordMediaBatchPayload({
+        ctx,
+        sendContext,
+        text: payload.text ?? "",
+        mediaUrls,
       });
       return attachChannelToResult("discord", result);
     }

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -7,7 +7,10 @@ import type { OutboundMediaAccess, PollInput } from "openclaw/plugin-sdk/media-r
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { resolveChunkMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeOptionalString,
+  normalizeStringEntries,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
@@ -37,6 +40,7 @@ type DiscordSendOpts = {
   token?: string;
   accountId?: string;
   mediaUrl?: string;
+  mediaUrls?: string[];
   filename?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
@@ -60,6 +64,14 @@ type DiscordClientRequest = ReturnType<typeof createDiscordClient>["request"];
 const DEFAULT_DISCORD_MEDIA_MAX_MB = 100;
 
 type DiscordChannelMessageResult = DiscordReceiptResultSource;
+
+function resolveDiscordMediaUrls(opts: Pick<DiscordSendOpts, "mediaUrl" | "mediaUrls">): string[] {
+  const mediaUrls = normalizeStringEntries(opts.mediaUrls ?? []);
+  if (mediaUrls.length > 0) {
+    return mediaUrls;
+  }
+  return normalizeStringEntries(opts.mediaUrl ? [opts.mediaUrl] : []);
+}
 
 async function sendDiscordThreadTextChunks(params: {
   rest: RequestClient;
@@ -181,6 +193,7 @@ export async function sendMessageDiscord(
     accountId: accountInfo.accountId,
     mentionAliases: accountInfo.config.mentionAliases,
   });
+  const mediaUrls = resolveDiscordMediaUrls(opts);
   const { token, rest, request } = createDiscordClient({ ...opts, cfg });
   const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
@@ -234,7 +247,7 @@ export async function sendMessageDiscord(
         cfg,
         rest,
         token,
-        hasMedia: Boolean(opts.mediaUrl),
+        hasMedia: mediaUrls.length > 0,
       });
     }
 
@@ -244,13 +257,13 @@ export async function sendMessageDiscord(
     const remainingChunks = chunks.slice(1);
 
     try {
-      if (opts.mediaUrl) {
+      if (mediaUrls.length > 0) {
         const [mediaCaption, ...afterMediaChunks] = remainingChunks;
         await sendDiscordMedia(
           rest,
           threadId,
           mediaCaption ?? "",
-          opts.mediaUrl,
+          mediaUrls,
           opts.filename,
           opts.mediaAccess,
           opts.mediaLocalRoots,
@@ -296,7 +309,7 @@ export async function sendMessageDiscord(
         cfg,
         rest,
         token,
-        hasMedia: Boolean(opts.mediaUrl),
+        hasMedia: mediaUrls.length > 0,
       });
     }
 
@@ -311,18 +324,18 @@ export async function sendMessageDiscord(
         channel_id: resultChannelId,
       },
       channelId,
-      { kind: opts.mediaUrl ? "media" : "text", threadId },
+      { kind: mediaUrls.length > 0 ? "media" : "text", threadId },
     );
   }
 
   let result: DiscordChannelMessageResult;
   try {
-    if (opts.mediaUrl) {
+    if (mediaUrls.length > 0) {
       result = await sendDiscordMedia(
         rest,
         channelId,
         textWithMentions,
-        opts.mediaUrl,
+        mediaUrls,
         opts.filename,
         opts.mediaAccess,
         opts.mediaLocalRoots,
@@ -360,7 +373,7 @@ export async function sendMessageDiscord(
       cfg,
       rest,
       token,
-      hasMedia: Boolean(opts.mediaUrl),
+      hasMedia: mediaUrls.length > 0,
     });
   }
 
@@ -370,7 +383,7 @@ export async function sendMessageDiscord(
     direction: "outbound",
   });
   return toDiscordSendResult(result, channelId, {
-    kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
+    kind: mediaUrls.length > 0 ? "media" : opts.components || opts.embeds ? "card" : "text",
     replyToId: opts.replyTo,
   });
 }

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -121,6 +121,11 @@ function expectBodyFileName(body: unknown, expectedName: string) {
   expectRecordFields(files[0], "Discord file", { name: expectedName });
 }
 
+function expectBodyFileNames(body: unknown, expectedNames: string[]) {
+  const files = requireArray(requireRecord(body, "Discord REST body").files, "Discord files");
+  expect(files.map((file) => requireRecord(file, "Discord file").name)).toEqual(expectedNames);
+}
+
 describe("resolveDiscordTargetChannelId", () => {
   it("creates a DM channel for user targets", async () => {
     const { rest, postMock } = makeDiscordRest();
@@ -572,6 +577,60 @@ describe("sendMessageDiscord", () => {
     expect(loadWebMedia).toHaveBeenCalledWith("file:///tmp/photo.jpg", {
       maxBytes: 100 * 1024 * 1024,
     });
+  });
+
+  it("uploads ordered media attachments in one Discord message", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock.mockResolvedValue({ id: "msg", channel_id: "789" });
+    vi.mocked(loadWebMedia).mockImplementation(async (url) => ({
+      buffer: Buffer.from(url),
+      fileName: url.split("/").pop() ?? "upload",
+      contentType: "image/png",
+      kind: "image",
+    }));
+
+    const res = await sendMessageDiscord("channel:789", "gallery", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls: ["file:///tmp/one.png", "file:///tmp/two.png"],
+    } as Parameters<typeof sendMessageDiscord>[2]);
+
+    expect(res.messageId).toBe("msg");
+    expectRestRoute(postMock, 0, Routes.channelMessages("789"));
+    expectBodyFileNames(requireRestBody(postMock), ["one.png", "two.png"]);
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("splits media attachments beyond Discord's per-message upload limit", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+    vi.mocked(loadWebMedia).mockImplementation(async (url) => ({
+      buffer: Buffer.from(url),
+      fileName: url.split("/").pop() ?? "upload",
+      contentType: "image/png",
+      kind: "image",
+    }));
+    const mediaUrls = Array.from({ length: 11 }, (_, index) => `file:///tmp/${index + 1}.png`);
+
+    const res = await sendMessageDiscord("channel:789", "gallery", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrls,
+    } as Parameters<typeof sendMessageDiscord>[2]);
+
+    expect(res.messageId).toBe("msg1");
+    expect(res.receipt.platformMessageIds).toEqual(["msg1", "msg2"]);
+    expectBodyFileNames(
+      requireRestBody(postMock, 0),
+      Array.from({ length: 10 }, (_, index) => `${index + 1}.png`),
+    );
+    expectBodyFileNames(requireRestBody(postMock, 1), ["11.png"]);
+    expect(requireRestBody(postMock, 0).content).toBe("gallery");
+    expect(requireRestBody(postMock, 1)).not.toHaveProperty("content");
   });
 
   it("passes mediaAccess workspaceDir when loading relative media attachments", async () => {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -31,6 +31,7 @@ import { DiscordSendError } from "./send.types.js";
 
 const DISCORD_TEXT_LIMIT = 2000;
 const DISCORD_MAX_STICKERS = 3;
+const DISCORD_MAX_FILES_PER_MESSAGE = 10;
 const DISCORD_POLL_MAX_ANSWERS = 10;
 const DISCORD_POLL_MAX_DURATION_HOURS = 32 * 24;
 const DISCORD_MISSING_PERMISSIONS = 50013;
@@ -357,7 +358,7 @@ async function sendDiscordMedia(
   rest: RequestClient,
   channelId: string,
   text: string,
-  mediaUrl: string,
+  mediaUrls: readonly string[],
   filename: string | undefined,
   mediaAccess: OutboundMediaAccess | undefined,
   mediaLocalRoots: readonly string[] | undefined,
@@ -373,49 +374,84 @@ async function sendDiscordMedia(
   suppressEmbeds?: boolean,
   maxChars?: number,
 ) {
-  const media = await loadWebMedia(
-    mediaUrl,
-    buildOutboundMediaLoadOptions({ maxBytes, mediaAccess, mediaLocalRoots, mediaReadFile }),
-  );
-  const requestedFileName = filename?.trim();
-  const resolvedFileName =
-    requestedFileName ||
-    media.fileName ||
-    (media.contentType ? `upload${extensionForMime(media.contentType) ?? ""}` : "") ||
-    "upload";
+  const loadOptions = buildOutboundMediaLoadOptions({
+    maxBytes,
+    mediaAccess,
+    mediaLocalRoots,
+    mediaReadFile,
+  });
+  const normalizedMediaUrls = normalizeStringEntries(mediaUrls);
+  if (normalizedMediaUrls.length === 0) {
+    return await sendDiscordText(
+      rest,
+      channelId,
+      text,
+      replyTo,
+      request,
+      maxLinesPerMessage,
+      components,
+      embeds,
+      chunkMode,
+      silent,
+      suppressEmbeds,
+      maxChars,
+    );
+  }
   const chunks = text
     ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, maxChars })
     : [];
   const caption = chunks[0] ?? "";
-  const fileData = toDiscordFileBlob(media.buffer);
-  const captionComponents = resolveDiscordSendComponents({
-    components,
-    text: caption,
-    isFirst: true,
-  });
-  const captionEmbeds = resolveDiscordSendEmbeds({ embeds, isFirst: true });
-  const flags = resolveDiscordMessageFlags({
-    silent,
-    suppressEmbeds: suppressEmbeds && !captionEmbeds?.length,
-  });
-  const body = buildDiscordMessageRequest({
-    text: caption,
-    components: captionComponents,
-    embeds: captionEmbeds,
-    flags,
-    replyTo,
-    files: [
-      {
-        data: fileData,
-        name: resolvedFileName,
-      },
-    ],
-  });
-  const res = (await request(
-    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
-    "media",
-  )) as { id: string; channel_id: string };
-  const platformMessageIds = res.id ? [res.id] : [];
+  let res: { id: string; channel_id: string } | undefined;
+  const platformMessageIds: string[] = [];
+  for (let index = 0; index < normalizedMediaUrls.length; index += DISCORD_MAX_FILES_PER_MESSAGE) {
+    const isFirst = index === 0;
+    const urlBatch = normalizedMediaUrls.slice(index, index + DISCORD_MAX_FILES_PER_MESSAGE);
+    const fileBatch = await Promise.all(
+      urlBatch.map(async (mediaUrl, offset) => {
+        const media = await loadWebMedia(mediaUrl, loadOptions);
+        const requestedFileName = index === 0 && offset === 0 ? filename?.trim() : undefined;
+        const resolvedFileName =
+          requestedFileName ||
+          media.fileName ||
+          (media.contentType ? `upload${extensionForMime(media.contentType) ?? ""}` : "") ||
+          "upload";
+        return {
+          data: toDiscordFileBlob(media.buffer),
+          name: resolvedFileName,
+        };
+      }),
+    );
+    const batchCaption = isFirst ? caption : "";
+    const captionComponents = resolveDiscordSendComponents({
+      components,
+      text: batchCaption,
+      isFirst,
+    });
+    const captionEmbeds = resolveDiscordSendEmbeds({ embeds, isFirst });
+    const flags = resolveDiscordMessageFlags({
+      silent,
+      suppressEmbeds: suppressEmbeds && !captionEmbeds?.length,
+    });
+    const body = buildDiscordMessageRequest({
+      text: batchCaption,
+      components: captionComponents,
+      embeds: captionEmbeds,
+      flags,
+      replyTo,
+      files: fileBatch,
+    });
+    const batchRes = (await request(
+      () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
+      "media",
+    )) as { id: string; channel_id: string };
+    res ??= batchRes;
+    if (batchRes.id) {
+      platformMessageIds.push(batchRes.id);
+    }
+  }
+  if (!res) {
+    throw new Error("Discord media send failed (empty batch result)");
+  }
   for (const chunk of chunks.slice(1)) {
     if (!chunk.trim()) {
       continue;

--- a/src/channels/plugins/contracts/outbound-payload-testkit.ts
+++ b/src/channels/plugins/contracts/outbound-payload-testkit.ts
@@ -47,6 +47,7 @@ function sendCall(sendMock: Mock, index: number): unknown[] {
 export function installChannelOutboundPayloadContractSuite(params: {
   channel: string;
   chunking: ChunkingMode;
+  multiMediaMode?: "sequence" | "native-batch";
   createHarness: (
     params: OutboundPayloadHarnessParams,
   ) => OutboundPayloadHarness | Promise<OutboundPayloadHarness>;
@@ -92,6 +93,21 @@ export function installChannelOutboundPayloadContractSuite(params: {
       sendResults: [{ messageId: "m-1" }, { messageId: "m-2" }],
     });
     const result = await run();
+
+    if (params.multiMediaMode === "native-batch") {
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      const call = sendCall(sendMock, 0);
+      expect(call[0]).toBe(to);
+      expect(call[1]).toBe("caption");
+      expect((call[2] as Record<string, unknown>).mediaUrl).toBeUndefined();
+      expect((call[2] as Record<string, unknown>).mediaUrls).toEqual([
+        "https://example.com/1.jpg",
+        "https://example.com/2.jpg",
+      ]);
+      expect(result.channel).toBe(params.channel);
+      expect(result.messageId).toBe("m-1");
+      return;
+    }
 
     expect(sendMock).toHaveBeenCalledTimes(2);
     const first = sendCall(sendMock, 0);


### PR DESCRIPTION
## Summary

Closes #24196.

The Discord API accepts up to 10 file attachments per message, but the integration only ever uploaded a single file. This adds an ordered multi-attachment path so a message can carry up to 10 files in one native Discord send, with any overflow split into follow-up messages (the issue's preferred option over "1 message per file").

What changed:

- **Agent send action** (`handle-action.ts`, `runtime.messaging.send.ts`): read an ordered `mediaUrls` array param and forward it; `message` is no longer required when `mediaUrls` is present.
- **Portable outbound payloads** (`outbound-payload.ts`): when a payload resolves multiple `mediaUrls`, batch them into one native send (`sendDiscordMediaBatchPayload`) instead of one message per URL. The existing video+caption split is preserved via `shouldPreserveDiscordVideoCaptionSplit`, mirroring the single-media behavior in `outbound-adapter.ts`.
- **Low-level send** (`send.outbound.ts`, `send.shared.ts`): `sendMessageDiscord` accepts `mediaUrls` (falling back to the legacy single `mediaUrl`), and `sendDiscordMedia` uploads in batches of `DISCORD_MAX_FILES_PER_MESSAGE = 10`, applying caption/components/embeds/filename to the first batch and aggregating every `platformMessageIds`.
- **Shared contract testkit** (`outbound-payload-testkit.ts`): adds an optional `multiMediaMode: "native-batch"` so Discord asserts the single batched send; other channels keep the sequence assertion unchanged.
- **Docs** (`docs/channels/discord.md`): document passing ordered attachments via `mediaUrls` and the 10-per-message + overflow-split behavior.

## Verification

- `pnpm test extensions/discord` — 211 tests pass, including new coverage for batched uploads, the 11-file overflow split (10 + 1 follow-up), action param forwarding, and the native-batch payload contract.
- Core + sibling channel contract suites pass (`src/channels/plugins/contracts/outbound-payload.contract.test.ts`, slack/whatsapp/zalo) — the new testkit param is optional and defaults to the existing sequence behavior, so no other channel changes behavior.
- `pnpm tsgo:extensions` / `pnpm tsgo:test:extensions` — clean for the touched surface.
- Re-ran the full Discord + contract suites after rebasing onto latest `main`; all green.

### Real behavior proof

- **Behavior addressed**: Discord message sends now upload up to 10 ordered file attachments in one message via `mediaUrls`, splitting any beyond 10 into follow-up messages, instead of dropping all but one file.
- **Real environment tested**: Local Linux (WSL2) checkout, Node 22, Vitest extension + core contract suites and `tsgo` typecheck lanes.
- **Exact steps or command run after this patch**: `pnpm test extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/outbound-payload.contract.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/actions/handle-action.test.ts extensions/discord/src/actions/runtime.test.ts src/channels/plugins/contracts/outbound-payload.contract.test.ts`
- **Evidence after fix**: New test `splits media attachments beyond Discord's per-message upload limit` asserts the REST body of message 1 carries files `1.png`..`10.png` with the caption, and message 2 carries `11.png` with no `content`; `uploads ordered media attachments in one Discord message` asserts a single POST with both files; the native-batch contract asserts one `send` call with `mediaUrls` set and `mediaUrl` undefined.
- **Observed result after fix**: 211 Discord tests + core/sibling contract suites pass; `mediaUrls` of length ≤10 → one Discord message with all files, length >10 → batched messages of 10.
- **What was not tested**: No live Discord bot round-trip (no bot credentials available in this environment); behavior is proven through the REST-body assertions and contract suites, not a real channel send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
