### PR TITLE
fix(skills): preserve skillKey in SkillSnapshot for correct env override lookup

### DIFF
--- a/src/skills/loading/skills.test.ts
+++ b/src/skills/loading/skills.test.ts
@@ -862,4 +862,41 @@ describe("applySkillEnvOverrides", () => {
       }
     });
   });
+
+  it("resolves snapshot env overrides by skillKey when name differs from skillKey", () => {
+    const snapshot: SkillSnapshot = {
+      prompt: "",
+      skills: [
+        {
+          name: "Pretty Weather",
+          skillKey: "weather",
+          primaryEnv: "WEATHER_API_KEY",
+        },
+      ],
+    };
+
+    const config: OpenClawConfig = {
+      skills: {
+        entries: {
+          weather: {
+            apiKey: "weather-secret", // pragma: allowlist secret
+          },
+        },
+      },
+    };
+
+    withClearedEnv(["WEATHER_API_KEY"], () => {
+      const restore = applySkillEnvOverridesFromSnapshot({
+        snapshot,
+        config,
+      });
+
+      try {
+        expect(process.env.WEATHER_API_KEY).toBe("weather-secret");
+      } finally {
+        restore();
+        expect(process.env.WEATHER_API_KEY).toBeUndefined();
+      }
+    });
+  });
 });

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -64,8 +64,8 @@ function resolveNativeUserHomeDir(): string | undefined {
 }
 
 function resolveCompactHomePrefixes(): string[] {
-  const homes = [resolveUserHomeDir(), resolveNativeUserHomeDir()].filter(
-    (home): home is string => Boolean(home),
+  const homes = [resolveUserHomeDir(), resolveNativeUserHomeDir()].filter((home): home is string =>
+    Boolean(home),
   );
   const resolvedHomes = homes.map((home) => path.resolve(home));
   const realHomes = resolvedHomes
@@ -111,15 +111,15 @@ function resolvePromptTildeRoots(): string[] {
     return [];
   }
   const realNativeHome = tryRealpath(resolvedNativeHome);
-  return uniqueStrings([
-    resolvedNativeHome,
-    ...(realNativeHome ? [realNativeHome] : []),
-  ]);
+  return uniqueStrings([resolvedNativeHome, ...(realNativeHome ? [realNativeHome] : [])]);
 }
 
 function isContainerStateHomeWherePromptTildeEscapes(home: string): boolean {
   const configDir = path.resolve(resolveConfigDir());
-  return home === "/data" && (configDir === "/data/.openclaw" || isPathInside("/data/.openclaw", configDir));
+  return (
+    home === "/data" &&
+    (configDir === "/data/.openclaw" || isPathInside("/data/.openclaw", configDir))
+  );
 }
 
 function shouldPreservePromptSkillPath(
@@ -1412,6 +1412,7 @@ export function buildWorkspaceSkillSnapshot(
     prompt,
     skills: eligible.map((entry) => ({
       name: entry.skill.name,
+      skillKey: entry.metadata?.skillKey,
       primaryEnv: entry.metadata?.primaryEnv,
       requiredEnv: entry.metadata?.requires?.env?.slice(),
     })),

--- a/src/skills/runtime/env-overrides.ts
+++ b/src/skills/runtime/env-overrides.ts
@@ -260,7 +260,8 @@ export function applySkillEnvOverridesFromSnapshot(params: {
   const updates: EnvUpdate[] = [];
 
   for (const skill of snapshot.skills) {
-    const skillConfig = resolveSkillConfig(config, skill.name);
+    const resolvedKey = skill.skillKey ?? skill.name;
+    const skillConfig = resolveSkillConfig(config, resolvedKey);
     if (!skillConfig) {
       continue;
     }
@@ -273,7 +274,7 @@ export function applySkillEnvOverridesFromSnapshot(params: {
       skillConfig,
       primaryEnv: skill.primaryEnv,
       requiredEnv: skill.requiredEnv,
-      skillKey: skill.name,
+      skillKey: resolvedKey,
     });
   }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -103,7 +103,7 @@ export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 1;
 
 export type SkillSnapshot = {
   prompt: string;
-  skills: Array<{ name: string; primaryEnv?: string; requiredEnv?: string[] }>;
+  skills: Array<{ name: string; skillKey?: string; primaryEnv?: string; requiredEnv?: string[] }>;
   /** Normalized agent-level filter used to build this snapshot; undefined means unrestricted. */
   skillFilter?: string[];
   resolvedSkills?: Skill[];


### PR DESCRIPTION
## Summary

SkillSnapshot.skills[] stores `name`, `primaryEnv`, and `requiredEnv` but does not persist the resolved `skillKey`. When a skill has `metadata.skillKey` that differs from its display name (e.g., name="Pretty Weather", skillKey="weather"), the snapshot env override logic (`applySkillEnvOverridesFromSnapshot()`) looks up config by `skill.name` instead of `skillKey` — missing the configured env/apiKey stored under `skills.entries.<skillKey>`.

## Changes

Three files touched:

1. **`src/skills/types.ts`** — added optional `skillKey?: string` to `SkillSnapshot.skills[]` array element type.

2. **`src/skills/loading/workspace.ts`** — populate `skillKey` from `entry.metadata.skillKey` in `buildWorkspaceSkillSnapshot()`.

3. **`src/skills/runtime/env-overrides.ts`** — use `skill.skillKey ?? skill.name` for config lookup in `applySkillEnvOverridesFromSnapshot()`, preserving backward compatibility with existing snapshots that only have `name`.

4. **`src/skills/loading/skills.test.ts`** — added a regression test where `name !== skillKey`, verifying that env overrides are correctly resolved via `skillKey`.

## Real behavior proof

### Behavior or issue addressed
SkillSnapshot loses skillKey, causing snapshot env overrides to miss skills.entries.<skillKey> config.

### Real environment tested
Code review of the snapshot builder, type definition, and env override lookup chain. The fix is verified by the existing test suite and a new regression test.

### Exact steps or command run after this patch
1. A skill with `metadata.skillKey: "weather"` and `name: "Pretty Weather"` is loaded into a snapshot. The snapshot now includes `skillKey: "weather"`.
2. `applySkillEnvOverridesFromSnapshot()` uses `skill.skillKey ?? skill.name` → resolves to `"weather"` → finds config at `skills.entries.weather.apiKey` → injects the env var. Verified by the new test.
3. Older snapshots without `skillKey` still resolve via `skill.name` fallback (existing tests cover this).

### Evidence after fix
The diff is 4 files, +49/-10 lines:
- Type definition adds one optional field
- Snapshot builder adds one field population
- Env override logic changes two references from `skill.name` to `resolvedKey = skill.skillKey ?? skill.name`
- New test directly validates the name!=skillKey case

### Observed result after the fix
Skills configured with a distinct `metadata.skillKey` now receive their env/apiKey overrides at runtime when loaded from a SkillSnapshot. Previously the config was silently missed, causing skills to operate without their required credentials. Backward compatibility with existing snapshots is preserved.

### What was not tested
Full integration test with a live OpenClaw gateway (not available in this environment). The fix targets a focused data-propagation gap and is covered by unit tests.

## Related

Fixes #94146

Co-Authored-By: Claude <noreply@anthropic.com>