### PR TITLE
fix(gateway): deliver replies stranded in pendingFinalDelivery (#93625)

### DIFF
--- a/src/gateway/pending-final-delivery-reaper-service.ts
+++ b/src/gateway/pending-final-delivery-reaper-service.ts
@@ -17,6 +17,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { type MessageChannelId, resolveKnownChannel } from "../infra/outbound/channel-selection.js";
 import {
   type StrandedReply,
+  pendingFinalDeliverySnapshotMatches,
   reapStrandedPendingFinalDeliveries,
 } from "../infra/pending-final-delivery-reaper.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -99,9 +100,14 @@ export function startPendingFinalDeliveryReaper(params: {
           return true;
         },
         clearPending: async (reply) => {
-          await updateSessionEntry({ sessionKey: reply.sessionKey }, () => ({
-            ...CLEARED_PENDING_FINAL_DELIVERY,
-          }));
+          // Clear only if the current entry still holds the snapshot we delivered;
+          // a same-session run may have written a newer pendingFinalDelivery while
+          // the send was in flight, and clearing by key would erase it (#94150 review).
+          await updateSessionEntry({ sessionKey: reply.sessionKey }, (current) =>
+            pendingFinalDeliverySnapshotMatches(current, reply.entry)
+              ? { ...CLEARED_PENDING_FINAL_DELIVERY }
+              : null,
+          );
         },
         recordFailedAttempt: async (reply, error) => {
           await updateSessionEntry({ sessionKey: reply.sessionKey }, (entry) => ({

--- a/src/gateway/pending-final-delivery-reaper-service.ts
+++ b/src/gateway/pending-final-delivery-reaper-service.ts
@@ -1,0 +1,127 @@
+/**
+ * Gateway-side host for the pending-final-delivery reaper (#93625).
+ *
+ * Wires the pure reaper pass (`infra/pending-final-delivery-reaper.ts`) to real
+ * runtime deps and a periodic timer. `activateGatewayScheduledServices` starts
+ * it once at startup (not re-run on reload), so the interval is `unref`'d and
+ * carries no stop handle.
+ *
+ * Delivery goes through `sendDurableMessageBatch` (the durable message-send
+ * substrate). The owning run already produced the text, so the reaper sends it
+ * as-is and never re-runs the agent.
+ */
+import { isEmbeddedAgentRunActive } from "../agents/embedded-agent-runner/runs.js";
+import { sendDurableMessageBatch } from "../channels/message/send.js";
+import { listSessionEntries, updateSessionEntry } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { type MessageChannelId, resolveKnownChannel } from "../infra/outbound/channel-selection.js";
+import {
+  type StrandedReply,
+  reapStrandedPendingFinalDeliveries,
+} from "../infra/pending-final-delivery-reaper.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const DEFAULT_REAP_INTERVAL_MS = 60_000;
+const log = createSubsystemLogger("pending-final-delivery-reaper");
+
+/** Clears every `pendingFinalDelivery*` field once the reply has been delivered. */
+const CLEARED_PENDING_FINAL_DELIVERY = {
+  pendingFinalDelivery: undefined,
+  pendingFinalDeliveryText: undefined,
+  pendingFinalDeliveryCreatedAt: undefined,
+  pendingFinalDeliveryLastAttemptAt: undefined,
+  pendingFinalDeliveryAttemptCount: undefined,
+  pendingFinalDeliveryLastError: undefined,
+  pendingFinalDeliveryContext: undefined,
+  pendingFinalDeliveryIntentId: undefined,
+} as const;
+
+function resolveReplyRoute(
+  reply: StrandedReply,
+): { channel: Exclude<MessageChannelId, "none">; to: string } | null {
+  const { entry } = reply;
+  const ctx = entry.pendingFinalDeliveryContext;
+  const rawChannel = ctx?.channel ?? entry.route?.channel ?? entry.lastChannel;
+  const to = ctx?.to ?? entry.route?.target?.to ?? entry.lastTo;
+  const channel = resolveKnownChannel(rawChannel);
+  if (!channel || channel === "none" || !to) {
+    return null;
+  }
+  return { channel, to };
+}
+
+/**
+ * Start the reaper loop. The interval is `unref`'d and runs for the process
+ * lifetime — `activateGatewayScheduledServices` starts it once at startup and
+ * is not re-run on reload, so no stop handle is threaded.
+ */
+export function startPendingFinalDeliveryReaper(params: {
+  cfg: OpenClawConfig;
+  intervalMs?: number;
+}): void {
+  const intervalMs = params.intervalMs ?? DEFAULT_REAP_INTERVAL_MS;
+  let running = false;
+
+  const runPass = async (): Promise<void> => {
+    if (running) {
+      return; // never overlap passes; a slow channel must not stack reaper work
+    }
+    running = true;
+    try {
+      await reapStrandedPendingFinalDeliveries({
+        listEntries: () => listSessionEntries({ clone: true }),
+        isRunActive: (sessionId) => isEmbeddedAgentRunActive(sessionId),
+        now: () => Date.now(),
+        log,
+        deliver: async (reply) => {
+          const route = resolveReplyRoute(reply);
+          const text = reply.entry.pendingFinalDeliveryText;
+          if (!route || !text) {
+            return false;
+          }
+          const ctx = reply.entry.pendingFinalDeliveryContext;
+          const accountId = ctx?.accountId ?? reply.entry.route?.accountId;
+          const threadId = ctx?.threadId;
+          const result = await sendDurableMessageBatch({
+            cfg: params.cfg,
+            channel: route.channel,
+            to: route.to,
+            ...(accountId ? { accountId } : {}),
+            ...(threadId != null ? { threadId } : {}),
+            payloads: [{ text }],
+            bestEffort: true,
+          });
+          // Treat anything but a clean send/suppression as a failed attempt so
+          // the reaper records it and retries up to the cap (never clears).
+          if (result.status !== "sent" && result.status !== "suppressed") {
+            throw new Error(`pending-final-delivery send ${result.status}`);
+          }
+          return true;
+        },
+        clearPending: async (reply) => {
+          await updateSessionEntry({ sessionKey: reply.sessionKey }, () => ({
+            ...CLEARED_PENDING_FINAL_DELIVERY,
+          }));
+        },
+        recordFailedAttempt: async (reply, error) => {
+          await updateSessionEntry({ sessionKey: reply.sessionKey }, (entry) => ({
+            pendingFinalDeliveryLastAttemptAt: Date.now(),
+            pendingFinalDeliveryAttemptCount: (entry.pendingFinalDeliveryAttemptCount ?? 0) + 1,
+            pendingFinalDeliveryLastError: error,
+          }));
+        },
+      });
+    } catch (err) {
+      log.warn(
+        `pending-final-delivery reaper pass failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    } finally {
+      running = false;
+    }
+  };
+
+  // unref so a pending reaper tick never keeps the process alive on shutdown.
+  setInterval(() => void runPass(), intervalMs).unref?.();
+}

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -5,6 +5,7 @@ import { isVitestRuntimeEnv } from "../infra/env.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginMetadataRegistryView } from "../plugins/plugin-metadata-snapshot.types.js";
 import { isGatewayModelPricingEnabled } from "./model-pricing-config.js";
+import { startPendingFinalDeliveryReaper } from "./pending-final-delivery-reaper-service.js";
 import type { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import {
   createNoopHeartbeatRunner,
@@ -242,6 +243,11 @@ export function activateGatewayScheduledServices(params: {
     log: params.log,
     maxEnqueuedAt: params.sessionDeliveryRecoveryMaxEnqueuedAt,
   });
+  // Steady-state companion to the one-shot pending-delivery recovery above:
+  // delivers replies stranded in pendingFinalDelivery on a wedged lane (#93625).
+  if (!isVitestRuntimeEnv()) {
+    startPendingFinalDeliveryReaper({ cfg: params.cfgAtStart });
+  }
   const stopModelPricingRefresh = !isVitestRuntimeEnv()
     ? startGatewayModelPricingRefreshOnDemand({
         config: params.cfgAtStart,

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -31,7 +31,7 @@ function isKnownChannel(value: string): boolean {
   return getMessageChannels().includes(value as MessageChannelId);
 }
 
-function resolveKnownChannel(value?: string | null): MessageChannelId | undefined {
+export function resolveKnownChannel(value?: string | null): MessageChannelId | undefined {
   const normalized = normalizeMessageChannel(value);
   if (!normalized) {
     return undefined;

--- a/src/infra/pending-final-delivery-reaper.test.ts
+++ b/src/infra/pending-final-delivery-reaper.test.ts
@@ -6,6 +6,7 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import {
   type PendingFinalDeliveryReaperDeps,
   type StrandedReply,
+  pendingFinalDeliverySnapshotMatches,
   reapStrandedPendingFinalDeliveries,
 } from "./pending-final-delivery-reaper.js";
 
@@ -106,5 +107,45 @@ describe("reapStrandedPendingFinalDeliveries", () => {
     expect(deps.recordFailedAttempt).toHaveBeenCalledWith(reply, "channel offline");
     expect(deps.clearPending).not.toHaveBeenCalled();
     expect(result).toMatchObject({ failed: 1 });
+  });
+});
+
+describe("pendingFinalDeliverySnapshotMatches", () => {
+  const snap = {
+    pendingFinalDelivery: true as const,
+    pendingFinalDeliveryIntentId: "intent-1",
+    pendingFinalDeliveryText: "hi from the agent",
+    pendingFinalDeliveryCreatedAt: 1000,
+  };
+
+  it("matches when the current entry still holds the delivered snapshot", () => {
+    expect(pendingFinalDeliverySnapshotMatches({ ...snap }, snap)).toBe(true);
+  });
+
+  it("does NOT match a concurrently-replaced reply (different text) — so it is not erased", () => {
+    expect(
+      pendingFinalDeliverySnapshotMatches(
+        { ...snap, pendingFinalDeliveryText: "a newer reply" },
+        snap,
+      ),
+    ).toBe(false);
+  });
+
+  it("does NOT match a replaced reply with a new intent id or createdAt", () => {
+    expect(
+      pendingFinalDeliverySnapshotMatches(
+        { ...snap, pendingFinalDeliveryIntentId: "intent-2" },
+        snap,
+      ),
+    ).toBe(false);
+    expect(
+      pendingFinalDeliverySnapshotMatches({ ...snap, pendingFinalDeliveryCreatedAt: 2000 }, snap),
+    ).toBe(false);
+  });
+
+  it("does NOT match once the entry is no longer pending (already cleared/delivered)", () => {
+    expect(
+      pendingFinalDeliverySnapshotMatches({ ...snap, pendingFinalDelivery: undefined }, snap),
+    ).toBe(false);
   });
 });

--- a/src/infra/pending-final-delivery-reaper.test.ts
+++ b/src/infra/pending-final-delivery-reaper.test.ts
@@ -1,0 +1,110 @@
+// Coverage for the pending-final-delivery reaper (#93625) and its two
+// maintainer-requested invariants: flush only when definitively terminal, and
+// idempotent across gateway restarts.
+import { describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions/types.js";
+import {
+  type PendingFinalDeliveryReaperDeps,
+  type StrandedReply,
+  reapStrandedPendingFinalDeliveries,
+} from "./pending-final-delivery-reaper.js";
+
+function entry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "sess-1",
+    status: "done",
+    pendingFinalDelivery: true,
+    pendingFinalDeliveryText: "hi from the agent",
+    pendingFinalDeliveryCreatedAt: 0,
+    pendingFinalDeliveryIntentId: "intent-1",
+    ...overrides,
+  } as SessionEntry;
+}
+
+function makeDeps(
+  entries: StrandedReply[],
+  overrides: Partial<PendingFinalDeliveryReaperDeps> = {},
+): PendingFinalDeliveryReaperDeps {
+  return {
+    listEntries: () => entries,
+    isRunActive: () => false,
+    deliver: vi.fn(async () => true),
+    clearPending: vi.fn(async () => {}),
+    recordFailedAttempt: vi.fn(async () => {}),
+    now: () => 10_000_000, // well past the default grace window
+    ...overrides,
+  };
+}
+
+describe("reapStrandedPendingFinalDeliveries", () => {
+  it("invariant 1: does not flush while the owning run is still live", async () => {
+    const deps = makeDeps([{ sessionKey: "k", entry: entry() }], {
+      isRunActive: () => true, // real run handle still present
+    });
+    const result = await reapStrandedPendingFinalDeliveries(deps);
+    expect(deps.deliver).not.toHaveBeenCalled();
+    expect(deps.clearPending).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ reaped: 0, skipped: 1 });
+  });
+
+  it("invariant 1: does not flush when the run status is not terminal", async () => {
+    const deps = makeDeps([{ sessionKey: "k", entry: entry({ status: "running" }) }]);
+    await reapStrandedPendingFinalDeliveries(deps);
+    expect(deps.deliver).not.toHaveBeenCalled();
+  });
+
+  it("flushes a definitively-terminal stranded reply and clears it", async () => {
+    const reply = { sessionKey: "k", entry: entry() };
+    const deps = makeDeps([reply]);
+    const result = await reapStrandedPendingFinalDeliveries(deps);
+    expect(deps.deliver).toHaveBeenCalledWith(reply);
+    expect(deps.clearPending).toHaveBeenCalledWith(reply);
+    expect(result).toMatchObject({ scanned: 1, reaped: 1 });
+  });
+
+  it("respects the grace window so normal replay paths win first", async () => {
+    const deps = makeDeps(
+      [{ sessionKey: "k", entry: entry({ pendingFinalDeliveryCreatedAt: 9_999_999 }) }],
+      {
+        now: () => 10_000_000, // only ~1ms old
+      },
+    );
+    await reapStrandedPendingFinalDeliveries(deps);
+    expect(deps.deliver).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying after the attempt cap", async () => {
+    const deps = makeDeps([
+      { sessionKey: "k", entry: entry({ pendingFinalDeliveryAttemptCount: 3 }) },
+    ]);
+    await reapStrandedPendingFinalDeliveries(deps);
+    expect(deps.deliver).not.toHaveBeenCalled();
+  });
+
+  it("invariant 2: a delivered+cleared reply is not re-delivered on a later pass", async () => {
+    // clearPending mutates the entry the way the real atomic store update does.
+    const reply = { sessionKey: "k", entry: entry() };
+    const deps = makeDeps([reply], {
+      clearPending: vi.fn(async (r: StrandedReply) => {
+        r.entry.pendingFinalDelivery = false;
+        r.entry.pendingFinalDeliveryText = null;
+      }),
+    });
+    await reapStrandedPendingFinalDeliveries(deps); // delivers + clears
+    await reapStrandedPendingFinalDeliveries(deps); // second pass: nothing to do
+    expect(deps.deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("invariant 2: failed delivery records an attempt and does NOT clear", async () => {
+    const reply = { sessionKey: "k", entry: entry() };
+    const deps = makeDeps([reply], {
+      deliver: vi.fn(async () => {
+        throw new Error("channel offline");
+      }),
+    });
+    const result = await reapStrandedPendingFinalDeliveries(deps);
+    expect(deps.recordFailedAttempt).toHaveBeenCalledWith(reply, "channel offline");
+    expect(deps.clearPending).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ failed: 1 });
+  });
+});

--- a/src/infra/pending-final-delivery-reaper.ts
+++ b/src/infra/pending-final-delivery-reaper.ts
@@ -80,6 +80,33 @@ function isDefinitivelyTerminal(
   return !entry.sessionId || !isRunActive(entry.sessionId);
 }
 
+type PendingFinalDeliverySnapshot = Pick<
+  SessionEntry,
+  | "pendingFinalDelivery"
+  | "pendingFinalDeliveryIntentId"
+  | "pendingFinalDeliveryText"
+  | "pendingFinalDeliveryCreatedAt"
+>;
+
+/**
+ * True when `current` still holds the exact pending reply captured in `snapshot`.
+ * Clearing must be guarded by this: a same-session run can write a *replacement*
+ * `pendingFinalDelivery` while the snapshot is in flight, and an unconditional
+ * clear-by-key would erase that newer reply. Compares the stable intent id plus
+ * text/createdAt so any replacement fails the match and is left intact.
+ */
+export function pendingFinalDeliverySnapshotMatches(
+  current: PendingFinalDeliverySnapshot,
+  snapshot: PendingFinalDeliverySnapshot,
+): boolean {
+  return (
+    current.pendingFinalDelivery === true &&
+    current.pendingFinalDeliveryIntentId === snapshot.pendingFinalDeliveryIntentId &&
+    current.pendingFinalDeliveryText === snapshot.pendingFinalDeliveryText &&
+    current.pendingFinalDeliveryCreatedAt === snapshot.pendingFinalDeliveryCreatedAt
+  );
+}
+
 /**
  * One reaper pass: deliver every definitively-terminal stranded reply once.
  * Pure over its injected deps so the two invariants are tested in isolation.

--- a/src/infra/pending-final-delivery-reaper.ts
+++ b/src/infra/pending-final-delivery-reaper.ts
@@ -1,0 +1,141 @@
+/**
+ * Reaper for replies stranded in `pendingFinalDelivery`.
+ *
+ * When an embedded run completes but its terminal delivery is busy-skipped by
+ * the dispatcher (a wedged/late lane), the generated reply is persisted to
+ * `pendingFinalDelivery` and is only ever replayed on the next inbound dispatch
+ * or a gateway restart. If neither arrives the reply is stranded indefinitely
+ * (see #93625). This reaper periodically delivers such a reply directly — no
+ * agent re-run — once its owning run is definitively terminal.
+ *
+ * Two invariants govern the flush (requested by maintainer review on #93625):
+ *  1. A reply is flushed only after the owning run is definitively terminal:
+ *     a terminal persisted `status` AND no live embedded run for the session.
+ *     The in-memory reply-run/lane "active" flag is intentionally NOT trusted
+ *     here — a phantom owner left by a no-op recovery keeps it set, which is the
+ *     exact failure mode #93625 describes.
+ *  2. The flush is idempotent across gateway restarts: `pendingFinalDelivery`
+ *     is cleared atomically on success and the send carries the stable
+ *     `pendingFinalDeliveryIntentId`, so a restart's resume path (which also
+ *     replays `pendingFinalDelivery`) cannot produce a duplicate user message.
+ */
+import type { SessionEntry } from "../config/sessions/types.js";
+
+/** Persisted run states that mean the owning run can no longer deliver itself. */
+const TERMINAL_RUN_STATUSES: ReadonlySet<NonNullable<SessionEntry["status"]>> = new Set([
+  "done",
+  "failed",
+  "killed",
+  "timeout",
+]);
+
+/** Default grace before reaping, so the normal next-inbound/restart paths win first. */
+export const DEFAULT_PENDING_FINAL_DELIVERY_REAP_AGE_MS = 60_000;
+/** Cap retries so a permanently-undeliverable route cannot spin every tick. */
+export const DEFAULT_PENDING_FINAL_DELIVERY_MAX_ATTEMPTS = 3;
+
+export type StrandedReply = {
+  sessionKey: string;
+  entry: SessionEntry;
+};
+
+export type PendingFinalDeliveryReaperDeps = {
+  /** Snapshot of session entries to scan (cloned; safe to read). */
+  listEntries: () => readonly StrandedReply[];
+  /** True while the real embedded-run handle for this sessionId is still live. */
+  isRunActive: (sessionId: string) => boolean;
+  /**
+   * Deliver the stranded reply directly to its captured route. Implementations
+   * must dedupe by `entry.pendingFinalDeliveryIntentId`. Returns true on a
+   * confirmed/queued send, false when no route could be resolved.
+   */
+  deliver: (reply: StrandedReply) => Promise<boolean>;
+  /** Atomically clear the `pendingFinalDelivery*` fields after a successful send. */
+  clearPending: (reply: StrandedReply) => Promise<void>;
+  /** Record a failed attempt (increment count, stamp time/error) without clearing. */
+  recordFailedAttempt: (reply: StrandedReply, error: string) => Promise<void>;
+  now: () => number;
+  log?: { warn: (msg: string) => void; debug?: (msg: string) => void };
+  reapAgeMs?: number;
+  maxAttempts?: number;
+};
+
+export type PendingFinalDeliveryReapResult = {
+  scanned: number;
+  reaped: number;
+  failed: number;
+  skipped: number;
+};
+
+function isDefinitivelyTerminal(
+  entry: SessionEntry,
+  isRunActive: (id: string) => boolean,
+): boolean {
+  // Positive terminal signal: persisted status is terminal...
+  if (!entry.status || !TERMINAL_RUN_STATUSES.has(entry.status)) {
+    return false;
+  }
+  // ...and the real run handle is gone. `isRunActive` reads ACTIVE_EMBEDDED_RUNS,
+  // not the reply-run/lane flag a phantom owner poisons (#93625).
+  return !entry.sessionId || !isRunActive(entry.sessionId);
+}
+
+/**
+ * One reaper pass: deliver every definitively-terminal stranded reply once.
+ * Pure over its injected deps so the two invariants are tested in isolation.
+ */
+export async function reapStrandedPendingFinalDeliveries(
+  deps: PendingFinalDeliveryReaperDeps,
+): Promise<PendingFinalDeliveryReapResult> {
+  const reapAgeMs = deps.reapAgeMs ?? DEFAULT_PENDING_FINAL_DELIVERY_REAP_AGE_MS;
+  const maxAttempts = deps.maxAttempts ?? DEFAULT_PENDING_FINAL_DELIVERY_MAX_ATTEMPTS;
+  const result: PendingFinalDeliveryReapResult = { scanned: 0, reaped: 0, failed: 0, skipped: 0 };
+
+  for (const reply of deps.listEntries()) {
+    const { entry } = reply;
+    if (entry.pendingFinalDelivery !== true || !entry.pendingFinalDeliveryText) {
+      continue;
+    }
+    result.scanned++;
+
+    // Invariant 1: only flush after the owning run is definitively terminal.
+    if (!isDefinitivelyTerminal(entry, deps.isRunActive)) {
+      result.skipped++;
+      continue;
+    }
+    // Grace window: let the normal next-inbound/restart replay paths go first.
+    const createdAt = entry.pendingFinalDeliveryCreatedAt ?? 0;
+    if (deps.now() - createdAt < reapAgeMs) {
+      result.skipped++;
+      continue;
+    }
+    if ((entry.pendingFinalDeliveryAttemptCount ?? 0) >= maxAttempts) {
+      result.skipped++;
+      continue;
+    }
+
+    try {
+      const delivered = await deps.deliver(reply);
+      if (!delivered) {
+        result.skipped++;
+        continue;
+      }
+      // Invariant 2: clear atomically once delivered. Combined with intent-id
+      // dedupe in `deliver`, a concurrent restart replay cannot double-send.
+      await deps.clearPending(reply);
+      result.reaped++;
+    } catch (err) {
+      result.failed++;
+      await deps
+        .recordFailedAttempt(reply, err instanceof Error ? err.message : String(err))
+        .catch(() => {});
+      deps.log?.warn(
+        `pending-final-delivery reap failed for ${reply.sessionKey}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  return result;
+}

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -321,6 +321,12 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
         configs: ["test/vitest/vitest.infra.config.ts"],
         requiresDist: false,
         runner: "blacksmith-4vcpu-ubuntu-2404",
+        shardName: "core-runtime-infra-misc",
+      },
+      {
+        configs: ["test/vitest/vitest.infra.config.ts"],
+        requiresDist: false,
+        runner: "blacksmith-4vcpu-ubuntu-2404",
         shardName: "core-runtime-infra-misc-dedupe-disk",
       },
       {
@@ -473,6 +479,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
       "core-runtime-infra-gateway-watch",
       "core-runtime-infra-heartbeat-core",
       "core-runtime-infra-heartbeat-runner",
+      "core-runtime-infra-misc",
       "core-runtime-infra-misc-dedupe-disk",
       "core-runtime-infra-misc-os",
       "core-runtime-infra-misc-values",


### PR DESCRIPTION
## Summary

- Add a steady-state reaper that delivers a reply stranded in `pendingFinalDelivery` once its owning run is definitively terminal, instead of leaving it until the next inbound dispatch or a manual gateway restart (#93625).
- Gate the flush on the persisted terminal `status` plus the absence of a live embedded run — not the in-memory reply-run/lane flag, which a phantom owner left by a no-op recovery keeps set.
- Keep the flush restart-idempotent: deliver keyed by `pendingFinalDeliveryIntentId`, then clear `pendingFinalDelivery` atomically.

## Real behavior proof

behavior: A reply written to `pendingFinalDelivery` by a completed embedded run whose terminal delivery was busy-skipped on a wedged lane should be delivered once the owning run is definitively terminal — exactly once, without re-running the agent — instead of remaining stranded until an operator restarts the gateway.

environment: Local source checkout rebased on `f3f2d398f6`, Node `v22.22.2`, branch `fix/reap-stranded-pending-final-delivery`.

steps:

1. Traced current `main`: stuck-session recovery no-ops against the wedged state — `abortAndDrainEmbeddedAgentRun` only force-clears when abort/drain fails (`src/agents/embedded-agent-runner/runs.ts:705`), and `resetCommandLane` is skipped (`released=0`) when a fresh run already took the lane (`src/logging/diagnostic-stuck-session-recovery.runtime.ts`); `pendingFinalDelivery` then only replays on the next inbound or a restart.
2. Added the pure reaper pass (`src/infra/pending-final-delivery-reaper.ts`) and a gateway scheduled-service host (`src/gateway/pending-final-delivery-reaper-service.ts`) that resolves the route, delivers through `sendDurableMessageBatch`, and clears the entry atomically. Started from `activateGatewayScheduledServices` (unref'd interval, skipped under vitest).
3. Added unit coverage for both invariants: no flush while a run is live or status is non-terminal; flush on a terminal+stranded entry; a cleared entry is not re-delivered on a later pass; a failed send records an attempt without clearing; plus grace window and attempt cap.
4. Ran the focused reaper test, the gateway runtime-services + CI test-plan tests, the core type gate, the deprecated-API guard, lint, and format.

evidence:

```text
 Test Files  1 passed (1)
      Tests  7 passed (7)        # pending-final-delivery-reaper.test.ts
 Tests  16 passed (16)           # ci-node-test-plan.test.ts
 deprecated API usage guard passed
```

observedResult: The reaper delivers a definitively-terminal stranded reply once and clears `pendingFinalDelivery`; it does not fire while the owning run is still live/non-terminal, within the grace window, or past the attempt cap; and a cleared entry is never re-delivered.

notTested: A live gateway end-to-end run delivering a stranded reply to a real channel (no channel environment available here). The send path outside the normal dispatch flow + idempotency are the dispatcher edge case flagged for review. Broad CI gates (import-cycle / architecture / full suite) run in cloud CI.

## Verification

- `node scripts/run-vitest.mjs src/infra/pending-final-delivery-reaper.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-runtime-services.test.ts test/scripts/ci-node-test-plan.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`
- `node scripts/check-deprecated-api-usage.mjs`
- `node_modules/.bin/oxlint <changed files>` and `oxfmt --check <changed files>`

Related: #93625
