### PR TITLE
fix(control-ui): restore provider usage quota pill in sidebar session switcher (fixes #93041)

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1816,6 +1816,21 @@
   grid-template-areas: "session";
 }
 
+.chat-controls__session-row--session-switcher.chat-controls__session-row--has-quota {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "agent"
+    "session"
+    "quota";
+}
+
+.chat-controls__session-row--session-switcher.chat-controls__session-row--single-agent.chat-controls__session-row--has-quota {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "session"
+    "quota";
+}
+
 .chat-controls__session-row--compact {
   width: 44px;
 }

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -94,7 +94,10 @@ export function renderChatSessionSelect(
   const agentSelect = compact ? "" : renderChatAgentSelect(state, onSwitchSession, agentOptions);
   const sessionSwitcherOnly = options.sessionSwitcherOnly ?? false;
   const modelSelect = sessionSwitcherOnly ? "" : renderChatModelSelect(state);
-  const quotaPill = sessionSwitcherOnly ? "" : renderChatQuotaPill(state);
+  // Quota is informational, not a control: show it whenever there is room
+  // (hidden only in the collapsed/compact sidebar), independent of
+  // sessionSwitcherOnly which suppresses the model *control* (#93041).
+  const quotaPill = compact ? "" : renderChatQuotaPill(state);
   const surface = options.surface ?? "desktop";
   const selectedSessionLabel = resolveSelectedChatSessionLabel(state, sessionGroups);
   const pickerOpen = state.chatSessionPickerOpen && state.chatSessionPickerSurface === surface;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -3393,6 +3393,70 @@ describe("chat session controls", () => {
     expect(state.setTab).toHaveBeenCalledWith("usage");
   });
 
+  it("shows provider quota in the sidebar session switcher (regression #93041)", () => {
+    const { state } = createChatHeaderState();
+    state.modelAuthStatusResult = {
+      ts: Date.now(),
+      providers: [
+        {
+          provider: "openai",
+          displayName: "Codex",
+          status: "ok",
+          profiles: [{ profileId: "codex", type: "oauth", status: "ok" }],
+          usage: {
+            windows: [
+              { label: "3h", usedPercent: 18 },
+              { label: "Week", usedPercent: 72 },
+            ],
+          },
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(
+      renderChatSessionSelect(state, () => undefined, {
+        sessionSwitcherOnly: true,
+        surface: "sidebar",
+      }),
+      container,
+    );
+
+    const quota = container.querySelector<HTMLAnchorElement>('[data-chat-provider-usage="true"]');
+    expect(quota?.textContent?.replace(/\s+/g, " ").trim()).toBe("Usage 28%");
+
+    const row = container.querySelector(".chat-controls__session-row");
+    expect(row?.classList.contains("chat-controls__session-row--has-quota")).toBe(true);
+  });
+
+  it("hides provider quota when the sidebar session switcher is collapsed", () => {
+    const { state } = createChatHeaderState();
+    state.modelAuthStatusResult = {
+      ts: Date.now(),
+      providers: [
+        {
+          provider: "openai",
+          displayName: "Codex",
+          status: "ok",
+          profiles: [{ profileId: "codex", type: "oauth", status: "ok" }],
+          usage: {
+            windows: [{ label: "3h", usedPercent: 18 }],
+          },
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(
+      renderChatSessionSelect(state, () => undefined, {
+        sessionSwitcherOnly: true,
+        compact: true,
+        surface: "sidebar",
+      }),
+      container,
+    );
+
+    expect(container.querySelector('[data-chat-provider-usage="true"]')).toBeNull();
+  });
+
   it("falls back to the selected agent's main session when no sessions exist yet", () => {
     const { state } = createChatHeaderState();
     const onSwitchSession = vi.fn();


### PR DESCRIPTION
## Summary

- **Problem:** After 2026.6.6 the Codex/OpenAI usage quota pill disappeared from the Control UI chat. PR #88772 ("calm composer controls") moved the chat header into a sidebar that renders `renderChatSessionSelect(...)` with `sessionSwitcherOnly: true`. That flag was meant to hide the model *selector*, but it also suppressed the **quota pill**.
- **What changed:** The quota pill is informational, not a control, so it is now gated on `compact` (available space) instead of `sessionSwitcherOnly`. It renders in the expanded sidebar / desktop / mobile, and stays hidden only in the collapsed (44px) sidebar where there is no room.
- **CSS:** The `--session-switcher` grid only defined `agent`/`session` areas, so a rendered quota pill (`grid-area: quota`) had no slot. Added explicit `quota` rows to the session-switcher grid templates so the pill stacks deterministically under the session picker.
- **Out of scope:** No change to the quota data path (`fetchCodexUsage`, `collectQuotaWindowsFromAuthStatus`, `renderChatQuotaPill`) or to desktop/mobile behavior. The model-selector suppression in `sessionSwitcherOnly` mode is unchanged.

## Linked context

Closes #93041

Related #93157 — an earlier attempt that removed the guard unconditionally but added no regression test and did not address the missing `quota` grid area in the session-switcher layout.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex/OpenAI usage quota pill missing from the Control UI chat sidebar after 2026.6.6.
- Real environment tested: Ubuntu/WSL2, Node.js v22.22.0, OpenClaw checked out at `origin/main`.
- Exact steps or command run after this patch:

```
node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json
node node_modules/vite/bin/vite.js build   # via pnpm ui:build
```

- Evidence after fix (copied live output): rendering the real `renderChatSessionSelect(...)` in sidebar session-switcher mode (`sessionSwitcherOnly: true`) now emits the quota pill. Copied live `node` output of the rendered DOM:

```
PROBE_ROW_CLASS=chat-controls__session-row chat-controls__session-row--session-switcher chat-controls__session-row--single-agent chat-controls__session-row--has-quota
PROBE_PILL_HTML=<a data-chat-provider-usage="true" class="chat-controls__quota chat-controls__quota--ok" href="/usage" title="Codex · Week · Codex 3h 82% left" aria-label="Provider usage: Codex · Week · Codex 3h 82% left"> <span class="chat-controls__quota-label">Usage</span> <span class="chat-controls__quota-value">28%</span> </a>
```

  Before the patch the same render produced no `data-chat-provider-usage` node (the regression assertion read `undefined`):

```
FAIL ui/src/ui/views/chat.test.ts > shows provider quota in the sidebar session switcher (regression #93041)
AssertionError: expected undefined to be "Usage 28%"
- Expected: "Usage 28%"
+ Received: undefined
```

- Observed result after fix: the sidebar render output contains the `data-chat-provider-usage="true"` anchor reading `Usage 28%`, and the row carries `chat-controls__session-row--has-quota` so the new `quota` grid area applies. `node scripts/run-tsgo.mjs` exits 0 and the `vite build` of the Control UI completes (`✓ built`).
- What was not tested: a live in-browser screenshot against a real OAuth-connected OpenAI account showing live percentages — this environment has no OAuth session. The rendered markup and grid class above are copied from running the real render code under `node`; the displayed percentages depend only on the unchanged `renderChatQuotaPill` data path.
- Proof limitations or environment constraints: Codex-based `autoreview` could not run here (no Codex auth, HTTP 401), so verification relied on the live `node` render output plus the production `vite build`.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts` — 112 passed (2 new regression tests added).
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json` — exit 0.
- `pnpm ui:build` — `✓ built`.

What regression coverage was added or updated?

- `shows provider quota in the sidebar session switcher (regression #93041)` — fails before the patch, passes after.
- `hides provider quota when the sidebar session switcher is collapsed`.

## Risk checklist

Did user-visible behavior change? Yes — the usage quota pill is restored in the expanded sidebar chat; it stays hidden in the collapsed rail.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? No — the quota data path is untouched; only render gating and CSS grid areas changed.

What is the highest-risk area? Sidebar grid layout when the quota pill is present.

How is that risk mitigated? Explicit `grid-template-areas` were added for the `--session-switcher` + `--has-quota` combinations; covered by the render output above and a clean `pnpm ui:build`.

## Current review state

What is the next action? Maintainer review.

What is still waiting on author, maintainer, CI, or external proof? CI on the pushed head.

Which bot or reviewer comments were addressed? None yet (new PR).

*AI-assisted: implemented with Claude Code; verified via the live render output, tsgo, and ui:build above. Author understands the change.*
