### PR TITLE
fix(telegram): drop unsupported local markdown link hrefs in rich HTML (fixes #94117)

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -206,6 +206,21 @@ describe("markdownToTelegramHtml", () => {
     ).toBe('<a href="https://example.com">docs</a>');
   });
 
+  it("keeps unsupported markdown link hrefs as visible text in rich HTML", () => {
+    expect(
+      markdownToTelegramRichHtml(
+        "[scripts/yougile.py](/home/dankar/.openclaw/workspace-yougile/scripts/yougile.py#L41)",
+      ),
+    ).toBe("<code>scripts/yougile.py</code>");
+    expect(markdownToTelegramRichHtml("[config](./openclaw.json)")).toBe("config");
+    expect(markdownToTelegramRichHtml("[docs](https://example.com/docs)")).toBe(
+      '<a href="https://example.com/docs">docs</a>',
+    );
+    expect(markdownToTelegramRichHtml("[user](tg://user?id=123)")).toBe(
+      '<a href="tg://user?id=123">user</a>',
+    );
+  });
+
   it("preserves Markdown heading levels in rich HTML", () => {
     expect(markdownToTelegramRichHtml("# Title\n\n### Detail")).toBe(
       "<h1>Title</h1>\n\n<h3>Detail</h3>",

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -219,6 +219,13 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramRichHtml("[user](tg://user?id=123)")).toBe(
       '<a href="tg://user?id=123">user</a>',
     );
+    expect(markdownToTelegramRichHtml("[support](mailto:user@example.com)")).toBe(
+      '<a href="mailto:user@example.com">support</a>',
+    );
+    expect(markdownToTelegramRichHtml("[call](tel:+123456789)")).toBe(
+      '<a href="tel:+123456789">call</a>',
+    );
+    expect(markdownToTelegramRichHtml("[back](#top)")).toBe('<a href="#top">back</a>');
   });
 
   it("preserves Markdown heading levels in rich HTML", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -32,6 +32,10 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
+function isTelegramRichLinkHref(href: string): boolean {
+  return /^(?:https?:\/\/|tg:\/\/)/i.test(href);
+}
+
 /**
  * File extensions that share TLDs and commonly appear in code/documentation.
  * These are wrapped in <code> tags to prevent Telegram from generating
@@ -49,6 +53,11 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
     return null;
   }
   if (link.start === link.end) {
+    return null;
+  }
+  // Telegram rich links reject local/relative hrefs; keep the label visible
+  // instead of letting one unsupported anchor drop the whole sendRichMessage.
+  if (!isTelegramRichLinkHref(href)) {
     return null;
   }
   // Suppress auto-linkified file references (e.g. README.md → http://README.md)

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -32,8 +32,12 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
+// Telegram accepts these inline-link schemes in rich HTML; local/relative paths
+// are rejected by sendRichMessage with RICH_MESSAGE_URL_INVALID, which drops the
+// whole reply. mailto/tel and in-document #anchors are part of the supported
+// set, so keep them clickable instead of flattening the label to plain text.
 function isTelegramRichLinkHref(href: string): boolean {
-  return /^(?:https?:\/\/|tg:\/\/)/i.test(href);
+  return /^(?:https?:\/\/|tg:\/\/|mailto:|tel:|#)/i.test(href);
 }
 
 /**
@@ -55,8 +59,7 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
   if (link.start === link.end) {
     return null;
   }
-  // Telegram rich links reject local/relative hrefs; keep the label visible
-  // instead of letting one unsupported anchor drop the whole sendRichMessage.
+  // Drop the anchor for unsupported hrefs; the label still renders as text.
   if (!isTelegramRichLinkHref(href)) {
     return null;
   }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1044,6 +1044,27 @@ describe("sendMessageTelegram", () => {
     expect(botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message.html).toBe(markdown);
   });
 
+  it("keeps the rich reply deliverable when a markdown link targets a local path (#94117)", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 48, chat: { id: "123" } });
+    const markdown =
+      "See [scripts/yougile.py](/home/user/.openclaw/workspace/scripts/yougile.py#L41) and [docs](https://example.com/docs)";
+
+    await sendMessageTelegram("123", markdown, {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    // Local/relative hrefs once emitted an <a href> that Telegram rejects with
+    // RICH_MESSAGE_URL_INVALID, dropping the entire reply. The rich payload must
+    // now deliver with the unsupported anchor stripped to its label while the
+    // supported https link stays clickable.
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    const richHtml = String(botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message.html ?? "");
+    expect(richHtml).not.toContain('<a href="/home');
+    expect(richHtml).toContain("<code>scripts/yougile.py</code>");
+    expect(richHtml).toContain('<a href="https://example.com/docs">docs</a>');
+  });
+
   it("renders complex markdown into HTML text", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
     const markdown = [

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1065,6 +1065,22 @@ describe("sendMessageTelegram", () => {
     expect(richHtml).toContain('<a href="https://example.com/docs">docs</a>');
   });
 
+  it("keeps the rich reply deliverable when a markdown link uses a relative path (#94117)", async () => {
+    botApi.sendMessage.mockResolvedValue({ message_id: 49, chat: { id: "123" } });
+    const markdown = "Edit [config](./openclaw.json) or see [docs](https://example.com/docs)";
+
+    await sendMessageTelegram("123", markdown, {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    const richHtml = String(botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message.html ?? "");
+    expect(richHtml).not.toContain('<a href="./');
+    expect(richHtml).toContain("config");
+    expect(richHtml).toContain('<a href="https://example.com/docs">docs</a>');
+  });
+
   it("renders complex markdown into HTML text", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 46, chat: { id: "123" } });
     const markdown = [


### PR DESCRIPTION
## Summary

- Fixes #94117.
- Telegram `sendRichMessage` rejects rich payloads when a Markdown link href is a local or relative path, returning `RICH_MESSAGE_URL_INVALID` and dropping the entire final reply.
- Skip emitting `<a href>` only for hrefs outside Telegram's supported inline-link set. Supported schemes — `http://`, `https://`, `tg://`, `mailto:`, `tel:`, and in-document `#anchor` — stay clickable; everything else (local/relative paths) degrades to the visible link label (or existing file-ref `<code>` wrapping when applicable).

This matches Telegram's full inline-link contract: `mailto:`, `tel:`, and in-document `#anchor` hrefs stay clickable; only local/relative paths degrade to visible text.

## Real behavior proof

**Behavior addressed:** Telegram final replies containing Markdown links to local filesystem or relative paths fail delivery with `RICH_MESSAGE_URL_INVALID` instead of degrading unsupported hrefs to visible text, while supported link targets stay clickable.

**Real environment tested:** Local OpenClaw source checkout on Linux (WSL2), driving the Telegram formatter and the rich `sendMessageTelegram` → `sendRichMessage` path with mocked Bot API calls (no live bot credentials in this environment).

**Exact steps or command run after this patch:**
```bash
node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts extensions/telegram/src/send.test.ts
node -e "
const { markdownToTelegramRichHtml } = await import('./extensions/telegram/src/format.ts');
const cases = {
  local: '[scripts/yougile.py](/home/user/.openclaw/workspace/scripts/yougile.py#L41)',
  relative: '[config](./openclaw.json)',
  https: '[docs](https://example.com/docs)',
  tg: '[user](tg://user?id=123)',
  mailto: '[support](mailto:user@example.com)',
  tel: '[call](tel:+123456789)',
  anchor: '[back](#top)',
};
for (const [k,v] of Object.entries(cases)) console.log(k+':', markdownToTelegramRichHtml(v));
"
```

**Evidence after fix:** Formatter regression (`format.test.ts`, 49 cases) and send-boundary regression (`send.test.ts`, including local-path and relative-path rich delivery cases) pass. Local/relative href output contains no rejected `<a href>` anchor; supported schemes still render anchors.

**Observed result after fix:**
```
local: <code>scripts/yougile.py</code>
relative: config
https: <a href="https://example.com/docs">docs</a>
tg: <a href="tg://user?id=123">user</a>
mailto: <a href="mailto:user@example.com">support</a>
tel: <a href="tel:+123456789">call</a>
anchor: <a href="#top">back</a>
```

Send-layer checks (mocked `sendRichMessage` payload):
- absolute local path: no `<a href="/home...">`; label preserved as `<code>…</code>`; supported `https` link kept
- relative path: no `<a href="./…">`; label preserved as plain text; supported `https` link kept

**What was not tested:** Live Telegram Bot API roundtrip (no bot token in this environment). Proof covers formatter output and the rich send payload handed to `sendRichMessage`.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts extensions/telegram/src/send.test.ts` — 181 passed.

## Risk checklist

Did user-visible behavior change? Yes  
Did config, environment, or migration behavior change? No  
Did security, auth, secrets, network, or tool execution behavior change? No  
Highest-risk area: Telegram rich-message link rendering for non-http hrefs  
Mitigation: Only suppresses anchors for hrefs Telegram already rejects; labels remain visible and supported `http`/`https`/`tg`/`mailto`/`tel`/`#anchor` links are unchanged.

AI-assisted: yes
