### PR TITLE
fix(agent): surface non_deliverable_terminal_turn with specific message instead of generic /new fallback

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3850,6 +3850,7 @@ async function runEmbeddedAgentInternal(
             livenessState,
             stopReason,
             yielded: attempt.yieldDetected === true,
+            terminalError: attempt.terminalError,
           });
           return {
             payloads: terminalPayloads?.length ? terminalPayloads : undefined,
@@ -3866,6 +3867,7 @@ async function runEmbeddedAgentInternal(
               finalAssistantRawText,
               replayInvalid,
               livenessState,
+              terminalError: attempt.terminalError,
               agentHarnessResultClassification: attempt.agentHarnessResultClassification,
               ...(attempt.yieldDetected ? { yielded: true } : {}),
               ...(emptyAssistantReplyIsSilent

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5586,7 +5586,6 @@ export async function runEmbeddedAttempt(
         promptError,
         promptErrorSource,
         terminalError: attemptTrajectoryTerminal.terminalError,
-        terminalStatus: attemptTrajectoryTerminal.status,
         preflightRecovery,
         sessionIdUsed,
         sessionFileUsed,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5585,6 +5585,8 @@ export async function runEmbeddedAttempt(
         timedOutDuringToolExecution,
         promptError,
         promptErrorSource,
+        terminalError: attemptTrajectoryTerminal.terminalError,
+        terminalStatus: attemptTrajectoryTerminal.status,
         preflightRecovery,
         sessionIdUsed,
         sessionFileUsed,

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -174,6 +174,7 @@ export type EmbeddedRunAttemptResult = {
   messagesSnapshot: AgentMessage[];
   beforeAgentFinalizeRevisionReason?: string;
   assistantTexts: string[];
+  terminalError?: string;
   lastAssistantTextMessageIndex?: number;
   toolMetas: Array<{
     toolName: string;
@@ -230,5 +231,6 @@ export type EmbeddedRunAttemptResult = {
     timeoutPhase?: AgentRunTimeoutPhase;
     providerStarted?: boolean;
     aborted?: boolean;
+    terminalError?: string;
   }) => void;
 };

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -148,6 +148,7 @@ export type EmbeddedAgentRunMeta = {
   finalAssistantRawText?: string;
   replayInvalid?: boolean;
   livenessState?: EmbeddedRunLivenessState;
+  terminalError?: string;
   timeoutPhase?: AgentRunTimeoutPhase;
   providerStarted?: boolean;
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -21,6 +21,7 @@ const DEFERRED_TERMINAL_METADATA_KEYS = [
   "aborted",
   "livenessState",
   "replayInvalid",
+  "terminalError",
 ] as const;
 
 export function resolveAgentLifecycleTerminalMetadata(meta: unknown): Record<string, unknown> {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -26,7 +26,11 @@ import {
   resolveSessionRuntimeOverrideForProvider,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
 } from "./agent-runner-execution.js";
-import { HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
+import {
+  HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+  NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT,
+  NON_DELIVERABLE_TERMINAL_TURN_REASON,
+} from "./agent-runner-failure-copy.js";
 import {
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
   PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
@@ -6427,6 +6431,40 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
+  it("surfaces non-deliverable terminal turns instead of generic /new fallback copy", async () => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {
+        terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+        replayInvalid: false,
+        livenessState: "blocked",
+      },
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "direct",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult?.payloads).toEqual([
+        expect.objectContaining({
+          isError: true,
+          text: NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT,
+        }),
+      ]);
+      expect(result.runResult?.payloads?.[0]?.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -117,8 +117,8 @@ import {
 } from "./agent-runner-cli-dispatch.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
-  NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+  resolveExternalRunFailureTextForTerminalError,
 } from "./agent-runner-failure-copy.js";
 import {
   buildEmbeddedRunExecutionParams,
@@ -993,9 +993,6 @@ function buildExternalRunFailureReply(
   const codexAppServerFailure = buildCodexAppServerFailureText(normalizedMessage);
   if (codexAppServerFailure) {
     return { text: codexAppServerFailure, isGenericRunnerFailure: false };
-  }
-  if (/non.deliverable/i.test(normalizedMessage) || /tool.?(use|call).*no.*(reply|delivery)/i.test(normalizedMessage)) {
-    return { text: NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT, isGenericRunnerFailure: false };
   }
   return {
     text: options?.includeDetails
@@ -2939,18 +2936,14 @@ export async function runAgentTurnWithFallback(params: {
       const userFacingErrorPayload = runResult.payloads?.find(
         (payload) => payload.isError === true && typeof payload.text === "string",
       )?.text;
-      const trajectoryTerminalError =
-        runResult.meta && typeof runResult.meta === "object" && "terminalError" in runResult.meta
-          ? (runResult.meta as Record<string, unknown>).terminalError
-          : undefined;
+      const terminalErrorFailureText = resolveExternalRunFailureTextForTerminalError(
+        runResult.meta.terminalError,
+      );
       const terminalErrorMessage =
         deferredLifecycleError ??
         userFacingErrorPayload ??
-        (trajectoryTerminalError === "non_deliverable_terminal_turn"
-          ? NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT
-          : embeddedError
-            ? "Agent run failed"
-            : undefined);
+        terminalErrorFailureText ??
+        (embeddedError ? "Agent run failed" : undefined);
       const emitSettledLifecycleError = (error: Error, extraData?: Record<string, unknown>) => {
         if (settledLifecycleTerminal) {
           settledLifecycleTerminal.emit("error", error, extraData);
@@ -3018,7 +3011,7 @@ export async function runAgentTurnWithFallback(params: {
         });
         params.replyOperation?.retainFailureUntilComplete();
         params.replyOperation?.fail("run_failed", exhaustionError);
-      } else if (deferredLifecycleError || embeddedError) {
+      } else if (deferredLifecycleError || embeddedError || terminalErrorFailureText) {
         const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
         emitSettledLifecycleError(terminalError, terminalMetadata);
         params.replyOperation?.retainFailureUntilComplete();
@@ -3324,6 +3317,22 @@ export async function runAgentTurnWithFallback(params: {
       (p) => !p.isError && !p.isReasoning && hasOutboundReplyContent(p, { trimText: true }),
     );
     if (!hasNonErrorContent) {
+      const terminalErrorFailureText = resolveExternalRunFailureTextForTerminalError(
+        runResult.meta.terminalError,
+      );
+      if (terminalErrorFailureText) {
+        runResult.payloads = [
+          markAgentRunFailureReplyPayload({
+            text: resolveExternalRunFailureTextForConversation({
+              text: terminalErrorFailureText,
+              sessionCtx: params.sessionCtx,
+              isGenericRunnerFailure: false,
+              cfg: params.followupRun.run.config,
+            }),
+            isError: true,
+          }),
+        ];
+      }
       const metaErrorMsg = finalEmbeddedError?.message ?? "";
       const rawErrorPayloadText =
         runResult.payloads?.find(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -117,6 +117,7 @@ import {
 } from "./agent-runner-cli-dispatch.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+  NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
 } from "./agent-runner-failure-copy.js";
 import {
@@ -992,6 +993,9 @@ function buildExternalRunFailureReply(
   const codexAppServerFailure = buildCodexAppServerFailureText(normalizedMessage);
   if (codexAppServerFailure) {
     return { text: codexAppServerFailure, isGenericRunnerFailure: false };
+  }
+  if (/non.deliverable/i.test(normalizedMessage) || /tool.?(use|call).*no.*(reply|delivery)/i.test(normalizedMessage)) {
+    return { text: NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT, isGenericRunnerFailure: false };
   }
   return {
     text: options?.includeDetails
@@ -2935,10 +2939,18 @@ export async function runAgentTurnWithFallback(params: {
       const userFacingErrorPayload = runResult.payloads?.find(
         (payload) => payload.isError === true && typeof payload.text === "string",
       )?.text;
+      const trajectoryTerminalError =
+        runResult.meta && typeof runResult.meta === "object" && "terminalError" in runResult.meta
+          ? (runResult.meta as Record<string, unknown>).terminalError
+          : undefined;
       const terminalErrorMessage =
         deferredLifecycleError ??
         userFacingErrorPayload ??
-        (embeddedError ? "Agent run failed" : undefined);
+        (trajectoryTerminalError === "non_deliverable_terminal_turn"
+          ? NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT
+          : embeddedError
+            ? "Agent run failed"
+            : undefined);
       const emitSettledLifecycleError = (error: Error, extraData?: Record<string, unknown>) => {
         if (settledLifecycleTerminal) {
           settledLifecycleTerminal.emit("error", error, extraData);

--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -5,8 +5,18 @@ export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT =
 export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT =
   "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available.";
 
+export const NON_DELIVERABLE_TERMINAL_TURN_REASON = "non_deliverable_terminal_turn";
+
 export const NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT =
   "⚠️ The model stopped between tool calls without producing a reply. Please try the same message again — this usually resolves on retry. If it persists, use /new or a lighter model.";
+
+export function resolveExternalRunFailureTextForTerminalError(
+  terminalError: string | undefined,
+): string | undefined {
+  return terminalError === NON_DELIVERABLE_TERMINAL_TURN_REASON
+    ? NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT
+    : undefined;
+}
 
 /** True when text is exactly the generic external run failure copy. */
 export function isGenericExternalRunFailureText(text: string | undefined): boolean {

--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -5,6 +5,9 @@ export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT =
 export const HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT =
   "⚠️ Heartbeat check failed before it could produce an update. The main chat session remains available.";
 
+export const NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT =
+  "⚠️ The model stopped between tool calls without producing a reply. Please try the same message again — this usually resolves on retry. If it persists, use /new or a lighter model.";
+
 /** True when text is exactly the generic external run failure copy. */
 export function isGenericExternalRunFailureText(text: string | undefined): boolean {
   return text?.trim() === GENERIC_EXTERNAL_RUN_FAILURE_TEXT;

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1256,10 +1256,18 @@ export function createFollowupRunner(params: {
         const userFacingErrorPayload = runResult.payloads?.find(
           (payload) => payload.isError === true && typeof payload.text === "string",
         )?.text;
+        const trajectoryTerminalError =
+          runResult.meta && typeof runResult.meta === "object" && "terminalError" in runResult.meta
+            ? (runResult.meta as Record<string, unknown>).terminalError
+            : undefined;
         const terminalErrorMessage =
           deferredLifecycleError ??
           userFacingErrorPayload ??
-          (runResult.meta?.error ? "Agent run failed" : undefined);
+          (trajectoryTerminalError === "non_deliverable_terminal_turn"
+            ? "Agent run failed: non-deliverable terminal turn"
+            : runResult.meta?.error
+              ? "Agent run failed"
+              : undefined);
         const terminalMetadata = resolveAgentLifecycleTerminalMetadata(runResult.meta);
         if (fallbackExhausted) {
           const exhaustionError = new Error(

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -62,6 +62,7 @@ import {
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
   resolveSessionRuntimeOverrideForProvider,
 } from "./agent-runner-execution.js";
+import { resolveExternalRunFailureTextForTerminalError } from "./agent-runner-failure-copy.js";
 import { runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
 import {
   resolveQueuedReplyExecutionConfig,
@@ -1256,18 +1257,14 @@ export function createFollowupRunner(params: {
         const userFacingErrorPayload = runResult.payloads?.find(
           (payload) => payload.isError === true && typeof payload.text === "string",
         )?.text;
-        const trajectoryTerminalError =
-          runResult.meta && typeof runResult.meta === "object" && "terminalError" in runResult.meta
-            ? (runResult.meta as Record<string, unknown>).terminalError
-            : undefined;
+        const terminalErrorFailureText = resolveExternalRunFailureTextForTerminalError(
+          runResult.meta.terminalError,
+        );
         const terminalErrorMessage =
           deferredLifecycleError ??
           userFacingErrorPayload ??
-          (trajectoryTerminalError === "non_deliverable_terminal_turn"
-            ? "Agent run failed: non-deliverable terminal turn"
-            : runResult.meta?.error
-              ? "Agent run failed"
-              : undefined);
+          terminalErrorFailureText ??
+          (runResult.meta?.error ? "Agent run failed" : undefined);
         const terminalMetadata = resolveAgentLifecycleTerminalMetadata(runResult.meta);
         if (fallbackExhausted) {
           const exhaustionError = new Error(
@@ -1279,7 +1276,7 @@ export function createFollowupRunner(params: {
           });
           replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", exhaustionError);
-        } else if (deferredLifecycleError || runResult.meta?.error) {
+        } else if (deferredLifecycleError || runResult.meta?.error || terminalErrorFailureText) {
           const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
           emitSettledLifecycleError(terminalError, terminalMetadata);
           replyOperation.retainFailureUntilComplete();


### PR DESCRIPTION
## Summary

Surface terminalError=non_deliverable_terminal_turn with specific retry guidance instead of the misleading generic /new fallback.

## Problem

When the model stops between tool calls without producing a reply, users see:
"Something went wrong while processing your request. Please try again, or use /new to start a fresh session."

/new is the wrong remediation — it clears context unnecessarily when a simple retry would succeed. The user receives no diagnostic signal about what actually happened.

## Root Cause

terminalError from resolveAttemptTrajectoryTerminal() was recorded in trajectory events but NOT included in runResult.meta, so the reply system never saw it. The empty terminalErrorMessage caused the lifecycle to emit end instead of error, and the generic fallback was used downstream.

## Changes

- **`src/auto-reply/reply/agent-runner-failure-copy.ts`** — Add NON_DELIVERABLE_TERMINAL_TURN_FAILURE_TEXT message: "The model stopped between tool calls without producing a reply. Please try the same message again — this usually resolves on retry. If it persists, use /new or a lighter model."
- **`src/auto-reply/reply/agent-lifecycle-terminal.ts`** — Add terminalError to deferred metadata keys so it propagates through the lifecycle
- **`src/agents/embedded-agent-runner/run/attempt.ts`** — Surface terminalError and terminalStatus in runResult.meta
- **`src/auto-reply/reply/agent-runner-execution.ts`** — Check terminalError in terminalErrorMessage and build external run failure reply using the specific message
- **`src/auto-reply/reply/followup-runner.ts`** — Same terminalError check for the followup runner path

## Testing

- agent-runner-execution.test.ts: 205 passed — confirms embedded run metadata propagates terminalError and the user-facing reply uses the specific retry guidance
- Plugin-sdk full shard: 385 passed — validates the rebased branch clears prior failures
- oxfmt, oxlint, tsgo:core, git diff --check all pass
- Manual verification: source harness with mocked embedded-run metadata for the terminal-error path confirms the new message replaces the generic fallback

## Related

Closes #94176