### PR TITLE
fix(session): prevent stale finalizer from recreating deleted session rows

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -998,10 +998,16 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       meta: { durationMs: 0, stopReason: "end_turn" },
     }));
     state.persistCliTurnTranscriptMock.mockImplementation(
-      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
+      async (params: { sessionEntry?: unknown }) => ({
+        kind: "persisted",
+        sessionEntry: params.sessionEntry,
+      }),
     );
     state.persistAcpTurnTranscriptMock.mockImplementation(
-      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
+      async (params: { sessionEntry?: unknown }) => ({
+        kind: "persisted",
+        sessionEntry: params.sessionEntry,
+      }),
     );
     state.runCliTurnCompactionLifecycleMock.mockImplementation(
       async (params: { sessionEntry?: unknown }) => params.sessionEntry,
@@ -1244,7 +1250,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.persistAcpTurnTranscriptMock.mockImplementation(
       async (params: { sessionEntry?: unknown }) => {
         controller.abort(createAgentRunRestartAbortError());
-        return params.sessionEntry;
+        return { kind: "persisted", sessionEntry: params.sessionEntry };
       },
     );
 
@@ -1792,7 +1798,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.updateSessionStoreAfterAgentRunMock.mockImplementation(async () => {
       state.sessionStoreMock = { "agent:main:main": rotatedEntry };
     });
-    state.persistCliTurnTranscriptMock.mockResolvedValue(rotatedEntry);
+    state.persistCliTurnTranscriptMock.mockResolvedValue({
+      kind: "persisted",
+      sessionEntry: rotatedEntry,
+    });
     state.runCliTurnCompactionLifecycleMock.mockResolvedValue(rotatedEntry);
 
     await runBasicAgentCommand();
@@ -1828,14 +1837,14 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       winnerModel: "gpt-5.4",
     };
     state.runAgentAttemptMock.mockResolvedValue(result);
