### PR TITLE
fix: populate persisted threadId for system events in reply route

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2629,9 +2629,7 @@ describe("createTelegramBot", () => {
             headers: { "content-type": "image/png" },
           }),
       );
-      const runtimeLog = vi.fn();
       const runtimeError = vi.fn();
-      const runtimeExit = vi.fn();
       const ssrfMock = mockPinnedHostnameResolution();
 
       try {
@@ -2639,7 +2637,7 @@ describe("createTelegramBot", () => {
           token: "tok",
           config: startupConfig,
           ...(optionGroupAllowFrom ? { groupAllowFrom: optionGroupAllowFrom } : {}),
-          runtime: { log: runtimeLog, error: runtimeError, exit: runtimeExit },
+          runtime: { error: runtimeError, log: vi.fn(), exit: vi.fn() },
           telegramTransport: {
             fetch: mediaFetch as typeof fetch,
             sourceFetch: mediaFetch as typeof fetch,

--- a/src/auto-reply/reply/effective-reply-route.test.ts
+++ b/src/auto-reply/reply/effective-reply-route.test.ts
@@ -396,6 +396,160 @@ describe("resolveEffectiveReplyRoute", () => {
       chatType: "direct",
     });
   });
+
+  it("inherits persisted threadId from deliveryContext for system events", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({ Provider: "exec-event" }),
+        entry: entry({
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:persisted",
+            accountId: "persisted-account",
+            threadId: "1712345678.123456",
+          },
+        }),
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:persisted",
+      accountId: "persisted-account",
+      threadId: "1712345678.123456",
+    });
+  });
+
+  it("inherits persisted threadId from lastThreadId for system events", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({ Provider: "heartbeat" }),
+        entry: entry({
+          lastChannel: "slack",
+          lastTo: "channel:persisted",
+          lastAccountId: "persisted-account",
+          lastThreadId: "1712345678.123456",
+        }),
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:persisted",
+      accountId: "persisted-account",
+      threadId: "1712345678.123456",
+    });
+  });
+
+  it("inherits persisted threadId from origin.threadId for system events", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({ Provider: "cron-event" }),
+        entry: entry({
+          lastChannel: "slack",
+          lastTo: "channel:persisted",
+          lastAccountId: "persisted-account",
+          origin: { threadId: "1712345678.123456" },
+        }),
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:persisted",
+      accountId: "persisted-account",
+      threadId: "1712345678.123456",
+    });
+  });
+
+  it("prefers deliveryContext.threadId over lastThreadId and origin.threadId", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({ Provider: "exec-event" }),
+        entry: entry({
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:persisted",
+            accountId: "persisted-account",
+            threadId: "1712345678.delivery",
+          },
+          lastChannel: "slack",
+          lastTo: "channel:persisted",
+          lastAccountId: "persisted-account",
+          lastThreadId: "1712345678.last",
+          origin: { threadId: "1712345678.origin" },
+        }),
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:persisted",
+      accountId: "persisted-account",
+      threadId: "1712345678.delivery",
+    });
+  });
+
+  it("does not inherit threadId for system events when live channel differs from persisted", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({
+          Provider: "exec-event",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "chat:live",
+        }),
+        entry: entry({
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:persisted",
+            accountId: "persisted-account",
+            threadId: "1712345678.123456",
+          },
+        }),
+      }),
+    ).toEqual({
+      channel: "telegram",
+      to: "chat:live",
+      accountId: undefined,
+    });
+  });
+
+  it("inherits threadId for system events when live channel matches persisted channel", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({
+          Provider: "exec-event",
+          OriginatingChannel: "slack",
+          OriginatingTo: "channel:live",
+          AccountId: "live-account",
+        }),
+        entry: entry({
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:persisted",
+            accountId: "persisted-account",
+            threadId: "1712345678.123456",
+          },
+        }),
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:live",
+      accountId: "live-account",
+      threadId: "1712345678.123456",
+    });
+  });
+
+  it("does not include threadId when no thread source is available for system events", () => {
+    expect(
+      resolveEffectiveReplyRoute({
+        ctx: ctx({ Provider: "exec-event" }),
+        entry: entry({
+          deliveryContext: {
+            channel: "slack",
+            to: "channel:persisted",
+            accountId: "persisted-account",
+          },
+        }),
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "channel:persisted",
+      accountId: "persisted-account",
+    });
+  });
 });
 
 describe("isSystemEventProvider", () => {

--- a/src/auto-reply/reply/effective-reply-route.ts
+++ b/src/auto-reply/reply/effective-reply-route.ts
@@ -21,7 +21,14 @@ export type EffectiveReplyRouteContext = Pick<
 /** Persisted session fields used as route fallback/inheritance. */
 export type EffectiveReplyRouteEntry = Pick<
   SessionEntry,
-  "deliveryContext" | "lastChannel" | "lastTo" | "lastAccountId" | "route" | "chatType" | "origin"
+  | "deliveryContext"
+  | "lastChannel"
+  | "lastTo"
+  | "lastAccountId"
+  | "lastThreadId"
+  | "route"
+  | "chatType"
+  | "origin"
 >;
 
 /** Effective channel target selected for source reply delivery. */
@@ -113,6 +120,10 @@ export function resolveEffectiveReplyRoute(params: {
     !liveChannel ||
     normalizeMessageChannel(liveChannel) === normalizeMessageChannel(persistedChannel);
   const chatType = liveChatType ?? (canInheritPersistedTuple ? persistedChatType : undefined);
+  const persistedThreadId =
+    persistedDeliveryContext?.threadId ??
+    params.entry?.lastThreadId ??
+    params.entry?.origin?.threadId;
   return {
     channel: liveChannel ?? persistedChannel,
     to:
@@ -126,5 +137,8 @@ export function resolveEffectiveReplyRoute(params: {
         ? (persistedDeliveryContext?.accountId ?? params.entry?.lastAccountId)
         : undefined),
     ...(chatType ? { chatType } : {}),
+    ...(canInheritPersistedTuple && persistedThreadId != null
+      ? { threadId: persistedThreadId }
+      : {}),
   };
 }


### PR DESCRIPTION
## Summary

- Fixes Slack media/generated-completion posts on cron/wake turns going to channel root instead of the active thread
- `resolveEffectiveReplyRoute` failed to include the session entry's persisted threadId for system events (heartbeat/cron-event/exec-event), causing `MessageThreadId` to be undefined in the Slack threading tool context
- Adds threadId resolution from `deliveryContext.threadId`, `lastThreadId`, and `origin.threadId` (in priority order) to the system event fallthrough path

Fixes #93497

## Linked context

- Issue: #93497 — Slack media/generated-completion sends on internal-wake turns post to channel root instead of active thread
- Root cause: When a Slack wake turn fires, `OriginatingChannel` is undefined, triggering the system event fallthrough path in `resolveEffectiveReplyRoute`. This path resolved channel/to/accountId from `deliveryContext`/`last*` fields but omitted threadId entirely. The missing `replyRoute.threadId` propagated through `get-reply-run.ts` → `buildEmbeddedContextFromTemplate` → `buildSlackThreadingToolContext` as undefined `MessageThreadId`, producing `currentThreadTs=undefined`, which routed media uploads to the channel root.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Thread ID inheritance for system event reply routes — previously system events (cron/heartbeat/exec-event) would drop persisted thread IDs from the session entry, causing Slack media uploads on wake turns to post to channel root instead of the active thread.

**Real setup tested**: This fix addresses a stateless routing resolution path that is exercised through unit tests covering the full matrix of system event scenarios. The fix itself is a data-flow change within `resolveEffectiveReplyRoute` — the function now reads `deliveryContext.threadId` / `lastThreadId` / `origin.threadId` and includes the resolved value in the return value for system events when the channel tuple is consistent.

- **Runtime**: node

**Exact steps or command run after fix**:

```
pnpm vitest run src/auto-reply/reply/effective-reply-route.test.ts
```

**After-fix evidence**:

```
 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  17:48:14
   Duration  2.66s (transform 1.86s, setup 0ms, import 2.22s, tests 31ms, environment 0ms)
```

**Observed result after the fix**: All 22 tests pass with zero regressions. The 7 new test cases specifically validate:
- `deliveryContext.threadId` is inherited for system events
- `lastThreadId` is inherited (when deliveryContext.threadId is absent)
- `origin.threadId` is inherited (as third fallback)
- Priority ordering: deliveryContext.threadId > lastThreadId > origin.threadId
- ThreadId is NOT inherited when live channel differs from persisted channel (canInheritPersistedTuple=false)
- ThreadId IS inherited when live channel matches persisted channel
- No threadId is included when no thread source is available

**What was not tested**: End-to-end integration test with a live Slack gateway and actual wake-turn execution. The fix is a purely functional data-flow change in `resolveEffectiveReplyRoute` — the propagation path through `get-reply-run.ts` → `buildEmbeddedContextFromTemplate` → `buildSlackThreadingToolContext` is existing wiring that already forwards `replyRoute.threadId` into `MessageThreadId`. With the fix, that field is now populated for system events where it was previously undefined.

**Proof limitations or environment constraints**: Unit tests provide functional verification of the routing logic. Full end-to-end validation requires Slack API credentials and a running gateway instance.

## Tests and validation

22 test cases covering all reply route resolution paths:

- 15 existing tests (no regression) covering normal providers, sessions_send handoffs, and exec-event fallbacks
- 7 new tests covering system event thread ID inheritance:
  - `inherits persisted threadId from deliveryContext for system events`
  - `inherits persisted threadId from lastThreadId for system events`
  - `inherits persisted threadId from origin.threadId for system events`
  - `prefers deliveryContext.threadId over lastThreadId and origin.threadId`
  - `does not inherit threadId for system events when live channel differs from persisted`
  - `inherits threadId for system events when live channel matches persisted channel`
  - `does not include threadId when no thread source is available for system events`

## Risk checklist

Did user-visible behavior change? (`Yes`)
- For system event providers with persisted thread context: media/messages will now correctly route to the active thread instead of channel root
- For all other providers and system events without thread context: no change

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

What is the highest-risk area?
- The `persistedThreadId` field is new in the system event return; if a system event consumer incorrectly treats an undefined `threadId` as "must not post to thread", they will now get a threadId value. However, the propagation chain (replyRoute → originatingThreadId → MessageThreadId) is existing and additive — the thread ID only enables threading behavior that was already desired but broken.

How is that risk mitigated?
- Thread ID is only included when `canInheritPersistedTuple` is true (live channel == persisted channel), preventing cross-channel thread contamination
- The 7 new test cases explicitly verify channel-match gating
- All 15 existing tests pass without modification, confirming zero regression in normal provider and existing system event paths

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- Maintainer review and CI pipeline validation

Which bot or reviewer comments were addressed?
- N/A — first submission