### PR TITLE
fix(telegram): export sender isBot field to agent context (fixes #40838)

### DIFF
--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -521,6 +521,7 @@ export async function buildTelegramInboundContextPayload(params: {
       ...(senderId ? { id: senderId } : {}),
       name: senderName,
       username: senderUsername || undefined,
+      isBot: msg.from?.is_bot === true,
     },
     conversation: {
       kind: conversationKind,


### PR DESCRIPTION
## What does this PR do?

Exports the `isBot` boolean from the Telegram sender identity into the agent context payload. This allows agents to distinguish bot senders from human users in Telegram group conversations.

## Related Issue

Fixes #40838

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `extensions/telegram/src/bot-message-context.session.ts`: Add `isBot: msg.from?.is_bot === true` to the sender object in `buildTelegramInboundContextPayload`

## How to Test

1. Send a message in a Telegram group where a bot is present
2. Check that the agent context includes `sender.isBot: true` for bot messages and `false` for human messages

## Real behavior proof

- **Behavior or issue addressed:** The Telegram inbound context payload did not include the `isBot` field in the sender identity, preventing agents from distinguishing bot senders from human users in group conversations.
- **Environment tested:** macOS, Node v22, pnpm build + verification
- **Steps run after the patch:** Verified the isBot field is present in source and bundled dist output
- **Evidence after fix:**

```
$ node -e "const fs=require('fs'); const c=fs.readFileSync('extensions/telegram/src/bot-message-context.session.ts','utf8'); console.log('isBot field in sender:', c.includes('isBot: msg.from?.is_bot === true'));"
isBot field in sender: true

$ grep -n "isBot" extensions/telegram/src/bot-message-context.session.ts
524:      isBot: msg.from?.is_bot === true,

$ node -e "const fs=require('fs'); const files=fs.readdirSync('dist/').filter(f=>f.endsWith('.js')); for(const f of files){const c=fs.readFileSync('dist/'+f,'utf8'); if(c.includes('isBot:')){console.log('Found in dist/'+f); break;}}"
Found in dist/bot-DmCrE7B9.js

$ pnpm build
[build-all] phase timings: total 181.1s — build succeeded
```

- **Observed result after fix:** The `isBot` field is correctly exported in both source and bundled output. The `SenderFacts` type at `src/channels/turn/types.ts:63` already declares `isBot?: boolean` so no type changes were needed.
- **What was not tested:** Live Telegram group interaction (requires Telegram bot token and group setup)
