### PR TITLE
fix(codex): backoff startup connection-close retries and surface exhaustion (#83959) [AI-assisted]

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startCodexAttemptThread } from "./attempt-startup.js";
 import { CodexAppServerClient } from "./client.js";
 import { type CodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { threadStartResult } from "./run-attempt-test-harness.js";
 import { testCodexAppServerBindingStore } from "./session-binding.test-helpers.js";
 import {
   clearSharedCodexAppServerClient,
@@ -390,5 +391,89 @@ describe("startCodexAttemptThread", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("plugin/list timed out");
     expect(harness.process.stdin.destroyed).toBe(true);
+  });
+
+  it("retries startup across transient connection-close failures with a backoff (#83959)", async () => {
+    // The app-server connection closes during startup on the first few attempts
+    // while the replacement process is still warming up. Startup must survive
+    // those transient closes (with a bounded backoff between attempts) instead
+    // of exhausting the retry budget before the server is ready.
+    const closeFailuresBeforeSuccess = 4;
+    let factoryInvocations = 0;
+    const backoffDelays: number[] = [];
+    const backoffModule = await import("openclaw/plugin-sdk/runtime-env");
+    const sleepSpy = vi
+      .spyOn(backoffModule, "sleepWithAbort")
+      .mockImplementation(async (ms: number) => {
+        backoffDelays.push(ms);
+      });
+
+    const { harness, run } = startThreadWithHarness(30_000, new AbortController().signal, {
+      attemptClientFactory:
+        () =>
+        async (...args) => {
+          factoryInvocations += 1;
+          if (factoryInvocations <= closeFailuresBeforeSuccess) {
+            throw new Error("codex app-server client is closed");
+          }
+          // On the recovering attempt, delegate to the default leased factory so
+          // the shared-client + initialize handshake path matches a real startup.
+          return getLeasedSharedCodexAppServerClient(...args);
+        },
+    });
+
+    const settled = run.then(
+      (result) => result,
+      (error: unknown) => error,
+    );
+    // The successful attempt still needs to answer the initialize handshake.
+    await answerInitialize(harness);
+    const threadStart = await waitForThreadStart(harness);
+    harness.send({ id: threadStart.id, result: threadStartResult("recovered-thread") });
+
+    const result = await settled;
+    expect(result).not.toBeInstanceOf(Error);
+    expect(factoryInvocations).toBe(closeFailuresBeforeSuccess + 1);
+    // A backoff was awaited before every retry (one less than the number of
+    // failed attempts, since the last failure is followed by the successful attempt).
+    expect(backoffDelays.length).toBe(closeFailuresBeforeSuccess);
+    // Backoff is bounded and non-negative.
+    for (const delay of backoffDelays) {
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThanOrEqual(4_000);
+    }
+    sleepSpy.mockRestore();
+  });
+
+  it("surfaces a distinct startup-exhausted error when connection-close persists (#83959)", async () => {
+    // When the app-server connection keeps closing through the entire bounded
+    // retry window, startup must fail with a distinguishable exhaustion error
+    // (not the raw "client is closed" message) so callers can tell a startup
+    // lifecycle failure apart from a mid-turn client close.
+    const backoffModule = await import("openclaw/plugin-sdk/runtime-env");
+    const sleepSpy = vi.spyOn(backoffModule, "sleepWithAbort").mockImplementation(async () => {});
+
+    let factoryInvocations = 0;
+    const { run } = startThreadWithHarness(30_000, new AbortController().signal, {
+      attemptClientFactory: () => async () => {
+        factoryInvocations += 1;
+        throw new Error("codex app-server client is closed");
+      },
+    });
+
+    const error = await run.then(
+      () => undefined,
+      (err: unknown) => err as Error,
+    );
+    expect(error).toBeInstanceOf(Error);
+    // Distinct exhaustion marker, not the raw connection-closed message.
+    expect(error?.message).not.toBe("codex app-server client is closed");
+    expect(error?.message.toLowerCase()).toContain("startup");
+    expect(error?.message.toLowerCase()).toContain("exhaust");
+    // The original connection-closed cause is preserved for diagnostics.
+    expect((error as { cause?: unknown })?.cause).toBeInstanceOf(Error);
+    // Bounded: the loop did not retry forever.
+    expect(factoryInvocations).toBeLessThanOrEqual(8);
+    sleepSpy.mockRestore();
   });
 });

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -10,6 +10,11 @@ import {
   type EmbeddedRunAttemptParams,
   type resolveSandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  computeBackoff,
+  sleepWithAbort,
+  type BackoffPolicy,
+} from "openclaw/plugin-sdk/runtime-env";
 import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -75,7 +80,40 @@ import {
 } from "./turn-router.js";
 import type { CodexNativeWebSearchSupport } from "./web-search.js";
 
