### PR TITLE
fix(control-ui): rewrite manifest hrefs for configured base path

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -787,6 +787,30 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("rewrites public asset hrefs in index.html when Control UI uses a configured base path (#94157)", async () => {
+    const html =
+      '<html><head><link rel="manifest" href="/manifest.webmanifest" /><link rel="icon" href="/favicon.svg" /></head><body></body></html>\n';
+    await withControlUiRoot({
+      indexHtml: html,
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = await handleControlUiHttpRequest(
+          { url: "/openclaw/chat", method: "GET" } as IncomingMessage,
+          res,
+          {
+            basePath: "/openclaw",
+            root: { kind: "resolved", path: tmp },
+          },
+        );
+        expect(handled).toBe(true);
+        const body = String(end.mock.calls[0]?.[0] ?? "");
+        expect(body).toContain('href="/openclaw/manifest.webmanifest"');
+        expect(body).toContain('href="/openclaw/favicon.svg"');
+        expect(body).not.toContain('href="/manifest.webmanifest"');
+      },
+    });
+  });
+
   it("serves bootstrap config JSON", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -154,6 +154,21 @@ const CONTROL_UI_ROOT_PUBLIC_ASSETS = new Set([
   "sw.js",
 ]);
 
+/** Rewrites root-absolute Control UI public asset hrefs for configured base paths. */
+export function rewriteControlUiIndexHtmlPublicAssetHrefs(html: string, basePath: string): string {
+  const normalized = normalizeControlUiBasePath(basePath);
+  if (!normalized) {
+    return html;
+  }
+  let next = html;
+  for (const asset of CONTROL_UI_ROOT_PUBLIC_ASSETS) {
+    const rootHref = `href="/${asset}"`;
+    const baseHref = `href="${normalized}/${asset}"`;
+    next = next.split(rootHref).join(baseHref);
+  }
+  return next;
+}
+
 type ControlUiAvatarResolution =
   | { kind: "none"; reason: string; source?: string | null }
   | { kind: "local"; filePath: string; source?: string | null }
@@ -743,8 +758,9 @@ function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) 
   res.end(body);
 }
 
