### PR TITLE
fix(feishu): paginate document block listing when clearing a document

### DIFF
--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -11,6 +11,7 @@ const loadWebMediaMock = vi.hoisted(() => vi.fn());
 const convertMock = vi.hoisted(() => vi.fn());
 const documentCreateMock = vi.hoisted(() => vi.fn());
 const blockListMock = vi.hoisted(() => vi.fn());
+const blockListWithIteratorMock = vi.hoisted(() => vi.fn());
 const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
 const blockChildrenGetMock = vi.hoisted(() => vi.fn());
 const blockChildrenBatchDeleteMock = vi.hoisted(() => vi.fn());
@@ -110,6 +111,7 @@ describe("feishu_doc image fetch hardening", () => {
         },
         documentBlock: {
           list: blockListMock,
+          listWithIterator: blockListWithIteratorMock,
           patch: blockPatchMock,
         },
         documentBlockChildren: {
@@ -153,6 +155,11 @@ describe("feishu_doc image fetch hardening", () => {
         items: [],
       },
     });
+    blockListWithIteratorMock.mockResolvedValue(
+      (async function* () {
+        yield { items: [] };
+      })(),
+    );
 
     blockChildrenCreateMock.mockResolvedValue({
       code: 0,
@@ -410,6 +417,46 @@ describe("feishu_doc image fetch hardening", () => {
     expect(result.details.images_processed).toBe(0);
     expect(consoleErrorSpy).toHaveBeenCalled();
     consoleErrorSpy.mockRestore();
+  });
+
+  it("clears all top-level blocks from every document block page", async () => {
+    blockListWithIteratorMock.mockResolvedValueOnce(
+      (async function* () {
+        yield {
+          items: [
+            { block_id: "doc_1", parent_id: undefined, block_type: 1 },
+            { block_id: "first_page_1", parent_id: "doc_1", block_type: 2 },
+            { block_id: "first_page_2", parent_id: "doc_1", block_type: 3 },
+            { block_id: "nested_1", parent_id: "first_page_1", block_type: 2 },
+          ],
+        };
+        yield {
+          items: [
+            { block_id: "second_page_1", parent_id: "doc_1", block_type: 2 },
+            { block_id: "second_page_page", parent_id: "doc_1", block_type: 1 },
+            { block_id: "second_page_2", parent_id: "doc_1", block_type: 4 },
+          ],
+        };
+      })(),
+    );
+
+    const feishuDocTool = resolveFeishuDocTool();
+
+    const result = await executeFeishuDocTool(feishuDocTool, {
+      action: "write",
+      doc_token: "doc_1",
+      content: "replacement content",
+    });
+
+    expect(blockListWithIteratorMock).toHaveBeenCalledWith({
+      path: { document_id: "doc_1" },
+    });
+    expect(blockChildrenBatchDeleteMock).toHaveBeenCalledTimes(1);
+    expect(blockChildrenBatchDeleteMock.mock.calls[0]?.[0]).toMatchObject({
+      path: { document_id: "doc_1", block_id: "doc_1" },
+      data: { start_index: 0, end_index: 4 },
+    });
+    expect(result.details.blocks_deleted).toBe(4);
   });
 
   it("create grants permission only to trusted Feishu requester", async () => {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -455,16 +455,16 @@ async function insertBlocksWithDescendant(
 }
 
 async function clearDocumentContent(client: Lark.Client, docToken: string) {
-  const existing = await client.docx.documentBlock.list({
+  const existingBlocks: FeishuDocxBlock[] = [];
+  for await (const page of await client.docx.documentBlock.listWithIterator({
     path: { document_id: docToken },
-  });
-  if (existing.code !== 0) {
-    throw new Error(existing.msg);
+  })) {
+    existingBlocks.push(...(page?.items ?? []));
   }
 
   const childIds =
-    existing.data?.items
-      ?.filter((b) => b.parent_id === docToken && b.block_type !== 1)
+    existingBlocks
+      .filter((b) => b.parent_id === docToken && b.block_type !== 1)
       .map((b) => b.block_id) ?? [];
 
   if (childIds.length > 0) {


### PR DESCRIPTION
## Problem
`clearDocumentContent()` (the "clear document" action) listed blocks with a single `client.docx.documentBlock.list` call — the first page only — then filtered top-level children and `batchDelete`d `start_index: 0 .. end_index: childIds.length`. For a document with more blocks than one API page, the remaining pages were silently dropped: `childIds` was undercounted, `end_index` too small, and the clear left residual content behind (a destructive op that doesn't fully clear).

`documentBlock.list` exposes no `has_more` / `page_token` on its response, so the SDK provides `documentBlock.listWithIterator` for this.

## Fix
Accumulate all blocks via `for await (const page of await client.docx.documentBlock.listWithIterator(...))` before computing the top-level child set. Filtering, `batchDelete`, and the rest are unchanged. (API errors still propagate — the iterator throws on failure, replacing the previous explicit `code !== 0` check on the single response.)

## Test
Added a test in `docx.test.ts` that mocks `listWithIterator` returning two pages of blocks and asserts the clear issues a single `batchDelete` with `end_index` equal to the total top-level children across both pages (not just the first page).

```
node scripts/run-vitest.mjs run extensions/feishu/src/docx.test.ts \
  -t "clears all top-level blocks from every document block page"  →  1 passed
oxlint clean
```

## Real behavior proof

**Behavior addressed**: When a document spans more than one block-list API page, clearing it now deletes every top-level child across all pages instead of only the first page's children.

**Real environment**: local, Node v22.22, `node --import tsx`, driving the **real production code** — the exported `registerFeishuDocTools` registers the real `feishu_doc` tool, and `tool.execute({ action: "write", ... })` runs the real (private) `clearDocumentContent`. A fake Lark client returns a real two-page block iterator (page 1 → page 2); no business logic is mocked.

**Exact steps or command run after this patch**: drive the real `feishu_doc` write action against a doc whose blocks span 2 pages (page 1: 2 top-level children + 1 nested; page 2: 2 top-level children + 1 page block), then read back the `batchDelete` `end_index` actually sent to the API and the tool's `details.blocks_deleted`.

**Evidence after fix** (real functions):
```
paginated listWithIterator() called: true
legacy single-page list() called:    false
batchDelete data.end_index sent:     4
tool result details.blocks_deleted:  4
RESULT: FIXED — all 4 top-level blocks across BOTH pages are deleted
```

**Observed result after fix**: all 4 top-level children (2 from page 1 + 2 from page 2) are batch-deleted; the iterator drains both pages and `end_index` covers the full set.

**Negative control** (revert `docx.ts` to the pre-fix single-page `list()`, then re-run the exact same tsx proof against the real, now-buggy `clearDocumentContent`):
```
legacy single-page list() called:    true
paginated listWithIterator() called: false
batchDelete data.end_index sent:     2
tool result details.blocks_deleted:  2
RESULT: BUG REPRODUCED — only 2 (first page) deleted; 2 page-2 top-level blocks left behind
```

**What was not tested**: no live Feishu/Lark API call (requires real tenant credentials); the change is confined to the deterministic pagination/accumulation path, exercised here via the real exported tool and the real `clearDocumentContent`.
