### PR TITLE
fix(feishu): paginate bitable table and field listings

### DIFF
--- a/extensions/feishu/src/bitable.test.ts
+++ b/extensions/feishu/src/bitable.test.ts
@@ -35,9 +35,22 @@ function createConfig(): OpenClawPluginApi["config"] {
 
 function createBitableClient(records: MockRecord[]) {
   const batchDelete = vi.fn(async () => ({ code: 0 }));
+  const appTableList = vi.fn(async () => ({
+    code: 0,
+    data: { items: [{ table_id: "tbl_main", name: "Table 1" }] },
+  }));
+  const appTableFieldList = vi.fn(async () => ({ code: 0, data: { items: [] } }));
   const client = {
     bitable: {
       app: {
+        get: vi.fn(async () => ({
+          code: 0,
+          data: {
+            app: {
+              name: "Project Tracker",
+            },
+          },
+        })),
         create: vi.fn(async () => ({
           code: 0,
           data: {
@@ -50,13 +63,10 @@ function createBitableClient(records: MockRecord[]) {
         })),
       },
       appTable: {
-        list: vi.fn(async () => ({
-          code: 0,
-          data: { items: [{ table_id: "tbl_main", name: "Table 1" }] },
-        })),
+        list: appTableList,
       },
       appTableField: {
-        list: vi.fn(async () => ({ code: 0, data: { items: [] } })),
+        list: appTableFieldList,
         update: vi.fn(async () => ({ code: 0 })),
         delete: vi.fn(async () => ({ code: 0 })),
       },
@@ -68,10 +78,10 @@ function createBitableClient(records: MockRecord[]) {
     },
   } as unknown as Lark.Client;
 
-  return { batchDelete, client };
+  return { appTableFieldList, appTableList, batchDelete, client };
 }
 
-describe("feishu bitable create app cleanup", () => {
+describe("feishu bitable tools", () => {
   afterAll(() => {
     vi.doUnmock("./client.js");
     vi.resetModules();
@@ -132,6 +142,113 @@ describe("feishu bitable create app cleanup", () => {
           "rec_empty_nested",
         ],
       },
+    });
+  });
+
+  it("get_meta accumulates tables from every Bitable table page", async () => {
+    const { appTableList, client } = createBitableClient([]);
+    appTableList.mockReset();
+    appTableList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ table_id: "tbl_first", name: "First Table" }],
+          has_more: true,
+          page_token: "page-2",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ table_id: "tbl_second", name: "Second Table" }],
+          has_more: false,
+        },
+      });
+    createFeishuClientMock.mockReturnValue(client);
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_get_meta").execute("call_get_meta", {
+      url: "https://example.feishu.cn/base/apptoken",
+    });
+
+    expect(appTableList).toHaveBeenNthCalledWith(1, {
+      path: { app_token: "apptoken" },
+      params: { page_token: undefined },
+    });
+    expect(appTableList).toHaveBeenNthCalledWith(2, {
+      path: { app_token: "apptoken" },
+      params: { page_token: "page-2" },
+    });
+    expect(result.details.tables).toEqual([
+      { table_id: "tbl_first", name: "First Table" },
+      { table_id: "tbl_second", name: "Second Table" },
+    ]);
+  });
+
+  it("list_fields accumulates fields from every Bitable field page", async () => {
+    const { appTableFieldList, client } = createBitableClient([]);
+    appTableFieldList.mockReset();
+    appTableFieldList
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            { field_id: "fld_name", field_name: "Name", type: 1, is_primary: true },
+          ],
+          has_more: true,
+          page_token: "page-2",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            { field_id: "fld_due", field_name: "Due Date", type: 5, is_primary: false },
+          ],
+          has_more: false,
+        },
+      });
+    createFeishuClientMock.mockReturnValue(client);
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = await resolveTool("feishu_bitable_list_fields").execute(
+      "call_list_fields",
+      {
+        app_token: "app_token",
+        table_id: "tbl_main",
+      },
+    );
+
+    expect(appTableFieldList).toHaveBeenNthCalledWith(1, {
+      path: { app_token: "app_token", table_id: "tbl_main" },
+      params: { page_token: undefined },
+    });
+    expect(appTableFieldList).toHaveBeenNthCalledWith(2, {
+      path: { app_token: "app_token", table_id: "tbl_main" },
+      params: { page_token: "page-2" },
+    });
+    expect(result.details).toMatchObject({
+      fields: [
+        {
+          field_id: "fld_name",
+          field_name: "Name",
+          type: 1,
+          type_name: "Text",
+          is_primary: true,
+        },
+        {
+          field_id: "fld_due",
+          field_name: "Due Date",
+          type: 5,
+          type_name: "DateTime",
+          is_primary: false,
+        },
+      ],
+      total: 2,
     });
   });
 

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -144,17 +144,28 @@ async function getBitableMeta(client: Lark.Client, url: string) {
   ensureLarkSuccess(res, "bitable.app.get", { appToken });
 
   // List tables if no table_id specified
-  let tables: { table_id: string; name: string }[] = [];
+  const tables: { table_id: string; name: string }[] = [];
   if (!parsed.tableId) {
-    const tablesRes = await client.bitable.appTable.list({
-      path: { app_token: appToken },
-    });
-    if (tablesRes.code === 0) {
-      tables = (tablesRes.data?.items ?? []).map((t) => ({
-        table_id: t.table_id!,
-        name: t.name!,
-      }));
-    }
+    let pageToken: string | undefined;
+    let hasMore: boolean;
+    do {
+      const tablesRes = await client.bitable.appTable.list({
+        path: { app_token: appToken },
+        params: { page_token: pageToken },
+      });
+      if (tablesRes.code === 0) {
+        tables.push(
+          ...(tablesRes.data?.items ?? []).map((t) => ({
+            table_id: t.table_id!,
+            name: t.name!,
+          })),
+        );
+        pageToken = tablesRes.data?.page_token;
+        hasMore = tablesRes.data?.has_more ?? false;
+      } else {
+        hasMore = false;
+      }
+    } while (hasMore && pageToken);
   }
 
   return {
@@ -170,12 +181,26 @@ async function getBitableMeta(client: Lark.Client, url: string) {
 }
 
 async function listFields(client: Lark.Client, appToken: string, tableId: string) {
-  const res = await client.bitable.appTableField.list({
-    path: { app_token: appToken, table_id: tableId },
-  });
-  ensureLarkSuccess(res, "bitable.appTableField.list", { appToken, tableId });
+  type FieldListResponse = Awaited<
+    ReturnType<Lark.Client["bitable"]["appTableField"]["list"]>
+  >;
+  type FieldListItem = NonNullable<NonNullable<FieldListResponse["data"]>["items"]>[number];
 
-  const fields = res.data?.items ?? [];
+  const fields: FieldListItem[] = [];
+  let pageToken: string | undefined;
+  let hasMore: boolean;
+  do {
+    const res = await client.bitable.appTableField.list({
+      path: { app_token: appToken, table_id: tableId },
+      params: { page_token: pageToken },
+    });
+    ensureLarkSuccess(res, "bitable.appTableField.list", { appToken, tableId });
+
+    fields.push(...(res.data?.items ?? []));
+    pageToken = res.data?.page_token;
+    hasMore = res.data?.has_more ?? false;
+  } while (hasMore && pageToken);
+
   return {
     fields: fields.map((f) => ({
       field_id: f.field_id,


### PR DESCRIPTION
## Problem
`getBitableMeta()` (table list) and `listFields()` (field list) call the Lark `appTable.list` / `appTableField.list` endpoints exactly once and return only the first page. A Bitable base with more tables than one API page, or a table with more fields than one page, silently loses everything past page 1 — the `get_meta` and `list_fields` tools then report an incomplete picture. `listRecords()` in the same file already paginates correctly via `has_more` / `page_token`.

## Fix
Loop both listings on `has_more` / `page_token`, accumulating items across pages, mirroring `listRecords()` in this file (and the listing pattern in `wiki.ts`). Error handling is intentionally unchanged:
- `getBitableMeta` keeps its `code === 0` soft-check — a failing page just stops accumulation and returns partial results, no throw.
- `listFields` keeps `ensureLarkSuccess` on every page.

## Test
Two new tests in `bitable.test.ts` mock a paginated Lark client (page 1 `has_more: true` + `page_token`, page 2 `has_more: false`) and assert that both tools merge items from every page and issue the follow-up call with the returned `page_token`.

```
node scripts/run-vitest.mjs extensions/feishu/src/bitable.test.ts  →  4 passed
node_modules/.bin/oxlint extensions/feishu/src/bitable.ts          →  clean
```

## Real behavior proof

**Behavior addressed**: `feishu_bitable_get_meta` and `feishu_bitable_list_fields` now follow the Lark `has_more` / `page_token` pagination across every page; a Bitable base or table whose tables/fields span more than one API page no longer silently loses everything past page 1.

**Real environment tested**: Local source checkout of `openclaw/openclaw` at this PR's head (`fix/feishu-bitable-meta-pagination`, commit `e9b02cdbac`), Node v22.22.0, vitest v4.1.7. A real-runtime harness drives the genuine production tool path — `registerFeishuBitableTools(api)` → the registered `feishu_bitable_get_meta` / `feishu_bitable_list_fields` tools → the real `getBitableMeta()` / `listFields()` in `extensions/feishu/src/bitable.ts` — with `./client.js`'s `createFeishuClient` replaced via a Node ESM loader hook by a fake Lark client that returns a two-page response sequence (page 1 `has_more: true` + `page_token: "page-2"` + one item; page 2 `has_more: false` + one item). The harness records each `appTable.list` / `appTableField.list` call's `page_token`, so the assertion is on the real function's actual paging traffic and the final accumulated result, not on mocked outputs.

**Exact steps or command run after this patch**:
```
# after-fix (current PR source)
node ./proof-bootstrap.mjs

# vitest regression
node scripts/run-vitest.mjs extensions/feishu/src/bitable.test.ts --run

# negative control: revert just bitable.ts to the pre-fix (single-page) source and re-run
git checkout HEAD^ -- extensions/feishu/src/bitable.ts
node ./proof-bootstrap.mjs
git checkout HEAD  -- extensions/feishu/src/bitable.ts   # restore the fix
```

**Evidence after fix** (after-fix run — both tools page through to completion):
```
[get_meta]   appTable.list page requests   : 2
[get_meta]   page_token sequence requested  : [null,"page-2"]
[get_meta]   tables returned                : 2 / 2 expected
[get_meta]   table ids                      : ["tbl_first","tbl_second"]
[get_meta]   MISSING tables (page-2 loss)   : 0
[list_fields] appTableField.list requests   : 2
[list_fields] page_token sequence requested  : [null,"page-2"]
[list_fields] fields returned                : 2 / 2 expected
[list_fields] field ids                      : ["fld_name","fld_due"]
[list_fields] MISSING fields (page-2 loss)   : 0
RESULT: PASS — all pages accumulated, zero data loss (after-fix behavior).
```
Negative control (same harness, `bitable.ts` reverted to pre-fix single-page source) — page 2 is silently dropped, reproducing the bug:
```
[get_meta]   appTable.list page requests   : 1
[get_meta]   page_token sequence requested  : [null]
[get_meta]   tables returned                : 1 / 2 expected      (MISSING tables: 1)
[list_fields] appTableField.list requests   : 1
[list_fields] page_token sequence requested  : [null]
[list_fields] fields returned                : 1 / 2 expected      (MISSING fields: 1)
RESULT: FAIL — page-2 data lost (before-fix / unpaginated behavior).
```
vitest regression:
```
Test Files  1 passed (1)
     Tests  4 passed (4)
```

**Observed result after fix**: Both production functions issue a second `appTable.list` / `appTableField.list` call carrying the returned `page_token` ("page-2") and accumulate items from every page — `get_meta` returns both tables (`tbl_first`, `tbl_second`) and `list_fields` returns both fields (`fld_name`, `fld_due`), zero items lost. The negative control on the unpatched source requests only the first page (`page_token` sequence `[null]`) and drops one item from each listing, confirming the harness exercises the real code path and that this patch is what closes the gap.

**What was not tested**: No call was made against the live Lark/Feishu Open Platform (no real Bitable base / app credentials); the multi-page Lark responses are supplied by an injected client. The `has_more` / `page_token` contract being mirrored is the same one `listRecords()` already relies on against the real API in this file, and the wiki-node and error-handling branches were left unchanged by this PR and not separately re-exercised here.