-function serveResolvedIndexHtml(res: ServerResponse, body: string) {
-  const hashes = computeInlineScriptHashes(body);
+function serveResolvedIndexHtml(res: ServerResponse, body: string, basePath?: string) {
+  const prepared = rewriteControlUiIndexHtmlPublicAssetHrefs(body, basePath ?? "");
+  const hashes = computeInlineScriptHashes(prepared);
   if (hashes.length > 0) {
     res.setHeader(
       "Content-Security-Policy",
@@ -753,7 +769,7 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
   }
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
-  res.end(body);
+  res.end(prepared);
 }
 
 function readOpenedFile(fd: number): Promise<Buffer> {
@@ -1069,7 +1085,7 @@ export async function handleControlUiHttpRequest(
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
-        serveResolvedIndexHtml(res, await readOpenedFileText(safeFile.fd));
+        serveResolvedIndexHtml(res, await readOpenedFileText(safeFile.fd), basePath);
         return true;
       }
       serveResolvedFile(res, safeFile.path, await readOpenedFile(safeFile.fd));
@@ -1097,7 +1113,7 @@ export async function handleControlUiHttpRequest(
       if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
-      serveResolvedIndexHtml(res, await readOpenedFileText(safeIndex.fd));
+      serveResolvedIndexHtml(res, await readOpenedFileText(safeIndex.fd), basePath);
       return true;
     } finally {
       fs.closeSync(safeIndex.fd);


### PR DESCRIPTION
## Summary

- **Problem:** When `gateway.controlUi.basePath` is set (e.g. `/openclaw` behind oauth2-proxy or an ingress path prefix), served `index.html` still contained root-absolute public asset links such as `href="/manifest.webmanifest"`. Browsers can prefetch those links before client JS rewrites paths, so the manifest request hits the host root and reverse proxies often return **403**.
- **Why this matters now:** Control UI behind path-prefixed gateways is a common production layout; a silent manifest 403 breaks PWA install/metadata and confuses operators debugging auth/proxy issues ([#94157](https://github.com/openclaw/openclaw/issues/94157)).
- **Intended outcome:** Gateway serves `index.html` with base-path-prefixed hrefs for known public assets (`manifest.webmanifest`, favicons, `sw.js`, etc.) whenever a non-empty `basePath` is configured.
- **Out of scope:** Changing client-side runtime path rewriting, oauth2-proxy configuration docs, or non-`index.html` asset URL generation beyond the existing static handler paths.
- **Success looks like:** `GET /<basePath>/…` HTML responses contain `href="/<basePath>/manifest.webmanifest"` (and siblings) with no remaining root-absolute `href="/manifest.webmanifest"` in served HTML; root-mounted Control UI (no `basePath`) is unchanged.
- **Reviewers should focus on:** `rewriteControlUiIndexHtmlPublicAssetHrefs()` coverage of `CONTROL_UI_ROOT_PUBLIC_ASSETS`, call site in `serveResolvedIndexHtml`, and that rewrite is a no-op when `basePath` is empty.

## Linked context

Closes #94157

Related: none

Was this requested by a maintainer or owner? No — external contributor fix from open issue triage.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Root-absolute manifest/favicon/sw hrefs in served Control UI `index.html` under a configured `basePath`.
- **Real environment tested:** macOS (darwin 24.3.0, arm64), Node 22+, OpenClaw dev tree on branch `fix/issue-94157-manifest-base-path-v2` (same patch as `fix/issue-94157-manifest-base-path`).
- **Exact steps or command run after this patch:**

```bash
# 1) Direct helper proof (production code path)
node --import tsx -e "
import { rewriteControlUiIndexHtmlPublicAssetHrefs } from './src/gateway/control-ui.ts';
const html = '<link rel=\"manifest\" href=\"/manifest.webmanifest\" /><link rel=\"icon\" href=\"/favicon.svg\" />';
console.log(rewriteControlUiIndexHtmlPublicAssetHrefs(html, '/openclaw'));
"

# 2) Gateway HTTP regression (served index.html)
node scripts/run-vitest.mjs run src/gateway/control-ui.http.test.ts -t "rewrites public asset hrefs"
```

- **Evidence after fix (terminal output):**

```text
<link rel="manifest" href="/openclaw/manifest.webmanifest" /><link rel="icon" href="/openclaw/favicon.svg" />

 Test Files  1 passed (1)
      Tests  1 passed
```

- **Observed result after fix:** Manifest and favicon hrefs are rewritten to `/openclaw/...` before HTML is sent; HTTP test confirms served body has no root-absolute `href="/manifest.webmanifest"`.
- **What was not tested:** Live oauth2-proxy / Kubernetes ingress with production TLS, cookies, and real operator SSO flow.
- **Proof limitations or environment constraints:** Proof is local dev-tree execution plus gateway HTTP test; no production cluster in this session.
- **Before evidence (optional):** Issue reporter observed browser prefetch of `/manifest.webmanifest` at host root → **403** when UI is mounted at `gateway.controlUi.basePath` (see [#94157](https://github.com/openclaw/openclaw/issues/94157)).

## Tests and validation

Commands run:

- `node scripts/run-vitest.mjs run src/gateway/control-ui.http.test.ts -t "rewrites public asset hrefs"` — pass
- `node --import tsx -e "…rewriteControlUiIndexHtmlPublicAssetHrefs…"` — pass (see Real behavior proof)

Regression coverage added/updated:

- `src/gateway/control-ui.http.test.ts` — `rewrites public asset hrefs in index.html when Control UI uses a configured base path (#94157)`

What failed before this fix, if known:

- With `basePath: "/openclaw"`, served HTML kept `href="/manifest.webmanifest"`; browsers requested host-root manifest and reverse proxies returned 403.

If no test was added, why not?

- N/A — regression test added.

## Risk checklist

- Did user-visible behavior change? **Yes** — manifest/favicon/sw hrefs in served HTML when `basePath` is configured.
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No**
- **Highest-risk area:** Control UI static `index.html` serving path.
- **Mitigation:** Rewrite runs only when normalized `basePath` is non-empty; asset set is limited to `CONTROL_UI_ROOT_PUBLIC_ASSETS`; root-mounted UI unchanged.

## Current review state

- **Next action:** Awaiting maintainer review.
- **Still waiting on:** CI green + maintainer triage.
- **Bot/reviewer comments addressed:** None yet.

## AI-assisted disclosure

- [x] AI-assisted (Codex / Claude / other agent)
- [x] Human-run Real behavior proof from your own setup
- [ ] `codex review --base origin/main` run and findings addressed (not run in this session — happy to run if reviewers want)
