### PR TITLE
fix(feishu): paginate message reaction listing

### DIFF
--- a/extensions/feishu/src/reactions.test.ts
+++ b/extensions/feishu/src/reactions.test.ts
@@ -1,0 +1,93 @@
+// Feishu tests cover message reaction API behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { listReactionsFeishu } from "./reactions.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+function makeConfiguredCfg(): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        appId: "cli_test_app_id",
+        appSecret: "cli_test_app_secret",
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+describe("listReactionsFeishu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("paginates Feishu message reactions", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            {
+              reaction_id: "reaction_a",
+              reaction_type: { emoji_type: "THUMBSUP" },
+              operator_type: "app",
+              operator_id: { open_id: "ou_app" },
+            },
+          ],
+          has_more: true,
+          page_token: "p2",
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [
+            {
+              reaction_id: "reaction_b",
+              reaction_type: { emoji_type: "HEART" },
+              operator_type: "user",
+              operator_id: { user_id: "user_b" },
+            },
+          ],
+          has_more: false,
+        },
+      });
+    createFeishuClientMock.mockReturnValue({
+      im: {
+        messageReaction: {
+          list,
+        },
+      },
+    });
+
+    const reactions = await listReactionsFeishu({
+      cfg: makeConfiguredCfg(),
+      messageId: "om_msg1",
+    });
+
+    expect(reactions).toEqual([
+      {
+        reactionId: "reaction_a",
+        emojiType: "THUMBSUP",
+        operatorType: "app",
+        operatorId: "ou_app",
+      },
+      {
+        reactionId: "reaction_b",
+        emojiType: "HEART",
+        operatorType: "user",
+        operatorId: "user_b",
+      },
+    ]);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenNthCalledWith(2, {
+      path: { message_id: "om_msg1" },
+      params: { page_token: "p2" },
+    });
+  });
+});

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -95,25 +95,45 @@ export async function listReactionsFeishu(params: {
   const { cfg, messageId, emojiType, accountId } = params;
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
-  const response = (await client.im.messageReaction.list({
-    path: { message_id: messageId },
-    params: emojiType ? { reaction_type: emojiType } : undefined,
-  })) as {
-    code?: number;
-    msg?: string;
-    data?: {
-      items?: Array<{
-        reaction_id?: string;
-        reaction_type?: { emoji_type?: string };
-        operator_type?: string;
-        operator_id?: { open_id?: string; user_id?: string; union_id?: string };
-      }>;
+  const items: Array<{
+    reaction_id?: string;
+    reaction_type?: { emoji_type?: string };
+    operator_type?: string;
+    operator_id?: { open_id?: string; user_id?: string; union_id?: string };
+  }> = [];
+  let pageToken: string | undefined;
+  do {
+    const response = (await client.im.messageReaction.list({
+      path: { message_id: messageId },
+      params: {
+        ...(emojiType ? { reaction_type: emojiType } : {}),
+        ...(pageToken ? { page_token: pageToken } : {}),
+      },
+    })) as {
+      code?: number;
+      msg?: string;
+      data?: {
+        items?: Array<{
+          reaction_id?: string;
+          reaction_type?: { emoji_type?: string };
+          operator_type?: string;
+          operator_id?: { open_id?: string; user_id?: string; union_id?: string };
+        }>;
+        has_more?: boolean;
+        page_token?: string;
+      };
     };
-  };
 
-  assertFeishuReactionApiSuccess(response, "list reactions");
+    assertFeishuReactionApiSuccess(response, "list reactions");
 
-  const items = response.data?.items ?? [];
+    items.push(...(response.data?.items ?? []));
+    const nextPageToken = response.data?.page_token?.trim();
+    if (response.data?.has_more !== true || !nextPageToken) {
+      break;
+    }
+    pageToken = nextPageToken;
+  } while (pageToken);
+
   return items.map((item) => ({
     reactionId: item.reaction_id ?? "",
     emojiType: item.reaction_type?.emoji_type ?? "",


### PR DESCRIPTION
## Problem
`listReactionsFeishu()` called `client.im.messageReaction.list` once and returned only the first page. The Feishu reaction list endpoint paginates (default page_size 20), so for a message with more than ~20 reactions the later pages were silently dropped. Two concrete effects:

- The `clearAll` action (`channel.ts`) iterates `reactions.filter(operatorType === "app")` to remove every bot-posted reaction — with a truncated list it can never remove reactions past the first page, so "clear all" leaves some behind.
- Reaction queries returned an incomplete list to the agent.

## Fix
Loop on `has_more` / `page_token`, accumulating items across pages before mapping to `FeishuReaction[]` (mirroring the pattern in `monitor.comment.ts`). `page_token` is passed alongside the existing `reaction_type` filter, and per-page success is still asserted via `assertFeishuReactionApiSuccess`.

## Test
`reactions.test.ts` mocks a paginated client (page 1 `has_more: true` + `page_token`, page 2 `has_more: false`) and asserts both pages' reactions are returned and the follow-up call carries `page_token`.

```
node scripts/run-vitest.mjs extensions/feishu/src/reactions.test.ts  →  passed
oxlint clean
```

Note: #83531 also edits `listReactionsFeishu` (operator-id normalization in the `.map`) — no semantic overlap with this pagination change, but they touch the same function.

## Real Behavior Proof

**Behavior addressed**: `listReactionsFeishu()` now follows the Feishu reaction-list pagination (`has_more` / `page_token`) and returns reactions from every page, instead of dropping everything past the first page. This was driven against the actual production function exported from `extensions/feishu/src/reactions.ts` at this PR head, with only the Lark transport (`createFeishuClient`) substituted so a deterministic multi-page response sequence could be replayed.

**Real environment tested**: PR head `494186db5e1ccd2cbd18b76430bcc3ec2162eb63` checked out in an isolated local git worktree (Node v22.22.0), real plugin dependency tree. A real-runtime harness imported `listReactionsFeishu` from this branch's source and executed it; the only mock was the `im.messageReaction.list` transport, returning page 1 `{ has_more: true, page_token: "p2", items: [reaction_a (app)] }` then page 2 `{ has_more: false, items: [reaction_b (user)] }`.

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs extensions/feishu/src/reactions.test.ts --run` (the shipped regression); plus a standalone real-runtime proof: `node --import tsx --import ./register-mock.mjs ./proof.mts`, which calls the real `listReactionsFeishu({ cfg, messageId: "om_msg1" })` and inspects both the returned `FeishuReaction[]` and the recorded transport calls. A negative control then replaced `reactions.ts` with the pre-patch single-call version (`git show HEAD^:extensions/feishu/src/reactions.ts`) and re-ran the same harness before restoring the patched file.

**Evidence after fix**: The shipped Vitest regression passed (1 file / 1 test). The real-runtime proof recorded **2 transport calls**, with the 2nd call params equal to `{"page_token":"p2"}`, and the production function returned the full dataset `[{reactionId:"reaction_a",emojiType:"THUMBSUP",operatorType:"app",operatorId:"ou_app"},{reactionId:"reaction_b",emojiType:"HEART",operatorType:"user",operatorId:"user_b"}]` — both pages, 0 dropped. The negative control (pre-patch code) recorded only **1 transport call**, no `page_token` follow-up, and returned only `[reaction_a]`, silently dropping `reaction_b`; the proof's assertions correctly FAILED in that run (exit 1), confirming the harness detects the bug rather than passing unconditionally.

**Observed result after fix**: A message whose reactions span more than one Feishu page now resolves to the complete reaction list. The page-2 reaction (`reaction_b`) that the original code lost is present after the fix, so `clearAll` can reach bot reactions beyond the first page and reaction queries see the full set. Before: 1 reaction returned, 1 dropped. After: 2 reactions returned, 0 dropped.

**What was not tested**: No call was made against the live Feishu/Lark cloud API with a real tenant message carrying 20+ reactions (that requires a provisioned Feishu app + tenant data). The pagination control flow and `page_token` propagation were exercised against the real production function via a deterministic multi-page transport; the live network round-trip and Feishu's own page_size boundary were not exercised end to end.
