### PR TITLE
fix: expose OpenAI image quality and moderation CLI options

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -189,6 +189,7 @@ Use `image` for generation, edit, and description.
 openclaw infer image generate --prompt "friendly lobster illustration" --json
 openclaw infer image generate --prompt "cinematic product photo of headphones" --json
 openclaw infer image generate --model openai/gpt-image-1.5 --output-format png --background transparent --prompt "simple red circle sticker on a transparent background" --json
+openclaw infer image generate --model openai/gpt-image-2 --quality low --openai-moderation low --prompt "low-cost draft poster" --json
 openclaw infer image generate --prompt "slow image backend" --timeout-ms 180000 --json
 openclaw infer image edit --file ./logo.png --model openai/gpt-image-1.5 --output-format png --background transparent --prompt "keep the logo, remove the background" --json
 openclaw infer image edit --file ./poster.png --prompt "make this a vertical story ad" --size 2160x3840 --aspect-ratio 9:16 --resolution 4K --json
@@ -209,6 +210,9 @@ Notes:
   `--model openai/gpt-image-1.5` for transparent-background OpenAI PNG output;
   `--openai-background` remains available as an OpenAI-specific alias. Providers
   that do not declare background support report the hint as an ignored override.
+- Use `--quality low|medium|high|auto` for providers that support image quality
+  hints, including OpenAI. OpenAI also accepts `--openai-moderation low|auto` for
+  the provider-specific moderation hint.
 - Use `image providers --json` to verify which bundled image providers are
   discoverable, configured, selected, and which generation/edit capabilities
   each provider exposes.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -506,6 +506,9 @@ openclaw infer image generate \
 Use the same `--output-format` and `--background` flags with
 `openclaw infer image edit` when starting from an input file.
 `--openai-background` remains available as an OpenAI-specific alias.
+Use `--quality low|medium|high|auto` when you need to control OpenAI Images
+quality and cost. Use `--openai-moderation low|auto` to pass OpenAI's
+provider-specific moderation hint from either `image generate` or `image edit`.
 
 For ChatGPT/Codex OAuth installs, keep the same `openai/gpt-image-2` ref. When an
 `openai` OAuth profile is configured, OpenClaw resolves that stored OAuth

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -495,6 +495,23 @@ openclaw infer image generate \
 ```
 
   </Tab>
+  <Tab title="Generate (OpenAI low quality)">
+```text
+/tool image_generate action=generate model=openai/gpt-image-2 prompt="Low-cost draft poster for a quiet productivity app" quality=low openai='{"moderation":"low"}'
+```
+
+Equivalent CLI:
+
+```bash
+openclaw infer image generate \
+  --model openai/gpt-image-2 \
+  --quality low \
+  --openai-moderation low \
+  --prompt "Low-cost draft poster for a quiet productivity app" \
+  --json
+```
+
+  </Tab>
   <Tab title="Generate (two square)">
 ```text
 /tool image_generate action=generate model=openai/gpt-image-2 prompt="Two visual directions for a calm productivity app icon" size=1024x1024 count=2
@@ -517,11 +534,11 @@ openclaw infer image generate \
   </Tab>
 </Tabs>
 
-The same `--output-format` and `--background` flags are available on
-`openclaw infer image edit`; `--openai-background` remains as an
-OpenAI-specific alias. Bundled providers other than OpenAI do not declare
-explicit background control today, so `background: "transparent"` is reported
-as ignored for them.
+The same `--output-format`, `--background`, `--quality`, and
+`--openai-moderation` flags are available on `openclaw infer image edit`;
+`--openai-background` remains as an OpenAI-specific alias. Bundled providers
+other than OpenAI do not declare explicit background control today, so
+`background: "transparent"` is reported as ignored for them.
 
 ## Related
 

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1189,6 +1189,31 @@ describe("openai image generation provider", () => {
     expect(result.model).toBe("gpt-image-1.5");
   });
 
