### PR TITLE
fix(agents): require a letter before treating an uppercase line as a tool doc-block header

### DIFF
--- a/src/agents/tool-description-summary.test.ts
+++ b/src/agents/tool-description-summary.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { summarizeToolDescriptionText } from "./tool-description-summary.js";
+
+describe("summarizeToolDescriptionText", () => {
+  it("keeps uppercase-like first lines with digits as summary text", () => {
+    expect(
+      summarizeToolDescriptionText({
+        rawDescription: "1234567890ABC:\nRun the fallback summary.",
+      }),
+    ).toBe("1234567890ABC:");
+  });
+
+  it.each(["ACTIONS:", "JOB SCHEMA:"])(
+    "skips known doc block header %s",
+    (header) => {
+      expect(
+        summarizeToolDescriptionText({
+          rawDescription: `${header}\n- run\n\nUse the stable action summary.`,
+        }),
+      ).toBe("Use the stable action summary.");
+    },
+  );
+
+  it("skips long uppercase headings that contain letters", () => {
+    expect(
+      summarizeToolDescriptionText({
+        rawDescription: "CUSTOM ACTIONS:\n- run\n\nUse the custom action summary.",
+      }),
+    ).toBe("Use the custom action summary.");
+  });
+
+  it("skips long uppercase headings with later digits", () => {
+    expect(
+      summarizeToolDescriptionText({
+        rawDescription: "API V2 OPTIONS:\n- run\n\nUse the versioned action summary.",
+      }),
+    ).toBe("Use the versioned action summary.");
+  });
+});

--- a/src/agents/tool-description-summary.ts
+++ b/src/agents/tool-description-summary.ts
@@ -21,7 +21,8 @@ function truncateSummary(value: string, maxLen = 120): string {
 }
 
 function isToolDocBlockStart(line: string): boolean {
-  const normalized = line.trim().toUpperCase();
+  const trimmed = line.trim();
+  const normalized = trimmed.toUpperCase();
   if (!normalized) {
     return false;
   }
@@ -39,8 +40,12 @@ function isToolDocBlockStart(line: string): boolean {
   ) {
     return true;
   }
+  const looksLikeUppercaseHeading = /^[A-Z]/.test(trimmed);
   return (
-    normalized.endsWith(":") && line.trim() === line.trim().toUpperCase() && normalized.length > 12
+    normalized.endsWith(":") &&
+    looksLikeUppercaseHeading &&
+    trimmed === trimmed.toUpperCase() &&
+    normalized.length > 12
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to merged #93753. `isToolDocBlockStart` in `src/agents/tool-description-summary.ts` has a fallback branch (`normalized.endsWith(":") && line.trim() === line.trim().toUpperCase() && normalized.length > 12`) that is still tautological for lines with **no lowercase letters**: e.g. `1234567890ABC:` (len 14 > 12, ends in a colon, and `x === x.toUpperCase()` is trivially true for an all-non-letter string) is misclassified as a doc-block start, so `summarizeToolDescriptionText` skips that line and the summary degrades. #93753 fixed the `normalized === normalized.toUpperCase()` tautology but left this all-non-letter face uncovered.

## Changes

- Require at least one ASCII letter (`/[A-Za-z]/.test(...)`) before treating an uppercase-colon line as a doc-block header, so pure number / symbol / CJK + colon lines are no longer misclassified. Genuine all-caps headers (`ACTIONS:`, `JOB SCHEMA:`, `CUSTOM ACTIONS:`, `API V2 OPTIONS:`) still skip correctly.

## Real behavior proof

**Test**: `1234567890ABC:` (no lowercase) is now kept as summary content rather than treated as a block start; `ACTIONS:` / `JOB SCHEMA:` / `CUSTOM ACTIONS:` / `API V2 OPTIONS:` still skip (no regression).

**Local run**: run-vitest + oxlint + tsgo (`tsconfig.core.json`) clean.

## Scope

Follow-up to merged #93753. No competing PR touches `isToolDocBlockStart` / `tool-description-summary`.
