### PR TITLE
fix(config): fail closed when configure runs without an interactive TTY (#93953)

### DIFF
--- a/src/commands/configure.commands.test.ts
+++ b/src/commands/configure.commands.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { formatCliCommand } from "../cli/command-format.js";
+import { configureCommandFromSectionsArg } from "./configure.commands.js";
+
+// Hoisted mock so the wizard never actually runs; the tests assert whether the
+// fail-closed guard reached the wizard at all.
+const runConfigureWizardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./configure.wizard.js", () => ({
+  runConfigureWizard: runConfigureWizardMock,
+}));
+
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    // `exit` throws so an assertion failure surfaces in-test instead of killing
+    // the process; we assert it is called with code 1.
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }),
+  };
+}
+
+describe("configureCommandFromSectionsArg", () => {
+  beforeEach(() => {
+    runConfigureWizardMock.mockReset();
+    runConfigureWizardMock.mockResolvedValue(undefined);
+  });
+
+  it("fails closed on a non-interactive terminal before reaching the wizard (#93953)", async () => {
+    const runtime = makeRuntime();
+
+    // `interactive: false` stands in for a piped stdin/stdout without mutating
+    // the global `process` streams.
+    await expect(
+      configureCommandFromSectionsArg(undefined, runtime, { interactive: false }),
+    ).rejects.toThrow("exit 1");
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+    // The hint must point at real subcommands, not the wizard itself.
+    const message = runtime.error.mock.calls[0]?.[0] as string;
+    expect(message).toContain("requires an interactive terminal (TTY)");
+    expect(message).toContain(formatCliCommand("openclaw config set"));
+    expect(message).toContain(formatCliCommand("openclaw config validate"));
+    // The wizard must never start on a non-TTY.
+    expect(runConfigureWizardMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for an explicit --section list on a non-interactive terminal", async () => {
+    const runtime = makeRuntime();
+
+    await expect(
+      configureCommandFromSectionsArg(["channels"], runtime, { interactive: false }),
+    ).rejects.toThrow("exit 1");
+
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runConfigureWizardMock).not.toHaveBeenCalled();
+  });
+
+  it("runs the wizard on an interactive terminal with no sections", async () => {
+    const runtime = makeRuntime();
+
+    await configureCommandFromSectionsArg(undefined, runtime, { interactive: true });
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(runConfigureWizardMock).toHaveBeenCalledTimes(1);
+    expect(runConfigureWizardMock).toHaveBeenCalledWith({ command: "configure" }, runtime);
+  });
+
+  it("runs the wizard with sections on an interactive terminal", async () => {
+    const runtime = makeRuntime();
+
+    await configureCommandFromSectionsArg(["channels", "plugins"], runtime, {
+      interactive: true,
+    });
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(runConfigureWizardMock).toHaveBeenCalledWith(
+      { command: "configure", sections: ["channels", "plugins"] },
+      runtime,
+    );
+  });
+
+  it("fails closed for a mixed valid/invalid section list on a non-interactive terminal", async () => {
+    const runtime = makeRuntime();
+
+    await expect(
+      configureCommandFromSectionsArg(["channels", "bogus"], runtime, {
+        interactive: false,
+      }),
+    ).rejects.toThrow("exit 1");
+
+    // Non-TTY guard fires before any section validation, so the wizard never runs.
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.error.mock.calls[0]?.[0]).toContain("interactive terminal (TTY)");
+    expect(runConfigureWizardMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -1,10 +1,50 @@
 // Entry points for the full configure wizard and section-limited runs.
+import process from "node:process";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import type { WizardSection } from "./configure.shared.js";
 import { CONFIGURE_WIZARD_SECTIONS, parseConfigureWizardSections } from "./configure.shared.js";
 import { runConfigureWizard } from "./configure.wizard.js";
+
+/**
+ * Non-interactive config subcommands surfaced when the wizard cannot run.
+ * Mirrors the real `openclaw config <sub>` surface so the message only ever
+ * points users at commands that exist (see `src/cli/config-cli.ts`).
+ */
+const CONFIGURE_NON_TTY_HINT = [
+  "Interactive configuration requires an interactive terminal (TTY).",
+  "For non-interactive setup, use these subcommands instead:",
+  `  ${formatCliCommand("openclaw config set <path> <value>")}  write a config entry`,
+  `  ${formatCliCommand("openclaw config get <path>")}          read a config entry`,
+  `  ${formatCliCommand("openclaw config patch")}              apply a JSON patch`,
+  `  ${formatCliCommand("openclaw config validate")}           validate configuration`,
+].join("\n");
+
+/**
+ * Refuses to launch the interactive wizard without a TTY.
+ *
+ * `interactive` lets callers/tests override the detected terminal state
+ * (mirrors the `params.interactive ?? process.stdin.isTTY` pattern used by
+ * `src/commands/gateway-readiness.ts`), so the fail-closed path is exercisable
+ * without mutating the global `process` streams. Both stdin and stdout must be
+ * TTYs: the wizard reads from stdin and renders prompts to stdout, so either
+ * being piped means it cannot run correctly.
+ *
+ * Returns true when the wizard may proceed.
+ */
+function assertInteractiveConfigureTerminal(
+  runtime: RuntimeEnv,
+  interactive?: boolean,
+): boolean {
+  const interactiveTerminal = interactive ?? (process.stdin.isTTY && process.stdout.isTTY);
+  if (interactiveTerminal) {
+    return true;
+  }
+  runtime.error(CONFIGURE_NON_TTY_HINT);
+  runtime.exit(1);
+  return false;
+}
 
 async function configureCommand(runtime: RuntimeEnv = defaultRuntime) {
   await runConfigureWizard({ command: "configure" }, runtime);
@@ -21,7 +61,17 @@ async function configureCommandWithSections(
 export async function configureCommandFromSectionsArg(
   rawSections: unknown,
   runtime: RuntimeEnv = defaultRuntime,
+  options?: { interactive?: boolean },
 ): Promise<void> {
+  // Fail closed once at the shared entry: both `openclaw configure` and the
+  // no-subcommand `openclaw config` route here, so a single guard keeps them
+  // consistent instead of partially entering the wizard on a non-TTY pipe.
+  // `options.interactive` lets tests drive the fail-closed path directly
+  // instead of mutating global `process` streams.
+  if (!assertInteractiveConfigureTerminal(runtime, options?.interactive)) {
+    return;
+  }
+
   const { sections, invalid } = parseConfigureWizardSections(rawSections);
   if (sections.length === 0) {
     await configureCommand(runtime);


### PR DESCRIPTION
## Summary

Closes #93953.

`openclaw configure` and the no-subcommand `openclaw config` both fall into the interactive configure wizard even when stdin/stdout are not TTYs. On a piped stdin the wizard partially renders and then exits dirty (exit code `13`, unsettled top-level await), leaving the user uncertain about what happened.

Both CLI entry points (`openclaw configure` and `openclaw config` without a subcommand) route through `configureCommandFromSectionsArg`, so a single fail-closed guard there covers both surfaces instead of partially entering the wizard on a non-TTY pipe.

## Root cause

The configure wizard entry point (`src/commands/configure.commands.ts`) launched `runConfigureWizard` unconditionally, without checking whether stdin/stdout were interactive. A piped stdin is not a TTY, so the wizard tried to render prompts it could not drive.

## Fix

- Fail closed once at the shared entry (`configureCommandFromSectionsArg`) when the terminal is not interactive, covering both `openclaw configure` and `openclaw config`.
- Require **both** stdin and stdout to be TTYs (the wizard reads from stdin and renders prompts to stdout; either being piped means it cannot run).
- Surface the real non-interactive `openclaw config` subcommands (`set`, `get`, `patch`, `validate`) so users are pointed only at commands that exist.
- Accept an optional `interactive` override (mirroring the `params.interactive ?? process.stdin.isTTY` pattern already used in `src/commands/gateway-readiness.ts`) so the fail-closed path is exercisable without mutating the global `process` streams in tests.

Out of scope: changing the wizard UX, section validation ordering, or any other configure behavior.

## Real behavior proof

**Behavior addressed:** `openclaw configure` / `openclaw config` must fail closed with a clear non-TTY error instead of entering the interactive wizard and exiting dirty (exit `13`) when stdin/stdout are piped.

**Real environment tested:** Windows 10, Node 22.22.3, OpenClaw source checkout at `f4a2024b`, real Node process with stdin piped (`< /dev/null`) so `process.stdin.isTTY` is `undefined`.

**Exact steps or command run after this patch:**
```bash
node --import tsx proof-configure-non-tty.mts config-no-subcommand < /dev/null
```

**Evidence after fix (head `f4a2024b`, piped stdin):**
```
[proof] stdin.isTTY=undefined stdout.isTTY=undefined
Interactive configuration requires an interactive terminal (TTY).
For non-interactive setup, use these subcommands instead:
  openclaw config set <path> <value>  write a config entry
  openclaw config get <path>          read a config entry
  openclaw config patch              apply a JSON patch
  openclaw config validate           validate configuration
[proof exit=1]
```

**Observed result after fix:** Before the patch, the same piped invocation entered the interactive wizard (`OpenClaw configure` / `Where will the Gateway run?`) and exited with code `13` (`Warning: Detected unsettled top-level await`). After the patch it fail-closes with the non-TTY message and exit code `1`, and the wizard is never reached. The same before/after holds for the `--section` path.

Unit tests (`src/commands/configure.commands.test.ts`, 5/5) cover the fail-closed path, the no-section interactive path, the sectioned interactive path, and the non-interactive section path without mutating `process`:
```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

**What was not tested:** Not run against a fully built CLI install or in CI; the proof drives the real exported entry in a real Node process with a piped stdin rather than invoking the built `openclaw` binary.

This PR is AI-assisted; the code, tests, and proof output above were produced and verified in my local environment.

Co-Authored-By: Claude <noreply@anthropic.com>
