### PR TITLE
fix(workspace): skip optional bootstrap files when workspace setup is already completed

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -713,6 +713,56 @@ describe("ensureAgentWorkspace", () => {
       "# Add tasks below when you want the agent to check something periodically.",
     );
   });
+
+  it("does not recreate optional bootstrap files when workspace setup is already completed", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    // First call: set up the workspace and complete setup by customizing profile files.
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_IDENTITY_FILENAME,
+      content: "custom identity",
+    });
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_USER_FILENAME,
+      content: "custom user",
+    });
+    // Delete BOOTSTRAP.md to trigger completion on next ensure call.
+    await fs.unlink(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    // Verify setup is completed.
+    const state = await readWorkspaceState(tempDir);
+    expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+
+    // Delete optional bootstrap files and customize AGENTS.md to simulate
+    // a repository workspace where optional files only exist under agent
+    // subdirectories but the root still has customized required files.
+    await fs.unlink(path.join(tempDir, DEFAULT_SOUL_FILENAME));
+    await fs.unlink(path.join(tempDir, DEFAULT_IDENTITY_FILENAME));
+    await fs.unlink(path.join(tempDir, DEFAULT_USER_FILENAME));
+    await fs.unlink(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME));
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_AGENTS_FILENAME,
+      content: "custom agents instructions\n",
+    });
+
+    // Third call: should NOT recreate optional files for an already-configured workspace.
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    // Verify optional files are NOT recreated at the root level.
+    await expectPathMissing(path.join(tempDir, DEFAULT_SOUL_FILENAME));
+    await expectPathMissing(path.join(tempDir, DEFAULT_IDENTITY_FILENAME));
+    await expectPathMissing(path.join(tempDir, DEFAULT_USER_FILENAME));
+    await expectPathMissing(path.join(tempDir, DEFAULT_HEARTBEAT_FILENAME));
+
+    // Verify required files (AGENTS.md, TOOLS.md) still exist.
+    await expect(fs.access(path.join(tempDir, DEFAULT_AGENTS_FILENAME))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(tempDir, DEFAULT_TOOLS_FILENAME))).resolves.toBeUndefined();
+  });
 });
 
 describe("loadWorkspaceBootstrapFiles", () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -954,6 +954,15 @@ export async function ensureAgentWorkspace(params?: {
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
   const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const skipOptionalBootstrapFiles = new Set(params?.skipOptionalBootstrapFiles ?? []);
+  // When the workspace is already configured, skip optional bootstrap files to
+  // prevent subagent spawns from recreating root-level SOUL.md, USER.md,
+  // IDENTITY.md, or HEARTBEAT.md that were removed intentionally or only exist
+  // under agent-specific subdirectories.
+  if (await isWorkspaceSetupCompleted(dir)) {
+    for (const filename of OPTIONAL_BOOTSTRAP_FILENAMES) {
+      skipOptionalBootstrapFiles.add(filename);
+    }
+  }
   const shouldWriteBootstrapFile = (fileName: string): boolean =>
     !OPTIONAL_BOOTSTRAP_FILENAMES.has(fileName) || !skipOptionalBootstrapFiles.has(fileName);
 


### PR DESCRIPTION
## Summary

When `ensureAgentWorkspace` is called for an already-configured workspace where `setupCompletedAt` is set, optional bootstrap files (`SOUL.md`, `USER.md`, `IDENTITY.md`, `HEARTBEAT.md`) are no longer recreated at the workspace root.

## Problem

Subagent runs inherit the owning agent workspace. Repeated workspace setup could recreate optional persona files at that root after they were intentionally removed or moved into an agent-specific location.

## Fix

Completed workspaces now skip only optional bootstrap files. Required setup files (`AGENTS.md`, `TOOLS.md`) and the existing completion reconciliation path remain unchanged.

## Verification

- `node scripts/run-vitest.mjs src/agents/workspace.test.ts` (49 passed)
- Blacksmith Testbox `tbx_01kvb1sg0cw89avaarr5rw9bmp`: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed` (passed)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)

## Real behavior proof

Behavior addressed: completed repository workspaces no longer recreate intentionally removed optional persona files during repeated setup.

Real environment tested: Linux Blacksmith Testbox `tbx_01kvb1sg0cw89avaarr5rw9bmp`, using a fresh OpenClaw state directory and a newly created `proof` agent workspace at head `aab9bb2cdc2b379c100b645e8d749fa38ebe97bd`.

Exact steps or command run after this patch: created the agent with `node openclaw.mjs agents add proof --workspace <workspace> --non-interactive --json`; customized `IDENTITY.md`, `USER.md`, and required `AGENTS.md`; removed `BOOTSTRAP.md` to complete setup; removed all four optional files; then ran `node openclaw.mjs agent --agent proof --local --message workspace-proof --json`.

Evidence after fix: terminal output after the second actual `openclaw agent` initialization:

```json
{"optional":{"SOUL.md":false,"IDENTITY.md":false,"USER.md":false,"HEARTBEAT.md":false},"required":{"AGENTS.md":true,"TOOLS.md":true}}
```

Observed result after fix: the CLI completed workspace initialization and advanced to the model-auth stage; the later file check showed that optional files remained absent while required files were preserved.

What was not tested: model response or delivery. The disposable environment intentionally had no model credentials.
