### PR TITLE
fix(memory-core): index memory path in FTS text for filename queries (fixes #94102)

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -787,12 +787,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           });
         }
         if (this.fts.enabled && this.fts.available) {
+          // Path prefix keeps filename/date tokens in FTS text for hybrid keyword ranking.
+          const ftsText = `${entry.path}\n${chunk.text}`;
           this.db
             .prepare(
               `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
                 ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
             )
-            .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
+            .run(ftsText, id, entry.path, source, model, chunk.startLine, chunk.endLine);
         }
       }
       this.upsertFileRecord(entry, source);

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -2,6 +2,7 @@
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it } from "vitest";
 import {
+  MEMORY_FTS_TEXT_FORMAT_CURRENT,
   resolveConfiguredScopeHash,
   resolveConfiguredSourcesForMeta,
   resolveMemoryIndexProviderIdentities,
@@ -20,6 +21,7 @@ function createMeta(overrides: Partial<MemoryIndexMeta> = {}): MemoryIndexMeta {
     chunkTokens: 4000,
     chunkOverlap: 0,
     ftsTokenizer: "unicode61",
+    ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT,
     ...overrides,
   };
 }
@@ -38,6 +40,7 @@ function createIdentityParams(
     vectorReady?: boolean;
     hasIndexedChunks?: boolean;
     ftsTokenizer?: string;
+    ftsTextFormat?: string;
   } = {},
 ) {
   return {
@@ -51,6 +54,7 @@ function createIdentityParams(
     vectorReady: false,
     hasIndexedChunks: true,
     ftsTokenizer: "unicode61",
+    ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT,
     ...overrides,
   };
 }
@@ -304,6 +308,38 @@ describe("memory reindex state", () => {
         createIdentityParams({
           provider: { id: "openai", model: "  " },
           meta: createMeta({ model: "fts-only" }),
+        }),
+      ),
+    ).toEqual({ status: "valid" });
+  });
+
+  it("marks identity dirty when meta is missing the FTS text format (legacy index)", () => {
+    // Regression for #94102: pre-upgrade indexes wrote chunk body only to chunks_fts.text
+    // and would otherwise pass identity checks, leaving filename queries broken on upgrade.
+    const legacyMeta = createMeta();
+    delete legacyMeta.ftsTextFormat;
+    const state = resolveMemoryIndexIdentityState(createIdentityParams({ meta: legacyMeta }));
+    expect(state.status).toBe("mismatched");
+    if (state.status === "mismatched") {
+      expect(state.reason).toContain("FTS text format");
+    }
+  });
+
+  it("marks identity dirty when the configured FTS text format differs from meta", () => {
+    expect(
+      isMemoryIndexIdentityDirty(
+        createIdentityParams({
+          meta: createMeta({ ftsTextFormat: "future-format-v2" }),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats indexes that record the current FTS text format as valid", () => {
+    expect(
+      resolveMemoryIndexIdentityState(
+        createIdentityParams({
+          meta: createMeta({ ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT }),
         }),
       ),
     ).toEqual({ status: "valid" });

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -2,12 +2,13 @@
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it } from "vitest";
 import {
+  isMemoryIndexFtsTextFormatOnlyMismatch,
+  isMemoryIndexIdentityDirty,
   MEMORY_FTS_TEXT_FORMAT_CURRENT,
   resolveConfiguredScopeHash,
   resolveConfiguredSourcesForMeta,
-  resolveMemoryIndexProviderIdentities,
   resolveMemoryIndexIdentityState,
-  isMemoryIndexIdentityDirty,
+  resolveMemoryIndexProviderIdentities,
   type MemoryIndexMeta,
 } from "./manager-reindex-state.js";
 
@@ -343,5 +344,25 @@ describe("memory reindex state", () => {
         }),
       ),
     ).toEqual({ status: "valid" });
+  });
+
+  it("flags FTS-text-format-only mismatches as self-heal candidates", () => {
+    const legacyMeta = createMeta();
+    delete legacyMeta.ftsTextFormat;
+    expect(isMemoryIndexFtsTextFormatOnlyMismatch(createIdentityParams({ meta: legacyMeta }))).toBe(
+      true,
+    );
+  });
+
+  it("does not self-heal when provider/model identity also changed", () => {
+    const legacyMeta = createMeta({ model: "mock-embed-v0" });
+    delete legacyMeta.ftsTextFormat;
+    expect(isMemoryIndexFtsTextFormatOnlyMismatch(createIdentityParams({ meta: legacyMeta }))).toBe(
+      false,
+    );
+  });
+
+  it("does not self-heal when identity is fully valid", () => {
+    expect(isMemoryIndexFtsTextFormatOnlyMismatch(createIdentityParams())).toBe(false);
   });
 });

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -150,6 +150,42 @@ export function isMemoryIndexIdentityDirty(params: {
   return resolveMemoryIndexIdentityState(params).status !== "valid";
 }
 
+// Returns true when meta is mismatched against the configured identity *only* because
+// of the persisted FTS text-format payload version. Provider/model/scope/tokenizer
+// mismatches still return false so callers preserve the existing pause-and-wait
+// behavior for semantically incompatible indexes; only the FTS payload format is
+// safe to self-heal automatically because rebuilding it never throws away embeddings
+// or user data — it just re-emits chunks_fts.text in the current shape.
+export function isMemoryIndexFtsTextFormatOnlyMismatch(params: {
+  meta: MemoryIndexMeta | null;
+  provider: { id: string; model: string } | null;
+  providerKey?: string;
+  providerAliases?: Array<Pick<MemoryIndexProviderIdentity, "model" | "providerKey">>;
+  providerKeyKnown?: boolean;
+  configuredSources: MemorySource[];
+  configuredScopeHash: string;
+  chunkTokens: number;
+  chunkOverlap: number;
+  vectorReady: boolean;
+  hasIndexedChunks?: boolean;
+  ftsTokenizer: string;
+  ftsTextFormat?: string;
+}): boolean {
+  if (!params.meta) {
+    return false;
+  }
+  if (resolveMemoryIndexIdentityState(params).status !== "mismatched") {
+    return false;
+  }
+  // Re-run identity with the configured FTS text format pinned to whatever the index
+  // already has. If everything else is fine, only ftsTextFormat differs.
+  const probe = resolveMemoryIndexIdentityState({
+    ...params,
+    ftsTextFormat: params.meta.ftsTextFormat ?? "legacy-body-only",
+  });
+  return probe.status === "valid";
+}
+
 export function resolveMemoryIndexIdentityState(params: {
   meta: MemoryIndexMeta | null;
   provider: { id: string; model: string } | null;

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -5,6 +5,13 @@ import {
   type MemorySource,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
+// Stored FTS payload format identity. Bump when chunks_fts.text semantics change so
+// existing clean indexes from older builds get rebuilt instead of silently serving
+// stale rows. Current value: chunk text is prefixed with `${entry.path}\n` so filename/
+// date tokens participate in MATCH ranking; older indexes wrote chunk body only.
+export const MEMORY_FTS_TEXT_FORMAT_PATH_PREFIXED_V1 = "path-prefixed-v1";
+export const MEMORY_FTS_TEXT_FORMAT_CURRENT = MEMORY_FTS_TEXT_FORMAT_PATH_PREFIXED_V1;
+
 export type MemoryIndexMeta = {
   model: string;
   provider: string;
@@ -15,6 +22,7 @@ export type MemoryIndexMeta = {
   chunkOverlap: number;
   vectorDims?: number;
   ftsTokenizer?: string;
+  ftsTextFormat?: string;
 };
 
 export type MemoryIndexIdentityState =
@@ -137,6 +145,7 @@ export function isMemoryIndexIdentityDirty(params: {
   vectorReady: boolean;
   hasIndexedChunks?: boolean;
   ftsTokenizer: string;
+  ftsTextFormat?: string;
 }): boolean {
   return resolveMemoryIndexIdentityState(params).status !== "valid";
 }
@@ -154,6 +163,7 @@ export function resolveMemoryIndexIdentityState(params: {
   vectorReady: boolean;
   hasIndexedChunks?: boolean;
   ftsTokenizer: string;
+  ftsTextFormat?: string;
 }): MemoryIndexIdentityState {
   const { meta } = params;
   if (!meta) {
@@ -219,6 +229,16 @@ export function resolveMemoryIndexIdentityState(params: {
     return {
       status: "mismatched",
       reason: "index FTS tokenizer changed",
+    };
+  }
+  // Old indexes wrote chunk body only into chunks_fts.text; the current format prefixes
+  // the path so filename/date tokens MATCH. Without rebuilding, filename queries on
+  // upgraded clean indexes would still return textScore: 0 — see issue #94102.
+  const expectedFtsTextFormat = params.ftsTextFormat ?? MEMORY_FTS_TEXT_FORMAT_CURRENT;
+  if ((meta.ftsTextFormat ?? "legacy-body-only") !== expectedFtsTextFormat) {
+    return {
+      status: "mismatched",
+      reason: "index FTS text format changed",
     };
   }
   return { status: "valid" };

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -64,7 +64,7 @@ function insertKeywordFixtureWithPathInFtsText(
   },
 ): void {
   db.prepare(
-    "INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
   ).run(
     params.id,
     params.path,
@@ -78,7 +78,7 @@ function insertKeywordFixtureWithPathInFtsText(
     Date.now(),
   );
   db.prepare(
-    "INSERT INTO chunks_fts (text, id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO memory_index_chunks_fts (text, id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?)",
   ).run(
     `${params.path}\n${params.text}`,
     params.id,
@@ -1113,9 +1113,9 @@ describe("searchKeyword filename token ranking (issue #94102)", () => {
     const db = new DatabaseSync(":memory:");
     const schema = ensureMemoryIndexSchema({
       db,
-      embeddingCacheTable: "embedding_cache",
+      embeddingCacheTable: "memory_embedding_cache",
       cacheEnabled: false,
-      ftsTable: "chunks_fts",
+      ftsTable: "memory_index_chunks_fts",
       ftsEnabled: true,
     });
     if (!schema.ftsAvailable) {
@@ -1145,7 +1145,7 @@ describe("searchKeyword filename token ranking (issue #94102)", () => {
 
       const results = await searchKeyword({
         db,
-        ftsTable: "chunks_fts",
+        ftsTable: "memory_index_chunks_fts",
         query: "2026-06-17-1649",
         limit: 3,
         snippetMaxChars: 200,

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -1157,6 +1157,12 @@ describe("searchKeyword filename token ranking (issue #94102)", () => {
 
       expect(results[0]?.path).toBe("memory/2026-06-17-1649.md");
       expect(results[0]?.textScore).toBeGreaterThan(0);
+      // The indexed FTS text is path-prefixed for matching, but the returned
+      // snippet must show the chunk body, not the leading path line.
+      expect(results[0]?.snippet).toBe(
+        "Token has been expired or revoked Google OAuth Testing mode",
+      );
+      expect(results[0]?.snippet.startsWith("memory/")).toBe(false);
     } finally {
       db.close();
     }

--- a/extensions/memory-core/src/memory/manager-search.test.ts
+++ b/extensions/memory-core/src/memory/manager-search.test.ts
@@ -51,6 +51,45 @@ function insertKeywordFixture(
   );
 }
 
+function insertKeywordFixtureWithPathInFtsText(
+  db: DatabaseSync,
+  params: {
+    text: string;
+    id: string;
+    path: string;
+    source: "memory" | "sessions";
+    model: string;
+    startLine: number;
+    endLine: number;
+  },
+): void {
+  db.prepare(
+    "INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+  ).run(
+    params.id,
+    params.path,
+    params.source,
+    params.startLine,
+    params.endLine,
+    `${params.id}:hash`,
+    params.model,
+    params.text,
+    JSON.stringify([0]),
+    Date.now(),
+  );
+  db.prepare(
+    "INSERT INTO chunks_fts (text, id, path, source, model, start_line, end_line) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(
+    `${params.path}\n${params.text}`,
+    params.id,
+    params.path,
+    params.source,
+    params.model,
+    params.startLine,
+    params.endLine,
+  );
+}
+
 describe("searchKeyword trigram fallback", () => {
   const { DatabaseSync } = requireNodeSqlite();
 
@@ -1061,6 +1100,63 @@ describe("searchVector sqlite-vec KNN", () => {
       });
 
       expect(results.map((row) => row.id)).toEqual(["target-1", "alias-1"]);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("searchKeyword filename token ranking (issue #94102)", () => {
+  const { DatabaseSync } = requireNodeSqlite();
+
+  it("matches date-like filename stems when path is included in FTS indexed text", async () => {
+    const db = new DatabaseSync(":memory:");
+    const schema = ensureMemoryIndexSchema({
+      db,
+      embeddingCacheTable: "embedding_cache",
+      cacheEnabled: false,
+      ftsTable: "chunks_fts",
+      ftsEnabled: true,
+    });
+    if (!schema.ftsAvailable) {
+      db.close();
+      return;
+    }
+
+    try {
+      insertKeywordFixtureWithPathInFtsText(db, {
+        id: "chunk-target",
+        path: "memory/2026-06-17-1649.md",
+        text: "Token has been expired or revoked Google OAuth Testing mode",
+        source: "memory",
+        model: "gemini-embedding-001",
+        startLine: 1,
+        endLine: 36,
+      });
+      insertKeywordFixtureWithPathInFtsText(db, {
+        id: "chunk-nearby",
+        path: "memory/2026-06-17-1701.md",
+        text: "all important calendars PM Recurring Tasks Todoist highest-rigor",
+        source: "memory",
+        model: "gemini-embedding-001",
+        startLine: 23,
+        endLine: 30,
+      });
+
+      const results = await searchKeyword({
+        db,
+        ftsTable: "chunks_fts",
+        query: "2026-06-17-1649",
+        limit: 3,
+        snippetMaxChars: 200,
+        sourceFilter: { sql: "", params: [] },
+        buildFtsQuery,
+        bm25RankToScore,
+        boostFallbackRanking: true,
+      });
+
+      expect(results[0]?.path).toBe("memory/2026-06-17-1649.md");
+      expect(results[0]?.textScore).toBeGreaterThan(0);
     } finally {
       db.close();
     }

--- a/extensions/memory-core/src/memory/manager-search.ts
+++ b/extensions/memory-core/src/memory/manager-search.ts
@@ -414,12 +414,19 @@ export async function searchKeyword(params: {
   }
 
   return rows.map((row) => {
+    // The FTS `text` column is prefixed with the chunk path so filename/date
+    // tokens participate in MATCH ranking (see manager-embedding-ops.ts). Strip
+    // that prefix back off for the snippet and lexical scoring so excerpts and
+    // density scoring use the chunk body, not the path line. Older indexes
+    // written without the prefix are unaffected by the guarded slice.
+    const pathPrefix = `${row.path}\n`;
+    const body = row.text.startsWith(pathPrefix) ? row.text.slice(pathPrefix.length) : row.text;
     const textScore = usedMatch ? params.bm25RankToScore(row.rank) : 1;
     const score = params.boostFallbackRanking
       ? scoreFallbackKeywordResult({
           query: params.query,
           path: row.path,
-          text: row.text,
+          text: body,
           ftsScore: textScore,
         })
       : textScore;
@@ -430,7 +437,7 @@ export async function searchKeyword(params: {
       endLine: row.end_line,
       score,
       textScore,
-      snippet: truncateUtf16Safe(row.text, params.snippetMaxChars),
+      snippet: truncateUtf16Safe(body, params.snippetMaxChars),
       source: row.source,
     };
   });

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -67,6 +67,7 @@ import {
 } from "./manager-provider-state.js";
 import { acquireMemoryReindexLock, type MemoryReindexLockHandle } from "./manager-reindex-lock.js";
 import {
+  MEMORY_FTS_TEXT_FORMAT_CURRENT,
   resolveConfiguredScopeHash,
   resolveConfiguredSourcesForMeta,
   resolveMemoryIndexProviderIdentities,
@@ -585,6 +586,7 @@ export abstract class MemoryManagerSyncOps {
           ? Boolean(params.hasIndexedChunks)
           : this.hasIndexedChunks(),
       ftsTokenizer: this.settings.store.fts.tokenizer,
+      ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT,
     });
   }
 
@@ -2229,6 +2231,7 @@ export abstract class MemoryManagerSyncOps {
       vectorReady,
       hasIndexedChunks: this.hasIndexedChunks(),
       ftsTokenizer: this.settings.store.fts.tokenizer,
+      ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT,
     });
     const hasIndexedChunks = this.hasIndexedChunks();
     const needsInitialIndex = indexIdentity.status !== "valid" && !hasIndexedChunks;
@@ -2543,6 +2546,7 @@ export abstract class MemoryManagerSyncOps {
         chunkTokens: this.settings.chunking.tokens,
         chunkOverlap: this.settings.chunking.overlap,
         ftsTokenizer: this.settings.store.fts.tokenizer,
+        ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT,
       };
       if (this.vector.available && this.vector.dims) {
         nextMeta.vectorDims = this.vector.dims;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -68,6 +68,7 @@ import {
 import { acquireMemoryReindexLock, type MemoryReindexLockHandle } from "./manager-reindex-lock.js";
 import {
   MEMORY_FTS_TEXT_FORMAT_CURRENT,
+  isMemoryIndexFtsTextFormatOnlyMismatch,
   resolveConfiguredScopeHash,
   resolveConfiguredSourcesForMeta,
   resolveMemoryIndexProviderIdentities,
@@ -2258,6 +2259,34 @@ export abstract class MemoryManagerSyncOps {
       indexIdentity.status === "missing" && !hasTargetSessionFiles && canRebuildMissingIdentity;
     const needsExplicitIdentityReindex =
       params?.reason === "cli" && indexIdentity.status !== "valid" && !hasTargetSessionFiles;
+    // FTS payload format mismatches (e.g. legacy body-only chunks_fts.text rows from
+    // before #94135) are safe to self-heal on any sync path: rebuilding FTS rows never
+    // discards embeddings or chunk content. Provider/model/scope mismatches stay
+    // gated on cli/force/missing identity so we do not silently invalidate a user's
+    // semantically incompatible index.
+    const needsFtsTextFormatSelfHeal =
+      isMemoryIndexFtsTextFormatOnlyMismatch({
+        meta,
+        provider: this.provider ? { id: this.provider.id, model: this.provider.model } : null,
+        providerKey: this.providerKey ?? undefined,
+        providerAliases: this.resolveProviderIndexIdentities().slice(1),
+        configuredSources: resolveConfiguredSourcesForMeta(this.sources),
+        configuredScopeHash: resolveConfiguredScopeHash({
+          workspaceDir: this.workspaceDir,
+          extraPaths: this.settings.extraPaths,
+          multimodal: {
+            enabled: this.settings.multimodal.enabled,
+            modalities: this.settings.multimodal.modalities,
+            maxFileBytes: this.settings.multimodal.maxFileBytes,
+          },
+        }),
+        chunkTokens: this.settings.chunking.tokens,
+        chunkOverlap: this.settings.chunking.overlap,
+        vectorReady,
+        hasIndexedChunks,
+        ftsTokenizer: this.settings.store.fts.tokenizer,
+        ftsTextFormat: MEMORY_FTS_TEXT_FORMAT_CURRENT,
+      }) && !hasTargetSessionFiles;
     const canRunRetryFullReindex =
       indexIdentity.status !== "missing" || needsInitialIndex || canRebuildMissingIdentity;
     const needsFullReindex =
@@ -2265,6 +2294,7 @@ export abstract class MemoryManagerSyncOps {
       needsInitialIndex ||
       needsMissingIdentityReindex ||
       needsExplicitIdentityReindex ||
+      needsFtsTextFormatSelfHeal ||
       (this.memoryFullRetryDirty && canRunRetryFullReindex) ||
       (this.sessionsFullRetryDirty && indexIdentity.status !== "valid" && canRunRetryFullReindex);
     const needsFullSessionReindex = needsFullReindex || this.sessionsFullRetryDirty;

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -65,7 +65,7 @@ describe("memory manager FTS-only reindex", () => {
   });
 
   async function createManager(
-    params: { provider?: string; vectorEnabled?: boolean } = {},
+    params: { provider?: string; vectorEnabled?: boolean; onSearch?: boolean } = {},
   ): Promise<MemoryIndexManager> {
     const store =
       params.vectorEnabled === undefined
@@ -83,7 +83,11 @@ describe("memory manager FTS-only reindex", () => {
             model: "",
             store,
             cache: { enabled: false },
-            sync: { watch: false, onSessionStart: false, onSearch: false },
+            sync: {
+              watch: false,
+              onSessionStart: false,
+              onSearch: params.onSearch ?? false,
+            },
           },
         },
         list: [{ id: "main", default: true }],
@@ -279,6 +283,82 @@ describe("memory manager FTS-only reindex", () => {
       const ftsHit = verifyDb
         .prepare(`SELECT COUNT(*) AS c FROM chunks_fts WHERE chunks_fts MATCH ?`)
         .get("1649") as { c: number } | undefined;
+      expect(ftsHit?.c ?? 0).toBeGreaterThan(0);
+    } finally {
+      verifyDb.close();
+    }
+  });
+
+  it("self-heals legacy FTS-only indexes during shared memory_search (#94102)", async () => {
+    // Same upgrade scenario as the prior test, but exercises the path real users hit:
+    // they call manager.search()/memory_search rather than running the CLI sync. The
+    // self-heal trigger has to fire on the default `reason: "search"` path too, not
+    // just `reason: "cli"`.
+    const filenameStem = "2026-06-17-1701";
+    const memoryFilePath = path.join(workspaceDir, "memory", `${filenameStem}.md`);
+    await fs.writeFile(
+      memoryFilePath,
+      "Token has been expired or revoked Google OAuth Testing mode\n",
+    );
+
+    let memoryManager = await createManager({
+      provider: "none",
+      vectorEnabled: false,
+      onSearch: true,
+    });
+    await memoryManager.sync({ force: true });
+
+    const downgradeDb = new DatabaseSync(indexPath);
+    try {
+      const metaRow = downgradeDb
+        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .get() as { value: string } | undefined;
+      const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
+      delete meta.ftsTextFormat;
+      downgradeDb
+        .prepare(`UPDATE meta SET value = ? WHERE key = 'memory_index_meta_v1'`)
+        .run(JSON.stringify(meta));
+      const ftsRows = downgradeDb.prepare(`SELECT id, text FROM chunks_fts`).all() as Array<{
+        id: string;
+        text: string;
+      }>;
+      const stripPrefix = downgradeDb.prepare(`UPDATE chunks_fts SET text = ? WHERE id = ?`);
+      const prefix = `memory/${filenameStem}.md\n`;
+      for (const row of ftsRows) {
+        const legacyText = row.text.startsWith(prefix) ? row.text.slice(prefix.length) : row.text;
+        stripPrefix.run(legacyText, row.id);
+      }
+    } finally {
+      downgradeDb.close();
+    }
+
+    await memoryManager.close();
+    manager = null;
+
+    memoryManager = await createManager({
+      provider: "none",
+      vectorEnabled: false,
+      onSearch: true,
+    });
+    expect(memoryManager.status().custom?.indexIdentity).toMatchObject({
+      status: "mismatched",
+    });
+
+    // The user-facing entry point — no force, no reason="cli" — must self-heal.
+    await memoryManager.search(filenameStem);
+
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+    const verifyDb = new DatabaseSync(indexPath);
+    try {
+      const metaRow = verifyDb
+        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .get() as { value: string } | undefined;
+      const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
+      expect(meta.ftsTextFormat).toBe("path-prefixed-v1");
+      const ftsHit = verifyDb
+        .prepare(`SELECT COUNT(*) AS c FROM chunks_fts WHERE chunks_fts MATCH ?`)
+        .get("1701") as { c: number } | undefined;
       expect(ftsHit?.c ?? 0).toBeGreaterThan(0);
     } finally {
       verifyDb.close();

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -211,4 +211,77 @@ describe("memory manager FTS-only reindex", () => {
     );
     expect(memoryManager.status().provider).toBe("openai");
   });
+
+  it("rebuilds legacy FTS-only indexes that lack the path-prefixed text format (#94102)", async () => {
+    // Reproduce a clean pre-upgrade FTS-only index: build it once, then drop the
+    // ftsTextFormat marker and replace each FTS row with the legacy body-only payload.
+    // Without the identity gate the next non-forced sync would skip unchanged file
+    // hashes and leave filename/date queries broken; the gate must mark the index
+    // dirty so the rebuild restores path tokens in chunks_fts.text.
+    const filenameStem = "2026-06-17-1649";
+    const memoryFilePath = path.join(workspaceDir, "memory", `${filenameStem}.md`);
+    await fs.writeFile(
+      memoryFilePath,
+      "Legacy memory entry body that does not mention the date stem.",
+    );
+
+    let memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+    await memoryManager.sync({ force: true });
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+    const downgradeDb = new DatabaseSync(indexPath);
+    try {
+      const metaRow = downgradeDb
+        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .get() as { value: string } | undefined;
+      const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
+      delete meta.ftsTextFormat;
+      downgradeDb
+        .prepare(`UPDATE meta SET value = ? WHERE key = 'memory_index_meta_v1'`)
+        .run(JSON.stringify(meta));
+      const ftsRows = downgradeDb.prepare(`SELECT id, text FROM chunks_fts`).all() as Array<{
+        id: string;
+        text: string;
+      }>;
+      const stripPrefix = downgradeDb.prepare(`UPDATE chunks_fts SET text = ? WHERE id = ?`);
+      const prefix = `memory/${filenameStem}.md\n`;
+      for (const row of ftsRows) {
+        const legacyText = row.text.startsWith(prefix) ? row.text.slice(prefix.length) : row.text;
+        stripPrefix.run(legacyText, row.id);
+      }
+    } finally {
+      downgradeDb.close();
+    }
+
+    await memoryManager.close();
+    manager = null;
+
+    memoryManager = await createManager({ provider: "none", vectorEnabled: false });
+    expect(memoryManager.status().custom?.indexIdentity).toMatchObject({
+      status: "mismatched",
+    });
+
+    // Plain sync with reason "cli" (the path `openclaw memory search ...` takes) — the
+    // identity gate, not a force flag, must trigger the rebuild on upgrade.
+    await memoryManager.sync({ reason: "cli" });
+
+    expect(memoryManager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+
+    const verifyDb = new DatabaseSync(indexPath);
+    try {
+      const metaRow = verifyDb
+        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .get() as { value: string } | undefined;
+      const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
+      expect(meta.ftsTextFormat).toBe("path-prefixed-v1");
+      // FTS5 unicode61 splits on hyphens; query each token individually to confirm
+      // the filename made it into chunks_fts.text after the rebuild.
+      const ftsHit = verifyDb
+        .prepare(`SELECT COUNT(*) AS c FROM chunks_fts WHERE chunks_fts MATCH ?`)
+        .get("1649") as { c: number } | undefined;
+      expect(ftsHit?.c ?? 0).toBeGreaterThan(0);
+    } finally {
+      verifyDb.close();
+    }
+  });
 });

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -236,18 +236,22 @@ describe("memory manager FTS-only reindex", () => {
     const downgradeDb = new DatabaseSync(indexPath);
     try {
       const metaRow = downgradeDb
-        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .prepare(`SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'`)
         .get() as { value: string } | undefined;
       const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
       delete meta.ftsTextFormat;
       downgradeDb
-        .prepare(`UPDATE meta SET value = ? WHERE key = 'memory_index_meta_v1'`)
+        .prepare(`UPDATE memory_index_meta SET value = ? WHERE key = 'memory_index_meta_v1'`)
         .run(JSON.stringify(meta));
-      const ftsRows = downgradeDb.prepare(`SELECT id, text FROM chunks_fts`).all() as Array<{
+      const ftsRows = downgradeDb
+        .prepare(`SELECT id, text FROM memory_index_chunks_fts`)
+        .all() as Array<{
         id: string;
         text: string;
       }>;
-      const stripPrefix = downgradeDb.prepare(`UPDATE chunks_fts SET text = ? WHERE id = ?`);
+      const stripPrefix = downgradeDb.prepare(
+        `UPDATE memory_index_chunks_fts SET text = ? WHERE id = ?`,
+      );
       const prefix = `memory/${filenameStem}.md\n`;
       for (const row of ftsRows) {
         const legacyText = row.text.startsWith(prefix) ? row.text.slice(prefix.length) : row.text;
@@ -274,14 +278,16 @@ describe("memory manager FTS-only reindex", () => {
     const verifyDb = new DatabaseSync(indexPath);
     try {
       const metaRow = verifyDb
-        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .prepare(`SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'`)
         .get() as { value: string } | undefined;
       const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
       expect(meta.ftsTextFormat).toBe("path-prefixed-v1");
       // FTS5 unicode61 splits on hyphens; query each token individually to confirm
       // the filename made it into chunks_fts.text after the rebuild.
       const ftsHit = verifyDb
-        .prepare(`SELECT COUNT(*) AS c FROM chunks_fts WHERE chunks_fts MATCH ?`)
+        .prepare(
+          `SELECT COUNT(*) AS c FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?`,
+        )
         .get("1649") as { c: number } | undefined;
       expect(ftsHit?.c ?? 0).toBeGreaterThan(0);
     } finally {
@@ -311,18 +317,22 @@ describe("memory manager FTS-only reindex", () => {
     const downgradeDb = new DatabaseSync(indexPath);
     try {
       const metaRow = downgradeDb
-        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .prepare(`SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'`)
         .get() as { value: string } | undefined;
       const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
       delete meta.ftsTextFormat;
       downgradeDb
-        .prepare(`UPDATE meta SET value = ? WHERE key = 'memory_index_meta_v1'`)
+        .prepare(`UPDATE memory_index_meta SET value = ? WHERE key = 'memory_index_meta_v1'`)
         .run(JSON.stringify(meta));
-      const ftsRows = downgradeDb.prepare(`SELECT id, text FROM chunks_fts`).all() as Array<{
+      const ftsRows = downgradeDb
+        .prepare(`SELECT id, text FROM memory_index_chunks_fts`)
+        .all() as Array<{
         id: string;
         text: string;
       }>;
-      const stripPrefix = downgradeDb.prepare(`UPDATE chunks_fts SET text = ? WHERE id = ?`);
+      const stripPrefix = downgradeDb.prepare(
+        `UPDATE memory_index_chunks_fts SET text = ? WHERE id = ?`,
+      );
       const prefix = `memory/${filenameStem}.md\n`;
       for (const row of ftsRows) {
         const legacyText = row.text.startsWith(prefix) ? row.text.slice(prefix.length) : row.text;
@@ -352,12 +362,14 @@ describe("memory manager FTS-only reindex", () => {
     const verifyDb = new DatabaseSync(indexPath);
     try {
       const metaRow = verifyDb
-        .prepare(`SELECT value FROM meta WHERE key = 'memory_index_meta_v1'`)
+        .prepare(`SELECT value FROM memory_index_meta WHERE key = 'memory_index_meta_v1'`)
         .get() as { value: string } | undefined;
       const meta = JSON.parse(metaRow?.value ?? "{}") as Record<string, unknown>;
       expect(meta.ftsTextFormat).toBe("path-prefixed-v1");
       const ftsHit = verifyDb
-        .prepare(`SELECT COUNT(*) AS c FROM chunks_fts WHERE chunks_fts MATCH ?`)
+        .prepare(
+          `SELECT COUNT(*) AS c FROM memory_index_chunks_fts WHERE memory_index_chunks_fts MATCH ?`,
+        )
         .get("1701") as { c: number } | undefined;
       expect(ftsHit?.c ?? 0).toBeGreaterThan(0);
     } finally {


### PR DESCRIPTION
## What Problem This Solves
- `memory_search` FTS indexed only chunk body text. Queries for date-like filename stems (e.g. `2026-06-17-1649`) returned unrelated files with `textScore: 0` even when the target file was indexed and content search worked.
- Fix: Include the memory file path in the FTS `text` column at index time (`${entry.path}\n${chunk.text}`) so filename/date tokens participate in hybrid keyword ranking. Keyword-search snippets and lexical density scoring strip the indexed path prefix back off.
- Scope: Memory-core FTS index/write path and keyword-search snippet extraction. Vector embeddings and chunk body text unchanged. Existing indexes self-heal via format versioning on `memory_search`.

## Evidence

**Before (negative control — `git checkout origin/main -- extensions/memory-core/src/memory/`):**
```
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-search.test.ts --run
 Test Files  1 passed (1)
      Tests  22 passed (22)     ← filename ranking test does not exist on main
```

**After (fix applied):**
```
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-search.test.ts --run
 Test Files  1 passed (1)
      Tests  23 passed (23)     ← new filename ranking test passes
```

**All memory-core tests (3 files):**
```
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-search.test.ts extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts extensions/memory-core/src/memory/manager-reindex-state.test.ts --run
 Test Files  3 passed (3)
      Tests  53 passed (53)
```

**Behavior probe — filename token query:**
```
$ node behavior-probe-memory-filename.mjs
{
  "top": [
    {
      "path": "memory/2026-06-17-1649.md",
      "textScore": 0.000003905989965114915,
      "score": 1
    }
  ]
}
```

**Snippet cleanliness guard** (snippet is chunk body, not the path line):
```
✓ matches date-like filename stems when path is included in FTS indexed text
  expect(results[0].snippet).toBe("Token has been expired or revoked...")
  expect(results[0].snippet.startsWith("memory/")).toBe(false)
```