### PR TITLE
fix(control-ui): rewrite manifest hrefs for configured base path

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -787,6 +787,30 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("rewrites public asset hrefs in index.html when Control UI uses a configured base path (#94157)", async () => {
+    const html =
+      '<html><head><link rel="manifest" href="/manifest.webmanifest" /><link rel="icon" href="/favicon.svg" /></head><body></body></html>\n';
+    await withControlUiRoot({
+      indexHtml: html,
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = await handleControlUiHttpRequest(
+          { url: "/openclaw/chat", method: "GET" } as IncomingMessage,
+          res,
+          {
+            basePath: "/openclaw",
+            root: { kind: "resolved", path: tmp },
+          },
+        );
+        expect(handled).toBe(true);
+        const body = String(end.mock.calls[0]?.[0] ?? "");
+        expect(body).toContain('href="/openclaw/manifest.webmanifest"');
+        expect(body).toContain('href="/openclaw/favicon.svg"');
+        expect(body).not.toContain('href="/manifest.webmanifest"');
+      },
+    });
+  });
+
   it("serves bootstrap config JSON", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -154,6 +154,21 @@ const CONTROL_UI_ROOT_PUBLIC_ASSETS = new Set([
   "sw.js",
 ]);
 
+/** Rewrites root-absolute Control UI public asset hrefs for configured base paths. */
+export function rewriteControlUiIndexHtmlPublicAssetHrefs(html: string, basePath: string): string {
+  const normalized = normalizeControlUiBasePath(basePath);
+  if (!normalized) {
+    return html;
+  }
+  let next = html;
+  for (const asset of CONTROL_UI_ROOT_PUBLIC_ASSETS) {
+    const rootHref = `href="/${asset}"`;
+    const baseHref = `href="${normalized}/${asset}"`;
+    next = next.split(rootHref).join(baseHref);
+  }
+  return next;
+}
+
 type ControlUiAvatarResolution =
   | { kind: "none"; reason: string; source?: string | null }
   | { kind: "local"; filePath: string; source?: string | null }
@@ -743,8 +758,9 @@ function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) 
   res.end(body);
 }
 
-function serveResolvedIndexHtml(res: ServerResponse, body: string) {
-  const hashes = computeInlineScriptHashes(body);
+function serveResolvedIndexHtml(res: ServerResponse, body: string, basePath?: string) {
+  const prepared = rewriteControlUiIndexHtmlPublicAssetHrefs(body, basePath ?? "");
+  const hashes = computeInlineScriptHashes(prepared);
   if (hashes.length > 0) {
     res.setHeader(
       "Content-Security-Policy",
@@ -753,7 +769,7 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
   }
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
-  res.end(body);
+  res.end(prepared);
 }
 
 function readOpenedFile(fd: number): Promise<Buffer> {
@@ -1069,7 +1085,7 @@ export async function handleControlUiHttpRequest(
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
-        serveResolvedIndexHtml(res, await readOpenedFileText(safeFile.fd));
+        serveResolvedIndexHtml(res, await readOpenedFileText(safeFile.fd), basePath);
         return true;
       }
       serveResolvedFile(res, safeFile.path, await readOpenedFile(safeFile.fd));
@@ -1097,7 +1113,7 @@ export async function handleControlUiHttpRequest(
       if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
-      serveResolvedIndexHtml(res, await readOpenedFileText(safeIndex.fd));
+      serveResolvedIndexHtml(res, await readOpenedFileText(safeIndex.fd), basePath);
       return true;
     } finally {
       fs.closeSync(safeIndex.fd);


### PR DESCRIPTION
Serve Control UI `index.html` with base-path-prefixed public asset links so browsers do not prefetch `/manifest.webmanifest` at the host root behind reverse proxies.

Fixes #94157

## Summary

- Fixes Control UI `manifest.webmanifest` (and other public asset) links being served with root-absolute `/manifest.webmanifest` hrefs when the gateway uses a configured `gateway.controlUi.basePath`.
- Browsers can prefetch the manifest before client JS rewrites links, causing requests to hit the host root behind oauth2-proxy/reverse proxies and return 403.
- Gateway now rewrites public asset hrefs in served `index.html` using the configured base path.

## Linked context

Closes #94157

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `index.html` manifest link is rewritten from `/manifest.webmanifest` to `/openclaw/manifest.webmanifest` when base path is `/openclaw`.
- Real environment tested: macOS, OpenClaw dev tree on branch `fix/issue-94157-manifest-base-path`, Node 22+ with `tsx`.
- Exact steps or command run after this patch:

```bash
node --import tsx -e "
import { rewriteControlUiIndexHtmlPublicAssetHrefs } from './src/gateway/control-ui.ts';
const html = '<link rel=\"manifest\" href=\"/manifest.webmanifest\" />';
const out = rewriteControlUiIndexHtmlPublicAssetHrefs(html, '/openclaw');
console.log('output:', out);
"
```

- Evidence after fix (terminal output):

```
output: <link rel="manifest" href="/openclaw/manifest.webmanifest" />
```

- Observed result after fix: manifest href is base-path prefixed before the browser parses the HTML link tag.
- What was not tested: Live oauth2-proxy/Kubernetes ingress with production cookies and TLS termination.
- Proof limitations or environment constraints: Local rewrite helper + gateway HTTP regression test only; no live cluster in this session.

## Tests and validation

- `node scripts/run-vitest.mjs run src/gateway/control-ui.http.test.ts -t "rewrites public asset hrefs"`
- Regression test added: `src/gateway/control-ui.http.test.ts` (`rewrites public asset hrefs in index.html when Control UI uses a configured base path (#94157)`)

## Risk checklist

- Did user-visible behavior change? Yes (manifest/favicon/sw hrefs in served HTML under configured base paths)
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? No
- Highest-risk area: Control UI static HTML serving
- Mitigation: Rewrite only applies when `basePath` is configured; root-mounted UI unchanged

## Current review state

- Next action: awaiting maintainer review
- Bot comments addressed: none yet

## AI-assisted disclosure

- [x] AI-assisted (Codex / Claude / other agent)
- [x] Human-run Real behavior proof from your own setup
