### PR TITLE
fix(telegram): warn about Web compatibility when richMessages is enabled

### DIFF
--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -85,7 +85,11 @@ function resolveStatusChannelFeatureLine(params: {
   );
   const richMessagesSetting = accountConfig?.richMessages ?? telegramConfig?.richMessages;
   if (richMessagesSetting === true) {
-    return "Telegram rich messages: on · Bot API 10.1 sendRichMessage enabled";
+    return (
+      "Telegram rich messages: on · Bot API 10.1 sendRichMessage enabled\n" +
+      "  ⚠️ Web/Desktop clients may not render these messages (shows as unsupported).\n" +
+      "  → Set channels.telegram.richMessages: false to use standard sendMessage for compatibility."
+    );
   }
   return accountConfig?.richMessages === false
     ? "Telegram rich messages: off · enable richMessages for this Telegram account"


### PR DESCRIPTION
## Summary

When `channels.telegram.richMessages` is enabled (Bot API 10.1 `sendRichMessage`), Telegram Web clients display the message as unsupported:

> This message is currently not supported on Telegram Web. Try getdesktop.telegram.org

This does not affect standard `sendMessage` delivery (the default when `richMessages` is `false` or unset).

## Changes

- **Status text (`/status`) now warns about Web compatibility** when `richMessages: true` is active, and shows the user how to disable it for full Web compatibility.

## Real behavior proof

When `richMessages: true` is set, `/status` now shows:

```
Telegram rich messages: on · Bot API 10.1 sendRichMessage enabled
  ⚠️ Web/Desktop clients may not render these messages (shows as unsupported).
  → Set channels.telegram.richMessages: false to use standard sendMessage for compatibility.
```

When `richMessages` is off (default):

```
Telegram rich messages: off · set channels.telegram.richMessages=true for tables/details/rich media
```

The underlying `channels.telegram.richMessages` config flag already exists and defaults to `false` (use standard `sendMessage`). Users who have opted into rich messages via `richMessages: true` were unaware that this breaks Telegram Web. This change surfaces the warning directly in the status output.

## Related

Fixes #94145

Co-Authored-By: Claude <noreply@anthropic.com>
