### PR TITLE
fix(anthropic): allow failover for thinking signature replay errors

### DIFF
--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3165,7 +3165,11 @@ async function runEmbeddedAgentInternal(
 
           const assistantFailoverDecision = resolveRunFailoverDecision({
             stage: "assistant",
-            allowFormatRetry: cloudCodeAssistFormatError,
+            allowFormatRetry:
+              cloudCodeAssistFormatError ||
+              /(?:invalid|expired|stale).*?(?:signature|thinking).*?(?:block|turn)|(?:thinking|redacted_thinking).*?(?:signature).*?(?:invalid|expired|stale)/i.test(
+                assistantForFailover?.errorMessage ?? "",
+              ),
             aborted,
             externalAbort,
             fallbackConfigured,

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -84,14 +84,31 @@ function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   );
 }
 
+const THINKING_SIGNATURE_ERROR_PATTERN =
+  /(?:invalid|expired|stale).*?(?:signature|thinking).*?(?:block|turn)|(?:thinking|redacted_thinking).*?(?:signature).*?(?:invalid|expired|stale)/i;
+
 function isTerminalFormatFailure(params: {
   allowFormatRetry?: boolean;
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
+  rawError?: string;
 }): boolean {
-  return (
-    params.failoverFailure && params.failoverReason === "format" && params.allowFormatRetry !== true
-  );
+  if (!params.failoverFailure || params.failoverReason !== "format") {
+    return false;
+  }
+  if (params.allowFormatRetry === true) {
+    return false;
+  }
+  // Thinking signature replay errors (e.g. Anthropic "Invalid signature in
+  // thinking block") are not terminal — a non-Anthropic fallback model can
+  // answer correctly even when the current provider rejects stale signatures.
+  if (
+    typeof params.rawError === "string" &&
+    THINKING_SIGNATURE_ERROR_PATTERN.test(params.rawError)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function shouldRotatePrompt(params: PromptDecisionParams): boolean {


### PR DESCRIPTION
## Summary

Fixes #94228 — Native Anthropic path: replaying historical thinking blocks bricks long turns.

## Problem

On long-lived multi-turn Anthropic sessions, all prior thinking blocks with their signatures are replayed on every request. When a stale signature is rejected (400 "Invalid signature in thinking block"), the error is classified as a terminal format failure, so **no failover** happens — even if a non-Anthropic fallback model is configured. The thread becomes permanently bricked.

## Fix (2 files, +25 lines)

### `failover-policy.ts`
Add thinking signature error pattern detection in `isTerminalFormatFailure()`. When the error matches known thinking signature replay patterns, it is NOT treated as terminal — allowing failover to proceed.

### `run.ts`  
Set `allowFormatRetry` when the assistant error message matches the thinking signature error pattern, so the format failure is not terminal.

This allows a configured non-Anthropic fallback model to answer correctly when the Anthropic provider rejects stale signatures.