+  it("forwards OpenAI moderation into Codex Responses image-generation tool requests", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageStream({ imageData: "codex-moderated-image" });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: "gpt-image-2",
+      prompt: "Draw a low-moderation Codex preview",
+      cfg: {},
+      authStore: { version: 1, profiles: {} },
+      providerOptions: {
+        openai: {
+          moderation: "low",
+        },
+      },
+    });
+
+    const request = jsonRequestCall();
+    const body = request.body as { tools?: Array<Record<string, unknown>> };
+    expect(request.url).toBe("https://chatgpt.com/backend-api/codex/responses");
+    expect(body.tools?.[0]?.type).toBe("image_generation");
+    expect(body.tools?.[0]?.moderation).toBe("low");
+  });
+
   it("omits output compression for PNG Codex image requests", async () => {
     mockCodexAuthOnly();
     mockCodexImageStream({ imageData: "codex-png-image" });

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -767,6 +767,7 @@ async function generateOpenAICodexImage(params: {
             ...(req.quality !== undefined ? { quality: req.quality } : {}),
             ...(req.outputFormat !== undefined ? { output_format: req.outputFormat } : {}),
             ...(background !== undefined ? { background } : {}),
+            ...(openai?.moderation !== undefined ? { moderation: openai.moderation } : {}),
             ...(outputCompression !== undefined ? { output_compression: outputCompression } : {}),
           },
         ],

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1603,7 +1603,47 @@ describe("capability cli", () => {
     expect(generationCall?.providerOptions).toBeUndefined();
   });
 
-  it("passes image output format and OpenAI background hints through to edit runtime", async () => {
+  it("passes image quality and OpenAI moderation hints through to generation runtime", async () => {
+    mocks.generateImage.mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-2",
+      attempts: [],
+      images: [
+        {
+          buffer: Buffer.from("png-bytes"),
+          mimeType: "image/png",
+          fileName: "draft.png",
+        },
+      ],
+    });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "generate",
+        "--prompt",
+        "low-cost draft",
+        "--quality",
+        "low",
+        "--openai-moderation",
+        "low",
+        "--json",
+      ],
+    });
+
+    const generationCall = firstImageGenerationCall();
+    expect(generationCall?.prompt).toBe("low-cost draft");
+    expect(generationCall?.quality).toBe("low");
+    expect(generationCall?.providerOptions).toEqual({
+      openai: {
+        moderation: "low",
+      },
+    });
+  });
+
+  it("passes image output format, quality, and OpenAI hints through to edit runtime", async () => {
     mocks.generateImage.mockResolvedValue({
       provider: "openai",
       model: "gpt-image-1.5",
@@ -1635,6 +1675,10 @@ describe("capability cli", () => {
         "png",
         "--openai-background",
         "transparent",
+        "--openai-moderation",
+        "auto",
+        "--quality",
+        "high",
         "--json",
       ],
     });
@@ -1644,10 +1688,12 @@ describe("capability cli", () => {
     expect(generationCall?.prompt).toBe("make background transparent");
     expect(generationCall?.modelOverride).toBe("openai/gpt-image-1.5");
     expect(generationCall?.outputFormat).toBe("png");
+    expect(generationCall?.quality).toBe("high");
     expect(generationCall?.background).toBeUndefined();
     expect(generationCall?.providerOptions).toEqual({
       openai: {
         background: "transparent",
+        moderation: "auto",
       },
     });
     expect(inputImages).toHaveLength(1);
@@ -1712,6 +1758,46 @@ describe("capability cli", () => {
     ).rejects.toThrow("exit 1");
     expect(mocks.runtime.error).toHaveBeenCalledWith(
       "Error: --background must be one of transparent, opaque, or auto",
+    );
+
+    mocks.runtime.error.mockClear();
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: [
+          "capability",
+          "image",
+          "generate",
+          "--prompt",
+          "transparent sticker",
+          "--quality",
+          "expensive",
+          "--json",
+        ],
+      }),
+    ).rejects.toThrow("exit 1");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "Error: --quality must be one of low, medium, high, or auto",
+    );
+
+    mocks.runtime.error.mockClear();
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: [
+          "capability",
+          "image",
+          "generate",
+          "--prompt",
+          "transparent sticker",
+          "--openai-moderation",
+          "none",
+          "--json",
+        ],
+      }),
+    ).rejects.toThrow("exit 1");
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "Error: --openai-moderation must be one of low or auto",
     );
   });
 
