### PR TITLE
fix(skills): preserve skillKey in SkillSnapshot for env override resolution

### DIFF
--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1414,6 +1414,7 @@ export function buildWorkspaceSkillSnapshot(
       name: entry.skill.name,
       primaryEnv: entry.metadata?.primaryEnv,
       requiredEnv: entry.metadata?.requires?.env?.slice(),
+      skillKey: entry.metadata?.skillKey,
     })),
     ...(skillFilter === undefined ? {} : { skillFilter }),
     resolvedSkills,

--- a/src/skills/runtime/env-overrides.ts
+++ b/src/skills/runtime/env-overrides.ts
@@ -260,7 +260,8 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const updates: EnvUpdate[] = [];
 
   for (const skill of snapshot.skills) {
-    const skillConfig = resolveSkillConfig(config, skill.name);
+    const skillKey = skill.skillKey ?? skill.name;
+    const skillConfig = resolveSkillConfig(config, skillKey);
     if (!skillConfig) {
       continue;
     }
@@ -273,7 +274,7 @@ export function applySkillEnvOverridesFromSnapshot(params: {
       skillConfig,
       primaryEnv: skill.primaryEnv,
       requiredEnv: skill.requiredEnv,
-      skillKey: skill.name,
+      skillKey,
     });
   }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -103,7 +103,7 @@ export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 1;
 
 export type SkillSnapshot = {
   prompt: string;
-  skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
+  skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[]; skillKey?: string }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   resolvedSkills?: Skill[];


### PR DESCRIPTION
## Summary

Fixes #94146

`SkillSnapshot.skills[]` only stored `name`/`primaryEnv`/`requiredEnv`, omitting `skillKey`. This caused `applySkillEnvOverridesFromSnapshot()` to look up config by `skill.name` instead of the resolved `skillKey`, so skills configured under `skills.entries.<skillKey>` received no env/API key injections at runtime.

## Root Cause

A skill can define `metadata.openclaw.skillKey` (e.g. `weather`) while its name is different (e.g. `Pretty Weather`). The snapshot only captured the display name, so runtime config lookup used the wrong key.

## Changes (3 files, 5 insertions)

- `src/skills/types.ts` — add optional `skillKey` to skill entry type
- `src/skills/loading/workspace.ts` — preserve `skillKey` when building snapshots
- `src/skills/runtime/env-overrides.ts` — use `skill.skillKey ?? skill.name` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)