### PR TITLE
Fix custom scheme origin allowlist matching

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -101,6 +101,33 @@ describe("checkBrowserOrigin", () => {
       expected: { ok: true as const, matchedBy: "allowlist" as const },
     },
     {
+      name: "accepts custom app scheme allowlist matches",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "app://localhost",
+        allowedOrigins: ["app://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "accepts custom electron scheme allowlist matches",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "electron://localhost",
+        allowedOrigins: ["electron://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "accepts custom tauri scheme allowlist matches",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "tauri://localhost",
+        allowedOrigins: ["tauri://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
       name: "accepts wildcard allowlists even alongside specific entries",
       input: {
         requestHost: "gateway.tailnet.ts.net:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -9,9 +9,9 @@ import { isLoopbackHost, normalizeHostHeader, resolveHostName } from "./net.js";
 
 type OriginCheckResult =
   | {
-      ok: true;
-      matchedBy: "allowlist" | "host-header-fallback" | "private-same-origin" | "local-loopback";
-    }
+    ok: true;
+    matchedBy: "allowlist" | "host-header-fallback" | "private-same-origin" | "local-loopback";
+  }
   | { ok: false; reason: string };
 
 function parseOrigin(
@@ -23,9 +23,22 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    const host = normalizeLowercaseStringOrEmpty(url.host);
+    const protocol = normalizeLowercaseStringOrEmpty(url.protocol);
+    const origin =
+      url.origin && url.origin !== "null"
+        ? normalizeLowercaseStringOrEmpty(url.origin)
+        : protocol && host
+          ? `${protocol}//${host}`
+          : "";
+
+    if (!origin) {
+      return null;
+    }
+
     return {
-      origin: normalizeLowercaseStringOrEmpty(url.origin),
-      host: normalizeLowercaseStringOrEmpty(url.host),
+      origin,
+      host,
       hostname: normalizeLowercaseStringOrEmpty(url.hostname),
     };
   } catch {


### PR DESCRIPTION
## Summary

- Fixes explicit origin allowlist matching for custom URL schemes such as `app://localhost`, used by ClawControl.
- Node’s `URL.origin` returns `"null"` for non-special schemes, so OpenClaw was comparing `"null"` instead of the configured origin, causing `gateway.controlUi.allowedOrigins = ["app://localhost"]` to fail.
- The intended outcome is that custom-scheme origins with a valid host can be allowlisted explicitly, without requiring wildcard `"*"`.
- Intentionally out of scope: changing broader origin policy, default trust behavior, wildcard behavior, or same-origin/private-network fallback logic.
- Success looks like `app://localhost` matching only when explicitly listed in `allowedOrigins`, while existing HTTP/HTTPS origin behavior remains unchanged.
- Reviewers should focus on the fallback construction for `url.origin === "null"` and whether the added test coverage captures the intended security boundary.

## Linked context

Closes #46520

Related #28172

Was this requested by a maintainer or owner?

No direct maintainer request. This was investigated after reproducing the ClawControl connection failure on a real OpenClaw gateway setup.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed:
  - ClawControl could not connect to the gateway via WSS when `gateway.controlUi.allowedOrigins` was set to `["app://localhost"]`.
  - The gateway reported the origin as not allowed.
  - Using wildcard `["*"]` worked, but that is broader than necessary.

- Real environment tested:
  - OpenClaw built from source on a VPS.
  - Gateway running in Docker.
  - Windows ClawControl app connecting to the gateway via WSS.

- Exact steps or command run after this patch:
  - Rebuilt OpenClaw base image from patched source.
  - Restarted the gateway container.
  - Configured the gateway with:

```sh
openclaw config set gateway.controlUi.allowedOrigins '["app://localhost"]'
```

  - Restarted the gateway.
  - Connected from the Windows ClawControl app via WSS.

- Evidence after fix:
  - This PR author is using the Windows ClawControl app to communicate through the patched gateway after setting `allowedOrigins` to `["app://localhost"]`.
  - Unit test output from the patched checkout:

```text
Test Files 3 passed (3)
Tests 57 passed (57)
Start at 11:37:09
Duration 6.18s (transform 5.84s, setup 3.74s, import 510ms, tests 1.08s, environment 0ms)
```

- Observed result after fix:
  - ClawControl connects successfully via WSS with `gateway.controlUi.allowedOrigins = ["app://localhost"]`.
  - Wildcard `["*"]` is no longer required for this app-origin case.

- What was not tested:
  - Other desktop-shell schemes such as `tauri://localhost` or `electron://localhost` in a live app.
  - Browser extension origins in a live extension environment.
  - Full project test suite.

- Proof limitations or environment constraints:
  - The live behavior proof was validated on my own deployment, not a public reproduction environment.
  - Runtime logs/screenshots are not attached here to avoid exposing private gateway details.
  - The focused regression test covers the allowlist behavior directly.

- Before evidence:
  - Before this patch, the same setup showed the ClawControl error:
    `origin not allowed`
  - The app only connected when `gateway.controlUi.allowedOrigins` was set to `["*"]`.

## Tests and validation

Which commands did you run?

```sh
pnpm vitest run src/gateway/origin-check.test.ts
```

Result:

```text
Test Files 3 passed (3)
Tests 57 passed (57)
Start at 11:37:09
Duration 6.18s (transform 5.84s, setup 3.74s, import 510ms, tests 1.08s, environment 0ms)
```

What regression coverage was added or updated?

- Added coverage for explicit allowlist matching of `app://localhost`.
- The test verifies that a configured custom-scheme origin matches through the normal allowlist path.

What failed before this fix, if known?

- `app://localhost` did not match `allowedOrigins: ["app://localhost"]` because `new URL("app://localhost").origin` evaluates to `"null"`.

If no test was added, why not?

- A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes.

What is the highest-risk area?

- Origin allowlist handling for non-special URL schemes.

How is that risk mitigated?

- The change does not broaden trust by default.
- Custom-scheme origins are accepted only when they exactly match an explicit allowlist entry, unless existing wildcard behavior is already configured.
- Existing HTTP/HTTPS behavior continues to use `url.origin`.
- Missing, malformed, or literal `"null"` origins are still rejected.
- Same-origin, private-network, loopback, and host-header fallback logic is intentionally unchanged.

## Current review state

What is the next action?

- Await maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

- Waiting on CI and maintainer feedback.
- Author can provide additional logs or screenshots if maintainers want more live proof, with private gateway details redacted.

Which bot or reviewer comments were addressed?

- None yet.