### PR TITLE
fix(tui): handle /status and /compact in local mode instead of falling through to model (fixes #71592)

### DIFF
--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -709,6 +709,16 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "quit":
         requestExit();
         break;
+      case "status":
+      case "compact":
+        if (opts.local === true) {
+          chatLog.addSystem(
+            `/${name} is not supported in local TUI mode — use gateway-connected TUI for this command`,
+          );
+        } else {
+          await sendMessage(raw);
+        }
+        break;
       default:
         await sendMessage(raw);
         break;


### PR DESCRIPTION
## What

Handle `/status` and `/compact` in TUI local mode instead of falling through to `sendMessage(raw)`, which sends the command text as a user message to the model.

When `opts.local === true`, the TUI now shows a system message explaining that these commands are not supported in local mode. In gateway-connected mode, behavior is unchanged — the commands are sent to the gateway for processing.

## Why

Fixes #71592. The TUI slash command list advertises `/status` and `/compact` as available commands, but the local-mode command switch has no `case` for them. They fall through to the `default` branch and get sent as plain text to the model, producing confusing model responses instead of executing the command.

## Changes Made

- `src/tui/tui-command-handlers.ts`: Add `case "status"` and `case "compact"` to the command switch. In local mode (`opts.local === true`), emit a system message indicating the command is not supported. In gateway mode, forward to `sendMessage(raw)` as before.

## How to Test

1. Run `openclaw tui --local`
2. Type `/status` — should show "not supported in local TUI mode" instead of sending to model
3. Type `/compact` — same behavior
4. Run `openclaw tui` (gateway mode) — `/status` and `/compact` should work normally via gateway

## Real behavior proof

- **Behavior addressed:** TUI local mode falls through `/status` and `/compact` to model text instead of handling them
- **Environment tested:** macOS, OpenClaw main branch, Node.js
- **Steps run after the patch:** Ran the TUI command handler test suite and built the project
- **Evidence after fix:**
```
$ grep -n 'case "status"\|case "compact"' src/tui/tui-command-handlers.ts
712:      case "status":
713:      case "compact":

$ node scripts/run-vitest.mjs run src/tui/tui-command-handlers.test.ts
 ✓  tui  src/tui/tui-command-handlers.test.ts (59 tests) 99ms
 Test Files  1 passed (1)
      Tests  59 passed (59)

$ pnpm build
✓ built in 1.38s
[build-all] phase timings: total 204.4s
```
- **Observed result after fix:** All 59 existing tests pass. Build succeeds. The new `case "status"` and `case "compact"` branches correctly check `opts.local` and either show a system message or forward to gateway.
- **What was not tested:** Manual TUI interaction (requires terminal UI). The test suite covers command handler logic but not the full TUI rendering pipeline.
