### PR TITLE
fix: update health check hints to reference openclaw onboard instead of bare flags

### DIFF
--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -283,7 +283,7 @@ export async function runNonInteractiveLocalSetup(params: {
         hints:
           daemonInstall.skippedReason === "systemd-user-unavailable"
             ? [
-                "Fix: rerun without `--install-daemon` for one-shot setup, or enable a working user-systemd session and retry.",
+                "Fix: rerun without `--install-daemon` for one-shot setup (via `openclaw onboard`), or enable a working user-systemd session and retry.",
                 "If your auth profile uses env-backed refs, keep those env vars set in the shell that runs `openclaw gateway run` or `openclaw agent --local`.",
               ]
             : [`Run \`${formatCliCommand("openclaw gateway status --deep")}\` for more detail.`],
@@ -343,7 +343,7 @@ export async function runNonInteractiveLocalSetup(params: {
         hints: !opts.installDaemon
           ? [
               "Non-interactive local setup only waits for an already-running gateway unless you pass --install-daemon.",
-              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, re-run with \`--install-daemon\`, or use \`--skip-health\`.`,
+              `Fix: start \`${formatCliCommand("openclaw gateway run")}\`, use \`openclaw onboard --install-daemon\`, or \`openclaw onboard --skip-health\`.`,
               process.platform === "win32"
                 ? "Native Windows managed gateway install tries Scheduled Tasks first and falls back to a per-user Startup-folder login item when task creation is denied."
                 : undefined,


### PR DESCRIPTION
## Summary

- Fix misleading error hints in the non-interactive setup health check path
- `openclaw setup --non-interactive` routes to the same non-interactive code as onboarding, but the flags `--install-daemon` and `--skip-health` are only registered on the `openclaw onboard` command
- Updated both hint messages to explicitly reference `openclaw onboard` so users know which command provides those flags

## Problem

When `openclaw setup --non-interactive --accept-risk` fails during the gateway health check, the error hints suggest using `--install-daemon` or `--skip-health`. However, these flags are only registered on `openclaw onboard` (see `src/cli/program/register.onboard.ts`), not on `openclaw setup` (see `src/cli/program/register.setup.ts`). Users are directed to flags that do not exist on the command they just ran.

## Fix

Updated two hint strings in `src/commands/onboard-non-interactive/local.ts`:

1. **Line 286** (daemon install skipped — systemd-unavailable):
   - Before: "rerun without `--install-daemon` for one-shot setup"
   - After: "rerun without `--install-daemon` for one-shot setup (via `openclaw onboard`)"

2. **Line 346** (health check failure — no --install-daemon passed):
   - Before: "re-run with `--install-daemon`, or use `--skip-health`"
   - After: "use `openclaw onboard --install-daemon`, or `openclaw onboard --skip-health`"

This is consistent with how `src/wizard/setup.finalize.ts` already formats its hints (it correctly prefixes with `openclaw onboard`).

## Real behavior proof

**Behavior addressed**: Error hints in the non-interactive health check path now prefix the flags `--install-daemon` and `--skip-health` with `openclaw onboard` so users know exactly which subcommand provides those flags.

**Real environment tested**: Linux x86_64 (kernel 4.19.112), Node.js v26.2.0, openclaw source at `fix/issue-93947-setup-health-hint`

**Exact steps or command run after this patch**: Run `node -e` script to verify the hint string change in the source code, confirming the old bare-flag pattern is replaced with the new command-prefixed pattern.

**After-fix evidence**:
```
=== #94245 Health Check Hint Change ===

BEFORE (misleading):
  Fix: start `openclaw gateway run`, re-run with `--install-daemon`, or use `--skip-health`.

AFTER (fixed):
  Fix: start `openclaw gateway run`, use `openclaw onboard --install-daemon`, or `openclaw onboard --skip-health`.

Key difference: users are now told which command has --install-daemon / --skip-health

=== Source Verification ===
Old flag pattern still present: false
New onboard-prefixed pattern present: true
```

**Observed result after the fix**: The old misleading hint `re-run with \`--install-daemon\`, or use \`--skip-health\`` (which sends users looking for flags on the wrong command) is replaced with `use \`openclaw onboard --install-daemon\`, or \`openclaw onboard --skip-health\``. Source verification confirms the old pattern is absent and the new prefix pattern is present in the fix branch.

**What was not tested**: Full end-to-end `openclaw setup --non-interactive --accept-risk` execution that triggers the health check failure path (requires a systemd environment and gateway health check failure setup). The change is limited to two string literals with no logic changes, so code review and grep-based verification are sufficient.

## Tests and validation

- `git diff` confirms only the two hint strings changed
- TypeScript compilation: no type errors (string-only change)
- Existing pattern from `src/wizard/setup.finalize.ts` uses `openclaw onboard --install-daemon` / `openclaw onboard --skip-health` — change aligns with that convention

Closes #93947