-const CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS = 3;
+const CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS = 5;
+
+/**
+ * Bounded backoff between startup connection-close retries. The replacement
+ * app-server process needs a short warm-up window to bind and become ready
+ * before the next startup attempt re-acquires the shared client; retrying
+ * immediately re-enters the same failing window and exhausts the budget
+ * before the server is viable. See issue #83959.
+ */
+const CODEX_APP_SERVER_STARTUP_RETRY_BACKOFF: BackoffPolicy = {
+  initialMs: 500,
+  maxMs: 4_000,
+  factor: 2,
+  jitter: 0.2,
+};
+
+/**
+ * Terminal error raised when the Codex app-server connection keeps closing
+ * throughout the bounded startup retry window. Carries the original
+ * connection-closed error as `cause` so callers can distinguish a startup
+ * lifecycle exhaustion from a mid-turn client close. See issue #83959.
+ */
+export class CodexAppServerStartupExhaustedError extends Error {
+  constructor(
+    public readonly attempts: number,
+    cause: unknown,
+  ) {
+    super(
+      `codex app-server startup exhausted after ${attempts} connection-close retries`,
+      cause !== undefined ? { cause } : undefined,
+    );
+    this.name = "CodexAppServerStartupExhaustedError";
+  }
+}
 
 type CodexSandboxContext = Awaited<ReturnType<typeof resolveSandboxContext>>;
 
@@ -509,18 +547,25 @@ export async function startCodexAttemptThread(params: {
                   error: formatErrorMessage(error),
                 },
               );
-              throw error;
+              throw new CodexAppServerStartupExhaustedError(attempt, error);
             }
+            const backoffMs = computeBackoff(CODEX_APP_SERVER_STARTUP_RETRY_BACKOFF, attempt);
             embeddedAgentLog.warn(
               "codex app-server connection closed during startup; restarting app-server and retrying",
               {
                 attempt,
                 nextAttempt: attempt + 1,
                 maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
+                backoffMs,
                 clearedSharedClient,
                 error: formatErrorMessage(error),
               },
             );
+            // Give the replacement app-server process a bounded warm-up window
+            // before re-acquiring the shared client, so the next attempt does
+            // not re-enter the same failing window. Abortable so a cancelled
+            // run does not stall on the backoff. See issue #83959.
+            await sleepWithAbort(backoffMs, params.signal);
           }
         }
         throw new Error("codex app-server startup retry loop exited unexpectedly");


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## Summary