-    state.updateSessionStoreAfterAgentRunMock.mockImplementation(async () => {
-      delete (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
-      return { kind: "deleted" };
+    state.persistCliTurnTranscriptMock.mockResolvedValue({
+      kind: "session-rebound",
+      sessionEntry: undefined,
     });
 
     await runBasicAgentCommand();
 
-    expect(state.persistCliTurnTranscriptMock).not.toHaveBeenCalled();
+    expect(state.persistCliTurnTranscriptMock).toHaveBeenCalledTimes(1);
     expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1813,6 +1813,33 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
   });
 
+  it("skips post-run persistence after the session is deleted", async () => {
+    setupSingleAttemptFallback();
+    setupSessionTouchStore();
+    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+      typeof makeSuccessResult
+    > & {
+      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
+    };
+    result.meta.executionTrace = {
+      runner: "cli",
+      fallbackUsed: false,
+      winnerProvider: "openai",
+      winnerModel: "gpt-5.4",
+    };
+    state.runAgentAttemptMock.mockResolvedValue(result);
+    state.updateSessionStoreAfterAgentRunMock.mockImplementation(async () => {
+      delete (state.sessionStoreMock as Record<string, SessionEntry>)["agent:main:main"];
+      return { kind: "deleted" };
+    });
+
+    await runBasicAgentCommand();
+
+    expect(state.persistCliTurnTranscriptMock).not.toHaveBeenCalled();
+    expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not treat backend CLI session id as OpenClaw session identity", async () => {
     setupSingleAttemptFallback();
     setupSessionTouchStore();

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -891,7 +891,7 @@ async function agentCommandInternal(
   assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
   const effectiveCwd = cwd ? resolveUserPath(cwd) : workspaceDir;
   let sessionEntry = prepared.sessionEntry;
-  let sessionDeletedDuringRun = false;
+  let sessionReboundDuringRun = false;
   let trackedRestartRecoveryDeliveryContext = false;
   let currentRunDeliveryContext: DeliveryContext | undefined;
 
@@ -1100,7 +1100,7 @@ async function agentCommandInternal(
               sessionFile: internalSessionFile,
             }
           : sessionEntry;
-        sessionEntry = await attemptExecutionRuntime.persistAcpTurnTranscript({
+        const transcriptResult = await attemptExecutionRuntime.persistAcpTurnTranscript({
           body,
           transcriptBody,
           finalText: finalTextRaw,
@@ -1114,6 +1114,7 @@ async function agentCommandInternal(
           sessionCwd: resolveAcpSessionCwd(acpResolution.meta) ?? workspaceDir,
           config: cfg,
         });
+        sessionEntry = transcriptResult.sessionEntry;
         if (internalSessionFile) {
           sessionEntry = prepared.sessionEntry;
         }
@@ -2137,7 +2138,7 @@ async function agentCommandInternal(
       // Update token+model fields in the session store.
       if (sessionStore && sessionKey && !suppressVisibleSessionEffects) {
         const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
-        const updateOutcome = await updateSessionStoreAfterAgentRun({
+        await updateSessionStoreAfterAgentRun({
           cfg,
           contextTokensOverride: agentCfg?.contextTokens,
           sessionId: effectiveSessionId,
@@ -2159,10 +2160,7 @@ async function agentCommandInternal(
             preserveUserFacingSessionModelState,
           preserveUserFacingSessionModelState,
         });
-        sessionDeletedDuringRun = updateOutcome?.kind === "deleted";
-        if (!sessionDeletedDuringRun) {
-          sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
-        }
+        sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
       }
 
       const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
@@ -2171,7 +2169,7 @@ async function agentCommandInternal(
         (transcriptPersistenceRunner === undefined &&
           Boolean(result.meta.finalAssistantVisibleText?.trim()));
       if (
-        !sessionDeletedDuringRun &&
+        !sessionReboundDuringRun &&
         (transcriptPersistenceRunner === "cli" || embeddedAssistantGapFill)
       ) {
         let persistedCliTurnTranscript = false;
@@ -2187,7 +2185,7 @@ async function agentCommandInternal(
                 sessionFile: effectiveSessionFile,
               }
             : sessionEntry;
-          sessionEntry = await attemptExecutionRuntime.persistCliTurnTranscript({
+          const transcriptResult = await attemptExecutionRuntime.persistCliTurnTranscript({
             body,
             transcriptBody,
             result,
@@ -2202,10 +2200,12 @@ async function agentCommandInternal(
             config: cfg,
             embeddedAssistantGapFill,
           });
+          sessionEntry = transcriptResult.sessionEntry;
+          sessionReboundDuringRun = transcriptResult.kind === "session-rebound";
           if (suppressVisibleSessionEffects) {
             sessionEntry = prepared.sessionEntry;
           }
-          persistedCliTurnTranscript = true;
+          persistedCliTurnTranscript = transcriptResult.kind === "persisted";
         } catch (error) {
           log.warn(
             `Turn transcript persistence failed for ${sessionKey ?? sessionId}: ${error instanceof Error ? error.message : String(error)}`,
@@ -2247,7 +2247,7 @@ async function agentCommandInternal(
         sessionStore &&
         sessionKey &&
         !suppressVisibleSessionEffects &&
-        !sessionDeletedDuringRun &&
+        !sessionReboundDuringRun &&
         payloads.length > 0 &&
         !isSubagentSessionKey(sessionKey)
       ) {
@@ -2325,7 +2325,7 @@ async function agentCommandInternal(
         sessionKey &&
         !isSubagentSessionKey(sessionKey) &&
         !suppressVisibleSessionEffects &&
-        !sessionDeletedDuringRun
+        !sessionReboundDuringRun
       ) {
         const entry = sessionStore[sessionKey] ?? sessionEntry;
         const noPendingTextForThisRun =
@@ -2358,7 +2358,7 @@ async function agentCommandInternal(
     }
   } finally {
     if (
-      !sessionDeletedDuringRun &&
+      !sessionReboundDuringRun &&
       trackedRestartRecoveryDeliveryContext &&
       sessionStore &&
       sessionKey

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -891,6 +891,7 @@ async function agentCommandInternal(
   assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
   const effectiveCwd = cwd ? resolveUserPath(cwd) : workspaceDir;
   let sessionEntry = prepared.sessionEntry;
+  let sessionDeletedDuringRun = false;
   let trackedRestartRecoveryDeliveryContext = false;
   let currentRunDeliveryContext: DeliveryContext | undefined;
 
@@ -2136,7 +2137,7 @@ async function agentCommandInternal(
       // Update token+model fields in the session store.
       if (sessionStore && sessionKey && !suppressVisibleSessionEffects) {
         const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
-        await updateSessionStoreAfterAgentRun({
+        const updateOutcome = await updateSessionStoreAfterAgentRun({
           cfg,
           contextTokensOverride: agentCfg?.contextTokens,
           sessionId: effectiveSessionId,
@@ -2158,7 +2159,10 @@ async function agentCommandInternal(
             preserveUserFacingSessionModelState,
           preserveUserFacingSessionModelState,
         });
-        sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
+        sessionDeletedDuringRun = updateOutcome?.kind === "deleted";
+        if (!sessionDeletedDuringRun) {
+          sessionEntry = sessionStore[sessionKey] ?? sessionEntry;
+        }
       }
 
       const transcriptPersistenceRunner = result.meta.executionTrace?.runner;
@@ -2166,7 +2170,10 @@ async function agentCommandInternal(
         transcriptPersistenceRunner === "embedded" ||
         (transcriptPersistenceRunner === undefined &&
           Boolean(result.meta.finalAssistantVisibleText?.trim()));
-      if (transcriptPersistenceRunner === "cli" || embeddedAssistantGapFill) {
+      if (
+        !sessionDeletedDuringRun &&
+        (transcriptPersistenceRunner === "cli" || embeddedAssistantGapFill)
+      ) {
         let persistedCliTurnTranscript = false;
         try {
           const transcriptSessionEntry: SessionEntry | undefined = suppressVisibleSessionEffects
@@ -2240,6 +2247,7 @@ async function agentCommandInternal(
         sessionStore &&
         sessionKey &&
         !suppressVisibleSessionEffects &&
+        !sessionDeletedDuringRun &&
         payloads.length > 0 &&
         !isSubagentSessionKey(sessionKey)
       ) {
@@ -2316,7 +2324,8 @@ async function agentCommandInternal(
         sessionStore &&
         sessionKey &&
         !isSubagentSessionKey(sessionKey) &&
-        !suppressVisibleSessionEffects
+        !suppressVisibleSessionEffects &&
+        !sessionDeletedDuringRun
       ) {
         const entry = sessionStore[sessionKey] ?? sessionEntry;
         const noPendingTextForThisRun =
@@ -2348,7 +2357,12 @@ async function agentCommandInternal(
       throw error;
     }
   } finally {
-    if (trackedRestartRecoveryDeliveryContext && sessionStore && sessionKey) {
+    if (
+      !sessionDeletedDuringRun &&
+      trackedRestartRecoveryDeliveryContext &&
+      sessionStore &&
+      sessionKey
+    ) {
       try {
         const entry = sessionStore[sessionKey] ?? sessionEntry;
         if (entry?.restartRecoveryDeliveryContext && entry.restartRecoveryDeliveryRunId === runId) {

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -127,6 +127,16 @@ function makeCliResult(text: string): EmbeddedAgentRunResult {
   };
 }
 
+async function persistCliTranscriptEntry(
+  params: Parameters<typeof persistCliTurnTranscript>[0],
+): Promise<SessionEntry | undefined> {
+  const result = await persistCliTurnTranscript(params);
+  if (result.kind !== "persisted") {
+    throw new Error("expected CLI transcript persistence to keep the current session");
+  }
+  return result.sessionEntry;
+}
+
 async function readSessionMessages(sessionFile: string) {
   return (await readSessionFileJsonLines<{ type?: string; message?: unknown }>(sessionFile))
     .filter((entry) => entry.type === "message")
@@ -1143,7 +1153,7 @@ describe("CLI attempt execution", () => {
     });
     let updatedEntry: SessionEntry | undefined;
     try {
-      updatedEntry = await persistCliTurnTranscript({
+      updatedEntry = await persistCliTranscriptEntry({
         body: "persist this",
         result: makeCliResult("hello from cli"),
         sessionId: sessionEntry.sessionId,
@@ -1204,6 +1214,40 @@ describe("CLI attempt execution", () => {
     expect(sessionStore[sessionKey]?.updatedAt).toBe(persisted[sessionKey]?.updatedAt);
   });
 
+  it("does not append a CLI transcript after the session is deleted", async () => {
+    const sessionKey = "agent:main:subagent:cli-transcript-deleted";
+    const staleSessionFile = path.join(tmpDir, "session-cli-stale.jsonl");
+    const staleEntry: SessionEntry = {
+      sessionId: "session-cli-stale",
+      sessionFile: staleSessionFile,
+      updatedAt: 1,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: staleEntry };
+    await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf-8");
+    clearSessionStoreCacheForTest();
+
+    const result = await persistCliTurnTranscript({
+      body: "late prompt",
+      result: makeCliResult("late reply"),
+      sessionId: staleEntry.sessionId,
+      sessionKey,
+      sessionEntry: staleEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+    });
+
+    expect(result).toEqual({ kind: "session-rebound", sessionEntry: undefined });
+    await expect(fs.stat(staleSessionFile)).rejects.toMatchObject({ code: "ENOENT" });
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persisted[sessionKey]).toBeUndefined();
+  });
+
   it("embedded assistant gap-fill skips user mirror and dedupes identical assistant tails", async () => {
     const sessionKey = "agent:main:subagent:embedded-gap-fill";
     const sessionEntry: SessionEntry = {
@@ -1221,7 +1265,7 @@ describe("CLI attempt execution", () => {
       runner: "embedded",
     };
 
-    const updatedFirst = await persistCliTurnTranscript({
+    const updatedFirst = await persistCliTranscriptEntry({
       body: "ignored for gap fill",
       transcriptBody: "also ignored",
       result,
@@ -1278,7 +1322,7 @@ describe("CLI attempt execution", () => {
       runner: "embedded",
     };
 
-    const updatedFirst = await persistCliTurnTranscript({
+    const updatedFirst = await persistCliTranscriptEntry({
       body: "ignored for gap fill",
       result,
       sessionId: sessionEntry.sessionId,
@@ -1344,7 +1388,7 @@ describe("CLI attempt execution", () => {
       runner: "embedded",
     };
 
-    const updatedFirst = await persistCliTurnTranscript({
+    const updatedFirst = await persistCliTranscriptEntry({
       body: "ignored for gap fill",
       result,
       sessionId: sessionEntry.sessionId,
@@ -1415,7 +1459,7 @@ describe("CLI attempt execution", () => {
       runner: "embedded",
     };
 
-    const updatedFirst = await persistCliTurnTranscript({
+    const updatedFirst = await persistCliTranscriptEntry({
       body: "ignored for gap fill",
       result,
       sessionId: sessionEntry.sessionId,
@@ -1484,7 +1528,7 @@ describe("CLI attempt execution", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
 
-    const updatedEntry = await persistCliTurnTranscript({
+    const updatedEntry = await persistCliTranscriptEntry({
       body: [
         "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
         "secret runtime context",

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -127,6 +127,10 @@ type PersistTextTurnTranscriptParams = {
   };
 };
 
+type PersistTextTurnTranscriptResult =
+  | { kind: "persisted"; sessionEntry: SessionEntry | undefined }
+  | { kind: "session-rebound"; sessionEntry: undefined };
+
 type HarnessAuthProfileSelection = {
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
@@ -285,11 +289,11 @@ function resolveTranscriptUsage(usage: PersistTextTurnTranscriptParams["assistan
 
 async function persistTextTurnTranscript(
   params: PersistTextTurnTranscriptParams,
-): Promise<SessionEntry | undefined> {
+): Promise<PersistTextTurnTranscriptResult> {
   const promptText = params.transcriptBody ?? params.body;
   const replyText = params.finalText;
   if (!promptText && !replyText) {
-    return params.sessionEntry;
+    return { kind: "persisted", sessionEntry: params.sessionEntry };
   }
 
   const messages = [];
@@ -356,9 +360,13 @@ async function persistTextTurnTranscript(
       publishWhen: "always",
       touchSessionEntry: true,
       updateMode: "file-only",
+      ...(params.sessionStore && params.storePath ? { expectedSessionId: params.sessionId } : {}),
     },
   );
-  return turn.sessionEntry;
+  if (turn.rejectedReason === "session-rebound") {
+    return { kind: "session-rebound", sessionEntry: undefined };
+  }
+  return { kind: "persisted", sessionEntry: turn.sessionEntry };
 }
 
 function resolveCliTranscriptReplyText(result: EmbeddedAgentRunResult): string {
@@ -391,7 +399,7 @@ export async function persistAcpTurnTranscript(params: {
   threadId?: string | number;
   sessionCwd: string;
   config: OpenClawConfig;
-}): Promise<SessionEntry | undefined> {
+}): Promise<PersistTextTurnTranscriptResult> {
   return await persistTextTurnTranscript({
     ...params,
     assistant: {
@@ -417,7 +425,7 @@ export async function persistCliTurnTranscript(params: {
   sessionCwd: string;
   config: OpenClawConfig;
   embeddedAssistantGapFill?: boolean;
-}): Promise<SessionEntry | undefined> {
+}): Promise<PersistTextTurnTranscriptResult> {
   const replyText = resolveCliTranscriptReplyText(params.result);
   const provider = params.result.meta.agentMeta?.provider?.trim() ?? "cli";
   const model = params.result.meta.agentMeta?.model?.trim() ?? "default";

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -679,6 +679,7 @@ export async function runCliTurnCompactionLifecycle(params: {
         sessionKey: params.sessionKey,
         sessionStore: params.sessionStore,
         storePath: params.storePath,
+        expectedSessionId: params.sessionId,
       })) ?? params.sessionEntry
     );
   }
@@ -696,6 +697,7 @@ export async function runCliTurnCompactionLifecycle(params: {
       tokensAfter: nativeCompactionResult?.result?.tokensAfter,
       newSessionId: nativeCompactionResult?.result?.sessionId,
       newSessionFile: nativeCompactionResult?.result?.sessionFile,
+      expectedSessionId: params.sessionId,
     })) ?? params.sessionEntry
   );
 }

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1849,7 +1849,10 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
-  it("does not recreate a missing persisted row while preserving user-facing state", async () => {
+  it.each([
+    ["normal", false],
+    ["user-facing state preserving", true],
+  ])("does not recreate a missing persisted row after a %s run", async (_mode, preserve) => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;
       const sessionKey = "agent:main:explicit:missing-visible-row";
@@ -1872,7 +1875,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         sessionStore,
         defaultProvider: "claude-cli",
         defaultModel: "claude-sonnet-4-6",
-        preserveUserFacingSessionModelState: true,
+        preserveUserFacingSessionModelState: preserve,
         result: {
           meta: {
             durationMs: 1,
@@ -1892,6 +1895,41 @@ describe("updateSessionStoreAfterAgentRun", () => {
         model: "gpt-5.5",
       });
       expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
+    });
+  });
+
+  it("creates a missing persisted row for a new normal run", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:new-normal-row";
+      const sessionId = "new-normal-row-session";
+      const sessionStore: Record<string, SessionEntry> = {};
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "openai",
+              model: "gpt-5.5",
+            },
+          },
+        },
+      });
+
+      expect(sessionStore[sessionKey]).toMatchObject({ sessionId });
+      expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toMatchObject({
+        sessionId,
+      });
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1867,7 +1867,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       };
       await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
 
-      await updateSessionStoreAfterAgentRun({
+      const outcome = await updateSessionStoreAfterAgentRun({
         cfg,
         sessionId,
         sessionKey,
@@ -1895,6 +1895,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         model: "gpt-5.5",
       });
       expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
+      expect(outcome).toEqual({ kind: "deleted" });
     });
   });
 
@@ -1906,7 +1907,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       const sessionStore: Record<string, SessionEntry> = {};
       await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
 
-      await updateSessionStoreAfterAgentRun({
+      const outcome = await updateSessionStoreAfterAgentRun({
         cfg,
         sessionId,
         sessionKey,
@@ -1930,6 +1931,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toMatchObject({
         sessionId,
       });
+      expect(outcome).toBeUndefined();
     });
   });
 

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1867,7 +1867,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       };
       await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
 
-      const outcome = await updateSessionStoreAfterAgentRun({
+      await updateSessionStoreAfterAgentRun({
         cfg,
         sessionId,
         sessionKey,
@@ -1895,7 +1895,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
         model: "gpt-5.5",
       });
       expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
-      expect(outcome).toEqual({ kind: "deleted" });
     });
   });
 
@@ -1907,7 +1906,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
       const sessionStore: Record<string, SessionEntry> = {};
       await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
 
-      const outcome = await updateSessionStoreAfterAgentRun({
+      await updateSessionStoreAfterAgentRun({
         cfg,
         sessionId,
         sessionKey,
@@ -1931,7 +1930,6 @@ describe("updateSessionStoreAfterAgentRun", () => {
       expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toMatchObject({
         sessionId,
       });
-      expect(outcome).toBeUndefined();
     });
   });
 
@@ -2341,6 +2339,35 @@ describe("recordCliCompactionInStore", () => {
       expect(persisted?.cliSessionBindings?.codex).toBeUndefined();
     });
   });
+
+  it("does not recreate a missing row when a post-run compaction has an expected session id", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:test-record-cli-compaction-deleted";
+      const sessionId = "test-record-cli-compaction-deleted-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          cliSessionIds: {
+            codex: "stale-cli-session",
+          },
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
+
+      const result = await recordCliCompactionInStore({
+        provider: "codex",
+        sessionKey,
+        sessionStore,
+        storePath,
+        expectedSessionId: sessionId,
+        tokensAfter: 42,
+      });
+
+      expect(result).toEqual(sessionStore[sessionKey]);
+      expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
+    });
+  });
 });
 
 describe("clearCliSessionInStore", () => {
@@ -2473,6 +2500,31 @@ describe("clearCliSessionInStore", () => {
         sessionId: "codex-session-1",
       });
       expect(persisted?.claudeCliSessionId).toBeUndefined();
+    });
+  });
+
+  it("does not recreate a missing row when a post-run binding clear has an expected session id", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const sessionKey = "agent:main:explicit:test-clear-cli-deleted-row";
+      const sessionId = "openclaw-session-1";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          claudeCliSessionId: "claude-session-1",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify({}, null, 2), "utf8");
+
+      await clearCliSessionInStore({
+        provider: "claude-cli",
+        sessionKey,
+        sessionStore,
+        storePath,
+        expectedSessionId: sessionId,
+      });
+
+      expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toBeUndefined();
     });
   });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1933,6 +1933,53 @@ describe("updateSessionStoreAfterAgentRun", () => {
     });
   });
 
+  it("does not overwrite a replacement persisted row after a normal run", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:rebound-visible-row";
+      const sessionId = "run-session-id";
+      const replacementEntry: SessionEntry = {
+        sessionId: "replacement-session-id",
+        updatedAt: 2,
+        modelProvider: "openai",
+        model: "gpt-5.5",
+      };
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          modelProvider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify({ [sessionKey]: replacementEntry }, null, 2));
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+        result: {
+          meta: {
+            durationMs: 1,
+            agentMeta: {
+              sessionId,
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+            },
+          },
+        },
+      });
+
+      expect(loadSessionStore(storePath, { skipCache: true })[sessionKey]).toEqual(
+        replacementEntry,
+      );
+    });
+  });
+
   it("leaves contextTokens unset when entry has prior model but no contextTokens (heartbeat bleed guard)", async () => {
     await withTempSessionStore(async ({ storePath }) => {
       const cfg = {} as OpenClawConfig;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -300,6 +300,8 @@ export async function updateSessionStoreAfterAgentRun(params: {
     },
     (_currentEntry, context) => {
       if (!context.existingEntry && sessionStore[sessionKey]) {
+        // sessions.delete removed the persisted row while this run retained an old snapshot.
+        // Do not let the stale finalizer recreate the deleted key.
         return null;
       }
       return metadataPatch;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -293,7 +293,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
       }
     : removeLifecycleStateFromMetadataPatch(next);
   const maintenanceConfig = resolveMaintenanceConfigFromInput(cfg.session?.maintenance);
-  let deletedDuringRun = false;
   const persisted = await patchSessionEntry(
     {
       storePath,
@@ -303,7 +302,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
       if (!context.existingEntry && sessionStore[sessionKey]) {
         // sessions.delete removed the persisted row while this run retained an old snapshot.
         // Do not let the stale finalizer recreate the deleted key.
-        deletedDuringRun = true;
         return null;
       }
       return metadataPatch;
@@ -313,12 +311,6 @@ export async function updateSessionStoreAfterAgentRun(params: {
       maintenanceConfig,
     },
   );
-  // State-preserving turns have no fallback entry, so patchSessionEntry skips
-  // the callback when deletion wins. Treat that stale in-memory row the same way.
-  const sessionDeletedDuringRun = deletedDuringRun || (!persisted && sessionStore[sessionKey]);
-  if (sessionDeletedDuringRun) {
-    return { kind: "deleted" } as const;
-  }
   if (persisted) {
     sessionStore[sessionKey] = persisted;
   }
@@ -330,8 +322,9 @@ export async function clearCliSessionInStore(params: {
   sessionKey: string;
   sessionStore: Record<string, SessionEntry>;
   storePath: string;
+  expectedSessionId?: string;
 }): Promise<SessionEntry | undefined> {
-  const { provider, sessionKey, sessionStore, storePath } = params;
+  const { provider, sessionKey, sessionStore, storePath, expectedSessionId } = params;
   const entry = sessionStore[sessionKey];
   if (!entry) {
     return undefined;
@@ -346,7 +339,15 @@ export async function clearCliSessionInStore(params: {
       storePath,
       sessionKey,
     },
-    () => next,
+    (currentEntry, context) => {
+      if (
+        expectedSessionId &&
+        (!context.existingEntry || currentEntry.sessionId !== expectedSessionId)
+      ) {
+        return null;
+      }
+      return next;
+    },
     { fallbackEntry: entry },
   );
   if (persisted) {
@@ -364,8 +365,9 @@ export async function recordCliCompactionInStore(params: {
   tokensAfter?: number;
   newSessionId?: string;
   newSessionFile?: string;
+  expectedSessionId?: string;
 }): Promise<SessionEntry | undefined> {
-  const { provider, sessionKey, sessionStore, storePath } = params;
+  const { provider, sessionKey, sessionStore, storePath, expectedSessionId } = params;
   const entry = sessionStore[sessionKey];
   if (!entry) {
     return undefined;
@@ -420,7 +422,15 @@ export async function recordCliCompactionInStore(params: {
       storePath,
       sessionKey,
     },
-    () => next,
+    (currentEntry, context) => {
+      if (
+        expectedSessionId &&
+        (!context.existingEntry || currentEntry.sessionId !== expectedSessionId)
+      ) {
+        return null;
+      }
+      return next;
+    },
     { fallbackEntry: entry },
   );
   if (persisted) {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -293,6 +293,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       }
     : removeLifecycleStateFromMetadataPatch(next);
   const maintenanceConfig = resolveMaintenanceConfigFromInput(cfg.session?.maintenance);
+  let deletedDuringRun = false;
   const persisted = await patchSessionEntry(
     {
       storePath,
@@ -302,6 +303,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       if (!context.existingEntry && sessionStore[sessionKey]) {
         // sessions.delete removed the persisted row while this run retained an old snapshot.
         // Do not let the stale finalizer recreate the deleted key.
+        deletedDuringRun = true;
         return null;
       }
       return metadataPatch;
@@ -311,6 +313,12 @@ export async function updateSessionStoreAfterAgentRun(params: {
       maintenanceConfig,
     },
   );
+  // State-preserving turns have no fallback entry, so patchSessionEntry skips
+  // the callback when deletion wins. Treat that stale in-memory row the same way.
+  const sessionDeletedDuringRun = deletedDuringRun || (!persisted && sessionStore[sessionKey]);
+  if (sessionDeletedDuringRun) {
+    return { kind: "deleted" } as const;
+  }
   if (persisted) {
     sessionStore[sessionKey] = persisted;
   }

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -299,9 +299,14 @@ export async function updateSessionStoreAfterAgentRun(params: {
       sessionKey,
     },
     (_currentEntry, context) => {
-      if (!context.existingEntry && sessionStore[sessionKey]) {
-        // sessions.delete removed the persisted row while this run retained an old snapshot.
-        // Do not let the stale finalizer recreate the deleted key.
+      if (
+        (!preserveUserFacingRunState &&
+          context.existingEntry &&
+          context.existingEntry.sessionId !== entry.sessionId) ||
+        (!context.existingEntry && sessionStore[sessionKey])
+      ) {
+        // A normal run may rotate its session id, so compare to the pre-run entry.
+        // Do not merge stale finalizer metadata after a delete or a competing reset.
         return null;
       }
       return metadataPatch;

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -299,7 +299,7 @@ export async function updateSessionStoreAfterAgentRun(params: {
       sessionKey,
     },
     (_currentEntry, context) => {
-      if (preserveUserFacingRunState && !context.existingEntry) {
+      if (!context.existingEntry && sessionStore[sessionKey]) {
         return null;
       }
       return metadataPatch;

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -41,9 +41,10 @@ const attemptExecutionMocks = vi.hoisted(() => ({
   emitAcpLifecycleError: vi.fn(),
   emitAcpPromptSubmitted: vi.fn(),
   emitAcpRuntimeEvent: vi.fn(),
-  persistAcpTurnTranscript: vi.fn(
-    async ({ sessionEntry }: { sessionEntry?: unknown }) => sessionEntry,
-  ),
+  persistAcpTurnTranscript: vi.fn(async ({ sessionEntry }: { sessionEntry?: unknown }) => ({
+    kind: "persisted",
+    sessionEntry,
+  })),
 }));
 
 vi.mock("../infra/agent-events.js", () => agentEventMocks);

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -93,12 +93,14 @@ vi.mock("../agents/command/attempt-execution.runtime.js", () => {
     emitAcpLifecycleEnd: vi.fn(),
     emitAcpLifecycleError: vi.fn(),
     emitAcpLifecycleStart: vi.fn(),
-    persistAcpTurnTranscript: vi.fn(
-      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
-    ),
-    persistCliTurnTranscript: vi.fn(
-      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
-    ),
+    persistAcpTurnTranscript: vi.fn(async (params: { sessionEntry?: unknown }) => ({
+      kind: "persisted",
+      sessionEntry: params.sessionEntry,
+    })),
+    persistCliTurnTranscript: vi.fn(async (params: { sessionEntry?: unknown }) => ({
+      kind: "persisted",
+      sessionEntry: params.sessionEntry,
+    })),
     runAgentAttempt: vi.fn(async (params: Record<string, unknown>) => {
       const opts = params.opts as Record<string, unknown>;
       const runContext = params.runContext as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- Stops stale post-run finalizers from recreating a session row after `sessions.delete` removes it.
- Fences metadata, transcript persistence, CLI compaction, and post-delivery cleanup writes by the session identity observed at run start.
- Preserves normal session-id rotation and the intentional user-facing-state update path.
- Fixes #40840.

## Verification

- `node scripts/run-vitest.mjs src/agents/command/session-store.test.ts src/agents/command/cli-compaction.test.ts src/agents/command/attempt-execution.cli.test.ts src/agents/agent-command.live-model-switch.test.ts src/commands/agent.test.ts src/commands/agent.acp.test.ts src/config/sessions/session-accessor.test.ts` (235 passed)
- Blacksmith Testbox `tbx_01kvb044cwwzh7v0n42y87eptr`: `OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm test:serial src/gateway/server.sessions.delete-lifecycle.test.ts src/gateway/session-lifecycle-state.test.ts` (98 passed)
- Blacksmith Testbox `tbx_01kvb044cwwzh7v0n42y87eptr`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed` (passed)
- `node_modules/.bin/oxfmt --check` on all modified files
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean; no accepted/actionable findings)
- `pnpm build` via `scripts/pr prepare-run` (passed)

## Real behavior proof

Behavior addressed: a successful `sessions.delete` could be followed by stale normal-run persistence recreating the same session key.

Real environment tested: Linux Blacksmith Testbox, verified branch head `958e5f8e860b415e2e66f78ebf58eae51f401d46`, Testbox `tbx_01kvb044cwwzh7v0n42y87eptr`. The branch was then cleanly rebased onto current `main` at `c56a4aad85617485e1446fb3e534cb726c759e98`; all nine modified files are byte-identical at the current head `66c992745b5a05368af6787977d6db85cd0d4536`.

Exact steps or command run after this patch:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm test:serial \
  src/gateway/server.sessions.delete-lifecycle.test.ts \
  src/gateway/session-lifecycle-state.test.ts
```

Evidence after fix: the gateway delete lifecycle and session lifecycle suites passed 98 tests in the Testbox. The focused stale-finalizer suite passed 235 tests across session-store, post-run metadata, transcript, compaction, CLI, ACP, and command paths.

Observed result after fix: stale writers with the old session identity are rejected after deletion or a competing session reset, while valid new sessions and normal rotation remain writable.

What was not tested: an external Mission Control deployment. The tested flow is the repository gateway/session lifecycle with the actual post-run persistence code paths.
