### PR TITLE
fix(cron): log cache tokens + cost and fix daily usage report totals

### DIFF
--- a/scripts/cron_usage_report.ts
+++ b/scripts/cron_usage_report.ts
@@ -17,6 +17,7 @@ type CronRunLogEntry = {
   model?: string;
   provider?: string;
   usage?: Usage;
+  estimated_cost_usd?: number;
 };
 
 function parseArgs(argv: string[]) {
@@ -95,6 +96,37 @@ function fmtInt(n: number) {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(n);
 }
 
+function fmtUsd(n: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(n);
+}
+
+type UsageTotals = {
+  runs: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+  missingUsageRuns: number;
+};
+
+function newUsageTotals(): Omit<UsageTotals, "runs" | "missingUsageRuns"> {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    total_tokens: 0,
+    cost_usd: 0,
+  };
+}
+
 export async function main() {
   const args = parseArgs(process.argv);
   const store = typeof args.store === "string" ? args.store : undefined;
@@ -126,23 +158,8 @@ export async function main() {
     string,
     {
       jobId: string;
-      runs: number;
-      models: Record<
-        string,
-        {
-          model: string;
-          runs: number;
-          input_tokens: number;
-          output_tokens: number;
-          total_tokens: number;
-          missingUsageRuns: number;
-        }
-      >;
-      input_tokens: number;
-      output_tokens: number;
-      total_tokens: number;
-      missingUsageRuns: number;
-    }
+      models: Record<string, { model: string } & UsageTotals>;
+    } & UsageTotals
   > = {};
 
   for (const file of files) {
@@ -177,22 +194,25 @@ export async function main() {
         jobId,
         runs: 0,
         models: {},
-        input_tokens: 0,
-        output_tokens: 0,
-        total_tokens: 0,
         missingUsageRuns: 0,
+        ...newUsageTotals(),
       });
       jobAgg.runs++;
 
       const modelAgg = (jobAgg.models[model] ??= {
         model,
         runs: 0,
-        input_tokens: 0,
-        output_tokens: 0,
-        total_tokens: 0,
         missingUsageRuns: 0,
+        ...newUsageTotals(),
       });
       modelAgg.runs++;
+
+      // Cost is snapshotted per run, so it is meaningful even when token usage
+      // is absent (e.g. provider returned cost without token counts).
+      const rawCost = entry.estimated_cost_usd ?? 0;
+      const cost = Number.isFinite(rawCost) ? Math.max(0, rawCost) : 0;
+      jobAgg.cost_usd += cost;
+      modelAgg.cost_usd += cost;
 
       if (!hasUsage) {
         jobAgg.missingUsageRuns++;
@@ -202,14 +222,27 @@ export async function main() {
 
       const input = Math.max(0, Math.trunc(usage?.input_tokens ?? 0));
       const output = Math.max(0, Math.trunc(usage?.output_tokens ?? 0));
-      const total = Math.max(0, Math.trunc(usage?.total_tokens ?? input + output));
+      const cacheRead = Math.max(0, Math.trunc(usage?.cache_read_tokens ?? 0));
+      const cacheWrite = Math.max(0, Math.trunc(usage?.cache_write_tokens ?? 0));
+      // The logged `total_tokens` is a prompt/context snapshot (input + cache,
+      // excludes output). Billable consumption = prompt side + output. Fall
+      // back to the component sum for older logs without `total_tokens`.
+      const promptSide =
+        usage?.total_tokens !== undefined
+          ? Math.max(0, Math.trunc(usage.total_tokens))
+          : input + cacheRead + cacheWrite;
+      const total = promptSide + output;
 
       jobAgg.input_tokens += input;
       jobAgg.output_tokens += output;
+      jobAgg.cache_read_tokens += cacheRead;
+      jobAgg.cache_write_tokens += cacheWrite;
       jobAgg.total_tokens += total;
 
       modelAgg.input_tokens += input;
       modelAgg.output_tokens += output;
+      modelAgg.cache_read_tokens += cacheRead;
+      modelAgg.cache_write_tokens += cacheWrite;
       modelAgg.total_tokens += total;
     }
   }
@@ -254,19 +287,34 @@ export async function main() {
     return;
   }
 
+  const grand = rows.reduce(
+    (acc, r) => {
+      acc.runs += r.runs;
+      acc.total_tokens += r.total_tokens;
+      acc.cost_usd += r.cost_usd;
+      return acc;
+    },
+    { runs: 0, total_tokens: 0, cost_usd: 0 },
+  );
+
   for (const job of rows) {
     console.log(`jobId: ${job.jobId}`);
     console.log(`  runs: ${fmtInt(job.runs)} (missing usage: ${fmtInt(job.missingUsageRuns)})`);
+    console.log(`  cost: ${fmtUsd(job.cost_usd)}`);
     console.log(
-      `  tokens: total ${fmtInt(job.total_tokens)} (in ${fmtInt(job.input_tokens)} / out ${fmtInt(job.output_tokens)})`,
+      `  tokens: total ${fmtInt(job.total_tokens)} (in ${fmtInt(job.input_tokens)} / out ${fmtInt(job.output_tokens)} / cache ${fmtInt(job.cache_read_tokens)} read + ${fmtInt(job.cache_write_tokens)} write)`,
     );
     for (const m of job.models) {
       console.log(
-        `    model ${m.model}: runs ${fmtInt(m.runs)} (missing usage: ${fmtInt(m.missingUsageRuns)}), total ${fmtInt(m.total_tokens)} (in ${fmtInt(m.input_tokens)} / out ${fmtInt(m.output_tokens)})`,
+        `    model ${m.model}: runs ${fmtInt(m.runs)} (missing usage: ${fmtInt(m.missingUsageRuns)}), cost ${fmtUsd(m.cost_usd)}, total ${fmtInt(m.total_tokens)} (in ${fmtInt(m.input_tokens)} / out ${fmtInt(m.output_tokens)} / cache ${fmtInt(m.cache_read_tokens)} read + ${fmtInt(m.cache_write_tokens)} write)`,
       );
     }
     console.log("");
   }
+
+  console.log(
+    `TOTAL: ${fmtUsd(grand.cost_usd)} across ${fmtInt(grand.runs)} runs, ${fmtInt(grand.total_tokens)} tokens`,
+  );
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -594,8 +594,18 @@ async function finalizeCronRun(params: {
       prepared.cronSession.sessionEntry.totalTokens = undefined;
       prepared.cronSession.sessionEntry.totalTokensFresh = false;
     }
-    prepared.cronSession.sessionEntry.cacheRead = usage.cacheRead ?? 0;
-    prepared.cronSession.sessionEntry.cacheWrite = usage.cacheWrite ?? 0;
+    const cacheRead = Math.max(0, Math.trunc(usage.cacheRead ?? 0));
+    const cacheWrite = Math.max(0, Math.trunc(usage.cacheWrite ?? 0));
+    prepared.cronSession.sessionEntry.cacheRead = cacheRead;
+    prepared.cronSession.sessionEntry.cacheWrite = cacheWrite;
+    // Log cache tokens so downstream usage/consumption reports can account for
+    // billable cache reads/writes instead of undercounting input.
+    if (cacheRead > 0) {
+      telemetryUsage.cache_read_tokens = cacheRead;
+    }
+    if (cacheWrite > 0) {
+      telemetryUsage.cache_write_tokens = cacheWrite;
+    }
     // Snapshot cost like tokens (runEstimatedCostUsd is already computed from
     // cumulative run usage, so assign directly instead of accumulating).
     // Fixes #69347: cost was inflated 1x-72x by accumulating on every persist.
@@ -607,6 +617,10 @@ async function finalizeCronRun(params: {
       provider: providerUsed,
       usage: telemetryUsage,
     };
+    // Persist per-run estimated cost so consumption reports can sum actual $.
+    if (runEstimatedCostUsd !== undefined && Number.isFinite(runEstimatedCostUsd)) {
+      telemetry.estimated_cost_usd = runEstimatedCostUsd;
+    }
   } else {
     telemetry = { model: modelUsed, provider: providerUsed };
   }

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -241,6 +241,7 @@ describe("cron run log", () => {
           cache_read_tokens: 2,
           cache_write_tokens: 1,
         },
+        estimated_cost_usd: 0.0123,
       });
 
       await fs.appendFile(
@@ -267,6 +268,7 @@ describe("cron run log", () => {
         cache_read_tokens: 2,
         cache_write_tokens: 1,
       });
+      expect(entries[0]?.estimated_cost_usd).toBe(0.0123);
       expect(entries[1]?.model).toBeUndefined();
       expect(entries[1]?.provider).toBeUndefined();
       expect(entries[1]?.usage?.input_tokens).toBeUndefined();

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -325,6 +325,9 @@ function parseAllRunLogEntries(raw: string, opts?: { jobId?: string }): CronRunL
       if (typeof obj.sessionKey === "string" && obj.sessionKey.trim().length > 0) {
         entry.sessionKey = obj.sessionKey;
       }
+      if (typeof obj.estimated_cost_usd === "number" && Number.isFinite(obj.estimated_cost_usd)) {
+        entry.estimated_cost_usd = obj.estimated_cost_usd;
+      }
       parsed.push(entry);
     } catch {
       // ignore invalid lines

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -58,6 +58,8 @@ export type CronRunTelemetry = {
   model?: string;
   provider?: string;
   usage?: CronUsageSummary;
+  /** Estimated cost in USD for this run, snapshotted (not accumulated). */
+  estimated_cost_usd?: number;
 };
 
 export type CronRunOutcome = {


### PR DESCRIPTION
## Problem

The daily cron usage report summed each run's logged `total_tokens` as if it were consumption. But `total_tokens` is a **prompt/context snapshot** (`input + cache`, intentionally excludes output — see `deriveSessionTotalTokens`). So the headline number dropped all output tokens, and the `total` / `in` / fallback paths used three different token meanings in one column. Cache tokens and per-run cost were also never written to the run log, so a "consumption" report had no $ figure at all.

## Changes

- **`src/cron/isolated-agent/run.ts`** — log `cache_read_tokens` / `cache_write_tokens` and `estimated_cost_usd` per run (cost was already computed for the session entry; now it's persisted to telemetry too).
- **`src/cron/types.ts` / `src/cron/run-log.ts`** — carry and parse `estimated_cost_usd`.
- **`scripts/cron_usage_report.ts`** — compute `total` as prompt-side + output (falls back to component sum for older logs), aggregate cache breakdown and USD cost per job/model, add a grand-total line. JSON output gains the new fields automatically.
- **`src/cron/run-log.test.ts`** — assert `estimated_cost_usd` passthrough.

## Notes

- Cache/cost fields only populate for runs logged after this change; older log lines degrade gracefully (cache shows 0, cost counts as 0).
- `estimated_cost_usd` is a local estimate from the model price table, not a provider bill.

## Verification

`pnpm check:changed` clean — typecheck, lint, import cycles, and all 644 cron tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)