### PR TITLE
Support owner-qualified ClawHub skill installs

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -438,6 +438,7 @@ describe("skills cli commands", () => {
     expect(help).toContain("<skill-ref>");
     expect(help).toContain("@owner/slug");
     expect(help).toContain("openclaw skills install @owner/weather");
+    expect(help).not.toContain("openclaw skills install weather");
   });
 
   it("installs a skill from a git source into the active workspace", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -399,6 +399,47 @@ describe("skills cli commands", () => {
     ).toBe(true);
   });
 
+  it("passes owner-qualified ClawHub skill refs through to the installer", async () => {
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "calendar",
+      version: "1.2.3",
+      targetDir: "/tmp/workspace/skills/calendar",
+    });
+
+    await runCommand(["skills", "install", "@demo-owner/calendar"]);
+
+    const installArgs = mockFirstObjectArg(installSkillFromClawHubMock);
+    expectObjectFields(installArgs, {
+      workspaceDir: "/tmp/workspace",
+      slug: "@demo-owner/calendar",
+      force: false,
+    });
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
+    expect(
+      runtimeLogs.some((line) =>
+        line.includes("Installed calendar@1.2.3 -> /tmp/workspace/skills/calendar"),
+      ),
+    ).toBe(true);
+  });
+
+  it("documents owner-qualified ClawHub install refs in command help", () => {
+    const skillsCommand = createProgram().commands.find((command) => command.name() === "skills");
+    const installCommand = skillsCommand?.commands.find((command) => command.name() === "install");
+    const output: string[] = [];
+
+    installCommand?.configureOutput({
+      writeOut: (value) => output.push(value),
+      writeErr: (value) => output.push(value),
+    });
+    installCommand?.outputHelp();
+    const help = output.join("");
+
+    expect(help).toContain("<skill-ref>");
+    expect(help).toContain("@owner/slug");
+    expect(help).toContain("openclaw skills install @owner/weather");
+  });
+
   it("installs a skill from a git source into the active workspace", async () => {
     installSkillFromSourceMock.mockResolvedValue({
       ok: true,
@@ -834,6 +875,34 @@ describe("skills cli commands", () => {
       },
     });
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
+  it("passes owner-qualified installed verification targets to ClawHub verification", async () => {
+    resolveClawHubSkillVerificationTargetMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      baseUrl: "https://private.example.com/clawhub",
+      version: "1.2.3",
+      tag: undefined,
+      resolution: {
+        source: "installed",
+        selector: "installed-version",
+        registry: "https://private.example.com/clawhub",
+        skillDir: "/tmp/workspace/skills/weather",
+        installedVersion: "1.2.3",
+      },
+    });
+
+    await runCommand(["skills", "verify", "weather"]);
+
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      version: "1.2.3",
+      tag: undefined,
+      baseUrl: "https://private.example.com/clawhub",
+    });
   });
 
   it("passes explicit verify selectors and shared workspace options to the resolver", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -287,7 +287,10 @@ export function registerSkillsCli(program: Command) {
   skills
     .command("install")
     .description("Install a skill from ClawHub, git, or a local directory")
-    .argument("<slug>", "ClawHub skill slug, git:<repo>, or local skill directory")
+    .argument(
+      "<skill-ref>",
+      "ClawHub skill slug, @owner/slug, git:<repo>, or local skill directory",
+    )
     .option("--version <version>", "Install a specific version")
     .option("--force", "Overwrite an existing workspace skill", false)
     .option(
@@ -298,6 +301,10 @@ export function registerSkillsCli(program: Command) {
     .option("--global", "Install into the shared managed skills directory", false)
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
     .option("--as <slug>", "Install a git/local skill under this slug")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  openclaw skills install weather\n  openclaw skills install @owner/weather\n",
+    )
     .action(
       async (
         slug: string,
@@ -480,6 +487,7 @@ export function registerSkillsCli(program: Command) {
           } else {
             const verification = await fetchClawHubSkillVerification({
               slug: target.slug,
+              ...(target.ownerHandle ? { ownerHandle: target.ownerHandle } : {}),
               version: target.version,
               tag: target.tag,
               baseUrl: target.baseUrl,

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -289,7 +289,7 @@ export function registerSkillsCli(program: Command) {
     .description("Install a skill from ClawHub, git, or a local directory")
     .argument(
       "<skill-ref>",
-      "ClawHub skill slug, @owner/slug, git:<repo>, or local skill directory",
+      "ClawHub skill ref (@owner/slug), git:<repo>, or local skill directory",
     )
     .option("--version <version>", "Install a specific version")
     .option("--force", "Overwrite an existing workspace skill", false)
@@ -301,10 +301,7 @@ export function registerSkillsCli(program: Command) {
     .option("--global", "Install into the shared managed skills directory", false)
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
     .option("--as <slug>", "Install a git/local skill under this slug")
-    .addHelpText(
-      "after",
-      "\nExamples:\n  openclaw skills install weather\n  openclaw skills install @owner/weather\n",
-    )
+    .addHelpText("after", "\nExamples:\n  openclaw skills install @owner/weather\n")
     .action(
       async (
         slug: string,

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -9,6 +9,8 @@ import {
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   downloadClawHubSkillArchiveUrl,
+  fetchClawHubSkillDetail,
+  fetchClawHubSkillInstallResolution,
   fetchClawHubSkillCard,
   fetchClawHubSkillSecurityVerdicts,
   fetchClawHubPackageArtifact,
@@ -316,6 +318,65 @@ describe("clawhub helpers", () => {
     expect(url.searchParams.get("q")).toBe("calendar");
   });
 
+  it("sends owner-qualified skill detail lookups as slug plus ownerHandle", async () => {
+    let requestedUrl = "";
+
+    await expect(
+      fetchClawHubSkillDetail({
+        slug: "weather",
+        ownerHandle: "demo-owner",
+        fetchImpl: async (input) => {
+          requestedUrl = input instanceof Request ? input.url : String(input);
+          return new Response(
+            JSON.stringify({
+              skill: {
+                slug: "weather",
+                displayName: "Weather",
+                createdAt: 1,
+                updatedAt: 2,
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        },
+      }),
+    ).resolves.toMatchObject({ skill: { slug: "weather" } });
+
+    const url = new URL(requestedUrl);
+    expect(url.pathname).toBe("/api/v1/skills/weather");
+    expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
+  });
+
+  it("sends owner-qualified skill install resolution lookups as slug plus ownerHandle", async () => {
+    let requestedUrl = "";
+
+    await expect(
+      fetchClawHubSkillInstallResolution({
+        slug: "weather",
+        ownerHandle: "demo-owner",
+        fetchImpl: async (input) => {
+          requestedUrl = input instanceof Request ? input.url : String(input);
+          return new Response(
+            JSON.stringify({
+              ok: true,
+              slug: "weather",
+              installKind: "archive",
+              archive: {
+                version: "1.0.0",
+                downloadUrl: "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        },
+      }),
+    ).resolves.toMatchObject({ ok: true, slug: "weather" });
+
+    const url = new URL(requestedUrl);
+    expect(url.pathname).toBe("/api/v1/skills/weather/install");
+    expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
+  });
+
   it("fetches skill verification reports and lets version take precedence over tag", async () => {
     let requestedUrl = "";
     const envelope = {
@@ -358,6 +419,43 @@ describe("clawhub helpers", () => {
     expect(url.pathname).toBe("/api/v1/skills/agentreceipt/verify");
     expect(url.searchParams.get("version")).toBe("1.2.3");
     expect(url.searchParams.has("tag")).toBe(false);
+  });
+
+  it("sends owner-qualified skill verification lookups as slug plus ownerHandle", async () => {
+    let requestedUrl = "";
+
+    await expect(
+      fetchClawHubSkillVerification({
+        slug: "weather",
+        ownerHandle: "demo-owner",
+        version: "1.0.0",
+        fetchImpl: async (input) => {
+          requestedUrl = input instanceof Request ? input.url : String(input);
+          return new Response(
+            JSON.stringify({
+              schema: "clawhub.skill.verify.v1",
+              ok: true,
+              decision: "pass",
+              reasons: [],
+              skill: {},
+              publisher: {},
+              version: {},
+              card: {},
+              artifact: {},
+              provenance: {},
+              security: {},
+              signature: {},
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        },
+      }),
+    ).resolves.toMatchObject({ schema: "clawhub.skill.verify.v1" });
+
+    const url = new URL(requestedUrl);
+    expect(url.pathname).toBe("/api/v1/skills/weather/verify");
+    expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
+    expect(url.searchParams.get("version")).toBe("1.0.0");
   });
 
   it("posts bulk skill security verdict requests", async () => {
@@ -855,6 +953,32 @@ describe("clawhub helpers", () => {
       const archiveDir = path.dirname(archive.archivePath);
       await archive.cleanup();
       await expectPathMissing(archiveDir);
+    }
+  });
+
+  it("sends owner-qualified skill archive downloads as slug plus ownerHandle", async () => {
+    let requestedUrl = "";
+    const archive = await downloadClawHubSkillArchive({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      version: "1.0.0",
+      fetchImpl: async (input) => {
+        requestedUrl = input instanceof Request ? input.url : String(input);
+        return new Response(new Uint8Array([7, 8, 9]), {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      },
+    });
+
+    try {
+      const url = new URL(requestedUrl);
+      expect(url.pathname).toBe("/api/v1/download");
+      expect(url.searchParams.get("slug")).toBe("weather");
+      expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
+      expect(url.searchParams.get("version")).toBe("1.0.0");
+    } finally {
+      await archive.cleanup();
     }
   });
 

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -800,13 +800,18 @@ export function isDefaultClawHubBaseUrl(baseUrl?: string): boolean {
 function buildVersionOrTagSearch(params: {
   version?: string;
   tag?: string;
-}): { version?: string; tag?: string } | undefined {
+  ownerHandle?: string;
+}): { version?: string; tag?: string; ownerHandle?: string } | undefined {
   const version = normalizeOptionalString(params.version);
+  const ownerHandle = normalizeOptionalString(params.ownerHandle);
   if (version) {
-    return { version };
+    return { version, ...(ownerHandle ? { ownerHandle } : {}) };
   }
   const tag = normalizeOptionalString(params.tag);
-  return tag ? { tag } : undefined;
+  if (tag) {
+    return { tag, ...(ownerHandle ? { ownerHandle } : {}) };
+  }
+  return ownerHandle ? { ownerHandle } : undefined;
 }
 
 function buildGitHubZipUrl(repo: string, commit: string): string {
@@ -1025,6 +1030,7 @@ export async function searchClawHubSkills(params: {
 
 export async function fetchClawHubSkillDetail(params: {
   slug: string;
+  ownerHandle?: string;
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
@@ -1036,11 +1042,13 @@ export async function fetchClawHubSkillDetail(params: {
     token: params.token,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
+    search: params.ownerHandle ? { ownerHandle: params.ownerHandle } : undefined,
   });
 }
 
 export async function fetchClawHubSkillInstallResolution(params: {
   slug: string;
+  ownerHandle?: string;
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
@@ -1054,6 +1062,7 @@ export async function fetchClawHubSkillInstallResolution(params: {
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
     search: {
+      ownerHandle: params.ownerHandle,
       forceInstall: params.forceInstall ? "1" : undefined,
     },
   });
@@ -1070,6 +1079,7 @@ export async function fetchClawHubSkillInstallResolution(params: {
 
 export async function fetchClawHubSkillVerification(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1109,6 +1119,7 @@ export async function fetchClawHubSkillSecurityVerdicts(params: {
 
 export async function fetchClawHubSkillCard(params: {
   slug?: string;
+  ownerHandle?: string;
   url?: string;
   version?: string;
   tag?: string;
@@ -1278,6 +1289,7 @@ export async function downloadClawHubPackageArchive(params: {
 
 export async function downloadClawHubSkillArchive(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1293,6 +1305,7 @@ export async function downloadClawHubSkillArchive(params: {
     fetchImpl: params.fetchImpl,
     search: {
       slug: params.slug,
+      ownerHandle: params.ownerHandle,
       version: params.version,
       tag: params.version ? undefined : params.tag,
     },

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -80,7 +80,8 @@ function installPolicyInput() {
   }
   return call[0] as
     | {
-        origin?: { registry?: string };
+        origin?: { registry?: string; slug?: string; ownerHandle?: string };
+        requestedSpecifier?: string;
         source?: { kind?: string; authority?: string; mutable?: boolean; network?: boolean };
       }
     | undefined;
@@ -117,6 +118,7 @@ async function writeClawHubOriginFixture(params: {
   workspaceDir: string;
   slug: string;
   originSlug?: string;
+  ownerHandle?: string;
   registry?: string;
   installedVersion?: string;
   installedAt?: number;
@@ -134,6 +136,7 @@ async function writeClawHubOriginFixture(params: {
         version: 1,
         registry,
         slug: params.originSlug ?? params.slug,
+        ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         installedVersion,
         installedAt,
       },
@@ -154,6 +157,7 @@ async function writeClawHubOriginFixture(params: {
               version: installedVersion,
               installedAt,
               registry,
+              ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
             },
           },
         },
@@ -304,6 +308,100 @@ describe("skills-clawhub", () => {
       "registry",
       "version",
     ]);
+  });
+
+  it("installs owner-qualified ClawHub skills without using owner as a local path", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-owner-skill-");
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir,
+      slug: "@demo-owner/weather",
+    });
+
+    expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      baseUrl: undefined,
+    });
+    expectInstallPackageSourceDir("/tmp/extracted-skill");
+    expect(installPolicyInput()).toMatchObject({
+      origin: {
+        registry: "https://clawhub.ai",
+        slug: "weather",
+        ownerHandle: "demo-owner",
+      },
+      requestedSpecifier: "clawhub:@demo-owner/weather@1.0.0",
+    });
+    expectInstalledSkill(result, {
+      slug: "weather",
+      version: "1.0.0",
+      targetDir: path.join(workspaceDir, "skills", "weather"),
+    });
+    await expect(fs.access(path.join(workspaceDir, "skills", "@demo-owner"))).rejects.toThrow();
+
+    const lock = JSON.parse(
+      await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+    ) as { skills: Record<string, Record<string, unknown>> };
+    expect(lock.skills.weather).toMatchObject({
+      version: "1.0.0",
+      registry: "https://clawhub.ai",
+      ownerHandle: "demo-owner",
+    });
+    const origin = JSON.parse(
+      await fs.readFile(
+        path.join(workspaceDir, "skills", "weather", ".clawhub", "origin.json"),
+        "utf8",
+      ),
+    ) as Record<string, unknown>;
+    expect(origin).toMatchObject({
+      version: 1,
+      registry: "https://clawhub.ai",
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      installedVersion: "1.0.0",
+    });
+  });
+
+  it("formats ambiguous ClawHub slug responses with owner-qualified guidance", async () => {
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: false,
+      slug: "weather",
+      reason: "ambiguous_slug",
+      message: "Multiple ClawHub publishers provide weather.",
+      status: 409,
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "weather",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected ambiguous slug failure");
+    }
+    expect(result.error).toContain('Skill "weather" is ambiguous on ClawHub.');
+    expect(result.error).toContain("openclaw skills install @owner/weather");
+    expect(result.error).toContain("Multiple ClawHub publishers provide weather.");
+  });
+
+  it("rejects malformed owner-qualified ClawHub install refs", async () => {
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "@@demo-owner/weather",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("expected invalid owner-qualified failure");
+    }
+    expect(result.error).toContain("Invalid ClawHub owner handle");
+    expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
   });
 
   it("persists install artifact and verification provenance in the ClawHub lockfile", async () => {
@@ -764,6 +862,127 @@ describe("skills-clawhub", () => {
     },
   );
 
+  it("updates owner-qualified ClawHub skills with the stored owner namespace", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-owner-update-");
+    await writeClawHubOriginFixture({
+      workspaceDir,
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      registry: "https://private.example.com/clawhub",
+      installedVersion: "0.9.0",
+    });
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "archive",
+      archive: {
+        version: "1.0.0",
+        downloadUrl:
+          "https://private.example.com/clawhub/api/v1/download?slug=weather&ownerHandle=demo-owner&version=1.0.0",
+      },
+    });
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    const results = await updateSkillsFromClawHub({
+      workspaceDir,
+      slug: "weather",
+    });
+
+    expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      version: "1.0.0",
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(results).toEqual([
+      {
+        ok: true,
+        slug: "weather",
+        previousVersion: "0.9.0",
+        version: "1.0.0",
+        changed: true,
+        targetDir: path.join(workspaceDir, "skills", "weather"),
+      },
+    ]);
+    const lock = JSON.parse(
+      await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
+    ) as { skills: Record<string, Record<string, unknown>> };
+    expect(lock.skills.weather?.ownerHandle).toBe("demo-owner");
+  });
+
+  it("updates owner-qualified ClawHub skills when the requested owner matches tracking", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-owner-update-request-");
+    await writeClawHubOriginFixture({
+      workspaceDir,
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      installedVersion: "0.9.0",
+    });
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "archive",
+      archive: {
+        version: "1.0.0",
+        downloadUrl:
+          "https://clawhub.ai/api/v1/download?slug=weather&ownerHandle=demo-owner&version=1.0.0",
+      },
+    });
+    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+      await fs.mkdir(params.targetDir, { recursive: true });
+      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
+      return { ok: true, targetDir: params.targetDir };
+    });
+
+    const results = await updateSkillsFromClawHub({
+      workspaceDir,
+      slug: "@demo-owner/weather",
+    });
+
+    expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
+      slug: "weather",
+      ownerHandle: "demo-owner",
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(results).toEqual([
+      expect.objectContaining({
+        ok: true,
+        slug: "weather",
+        previousVersion: "0.9.0",
+        version: "1.0.0",
+      }),
+    ]);
+  });
+
+  it("rejects owner-qualified ClawHub updates when the requested owner does not match tracking", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-owner-update-mismatch-");
+    await writeClawHubOriginFixture({
+      workspaceDir,
+      slug: "weather",
+      ownerHandle: "other-owner",
+      installedVersion: "0.9.0",
+    });
+
+    await expect(
+      updateSkillsFromClawHub({
+        workspaceDir,
+        slug: "@demo-owner/weather",
+      }),
+    ).rejects.toThrow(
+      'Skill "weather" is tracked as @other-owner/weather, not @demo-owner/weather.',
+    );
+    expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
+  });
+
   describe("legacy tracked slugs remain updatable", () => {
     async function createLegacyTrackedSkillFixture(slug: string) {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
@@ -1039,6 +1258,41 @@ describe("skills-clawhub", () => {
       }
     });
 
+    it("uses installed owner namespace when resolving owner-qualified verification targets", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "weather",
+          ownerHandle: "demo-owner",
+          registry: "https://private.example.com/clawhub",
+          installedVersion: "2.0.0",
+        });
+
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir,
+            slug: "weather",
+          }),
+        ).resolves.toMatchObject({
+          ok: true,
+          slug: "weather",
+          ownerHandle: "demo-owner",
+          baseUrl: "https://private.example.com/clawhub",
+          version: "2.0.0",
+          tag: undefined,
+          resolution: {
+            source: "installed",
+            selector: "installed-version",
+            registry: "https://private.example.com/clawhub",
+            installedVersion: "2.0.0",
+          },
+        });
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
     it("keeps the installed registry when an explicit version overrides the installed version", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
@@ -1104,6 +1358,36 @@ describe("skills-clawhub", () => {
             installedVersion: "2.0.0",
           },
         });
+      } finally {
+        await fs.rm(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("rejects installed owner namespace metadata that does not match lock tracking", async () => {
+      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
+      try {
+        await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "weather",
+          ownerHandle: "demo-owner",
+        });
+        const lockPath = path.join(workspaceDir, ".clawhub", "lock.json");
+        const lock = JSON.parse(await fs.readFile(lockPath, "utf8")) as {
+          skills: Record<string, { ownerHandle?: string }>;
+        };
+        lock.skills.weather!.ownerHandle = "other-owner";
+        await fs.writeFile(lockPath, `${JSON.stringify(lock, null, 2)}\n`, "utf8");
+
+        const result = await resolveClawHubSkillVerificationTarget({
+          workspaceDir,
+          slug: "weather",
+        });
+
+        expect(result.ok).toBe(false);
+        if (result.ok) {
+          throw new Error("expected owner mismatch failure");
+        }
+        expect(result.error).toContain("origin metadata does not match");
       } finally {
         await fs.rm(workspaceDir, { recursive: true, force: true });
       }

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -66,6 +66,7 @@ type ClawHubSkillLockEntry = {
   version: string;
   installedAt: number;
   registry?: string;
+  ownerHandle?: string;
   sourceUrl?: string;
   artifact?: ClawHubSkillDownloadedArtifactLock;
   skillFile?: ClawHubSkillFileLock;
@@ -76,6 +77,7 @@ type ClawHubSkillOrigin = {
   version: 1;
   registry: string;
   slug: string;
+  ownerHandle?: string;
   installedVersion: string;
   installedAt: number;
   sourceUrl?: string;
@@ -99,6 +101,7 @@ export type ClawHubSkillStatusLink =
       valid: true;
       registry: string;
       slug: string;
+      ownerHandle?: string;
       installedVersion: string;
       installedAt: number;
       originPath: string;
@@ -154,23 +157,74 @@ type Logger = {
   info?: (message: string) => void;
 };
 
+type ClawHubSkillRef = {
+  slug: string;
+  ownerHandle?: string;
+};
+
+const CLAWHUB_OWNER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,38}[a-z0-9])?$/;
+
+function normalizeClawHubOwnerHandle(raw: string): string {
+  const ownerHandle = raw.trim().toLowerCase();
+  if (!CLAWHUB_OWNER_HANDLE_PATTERN.test(ownerHandle)) {
+    throw new Error(`Invalid ClawHub owner handle: ${raw}`);
+  }
+  return ownerHandle;
+}
+
+function parseRequestedClawHubSkillRef(raw: string): ClawHubSkillRef {
+  const value = raw.trim();
+  if (!value.startsWith("@")) {
+    return { slug: validateRequestedSkillSlug(value) };
+  }
+  const parts = value.slice(1).split("/");
+  if (parts.length !== 2) {
+    throw new Error(`Invalid ClawHub skill reference: ${raw}`);
+  }
+  const [owner, slug] = parts;
+  if (!owner || !slug) {
+    throw new Error(`Invalid ClawHub skill reference: ${raw}`);
+  }
+  return {
+    ownerHandle: normalizeClawHubOwnerHandle(owner),
+    slug: validateRequestedSkillSlug(slug),
+  };
+}
+
+function formatClawHubSkillRef(ref: ClawHubSkillRef): string {
+  return ref.ownerHandle ? `@${ref.ownerHandle}/${ref.slug}` : ref.slug;
+}
+
 async function resolveRequestedUpdateSlug(params: {
   workspaceDir: string;
   requestedSlug: string;
   lock: ClawHubSkillsLockfile;
 }): Promise<string> {
-  const trackedSlug = normalizeTrackedSkillSlug(params.requestedSlug);
+  const requested = params.requestedSlug.trim();
+  const requestedRef = requested.startsWith("@")
+    ? parseRequestedClawHubSkillRef(requested)
+    : { slug: normalizeTrackedSkillSlug(requested) };
+  const trackedSlug = requestedRef.slug;
   const trackedTargetDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
   const trackedOrigin = await readClawHubSkillOrigin(trackedTargetDir);
-  if (trackedOrigin || params.lock.skills[trackedSlug]) {
+  const trackedLockEntry = params.lock.skills[trackedSlug];
+  if (trackedOrigin || trackedLockEntry) {
+    const trackedOwnerHandle = trackedOrigin?.ownerHandle ?? trackedLockEntry?.ownerHandle;
+    if (requestedRef.ownerHandle && trackedOwnerHandle !== requestedRef.ownerHandle) {
+      const trackedRef = trackedOwnerHandle ? `@${trackedOwnerHandle}/${trackedSlug}` : trackedSlug;
+      throw new Error(
+        `Skill "${trackedSlug}" is tracked as ${trackedRef}, not @${requestedRef.ownerHandle}/${trackedSlug}.`,
+      );
+    }
     return trackedSlug;
   }
-  return validateRequestedSkillSlug(params.requestedSlug);
+  return validateRequestedSkillSlug(requestedRef.slug);
 }
 
 type ClawHubInstallParams = {
   workspaceDir: string;
   slug: string;
+  ownerHandle?: string;
   version?: string;
   baseUrl?: string;
   force?: boolean;
@@ -183,6 +237,7 @@ type TrackedUpdateTarget =
   | {
       ok: true;
       slug: string;
+      ownerHandle?: string;
       baseUrl?: string;
       previousVersion: string | null;
     }
@@ -199,6 +254,7 @@ type ClawHubSkillVerificationTargetResult =
   | {
       ok: true;
       slug: string;
+      ownerHandle?: string;
       baseUrl: string;
       version: string | undefined;
       tag: string | undefined;
@@ -215,9 +271,7 @@ type ClawHubSkillVerificationTargetResult =
       error: string;
     };
 
-async function readClawHubSkillsLockfile(
-  workspaceDir: string,
-): Promise<ClawHubSkillsLockfile> {
+async function readClawHubSkillsLockfile(workspaceDir: string): Promise<ClawHubSkillsLockfile> {
   const candidates = [
     path.join(workspaceDir, DOT_DIR, "lock.json"),
     path.join(workspaceDir, LEGACY_DOT_DIR, "lock.json"),
@@ -385,12 +439,14 @@ function snapshotClawHubSkillVerification(
 
 async function fetchInstallVerificationLock(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   baseUrl?: string;
 }): Promise<ClawHubSkillVerificationLock | undefined> {
   try {
     const verification = await fetchClawHubSkillVerification({
       slug: params.slug,
+      ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
       version: params.version,
       baseUrl: params.baseUrl,
     });
@@ -514,12 +570,24 @@ function normalizeClawHubSkillOrigin(
     typeof raw.installedAt === "number"
   ) {
     const sourceUrl = normalizeOptionalStringValue((raw as { sourceUrl?: unknown }).sourceUrl);
+    const ownerHandleRaw = normalizeOptionalStringValue(
+      (raw as { ownerHandle?: unknown }).ownerHandle,
+    );
+    let ownerHandle: string | undefined;
+    if (ownerHandleRaw) {
+      try {
+        ownerHandle = normalizeClawHubOwnerHandle(ownerHandleRaw);
+      } catch {
+        return null;
+      }
+    }
     const artifact = normalizeDownloadedArtifactLock((raw as { artifact?: unknown }).artifact);
     const skillFile = normalizeSkillFileLock((raw as { skillFile?: unknown }).skillFile);
     return {
       version: 1,
       registry: normalizeStoredRegistry(raw.registry),
       slug: raw.slug,
+      ...(ownerHandle ? { ownerHandle } : {}),
       installedVersion: raw.installedVersion,
       installedAt: raw.installedAt,
       ...(sourceUrl ? { sourceUrl } : {}),
@@ -737,9 +805,11 @@ export function resolveClawHubSkillStatusLinkSync(params: {
   const lockedRegistry =
     locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
   const lockedSourceUrl = normalizeOptionalStringValue(locked.sourceUrl);
+  const lockedOwnerHandle = normalizeOptionalStringValue(locked.ownerHandle);
   const lockedArtifact = normalizeDownloadedArtifactLock(locked.artifact);
   const lockedSkillFile = normalizeSkillFileLock(locked.skillFile);
   const provenanceMatches =
+    originRead.origin.ownerHandle === lockedOwnerHandle &&
     originRead.origin.sourceUrl === lockedSourceUrl &&
     originRead.origin.artifact?.kind === lockedArtifact?.kind &&
     originRead.origin.artifact?.sha256 === lockedArtifact?.sha256 &&
@@ -771,6 +841,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     valid: true,
     registry: lockedRegistry,
     slug: trackedSlug,
+    ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
     installedVersion: locked.version,
     installedAt: locked.installedAt,
     originPath: originRead.path,
@@ -914,10 +985,12 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       const originRegistry = normalizeStoredRegistry(originRead.origin.registry);
       const lockedRegistry =
         locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
+      const lockedOwnerHandle = normalizeOptionalStringValue(locked.ownerHandle);
       if (
         locked.version !== originRead.origin.installedVersion ||
         locked.installedAt !== originRead.origin.installedAt ||
-        lockedRegistry !== originRegistry
+        lockedRegistry !== originRegistry ||
+        originRead.origin.ownerHandle !== lockedOwnerHandle
       ) {
         return {
           ok: false,
@@ -932,6 +1005,7 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       return {
         ok: true,
         slug: trackedSlug,
+        ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
         baseUrl: lockedRegistry,
         version: version ?? (tag ? undefined : locked.version),
         tag,
@@ -983,11 +1057,13 @@ export async function resolveClawHubSkillVerificationTarget(params: {
 
 async function resolveInstallVersion(params: {
   slug: string;
+  ownerHandle?: string;
   version?: string;
   baseUrl?: string;
 }): Promise<{ detail: ClawHubSkillDetail; version: string }> {
   const detail = await fetchClawHubSkillDetail({
     slug: params.slug,
+    ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
     baseUrl: params.baseUrl,
   });
   if (!detail.skill) {
@@ -1019,6 +1095,7 @@ function resolveGitHubSkillSourceDir(repoRoot: string, sourcePath: string): stri
 async function installArchiveResolution(params: {
   workspaceDir: string;
   slug: string;
+  ownerHandle?: string;
   version: string;
   archivePath: string;
   registry: string;
@@ -1046,6 +1123,7 @@ async function installArchiveResolution(params: {
             type: "clawhub",
             registry: params.registry,
             slug: params.slug,
+            ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
             version: params.version,
           },
           source: {
@@ -1054,7 +1132,7 @@ async function installArchiveResolution(params: {
             mutable: false,
             network: true,
           },
-          requestedSpecifier: `clawhub:${params.slug}@${params.version}`,
+          requestedSpecifier: `clawhub:${formatClawHubSkillRef(params)}@${params.version}`,
         },
         rootMarkers: CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS,
       }),
@@ -1064,6 +1142,7 @@ async function installArchiveResolution(params: {
 async function installGitHubResolution(params: {
   workspaceDir: string;
   slug: string;
+  ownerHandle?: string;
   sourcePath: string;
   archivePath: string;
   registry: string;
@@ -1091,6 +1170,7 @@ async function installGitHubResolution(params: {
             type: "clawhub",
             registry: params.registry,
             slug: params.slug,
+            ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
             version: params.commit,
             repo: params.repo,
             path: params.sourcePath,
@@ -1102,7 +1182,7 @@ async function installGitHubResolution(params: {
             mutable: false,
             network: true,
           },
-          requestedSpecifier: `clawhub:${params.slug}@${params.commit}`,
+          requestedSpecifier: `clawhub:${formatClawHubSkillRef(params)}@${params.commit}`,
         },
         rootMarkers: CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS,
       }),
@@ -1114,6 +1194,12 @@ function assertInstallResolutionAllowed(
 ): Extract<ClawHubSkillInstallResolutionResponse, { ok: true }> {
   if (resolution.ok) {
     return resolution;
+  }
+  if (resolution.reason === "ambiguous_slug") {
+    const message = resolution.message ? ` ${resolution.message}` : "";
+    throw new Error(
+      `Skill "${resolution.slug}" is ambiguous on ClawHub. Install an owner-qualified skill, for example: openclaw skills install @owner/${resolution.slug}.${message}`,
+    );
   }
   throw new Error(resolution.message || `Skill "${resolution.slug}" is not installable.`);
 }
@@ -1141,6 +1227,7 @@ async function performClawHubSkillInstall(
       ? await (async () => {
           const resolved = await resolveInstallVersion({
             slug: params.slug,
+            ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
             version: params.version,
             baseUrl: params.baseUrl,
           });
@@ -1149,6 +1236,7 @@ async function performClawHubSkillInstall(
           params.logger?.info?.(`Downloading ${params.slug}@${version} from ClawHub…`);
           return await downloadClawHubSkillArchive({
             slug: params.slug,
+            ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
             version,
             baseUrl: params.baseUrl,
           });
@@ -1157,8 +1245,9 @@ async function performClawHubSkillInstall(
           latestResolution = assertInstallResolutionAllowed(
             await fetchClawHubSkillInstallResolution({
               slug: params.slug,
+              ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
               baseUrl: params.baseUrl,
-              forceInstall: params.forceInstall,
+              ...(params.forceInstall ? { forceInstall: true } : {}),
             }),
           );
           if (latestResolution.installKind === "github") {
@@ -1186,6 +1275,7 @@ async function performClawHubSkillInstall(
             ? await installGitHubResolution({
                 workspaceDir: params.workspaceDir,
                 slug: params.slug,
+                ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
                 sourcePath: latestResolution.github.path,
                 archivePath: archive.archivePath,
                 registry,
@@ -1198,6 +1288,7 @@ async function performClawHubSkillInstall(
             : await installArchiveResolution({
                 workspaceDir: params.workspaceDir,
                 slug: params.slug,
+                ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
                 version,
                 archivePath: archive.archivePath,
                 registry,
@@ -1210,6 +1301,7 @@ async function performClawHubSkillInstall(
         install = await installArchiveResolution({
           workspaceDir: params.workspaceDir,
           slug: params.slug,
+          ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
           version,
           archivePath: archive.archivePath,
           registry,
@@ -1231,6 +1323,7 @@ async function performClawHubSkillInstall(
         readInstalledSkillFileLock(install.targetDir),
         fetchInstallVerificationLock({
           slug: params.slug,
+          ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
           version: verificationVersion,
           baseUrl: params.baseUrl,
         }),
@@ -1242,6 +1335,7 @@ async function performClawHubSkillInstall(
         version: 1,
         registry: resolveClawHubBaseUrl(params.baseUrl),
         slug: params.slug,
+        ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         installedVersion: version,
         installedAt,
         ...(sourceUrl ? { sourceUrl } : {}),
@@ -1253,6 +1347,7 @@ async function performClawHubSkillInstall(
         version,
         installedAt,
         registry: resolveClawHubBaseUrl(params.baseUrl),
+        ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         ...(sourceUrl ? { sourceUrl } : {}),
         artifact,
         ...(skillFile ? { skillFile } : {}),
@@ -1287,9 +1382,11 @@ async function installRequestedSkillFromClawHub(
   params: ClawHubInstallParams,
 ): Promise<InstallClawHubSkillResult> {
   try {
+    const ref = parseRequestedClawHubSkillRef(params.slug);
     return await performClawHubSkillInstall({
       ...params,
-      slug: validateRequestedSkillSlug(params.slug),
+      slug: ref.slug,
+      ...(ref.ownerHandle ? { ownerHandle: ref.ownerHandle } : {}),
     });
   } catch (err) {
     return {
@@ -1330,11 +1427,14 @@ async function resolveTrackedUpdateTarget(params: {
       error: `Skill "${params.slug}" is not tracked as a ClawHub install.`,
     };
   }
+  const lockEntry = params.lock.skills[params.slug];
+  const ownerHandle = origin?.ownerHandle ?? lockEntry?.ownerHandle;
   return {
     ok: true,
     slug: params.slug,
+    ...(ownerHandle ? { ownerHandle } : {}),
     baseUrl: origin?.registry ?? params.baseUrl,
-    previousVersion: origin?.installedVersion ?? params.lock.skills[params.slug]?.version ?? null,
+    previousVersion: origin?.installedVersion ?? lockEntry?.version ?? null,
   };
 }
 
@@ -1387,6 +1487,7 @@ export async function updateSkillsFromClawHub(params: {
     const install = await installTrackedSkillFromClawHub({
       workspaceDir: params.workspaceDir,
       slug: tracked.slug,
+      ...(tracked.ownerHandle ? { ownerHandle: tracked.ownerHandle } : {}),
       baseUrl: tracked.baseUrl,
       force: true,
       forceInstall: params.forceInstall,


### PR DESCRIPTION
## Summary

- Accept owner-qualified ClawHub skill refs such as `@owner/slug` for `openclaw skills install` while preserving legacy slug-only compatibility in the parser and existing git/local source parsing.
- Propagate `ownerHandle` through ClawHub detail, install-resolution, archive download, verification, origin metadata, and workspace lock tracking.
- Keep future update and verify flows scoped to the stored owner namespace, including rejecting owner-qualified update requests that do not match the tracked install.
- Render ambiguous slug responses with actionable `openclaw skills install @owner/slug` guidance and document only the owner-qualified form in install help.

## Proof

CLI help render:

```bash
node --import tsx -e 'import { Command } from "commander"; import { registerSkillsCli } from "./src/cli/skills-cli.ts"; const program = new Command(); registerSkillsCli(program); const skills = program.commands.find((command) => command.name() === "skills"); const install = skills?.commands.find((command) => command.name() === "install"); const output = []; install?.configureOutput({ writeOut: (value) => output.push(value), writeErr: (value) => output.push(value) }); install?.outputHelp(); console.log(output.join(""));'
```

Exit code: 0

```text
Usage:  skills install [options] <skill-ref>

Arguments:
  skill-ref            ClawHub skill ref (@owner/slug), git:<repo>, or local
                       skill directory

Examples:
  openclaw skills install @owner/weather
```

Focused tests:

```bash
node scripts/run-vitest.mjs src/infra/clawhub.test.ts src/skills/lifecycle/clawhub.test.ts src/cli/skills-cli.commands.test.ts
```

Exit code: 0

```text
[test] passed 3 Vitest shards in 7.97s
```

Autoreview closeout before the help-copy-only follow-up:

```bash
.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs src/infra/clawhub.test.ts src/skills/lifecycle/clawhub.test.ts src/cli/skills-cli.commands.test.ts"
```

Exit code: 0

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.84)
tests exit: 0 after 131s
```

Review rerun after the help-copy-only follow-up was intentionally interrupted by maintainer request; its attached focused tests had already passed.

## Review Notes

Autoreview initially caught missing owner propagation in installed-skill verify and owner-qualified update paths; both were fixed before opening this PR and covered by regression tests.
