### PR TITLE
fix(mcp): evaluate environment variables at transport connection time

### DIFF
--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -11,6 +11,8 @@ import {
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { FetchLike, Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { substituteString, containsEnvVarReference } from "../config/env-substitution.js";
+import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { logDebug } from "../logger.js";
 import {
   buildMcpHttpFetch,
@@ -95,10 +97,24 @@ export function resolveMcpTransport(
     return null;
   }
   if (resolved.kind === "stdio") {
+    const processEnv = process.env;
+    const finalEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(resolved.env || {})) {
+      if (isDangerousHostEnvVarName(key)) {
+        throw new Error(
+          `Dynamic environment variable substitution generated a dangerous host environment variable: ${key}`,
+        );
+      }
+      finalEnv[key] =
+        value && containsEnvVarReference(value)
+          ? substituteString(value, processEnv, "mcp.servers.*.env")
+          : value;
+    }
+
     const transport = new OpenClawStdioClientTransport({
       command: resolved.command,
       args: resolved.args,
-      env: resolved.env,
+      env: finalEnv,
       cwd: resolved.cwd,
       stderr: "pipe",
     });
@@ -120,22 +136,50 @@ export function resolveMcpTransport(
           config: resolved.oauth,
         })
       : undefined;
+  const headers =
+    resolved.auth === "oauth" ? withoutMcpAuthorizationHeader(resolved.headers) : resolved.headers;
+
   const baseFetch = buildMcpHttpFetch({
     sslVerify: resolved.sslVerify,
     clientCert: resolved.clientCert,
     clientKey: resolved.clientKey,
     resourceUrl: resolved.url,
   });
-  const headers =
-    resolved.auth === "oauth" ? withoutMcpAuthorizationHeader(resolved.headers) : resolved.headers;
+
+  const substitutingFetch: FetchLike = (url, init) => {
+    let finalInit = init;
+    if (init?.headers) {
+      const mergedHeaders = new Headers(init.headers);
+      let needsReplace = false;
+      const processEnv = process.env;
+      for (const [key, value] of mergedHeaders.entries()) {
+        if (value && containsEnvVarReference(value)) {
+          mergedHeaders.set(key, substituteString(value, processEnv, "mcp.servers.*.headers"));
+          needsReplace = true;
+        }
+      }
+      if (needsReplace) {
+        // We reconstruct as a plain object to avoid surprising any fetch polyfills or assertions
+        // that expect a plain object, particularly in tests.
+        const plainHeaders: Record<string, string> = {};
+        for (const [key, value] of mergedHeaders.entries()) {
+          plainHeaders[key] = value;
+        }
+        finalInit = { ...init, headers: plainHeaders };
+      }
+    }
+    return baseFetch(url, finalInit);
+  };
+
   const httpFetch =
     resolved.auth === "oauth"
       ? withSameOriginMcpHttpHeaders({
-          fetchFn: baseFetch,
+          fetchFn: substitutingFetch,
           headers,
           resourceUrl: resolved.url,
         })
-      : baseFetch;
+      : substitutingFetch;
+
   if (resolved.transportType === "streamable-http") {
     return {
       transport: new StreamableHTTPClientTransport(new URL(resolved.url), {
@@ -150,11 +194,15 @@ export function resolveMcpTransport(
       supportsParallelToolCalls: resolved.supportsParallelToolCalls,
     };
   }
-  const sseHeaders: Record<string, string> = { ...headers };
-  const hasHeaders = Object.keys(sseHeaders).length > 0;
+
+  const sseHeaders = headers ? { ...headers } : {};
+  if (resolved.auth === "oauth" && sseHeaders.authorization) {
+    delete sseHeaders.authorization;
+  }
+
   return {
     transport: new SSEClientTransport(new URL(resolved.url), {
-      requestInit: resolved.auth === "oauth" || !hasHeaders ? undefined : { headers: sseHeaders },
+      requestInit: resolved.auth === "oauth" || !headers ? undefined : { headers },
       fetch: httpFetch,
       eventSourceInit: {
         fetch: buildSseEventSourceFetch(resolved.auth === "oauth" ? {} : sseHeaders, httpFetch),

--- a/src/config/env-substitution.ts
+++ b/src/config/env-substitution.ts
@@ -83,12 +83,14 @@ export type EnvSubstitutionWarning = {
   configPath: string;
 };
 
-type SubstituteOptions = {
+export type SubstituteOptions = {
   /** When set, missing vars call this instead of throwing and the original placeholder is preserved. */
   onMissing?: (warning: EnvSubstitutionWarning) => void;
+  /** Paths to skip substitution for. Supports simple wildcard '*' matches like 'mcp.servers.*.env'. */
+  ignorePaths?: string[];
 };
 
-function substituteString(
+export function substituteString(
   value: string,
   env: NodeJS.ProcessEnv,
   configPath: string,
@@ -168,6 +170,19 @@ function substituteAny(
   path: string,
   opts?: SubstituteOptions,
 ): unknown {
+  if (
+    opts?.ignorePaths &&
+    opts.ignorePaths.some((p) => {
+      if (!p.includes("*")) {
+        return path === p || path.startsWith(`${p}.`) || path.startsWith(`${p}[`);
+      }
+      const regexStr = "^" + p.replace(/\./g, "\\.").replace(/\*/g, "[^.]+") + "($|\\.|\\[)";
+      return new RegExp(regexStr).test(path);
+    })
+  ) {
+    return value;
+  }
+
   if (typeof value === "string") {
     return substituteString(value, env, path, opts);
   }

--- a/src/config/gateway-dispatch-config.ts
+++ b/src/config/gateway-dispatch-config.ts
@@ -98,7 +98,10 @@ function resolveGatewayDispatchEnvVars(config: unknown, env: NodeJS.ProcessEnv):
   if (isPlainRecord(config) && Object.hasOwn(config, "env")) {
     applyConfigEnvVars(config as OpenClawConfig, env);
   }
-  return resolveConfigEnvVars(config, env, { onMissing: () => undefined });
+  return resolveConfigEnvVars(config, env, {
+    onMissing: () => undefined,
+    ignorePaths: ["mcp.servers.*.env", "mcp.servers.*.headers"],
+  });
 }
 
 function readRawGatewayDispatchConfig(options: GatewayDispatchConfigReadOptions = {}): {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1370,6 +1370,7 @@ function resolveConfigForRead(
   return {
     resolvedConfigRaw: resolveConfigEnvVars(resolvedIncludes, env, {
       onMissing: (w) => envWarnings.push(w),
+      ignorePaths: ["mcp.servers.*.env", "mcp.servers.*.headers"],
     }),
     // Capture env snapshot after substitution for write-time ${VAR} restoration.
     envSnapshotForRestore: { ...env } as Record<string, string | undefined>,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1360,6 +1360,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     shouldResolveRawConfigEnvVars
       ? (resolveConfigEnvVars(rawConfig, env, {
           onMissing: () => undefined,
+          ignorePaths: ["mcp.servers.*.env", "mcp.servers.*.headers"],
         }) as OpenClawConfig)
       : rawConfig,
     env,
@@ -1367,6 +1368,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const activationSourceConfig = shouldResolveRawConfigEnvVars
     ? (resolveConfigEnvVars(rawActivationSourceConfig, env, {
         onMissing: () => undefined,
+        ignorePaths: ["mcp.servers.*.env", "mcp.servers.*.headers"],
       }) as OpenClawConfig)
     : rawActivationSourceConfig;
   const normalized = normalizePluginsConfig(cfg.plugins);


### PR DESCRIPTION
## Summary

What problem does this PR solve?
- Prior to this change, `${ENV_VAR}` templates in MCP config fields were resolved during Gateway startup. 
- If an environment variable changed dynamically (e.g. token rotation), the new value was never injected without restarting the Gateway process.

Why does this matter now?
- This enables workflows where secrets or auth tokens can refresh dynamically in the background without dropping existing Gateway states or interrupting user workflows.

What is the intended outcome?
- Defers the substitution logic to connection/request time so the latest environment variables are evaluated exactly when the transport initiates connections.

What is intentionally out of scope?
- N/A

What does success look like?
- Successfully rotating an auth token in the `process.env` during an active transport session and seeing the new token applied on the next request.

What should reviewers focus on?
- The inline `substitutingFetch` wrapper in `src/agents/mcp-transport.ts`.
- The removal of early resolution in `src/plugins/loader.ts`.

## Linked context

Which issue does this close?

Closes #93144

Which issues, PRs, or discussions are related?

Related #N/A

Was this requested by a maintainer or owner?
No

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Dynamic substitution of environment variables like `${DYNAMIC_SECRET_TOKEN}` in MCP transports without restarting.
- Real environment tested: Local development environment with a targeted script testing the transport connection.
- Exact steps or command run after this patch: Ran a local Vitest script validating the `substitutingFetch` wrapper behavior.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): 
<img width="1109" height="341" alt="Screenshot 2026-06-17 at 7 30 34 PM" src="https://github.com/user-attachments/assets/1d354f49-6ea4-4a60-b20c-49264f69bc84" />

- Observed result after fix: The test passes, demonstrating the initial fetch uses `TOKEN_VERSION_1`, and the subsequent fetch uses `TOKEN_VERSION_2_ROTATED` after `process.env` was updated in-memory.
- What was not tested: Integration with every other possible MCP transport type (focused primarily on fetch/sse).
- Proof limitations or environment constraints: None
- Before evidence (optional but encouraged): Previously, the second fetch would still use `TOKEN_VERSION_1`.

## Tests and validation

Which commands did you run?
Ran a local validation script simulating the `substitutingFetch` layer against an active Node environment.

What regression coverage was added or updated?
No permanent regression tests were added. The logic relies on the existing `resolveConfigEnvVars` coverage, combined with the real behavior proof attached above to prove the interceptor works.

What failed before this fix, if known?
Transport requests would use stale, startup-time environment variables indefinitely.

If no test was added, why not?
The fix is an architectural repositioning of existing, heavily-tested parsing logic (`resolveConfigEnvVars`). A manual proof script was used to verify the integration, which is attached as a screenshot above.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
No (backend substitution behavior only)

Did config, environment, or migration behavior change? (`Yes/No`)
Yes

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
Yes (Tokens are now dynamically refreshed at request-time)

What is the highest-risk area?
The highest risk is that some config validations that expect fully resolved URLs/Headers might be disrupted if they occur too early.

How is that risk mitigated?
By ensuring we still apply `resolveConfigEnvVars` dynamically via the HTTP proxy layer immediately before `fetch` fires, maintaining API contract integrity.

## Current review state

What is the next action?
Maintainer review and merge.

What is still waiting on author, maintainer, CI, or external proof?
Waiting for CI to pass and maintainers to review.

Which bot or reviewer comments were addressed?
N/A