### PR TITLE
fix(model-fallback): coalesce auth decision logs

### DIFF
--- a/src/agents/model-fallback-observation.test.ts
+++ b/src/agents/model-fallback-observation.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelFallbackDecisionParams } from "./model-fallback-observation.js";
+
+const loggerMocks = vi.hoisted(() => {
+  const warn = vi.fn();
+  return {
+    isEnabled: vi.fn(() => true),
+    warn,
+  };
+});
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    child: () => ({
+      isEnabled: loggerMocks.isEnabled,
+      warn: loggerMocks.warn,
+    }),
+    isEnabled: loggerMocks.isEnabled,
+    warn: loggerMocks.warn,
+  }),
+}));
+
+import {
+  logModelFallbackDecision,
+  resetModelFallbackDecisionLogCoalescingForTest,
+} from "./model-fallback-observation.js";
+
+function makeAuthFailure(
+  overrides: Partial<ModelFallbackDecisionParams> = {},
+): ModelFallbackDecisionParams {
+  return {
+    decision: "candidate_failed",
+    runId: "run-1",
+    sessionId: "session-1",
+    lane: "default",
+    requestedProvider: "modelstudio",
+    requestedModel: "glm-5",
+    candidate: { provider: "modelstudio", model: "glm-5" },
+    attempt: 1,
+    total: 2,
+    reason: "auth",
+    status: 401,
+    code: "invalid_token",
+    error: "HTTP 401: invalid access token or token expired",
+    nextCandidate: { provider: "minimax", model: "MiniMax-M2.7-highspeed" },
+    isPrimary: true,
+    requestedModelMatched: true,
+    fallbackConfigured: true,
+    ...overrides,
+  };
+}
+
+function loggedPayloads(): Array<Record<string, unknown>> {
+  return loggerMocks.warn.mock.calls.map(([, payload]) => payload as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-16T00:00:00Z"));
+  loggerMocks.isEnabled.mockReturnValue(true);
+  loggerMocks.warn.mockClear();
+  resetModelFallbackDecisionLogCoalescingForTest();
+});
+
+afterEach(() => {
+  resetModelFallbackDecisionLogCoalescingForTest();
+  vi.useRealTimers();
+});
+
+describe("logModelFallbackDecision", () => {
+  it("coalesces duplicate auth failures while preserving fallback step fields", () => {
+    const firstStep = logModelFallbackDecision(makeAuthFailure({ runId: "run-1" }));
+    const secondStep = logModelFallbackDecision(makeAuthFailure({ runId: "run-2" }));
+    const thirdStep = logModelFallbackDecision(makeAuthFailure({ runId: "run-3" }));
+
+    expect(firstStep).toMatchObject({
+      fallbackStepFromModel: "modelstudio/glm-5",
+      fallbackStepToModel: "minimax/MiniMax-M2.7-highspeed",
+      fallbackStepFromFailureReason: "auth",
+    });
+    expect(secondStep).toEqual(firstStep);
+    expect(thirdStep).toEqual(firstStep);
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    logModelFallbackDecision(makeAuthFailure({ runId: "run-4" }));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+    expect(loggedPayloads()[1]).toMatchObject({
+      suppressedDuplicateCount: 2,
+    });
+    expect(String(loggedPayloads()[1]?.consoleMessage)).toContain("2 duplicates suppressed");
+  });
+
+  it("drops stale duplicate counts before logging a later isolated auth failure", () => {
+    logModelFallbackDecision(makeAuthFailure({ runId: "run-1" }));
+    logModelFallbackDecision(makeAuthFailure({ runId: "run-2" }));
+
+    vi.advanceTimersByTime(60_001);
+    logModelFallbackDecision(makeAuthFailure({ runId: "run-3" }));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+    expect(loggedPayloads()[1]).not.toHaveProperty("suppressedDuplicateCount");
+    expect(String(loggedPayloads()[1]?.consoleMessage)).not.toContain("duplicates suppressed");
+  });
+
+  it("keeps distinct candidate models visible", () => {
+    logModelFallbackDecision(
+      makeAuthFailure({ candidate: { provider: "modelstudio", model: "glm-5" } }),
+    );
+    logModelFallbackDecision(
+      makeAuthFailure({ candidate: { provider: "modelstudio", model: "qwen3.5-plus" } }),
+    );
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+    expect(loggedPayloads().map((payload) => payload.candidateModel)).toEqual([
+      "glm-5",
+      "qwen3.5-plus",
+    ]);
+  });
+
+  it("keeps distinct sessions visible", () => {
+    logModelFallbackDecision(makeAuthFailure({ sessionId: "session-1" }));
+    logModelFallbackDecision(makeAuthFailure({ sessionId: "session-2" }));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps no-session runs visible by scoping coalescing to the run id", () => {
+    logModelFallbackDecision(makeAuthFailure({ sessionId: undefined, runId: "run-1" }));
+    logModelFallbackDecision(makeAuthFailure({ sessionId: undefined, runId: "run-2" }));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces skip-candidate auth cooldown decisions separately from failures", () => {
+    logModelFallbackDecision(makeAuthFailure({ decision: "skip_candidate" }));
+    logModelFallbackDecision(makeAuthFailure({ decision: "skip_candidate", runId: "run-2" }));
+    logModelFallbackDecision(makeAuthFailure({ decision: "candidate_failed", runId: "run-3" }));
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(2);
+    expect(loggedPayloads().map((payload) => payload.decision)).toEqual([
+      "skip_candidate",
+      "candidate_failed",
+    ]);
+  });
+
+  it("does not coalesce non-auth or success decisions", () => {
+    logModelFallbackDecision(makeAuthFailure({ reason: "rate_limit", status: 429 }));
+    logModelFallbackDecision(
+      makeAuthFailure({ reason: "rate_limit", status: 429, runId: "run-2" }),
+    );
+    logModelFallbackDecision(makeAuthFailure({ decision: "candidate_succeeded", reason: null }));
+    logModelFallbackDecision(
+      makeAuthFailure({ decision: "candidate_succeeded", reason: null, runId: "run-3" }),
+    );
+
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/agents/model-fallback-observation.ts
+++ b/src/agents/model-fallback-observation.ts
@@ -10,6 +10,8 @@ import type { FailoverReason } from "./embedded-agent-helpers.js";
 import type { FallbackAttempt, ModelCandidate } from "./model-fallback.types.js";
 
 const decisionLog = createSubsystemLogger("model-fallback").child("decision");
+const AUTH_DECISION_LOG_COALESCE_WINDOW_MS = 30_000;
+const AUTH_DECISION_LOG_COALESCE_MAX_ENTRIES = 100;
 
 /** Return whether fallback decision logging is enabled for warn-level events. */
 export function isModelFallbackDecisionLogEnabled(): boolean {
@@ -35,6 +37,18 @@ function buildErrorObservationFields(error?: string): {
     providerErrorMessagePreview: observed.providerErrorMessagePreview,
     requestIdHash: observed.requestIdHash,
   };
+}
+
+type ErrorObservationFields = ReturnType<typeof buildErrorObservationFields>;
+type AuthDecisionLogCoalesceEntry = {
+  lastLoggedAt: number;
+  suppressed: number;
+};
+
+const authDecisionLogCoalesceEntries = new Map<string, AuthDecisionLogCoalesceEntry>();
+
+export function resetModelFallbackDecisionLogCoalescingForTest(): void {
+  authDecisionLogCoalesceEntries.clear();
 }
 
 type FallbackStepOutcome = "next_fallback" | "succeeded" | "chain_exhausted";
@@ -80,6 +94,104 @@ export type ModelFallbackDecisionParams = {
 
 function formatModelRef(candidate: ModelCandidate): string {
   return `${candidate.provider}/${candidate.model}`;
+}
+
+function isAuthDecisionLogCoalescingEligible(params: ModelFallbackDecisionParams): boolean {
+  return (
+    (params.decision === "candidate_failed" || params.decision === "skip_candidate") &&
+    (params.reason === "auth" || params.reason === "auth_permanent")
+  );
+}
+
+function buildAuthDecisionLogCoalesceKey(
+  params: ModelFallbackDecisionParams,
+  observedError: ErrorObservationFields,
+): string {
+  return JSON.stringify([
+    params.sessionId ?? params.runId,
+    params.lane,
+    params.requestedProvider,
+    params.requestedModel,
+    params.decision,
+    params.candidate.provider,
+    params.candidate.model,
+    params.attempt,
+    params.total,
+    params.reason,
+    params.status,
+    params.code,
+    observedError.httpCode,
+    observedError.providerErrorType,
+    observedError.errorFingerprint ?? observedError.errorHash,
+    params.nextCandidate ? formatModelRef(params.nextCandidate) : null,
+    params.isPrimary,
+    params.requestedModelMatched,
+    params.fallbackConfigured,
+  ]);
+}
+
+function pruneAuthDecisionLogCoalesceEntries(now: number): void {
+  const staleBefore = now - AUTH_DECISION_LOG_COALESCE_WINDOW_MS * 2;
+  for (const [key, entry] of authDecisionLogCoalesceEntries) {
+    if (entry.lastLoggedAt < staleBefore) {
+      authDecisionLogCoalesceEntries.delete(key);
+    }
+  }
+}
+
+function evictOldestAuthDecisionLogCoalesceEntry(): void {
+  let oldestKey: string | undefined;
+  let oldestLoggedAt = Infinity;
+  for (const [key, entry] of authDecisionLogCoalesceEntries) {
+    if (entry.lastLoggedAt < oldestLoggedAt) {
+      oldestLoggedAt = entry.lastLoggedAt;
+      oldestKey = key;
+    }
+  }
+  if (oldestKey !== undefined) {
+    authDecisionLogCoalesceEntries.delete(oldestKey);
+  }
+}
+
+function rememberAuthDecisionLogCoalesceEntry(key: string, now: number): void {
+  if (!authDecisionLogCoalesceEntries.has(key)) {
+    pruneAuthDecisionLogCoalesceEntries(now);
+    if (authDecisionLogCoalesceEntries.size >= AUTH_DECISION_LOG_COALESCE_MAX_ENTRIES) {
+      evictOldestAuthDecisionLogCoalesceEntry();
+    }
+  }
+  authDecisionLogCoalesceEntries.set(key, { lastLoggedAt: now, suppressed: 0 });
+}
+
+function resolveAuthDecisionLogCoalescing(
+  params: ModelFallbackDecisionParams,
+  observedError: ErrorObservationFields,
+): { shouldLog: boolean; suppressedDuplicateCount?: number } {
+  if (!isAuthDecisionLogCoalescingEligible(params)) {
+    return { shouldLog: true };
+  }
+
+  const now = Date.now();
+  const key = buildAuthDecisionLogCoalesceKey(params, observedError);
+  const recent = authDecisionLogCoalesceEntries.get(key);
+  const recentAgeMs = recent ? now - recent.lastLoggedAt : undefined;
+  if (
+    recent &&
+    recentAgeMs !== undefined &&
+    recentAgeMs >= AUTH_DECISION_LOG_COALESCE_WINDOW_MS * 2
+  ) {
+    authDecisionLogCoalesceEntries.delete(key);
+    rememberAuthDecisionLogCoalesceEntry(key, now);
+    return { shouldLog: true };
+  }
+  if (recent && recentAgeMs !== undefined && recentAgeMs < AUTH_DECISION_LOG_COALESCE_WINDOW_MS) {
+    recent.suppressed += 1;
+    return { shouldLog: false };
+  }
+
+  const suppressedDuplicateCount = recent?.suppressed;
+  rememberAuthDecisionLogCoalesceEntry(key, now);
+  return { shouldLog: true, suppressedDuplicateCount };
 }
 
 function buildFallbackStepFields(params: {
@@ -158,6 +270,17 @@ export function logModelFallbackDecision(
     ? ` providerErrorType=${sanitizeForLog(observedError.providerErrorType)}`
     : "";
   const detailSuffix = detailText ? ` detail=${sanitizeForLog(detailText)}` : "";
+  const logCoalescing = resolveAuthDecisionLogCoalescing(params, observedError);
+  if (!logCoalescing.shouldLog) {
+    return fallbackStepFields;
+  }
+  const suppressedDuplicateCount = logCoalescing.suppressedDuplicateCount ?? 0;
+  const suppressedSuffix =
+    suppressedDuplicateCount > 0
+      ? ` (${suppressedDuplicateCount} duplicates suppressed in last ${
+          AUTH_DECISION_LOG_COALESCE_WINDOW_MS / 1000
+        }s)`
+      : "";
   decisionLog.warn("model fallback decision", {
     event: "model_fallback_decision",
     tags: ["error_handling", "model_fallback", params.decision],
@@ -183,6 +306,7 @@ export function logModelFallbackDecision(
     fallbackConfigured: params.fallbackConfigured,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     profileCount: params.profileCount,
+    ...(suppressedDuplicateCount > 0 ? { suppressedDuplicateCount } : {}),
     previousAttempts: params.previousAttempts?.map((attempt) => ({
       provider: attempt.provider,
       model: attempt.model,
@@ -193,7 +317,7 @@ export function logModelFallbackDecision(
     })),
     consoleMessage:
       `model fallback decision: decision=${params.decision} requested=${sanitizeForLog(params.requestedProvider)}/${sanitizeForLog(params.requestedModel)} ` +
-      `candidate=${sanitizeForLog(params.candidate.provider)}/${sanitizeForLog(params.candidate.model)} reason=${reasonText}${providerErrorTypeSuffix} next=${nextText}${detailSuffix}`,
+      `candidate=${sanitizeForLog(params.candidate.provider)}/${sanitizeForLog(params.candidate.model)} reason=${reasonText}${providerErrorTypeSuffix} next=${nextText}${detailSuffix}${suppressedSuffix}`,
   });
   return fallbackStepFields;
 }


### PR DESCRIPTION
## Summary

- Coalesces repeated auth-class model fallback decision warnings for the same session/requested model/candidate/next-candidate/error identity, reducing expired-token log spam without changing fallback routing.
- Preserves first-occurrence diagnostics, distinct candidate models, distinct sessions, no-session run scoping, non-auth decisions, and fallback-step callback fields.
- Reports `suppressedDuplicateCount` on the next emitted matching warning after the coalescing window, and drops stale counters before later isolated auth failures.
- Out of scope: provider quarantine, auth cooldown policy changes, fallback skip-cache defaults, and live provider credential refresh behavior.

What problem does this PR solve?

Repeated expired-token auth failures could emit `model-fallback/decision` warnings for every fallback candidate on every request.

Why does this matter now?

#56979 remains open and the linked prior attempts were closed unmerged; the current logger still emits every matching fallback decision directly.

What is the intended outcome?

Operators get one warning for the first matching auth fallback decision, duplicate warnings are counted during the coalescing window, and later emitted records summarize the suppressed duplicates.

What is intentionally out of scope?

Provider quarantine, auth profile cooldown policy, retry behavior, and `OPENCLAW_FALLBACK_SKIP_TTL_MS` defaults.

What does success look like?

The noisy auth-provider fallback path quiets duplicate warning lines while preserving distinct diagnostics and existing fallback behavior.

What should reviewers focus on?

Please check the coalescing key and eligibility rules in `src/agents/model-fallback-observation.ts`, especially that only auth/auth_permanent `candidate_failed` and `skip_candidate` decisions coalesce.

## Linked context

Which issue does this close?

Closes #56979

Which issues, PRs, or discussions are related?

Related #68184
Related #82260
Related #68621

Was this requested by a maintainer or owner?

No direct maintainer request beyond the open issue and contributor queue context.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: repeated auth-provider fallback decision warnings now coalesce instead of logging every identical expired-token fallback decision.
- Real environment tested: local OpenClaw checkout on macOS using the project test/build scripts with a Node runtime.
- Exact steps or command run after this patch: ran a local OpenClaw logger-path harness that invoked `logModelFallbackDecision` three times with the same simulated expired-token auth failure, waited 31 seconds, then invoked the same decision once more.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=modelstudio/glm-5 candidate=modelstudio/glm-5 reason=auth next=minimax/MiniMax-M2.7-highspeed detail=HTTP 401: invalid access token or token expired
after immediate duplicate calls
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=modelstudio/glm-5 candidate=modelstudio/glm-5 reason=auth next=minimax/MiniMax-M2.7-highspeed detail=HTTP 401: invalid access token or token expired (2 duplicates suppressed in last 30s)
```

- Observed result after fix: the first matching auth failure logged immediately, the two immediate duplicate warnings were suppressed, and the next emitted warning summarized the two suppressed duplicates.
- What was not tested: live provider credential expiry against ModelStudio/Z.ai credentials.
- Proof limitations or environment constraints: this proof uses the real OpenClaw fallback decision logger with a simulated expired-token decision payload; no live provider credentials were used.
- Before evidence (optional but encouraged): before the patch, adding the focused coalescing regression test failed because the coalescing reset/export path did not exist and every duplicate decision would call the logger directly.

## Tests and validation

Which commands did you run?

```text
node scripts/run-vitest.mjs run src/agents/model-fallback-observation.test.ts src/agents/model-fallback.probe.test.ts src/agents/model-fallback.test.ts src/agents/fallback-skip-cache.test.ts src/agents/auth-profiles/state-observation.test.ts
node scripts/run-oxlint.mjs src/agents/model-fallback-observation.ts src/agents/model-fallback-observation.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs
git diff --check
```

What regression coverage was added or updated?

Added `src/agents/model-fallback-observation.test.ts` coverage for duplicate auth failure coalescing, stale counter cleanup, distinct candidate/session/run scoping, skip-candidate auth cooldown coalescing, and non-auth/success decisions staying uncoalesced.

What failed before this fix, if known?

The new focused regression failed before implementation because there was no coalescing state/reset surface and duplicate auth fallback decisions still reached `decisionLog.warn` directly.

If no test was added, why not?

A focused regression test file was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Repeated auth fallback warning logs are quieter, and later emitted warnings can include `suppressedDuplicateCount`.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No. This changes logging behavior only; auth state, provider selection, retries, cooldowns, and tool execution are unchanged.

What is the highest-risk area?

Suppressing too much diagnostic information if the coalescing key is too broad.

How is that risk mitigated?

The key includes session/run scope, lane, requested provider/model, decision, candidate provider/model, attempt/total, reason, status/code, observed error identity, next candidate, and fallback flags. Tests cover distinct candidate models, distinct sessions, no-session run scoping, non-auth decisions, and stale counter cleanup.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on CI and maintainer review. Live provider-token-expiry proof is not included because no live provider credentials were used.

Which bot or reviewer comments were addressed?

No bot or reviewer comments have been posted on this PR yet.