### PR TITLE
feat(ios): auto-connect nearby gateways during onboarding

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -242,6 +242,10 @@ extension SettingsProTab {
         if setupAuth.hasBootstrapToken {
             GatewayOnboardingReset.prepareForBootstrapPairing(appModel: self.appModel, instanceId: instanceId)
         }
+        GatewayDiagnostics.log(
+            "setup link applied host=\(link.host) port=\(link.port) tls=\(link.tls) "
+                + "hasBootstrap=\(setupAuth.hasBootstrapToken) tokenLen=\(setupAuth.token.count) "
+                + "passwordLen=\(setupAuth.password.count) instance=\(instanceId)")
         if !instanceId.isEmpty {
             GatewaySettingsStore.saveGatewayBootstrapToken(setupAuth.bootstrapToken, instanceId: instanceId)
         }
@@ -312,6 +316,11 @@ extension SettingsProTab {
             pendingOverride: self.pendingManualAuthOverride,
             password: self.gatewayPassword)
         self.pendingManualAuthOverride = nil
+        GatewayDiagnostics.log(
+            "manual connect submit host=\(host) port=\(self.manualGatewayPort) tls=\(self.manualGatewayTLS) "
+                + "overrideToken=\(authOverride?.token != nil) "
+                + "overrideBootstrap=\(authOverride?.bootstrapToken != nil) "
+                + "overridePassword=\(authOverride?.password != nil)")
         await self.gatewayController.connectManual(
             host: host,
             port: self.manualGatewayPort,
@@ -474,9 +483,17 @@ extension SettingsProTab {
         guard !self.suppressCredentialPersist else { return }
         let instanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !instanceId.isEmpty else { return }
-        GatewaySettingsStore.saveGatewayToken(
-            value.trimmingCharacters(in: .whitespacesAndNewlines),
-            instanceId: instanceId)
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if Self.gatewayTokenLooksLikeSetupInput(trimmed) {
+            self.suppressCredentialPersist = true
+            self.setupCode = trimmed
+            self.gatewayToken = ""
+            self.suppressCredentialPersist = false
+            self.setupStatusText = "Setup code detected. Tap Apply Setup Code."
+            GatewaySettingsStore.saveGatewayToken("", instanceId: instanceId)
+            return
+        }
+        GatewaySettingsStore.saveGatewayToken(trimmed, instanceId: instanceId)
     }
 
     func persistGatewayPassword(_ value: String) {
@@ -491,6 +508,13 @@ extension SettingsProTab {
     func openNotificationSettings() {
         guard let url = URL(string: UIApplication.openNotificationSettingsURLString) else { return }
         UIApplication.shared.open(url)
+    }
+
+    private static func gatewayTokenLooksLikeSetupInput(_ value: String) -> Bool {
+        let raw = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return false }
+        if AppleReviewDemoMode.isSetupCode(raw) { return true }
+        return GatewayConnectDeepLink.fromSetupInput(raw) != nil
     }
 
     func title(for route: SettingsRoute) -> String {

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -166,7 +166,7 @@ final class GatewayConnectionController {
         self.discovery.setDebugLoggingEnabled(enabled)
     }
 
-    func requestLocalNetworkAccess(reason: String) {
+    func requestLocalNetworkAccess(reason: String, allowReconnect: Bool = true) {
         guard self.discoveryEnabled else {
             self.discovery.stop()
             self.updateFromDiscovery()
@@ -179,7 +179,9 @@ final class GatewayConnectionController {
         guard self.currentScenePhase != .background else { return }
         self.discovery.start()
         self.updateFromDiscovery()
-        self.attemptAutoReconnectIfNeeded()
+        if allowReconnect {
+            self.attemptAutoReconnectIfNeeded()
+        }
     }
 
     func setScenePhase(_ phase: ScenePhase) {
@@ -220,7 +222,7 @@ final class GatewayConnectionController {
         self.discoveryEnabled = true
         self.discoveryAutoConnectEnabled = allowAutoConnect
         guard self.localNetworkAccessRequested else {
-            self.requestLocalNetworkAccess(reason: "start_discovery")
+            self.requestLocalNetworkAccess(reason: "start_discovery", allowReconnect: allowAutoConnect)
             return
         }
         self.discovery.start()
@@ -231,7 +233,7 @@ final class GatewayConnectionController {
         self.discoveryEnabled = true
         self.discoveryAutoConnectEnabled = allowAutoConnect
         guard self.localNetworkAccessRequested else {
-            self.requestLocalNetworkAccess(reason: "restart_discovery")
+            self.requestLocalNetworkAccess(reason: "restart_discovery", allowReconnect: allowAutoConnect)
             return
         }
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -86,9 +86,9 @@ final class GatewayConnectionController {
                 return ManualAuthOverride.normalized(token: token, bootstrapToken: nil, password: password)
             }
             return ManualAuthOverride.explicit(
-                token: token,
+                token: pendingOverride.token,
                 bootstrapToken: pendingOverride.bootstrapToken,
-                password: password)
+                password: pendingOverride.password)
         }
 
         static func setupAuth(from link: GatewayConnectDeepLink) -> SetupAuth {
@@ -125,7 +125,8 @@ final class GatewayConnectionController {
     private(set) var pendingTrustPrompt: TrustPrompt?
 
     private let discovery = GatewayDiscoveryModel()
-    private let discoveryEnabled: Bool
+    private var discoveryEnabled: Bool
+    private var discoveryAutoConnectEnabled: Bool
     private weak var appModel: NodeAppModel?
     private var localNetworkAccessRequested: Bool
     private var currentScenePhase: ScenePhase = .inactive
@@ -145,6 +146,7 @@ final class GatewayConnectionController {
         deferDiscoveryUntilLocalNetworkRequest: Bool = false)
     {
         self.discoveryEnabled = startDiscovery
+        self.discoveryAutoConnectEnabled = startDiscovery
         self.appModel = appModel
         self.localNetworkAccessRequested = !deferDiscoveryUntilLocalNetworkRequest
 
@@ -184,6 +186,20 @@ final class GatewayConnectionController {
         self.currentScenePhase = phase
         guard self.discoveryEnabled else {
             self.discovery.stop()
+            switch phase {
+            case .active, .inactive:
+                if self.startDiscoveryForSavedDiscoveredAutoConnectIfNeeded() {
+                    return
+                }
+                self.attemptAutoReconnectIfNeeded()
+            case .background:
+                break
+            @unknown default:
+                if self.startDiscoveryForSavedDiscoveredAutoConnectIfNeeded() {
+                    return
+                }
+                self.attemptAutoReconnectIfNeeded()
+            }
             return
         }
         guard self.localNetworkAccessRequested else { return }
@@ -200,12 +216,20 @@ final class GatewayConnectionController {
         }
     }
 
-    func restartDiscovery() {
-        guard self.discoveryEnabled else {
-            self.discovery.stop()
-            self.updateFromDiscovery()
+    func startDiscovery(allowAutoConnect: Bool = true) {
+        self.discoveryEnabled = true
+        self.discoveryAutoConnectEnabled = allowAutoConnect
+        guard self.localNetworkAccessRequested else {
+            self.requestLocalNetworkAccess(reason: "start_discovery")
             return
         }
+        self.discovery.start()
+        self.updateFromDiscovery()
+    }
+
+    func restartDiscovery(allowAutoConnect: Bool = true) {
+        self.discoveryEnabled = true
+        self.discoveryAutoConnectEnabled = allowAutoConnect
         guard self.localNetworkAccessRequested else {
             self.requestLocalNetworkAccess(reason: "restart_discovery")
             return
@@ -215,6 +239,21 @@ final class GatewayConnectionController {
         self.didAutoConnect = false
         self.discovery.start()
         self.updateFromDiscovery()
+    }
+
+    func stopDiscovery() {
+        self.discoveryEnabled = false
+        self.discoveryAutoConnectEnabled = false
+        self.discovery.stop()
+        self.updateFromDiscovery()
+    }
+
+    func finishExplicitDiscoverySession() {
+        self.stopDiscovery()
+        if self.startDiscoveryForSavedDiscoveredAutoConnectIfNeeded() {
+            return
+        }
+        self.attemptAutoReconnectIfNeeded()
     }
 
     /// Returns `nil` when a connect attempt was started, otherwise returns a user-facing error.
@@ -237,21 +276,25 @@ final class GatewayConnectionController {
         let password = GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
 
         // Resolve the service endpoint (SRV/A/AAAA). TXT is unauthenticated; do not route via TXT.
-        guard let target = await self.resolveServiceEndpoint(gateway.endpoint) else {
+        guard let resolved = await self.resolveServiceEndpoint(gateway.endpoint),
+              let host = resolved.host,
+              let port = resolved.port
+        else {
             return "Failed to resolve the discovered gateway endpoint."
         }
+        let resolvedGateway = GatewayDiscoveryModel.mergingResolvedTXT(resolved.txt, into: gateway)
 
         let stableID = gateway.stableID
         // Discovery is a LAN operation; refuse unauthenticated plaintext connects.
         let tlsRequired = true
         let stored = GatewayTLSStore.loadFingerprint(stableID: stableID)
 
-        guard gateway.tlsEnabled || stored != nil else {
+        guard resolvedGateway.tlsEnabled || stored != nil else {
             return "Discovered gateway is missing TLS and no trusted fingerprint is stored."
         }
 
         if tlsRequired, stored == nil {
-            guard let url = self.buildGatewayURL(host: target.host, port: target.port, useTLS: true)
+            guard let url = self.buildGatewayURL(host: host, port: port, useTLS: true)
             else { return "Failed to build TLS URL for trust verification." }
             guard let fp = await self.probeTLSFingerprint(url: url) else {
                 return "Failed to read TLS fingerprint from discovered gateway."
@@ -264,8 +307,8 @@ final class GatewayConnectionController {
             self.pendingTrustPrompt = TrustPrompt(
                 stableID: stableID,
                 gatewayName: gateway.name,
-                host: target.host,
-                port: target.port,
+                host: host,
+                port: port,
                 fingerprintSha256: fp,
                 isManual: false)
             self.appModel?.gatewayStatusText = "Verify gateway TLS fingerprint"
@@ -277,8 +320,8 @@ final class GatewayConnectionController {
         }
 
         guard let url = self.buildGatewayURL(
-            host: target.host,
-            port: target.port,
+            host: host,
+            port: port,
             useTLS: tlsParams?.required == true)
         else { return "Failed to build discovered gateway URL." }
         GatewaySettingsStore.saveLastGatewayConnectionDiscovered(stableID: stableID, useTLS: true)
@@ -307,12 +350,22 @@ final class GatewayConnectionController {
     {
         self.requestLocalNetworkAccess(reason: "connect_manual")
         let instanceId = GatewaySettingsStore.currentInstanceID()
-        let token =
-            authOverride.map(\.token) ?? GatewaySettingsStore.loadGatewayToken(instanceId: instanceId)
-        let bootstrapToken =
-            authOverride.map(\.bootstrapToken) ?? GatewaySettingsStore.loadGatewayBootstrapToken(instanceId: instanceId)
-        let password =
-            authOverride.map(\.password) ?? GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
+        let token: String?
+        let bootstrapToken: String?
+        let password: String?
+        if let authOverride {
+            token = authOverride.token
+            bootstrapToken = authOverride.bootstrapToken
+            password = authOverride.password
+        } else {
+            token = GatewaySettingsStore.loadGatewayToken(instanceId: instanceId)
+            bootstrapToken = GatewaySettingsStore.loadGatewayBootstrapToken(instanceId: instanceId)
+            password = GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
+        }
+        GatewayDiagnostics.log(
+            "connect manual resolved host=\(host) port=\(port) tls=\(useTLS) "
+                + "authOverride=\(authOverride != nil) token=\(token != nil) "
+                + "bootstrap=\(bootstrapToken != nil) password=\(password != nil) instance=\(instanceId)")
         let pendingAuthOverride = authOverride ?? ManualAuthOverride.normalized(
             token: token,
             bootstrapToken: bootstrapToken,
@@ -435,13 +488,18 @@ final class GatewayConnectionController {
         }
 
         let instanceId = GatewaySettingsStore.currentInstanceID()
-        let token =
-            pending.authOverride.map(\.token) ?? GatewaySettingsStore.loadGatewayToken(instanceId: instanceId)
-        let bootstrapToken =
-            pending.authOverride.map(\.bootstrapToken) ?? GatewaySettingsStore.loadGatewayBootstrapToken(
-                instanceId: instanceId)
-        let password =
-            pending.authOverride.map(\.password) ?? GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
+        let token: String?
+        let bootstrapToken: String?
+        let password: String?
+        if let authOverride = pending.authOverride {
+            token = authOverride.token
+            bootstrapToken = authOverride.bootstrapToken
+            password = authOverride.password
+        } else {
+            token = GatewaySettingsStore.loadGatewayToken(instanceId: instanceId)
+            bootstrapToken = GatewaySettingsStore.loadGatewayBootstrapToken(instanceId: instanceId)
+            password = GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
+        }
         let tlsParams = GatewayTLSParams(
             required: true,
             expectedFingerprint: prompt.fingerprintSha256,
@@ -528,6 +586,7 @@ final class GatewayConnectionController {
     }
 
     private func maybeAutoConnect() {
+        guard self.discoveryAutoConnectEnabled else { return }
         guard !self.didAutoConnect else { return }
         guard let appModel = self.appModel else { return }
         guard appModel.gatewayServerName == nil else { return }
@@ -669,7 +728,42 @@ final class GatewayConnectionController {
         guard appModel.activeGatewayConnectConfig == nil else { return }
         guard UserDefaults.standard.bool(forKey: "gateway.autoconnect") else { return }
         self.didAutoConnect = false
+        if !self.discoveryAutoConnectEnabled {
+            self.maybeAutoConnectLastKnownWithoutDiscovery()
+            return
+        }
         self.maybeAutoConnect()
+    }
+
+    private func startDiscoveryForSavedDiscoveredAutoConnectIfNeeded() -> Bool {
+        guard UserDefaults.standard.bool(forKey: "gateway.autoconnect") else { return false }
+        guard case .discovered = GatewaySettingsStore.loadLastGatewayConnection() else { return false }
+        self.startDiscovery(allowAutoConnect: true)
+        self.attemptAutoReconnectIfNeeded()
+        return true
+    }
+
+    private func maybeAutoConnectLastKnownWithoutDiscovery() {
+        let defaults = UserDefaults.standard
+        let instanceId = defaults.string(forKey: "node.instanceId")?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !instanceId.isEmpty else { return }
+
+        let token = GatewaySettingsStore.loadGatewayToken(instanceId: instanceId)
+        let bootstrapToken = GatewaySettingsStore.loadGatewayBootstrapToken(instanceId: instanceId)
+        let password = GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
+
+        if let lastKnown = GatewaySettingsStore.loadLastGatewayConnection(),
+           self.startLastKnownAutoConnect(
+               lastKnown,
+               token: token,
+               bootstrapToken: bootstrapToken,
+               password: password)
+        {
+            return
+        }
+
+        _ = self.startSavedManualEndpointFallback()
     }
 
     private func savedManualEndpointFallback(defaults: UserDefaults = .standard) -> SavedManualEndpoint? {
@@ -738,6 +832,10 @@ final class GatewayConnectionController {
     {
         guard let appModel else { return }
         appModel.gatewayStatusText = "Connecting…"
+        GatewayDiagnostics.log(
+            "start auto connect url=\(url.absoluteString) stableID=\(gatewayStableID) "
+                + "token=\(token != nil) bootstrap=\(bootstrapToken != nil) password=\(password != nil) "
+                + "force=\(forceReconnect)")
         Task { [weak self, weak appModel] in
             guard let self, let appModel else { return }
             if forceReconnect {
@@ -807,7 +905,7 @@ final class GatewayConnectionController {
         }
     }
 
-    private func resolveServiceEndpoint(_ endpoint: NWEndpoint) async -> (host: String, port: Int)? {
+    private func resolveServiceEndpoint(_ endpoint: NWEndpoint) async -> ResolvedGatewayService? {
         guard case let .service(name, type, domain, _) = endpoint else { return nil }
         let key = "\(domain)|\(type)|\(name)"
         return await withCheckedContinuation { continuation in

--- a/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
+++ b/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
@@ -152,6 +152,36 @@ final class GatewayDiscoveryModel {
         }
     }
 
+    static func mergingResolvedTXT(
+        _ txt: [String: String],
+        into gateway: DiscoveredGateway) -> DiscoveredGateway
+    {
+        guard !txt.isEmpty else { return gateway }
+        var resolved = gateway
+        if let lanHost = self.txtValue(txt, key: "lanHost") {
+            resolved.lanHost = lanHost
+        }
+        if let tailnetDns = self.txtValue(txt, key: "tailnetDns") {
+            resolved.tailnetDns = tailnetDns
+        }
+        if let gatewayPort = self.txtIntValue(txt, key: "gatewayPort") {
+            resolved.gatewayPort = gatewayPort
+        }
+        if let canvasPort = self.txtIntValue(txt, key: "canvasPort") {
+            resolved.canvasPort = canvasPort
+        }
+        if self.txtBoolValue(txt, key: "gatewayTls") {
+            resolved.tlsEnabled = true
+        }
+        if let fingerprint = self.txtValue(txt, key: "gatewayTlsSha256") {
+            resolved.tlsFingerprintSha256 = fingerprint
+        }
+        if let cliPath = self.txtValue(txt, key: "cliPath") {
+            resolved.cliPath = cliPath
+        }
+        return resolved
+    }
+
     private func appendDebugLog(_ message: String) {
         guard self.debugLoggingEnabled else { return }
         self.debugLog.append(DebugLogEntry(ts: Date(), message: message))

--- a/apps/ios/Sources/Gateway/GatewayServiceResolver.swift
+++ b/apps/ios/Sources/Gateway/GatewayServiceResolver.swift
@@ -3,16 +3,22 @@ import OpenClawKit
 
 /// NetService-based resolver for Bonjour services.
 /// Used to resolve the service endpoint (SRV + A/AAAA) without trusting TXT for routing.
+struct ResolvedGatewayService: Equatable {
+    var txt: [String: String]
+    var host: String?
+    var port: Int?
+}
+
 final class GatewayServiceResolver: NSObject, NetServiceDelegate {
     private let service: NetService
-    private let completion: ((host: String, port: Int)?) -> Void
+    private let completion: (ResolvedGatewayService?) -> Void
     private var didFinish = false
 
     init(
         name: String,
         type: String,
         domain: String,
-        completion: @escaping ((host: String, port: Int)?) -> Void)
+        completion: @escaping (ResolvedGatewayService?) -> Void)
     {
         self.service = NetService(domain: domain, type: type, name: name)
         self.completion = completion
@@ -25,20 +31,21 @@ final class GatewayServiceResolver: NSObject, NetServiceDelegate {
     }
 
     func netServiceDidResolveAddress(_ sender: NetService) {
+        let txt = Self.decodeTXT(sender.txtRecordData())
         let host = Self.normalizeHost(sender.hostName)
-        let port = sender.port
-        guard let host, !host.isEmpty, port > 0 else {
+        let port = sender.port > 0 ? sender.port : nil
+        guard host != nil || port != nil || !txt.isEmpty else {
             self.finish(result: nil)
             return
         }
-        self.finish(result: (host: host, port: port))
+        self.finish(result: ResolvedGatewayService(txt: txt, host: host, port: port))
     }
 
     func netService(_ sender: NetService, didNotResolve errorDict: [String: NSNumber]) {
         self.finish(result: nil)
     }
 
-    private func finish(result: (host: String, port: Int)?) {
+    private func finish(result: ResolvedGatewayService?) {
         guard !self.didFinish else { return }
         self.didFinish = true
         self.service.stop()
@@ -48,5 +55,18 @@ final class GatewayServiceResolver: NSObject, NetServiceDelegate {
 
     private static func normalizeHost(_ raw: String?) -> String? {
         BonjourServiceResolverSupport.normalizeHost(raw)
+    }
+
+    private static func decodeTXT(_ data: Data?) -> [String: String] {
+        guard let data else { return [:] }
+        let dict = NetService.dictionary(fromTXTRecord: data)
+        var out: [String: String] = [:]
+        out.reserveCapacity(dict.count)
+        for (key, value) in dict {
+            if let str = String(data: value, encoding: .utf8) {
+                out[key] = str
+            }
+        }
+        return out
     }
 }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -242,6 +242,55 @@ final class NodeAppModel {
         self.isAppleReviewDemoModeEnabled || self.isScreenshotFixtureModeEnabled
     }
 
+    private static func gatewayAuthDebugDescription(_ error: Error) -> String {
+        guard let authError = error as? GatewayConnectAuthError else {
+            return error.localizedDescription
+        }
+        return [
+            "message=\(authError.message)",
+            "detail=\(authError.detailCode ?? "none")",
+            "reason=\(authError.detailsReason ?? "none")",
+            "next=\(authError.recommendedNextStepCode ?? "none")",
+            "retryDevice=\(authError.canRetryWithDeviceToken)",
+            "requestId=\(authError.requestId ?? "none")",
+        ].joined(separator: " ")
+    }
+
+    private func shouldStopReconnectAfterSharedAuthFailure(
+        _ error: Error,
+        token: String?,
+        bootstrapToken: String?,
+        password: String?) -> Bool
+    {
+        guard let authError = error as? GatewayConnectAuthError else { return false }
+        guard !authError.canRetryWithDeviceToken else { return false }
+        let hasToken = token?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let hasBootstrapToken = bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let hasPassword = password?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        guard hasToken, !hasBootstrapToken, !hasPassword else { return false }
+        return authError.detail == .authTokenMismatch
+    }
+
+    private func stopReconnectAfterSharedAuthFailure(stableID: String) async {
+        GatewayDiagnostics.log("gateway stale shared auth detected; disabling autoconnect stableID=\(stableID)")
+        self.gatewayAutoReconnectEnabled = false
+        self.gatewayPairingPaused = false
+        UserDefaults.standard.set(false, forKey: "gateway.autoconnect")
+
+        let instanceId = GatewaySettingsStore.currentInstanceID()
+        if !instanceId.isEmpty {
+            GatewaySettingsStore.saveGatewayToken("", instanceId: instanceId)
+        }
+
+        self.activeGatewayConnectConfig = nil
+        self.nodeGatewayTask?.cancel()
+        self.nodeGatewayTask = nil
+        self.operatorGatewayTask?.cancel()
+        self.operatorGatewayTask = nil
+        await self.operatorGateway.disconnect()
+        await self.nodeGateway.disconnect()
+    }
+
     var chatTransportModeID: String {
         if self.isScreenshotFixtureModeEnabled { return "screenshots" }
         if self.isAppleReviewDemoModeEnabled { return "apple-review-demo" }
@@ -2509,7 +2558,8 @@ extension NodeAppModel {
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                 } catch {
                     attempt += 1
-                    GatewayDiagnostics.log("operator gateway connect error: \(error.localizedDescription)")
+                    GatewayDiagnostics.log(
+                        "operator gateway connect error: \(Self.gatewayAuthDebugDescription(error))")
                     let problem: GatewayConnectionProblem? = await MainActor.run {
                         let nextProblem = GatewayConnectionProblemMapper.map(error: error)
                         guard !self.isLocalGatewayFixtureEnabled else { return nil }
@@ -2527,6 +2577,15 @@ extension NodeAppModel {
                         self.operatorGatewayTask?.cancel()
                         self.operatorGatewayTask = nil
                         await self.operatorGateway.disconnect()
+                        break
+                    }
+                    if self.shouldStopReconnectAfterSharedAuthFailure(
+                        error,
+                        token: reconnectAuth.token,
+                        bootstrapToken: reconnectAuth.bootstrapToken,
+                        password: reconnectAuth.password)
+                    {
+                        await self.stopReconnectAfterSharedAuthFailure(stableID: stableID)
                         break
                     }
                     if problem?.pauseReconnect == true {
@@ -2588,14 +2647,17 @@ extension NodeAppModel {
                         sessionKey: self.mainSessionKey)
                 }
 
+                let reconnectAuth = self.currentGatewayReconnectAuth(
+                    fallbackToken: token,
+                    fallbackBootstrapToken: bootstrapToken,
+                    fallbackPassword: password)
                 do {
                     let epochMs = Int(Date().timeIntervalSince1970 * 1000)
-                    let reconnectAuth = self.currentGatewayReconnectAuth(
-                        fallbackToken: token,
-                        fallbackBootstrapToken: bootstrapToken,
-                        fallbackPassword: password)
                     let connectedOptions = currentOptions
-                    GatewayDiagnostics.log("connect attempt epochMs=\(epochMs) url=\(url.absoluteString)")
+                    GatewayDiagnostics.log(
+                        "connect attempt epochMs=\(epochMs) url=\(url.absoluteString) "
+                            + "token=\(reconnectAuth.token != nil) bootstrap=\(reconnectAuth.bootstrapToken != nil) "
+                            + "password=\(reconnectAuth.password != nil)")
                     try await self.nodeGateway.connect(
                         url: url,
                         token: reconnectAuth.token,
@@ -2728,7 +2790,8 @@ extension NodeAppModel {
                         }
                         return nextProblem
                     }
-                    GatewayDiagnostics.log("gateway connect error: \(error.localizedDescription)")
+                    GatewayDiagnostics.log(
+                        "gateway connect error: \(Self.gatewayAuthDebugDescription(error))")
 
                     if problem?.needsPairingApproval == true {
                         // Hard stop the underlying WebSocket watchdog reconnects so the UI stays stable and
@@ -2738,6 +2801,16 @@ extension NodeAppModel {
                         self.operatorGatewayTask = nil
                         await self.operatorGateway.disconnect()
                         await self.nodeGateway.disconnect()
+                        break
+                    }
+
+                    if self.shouldStopReconnectAfterSharedAuthFailure(
+                        error,
+                        token: reconnectAuth.token,
+                        bootstrapToken: reconnectAuth.bootstrapToken,
+                        password: reconnectAuth.password)
+                    {
+                        await self.stopReconnectAfterSharedAuthFailure(stableID: stableID)
                         break
                     }
 

--- a/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift
@@ -82,7 +82,13 @@ struct OnboardingIntroStep: View {
 
 struct OnboardingWelcomeStep: View {
     let statusLine: String
+    let discoveredGateways: [GatewayDiscoveryModel.DiscoveredGateway]
+    let nearbyDiscoveryEnabled: Bool
+    let isRefreshingNearbyGateways: Bool
+    let discoveryStatusText: String
+    let onSetNearbyDiscoveryEnabled: (Bool) -> Void
     let onScanQRCode: () -> Void
+    let onSelectGateway: (GatewayDiscoveryModel.DiscoveredGateway) -> Void
     let onManualSetup: () -> Void
 
     var body: some View {
@@ -104,26 +110,19 @@ struct OnboardingWelcomeStep: View {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("How to pair")
-                    .font(.headline)
-                Text("In your OpenClaw chat, run")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                Text("/pair qr")
-                    .font(.system(.footnote, design: .monospaced).weight(.semibold))
-                Text("Then scan the QR code here to connect this device.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(16)
-            .background {
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .fill(Color(uiColor: .secondarySystemBackground))
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 20)
+            OnboardingPairingInstructionsSection()
+                .padding(.horizontal, 24)
+                .padding(.top, 20)
+
+            NearbyGatewaySetupSection(
+                isEnabled: self.nearbyDiscoveryEnabled,
+                discoveredGateways: self.discoveredGateways,
+                isRefreshing: self.isRefreshingNearbyGateways,
+                discoveryStatusText: self.discoveryStatusText,
+                onSetEnabled: self.onSetNearbyDiscoveryEnabled,
+                onSelectGateway: self.onSelectGateway)
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
 
             Spacer()
 
@@ -156,6 +155,131 @@ struct OnboardingWelcomeStep: View {
                 .padding(.horizontal, 24)
                 .padding(.bottom, 48)
         }
+    }
+}
+
+private struct OnboardingPairingInstructionsSection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("How to pair")
+                .font(.headline)
+            Text("In your OpenClaw chat, run")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            Text("/pair qr")
+                .font(.system(.footnote, design: .monospaced).weight(.semibold))
+            Text("Then scan the QR code here to connect this device.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(uiColor: .secondarySystemBackground))
+        }
+    }
+}
+
+private struct NearbyGatewaySetupSection: View {
+    let isEnabled: Bool
+    let discoveredGateways: [GatewayDiscoveryModel.DiscoveredGateway]
+    let isRefreshing: Bool
+    let discoveryStatusText: String
+    let onSetEnabled: (Bool) -> Void
+    let onSelectGateway: (GatewayDiscoveryModel.DiscoveredGateway) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("NEARBY DISCOVERY")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if self.isRefreshing {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                }
+            }
+            .padding(.horizontal, 16)
+
+            VStack(alignment: .leading, spacing: 0) {
+                NearbyGatewayDiscoveryToggleRow(
+                    isEnabled: self.isEnabled,
+                    onSetEnabled: self.onSetEnabled)
+
+                if self.isEnabled {
+                    Divider()
+                        .padding(.leading, 16)
+
+                    if self.discoveredGateways.isEmpty {
+                        Text(self.discoveryStatusText)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                    } else {
+                        ForEach(self.discoveredGateways) { gateway in
+                            NearbyGatewaySetupRow(
+                                name: gateway.name,
+                                host: gateway.lanHost ?? gateway.tailnetDns ?? "Local network")
+                            {
+                                self.onSelectGateway(gateway)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(Color(uiColor: .secondarySystemBackground))
+            }
+        }
+    }
+}
+
+private struct NearbyGatewayDiscoveryToggleRow: View {
+    let isEnabled: Bool
+    let onSetEnabled: (Bool) -> Void
+
+    var body: some View {
+        Toggle(
+            "Enabled",
+            isOn: Binding(
+                get: { self.isEnabled },
+                set: self.onSetEnabled))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+    }
+}
+
+private struct NearbyGatewaySetupRow: View {
+    let name: String
+    let host: String
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: self.onSelect) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(verbatim: self.name)
+                        .font(.subheadline.weight(.semibold))
+                    Text(verbatim: self.host)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -46,6 +46,7 @@ struct OnboardingWizardView: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage("node.instanceId") private var instanceId: String = UUID().uuidString
     @AppStorage("gateway.discovery.domain") private var discoveryDomain: String = ""
+    @AppStorage("gateway.discovery.nearbyDetectionEnabled") private var nearbyDetectionEnabled = false
     @AppStorage("onboarding.developerMode") private var developerModeEnabled: Bool = false
     @State private var step: OnboardingStep
     @State private var selectedMode: OnboardingConnectionMode?
@@ -55,19 +56,25 @@ struct OnboardingWizardView: View {
     @State private var manualTLS: Bool = true
     @State private var gatewayToken: String = ""
     @State private var gatewayPassword: String = ""
+    @State private var credentialPersistSuppressionCount = 0
     @State private var connectMessage: String?
     @State private var statusLine: String = "In your OpenClaw chat, run /pair qr, then scan the code here."
     @State private var connectingGatewayID: String?
     @State private var issue: GatewayConnectionIssue = .none
     @State private var didMarkCompleted = false
+    @State private var didStartWizardConnectAttempt = false
+    @State private var didRequestNearbyDetection = false
+    @State private var isRefreshingNearbyGateways = false
     @State private var pairingRequestId: String?
     @State private var discoveryRestartTask: Task<Void, Never>?
+    @State private var nearbyDiscoveryRefreshTask: Task<Void, Never>?
     @State private var showQRScanner: Bool = false
     @State private var scannerError: String?
     @State private var selectedPhoto: PhotosPickerItem?
     @State private var showGatewayProblemDetails: Bool = false
     @State private var lastPairingAutoResumeAttemptAt: Date?
     @State private var pendingManualAuthOverride: GatewayConnectionController.ManualAuthOverride?
+    @State private var selectedNearbyGatewayForAuth: GatewayDiscoveryModel.DiscoveredGateway?
     @State private var setupCode: String = ""
     @State private var setupCodeStatus: String?
     private static let pairingAutoResumeTicker = Timer.publish(every: 2.0, on: .main, in: .common).autoconnect()
@@ -93,7 +100,7 @@ struct OnboardingWizardView: View {
     }
 
     private var currentProblem: GatewayConnectionProblem? {
-        self.appModel.lastGatewayProblem
+        self.didStartWizardConnectAttempt ? self.appModel.lastGatewayProblem : nil
     }
 
     var body: some View {
@@ -242,6 +249,12 @@ struct OnboardingWizardView: View {
             .onDisappear {
                 self.discoveryRestartTask?.cancel()
                 self.discoveryRestartTask = nil
+                self.nearbyDiscoveryRefreshTask?.cancel()
+                self.nearbyDiscoveryRefreshTask = nil
+                self.isRefreshingNearbyGateways = false
+                if self.didRequestNearbyDetection {
+                    self.gatewayController.finishExplicitDiscoverySession()
+                }
             }
             .onChange(of: self.discoveryDomain) { _, _ in
                 self.scheduleDiscoveryRestart()
@@ -265,9 +278,18 @@ struct OnboardingWizardView: View {
                 }
             }
             .onChange(of: self.gatewayToken) { _, newValue in
+                guard self.shouldPersistCredentialFieldChange() else { return }
+                guard !self.gatewayTokenLooksLikeSetupInput(newValue) else {
+                    self.setupCode = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    self.gatewayToken = ""
+                    self.setupCodeStatus = "Setup code detected. Tap Apply Setup Code."
+                    self.saveGatewayCredentials(token: "", password: self.gatewayPassword)
+                    return
+                }
                 self.saveGatewayCredentials(token: newValue, password: self.gatewayPassword)
             }
             .onChange(of: self.gatewayPassword) { _, newValue in
+                guard self.shouldPersistCredentialFieldChange() else { return }
                 self.saveGatewayCredentials(token: self.gatewayToken, password: newValue)
             }
             .onChange(of: self.appModel.lastGatewayProblem) { _, newValue in
@@ -275,6 +297,9 @@ struct OnboardingWizardView: View {
             }
             .onChange(of: self.appModel.gatewayStatusText) { _, newValue in
                 self.updateConnectionIssue(problem: self.appModel.lastGatewayProblem, statusText: newValue)
+            }
+            .onChange(of: self.gatewayController.discoveryStatusText) { _, newValue in
+                self.handleNearbyDiscoveryStatus(newValue)
             }
             .onChange(of: self.appModel.gatewayServerName) { _, newValue in
                 guard newValue != nil else { return }
@@ -302,9 +327,19 @@ struct OnboardingWizardView: View {
     private var welcomeStep: some View {
         OnboardingWelcomeStep(
             statusLine: self.statusLine,
+            discoveredGateways: self.gatewayController.gateways,
+            nearbyDiscoveryEnabled: self.nearbyDetectionEnabled || !self.gatewayController.gateways.isEmpty,
+            isRefreshingNearbyGateways: self.isRefreshingNearbyGateways,
+            discoveryStatusText: self.gatewayController.discoveryStatusText,
+            onSetNearbyDiscoveryEnabled: { enabled in
+                self.setNearbyDiscoveryEnabled(enabled)
+            },
             onScanQRCode: {
                 self.statusLine = "Opening QR scanner…"
                 self.showQRScanner = true
+            },
+            onSelectGateway: { gateway in
+                self.beginNearbyGatewayAuth(gateway)
             },
             onManualSetup: {
                 self.step = .mode
@@ -438,37 +473,31 @@ struct OnboardingWizardView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(self.gatewayController.gateways) { gateway in
-                        let hasHost = self.gatewayHasResolvableHost(gateway)
-
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(gateway.name)
-                                if let host = gateway.lanHost ?? gateway.tailnetDns {
-                                    Text(host)
-                                        .font(.footnote)
-                                        .foregroundStyle(.secondary)
+                        Button {
+                            self.beginNearbyGatewayAuth(gateway)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(gateway.name)
+                                    if let host = gateway.lanHost ?? gateway.tailnetDns {
+                                        Text(host)
+                                            .font(.footnote)
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.footnote.weight(.semibold))
+                                    .foregroundStyle(.tertiary)
                             }
-                            Spacer()
-                            Button {
-                                Task { await self.connectDiscoveredGateway(gateway) }
-                            } label: {
-                                if self.connectingGatewayID == gateway.id {
-                                    ProgressView()
-                                        .progressViewStyle(.circular)
-                                } else if !hasHost {
-                                    Text("Resolving…")
-                                } else {
-                                    Text("Connect")
-                                }
-                            }
-                            .disabled(self.connectingGatewayID != nil || !hasHost)
+                            .contentShape(Rectangle())
                         }
+                        .buttonStyle(.plain)
                     }
                 }
 
                 Button("Restart Discovery") {
-                    self.gatewayController.restartDiscovery()
+                    self.gatewayController.restartDiscovery(allowAutoConnect: false)
                 }
                 .disabled(self.connectingGatewayID != nil)
             }
@@ -499,6 +528,8 @@ struct OnboardingWizardView: View {
 
     private var authStep: some View {
         Group {
+            self.setupCodeSection
+
             Section("Authentication") {
                 SecureField("Gateway Auth Token", text: self.$gatewayToken)
                     .textInputAutocapitalization(.never)
@@ -520,7 +551,7 @@ struct OnboardingWizardView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 } else {
-                    Text("Auth token looks valid.")
+                    Text("Paste a setup code or enter gateway credentials.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -724,6 +755,39 @@ extension OnboardingWizardView {
         await self.connectManual()
     }
 
+    private func gatewayTokenLooksLikeSetupInput(_ value: String) -> Bool {
+        let raw = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return false }
+        if AppleReviewDemoMode.isSetupCode(raw) { return true }
+        return GatewayConnectDeepLink.fromSetupInput(raw) != nil
+    }
+
+    private func applyGatewayTokenSetupInputIfNeeded() async -> Bool {
+        let raw = self.gatewayToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return false }
+
+        if AppleReviewDemoMode.isSetupCode(raw) {
+            self.gatewayToken = ""
+            self.gatewayPassword = ""
+            self.setupCodeStatus = "Apple Review demo mode enabled."
+            self.handleScannedSetupCode(raw)
+            return true
+        }
+
+        guard let link = GatewayConnectDeepLink.fromSetupInput(raw) else { return false }
+        self.gatewayToken = ""
+        self.gatewayPassword = ""
+        self.setupCode = ""
+        self.connectingGatewayID = "setup-code"
+        self.applyGatewayLink(link)
+        self.setupCodeStatus = "Setup code applied. Connecting..."
+        self.connectMessage = "Connecting via setup code..."
+        self.statusLine = "Setup code loaded. Connecting to \(link.host):\(link.port)..."
+        self.step = .connect
+        await self.connectManual()
+        return true
+    }
+
     private func handleScannedLink(_ link: GatewayConnectDeepLink) {
         self.applyGatewayLink(link)
         self.setupCodeStatus = nil
@@ -816,6 +880,8 @@ extension OnboardingWizardView {
     }
 
     private func updateConnectionIssue(problem: GatewayConnectionProblem?, statusText: String) {
+        guard self.didStartWizardConnectAttempt else { return }
+
         let next = GatewayConnectionIssue.detect(problem: problem)
         let fallback = next == .none ? GatewayConnectionIssue.detect(from: statusText) : next
 
@@ -937,22 +1003,119 @@ extension OnboardingWizardView {
         if !hasSavedGateway, !hasToken, !hasPassword {
             self.statusLine = "No saved pairing found. In your OpenClaw chat, run /pair qr, then scan the code here."
         }
+        if self.nearbyDetectionEnabled, self.step == .welcome {
+            self.didRequestNearbyDetection = true
+            self.startNearbyDiscoveryRefresh()
+        }
     }
 
     private func scheduleDiscoveryRestart() {
+        self.didRequestNearbyDetection = true
         self.discoveryRestartTask?.cancel()
         self.discoveryRestartTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 350_000_000)
             guard !Task.isCancelled else { return }
-            self.gatewayController.restartDiscovery()
+            self.isRefreshingNearbyGateways = true
+            self.gatewayController.restartDiscovery(allowAutoConnect: false)
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            guard !Task.isCancelled else { return }
+            self.isRefreshingNearbyGateways = false
         }
+    }
+
+    private func setNearbyDiscoveryEnabled(_ enabled: Bool) {
+        self.nearbyDetectionEnabled = enabled
+        self.didRequestNearbyDetection = enabled
+        if enabled {
+            self.statusLine = "Searching for nearby gateways…"
+            self.startNearbyDiscoveryRefresh()
+        } else {
+            self.stopNearbyDiscovery()
+        }
+    }
+
+    private func stopNearbyDiscovery() {
+        self.nearbyDiscoveryRefreshTask?.cancel()
+        self.nearbyDiscoveryRefreshTask = nil
+        self.discoveryRestartTask?.cancel()
+        self.discoveryRestartTask = nil
+        self.isRefreshingNearbyGateways = false
+        self.gatewayController.stopDiscovery()
+    }
+
+    private func handleNearbyDiscoveryStatus(_ status: String) {
+        guard self.nearbyDetectionEnabled else { return }
+        guard Self.isLocalNetworkAccessDeniedStatus(status) else { return }
+        self.nearbyDetectionEnabled = false
+        self.didRequestNearbyDetection = false
+        self.stopNearbyDiscovery()
+        self.statusLine = "Local network access was not allowed."
+    }
+
+    private static func isLocalNetworkAccessDeniedStatus(_ status: String) -> Bool {
+        let normalized = status.lowercased()
+        return normalized.contains("policydenied") || normalized.contains("denied")
+    }
+
+    private func startNearbyDiscoveryRefresh() {
+        guard self.nearbyDiscoveryRefreshTask == nil else { return }
+        self.nearbyDiscoveryRefreshTask = Task { @MainActor in
+            await self.refreshNearbyGateways(initial: true)
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                guard !Task.isCancelled else { return }
+                await self.refreshNearbyGateways(initial: false)
+            }
+        }
+    }
+
+    private func refreshNearbyGateways(initial: Bool) async {
+        self.isRefreshingNearbyGateways = true
+        if initial {
+            self.gatewayController.startDiscovery(allowAutoConnect: false)
+        } else {
+            self.gatewayController.restartDiscovery(allowAutoConnect: false)
+        }
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        guard !Task.isCancelled else { return }
+        self.isRefreshingNearbyGateways = false
+    }
+
+    private func beginNearbyGatewayAuth(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) {
+        self.selectedNearbyGatewayForAuth = gateway
+        self.selectedMode = .homeNetwork
+        self.didStartWizardConnectAttempt = false
+        self.issue = .none
+        self.connectMessage = nil
+        self.pairingRequestId = nil
+        self.setCredentialFields(token: "", password: "", persist: false)
+        self.pendingManualAuthOverride = nil
+        self.setupCodeStatus = nil
+        self.statusLine = "Enter a setup code or gateway credentials for \(gateway.name)."
+        self.step = .auth
+    }
+
+    private func setCredentialFields(token: String, password: String, persist: Bool) {
+        if !persist {
+            if self.gatewayToken != token { self.credentialPersistSuppressionCount += 1 }
+            if self.gatewayPassword != password { self.credentialPersistSuppressionCount += 1 }
+        }
+        self.gatewayToken = token
+        self.gatewayPassword = password
+    }
+
+    private func shouldPersistCredentialFieldChange() -> Bool {
+        guard self.credentialPersistSuppressionCount > 0 else { return true }
+        self.credentialPersistSuppressionCount -= 1
+        return false
     }
 
     private func saveGatewayCredentials(token: String, password: String) {
         let trimmedInstanceId = GatewaySettingsStore.currentInstanceID()
         guard !trimmedInstanceId.isEmpty else { return }
         let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
-        GatewaySettingsStore.saveGatewayToken(trimmedToken, instanceId: trimmedInstanceId)
+        let tokenToSave = self.gatewayTokenLooksLikeSetupInput(trimmedToken) ? "" : trimmedToken
+        GatewaySettingsStore.saveGatewayToken(tokenToSave, instanceId: trimmedInstanceId)
         let trimmedPassword = password.trimmingCharacters(in: .whitespacesAndNewlines)
         GatewaySettingsStore.saveGatewayPassword(trimmedPassword, instanceId: trimmedInstanceId)
     }
@@ -966,6 +1129,8 @@ extension OnboardingWizardView {
 
     private func connectDiscoveredGateway(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) async {
         self.connectingGatewayID = gateway.id
+        self.selectedNearbyGatewayForAuth = nil
+        self.didStartWizardConnectAttempt = true
         self.issue = .none
         self.connectMessage = "Connecting to \(gateway.name)…"
         self.statusLine = "Connecting to \(gateway.name)…"
@@ -986,6 +1151,7 @@ extension OnboardingWizardView {
         case .homeNetwork:
             if hostIsDefaultLike { self.manualHost = "openclaw.local" }
             self.manualTLS = true
+            self.setCredentialFields(token: "", password: "", persist: false)
             if self.manualPort <= 0 || self.manualPort > 65535 { self.manualPort = 18789 }
         case .remoteDomain:
             if host == "openclaw.local" || host == "localhost" { self.manualHost = "" }
@@ -998,17 +1164,12 @@ extension OnboardingWizardView {
         }
     }
 
-    private func gatewayHasResolvableHost(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) -> Bool {
-        let lanHost = gateway.lanHost?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !lanHost.isEmpty { return true }
-        let tailnetDns = gateway.tailnetDns?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return !tailnetDns.isEmpty
-    }
-
     private func connectManual() async {
         let host = self.manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !host.isEmpty, self.manualPort > 0, self.manualPort <= 65535 else { return }
         self.connectingGatewayID = "manual"
+        self.selectedNearbyGatewayForAuth = nil
+        self.didStartWizardConnectAttempt = true
         self.issue = .none
         self.connectMessage = "Connecting to \(host)…"
         self.statusLine = "Connecting to \(host):\(self.manualPort)…"
@@ -1026,7 +1187,19 @@ extension OnboardingWizardView {
     }
 
     private func retryLastAttempt(silent: Bool = false) async {
+        if !self.setupCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await self.applySetupCodeAndConnect()
+            return
+        }
+        if await self.applyGatewayTokenSetupInputIfNeeded() {
+            return
+        }
+        if let gateway = self.selectedNearbyGatewayForAuth {
+            await self.connectDiscoveredGateway(gateway)
+            return
+        }
         self.connectingGatewayID = silent ? "retry-auto" : "retry"
+        self.didStartWizardConnectAttempt = true
         // Keep current auth/pairing issue sticky while retrying to avoid Step 3 UI flip-flop.
         if !silent {
             self.connectMessage = "Retrying…"

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -646,7 +646,7 @@ struct OpenClawApp: App {
         _gatewayController = State(
             initialValue: GatewayConnectionController(
                 appModel: appModel,
-                startDiscovery: !Self.screenshotModeEnabled,
+                startDiscovery: false,
                 deferDiscoveryUntilLocalNetworkRequest: true))
     }
 

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -619,8 +619,10 @@ struct RootTabsSourceGuardTests {
         let controllerSource = try String(contentsOf: Self.gatewayConnectionControllerSourceURL(), encoding: .utf8)
 
         #expect(appSource.contains("deferDiscoveryUntilLocalNetworkRequest: true"))
-        #expect(controllerSource.contains("func requestLocalNetworkAccess(reason: String)"))
+        #expect(controllerSource.contains("func requestLocalNetworkAccess(reason: String, allowReconnect: Bool = true)"))
         #expect(controllerSource.contains("guard self.localNetworkAccessRequested else"))
+        #expect(controllerSource.contains("self.requestLocalNetworkAccess(reason: \"start_discovery\", allowReconnect: allowAutoConnect)"))
+        #expect(controllerSource.contains("self.requestLocalNetworkAccess(reason: \"restart_discovery\", allowReconnect: allowAutoConnect)"))
         #expect(controllerSource.contains("self.requestLocalNetworkAccess(reason: \"connect_manual\")"))
         #expect(controllerSource.contains("self.requestLocalNetworkAccess(reason: \"connect_discovered_gateway\")"))
         #expect(controllerSource.contains("self.requestLocalNetworkAccess(reason: \"connect_last_known\")"))

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -333,8 +333,9 @@ public actor GatewayChannelActor {
             } catch {
                 if self.shouldPauseReconnectAfterAuthFailure(error) {
                     self.reconnectPausedForAuthFailure = true
+                    let message = error.localizedDescription
                     self.logger.error(
-                        "gateway watchdog reconnect paused for non-recoverable auth failure \(error.localizedDescription, privacy: .public)")
+                        "gateway watchdog reconnect paused auth=\(message, privacy: .public)")
                     continue
                 }
                 let wrapped = self.wrap(error, context: "gateway watchdog reconnect")
@@ -492,7 +493,23 @@ public actor GatewayChannelActor {
             self.pendingDeviceTokenRetry = false
         }
         self.lastAuthSource = selectedAuth.authSource
-        self.logger.info("gateway connect auth=\(selectedAuth.authSource.rawValue, privacy: .public)")
+        let authSourceName = selectedAuth.authSource.rawValue
+        let hasAuthToken = selectedAuth.authToken != nil
+        let hasAuthBootstrapToken = selectedAuth.authBootstrapToken != nil
+        let hasAuthDeviceToken = selectedAuth.authDeviceToken != nil
+        let hasAuthPassword = selectedAuth.authPassword != nil
+        let hasStoredDeviceToken = selectedAuth.storedToken != nil
+        let connectAuthLog = [
+            "gateway connect auth=\(authSourceName)",
+            "role=\(role)",
+            "identity=\(includeDeviceIdentity)",
+            "token=\(hasAuthToken)",
+            "bootstrap=\(hasAuthBootstrapToken)",
+            "deviceToken=\(hasAuthDeviceToken)",
+            "password=\(hasAuthPassword)",
+            "storedDeviceToken=\(hasStoredDeviceToken)",
+        ].joined(separator: " ")
+        self.logger.info("\(connectAuthLog, privacy: .public)")
         if let authToken = selectedAuth.authToken {
             var auth: [String: ProtoAnyCodable] = ["token": ProtoAnyCodable(authToken)]
             if let authDeviceToken = selectedAuth.authDeviceToken {
@@ -599,15 +616,15 @@ public actor GatewayChannelActor {
             includeDeviceIdentity && self.pendingDeviceTokenRetry &&
             !requestedScopesExceedStoredToken && storedToken != nil && explicitToken != nil &&
             self.isTrustedDeviceRetryEndpoint()
+        let authBootstrapToken = includeDeviceIdentity ? explicitBootstrapToken : nil
+        let authPassword = authBootstrapToken == nil ? explicitPassword : nil
         let authToken =
-            explicitToken ??
-            // A freshly scanned setup code should force the bootstrap pairing path instead of
-            // silently reusing an older stored device token.
-            (includeDeviceIdentity && explicitPassword == nil && explicitBootstrapToken == nil
-                ? storedToken
-                : nil)
-        let authBootstrapToken =
-            authToken == nil && explicitPassword == nil ? explicitBootstrapToken : nil
+            authBootstrapToken == nil
+                ? explicitToken ??
+                    // A freshly scanned setup code should force the bootstrap pairing path instead of
+                    // silently reusing an older stored device token.
+                    (includeDeviceIdentity && authPassword == nil ? storedToken : nil)
+                : nil
         let authDeviceToken = shouldUseDeviceRetryToken ? storedToken : nil
         let authSource: GatewayAuthSource = if authDeviceToken != nil || (explicitToken == nil && authToken != nil) {
             .deviceToken
@@ -615,16 +632,34 @@ public actor GatewayChannelActor {
             .sharedToken
         } else if authBootstrapToken != nil {
             .bootstrapToken
-        } else if explicitPassword != nil {
+        } else if authPassword != nil {
             .password
         } else {
             .none
         }
+        let authSourceName = authSource.rawValue
+        let hasExplicitToken = explicitToken != nil
+        let hasExplicitBootstrap = explicitBootstrapToken != nil
+        let hasExplicitPassword = explicitPassword != nil
+        let hasStoredToken = storedToken != nil
+        let pendingDeviceRetry = self.pendingDeviceTokenRetry
+        let selectAuthLog = [
+            "gateway select auth=\(authSourceName)",
+            "role=\(role)",
+            "identity=\(includeDeviceIdentity)",
+            "explicitToken=\(hasExplicitToken)",
+            "explicitBootstrap=\(hasExplicitBootstrap)",
+            "explicitPassword=\(hasExplicitPassword)",
+            "storedDeviceToken=\(hasStoredToken)",
+            "pendingDeviceRetry=\(pendingDeviceRetry)",
+            "scopeUpgrade=\(requestedScopesExceedStoredToken)",
+        ].joined(separator: " ")
+        self.logger.info("\(selectAuthLog, privacy: .public)")
         return SelectedConnectAuth(
             authToken: authToken,
             authBootstrapToken: authBootstrapToken,
             authDeviceToken: authDeviceToken,
-            authPassword: explicitPassword,
+            authPassword: authPassword,
             signatureToken: authToken ?? authBootstrapToken,
             storedToken: storedToken,
             storedScopes: storedEntry?.scopes,
@@ -1053,8 +1088,9 @@ public actor GatewayChannelActor {
         } catch {
             if self.shouldPauseReconnectAfterAuthFailure(error) {
                 self.reconnectPausedForAuthFailure = true
+                let message = error.localizedDescription
                 self.logger.error(
-                    "gateway reconnect paused for non-recoverable auth failure \(error.localizedDescription, privacy: .public)")
+                    "gateway reconnect paused auth=\(message, privacy: .public)")
                 return
             }
             let wrapped = self.wrap(error, context: "gateway reconnect")
@@ -1261,8 +1297,9 @@ public actor GatewayChannelActor {
             let data = try self.encoder.encode(frame)
             return (id: id, data: data)
         } catch {
+            let message = error.localizedDescription
             self.logger.error(
-                "gateway \(kind) encode failed \(method, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                "gateway \(kind) encode failed method=\(method, privacy: .public) error=\(message, privacy: .public)")
             throw error
         }
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -306,9 +306,9 @@ struct GatewayNodeSessionTests {
 
         try await gateway.connect(
             url: #require(URL(string: "ws://example.invalid")),
-            token: nil,
+            token: "stale-shared-token",
             bootstrapToken: "fresh-bootstrap-token",
-            password: nil,
+            password: "stale-password",
             connectOptions: options,
             sessionBox: WebSocketSessionBox(session: session),
             onConnected: {},
@@ -321,6 +321,7 @@ struct GatewayNodeSessionTests {
         #expect(auth["bootstrapToken"] as? String == "fresh-bootstrap-token")
         #expect(auth["token"] == nil)
         #expect(auth["deviceToken"] == nil)
+        #expect(auth["password"] == nil)
 
         await gateway.disconnect()
     }

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -143,6 +143,20 @@ function warnIfIssuedBootstrapScopesWereStripped(params: {
   });
 }
 
+function summarizeBootstrapProfile(profile: DeviceBootstrapProfile): {
+  roles: string[];
+  scopes: string[];
+  roleCount: number;
+  scopeCount: number;
+} {
+  return {
+    roles: profile.roles,
+    scopes: profile.scopes,
+    roleCount: profile.roles.length,
+    scopeCount: profile.scopes.length,
+  };
+}
+
 function bootstrapProfileAllowsRequest(params: {
   allowedProfile: DeviceBootstrapProfile;
   requestedRole: string;
@@ -226,7 +240,17 @@ async function loadState(baseDir?: string): Promise<DeviceBootstrapStateFile> {
       lastUsedAtMs: typeof record.lastUsedAtMs === "number" ? record.lastUsedAtMs : undefined,
     };
   }
+  const beforePruneCount = Object.keys(state).length;
   pruneExpiredPending(state, asDateTimestampMs(Date.now()) ?? 0, DEVICE_BOOTSTRAP_TOKEN_TTL_MS);
+  const afterPruneCount = Object.keys(state).length;
+  if (afterPruneCount !== beforePruneCount) {
+    log.warn("bootstrap_token_state_pruned", {
+      removed: beforePruneCount - afterPruneCount,
+      remaining: afterPruneCount,
+      ttlMs: DEVICE_BOOTSTRAP_TOKEN_TTL_MS,
+      bootstrapPath,
+    });
+  }
   return state;
 }
 
@@ -266,6 +290,12 @@ export async function issueDeviceBootstrapToken(
       issuedAtMs,
     };
     await persistState(state, params.baseDir);
+    log.info("bootstrap_token_issued", {
+      expiresAtMs,
+      ttlMs: DEVICE_BOOTSTRAP_TOKEN_TTL_MS,
+      outstanding: Object.keys(state).length,
+      profile: summarizeBootstrapProfile(profile),
+    });
     return { token, expiresAtMs };
   });
 }
@@ -280,6 +310,9 @@ export async function clearDeviceBootstrapTokens(
     const state = await loadState(params.baseDir);
     const removed = Object.keys(state).length;
     await persistState({}, params.baseDir);
+    log.warn("bootstrap_tokens_cleared", {
+      removed,
+    });
     return { removed };
   });
 }
@@ -304,6 +337,12 @@ export async function revokeDeviceBootstrapToken(params: {
     const [tokenKey, record] = found;
     delete state[tokenKey];
     await persistState(state, params.baseDir);
+    log.info("bootstrap_token_revoked", {
+      removed: true,
+      remaining: Object.keys(state).length,
+      boundDevice: Boolean(record.deviceId),
+      lastUsedAtMs: record.lastUsedAtMs,
+    });
     return { removed: true, record };
   });
 }
@@ -335,6 +374,11 @@ export async function revokeDeviceBootstrapTokensForDevice(params: {
     if (removed > 0) {
       await persistState(state, params.baseDir);
     }
+    log.info("bootstrap_tokens_revoked_for_device", {
+      removed,
+      remaining: Object.keys(state).length,
+      deviceId,
+    });
     return { removed };
   });
 }
@@ -442,12 +486,21 @@ export async function verifyDeviceBootstrapToken(params: {
     const state = await loadState(params.baseDir);
     const providedToken = params.token.trim();
     if (!providedToken) {
+      log.warn("bootstrap_token_verify_failed", {
+        reason: "empty_token",
+        outstanding: Object.keys(state).length,
+      });
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
     const found = Object.entries(state).find(([, candidate]) =>
       verifyPairingToken(providedToken, candidate.token),
     );
     if (!found) {
+      log.warn("bootstrap_token_verify_failed", {
+        reason: "token_not_found_or_expired",
+        outstanding: Object.keys(state).length,
+        ttlMs: DEVICE_BOOTSTRAP_TOKEN_TTL_MS,
+      });
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
     const [tokenKey, record] = found;
@@ -456,6 +509,12 @@ export async function verifyDeviceBootstrapToken(params: {
     const publicKey = normalizeBootstrapPublicKey(params.publicKey);
     const role = params.role.trim();
     if (!deviceId || !publicKey || !role) {
+      log.warn("bootstrap_token_verify_failed", {
+        reason: "missing_identity_or_role",
+        devicePresent: Boolean(deviceId),
+        publicKeyPresent: Boolean(publicKey),
+        rolePresent: Boolean(role),
+      });
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
     const allowedProfile = resolvePersistedBootstrapProfile(record);
@@ -469,6 +528,12 @@ export async function verifyDeviceBootstrapToken(params: {
         requestedScopes: params.scopes,
       })
     ) {
+      log.warn("bootstrap_token_verify_failed", {
+        reason: "profile_rejected_request",
+        role,
+        requestedScopes: params.scopes,
+        allowedProfile: summarizeBootstrapProfile(allowedProfile),
+      });
       return { ok: false, reason: "bootstrap_token_invalid" };
     }
     const requestedProfile = resolveRequestedBootstrapProfile({
@@ -483,10 +548,25 @@ export async function verifyDeviceBootstrapToken(params: {
         : undefined;
     if (boundDeviceId || boundPublicKey) {
       if (boundDeviceId !== deviceId || boundPublicKey !== publicKey) {
+        log.warn("bootstrap_token_verify_failed", {
+          reason: "bound_identity_mismatch",
+          role,
+          boundDeviceMatches: boundDeviceId === deviceId,
+          boundPublicKeyMatches: boundPublicKey === publicKey,
+          ageMs: Date.now() - record.issuedAtMs,
+          lastUsedAtMs: record.lastUsedAtMs,
+        });
         return { ok: false, reason: "bootstrap_token_invalid" };
       }
       const pendingProfile = resolvePersistedPendingProfile(record);
       if (pendingProfile && !sameBootstrapProfile(pendingProfile, requestedProfile)) {
+        log.warn("bootstrap_token_verify_failed", {
+          reason: "pending_profile_mismatch",
+          role,
+          requestedProfile: summarizeBootstrapProfile(requestedProfile),
+          pendingProfile: summarizeBootstrapProfile(pendingProfile),
+          allowedProfile: summarizeBootstrapProfile(allowedProfile),
+        });
         return { ok: false, reason: "bootstrap_token_invalid" };
       }
       state[tokenKey] = {
@@ -498,6 +578,14 @@ export async function verifyDeviceBootstrapToken(params: {
         lastUsedAtMs: Date.now(),
       };
       await persistState(state, params.baseDir);
+      log.info("bootstrap_token_verify_ok", {
+        mode: "existing_binding",
+        role,
+        requestedScopes: params.scopes,
+        ageMs: Date.now() - record.issuedAtMs,
+        allowedProfile: summarizeBootstrapProfile(allowedProfile),
+        pendingProfile: summarizeBootstrapProfile(pendingProfile ?? requestedProfile),
+      });
       return { ok: true };
     }
 
@@ -510,6 +598,14 @@ export async function verifyDeviceBootstrapToken(params: {
       lastUsedAtMs: Date.now(),
     };
     await persistState(state, params.baseDir);
+    log.info("bootstrap_token_verify_ok", {
+      mode: "new_binding",
+      role,
+      requestedScopes: params.scopes,
+      ageMs: Date.now() - record.issuedAtMs,
+      allowedProfile: summarizeBootstrapProfile(allowedProfile),
+      pendingProfile: summarizeBootstrapProfile(requestedProfile),
+    });
     return { ok: true };
   });
 }


### PR DESCRIPTION
## Summary

- Adds nearby gateway discovery to iOS onboarding with an explicit discovery toggle.
- Lets users select a discovered local gateway and continue into setup-code authentication.
- Improves gateway connection/auth handling so fresh setup-code bootstrap auth wins over stale saved credentials.

## Real behavior proof

Behavior addressed: cold iOS onboarding can discover a nearby local OpenClaw gateway and connect through the onboarding flow.

Real environment tested: iPhone on the same local network as a running OpenClaw gateway.

Exact steps or command run after this patch: launched the iOS app from cold onboarding, toggled nearby gateway discovery, selected the local gateway, pasted a fresh setup code, and connected successfully.

Evidence after fix:

![Cold onboarding nearby gateway discovery and connection](https://github.com/user-attachments/assets/63b2831c-5415-462d-8ae6-00e49eaf651c)

Observed result after fix: the nearby gateway appears in onboarding and the app connects successfully.

What was not tested: App Store archive/export was not run; this PR does not change the watch target migration.

## Verification

- Confirmed branch is based on latest `origin/main`.
- Confirmed branch is exactly one commit ahead of `origin/main`.
- Confirmed branch contains only the onboarding nearby gateway commit delta and excludes the watch target migration.
