### PR TITLE
fix(cron): retry isolated setup timeouts

### DIFF
--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -37,6 +37,18 @@ describe("resolveCronExecutionRetryHint", () => {
     });
   });
 
+  it("classifies cron pre-execution watchdog failures as timeout retries", () => {
+    for (const message of [
+      "cron: isolated agent setup timed out before runner start",
+      "cron: isolated agent run stalled before execution start",
+    ]) {
+      expect(resolveCronExecutionRetryHint(message, ["timeout"])).toEqual({
+        retryable: true,
+        category: "timeout",
+      });
+    }
+  });
+
   it("does not classify bare 5xx-looking numbers as server_error", () => {
     for (const message of [
       "context limit 512 exceeded",

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -25,7 +25,7 @@ const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
     /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
-  timeout: /(timeout|etimedout)/i,
+  timeout: /(timeout|timed out|stalled before execution start|etimedout)/i,
   server_error: SERVER_ERROR_PATTERN,
 };
 

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -550,6 +550,49 @@ describe("cron service timer regressions", () => {
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
   });
 
+  it("retries recurring jobs after isolated setup timeouts before the next scheduled slot", async () => {
+    const store = timerRegressionFixtures.makeStorePath();
+    const scheduledAt = Date.parse("2026-06-08T13:00:00.000Z");
+    const everySixHoursMs = 6 * 60 * 60 * 1_000;
+
+    const cronJob = createIsolatedRegressionJob({
+      id: "recurring-setup-timeout-retry",
+      name: "ShadowTrader Auto Channel Bug Monitor",
+      scheduledAt,
+      schedule: { kind: "every", everyMs: everySixHoursMs, anchorMs: scheduledAt },
+      payload: { kind: "agentTurn", message: "monitor bugs" },
+      state: { nextRunAtMs: scheduledAt },
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
+
+    let now = scheduledAt;
+    const runIsolatedAgentJob = vi.fn().mockResolvedValueOnce({
+      status: "error",
+      error: "cron: isolated agent setup timed out before runner start",
+    });
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      cronConfig: {
+        retry: { maxAttempts: 1, backoffMs: [1000], retryOn: ["timeout"] },
+      },
+    });
+
+    await onTimer(state);
+    const jobAfterRetry = requireJob(state, "recurring-setup-timeout-retry");
+    expect(jobAfterRetry.enabled).toBe(true);
+    expect(jobAfterRetry.state.lastStatus).toBe("error");
+    expect(jobAfterRetry.state.lastError).toContain("setup timed out before runner start");
+    expect(jobAfterRetry.state.nextRunAtMs).toBeGreaterThan(scheduledAt);
+    expect(jobAfterRetry.state.nextRunAtMs).toBeLessThan(scheduledAt + everySixHoursMs);
+    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the normal recurring schedule after transient retry attempts are exhausted", async () => {
     const store = timerRegressionFixtures.makeStorePath();
     const scheduledAt = Date.parse("2026-05-29T02:28:00.000Z");


### PR DESCRIPTION
## Summary
- classify isolated cron setup timeouts and pre-execution stalls as retryable timeout errors
- cover the retry hint wording for setup watchdog failures
- add a cron timer regression proving recurring jobs schedule retry backoff before the next regular fire

## Tests
- pnpm exec vitest run src/cron/retry-hint.test.ts src/cron/service/timer.regression.test.ts
- pnpm test (started; unrelated failures in state DB permissions, git-root boundary, and plugin tooling/postbuild tests; tooling shard hung after failures and was stopped)

## Real behavior proof
- **Behavior or issue addressed**: Isolated cron watchdog setup failures like `cron: isolated agent setup timed out before runner start` are now classified as retryable timeout failures instead of terminal cron errors.
- **Real environment tested**: Local OpenClaw checkout on macOS in `/Users/aaroneden/.openclaw/workspace/openclaw-fix-cron-setup-watchdog-queue-saturation`, branch `fix/cron-setup-watchdog-queue-saturation`, commit `9cc60413a1b7a55cf956d8b22bd5a918ae278ee0`.
- **Exact steps or command run after this patch**: Ran `node --import tsx` against `./src/cron/retry-hint.ts` and called `resolveCronExecutionRetryHint(message, ["timeout"])` for both watchdog messages. Also ran the targeted cron vitest command listed above.
- **Evidence after fix**: Copied terminal output from the live source command:

```text
cron: isolated agent setup timed out before runner start -> {"retryable":true,"category":"timeout"}
cron: isolated agent run stalled before execution start -> {"retryable":true,"category":"timeout"}
```

- **Observed result after fix**: The exact setup-timeout and pre-execution-stall strings both return `retryable: true` with `category: "timeout"`; the recurring scheduler regression also passes and verifies retry backoff is scheduled earlier than the six-hour normal schedule.
- **What was not tested**: A forced live production cron cluster saturation was not performed; the live proof exercises the patched classifier and the regression test exercises the scheduler consequence without modifying production cron cadence.