### PR TITLE
fix(nodes): sanitize large base64 payloads in invoke results

### DIFF
--- a/src/agents/tools/nodes-tool-commands.ts
+++ b/src/agents/tools/nodes-tool-commands.ts
@@ -7,6 +7,12 @@ import crypto from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
+  parseScreenSnapshotPayload,
+  screenSnapshotTempPath,
+  writeScreenSnapshotToFile,
+} from "../../cli/nodes-screen.js";
+
+import {
   jsonResult,
   readNonNegativeIntegerParam,
   readPositiveIntegerParam,
@@ -165,7 +171,8 @@ export async function executeNodeCommandAction(params: {
         timeoutMs: invokeTimeoutMs,
         idempotencyKey: crypto.randomUUID(),
       });
-      return jsonResult(raw ?? {});
+      const sanitized = await sanitizeInvokeResult(invokeCommandNormalized, raw);
+      return sanitized;
     }
   }
   throw new Error("Unsupported node command action");
@@ -185,4 +192,69 @@ async function invokeNodeCommandPayload(params: {
     idempotencyKey: crypto.randomUUID(),
   });
   return raw && typeof raw === "object" && Object.hasOwn(raw, "payload") ? raw.payload : {};
+}
+
+/**
+ * Sanitize an invoke result to prevent base64 bloat in tool output.
+ *
+ * When a node command returns a large base64 payload (e.g. screen.snapshot,
+ * camera.snap), offload the binary data to a temp file and return a
+ * base64-free result that includes only the file path.
+ *
+ * This prevents tool output truncation that corrupts large base64 payloads
+ * and makes them unusable for downstream operations.
+ */
+async function sanitizeInvokeResult(
+  command: string,
+  raw: unknown,
+): Promise<{ content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> } | ReturnType<typeof jsonResult>> {
+  if (!raw || typeof raw !== "object") return jsonResult(raw ?? {});
+  const result = raw as Record<string, unknown>;
+
+  // Only process responses that have a payload with large base64 data
+  const payload = result.payload;
+  if (!payload || typeof payload !== "object") return jsonResult(raw ?? {});
+  const payloadObj = payload as Record<string, unknown>;
+  const base64 = payloadObj.base64;
+  if (typeof base64 !== "string" || base64.length <= 1024) {
+    return jsonResult(raw ?? {});
+  }
+
+  // Offload base64 to a temp file
+  try {
+    // Try screen snapshot handler first (most common large-payload case)
+    if (command === "screen.snapshot" || command === "screen.record") {
+      const parsed = parseScreenSnapshotPayload(payload);
+      const ext = parsed.format === "png" ? ".png" : ".jpg";
+      const filePath = screenSnapshotTempPath({ ext });
+      const written = await writeScreenSnapshotToFile(filePath, parsed.base64);
+      return {
+        content: [{ type: "text", text: `FILE:${written.path}` }],
+        details: {
+          path: written.path,
+          format: parsed.format,
+          width: parsed.width,
+          height: parsed.height,
+          screenIndex: parsed.screenIndex,
+        },
+      };
+    }
+
+    // Generic fallback: write base64 to temp file
+    const fmt = typeof payloadObj.format === "string" ? payloadObj.format : "bin";
+    const ext = fmt === "png" ? ".png" : fmt === "jpg" || fmt === "jpeg" ? ".jpg" : `.${fmt}`;
+    const filePath = screenSnapshotTempPath({ ext });
+    const written = await writeScreenSnapshotToFile(filePath, base64);
+    return {
+      content: [{ type: "text", text: `FILE:${written.path}` }],
+      details: {
+        ...payloadObj,
+        base64: undefined,
+        path: written.path,
+      },
+    };
+  } catch {
+    // If sanitization fails, fall back to raw result
+    return jsonResult(raw ?? {});
+  }
 }


### PR DESCRIPTION
## Problem

When `nodes.invoke` commands like `screen.snapshot` return large base64 payloads, the JSON tool output is often truncated by context limits, corrupting the base64 data and making images unusable.

### Root Cause

The dedicated `screen_snapshot` action already supports `outPath` and writes to file, but the generic `invoke` path (`action="invoke"`) returned raw JSON with inline base64 regardless of size.

## Fix

Added `sanitizeInvokeResult()` in `nodes-tool-commands.ts` that:
- Detects base64 payloads > 1KB in invoke responses
- Offloads them to temp files via the existing `writeScreenSnapshotToFile` helper
- Returns file path + metadata instead of raw base64
- Falls back to raw JSON if sanitization fails

### Changed file
- `src/agents/tools/nodes-tool-commands.ts` (+73 lines)

### Before/After
| Before | After |
|--------|-------|
| `invoke screen.snapshot` → JSON with 200KB+ base64 → truncated | → base64 written to temp file → `FILE:/tmp/openclaw-screen-snapshot-xxx.png` → always intact |

## Related

Closes: #94280

Reported-by: @Mateola74 (Mateo)