### PR TITLE
fix(cron): default mcp cron run to 'due' mode instead of 'force'

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -710,8 +710,8 @@ describe("cron tool", () => {
     ],
     ["remove", { action: "remove", jobId: "job-1" }, { id: "job-1" }],
     ["remove", { action: "remove", id: "job-2" }, { id: "job-2" }],
-    ["run", { action: "run", jobId: "job-1" }, { id: "job-1", mode: "force" }],
-    ["run", { action: "run", id: "job-2" }, { id: "job-2", mode: "force" }],
+    ["run", { action: "run", jobId: "job-1" }, { id: "job-1", mode: "due" }],
+    ["run", { action: "run", id: "job-2" }, { id: "job-2", mode: "due" }],
     ["get", { action: "get", jobId: "job-1" }, { id: "job-1" }],
     ["get", { action: "get", id: "job-2" }, { id: "job-2" }],
     ["runs", { action: "runs", jobId: "job-1" }, { id: "job-1" }],
@@ -732,7 +732,7 @@ describe("cron tool", () => {
       id: "job-legacy",
     });
 
-    expect(readGatewayCall().params).toEqual({ id: "job-primary", mode: "force" });
+    expect(readGatewayCall().params).toEqual({ id: "job-primary", mode: "due" });
   });
 
   it("supports due-only run mode", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -1086,7 +1086,7 @@ Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous me
             throw new Error("jobId required (id accepted for backward compatibility)");
           }
           const runMode =
-            params.runMode === "due" || params.runMode === "force" ? params.runMode : "force";
+            params.runMode === "due" || params.runMode === "force" ? params.runMode : "due";
           return jsonResult(await callGateway("cron.run", gatewayOpts, { id, mode: runMode }));
         }
         case "runs": {


### PR DESCRIPTION
## Summary

Fixes #94270 — mcp cron action=run defaults to force mode, bypassing all schedule guards.

## Problem

The mcp__openclaw__cron tool defaulted runMode to 'force' when not specified, which:  
1. Bypasses cron expression day-of-week/time checks  
2. Ignores isJobEnabled  
3. Ignores nextRunAtMs

Every agent calling action=run without explicit runMode would trigger jobs outside their schedule.

## Fix

1 line: change default from `"force"` to `"due"` in `src/agents/tools/cron-tool.ts`

Explicit `runMode: "force"` still works for intentional overrides.