### PR TITLE
fix(telegram): escape #digit and $uppercase patterns in markdown-to-HTML to prevent Telegram rendering artifacts

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -1,6 +1,8 @@
 // Telegram tests cover format plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
+  escapeTelegramProblematicMarkdown,
+  lintTelegramMarkdown,
   markdownToTelegramChunks,
   markdownToTelegramHtml,
   markdownToTelegramRichHtml,
@@ -448,6 +450,92 @@ describe("markdownToTelegramHtml", () => {
       expect(containsLoneSurrogate(chunk.html)).toBe(false);
       expect(containsLoneSurrogate(chunk.text)).toBe(false);
     }
+  });
+});
+
+describe("escapeTelegramProblematicMarkdown", () => {
+  it("escapes # at line start followed by digit", () => {
+    expect(escapeTelegramProblematicMarkdown("#12345")).toBe("\\#12345");
+    expect(escapeTelegramProblematicMarkdown("  #12345")).toBe("  \\#12345");
+  });
+
+  it("does not escape # followed by space (real heading)", () => {
+    expect(escapeTelegramProblematicMarkdown("# Title")).toBe("# Title");
+    expect(escapeTelegramProblematicMarkdown("## Section")).toBe("## Section");
+  });
+
+  it("escapes $ followed by digits", () => {
+    const result = escapeTelegramProblematicMarkdown("Entry $731.38 / TP");
+    expect(result).toContain("\\$731");
+  });
+
+  it("handles multi-line input", () => {
+    const input = ["Stocks: Entry $731.38", "#12345 feedback", "# Normal heading"].join("\n");
+    const result = escapeTelegramProblematicMarkdown(input);
+    expect(result).toContain("\\#12345");
+    expect(result).toContain("\\$731");
+    expect(result).toContain("# Normal heading");
+  });
+
+  it("handles empty/null input", () => {
+    expect(escapeTelegramProblematicMarkdown("")).toBe("");
+  });
+});
+
+describe("lintTelegramMarkdown", () => {
+  it("warns about $ followed by digits outside backticks", () => {
+    const warnings = lintTelegramMarkdown("Cost is $100 plus tax");
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it("does not warn about $ inside backticks", () => {
+    const warnings = lintTelegramMarkdown("Cost is `$100` plus tax");
+    expect(warnings.filter((w) => w.includes("$100"))).toHaveLength(0);
+  });
+
+  it("warns about inline bold mixed with regular text", () => {
+    const warnings = lintTelegramMarkdown("A: warning **entered**, B: watching");
+    expect(warnings.some((w) => w.includes("bold"))).toBe(true);
+  });
+
+  it("does not warn about bold-only lines", () => {
+    const warnings = lintTelegramMarkdown("**Warning: critical issue**");
+    expect(warnings.some((w) => w.includes("bold"))).toBe(false);
+  });
+
+  it("warns about hash at line start followed by digit", () => {
+    const warnings = lintTelegramMarkdown("#12345 feedback");
+    expect(warnings.some((w) => w.includes("#"))).toBe(true);
+  });
+
+  it("returns empty array for clean text", () => {
+    expect(lintTelegramMarkdown("Hello world, this is clean text.")).toEqual([]);
+  });
+});
+
+describe("markdownToTelegramHtml escape integration", () => {
+  it("preserves #digit at line start as literal text", () => {
+    const result = markdownToTelegramHtml("#12345 issue reference");
+    expect(result).toContain("#12345");
+  });
+
+  it("preserves $digit in output", () => {
+    const result = markdownToTelegramHtml("Cost $100 today");
+    expect(result).toContain("$100");
+  });
+});
+
+describe("markdownToTelegramRichHtml escape integration", () => {
+  it("prevents #digit from becoming H1 in rich mode", () => {
+    const result = markdownToTelegramRichHtml("#12345 issue reference");
+    expect(result).not.toMatch(/<h1[^>]*>/);
+    expect(result).toContain("#12345");
+  });
+
+  it("preserves real headings in rich mode", () => {
+    const result = markdownToTelegramRichHtml("# Actual Heading");
+    expect(result).toMatch(/<h1[^>]*>/);
+    expect(result).toContain("Actual Heading");
   });
 });
 

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -146,12 +146,92 @@ function preserveTelegramListBoundarySpacing(markdown: string): string {
   return out.join("\n");
 }
 
+/**
+ * Pre-processes markdown text to escape patterns that Telegram renders
+ * incorrectly when converting markdown to HTML.
+ *
+ * Handles:
+ * 1. `#` at line start followed by digit (e.g. `#12345`) — these are not
+ *    real headings but markdown-parsers treat them as such.
+ * 2. `$` followed by digit or uppercase letter (e.g. `$100`, `$USD`) —
+ *    can trigger unintended italic/variable rendering in Telegram.
+ */
+export function escapeTelegramProblematicMarkdown(text: string): string {
+  if (!text) return text;
+  return (
+    text
+      // Escape # at line-start followed by digit: "#12345" → "\#12345"
+      // Only when there's no space between # and digit (real headings like "# Title" are fine)
+      .replace(/^([ \t]*)#(\d)/gm, "$1\\#$2")
+      // Escape $ followed by digit/uppercase that's NOT inside backticks
+      // (simple heuristic: wrap in backtick-escape)
+      .replace(/(^|[^`\\])\$(\d|[A-Z]{2,})/gm, "$1\\$$2")
+  );
+}
+
+/**
+ * Lint markdown text for patterns that may render poorly in Telegram.
+ * Returns array of human-readable warning strings (empty if clean).
+ */
+export function lintTelegramMarkdown(text: string): string[] {
+  const warnings: string[] = [];
+  if (!text) return warnings;
+
+  // Check for $ followed by digit/uppercase not inside backticks
+  const segments = text.split("`");
+  for (let i = 0; i < segments.length; i += 2) {
+    // Even-indexed segments are outside backticks
+    const seg = segments[i] ?? "";
+    const dollarHits = [...seg.matchAll(/\$(\d|[A-Z]{2,})/g)];
+    for (const hit of dollarHits) {
+      const ctx = seg.slice(Math.max(0, hit.index! - 10), hit.index! + hit[0].length + 10);
+      warnings.push(
+        `\`$\` followed by digit/uppercase may trigger Telegram variable rendering: \`...${ctx}...\` — consider wrapping in backticks`,
+      );
+    }
+  }
+
+  // Check for inline **bold** mixed with regular text on same line
+  const lines = text.split("\n");
+  for (const line of lines) {
+    const boldRanges: Array<[number, number]> = [];
+    const re = /\*\*([^*]+)\*\*/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(line)) !== null) {
+      boldRanges.push([m.index, m.index + m[0].length]);
+    }
+    if (boldRanges.length > 0) {
+      const withoutBold =
+        line.slice(0, boldRanges[0]![0]) +
+        line.slice(boldRanges[boldRanges.length - 1]![1]);
+      if (withoutBold.trim().length > 0) {
+        warnings.push(
+          `Inline bold mixed with regular text may cause font-size inconsistency in Telegram: "${line.trim().slice(0, 80)}"`,
+        );
+      }
+    }
+  }
+
+  // Check for # at line start followed by digit
+  const hashLines = text.split("\n");
+  for (const line of hashLines) {
+    if (/^[ \t]*#\d/.test(line)) {
+      warnings.push(
+        `Line starts with \`#\` followed by digit, may render as heading in Telegram: "${line.trim().slice(0, 80)}"`,
+      );
+    }
+  }
+
+  return warnings;
+}
+
 export function markdownToTelegramHtml(
   markdown: string,
   options: { tableMode?: MarkdownTableMode; wrapFileRefs?: boolean } = {},
 ): string {
   const tableMode = options.tableMode === "block" ? "code" : options.tableMode;
-  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
+  const preprocessed = escapeTelegramProblematicMarkdown(markdown ?? "");
+  const ir = markdownToIR(preserveTelegramListBoundarySpacing(preprocessed), {
     linkify: true,
     enableSpoilers: true,
     headingStyle: "none",
@@ -974,7 +1054,8 @@ export function markdownToTelegramRichHtml(
   options: { tableMode?: MarkdownTableMode; skipEntityDetection?: boolean } = {},
 ): string {
   const tableMode = options.tableMode ?? "block";
-  const normalized = normalizeTelegramRichMarkdownMedia(markdown ?? "");
+  const preprocessed = escapeTelegramProblematicMarkdown(markdown ?? "");
+  const normalized = normalizeTelegramRichMarkdownMedia(preprocessed);
   const { ir, tables } = markdownToIRWithMeta(
     preserveTelegramListBoundarySpacing(normalized.markdown),
     {
@@ -1284,7 +1365,8 @@ export function markdownToTelegramChunks(
   limit: number,
   options: { tableMode?: MarkdownTableMode } = {},
 ): TelegramFormattedChunk[] {
-  const ir = markdownToIR(preserveTelegramListBoundarySpacing(markdown ?? ""), {
+  const preprocessed = escapeTelegramProblematicMarkdown(markdown ?? "");
+  const ir = markdownToIR(preserveTelegramListBoundarySpacing(preprocessed), {
     linkify: true,
     enableSpoilers: true,
     headingStyle: "none",

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -157,7 +157,9 @@ function preserveTelegramListBoundarySpacing(markdown: string): string {
  *    can trigger unintended italic/variable rendering in Telegram.
  */
 export function escapeTelegramProblematicMarkdown(text: string): string {
-  if (!text) return text;
+  if (!text) {
+    return text;
+  }
   return (
     text
       // Escape # at line-start followed by digit: "#12345" → "\#12345"
@@ -175,7 +177,9 @@ export function escapeTelegramProblematicMarkdown(text: string): string {
  */
 export function lintTelegramMarkdown(text: string): string[] {
   const warnings: string[] = [];
-  if (!text) return warnings;
+  if (!text) {
+    return warnings;
+  }
 
   // Check for $ followed by digit/uppercase not inside backticks
   const segments = text.split("`");
@@ -184,7 +188,8 @@ export function lintTelegramMarkdown(text: string): string[] {
     const seg = segments[i] ?? "";
     const dollarHits = [...seg.matchAll(/\$(\d|[A-Z]{2,})/g)];
     for (const hit of dollarHits) {
-      const ctx = seg.slice(Math.max(0, hit.index! - 10), hit.index! + hit[0].length + 10);
+      const idx = hit.index ?? 0;
+      const ctx = seg.slice(Math.max(0, idx - 10), idx + hit[0].length + 10);
       warnings.push(
         `\`$\` followed by digit/uppercase may trigger Telegram variable rendering: \`...${ctx}...\` — consider wrapping in backticks`,
       );
@@ -201,9 +206,9 @@ export function lintTelegramMarkdown(text: string): string[] {
       boldRanges.push([m.index, m.index + m[0].length]);
     }
     if (boldRanges.length > 0) {
-      const withoutBold =
-        line.slice(0, boldRanges[0]![0]) +
-        line.slice(boldRanges[boldRanges.length - 1]![1]);
+      const first = boldRanges[0] ?? [0, 0];
+      const last = boldRanges[boldRanges.length - 1] ?? [0, 0];
+      const withoutBold = line.slice(0, first[0]) + line.slice(last[1]);
       if (withoutBold.trim().length > 0) {
         warnings.push(
           `Inline bold mixed with regular text may cause font-size inconsistency in Telegram: "${line.trim().slice(0, 80)}"`,


### PR DESCRIPTION
## Summary

Fixes #94129 — Telegram markdown rendering: `#` → H1 heading, `$` → variable interpolation, inline bold → font inconsistency.

## Root Cause

In rich message mode (`markdownToTelegramRichHtml`), the markdown→HTML conversion uses `headingStyle: "rich"` which renders `#digit` patterns as `<h1>` tags. Even in plain mode, the heading text is stripped because markdown-parsers treat `#` at line start as a heading indicator.

## Fix

Added `escapeTelegramProblematicMarkdown()` pre-processing function that runs before markdown parsing:

1. **`#` at line start followed by digit** → backslash-escaped (`\#12345`) so it's not parsed as a heading
2. **`$` followed by digit/uppercase** → backslash-escaped (`\00`) to prevent unintended rendering

Also added `lintTelegramMarkdown()` that returns human-readable warnings for patterns that may render poorly (useful for future `--lint-telegram` flag).

Integration points: `markdownToTelegramHtml()`, `markdownToTelegramRichHtml()`, `markdownToTelegramChunks()`

## Tests

Added comprehensive test cases covering:
- Escaping `#digit` at line start
- Preserving real headings (`# Title`)
- Escaping `$digit` patterns
- Multi-line input handling
- Empty/null input
- Lint warnings for all three patterns
- Rich mode integration (no `<h1>` for non-headings)
- Plain mode integration