### PR TITLE
fix(cron): prevent lane timeout during long tool execution in isolated cron agents

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1853,169 +1853,178 @@ async function runEmbeddedAgentInternal(
           } else {
             parentAbortSignal?.addEventListener("abort", relayParentAbort, { once: true });
           }
-          const rawAttempt = await runEmbeddedAttemptWithBackend({
-            sessionId: activeSessionId,
-            sessionKey: resolvedSessionKey,
-            promptCacheKey: params.promptCacheKey,
-            sandboxSessionKey: params.sandboxSessionKey,
-            trigger: params.trigger,
-            memoryFlushWritePath: params.memoryFlushWritePath,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            chatType: params.chatType,
-            agentAccountId: params.agentAccountId,
-            messageTo: params.messageTo,
-            messageThreadId: params.messageThreadId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            memberRoleIds: params.memberRoleIds,
-            spawnedBy: params.spawnedBy,
-            isCanonicalWorkspace,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
-            currentChannelId: params.currentChannelId,
-            currentMessagingTarget: params.currentMessagingTarget,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            currentInboundAudio: params.currentInboundAudio,
-            replyToMode: params.replyToMode,
-            hasRepliedRef: params.hasRepliedRef,
-            sessionFile: activeSessionFile,
-            workspaceDir: resolvedWorkspace,
-            cwd: params.cwd,
-            agentDir,
-            config: params.config,
-            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-            contextEngine,
-            contextTokenBudget: ctxInfo.tokens,
-            contextWindowInfo: ctxInfo,
-            skillsSnapshot: params.skillsSnapshot,
-            prompt,
-            transcriptPrompt: params.transcriptPrompt,
-            userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
-            currentInboundEventKind: params.currentInboundEventKind,
-            currentInboundContext: params.currentInboundContext,
-            images: params.images,
-            imageOrder: params.imageOrder,
-            clientTools: params.clientTools,
-            disableTools: params.disableTools,
-            provider,
-            modelId,
-            requestedModelId,
-            fallbackActive: modelId !== requestedModelId || Boolean(resolveRuntimeFallbackReason()),
-            fallbackReason: resolveRuntimeFallbackReason(),
-            // Use the harness selected before model/auth setup for the actual
-            // attempt too. Otherwise plugin-owned transports can skip OpenClaw auth
-            // bootstrap but drift back to OpenClaw when the attempt is created.
-            agentHarnessId: agentHarness.id,
-            ...(params.sessionKey
-              ? {
-                  agentHarnessTaskRuntimeScope: createAgentHarnessTaskRuntimeScope({
-                    requesterSessionKey: params.sessionKey,
-                  }),
-                }
-              : {}),
-            runtimePlan,
-            model: applyAuthHeaderOverride(
-              applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
-              // When runtime auth exchange produced a different credential
-              // (runtimeAuthState is set), the exchanged token lives in
-              // authStorage and the SDK will pick it up automatically.
-              // Skip header injection to avoid leaking the pre-exchange key.
-              runtimeAuthState ? null : apiKeyInfo,
-              params.config,
-            ),
-            resolvedApiKey: resolvedStreamApiKey,
-            authProfileId: lastProfileId,
-            authProfileIdSource: lockedProfileId ? "user" : "auto",
-            initialReplayState: accumulatedReplayState,
-            authStorage,
-            authProfileStore: runAttemptAuthProfileStore,
-            // These harnesses build OpenClaw tools internally. Keep transport auth
-            // scoped while letting tool construction see plugin/provider creds.
-            toolAuthProfileStore: harnessBuildsOpenClawTools ? attemptAuthProfileStore : undefined,
-            modelRegistry,
-            agentId: workspaceResolution.agentId,
-            beforeAgentStartResult,
-            thinkLevel,
-            onToolOutcome: observeToolOutcome,
-            allocateToolOutcomeOrdinal,
-            onRunProgress: notifyRunProgress,
-            fastMode: params.fastMode,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            toolProgressDetail: params.toolProgressDetail,
-            execOverrides: params.execOverrides,
-            bashElevated: params.bashElevated,
-            timeoutMs: params.timeoutMs,
-            runTimeoutOverrideMs: params.runTimeoutOverrideMs,
-            runId: params.runId,
-            lifecycleGeneration,
-            abortSignal: attemptAbortController.signal,
-            replyOperation: params.replyOperation,
-            shouldEmitToolResult: params.shouldEmitToolResult,
-            shouldEmitToolOutput: params.shouldEmitToolOutput,
-            onPartialReply: params.onPartialReply,
-            onAssistantMessageStart: params.onAssistantMessageStart,
-            onBlockReply: params.onBlockReply,
-            onBlockReplyFlush: params.onBlockReplyFlush,
-            blockReplyBreak: params.blockReplyBreak,
-            blockReplyChunking: params.blockReplyChunking,
-            onReasoningStream: params.onReasoningStream,
-            onReasoningEnd: params.onReasoningEnd,
-            onToolResult: params.onToolResult,
-            onAgentToolResult: params.onAgentToolResult,
-            onAgentEvent: params.onAgentEvent,
-            deferTerminalLifecycle:
-              params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
-            deferTerminalLifecycleEnd:
-              params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
-            onExecutionPhase: params.onExecutionPhase,
-            extraSystemPrompt: params.extraSystemPrompt,
-            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-            inputProvenance: params.inputProvenance,
-            streamParams: params.streamParams,
-            modelRun: params.modelRun,
-            promptMode: params.promptMode,
-            ownerNumbers: params.ownerNumbers,
-            enforceFinalTag: params.enforceFinalTag,
-            silentExpected: params.silentExpected,
-            bootstrapContextMode: params.bootstrapContextMode,
-            bootstrapContextRunKind: params.bootstrapContextRunKind,
-            jobId: params.jobId,
-            toolsAllow: params.toolsAllow,
-            cleanupBundleMcpOnRunEnd: params.cleanupBundleMcpOnRunEnd,
-            disableMessageTool: params.disableMessageTool,
-            forceMessageTool: params.forceMessageTool,
-            enableHeartbeatTool: params.enableHeartbeatTool,
-            forceHeartbeatTool: params.forceHeartbeatTool,
-            requireExplicitMessageTarget: params.requireExplicitMessageTarget,
-            internalEvents: params.internalEvents,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature:
-              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-            suppressNextUserMessagePersistence,
-            beforeAgentFinalizeRevisionAttempts,
-            maxBeforeAgentFinalizeRevisions: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
-            suppressTranscriptOnlyAssistantPersistence:
-              params.suppressTranscriptOnlyAssistantPersistence,
-            suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
-            onUserMessagePersisted,
-            onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
-          })
-            .catch((err: unknown): never => {
-              throw postCompactionAbortError ?? err;
+          const rawAttempt = await (() => {
+            const progressInterval = setInterval(() => noteLaneTaskProgress(), 30_000);
+            return runEmbeddedAttemptWithBackend({
+              sessionId: activeSessionId,
+              sessionKey: resolvedSessionKey,
+              promptCacheKey: params.promptCacheKey,
+              sandboxSessionKey: params.sandboxSessionKey,
+              trigger: params.trigger,
+              memoryFlushWritePath: params.memoryFlushWritePath,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              chatType: params.chatType,
+              agentAccountId: params.agentAccountId,
+              messageTo: params.messageTo,
+              messageThreadId: params.messageThreadId,
+              groupId: params.groupId,
+              groupChannel: params.groupChannel,
+              groupSpace: params.groupSpace,
+              memberRoleIds: params.memberRoleIds,
+              spawnedBy: params.spawnedBy,
+              isCanonicalWorkspace,
+              senderId: params.senderId,
+              senderName: params.senderName,
+              senderUsername: params.senderUsername,
+              senderE164: params.senderE164,
+              currentChannelId: params.currentChannelId,
+              currentMessagingTarget: params.currentMessagingTarget,
+              currentThreadTs: params.currentThreadTs,
+              currentMessageId: params.currentMessageId,
+              currentInboundAudio: params.currentInboundAudio,
+              replyToMode: params.replyToMode,
+              hasRepliedRef: params.hasRepliedRef,
+              sessionFile: activeSessionFile,
+              workspaceDir: resolvedWorkspace,
+              cwd: params.cwd,
+              agentDir,
+              config: params.config,
+              allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+              contextEngine,
+              contextTokenBudget: ctxInfo.tokens,
+              contextWindowInfo: ctxInfo,
+              skillsSnapshot: params.skillsSnapshot,
+              prompt,
+              transcriptPrompt: params.transcriptPrompt,
+              userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+              currentInboundEventKind: params.currentInboundEventKind,
+              currentInboundContext: params.currentInboundContext,
+              images: params.images,
+              imageOrder: params.imageOrder,
+              clientTools: params.clientTools,
+              disableTools: params.disableTools,
+              provider,
+              modelId,
+              requestedModelId,
+              fallbackActive:
+                modelId !== requestedModelId || Boolean(resolveRuntimeFallbackReason()),
+              fallbackReason: resolveRuntimeFallbackReason(),
+              // Use the harness selected before model/auth setup for the actual
+              // attempt too. Otherwise plugin-owned transports can skip OpenClaw auth
+              // bootstrap but drift back to OpenClaw when the attempt is created.
+              agentHarnessId: agentHarness.id,
+              ...(params.sessionKey
+                ? {
+                    agentHarnessTaskRuntimeScope: createAgentHarnessTaskRuntimeScope({
+                      requesterSessionKey: params.sessionKey,
+                    }),
+                  }
+                : {}),
+              runtimePlan,
+              model: applyAuthHeaderOverride(
+                applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+                // When runtime auth exchange produced a different credential
+                // (runtimeAuthState is set), the exchanged token lives in
+                // authStorage and the SDK will pick it up automatically.
+                // Skip header injection to avoid leaking the pre-exchange key.
+                runtimeAuthState ? null : apiKeyInfo,
+                params.config,
+              ),
+              resolvedApiKey: resolvedStreamApiKey,
+              authProfileId: lastProfileId,
+              authProfileIdSource: lockedProfileId ? "user" : "auto",
+              initialReplayState: accumulatedReplayState,
+              authStorage,
+              authProfileStore: runAttemptAuthProfileStore,
+              // These harnesses build OpenClaw tools internally. Keep transport auth
+              // scoped while letting tool construction see plugin/provider creds.
+              toolAuthProfileStore: harnessBuildsOpenClawTools
+                ? attemptAuthProfileStore
+                : undefined,
+              modelRegistry,
+              agentId: workspaceResolution.agentId,
+              beforeAgentStartResult,
+              thinkLevel,
+              onToolOutcome: observeToolOutcome,
+              allocateToolOutcomeOrdinal,
+              onRunProgress: notifyRunProgress,
+              fastMode: params.fastMode,
+              verboseLevel: params.verboseLevel,
+              reasoningLevel: params.reasoningLevel,
+              toolResultFormat: resolvedToolResultFormat,
+              toolProgressDetail: params.toolProgressDetail,
+              execOverrides: params.execOverrides,
+              bashElevated: params.bashElevated,
+              timeoutMs: params.timeoutMs,
+              runTimeoutOverrideMs: params.runTimeoutOverrideMs,
+              runId: params.runId,
+              lifecycleGeneration,
+              abortSignal: attemptAbortController.signal,
+              replyOperation: params.replyOperation,
+              shouldEmitToolResult: params.shouldEmitToolResult,
+              shouldEmitToolOutput: params.shouldEmitToolOutput,
+              onPartialReply: params.onPartialReply,
+              onAssistantMessageStart: params.onAssistantMessageStart,
+              onBlockReply: params.onBlockReply,
+              onBlockReplyFlush: params.onBlockReplyFlush,
+              blockReplyBreak: params.blockReplyBreak,
+              blockReplyChunking: params.blockReplyChunking,
+              onReasoningStream: params.onReasoningStream,
+              onReasoningEnd: params.onReasoningEnd,
+              onToolResult: params.onToolResult,
+              onAgentToolResult: params.onAgentToolResult,
+              onAgentEvent: params.onAgentEvent,
+              deferTerminalLifecycle:
+                params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
+              deferTerminalLifecycleEnd:
+                params.deferTerminalLifecycle ?? params.deferTerminalLifecycleEnd,
+              onExecutionPhase: params.onExecutionPhase,
+              extraSystemPrompt: params.extraSystemPrompt,
+              sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+              inputProvenance: params.inputProvenance,
+              streamParams: params.streamParams,
+              modelRun: params.modelRun,
+              promptMode: params.promptMode,
+              ownerNumbers: params.ownerNumbers,
+              enforceFinalTag: params.enforceFinalTag,
+              silentExpected: params.silentExpected,
+              bootstrapContextMode: params.bootstrapContextMode,
+              bootstrapContextRunKind: params.bootstrapContextRunKind,
+              jobId: params.jobId,
+              toolsAllow: params.toolsAllow,
+              cleanupBundleMcpOnRunEnd: params.cleanupBundleMcpOnRunEnd,
+              disableMessageTool: params.disableMessageTool,
+              forceMessageTool: params.forceMessageTool,
+              enableHeartbeatTool: params.enableHeartbeatTool,
+              forceHeartbeatTool: params.forceHeartbeatTool,
+              requireExplicitMessageTarget: params.requireExplicitMessageTarget,
+              internalEvents: params.internalEvents,
+              bootstrapPromptWarningSignaturesSeen,
+              bootstrapPromptWarningSignature:
+                bootstrapPromptWarningSignaturesSeen[
+                  bootstrapPromptWarningSignaturesSeen.length - 1
+                ],
+              suppressNextUserMessagePersistence,
+              beforeAgentFinalizeRevisionAttempts,
+              maxBeforeAgentFinalizeRevisions: MAX_BEFORE_AGENT_FINALIZE_REVISIONS,
+              suppressTranscriptOnlyAssistantPersistence:
+                params.suppressTranscriptOnlyAssistantPersistence,
+              suppressAssistantErrorPersistence: params.suppressAssistantErrorPersistence,
+              onUserMessagePersisted,
+              onAssistantErrorMessagePersisted: params.onAssistantErrorMessagePersisted,
             })
-            .finally(() => {
-              parentAbortSignal?.removeEventListener?.("abort", relayParentAbort);
-              if (postCompactionAbortController === attemptAbortController) {
-                postCompactionAbortController = undefined;
-              }
-            });
+              .catch((err: unknown): never => {
+                throw postCompactionAbortError ?? err;
+              })
+              .finally(() => {
+                clearInterval(progressInterval);
+                parentAbortSignal?.removeEventListener?.("abort", relayParentAbort);
+                if (postCompactionAbortController === attemptAbortController) {
+                  postCompactionAbortController = undefined;
+                }
+              });
+          })();
           if (postCompactionAbortError) {
             throw postCompactionAbortError;
           }


### PR DESCRIPTION
## Summary

When a cron job with `isolated: true` runs a long-running tool (e.g., data processing scripts, builds) that exceeds ~10 minutes, the lane task timeout expires with a `CommandLaneTaskTimeoutError` even when `timeoutSeconds` is configured to 600s.

## Root Cause

`noteLaneTaskProgress()` in `src/agents/embedded-agent-runner/run.ts` was only called during startup phases and attempt progress events — it was **not** called during tool execution or LLM streaming output. The lane timeout uses a sliding window (`laneTaskTimeoutMs = timeoutMs + 30s grace`), so without periodic progress updates during long tool execution, the sliding window expires and triggers the timeout.

## Fix

Wrap the `runEmbeddedAttemptWithBackend()` call in an IIFE that sets up a 30-second `setInterval` to periodically call `noteLaneTaskProgress()`, keeping the lane timeout sliding window alive during long-running tools. The interval is cleared when the attempt completes or errors.

## Changes

- `src/agents/embedded-agent-runner/run.ts`: Added a 30-second progress interval around `runEmbeddedAttemptWithBackend()` that calls `noteLaneTaskProgress()` to keep the lane timeout from expiring during long tool execution.

## Testing

No test changes needed — the fix is a runtime behavior change that keeps existing timeout semantics intact while preventing false positives during legitimate long-running tools.

Fixes #94033