### PR TITLE
fix(ui): ensure raw config textarea is visible and scrollable

### DIFF
--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -1097,11 +1097,21 @@
   line-height: 1.45;
 }
 
+.config-raw-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .config-raw-field textarea {
   min-height: 500px;
+  flex: 1;
   font-family: var(--mono);
   font-size: 13px;
   line-height: 1.55;
+  overflow-y: auto;
+  resize: vertical;
 }
 
 .config-raw-field .config-raw-toggle {


### PR DESCRIPTION
## Summary

Fixes #94202 — UI glitch: Raw config JSON not visible in settings view.

## Root Cause

The `.config-layout` and `.config-main` containers use `overflow: clip` which prevents content from being scrolled into view. The raw config textarea had `min-height: 500px` but no flex sizing, so when the JSON content was larger than the viewport, it overflowed the clipped container and became invisible.

## Fix

`ui/src/styles/config.css` — +10 lines

- Add `flex: 1; display: flex; flex-direction: column; min-height: 0` to `.config-raw-field`
- Add `flex: 1; overflow-y: auto; resize: vertical` to `.config-raw-field textarea`

The textarea now fills the available vertical space and scrolls independently, ensuring the JSON content is always accessible regardless of length.