- **Problem:** When the Codex app-server connection closes during startup, `startCodexAttemptThread` cleared the shared client and retried **immediately** — before the replacement app-server process had bound/become ready — under a tight 3-attempt budget. All retries landed in the same failing window and exhausted, so a scheduled/background turn failed even though the Codex route became viable moments later. Cron automation reported job failure with no task-level problem. (Issue #83959)
- **Why now:** P1 for background/cron Codex turns; the issue's own local mitigation confirmed the direction (raise the startup-close retry budget + add a bounded backoff).
- **Intended outcome:** Startup tolerates a short replacement-server warm-up window before declaring failure, and when it does give up it says so distinctly instead of surfacing a misleading "client is closed".
- **Out of scope:** The separate per-run replay retry gate in `embedded-agent-runner/run.ts` (already correct, untouched) and the shared-client eviction work tracked under #79495.
- **Success:** A transient startup connection-close no longer fails the turn when the server recovers within the bounded window; persistent closes fail with a distinguishable error.
- **Reviewer focus:** The retry-loop change in `attempt-startup.ts` (budget 3→5, added `computeBackoff`+`sleepWithAbort` backoff, new `CodexAppServerStartupExhaustedError`) and the two new regression tests.

## Linked context

Closes #83959

Related #79495 (shared Codex app-server client eviction across agents — broader, separate).

Was this requested by a maintainer or owner? No — external contributor fix for an open P1.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex app-server startup connection-close retry loop exhausted before the replacement server was ready (#83959).
- Real environment tested: Windows 11, Node v22.22.3, OpenClaw checkout. The capture drives the REAL `startCodexAttemptThread` (the production function this PR changes) against a REAL local app-server subprocess spawned by the REAL `CodexAppServerClient.start` -> `createStdioTransport` -> `child_process.spawn`. The subprocess speaks the same newline-delimited JSON-RPC framing as the real Codex app-server; on the first N attempts it closes its connection during the `initialize` handshake (real child exit -> real `codex app-server exited:` error -> real `isCodexAppServerConnectionClosedError` -> the real startup retry loop), and completes the handshake on attempt N+1. It is a stand-in for the `codex` binary (no Codex account/backend is available on this host); it is NOT a reimplementation of the retry loop and does not stub `startCodexAttemptThread`.
- Exact steps or command run after this patch: `pnpm exec tsx .tmp/capture-83959-real.ts` with `CLOSES_BEFORE_SUCCESS=4` (recovery) and `CLOSES_BEFORE_SUCCESS=99` (persistent-close exhaustion), run on unpatched main and on this PR branch. Driver: `.tmp/capture-83959-real.ts`; stand-in app-server subprocess: `.tmp/fake-codex-app-server.mjs`.
- Evidence after fix (terminal capture):
```
$ CLOSES_BEFORE_SUCCESS=4 pnpm exec tsx .tmp/capture-83959-real.ts   # this PR (budget=5, bounded backoff)
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
{
  "outcome": "recovered",
  "closesBeforeSuccess": 4,
  "spawnAttempts": 5,
  "spawnModes": ["exit", "exit", "exit", "exit", "serve"],
  "observedWallClockGapsMs": [1962, 2531, 3399, 5340],
  "backoffPolicyComputedMs": [532, 1179, 2019, 4000],
  "elapsedMs": 14856
}

$ CLOSES_BEFORE_SUCCESS=99 pnpm exec tsx .tmp/capture-83959-real.ts  # this PR, persistent close
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; retries exhausted
{
  "outcome": "exhausted",
  "closesBeforeSuccess": 99,
  "spawnAttempts": 5,
  "spawnModes": ["exit", "exit", "exit", "exit", "exit"],
  "observedWallClockGapsMs": [1836, 2417, 3459, 5278],
  "backoffPolicyComputedMs": [575, 1183, 2332, 4000],
  "elapsedMs": 14385,
  "error": {
    "message": "codex app-server startup exhausted after 5 connection-close retries",
    "name": "CodexAppServerStartupExhaustedError",
    "cause": "codex app-server exited: code=1 signal=null"
  }
}
```
- Observed result after fix: BEFORE (unpatched, budget 3) — startup exhausted at 3 attempts with 2 flat ~1.3s gaps (no backoff sleep; the gaps are spawn/cleanup overhead only) and the turn failed with the raw `codex app-server exited: code=1 signal=null` (plain `Error`, no distinct exhaustion type). AFTER (this PR, budget 5 + bounded abortable backoff) — the same 4 leading closes were survived: startup recovered on the 5th attempt with 4 monotonically increasing gaps [1962, 2531, 3399, 5340] ms that track the real `computeBackoff` policy [532, 1179, 2019, 4000] ms (policy value + spawn/cleanup overhead), and the turn succeeded. Persistent-close AFTER — exhausted at 5 with the distinct `CodexAppServerStartupExhaustedError` ("codex app-server startup exhausted after 5 connection-close retries"), the original `codex app-server exited:` preserved as `cause`, instead of the raw close error.
- What was not tested: A live `codex` app-server process backed by a real Codex/LLM account (no local Codex harness or API key on this Windows host). The stand-in subprocess reproduces the connection-close-during-startup condition and the JSON-RPC initialize/thread-start handshake but does not execute Codex model turns. macOS/Linux runtime not exercised locally.
- Proof limitations or environment constraints: The stand-in app-server subprocess is a real local process exercising the real production startup retry path (real spawn, real stdio JSON-RPC, real child-exit close detection, real `computeBackoff`+`sleepWithAbort` wall-clock delays, real `CodexAppServerStartupExhaustedError`); it is not the real `codex` binary because no Codex backend is available on this host.
- Before evidence (optional but encouraged):
```
$ pnpm exec tsx .tmp/capture-83959-real.ts        # unpatched main (budget=3, no backoff)
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; restarting app-server and retrying
codex app-server connection closed during startup; retries exhausted
{
  "outcome": "exhausted",
  "closesBeforeSuccess": 4,
  "spawnAttempts": 3,
  "spawnModes": ["exit", "exit", "exit"],
  "observedWallClockGapsMs": [1329, 1231],
  "backoffPolicyComputedMs": [551, 1078, 2252, 4000],
  "elapsedMs": 3917,
  "error": { "message": "codex app-server exited: code=1 signal=null", "name": "Error" }
}
```

## Tests and validation

- Commands run: `pnpm exec oxfmt --check` (changed files, clean); `pnpm tsgo:extensions` (clean); `pnpm tsgo:extensions:test` (clean); `pnpm exec oxlint --type-aware` (changed files, clean); `node scripts/run-vitest.mjs extensions/codex/src/app-server/attempt-startup.test.ts -t "83959"` (2 passed).
- Regression coverage added: Two new tests in `attempt-startup.test.ts` covering the previously-**untested** startup connection-close retry loop — (1) survives N transient closes with bounded backoff and recovers, asserting `sleepWithAbort` is awaited between attempts with bounded delays; (2) persistent closes produce the distinct `CodexAppServerStartupExhaustedError` with the original error as `cause`, and the loop is bounded (no infinite retry).
- Failed before this fix: Both new tests fail on unpatched main (budget=3 exhausts before the 4th-close recovery; raw "client is closed" rethrown with no distinct exhaustion error).
- Note: `pnpm check:host-env-policy:swift` skipped on Windows (no Swift).

## Risk checklist

Did user-visible behavior change? `Yes` — a Codex startup that previously failed after 3 immediate retries now retries up to 5 times with a bounded backoff (worst case a few extra seconds before a transient-close recovery or a cleaner failure).

Did config, environment, or migration behavior change? `No`.

Did security, auth, secrets, network, or tool execution behavior change? `No` — the change only affects the Codex app-server startup retry timing/error shape; no auth, secret, network, or tool-execution surface touched. `extensions/codex/src/**` is not a CODEOWNERS secops path.

What is the highest-risk area? Added latency on a Codex startup that closes repeatedly during warm-up (bounded to ~8s worst case across 5 attempts).

How is that risk mitigated? Backoff only fires after a connection-close failure (never on the success path); `sleepWithAbort` is abortable so a cancelled/aborted run fails fast instead of stalling; the budget is still bounded (5) so a permanently-broken server fails rather than retrying forever; the distinct exhaustion error preserves the original cause for diagnostics.

## Current review state

What is the next action? Awaiting maintainer review. The real behavior proof was upgraded (see above) from a synthetic retry-loop model to a real local app-server subprocess driving the actual `startCodexAttemptThread`; `@clawsweeper re-review` requested.

What is still waiting on author, maintainer, CI, or external proof? External-fork heavy CI shards require maintainer workflow approval to run. A maintainer proof/latency override is also an acceptable path per ClawSweeper's option 2 if the stand-in-subprocess proof is deemed sufficient.

Which bot or reviewer comments were addressed? Upgraded the real behavior proof in response to ClawSweeper's `status: 📣 needs proof` ("supplies tests and a synthetic terminal model, but not after-fix live OpenClaw/Codex app-server startup proof").

