### PR TITLE
fix(reply): preserve routed transcript mirror metadata

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1648,6 +1648,53 @@ describe("dispatchReplyFromConfig", () => {
     expect(firstFinalReplyPayload(dispatcher)?.mediaUrl).toBe("https://example.com/tts-synth.opus");
   });
 
+  it("passes source reply transcript mirror through routed final delivery", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    mocks.routeReply.mockClear();
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+    installThreadingTestPlugin({ id: "telegram", defaultAccountId: "default" });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:999",
+        AccountId: "default",
+        SessionKey: "agent:main:telegram:group:999",
+      }),
+      cfg: automaticDirectReplyConfig,
+      dispatcher,
+      replyResolver: async () =>
+        setReplyPayloadMetadata(
+          { text: "Persisted routed internal reply" },
+          {
+            sourceReplyTranscriptMirror: {
+              sessionKey: "agent:main:telegram:group:999",
+              agentId: "main",
+              text: "Persisted routed internal reply",
+              idempotencyKey: "run-1:internal-source-reply:0",
+            },
+          },
+        ),
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: "Persisted routed internal reply" },
+        mirror: expect.objectContaining({
+          sessionKey: "agent:main:telegram:group:999",
+          agentId: "main",
+          text: "Persisted routed internal reply",
+          idempotencyKey: "run-1:internal-source-reply:0",
+        }),
+      }),
+    );
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+  });
+
   it("passes reply policy to routed block delivery", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2058,7 +2058,11 @@ export async function dispatchReplyFromConfig(
 
   const routeReplyToOriginating = async (
     payload: ReplyPayload,
-    options?: { abortSignal?: AbortSignal; mirror?: boolean; kind?: ReplyDispatchKind },
+    options?: {
+      abortSignal?: AbortSignal;
+      mirror?: boolean | TranscriptMirror;
+      kind?: ReplyDispatchKind;
+    },
   ) => {
     if (!shouldRouteToOriginating || !routeReplyChannel || !routeReplyTo || !routeReplyRuntime) {
       return null;
@@ -2813,7 +2817,11 @@ export async function dispatchReplyFromConfig(
       const result = await routeReplyToOriginating(normalizedPayload, {
         abortSignal,
         kind: "final",
-        ...(hasTranscriptOwner ? { mirror: false } : {}),
+        ...(hasTranscriptOwner
+          ? { mirror: false }
+          : sourceReplyTranscriptMirror
+            ? { mirror: sourceReplyTranscriptMirror }
+            : {}),
       });
       if (result) {
         if (!result.ok) {
@@ -2821,7 +2829,7 @@ export async function dispatchReplyFromConfig(
             `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
           );
         }
-        if (isRoutedReplyDelivered(result)) {
+        if (isRoutedReplyDelivered(result) && hasTranscriptOwner) {
           await mirrorDeliveredReplyToTranscript({
             metadata: sourceReplyTranscriptMirror,
             cfg,

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -1000,4 +1000,42 @@ describe("routeReply", () => {
       mirror: undefined,
     });
   });
+
+  it("passes explicit mirror metadata through outbound delivery", async () => {
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "slack",
+      to: "channel:C123",
+      sessionKey: "agent:main:main",
+      mirror: {
+        sessionKey: "agent:main:main",
+        agentId: "helper",
+        text: "persist me",
+        mediaUrls: ["https://example.com/image.png"],
+        idempotencyKey: "run-1:reply:0",
+        expectedSessionId: "session-1",
+        storePath: "/tmp/session-store.json",
+        deliveryMirror: {
+          kind: "channel-final",
+          sourceMessageId: "msg-1",
+        },
+      },
+      cfg: {} as never,
+    });
+    expectLastDeliveryFields({
+      mirror: {
+        sessionKey: "agent:main:main",
+        agentId: "helper",
+        text: "persist me",
+        mediaUrls: ["https://example.com/image.png"],
+        idempotencyKey: "run-1:reply:0",
+        expectedSessionId: "session-1",
+        storePath: "/tmp/session-store.json",
+        deliveryMirror: {
+          kind: "channel-final",
+          sourceMessageId: "msg-1",
+        },
+      },
+    });
+  });
 });

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -14,6 +14,7 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import { getBundledChannelPlugin } from "../../channels/plugins/bundled.js";
 import { getLoadedChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { normalizeChatChannelId } from "../../channels/registry.js";
+import type { SessionTranscriptDeliveryMirror } from "../../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
@@ -94,7 +95,20 @@ type RouteReplyParams = {
   /** Optional abort signal for cooperative cancellation. */
   abortSignal?: AbortSignal;
   /** Mirror reply into session transcript (default: true when sessionKey is set). */
-  mirror?: boolean;
+  mirror?:
+    | boolean
+    | {
+        sessionKey: string;
+        agentId?: string;
+        text?: string;
+        mediaUrls?: string[];
+        idempotencyKey?: string;
+        isGroup?: boolean;
+        groupId?: string;
+        expectedSessionId?: string;
+        storePath?: string;
+        deliveryMirror?: SessionTranscriptDeliveryMirror;
+      };
   /** Whether this message is being sent in a group/channel context */
   isGroup?: boolean;
   /** Group or channel identifier for correlation with received events */
@@ -300,16 +314,31 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       session: outboundSession,
       signal: abortSignal,
       mirror:
-        params.mirror !== false && params.sessionKey
-          ? {
-              sessionKey: params.sessionKey,
-              agentId: resolvedAgentId,
-              text,
-              mediaUrls,
-              ...(params.isGroup != null ? { isGroup: params.isGroup } : {}),
-              ...(params.groupId ? { groupId: params.groupId } : {}),
-            }
-          : undefined,
+        params.mirror === false
+          ? undefined
+          : typeof params.mirror === "object"
+            ? {
+                ...params.mirror,
+                agentId: params.mirror.agentId ?? resolvedAgentId,
+                text: params.mirror.text ?? text,
+                mediaUrls: params.mirror.mediaUrls ?? mediaUrls,
+                ...(params.mirror.isGroup === undefined && params.isGroup != null
+                  ? { isGroup: params.isGroup }
+                  : {}),
+                ...(params.mirror.groupId === undefined && params.groupId
+                  ? { groupId: params.groupId }
+                  : {}),
+              }
+            : params.sessionKey
+              ? {
+                  sessionKey: params.sessionKey,
+                  agentId: resolvedAgentId,
+                  text,
+                  mediaUrls,
+                  ...(params.isGroup != null ? { isGroup: params.isGroup } : {}),
+                  ...(params.groupId ? { groupId: params.groupId } : {}),
+                }
+              : undefined,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4315,6 +4315,59 @@ describe("deliverOutboundPayloads", () => {
     expect(appendOptions?.config).toBe(cfg);
   });
 
+  it("passes full mirror metadata through transcript append", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: async ({ text }) => ({ channel: "line", messageId: text }),
+            },
+          }),
+        },
+      ]),
+    );
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    await deliverOutboundPayloads({
+      cfg: {} as OpenClawConfig,
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "done" }],
+      mirror: {
+        sessionKey: "agent:main:main",
+        agentId: "helper",
+        text: "done",
+        idempotencyKey: "idem-full-mirror",
+        expectedSessionId: "session-42",
+        storePath: "/tmp/custom-sessions.json",
+        deliveryMirror: {
+          kind: "channel-final",
+          sourceMessageId: "msg-42",
+        },
+      },
+    });
+
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "helper",
+        sessionKey: "agent:main:main",
+        text: "done",
+        idempotencyKey: "idem-full-mirror",
+        expectedSessionId: "session-42",
+        storePath: "/tmp/custom-sessions.json",
+        deliveryMirror: {
+          kind: "channel-final",
+          sourceMessageId: "msg-42",
+        },
+      }),
+    );
+  });
+
   it("does not mirror a full payload when only an internal sub-send succeeded", async () => {
     const partialResult = { channel: "line" as const, messageId: "partial-1" };
     const sendFormattedText = vi.fn(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -2378,6 +2378,11 @@ async function deliverOutboundPayloadsCore(
           sessionKey: params.mirror.sessionKey,
           text: mirrorText,
           idempotencyKey: params.mirror.idempotencyKey,
+          ...(params.mirror.expectedSessionId
+            ? { expectedSessionId: params.mirror.expectedSessionId }
+            : {}),
+          ...(params.mirror.storePath ? { storePath: params.mirror.storePath } : {}),
+          ...(params.mirror.deliveryMirror ? { deliveryMirror: params.mirror.deliveryMirror } : {}),
           config: params.cfg,
         });
         if (!mirrorResult.ok) {

--- a/src/infra/outbound/mirror.ts
+++ b/src/infra/outbound/mirror.ts
@@ -1,3 +1,5 @@
+import type { SessionTranscriptDeliveryMirror } from "../../config/sessions/transcript.js";
+
 /**
  * Transcript append data emitted after an outbound send completes.
  */
@@ -7,6 +9,9 @@ export type OutboundMirror = {
   text?: string;
   mediaUrls?: string[];
   idempotencyKey?: string;
+  expectedSessionId?: string;
+  storePath?: string;
+  deliveryMirror?: SessionTranscriptDeliveryMirror;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Preserves full `sourceReplyTranscriptMirror` metadata when final replies are routed through `routeReply`, instead of collapsing that mirror state down to the minimal outbound shape.
- Extends outbound transcript mirroring so `expectedSessionId`, `storePath`, and `deliveryMirror` survive durable delivery and reach transcript append.
- Rebases on latest `upstream/main` while keeping current reply-completion and outbound-recovery behavior intact.
- Adds regression coverage across the routed reply caller path, the `routeReply` boundary, and the outbound transcript append boundary so future reply-routing changes do not silently drop transcript binding metadata.

## Linked context

Related #92489

## Real behavior proof

- **Behavior addressed:**
  Routed final replies were dropping source-reply transcript mirror metadata before transcript append, so `expectedSessionId`, `storePath`, or `deliveryMirror` could be lost across outbound delivery.

- **Real environment tested:**
  Local OpenClaw source checkout on macOS, rebased on latest `upstream/main`.

- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs run src/auto-reply/reply/route-reply.test.ts src/infra/outbound/deliver.test.ts -t "mirror metadata"
node scripts/run-vitest.mjs run src/auto-reply/reply/dispatch-from-config.test.ts -t "passes source reply transcript mirror"
```

- **Evidence after fix:**

```text
route-reply + deliver mirror metadata tests
  Test Files  2 passed (2)
  Tests  2 passed | 175 skipped (177)

dispatch-from-config routed mirror test
  Test Files  1 passed (1)
  Tests  1 passed | 254 skipped (255)
  passes source reply transcript mirror through routed final delivery
```

- **Observed result after fix:**
  Routed finals with `sourceReplyTranscriptMirror` pass the full mirror object into `routeReply`; outbound delivery forwards `expectedSessionId`, `storePath`, and `deliveryMirror` to transcript append; ordinary routed finals without source metadata keep default mirroring (`mirror` left undefined, not `false`).

- **What was not tested:**
  No live Slack/Telegram end-to-end run or transcript readback from a real channel account; no committed proof scripts.

## Review status

- Rebased on latest `upstream/main` (includes #99549 reply-completion and #99600 outbound-recovery fixes).
- Ready for `@clawsweeper re-review`.