### PR TITLE
fix: remove actionable config patch suggestions from sandbox error messages

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1535,7 +1535,7 @@ export function createExecTool(
         throw new Error(
           [
             "exec host=sandbox requires a sandbox runtime for this session.",
-            'Enable sandbox mode (`agents.defaults.sandbox.mode="non-main"` or `"all"`) or use host=auto/gateway/node.',
+            "Ask the operator to enable sandbox mode, or use host=auto/gateway/node.",
           ].join("\n"),
         );
       }

--- a/src/agents/sandbox/docker.execDockerRaw.enoent.test.ts
+++ b/src/agents/sandbox/docker.execDockerRaw.enoent.test.ts
@@ -1,11 +1,12 @@
 // Docker command tests cover actionable errors when sandbox mode cannot find
-// the docker executable.
+// the docker executable. Error text guides the operator rather than suggesting
+// direct agent-executable config commands.
 import { describe, expect, it } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { execDockerRaw } from "./docker.js";
 
 describe("execDockerRaw", () => {
-  it("wraps docker ENOENT with an actionable configuration error", async () => {
+  it("wraps docker ENOENT with an operator-visible configuration error", async () => {
     // ENOENT otherwise looks like a low-level spawn failure; operators need the
     // sandbox config remediation in the error text.
     await withEnvAsync({ PATH: "" }, async () => {
@@ -20,7 +21,7 @@ describe("execDockerRaw", () => {
       const error = err as Error & { code?: string };
       expect(error.code).toBe("INVALID_CONFIG");
       expect(error.message).toBe(
-        'Sandbox mode requires Docker, but the "docker" command was not found in PATH. Install Docker (and ensure "docker" is available), or set `agents.defaults.sandbox.mode=off` to disable sandboxing.',
+        'Sandbox mode requires Docker, but the "docker" command was not found in PATH. Install Docker, or ask the operator to disable sandbox mode.',
       );
     });
   });

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -122,7 +122,7 @@ export function execDockerRaw(
       ) {
         const friendly = Object.assign(
           new Error(
-            'Sandbox mode requires Docker, but the "docker" command was not found in PATH. Install Docker (and ensure "docker" is available), or set `agents.defaults.sandbox.mode=off` to disable sandboxing.',
+            'Sandbox mode requires Docker, but the "docker" command was not found in PATH. Install Docker, or ask the operator to disable sandbox mode.',
           ),
           { code: "INVALID_CONFIG", cause: error },
         );
@@ -330,7 +330,7 @@ export function formatDockerDaemonUnavailableError(stderr: string): string {
   const detail = stderr.trim();
   return [
     "Sandbox mode requires Docker, but the Docker daemon is not available.",
-    "Start Docker, or set `agents.defaults.sandbox.mode=off` to disable sandboxing.",
+    "Start Docker, or ask the operator to disable sandbox mode.",
     detail ? `Docker said: ${detail}` : undefined,
   ]
     .filter((line): line is string => Boolean(line))


### PR DESCRIPTION
## Summary

Sandbox error messages included executable config commands that agents could read and execute via host exec, bypassing the gateway tool config guard on `config.patch`.
- Problem: Error messages like `set agents.defaults.sandbox.mode=off` gave agents an actionable config patch command they could run unchecked
- Solution: Replace executable config suggestions with operator-notification wording that agents cannot act on
- What changed: `src/agents/sandbox/docker.ts` (2 error messages), `src/agents/bash-tools.exec.ts` (1 error message)
- What did NOT change: No runtime logic, no schema, no tool behavior, no config paths

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #93968
- [x] This PR fixes a bug or regression

## Motivation

Issue #93968 reports that sandbox error messages contain config commands (e.g. `set agents.defaults.sandbox.mode=off`) which agents can read from error output and execute via host exec, silently destroying cron jobs. The gateway tool's `assertGatewayConfigMutationAllowed` guard only protects against `config.patch` called through the gateway tool — it does not prevent agents from running `openclaw config patch` through a host exec shell command. Removing the executable config suggestion from error text is the first line of defense.

## Real behavior proof (required for external PRs)

- Behavior addressed: Error messages no longer contain agent-executable config patch commands
- Real environment tested: Linux, Node.js 22.x (via test runner), branch `fix/sandbox-errmsg-no-config-patch-93968` based on `origin/main`
- Exact steps or command run after this patch:

```bash
# Run sandbox Docker error tests
pnpm test src/agents/sandbox/docker.execDockerRaw.enoent.test.ts --run

# Run sandbox directory tests (22 files, 216 tests)
pnpm test src/agents/sandbox --run

# Build qaRuntime profile
pnpm build qaRuntime
```

- Evidence after fix:

```console
$ pnpm test src/agents/sandbox/docker.execDockerRaw.enoent.test.ts --run
 RUN  v4.1.8

 ✓ src/agents/sandbox/docker.execDockerRaw.enoent.test.ts (1)

 Test Files  1 passed (1)
      Tests  1 passed (1)

$ pnpm test src/agents/sandbox --run
 RUN  v4.1.8

 Test Files  22 passed (22)
      Tests  216 passed (216)
```

- Observed result after fix:
  1. Error text `set agents.defaults.sandbox.mode=off` removed from Docker ENOENT error
  2. Error text `set agents.defaults.sandbox.mode=off` removed from Docker daemon unavailable error
  3. Error text `agents.defaults.sandbox.mode="non-main"` or `"all"` removed from exec sandbox runtime check
  4. All 216 sandbox tests continue to pass
- What was not tested: Real Docker without Docker installed (error is still thrown with same code `INVALID_CONFIG`; only text changed)

## Root Cause (if applicable)

Agent-facing error messages contained executable config patch commands. Agents that have host exec access can read these error messages and run the suggested command via `openclaw config patch`, bypassing the gateway tool's `assertGatewayConfigMutationAllowed` guard entirely.

The guard only applies to `config.patch` called through the agent `gateway` tool; the `openclaw config patch` CLI is a separate code path that exec can invoke directly.

## User-visible / Behavior Changes

When sandbox mode is enabled without Docker installed, users will see:
- Before: `Install Docker, or set agents.defaults.sandbox.mode=off to disable sandboxing.`
- After: `Install Docker, or ask the operator to disable sandbox mode.`

## Security Impact (required)

- [ ] New permissions/capabilities? No
- [ ] Secrets/tokens handling changed? No
- [ ] New/changed network calls? No
- [ ] Command/tool execution surface changed? No
- [ ] Data access scope changed? No

**Security improvement**: Removes the vulnerability path where agent reads error message → parses config command → exec's `openclaw config patch` → silently mutates operator config.

## Human Verification (required)

- Verified scenarios:
  - Docker ENOENT error text updated with operator-notification wording
  - Docker daemon unavailable error text updated with operator-notification wording
  - Exec sandbox runtime error text updated with operator-notification wording
  - All sandbox tests (216 tests) pass
  - qaRuntime build succeeds
- Edge cases checked:
  - Only error messages changed; error codes (`INVALID_CONFIG`), error types, and exception behavior are preserved
  - The `sandbox-explain` command and `security/audit.ts` use different error text paths and were not changed (they output fix-it suggestions for human operators in CLI output, not as exception messages)
- What you did NOT verify:
  - Real Docker installation (error is still thrown; only text changed)
  - Real agent session that reads error messages (behavioral change, covered by code review)

## Compatibility / Migration

- [x] Backward compatible? Yes (only error text changed; no behavior change)
- [ ] Config/env changes? No
- [ ] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — minimal text-only change directly addresses the reported vulnerability path without touching runtime logic
- **Refactor needed**: No
- **Alternative considered**: Adding a CLI config patch guard similar to the gateway tool guard — more invasive, would require touching exec sandboxing enforcement in addditional execution code paths; text change is the simpler first fix

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Sonnet 4.6 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes (code reviewed and understood)

## Risks and Mitigations

**Highest risk area**: None. Only three error message strings changed; no runtime logic, schema, or behavior was modified.

**Mitigation**: Error objects preserve their original type (`INVALID_CONFIG`) and throwing behavior. All 216 sandbox directory tests pass with updated assertions.

**Compatibility**: Fully backward compatible. Error text is not a public API contract. Users/agents who were parsing the old error text will need to update, but that would not normally be a supported integration pattern.

---

Fixes #93968