@@ -1789,6 +1875,33 @@ describe("capability cli", () => {
       "--output-format",
       "--background",
       "--openai-background",
+      "--openai-moderation",
+      "--quality",
+      "--timeout-ms",
+      "--output",
+      "--json",
+    ]);
+  });
+
+  it("reports the expanded image.generate flags in capability inspect", async () => {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "inspect", "--name", "image.generate", "--json"],
+    });
+
+    expect(firstJsonOutput()?.id).toBe("image.generate");
+    expect(firstJsonOutput()?.flags).toEqual([
+      "--prompt",
+      "--model",
+      "--count",
+      "--size",
+      "--aspect-ratio",
+      "--resolution",
+      "--output-format",
+      "--background",
+      "--openai-background",
+      "--openai-moderation",
+      "--quality",
       "--timeout-ms",
       "--output",
       "--json",

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -49,7 +49,9 @@ import { ADMIN_SCOPE } from "../gateway/operator-scopes.js";
 import { generateImage, listRuntimeImageGenerationProviders } from "../image-generation/runtime.js";
 import type {
   ImageGenerationBackground,
+  ImageGenerationOpenAIModeration,
   ImageGenerationOutputFormat,
+  ImageGenerationQuality,
 } from "../image-generation/types.js";
 import {
   parseStrictFiniteNumber,
@@ -203,6 +205,12 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
       "--size",
       "--aspect-ratio",
       "--resolution",
+      "--output-format",
+      "--background",
+      "--openai-background",
+      "--openai-moderation",
+      "--quality",
+      "--timeout-ms",
       "--output",
       "--json",
     ],
@@ -222,6 +230,8 @@ const CAPABILITY_METADATA: CapabilityMetadata[] = [
       "--output-format",
       "--background",
       "--openai-background",
+      "--openai-moderation",
+      "--quality",
       "--timeout-ms",
       "--output",
       "--json",
@@ -979,6 +989,8 @@ async function runImageGenerate(params: {
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;
   openaiBackground?: ImageGenerationBackground;
+  openaiModeration?: ImageGenerationOpenAIModeration;
+  quality?: ImageGenerationQuality;
   file?: string[];
   output?: string;
   timeoutMs?: number;
@@ -1008,11 +1020,18 @@ async function runImageGenerate(params: {
     size: params.size,
     aspectRatio: params.aspectRatio,
     resolution: params.resolution,
+    quality: params.quality,
     outputFormat: params.outputFormat,
     background: params.background,
-    providerOptions: params.openaiBackground
-      ? { openai: { background: params.openaiBackground } }
-      : undefined,
+    providerOptions:
+      params.openaiBackground || params.openaiModeration
+        ? {
+            openai: {
+              ...(params.openaiBackground ? { background: params.openaiBackground } : {}),
+              ...(params.openaiModeration ? { moderation: params.openaiModeration } : {}),
+            },
+          }
+        : undefined,
     timeoutMs: params.timeoutMs,
     inputImages,
   });
@@ -1214,6 +1233,35 @@ function normalizeImageBackground(
     return normalized as ImageGenerationBackground;
   }
   throw new Error(`${label} must be one of transparent, opaque, or auto`);
+}
+
+function normalizeImageQuality(raw: string | undefined): ImageGenerationQuality | undefined {
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  if (
+    normalized === "low" ||
+    normalized === "medium" ||
+    normalized === "high" ||
+    normalized === "auto"
+  ) {
+    return normalized;
+  }
+  throw new Error("--quality must be one of low, medium, high, or auto");
+}
+
+function normalizeOpenAIModeration(
+  raw: string | undefined,
+): ImageGenerationOpenAIModeration | undefined {
+  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "low" || normalized === "auto") {
+    return normalized;
+  }
+  throw new Error("--openai-moderation must be one of low or auto");
 }
 
 function normalizeVideoResolution(raw: string | undefined): VideoGenerationResolution | undefined {
@@ -2229,6 +2277,8 @@ export function registerCapabilityCli(program: Command) {
     .option("--output-format <format>", "Output format hint: png, jpeg, or webp")
     .option("--background <value>", "Background hint: transparent, opaque, or auto")
     .option("--openai-background <value>", "OpenAI background hint: transparent, opaque, or auto")
+    .option("--openai-moderation <value>", "OpenAI moderation hint: low or auto")
+    .option("--quality <value>", "Quality hint: low, medium, high, or auto")
     .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
     .option("--output <path>", "Output path")
     .option("--json", "Output JSON", false)
@@ -2248,6 +2298,8 @@ export function registerCapabilityCli(program: Command) {
             opts.openaiBackground as string | undefined,
             "--openai-background",
           ),
+          openaiModeration: normalizeOpenAIModeration(opts.openaiModeration as string | undefined),
+          quality: normalizeImageQuality(opts.quality as string | undefined),
           timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
           output: opts.output as string | undefined,
         });
@@ -2267,6 +2319,8 @@ export function registerCapabilityCli(program: Command) {
     .option("--output-format <format>", "Output format hint: png, jpeg, or webp")
     .option("--background <value>", "Background hint: transparent, opaque, or auto")
     .option("--openai-background <value>", "OpenAI background hint: transparent, opaque, or auto")
+    .option("--openai-moderation <value>", "OpenAI moderation hint: low or auto")
+    .option("--quality <value>", "Quality hint: low, medium, high, or auto")
     .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")
     .option("--output <path>", "Output path")
     .option("--json", "Output JSON", false)
@@ -2287,6 +2341,8 @@ export function registerCapabilityCli(program: Command) {
             opts.openaiBackground as string | undefined,
             "--openai-background",
           ),
+          openaiModeration: normalizeOpenAIModeration(opts.openaiModeration as string | undefined),
+          quality: normalizeImageQuality(opts.quality as string | undefined),
           timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs),
           output: opts.output as string | undefined,
         });


### PR DESCRIPTION
## Summary

This PR adds image quality and OpenAI moderation controls to the `openclaw infer image` CLI:

- Adds `--quality low|medium|high|auto` to `openclaw infer image generate`
- Adds `--quality low|medium|high|auto` to `openclaw infer image edit`
- Adds OpenAI-specific `--openai-moderation low|auto` to generation and editing
- Passes `quality` through to the image generation runtime
- Passes `--openai-moderation` through as `providerOptions.openai.moderation`
- Passes OpenAI moderation into both native OpenAI image requests and Codex Responses `image_generation` tool requests
- Updates capability inspect metadata for `image.generate` and `image.edit`
- Documents the new flags in the CLI, OpenAI provider, and image generation docs

## Why this is needed

OpenClaw already exposes advanced image generation controls in the built-in `image_generate` agent tool, including OpenAI-specific moderation and quality-related options. The CLI also already exposes several image generation controls, such as:

- `--output-format`
- `--background`
- `--openai-background`

But the CLI did not expose quality or OpenAI moderation, even though these are important OpenAI image-generation controls.

That gap matters for two reasons.

First, image quality affects cost. OpenAI image generation pricing varies by quality level, so users running generation through the CLI need a direct way to choose cheaper draft output or higher quality final output.

Second, moderation is an OpenAI-specific generation option. The CLI already has the provider-specific `--openai-background` escape hatch, so `--openai-moderation` follows the same pattern instead of forcing users to leave the CLI path.

There was also an implementation gap in the OpenAI provider itself: the direct OpenAI image path already forwarded `openai.moderation`, but the Codex Responses image path did not pass it into the upstream `image_generation` tool payload. Since the Responses API image generation tool supports moderation, requests routed through Codex OAuth should preserve the same option instead of silently dropping it.

Without these flags and pass-through support, users who need cost-aware or moderation-aware OpenAI image generation have to use the agent tool directly, write custom wrappers, or bypass OpenClaw's CLI. That weakens the CLI as the stable local automation surface for media generation.

## How this solves it

The implementation keeps the existing CLI shape and runtime boundaries:

- `--quality` is implemented as a general image quality hint because quality is already modeled as a top-level image generation runtime option.
- `--openai-moderation` is implemented as an OpenAI-specific option, matching the existing `--openai-background` provider-specific pattern.
- Both options are available for `image generate` and `image edit`.
- Values are normalized and validated before provider dispatch.
- Invalid values fail early with clear CLI errors.
- Capability inspect output now advertises the new flags for both `image.generate` and `image.edit`.
- The OpenAI provider forwards moderation in both supported OpenAI image transports:
  - Native OpenAI image generation/editing requests
  - Codex Responses `image_generation` tool requests
- Documentation now shows how to use the new flags from the CLI and explains the OpenAI provider use case.

## Behavior details

For generation:
```bash
openclaw infer image generate \
  --model openai/gpt-image-2 \
  --quality low \
  --openai-moderation low \
  --prompt "Low-cost draft poster" \
  --json
```

For editing, the same controls are available:
```bash
openclaw infer image edit \
  --file ./poster.png \
  --model openai/gpt-image-2 \
  --quality high \
  --openai-moderation auto \
  --prompt "Refine this poster for final export" \
  --json
```

`--quality` accepts:

- `low`
- `medium`
- `high`
- `auto`

`--openai-moderation` accepts:

- `low`
- `auto`

## Verification

Ran:
```bash
pnpm docs:list
pnpm format:fix -- src/cli/capability-cli.ts src/cli/capability-cli.test.ts docs/cli/infer.md docs/providers/openai.md docs/tools/image-generation.md
pnpm test src/cli/capability-cli.test.ts
pnpm format:docs:check
pnpm tsgo:core
pnpm format:fix -- extensions/openai/image-generation-provider.ts extensions/openai/image-generation-provider.test.ts
pnpm test extensions/openai/image-generation-provider.test.ts
git diff --check
pnpm build
```

Observed result:

- `pnpm test src/cli/capability-cli.test.ts`: 97 tests passed
- `pnpm format:docs:check`: docs formatting clean
- `pnpm tsgo:core`: passed
- `pnpm test extensions/openai/image-generation-provider.test.ts`: 62 tests passed
- `git diff --check`: no whitespace errors
- `pnpm build`: build success

## Real behavior proof

Behavior addressed:

- The CLI accepts `--quality` for image generation and image editing.
- The CLI accepts `--openai-moderation` for image generation and image editing.
- The CLI forwards `quality` as a top-level runtime option.
- The CLI forwards OpenAI moderation as `providerOptions.openai.moderation`.
- Existing OpenAI background handling remains intact.
- Capability inspect metadata reports the expanded flags.
- The OpenAI provider forwards moderation into Codex Responses `image_generation` tool requests instead of dropping it on the OAuth/Codex route.

Evidence after fix:

- The generation CLI test asserts that the runtime receives `quality: "low"` and `providerOptions.openai.moderation: "low"`.
- The edit CLI test asserts that the runtime receives `quality: "high"` and OpenAI provider options containing both `background: "transparent"` and `moderation: "auto"`.
- Invalid `--quality` and `--openai-moderation` values are rejected before provider dispatch.
- Capability inspect tests assert that both `image.generate` and `image.edit` report `--quality` and `--openai-moderation`.
- The OpenAI provider test asserts that Codex Responses image generation sends `moderation: "low"` inside the `image_generation` tool payload.

Console help output after fix:
```bash
beru@beru:~/src/openclaw$ openclaw infer image generate --help
|
o  

OpenClaw 2026.6.8 (7f6d396) — All your chats, one OpenClaw.

Usage: openclaw infer image generate [options]

Generate images

Options:
  --aspect-ratio <ratio>       Aspect ratio hint like 16:9
  --background <value>         Background hint: transparent, opaque, or auto
  --count <n>                  Number of images
  -h, --help                   Display help for command
  --json                       Output JSON (default: false)
  --model <provider/model>     Model override
  --openai-background <value>  OpenAI background hint: transparent, opaque, or auto
  --openai-moderation <value>  OpenAI moderation hint: low or auto
  --output <path>              Output path
  --output-format <format>     Output format hint: png, jpeg, or webp
  --prompt <text>              Prompt text
  --quality <value>            Quality hint: low, medium, high, or auto
  --resolution <value>         Resolution hint: 1K, 2K, or 4K
  --size <size>                Size hint like 1024x1024
  --timeout-ms <ms>            Provider request timeout in milliseconds
beru@beru:~/src/openclaw$ openclaw infer image edit --help
|
o  

OpenClaw 2026.6.8 (7f6d396) — All your chats, one OpenClaw.

Usage: openclaw infer image edit [options]

Edit images with one or more input files

Options:
  --aspect-ratio <ratio>       Aspect ratio hint like 16:9
  --background <value>         Background hint: transparent, opaque, or auto
  --file <path>                Input file (default: [])
  -h, --help                   Display help for command
  --json                       Output JSON (default: false)
  --model <provider/model>     Model override
  --openai-background <value>  OpenAI background hint: transparent, opaque, or auto
  --openai-moderation <value>  OpenAI moderation hint: low or auto
  --output <path>              Output path
  --output-format <format>     Output format hint: png, jpeg, or webp
  --prompt <text>              Prompt text
  --quality <value>            Quality hint: low, medium, high, or auto
  --resolution <value>         Resolution hint: 1K, 2K, or 4K
  --size <size>                Size hint like 1024x1024
  --timeout-ms <ms>            Provider request timeout in milliseconds
```

As observed, the new options are present.

Generation after fix:
```bash
beru@beru:~/src/openclaw$ openclaw infer image generate --model openai/gpt-image-2 --output-format jpeg --json --output /home/beru/.openclaw/workspace/images/image-m1.jpeg --prompt "Two warriors fighting with swords, stabbing each other, blood splatter on the ground, war scene"
ProviderHttpError: OpenAI image generation failed (HTTP 400): Your request was rejected by the safety system. If you believe this is an error, contact us at help.openai.com and include the request ID req_574eb39cb0444577b02439e1397f381e. safety_violations=[violence]. [type=image_generation_user_error, code=moderation_blocked] [request_id=req_574eb39cb0444577b02439e1397f381e]

beru@beru:~/src/openclaw$ openclaw infer image generate --model openai/gpt-image-2 --output-format jpeg --json --output /home/beru/.openclaw/workspace/images/image-m1.jpeg --openai-moderation auto --prompt "Two warriors fighting with swords, stabbing each other, blood splatter on the ground, war scene"
ProviderHttpError: OpenAI image generation failed (HTTP 400): Your request was rejected by the safety system. If you believe this is an error, contact us at help.openai.com and include the request ID req_fd8c40e291fe4f88af95e4eef1e5932a. safety_violations=[violence]. [type=image_generation_user_error, code=moderation_blocked] [request_id=req_fd8c40e291fe4f88af95e4eef1e5932a]

beru@beru:~/src/openclaw$ openclaw infer image generate --model openai/gpt-image-2 --output-format jpeg --json --output /home/beru/.openclaw/workspace/images/image-m1.jpeg --openai-moderation low --prompt "Two warriors fighting with swords, stabbing each other, blood splatter on the ground, war scene"
{
  "ok": true,
  "capability": "image.generate",
  "transport": "local",
  "provider": "openai",
  "model": "gpt-image-2",
  "attempts": [],
  "outputs": [
    {
      "path": "/home/beru/.openclaw/workspace/images/image-m1.jpeg",
      "mimeType": "image/jpeg",
      "size": 212632,
      "width": 1024,
      "height": 1024
    }
  ],
  "ignoredOverrides": []
}
```

Generation is still working without `--openai-moderation`, but clearly accepts also `--openai-moderation auto` and `--openai-moderation low`.

After generating a slightly less violent `/home/beru/.openclaw/workspace/images/image-m2.jpeg`, let's try to edit it:

```bash
beru@beru:~/src/openclaw$ openclaw infer image edit --model openai/gpt-image-2 --output-format jpeg --json --output /home/beru/.openclaw/workspace/images/image-m2e1.jpeg --file /home/beru/.openclaw/workspace/images/image-m2.png --prompt "add a bit more blood"                        
{
  "ok": true,
  "capability": "image.edit",
  "transport": "local",
  "provider": "openai",
  "model": "gpt-image-2",
  "attempts": [],
  "outputs": [
    {
      "path": "/home/beru/.openclaw/workspace/images/image-m2e1.jpeg",
      "mimeType": "image/jpeg",
      "size": 202938,
      "width": 1024,
      "height": 1024
    }
  ],
  "ignoredOverrides": []
}

beru@beru:~/src/openclaw$ openclaw infer image edit --model openai/gpt-image-2 --output-format jpeg --json --output /home/beru/.openclaw/workspace/images/image-m2e2.jpeg --file /home/beru/.openclaw/workspace/images/image-m2.png --prompt "add a bit more blood" --openai-moderation low
{
  "ok": true,
  "capability": "image.edit",
  "transport": "local",
  "provider": "openai",
  "model": "gpt-image-2",
  "attempts": [],
  "outputs": [
    {
      "path": "/home/beru/.openclaw/workspace/images/image-m2e2.jpeg",
      "mimeType": "image/jpeg",
      "size": 197515,
      "width": 1024,
      "height": 1024
    }
  ],
  "ignoredOverrides": []
}
```

Editing is still working without `--openai-moderation`, but clearly accepts also `--openai-moderation low`.

## Documentation

Updated:

- `docs/cli/infer.md`
- `docs/providers/openai.md`
- `docs/tools/image-generation.md`
