### PR TITLE
fix(doctor): recover sibling moltbot.json config dropped on upgrade (#54200) [AI-assisted]

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,7 +1,9 @@
 // Gateway run option collision tests cover gateway run flag registration boundaries.
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../../daemon/constants.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
@@ -64,6 +66,7 @@ const gatewayLogMessages = vi.hoisted(() => [] as string[]);
 const configState = vi.hoisted(() => ({
   cfg: {} as Record<string, unknown>,
   snapshot: { config: {}, exists: false, sourceConfig: {}, valid: true } as Record<string, unknown>,
+  stateDir: "/tmp",
 }));
 const readBestEffortConfig = vi.fn(async () => configState.cfg);
 type ConfigSnapshotReadOptionsStub = {
@@ -145,7 +148,7 @@ vi.mock("../../config/paths.js", () => ({
   CONFIG_PATH: "/tmp/openclaw-test-missing-config.json",
   normalizeStateDirEnv: (env?: NodeJS.ProcessEnv) => normalizeStateDirEnv(env),
   pinRuntimePaths: (env?: NodeJS.ProcessEnv) => pinRuntimePaths(env),
-  resolveStateDir: () => "/tmp",
+  resolveStateDir: () => configState.stateDir,
   resolveGatewayPort: (cfg?: { gateway?: { port?: number } }) => cfg?.gateway?.port ?? 18789,
 }));
 
@@ -345,6 +348,7 @@ describe("gateway run option collisions", () => {
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;
     deleteTestEnvValue(GATEWAY_SERVICE_RUNTIME_PID_ENV);
     resetRuntimeCapture();
+    configState.stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-run-"));
     configState.cfg = {};
     configState.snapshot = { config: {}, exists: false, sourceConfig: {}, valid: true };
     netState.autoBindHost = "127.0.0.1";
@@ -382,6 +386,10 @@ describe("gateway run option collisions", () => {
     shouldEnableShellEnvFallback.mockReset();
     shouldEnableShellEnvFallback.mockReturnValue(false);
     callOrder.length = 0;
+  });
+
+  afterEach(() => {
+    fs.rmSync(configState.stateDir, { recursive: true, force: true });
   });
 
   async function runGatewayCli(argv: string[]) {
@@ -1488,10 +1496,33 @@ describe("gateway run option collisions", () => {
       "Gateway start blocked: existing config is missing gateway.mode. Treat this as suspicious or clobbered config. Re-run `openclaw onboard --mode local` or `openclaw setup`, set gateway.mode=local manually, or pass --allow-unconfigured.",
     );
     expect(runtimeErrors).toContain(
-      `Config write audit: ${path.join("/tmp", "logs", "config-audit.jsonl")}`,
+      `Config write audit: ${path.join(configState.stateDir, "logs", "config-audit.jsonl")}`,
     );
     expect(startGatewayServer).not.toHaveBeenCalled();
     expect(readBestEffortConfig).not.toHaveBeenCalled();
+  });
+
+  it("points missing gateway.mode users at sibling moltbot config recovery (#54200)", async () => {
+    const siblingConfigPath = path.join(configState.stateDir, "moltbot.json");
+    fs.writeFileSync(siblingConfigPath, '{"gateway":{"mode":"local"}}\n');
+    configState.cfg = {
+      gateway: {
+        mode: "local",
+      },
+    };
+    configState.snapshot = {
+      exists: true,
+      valid: true,
+      config: {},
+      parsed: {},
+    };
+
+    await expect(runGatewayCli(["gateway", "run"])).rejects.toThrow("__exit__:78");
+
+    expect(runtimeErrors).toContain(
+      `Gateway start blocked: existing config is missing gateway.mode. Treat this as suspicious or clobbered config. Found legacy sibling config at ${siblingConfigPath}. Run \`openclaw doctor --fix\` to recover it into openclaw.json if this was an upgrade from moltbot.json. Re-run \`openclaw onboard --mode local\` or \`openclaw setup\`, set gateway.mode=local manually, or pass --allow-unconfigured.`,
+    );
+    expect(startGatewayServer).not.toHaveBeenCalled();
   });
 
   it("blocks invalid startup config without automatic recovery", async () => {
@@ -1512,7 +1543,7 @@ describe("gateway run option collisions", () => {
       "Gateway start blocked: existing config is missing gateway.mode. Treat this as suspicious or clobbered config. Re-run `openclaw onboard --mode local` or `openclaw setup`, set gateway.mode=local manually, or pass --allow-unconfigured.",
     );
     expect(runtimeErrors).toContain(
-      `Config write audit: ${path.join("/tmp", "logs", "config-audit.jsonl")}`,
+      `Config write audit: ${path.join(configState.stateDir, "logs", "config-audit.jsonl")}`,
     );
     expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledOnce();
     expect(startGatewayServer).not.toHaveBeenCalled();

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -229,6 +229,7 @@ function getGatewayStartGuardErrors(params: {
   allowUnconfigured?: boolean;
   configExists: boolean;
   configAuditPath: string;
+  siblingMoltbotConfigPath?: string;
   mode: string | undefined;
 }): string[] {
   if (params.allowUnconfigured || params.mode === "local") {
@@ -240,10 +241,20 @@ function getGatewayStartGuardErrors(params: {
     ];
   }
   if (params.mode === undefined) {
+    // Surface a sibling moltbot.json (retired config filename) when gateway.mode is missing: this
+    // is the #54200 upgrade layout where the user's real config was never migrated out of moltbot.json.
+    const siblingMoltbotHint =
+      params.siblingMoltbotConfigPath && fs.existsSync(params.siblingMoltbotConfigPath)
+        ? [
+            `Found legacy sibling config at ${params.siblingMoltbotConfigPath}.`,
+            `Run \`${formatCliCommand("openclaw doctor --fix")}\` to recover it into openclaw.json if this was an upgrade from moltbot.json.`,
+          ].join(" ")
+        : null;
     return [
       [
         "Gateway start blocked: existing config is missing gateway.mode.",
         "Treat this as suspicious or clobbered config.",
+        ...(siblingMoltbotHint ? [siblingMoltbotHint] : []),
         `Re-run \`${formatCliCommand("openclaw onboard --mode local")}\` or \`${formatCliCommand("openclaw setup")}\`, set gateway.mode=local manually, or pass --allow-unconfigured.`,
       ].join(" "),
       `Config write audit: ${params.configAuditPath}`,
@@ -849,6 +860,7 @@ export async function runGatewayCommand(opts: GatewayRunOpts, hooks: GatewayRunR
     allowUnconfigured: opts.allowUnconfigured,
     configExists,
     configAuditPath,
+    siblingMoltbotConfigPath: path.join(resolveStateDir(process.env), "moltbot.json"),
     mode,
   });
   if (guardErrors.length > 0) {

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -1,6 +1,7 @@
 // Doctor config preflight tests cover last-known-good snapshots and config snapshot promotion.
 import fs from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
 import { promoteConfigSnapshotToLastKnownGood, readConfigFileSnapshot } from "../config/config.js";
 import { withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import {
@@ -51,6 +52,168 @@ describe("runDoctorConfigPreflight", () => {
       ).memorySearch;
       expect(memorySearch?.provider).toBe("local");
       expect(memorySearch?.fallback).toBe("none");
+    });
+  });
+
+  it("migrates sibling moltbot config when canonical openclaw config is missing (#54200)", async () => {
+    await withTempHome(async (home) => {
+      const legacyPath = path.join(home, ".openclaw", "moltbot.json");
+      await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 19091 } }, null, 2)}\n`,
+        "utf-8",
+      );
+
+      const preflight = await runDoctorConfigPreflight({
+        migrateState: false,
+        invalidConfigNote: false,
+      });
+
+      expect(preflight.snapshot.valid).toBe(true);
+      expect(preflight.snapshot.config.gateway?.mode).toBe("local");
+      await expect(
+        fs.readFile(path.join(home, ".openclaw", "openclaw.json"), "utf-8"),
+      ).resolves.toContain('"mode": "local"');
+    });
+  });
+
+  it("does not overwrite canonical config created during missing-config recovery (#54200)", async () => {
+    await withTempHome(async (home) => {
+      const targetPath = path.join(home, ".openclaw", "openclaw.json");
+      const legacyPath = path.join(home, ".openclaw", "moltbot.json");
+      await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 19091 } }, null, 2)}\n`,
+        "utf-8",
+      );
+      const originalCopyFile = fs.copyFile;
+      let wroteConcurrentConfig = false;
+      const copyFileSpy = vi.spyOn(fs, "copyFile").mockImplementation(async (...args) => {
+        const destination = String(args[1]);
+        if (!wroteConcurrentConfig && destination.endsWith(".tmp")) {
+          wroteConcurrentConfig = true;
+          await fs.writeFile(
+            targetPath,
+            `${JSON.stringify({ gateway: { mode: "remote", port: 19092 } }, null, 2)}\n`,
+            "utf-8",
+          );
+        }
+        return originalCopyFile(...args);
+      });
+
+      try {
+        const preflight = await runDoctorConfigPreflight({
+          migrateState: false,
+          invalidConfigNote: false,
+        });
+
+        expect(preflight.snapshot.valid).toBe(true);
+        expect(preflight.snapshot.config.gateway?.mode).toBe("remote");
+        await expect(fs.readFile(targetPath, "utf-8")).resolves.toContain('"mode": "remote"');
+      } finally {
+        copyFileSpy.mockRestore();
+      }
+    });
+  });
+
+  it("leaves skeletal canonical config untouched without repair preflight (#54200)", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, { update: { channel: "beta" } });
+      const legacyPath = path.join(home, ".openclaw", "moltbot.json");
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 19091 } }, null, 2)}\n`,
+        "utf-8",
+      );
+
+      const preflight = await runDoctorConfigPreflight({
+        migrateState: false,
+        invalidConfigNote: false,
+      });
+
+      expect(preflight.snapshot.config.gateway?.mode).toBeUndefined();
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"channel": "beta"');
+      const entries = await fs.readdir(path.dirname(configPath));
+      expect(
+        entries.some((entry) => entry.startsWith("openclaw.json.pre-moltbot-migration.")),
+      ).toBe(false);
+    });
+  });
+
+  it("recovers skeletal canonical config from sibling moltbot config during repair preflight (#54200)", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, { update: { channel: "beta" } });
+      const legacyPath = path.join(home, ".openclaw", "moltbot.json");
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 19091 } }, null, 2)}\n`,
+        "utf-8",
+      );
+      await fs.chmod(legacyPath, 0o644);
+
+      const preflight = await runDoctorConfigPreflight({
+        migrateState: false,
+        repairPrefixedConfig: true,
+        invalidConfigNote: false,
+      });
+
+      expect(preflight.snapshot.valid).toBe(true);
+      expect(preflight.snapshot.config.gateway?.mode).toBe("local");
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"mode": "local"');
+      if (process.platform !== "win32") {
+        const stat = await fs.stat(configPath);
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+      const entries = await fs.readdir(path.dirname(configPath));
+      expect(
+        entries.some((entry) => entry.startsWith("openclaw.json.pre-moltbot-migration.")),
+      ).toBe(true);
+    });
+  });
+
+  it("does not replace canonical config that already has gateway settings (#54200)", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, {
+        gateway: { mode: "remote" },
+      });
+      const legacyPath = path.join(home, ".openclaw", "moltbot.json");
+      await fs.writeFile(
+        legacyPath,
+        `${JSON.stringify({ gateway: { mode: "local", port: 19091 } }, null, 2)}\n`,
+        "utf-8",
+      );
+
+      const preflight = await runDoctorConfigPreflight({
+        migrateState: false,
+        invalidConfigNote: false,
+      });
+
+      expect(preflight.snapshot.config.gateway?.mode).toBe("remote");
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"mode": "remote"');
+    });
+  });
+
+  it("keeps skeletal canonical config when sibling moltbot copy fails (#54200)", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, { update: { channel: "beta" } });
+      const legacyPath = path.join(home, ".openclaw", "moltbot.json");
+      // A directory cannot be copied as a file, so recovery fails and the skeletal config is kept.
+      await fs.mkdir(legacyPath, { recursive: true });
+
+      const preflight = await runDoctorConfigPreflight({
+        migrateState: false,
+        repairPrefixedConfig: true,
+        invalidConfigNote: false,
+      });
+
+      expect(preflight.snapshot.config.gateway?.mode).toBeUndefined();
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"channel": "beta"');
+      const entries = await fs.readdir(path.dirname(configPath));
+      expect(
+        entries.some((entry) => entry.startsWith("openclaw.json.pre-moltbot-migration.")),
+      ).toBe(false);
     });
   });
 

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -24,47 +24,161 @@ const loadDoctorStateMigrations = createLazyRuntimeModule(
 
 const loadDoctorCron = createLazyRuntimeModule(() => import("./doctor/cron/index.js"));
 
-async function maybeMigrateLegacyConfig(): Promise<string[]> {
+// A canonical openclaw.json whose only top-level keys are auto-generated skeleton metadata
+// (no channels/agents/gateway bindings) is treated as "skeletal" — i.e. the user's real config
+// was never migrated into it. This is the upgrade layout from #54200: ~/.openclaw/openclaw.json
+// exists as a bare skeleton while the user's real legacy config still lives in moltbot.json.
+const SKELETAL_CONFIG_TOP_LEVEL_KEYS = new Set(["$schema", "_meta", "meta", "update"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSkeletalOpenClawConfig(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((key) => SKELETAL_CONFIG_TOP_LEVEL_KEYS.has(key));
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True when the canonical config is present but carries only skeleton metadata. */
+async function isSkeletalCanonicalConfig(targetPath: string): Promise<boolean> {
+  try {
+    const raw = await fs.readFile(targetPath, "utf-8");
+    return isSkeletalOpenClawConfig(JSON.parse(raw));
+  } catch {
+    return false;
+  }
+}
+
+function legacyConfigBackupPath(targetPath: string): string {
+  const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
+  return `${targetPath}.pre-moltbot-migration.${stamp}`;
+}
+
+function legacyConfigTempPath(targetPath: string): string {
+  const stamp = new Date().toISOString().replace(/[:.]/gu, "-");
+  return `${targetPath}.moltbot-migration.${stamp}.tmp`;
+}
+
+/**
+ * Atomically copies a legacy config into the canonical path. When the canonical config already
+ * exists (skeletal), it is renamed aside to `backupPath` first and restored on copy failure. The
+ * recovered file is staged through a temp file and chmod'd 0600 so recovered credentials/keys are
+ * not left world-readable. Missing-canonical recovery uses COPYFILE_EXCL so a canonical config
+ * created concurrently is never clobbered.
+ */
+async function copyLegacyConfigIntoPlace(params: {
+  backupPath?: string;
+  legacyPath: string;
+  targetPath: string;
+}): Promise<void> {
+  const tempPath = legacyConfigTempPath(params.targetPath);
+  let backedUp = false;
+  await fs.copyFile(params.legacyPath, tempPath);
+  await fs.chmod(tempPath, 0o600).catch(() => {});
+  try {
+    if (params.backupPath) {
+      await fs.rename(params.targetPath, params.backupPath);
+      backedUp = true;
+      await fs.rename(tempPath, params.targetPath);
+    } else {
+      await fs.copyFile(tempPath, params.targetPath, fs.constants.COPYFILE_EXCL);
+      await fs.unlink(tempPath).catch(() => {});
+    }
+  } catch (error) {
+    await fs.unlink(tempPath).catch(() => {});
+    if (backedUp && params.backupPath) {
+      await fs.rename(params.backupPath, params.targetPath).catch(() => {});
+    }
+    throw error;
+  }
+}
+
+/**
+ * Recovers legacy config into the canonical openclaw.json.
+ *
+ * The retired `moltbot.json` sibling (next to ~/.openclaw/openclaw.json) is recovered ONLY under
+ * `doctor --fix` (`allowSkeletalReplacement`): read-only doctor warns so users learn their real
+ * config still lives in moltbot.json, but never mutates. The pre-existing `.clawdbot/clawdbot.json`
+ * missing-canonical copy path is preserved unchanged. Normal runtime config resolution stays
+ * canonical — moltbot.json is never re-added to the config candidate list.
+ */
+async function maybeMigrateLegacyConfig(options: {
+  allowSkeletalReplacement: boolean;
+}): Promise<{ changes: string[]; warnings: string[] }> {
   const changes: string[] = [];
+  const warnings: string[] = [];
   const home = resolveHomeDir();
   if (!home) {
-    return changes;
+    return { changes, warnings };
   }
 
   const targetDir = path.join(home, ".openclaw");
   const targetPath = path.join(targetDir, "openclaw.json");
-  try {
-    await fs.access(targetPath);
-    return changes;
-  } catch {
-    // missing config
+  const siblingMoltbotPath = path.join(targetDir, "moltbot.json");
+
+  const targetExists = await pathExists(targetPath);
+  const siblingMoltbotExists = await pathExists(siblingMoltbotPath);
+  const targetIsSkeletal =
+    targetExists && siblingMoltbotExists && (await isSkeletalCanonicalConfig(targetPath));
+
+  // Skeletal canonical config (real config still in moltbot.json): read-only doctor warns so the
+  // upgrade surfaces a recovery hint instead of a silent crash-loop; only `doctor --fix` mutates.
+  if (targetIsSkeletal && !options.allowSkeletalReplacement) {
+    warnings.push(
+      `Found legacy sibling config at ${siblingMoltbotPath}; run openclaw doctor --fix to recover it into ${targetPath}.`,
+    );
   }
 
-  const legacyCandidates = [path.join(home, ".clawdbot", "clawdbot.json")];
+  // Build the legacy candidate list. A skeletal canonical config is replaced from moltbot.json
+  // only under --fix. A MISSING canonical config recovers moltbot.json (then .clawdbot) in both
+  // modes, matching the existing clawdbot missing-canonical copy path.
+  const legacyCandidates: string[] = [];
+  if (targetIsSkeletal && options.allowSkeletalReplacement) {
+    legacyCandidates.push(siblingMoltbotPath);
+  }
+  if (!targetExists) {
+    legacyCandidates.push(siblingMoltbotPath);
+    legacyCandidates.push(path.join(home, ".clawdbot", "clawdbot.json"));
+  }
 
   let legacyPath: string | null = null;
   for (const candidate of legacyCandidates) {
-    try {
-      await fs.access(candidate);
+    if (await pathExists(candidate)) {
       legacyPath = candidate;
       break;
-    } catch {
-      // continue
     }
   }
   if (!legacyPath) {
-    return changes;
+    return { changes, warnings };
   }
 
   await fs.mkdir(targetDir, { recursive: true });
+  const backupPath = targetExists ? legacyConfigBackupPath(targetPath) : undefined;
   try {
-    await fs.copyFile(legacyPath, targetPath, fs.constants.COPYFILE_EXCL);
+    await copyLegacyConfigIntoPlace({ backupPath, legacyPath, targetPath });
+    if (backupPath) {
+      changes.push(`Backed up skeletal config: ${targetPath} -> ${backupPath}`);
+    }
     changes.push(`Migrated legacy config: ${legacyPath} -> ${targetPath}`);
   } catch {
-    // If it already exists, skip silently.
+    if (targetExists) {
+      warnings.push(`Skipped legacy config migration after copy failed: ${legacyPath}`);
+    }
   }
 
-  return changes;
+  return { changes, warnings };
 }
 
 export type DoctorConfigPreflightResult = {
@@ -231,9 +345,17 @@ export async function runDoctorConfigPreflight(
     }
 
     if (options.migrateLegacyConfig !== false) {
-      const legacyConfigChanges = await maybeMigrateLegacyConfig();
-      if (legacyConfigChanges.length > 0) {
-        note(legacyConfigChanges.map((entry) => `- ${entry}`).join("\n"), "Doctor changes");
+      const legacyConfigResult = await maybeMigrateLegacyConfig({
+        allowSkeletalReplacement: options.repairPrefixedConfig === true,
+      });
+      if (legacyConfigResult.changes.length > 0) {
+        note(legacyConfigResult.changes.map((entry) => `- ${entry}`).join("\n"), "Doctor changes");
+      }
+      if (legacyConfigResult.warnings.length > 0) {
+        note(
+          legacyConfigResult.warnings.map((entry) => `- ${entry}`).join("\n"),
+          "Config warnings",
+        );
       }
     }
 


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

## Summary

What problem does this PR solve?

After the v2026.3.22 breaking change that retired the `moltbot.json` config filename, users who had already moved their state to `~/.openclaw/` but still kept their real config in `~/.openclaw/moltbot.json` silently lost every channel, agent, binding, model, hook, and plugin from the running gateway. The gateway started against a skeletal `openclaw.json` (only `$schema`/`update` metadata), crash-looped every ~10s with a misleading `Gateway start blocked: set gateway.mode=local (current: unset)`, and the Control UI connected but showed nothing under Agents/Sessions/Instances. The real cause — `moltbot.json` no longer being loaded — was surfaced nowhere.

Why does this matters now?

The breaking-change notice only warned about `~/.moltbot/` users; users on `~/.openclaw/moltbot.json` had no reason to act and were not warned. Current main still ignores a sibling `~/.openclaw/moltbot.json`: `maybeMigrateLegacyConfig` early-returns when `openclaw.json` exists (even skeletal) and the only legacy candidate is `.clawdbot/clawdbot.json`; `LEGACY_CONFIG_FILENAMES` is `["clawdbot.json"]` only.

What is the intended outcome?

A doctor-owned recovery path so an affected upgrade surfaces a recovery hint instead of a silent crash-loop, and `openclaw doctor --fix` restores the real config from `moltbot.json` with a backup. Normal runtime config resolution stays canonical — `moltbot.json` is never re-added to the config candidate list.

What is intentionally out of scope?

Re-adding `moltbot.json` to the runtime config resolver/candidate list (deliberately retired). Changing the existing `.clawdbot/clawdbot.json` missing-canonical copy behavior. macOS/Linux-only flows.

What does success look like?

Read-only `openclaw doctor` warns when a sibling `moltbot.json` exists beside a missing/skeletal canonical config; `openclaw doctor --fix` backs up the skeletal config and recovers `moltbot.json` into `openclaw.json` (chmod 0600); the gateway start guard points affected users at `openclaw doctor --fix`.

What should reviewers focus on?

The skeletal-config heuristic (`isSkeletalOpenClawConfig`: a config whose every top-level key is in `{$schema, _meta, meta, update}`) and the atomic copy/backup/restore in `copyLegacyConfigIntoPlace` — specifically that a failed copy restores the original canonical config and that missing-canonical recovery uses `COPYFILE_EXCL` so a concurrently-created `openclaw.json` is never clobbered.

## Linked context

Which issue does this close?

Closes #54200

Which issues, PRs, or discussions are related?

Related #54201 (the misleading missing-`gateway.mode` error message, closed as partially handled). Related #86057 (a prior attempt at this same recovery by another contributor that was closed unmerged — "closing - better to move forward"; ClawSweeper rated it ready-for-maintainer-review). This PR re-lands that recommended shape with the same atomic-recovery tests.

Was this requested by a maintainer or owner?

No. ClawSweeper's review of #54200 flagged this as a narrow, source-reproducible upgrade bug with a clear recommended fix ("Land a bounded doctor recovery for sibling `.openclaw/moltbot.json` ... while keeping normal runtime config resolution canonical") and no open canonical implementation.

## Real behavior proof

- Behavior or issue addressed: A sibling `~/.openclaw/moltbot.json` (the user's real config) is silently ignored after the v2026.3.22 upgrade when `~/.openclaw/openclaw.json` exists as a skeleton, causing a gateway crash-loop and a blank Control UI. #54200.
- Real environment tested: Windows 10, Node v22.22.3, OpenClaw main @ aa4978e9ab. A real isolated temp `OPENCLAW_HOME` was seeded with a skeletal `openclaw.json` (`{$schema, update:{channel:beta}}`) and a `moltbot.json` (`{gateway:{mode:local,port:19091}, agents:{defaults:{model:{primary:"openai/gpt-5.5"}}}}`), then the production `runDoctorConfigPreflight` was driven directly (read-only, then `--fix`).
- Exact steps or command run after this patch: `node .tmp/capture-54200.mjs` — sets up the temp home, invokes the real `runDoctorConfigPreflight({ repairPrefixedConfig: false })` (read-only) and `runDoctorConfigPreflight({ repairPrefixedConfig: true })` (`--fix`), and prints the captured doctor notes plus the resulting `openclaw.json` contents.
- Evidence after fix (terminal capture): Terminal capture (console output) from the real production preflight against the seeded temp home. `<temp>` abbreviates the arbitrary temp-home prefix; all config content, the warning text, and the backup filename are verbatim.
```
==== BEFORE (unpatched main) ====
----SCENARIO:read-only----
doctor notes:
(none)
openclaw.json after: {"$schema":"https://openclaw.ai/schema.json","update":{"channel":"beta"}}
gateway.mode present: NO  <-- user config silently dropped / crash-loop
gateway.port present: NO
skeletal config backed up: NO
----SCENARIO:fix----
doctor notes:
(none)
openclaw.json after: {"$schema":"https://openclaw.ai/schema.json","update":{"channel":"beta"}}
gateway.mode present: NO  <-- user config silently dropped / crash-loop
gateway.port present: NO
skeletal config backed up: NO

==== AFTER (this patch) ====
----SCENARIO:read-only----
doctor notes:
- Found legacy sibling config at <temp>/.openclaw/moltbot.json; run openclaw doctor --fix to recover it into <temp>/.openclaw/openclaw.json.
openclaw.json after: {"$schema":"https://openclaw.ai/schema.json","update":{"channel":"beta"}}
gateway.mode present: NO  <-- read-only does not mutate; warning surfaced
skeletal config backed up: NO
----SCENARIO:fix----
doctor notes:
- Backed up skeletal config: <temp>/.openclaw/openclaw.json -> <temp>/.openclaw/openclaw.json.pre-moltbot-migration.2026-06-17T14-41-47-407Z
- Migrated legacy config: <temp>/.openclaw/moltbot.json -> <temp>/.openclaw/openclaw.json
openclaw.json after: {"gateway":{"mode":"local","port":19091},"agents":{"defaults":{"model":{"primary":"openai/gpt-5.5"}}}}
gateway.mode present: YES (local)
gateway.port present: YES (19091)
skeletal config backed up: YES (openclaw.json.pre-moltbot-migration.2026-06-17T14-41-47-407Z)
```
- Observed result after fix: On unpatched main both read-only and `--fix` leave `openclaw.json` skeletal with no `gateway.mode` and no warning — the user's config is silently dropped (crash-loop). With this patch, read-only doctor emits a `Found legacy sibling config ... run openclaw doctor --fix` warning without mutating; `doctor --fix` backs up the skeleton to `openclaw.json.pre-moltbot-migration.<timestamp>` and restores `gateway.mode=local`, `gateway.port=19091`, and `agents.defaults.model.primary` into `openclaw.json`. Recovered file is chmod'd 0600 (POSIX; Windows chmod is a no-op).
- What was not tested: The full `openclaw` CLI end-to-end doctor invocation on Linux/macOS; the gateway start-guard hint path was covered by an automated regression test (`run.option-collisions.test.ts`) rather than a live `gateway run` capture; production deploy not tested; concurrent-canonical-create was covered by an automated regression test, not a live race.
- Proof limitations or environment constraints: Windows cannot demonstrate the 0600 permission bit (POSIX-only); the `process.platform !== "win32"` guard in the regression test skips that assertion locally. The temp-home prefix is abbreviated in the captured output for readability.

## Tests and validation

Which commands did you run?

- `oxfmt --check` on the 4 changed files — clean.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` — exit 0.
- `oxlint --type-aware -c .oxlintrc.json --tsconfig config/tsconfig/oxlint.core.json` on the 4 changed files — clean.
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.test.ts -t "54200"` — 6 passed (5 unrelated skipped by the filter).
- `node scripts/run-vitest.mjs src/cli/gateway-cli/run.option-collisions.test.ts -t "moltbot"` — 1 passed (the new hint test).
- `node scripts/run-vitest.mjs src/cli/gateway-cli/run.option-collisions.test.ts -t "observed snapshot loses gateway.mode|blocks invalid startup config without automatic recovery"` — 2 passed (the two existing guard tests whose audit-path assertion was updated to use the per-test temp `stateDir`).

What regression coverage was added or updated?

Six new tests in `doctor-config-preflight.test.ts` covering: (1) missing-canonical moltbot migration, (2) no-overwrite of a canonical config created concurrently during missing-config recovery, (3) read-only leaves a skeletal canonical config untouched, (4) `--fix` recovers a skeletal canonical config from sibling moltbot (backup + 0600 on POSIX), (5) a canonical config that already has gateway settings is not replaced, (6) a failed sibling copy keeps the skeletal config. One new test in `run.option-collisions.test.ts` covering the gateway start-guard moltbot hint; the two existing guard tests were switched from a hardcoded `/tmp` state dir to a per-test temp dir so the sibling `moltbot.json` actually exists.

What failed before this fix, if known?

Before the fix, read-only `openclaw doctor` produced no warning and `openclaw doctor --fix` performed no recovery for the sibling `moltbot.json`; the skeletal `openclaw.json` was left in place and the gateway crash-looped on the missing `gateway.mode`. See the BEFORE block above.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes — `openclaw doctor` now emits a recovery warning when a sibling `moltbot.json` exists beside a missing/skeletal canonical config, and `openclaw doctor --fix` performs a new bounded recovery.

Did config, environment, or migration behavior change? (`Yes/No`)

Yes — this revives a narrow, doctor-owned recovery path for the retired `moltbot.json` filename, gated behind `doctor --fix` for skeletal configs. The existing `.clawdbot/clawdbot.json` missing-canonical copy path is unchanged.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No new execution, network, or dependency surface. The recovered file is staged through a temp file and chmod'd 0600 so recovered credentials/keys are not left world-readable.

What is the highest-risk area?

`doctor --fix` replacing a skeletal canonical `openclaw.json` with sibling `moltbot.json` content.

How is that risk mitigated?

Replacement is gated behind `doctor --fix` (read-only doctor only warns); the skeletal heuristic is intentionally narrow (only `{$schema, _meta, meta, update}` top-level keys); the original skeletal config is renamed to `openclaw.json.pre-moltbot-migration.<timestamp>` before the new content is moved into place and restored on copy failure; missing-canonical recovery uses `COPYFILE_EXCL` so a concurrently-created `openclaw.json` is preserved; normal runtime config resolution is unchanged.

## Current review state

What is the next action?

Awaiting maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

External-fork workflow-approval-gated heavy CI shards require maintainer approval to run (same gate as other external PRs).

Which bot or reviewer comments were addressed?

None yet (PR just opened).
