### PR TITLE
fix(auto-reply): preserve partial image results when some attachments fail to resolve

### DIFF
--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -737,7 +737,7 @@ describe("runReplyAgent media path normalization", () => {
     expect(call?.imageOrder).toBeUndefined();
   });
 
-  it("falls back to prompt refs instead of forwarding partial current media", async () => {
+  it("preserves partial current media when some attachments fail to resolve", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-agent-partial-"));
     cleanupPaths.push(tmpDir);
     const imagePath = path.join(tmpDir, "present.png");
@@ -781,7 +781,12 @@ describe("runReplyAgent media path normalization", () => {
           imageOrder?: string[];
         }
       | undefined;
-    expect(call?.images).toBeUndefined();
-    expect(call?.imageOrder).toBeUndefined();
+    // The valid image (present.png) should be preserved even though missing.png fails to resolve.
+    expect(call?.images).toHaveLength(1);
+    expect(call?.images?.[0]).toMatchObject({
+      type: "image",
+      mimeType: "image/png",
+    });
+    expect(call?.imageOrder).toEqual(["inline"]);
   });
 });

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -130,4 +130,88 @@ describe("resolveCurrentTurnImages", () => {
       expect(result.imageOrder).toEqual(["inline", "inline"]);
     });
   });
+
+  it("preserves partial results when some attachments fail to resolve", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-images-" }, async (base) => {
+      const stateDir = path.join(base, "state");
+      const validPath = "media/inbound/valid.jpg";
+      const validAttachmentPath = path.join(stateDir, validPath);
+      const imageBytes = Buffer.from("valid-image-bytes");
+      await fs.mkdir(path.dirname(validAttachmentPath), { recursive: true });
+      await fs.writeFile(validAttachmentPath, imageBytes);
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      vi.spyOn(process, "cwd").mockReturnValue(path.join(base, "cwd"));
+      await fs.mkdir(path.join(base, "cwd"), { recursive: true });
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          MediaPaths: [validPath, "media/inbound/missing.jpg"],
+          MediaTypes: ["image/jpeg", "image/jpeg"],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      // missing.jpg doesn't exist → resolveAgentTurnAttachments loads 1/2.
+      // We should preserve the one valid image instead of dropping everything.
+      expect(result.images).toHaveLength(1);
+      expect(result.images?.[0]).toMatchObject({
+        type: "image",
+        data: imageBytes.toString("base64"),
+        mimeType: "image/jpeg",
+      });
+    });
+  });
+
+  it("falls back when no attachments resolve", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-images-" }, async (base) => {
+      const stateDir = path.join(base, "state");
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      vi.spyOn(process, "cwd").mockReturnValue(path.join(base, "cwd"));
+      await fs.mkdir(path.join(base, "cwd"), { recursive: true });
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          MediaPaths: ["media/inbound/missing1.jpg", "media/inbound/missing2.jpg"],
+          MediaTypes: ["image/jpeg", "image/jpeg"],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      // Neither file exists → no images loaded.
+      expect(result.images).toBeUndefined();
+      expect(result.imageOrder).toBeUndefined();
+    });
+  });
+
+  it("preserves partial results with correct ordering when middle attachment fails", async () => {
+    await withTempDir({ prefix: "openclaw-current-turn-images-" }, async (base) => {
+      const stateDir = path.join(base, "state");
+      const firstPath = "media/inbound/first.jpg";
+      const thirdPath = "media/inbound/third.jpg";
+      const firstBytes = Buffer.from("first-image");
+      const thirdBytes = Buffer.from("third-image");
+      await fs.mkdir(path.join(stateDir, "media/inbound"), { recursive: true });
+      await fs.writeFile(path.join(stateDir, firstPath), firstBytes);
+      await fs.writeFile(path.join(stateDir, thirdPath), thirdBytes);
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      vi.spyOn(process, "cwd").mockReturnValue(path.join(base, "cwd"));
+      await fs.mkdir(path.join(base, "cwd"), { recursive: true });
+
+      const result = await resolveCurrentTurnImages({
+        ctx: {
+          // Second attachment is missing; first and third should still resolve.
+          MediaPaths: [firstPath, "media/inbound/missing.jpg", thirdPath],
+          MediaTypes: ["image/jpeg", "image/jpeg", "image/jpeg"],
+        } satisfies MsgContext,
+        cfg: {} as OpenClawConfig,
+      });
+
+      // missing.jpg (index 1) doesn't exist → 2/3 loaded.
+      // Both valid images should be preserved and ordered by sourceIndex (0, 2).
+      expect(result.images).toHaveLength(2);
+      expect(result.images?.[0]?.data).toBe(firstBytes.toString("base64"));
+      expect(result.images?.[1]?.data).toBe(thirdBytes.toString("base64"));
+      expect(result.imageOrder).toEqual(["inline", "inline"]);
+    });
+  });
 });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -179,10 +179,13 @@ export async function resolveCurrentTurnImages(params: {
 
   try {
     // Only send undescribed current images natively; described images already exist as text context.
+    // Request attachmentIndexes so we can map resolved images back to their original
+    // MediaPaths positions when some attachments fail to resolve.
     const resolved = await resolveAgentTurnAttachments({
       ctx: createUndescribedImageContext(params.ctx, undescribedImageAttachments),
       cfg: params.cfg,
       includeRecentHistoryImages: false,
+      includeAttachmentIndexes: true,
     });
     const images = resolved.attachments.map(
       (attachment): ImageContent => ({
@@ -193,15 +196,29 @@ export async function resolveCurrentTurnImages(params: {
     );
     if (images.length < undescribedImageAttachments.length) {
       logVerbose(
-        `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s); falling back to prompt image refs`,
+        `agent-runner: native OpenClaw media resolution produced ${images.length}/${undescribedImageAttachments.length} current image attachment(s)`,
       );
+      // Preserve partial results when some attachments fail to resolve
+      // instead of dropping everything. Only fall back when nothing loaded.
+      if (images.length > 0) {
+        for (const [index, image] of images.entries()) {
+          const undescribedIndex = resolved.attachmentIndexes?.[index] ?? index;
+          appendOrderedImages({
+            entries,
+            images: [image],
+            sourceIndex: undescribedImageAttachments[undescribedIndex]?.index,
+          });
+        }
+        return resolveMergedTurnImages(entries);
+      }
       return resolveMergedTurnImages(entries);
     }
     for (const [index, image] of images.entries()) {
+      const undescribedIndex = resolved.attachmentIndexes?.[index] ?? index;
       appendOrderedImages({
         entries,
         images: [image],
-        sourceIndex: undescribedImageAttachments[index]?.index,
+        sourceIndex: undescribedImageAttachments[undescribedIndex]?.index,
       });
     }
     return resolveMergedTurnImages(entries);


### PR DESCRIPTION
## Summary

Fixes #93816 — `resolveCurrentTurnImages` dropped ALL images when some (but not all) attachments failed to load from disk. This affected all channel plugins relying on the disk-load path (Telegram, Discord, WhatsApp, etc.), not just Telegram.

## Root Cause

When `resolveAgentTurnAttachments` loaded fewer images than expected (e.g. 1/2 because one file was missing, too large, or blocked), the fallback path in `resolveCurrentTurnImages` unconditionally called `resolveMergedTurnImages(entries)` — discarding the images that _did_ load successfully.

## Fix

Modified `src/auto-reply/reply/current-turn-images.ts` to distinguish three outcomes:

| Outcome | Old behavior | New behavior |
|---------|-------------|-------------|
| All attachments loaded | Return all images | No change |
| Some loaded, some failed | Drop all, return empty | **Return partial results** with sourceIndex preserved |
| None loaded | Return empty | No change |

Key implementation details:
- Uses `includeAttachmentIndexes: true` in `resolveAgentTurnAttachments` call to map resolved images back to original `MediaPaths` positions
- Preserves `sourceIndex` via `undescribedImageAttachments[undescribedIndex]?.index`, compatible with the mixed-image-order contract from PR #99902
- Uses `appendOrderedImages` + `resolveMergedTurnImages` for consistent ordering

## Verification

### Test results (post-rebase onto main, 2026-07-05)
```
$ node scripts/run-vitest.mjs src/auto-reply/reply/current-turn-images.test.ts --reporter=verbose

 ✓ resolveCurrentTurnImages > hydrates Telegram-style state-relative media into native prompt images
 ✓ resolveCurrentTurnImages > appends extracted PDF page images without dropping current image attachments
 ✓ resolveCurrentTurnImages > orders extracted PDF page images before later current image attachments
 ✓ resolveCurrentTurnImages > preserves partial results when some attachments fail to resolve
 ✓ resolveCurrentTurnImages > falls back when no attachments resolve
 ✓ resolveCurrentTurnImages > preserves partial results with correct ordering when middle attachment fails
 Test Files  1 passed (1)
      Tests  6 passed (6)

$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.media-paths.test.ts --reporter=verbose

 ✓ preserves partial current media when some attachments fail to resolve
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

### Git diff
```
 src/auto-reply/reply/agent-runner.media-paths.test.ts | 11 ++--
 src/auto-reply/reply/current-turn-images.test.ts      | 84 ++++++++++++++++++++++
 src/auto-reply/reply/current-turn-images.ts           | 21 +++++-
 3 files changed, 111 insertions(+), 5 deletions(-)
```

## Risk Assessment

- **Low risk**: Only changes the fallback path. Normal (all-success) and zero-success paths are unchanged.
- **Backward compatible**: The return shape `{ images, imageOrder }` is unchanged. Callers already handle `images` being populated.
- **Compatible with PR #99902**: Uses `appendOrderedImages` + `resolveMergedTurnImages` with `sourceIndex`.
- **No config/plugin SDK changes needed**.

## Real behavior proof

**Behavior or issue addressed**: `resolveCurrentTurnImages` dropped ALL images when some (but not all) attachments failed to load from disk. Channel plugins relying on the disk-load path (Telegram, Discord, WhatsApp, etc.) would silently lose images even when some loaded successfully.

**Real environment tested**: OpenClaw worktree rebased onto `origin/main` (post-PR #99902, `731dfcc5f9`), Node 22, macOS arm64, running via vitest with the production `resolveCurrentTurnImages` function.

**Exact steps or command run after this patch**:
```console
$ node scripts/run-vitest.mjs src/auto-reply/reply/current-turn-images.test.ts --reporter=verbose
$ node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.media-paths.test.ts --reporter=verbose
```

**Evidence after fix**:
- Scenario 1 (1 valid + 1 missing): valid image preserved with correct mimeType ✅ — test "preserves partial results when some attachments fail to resolve"
- Scenario 2 (all missing): no images returned, graceful fallback ✅ — test "falls back when no attachments resolve"  
- Scenario 3 (3 images, middle fails): first and third preserved, ordered by sourceIndex (0, 2) ✅ — test "preserves partial results with correct ordering when middle attachment fails"
- Integration test: `runAgentTurnWithSessionContext` with partial media preserves the valid image ✅ — test "preserves partial current media when some attachments fail to resolve"
- No regression: existing tests (PDF page ordering from #99902, Telegram hydration) continue to pass ✅

**Observed result after fix**: The resolver now correctly preserves successfully-loaded images even when other attachments in the same turn fail. The `sourceIndex` is correctly mapped through `resolved.attachmentIndexes`, ensuring compatibility with the mixed-image ordering contract.

**What was not tested**: Full end-to-end Telegram roundtrip (requires real Telegram bot + credentials); non-macOS platforms (Windows, Linux).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)