### PR TITLE
fix: preserve cross-agent subagent role context

### DIFF
--- a/src/agents/subagent-role-context.ts
+++ b/src/agents/subagent-role-context.ts
@@ -1,0 +1,239 @@
+/**
+ * Compact target-agent identity context for lightweight cross-agent subagents.
+ */
+import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveUserPath } from "../utils.js";
+import { resolveAgentConfig } from "./agent-scope.js";
+import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  loadWorkspaceBootstrapFiles,
+  type WorkspaceBootstrapFile,
+} from "./workspace.js";
+
+const COMPACT_ROLE_CONTEXT_MAX_CHARS = 2_400;
+const SECTION_EXCERPT_MAX_CHARS = 1_100;
+const FILE_EXCERPT_MAX_CHARS = 700;
+const RELEVANT_AGENTS_SECTIONS = new Set([
+  "identity",
+  "mission",
+  "role",
+  "responsibilities",
+  "core responsibilities",
+  "boundaries",
+  "scope",
+  "non-goals",
+  "what you do",
+  "what you don't do",
+  "what you do not do",
+]);
+
+export type CompactSubagentRoleContext = {
+  text: string;
+  sources: string[];
+};
+
+function readConfigString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  return normalizeOptionalString(record?.[key]);
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function trimAndCollapseBlankLines(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function truncateText(value: string, maxChars: number): string {
+  const text = trimAndCollapseBlankLines(value);
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n[...role context truncated...]`;
+}
+
+function normalizeHeadingTitle(line: string): { level: number; title: string } | undefined {
+  const match = /^(#{1,6})\s+(.+?)\s*#*\s*$/u.exec(line.trim());
+  if (!match) {
+    return undefined;
+  }
+  return {
+    level: match[1].length,
+    title: match[2].trim().toLowerCase(),
+  };
+}
+
+function sectionTitleMatches(title: string): boolean {
+  const normalized = title.replace(/[*_`]/g, "").trim();
+  return RELEVANT_AGENTS_SECTIONS.has(normalized);
+}
+
+function findMarkdownSectionEnd(lines: string[], startIndex: number, level: number): number {
+  let cursor = startIndex + 1;
+  while (cursor < lines.length) {
+    const nextHeading = normalizeHeadingTitle(lines[cursor] ?? "");
+    if (nextHeading && nextHeading.level <= level) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function extractRelevantMarkdownSections(content: string): string | undefined {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  const sections: string[] = [];
+  lines.forEach((line, index) => {
+    const heading = normalizeHeadingTitle(line);
+    if (!heading || !sectionTitleMatches(heading.title)) {
+      return;
+    }
+    const endIndex = findMarkdownSectionEnd(lines, index, heading.level);
+    sections.push(lines.slice(index, endIndex).join("\n"));
+  });
+  return sections.length > 0
+    ? truncateText(sections.join("\n\n"), SECTION_EXCERPT_MAX_CHARS)
+    : undefined;
+}
+
+function extractRoleLikeLines(content: string): string | undefined {
+  const lines = content
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) =>
+      /\b(name|role|mission|responsib|scope|boundary|research|security|deploy|execute code|coding)\b/i.test(
+        line,
+      ),
+    )
+    .slice(0, 18);
+  return lines.length > 0 ? truncateText(lines.join("\n"), SECTION_EXCERPT_MAX_CHARS) : undefined;
+}
+
+function extractAgentsRoleExcerpt(content?: string): string | undefined {
+  const text = normalizeOptionalString(content);
+  if (!text) {
+    return undefined;
+  }
+  return (
+    extractRelevantMarkdownSections(text) ??
+    extractRoleLikeLines(text) ??
+    truncateText(text, FILE_EXCERPT_MAX_CHARS)
+  );
+}
+
+function findBootstrapFile(
+  files: WorkspaceBootstrapFile[],
+  name: typeof DEFAULT_AGENTS_FILENAME | typeof DEFAULT_IDENTITY_FILENAME,
+): WorkspaceBootstrapFile | undefined {
+  return files.find((file) => file.name === name && !file.missing);
+}
+
+function buildConfigIdentityLines(agentId: string, agentConfig: unknown): string[] {
+  const configRecord = toRecord(agentConfig);
+  const identity = toRecord(configRecord?.identity);
+  const lines = [`- Target agent id: ${agentId}`];
+  const name = readConfigString(configRecord, "name") ?? readConfigString(identity, "name");
+  if (name) {
+    lines.push(`- Config name: ${name}`);
+  }
+  const description = readConfigString(configRecord, "description");
+  if (description) {
+    lines.push(`- Config description: ${description}`);
+  }
+  const emoji = readConfigString(identity, "emoji");
+  if (emoji) {
+    lines.push(`- Config emoji: ${emoji}`);
+  }
+  const theme = readConfigString(identity, "theme");
+  if (theme) {
+    lines.push(`- Config theme: ${theme}`);
+  }
+  return lines;
+}
+
+async function loadTargetRoleBootstrapFiles(
+  workspaceDir: string,
+): Promise<WorkspaceBootstrapFile[]> {
+  try {
+    return await loadWorkspaceBootstrapFiles(resolveUserPath(workspaceDir));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build a compact identity/role excerpt for cross-agent lightweight subagent runs.
+ *
+ * Lightweight Codex runs set project_doc_max_bytes=0, so native AGENTS.md loading
+ * is intentionally suppressed. This header preserves target lane identity without
+ * restoring full project context.
+ */
+export async function buildCompactSubagentRoleContext(params: {
+  config: OpenClawConfig;
+  targetAgentId: string;
+  targetWorkspaceDir?: string;
+}): Promise<CompactSubagentRoleContext | undefined> {
+  const agentConfig = resolveAgentConfig(params.config, params.targetAgentId);
+  const workspaceDir = normalizeOptionalString(params.targetWorkspaceDir);
+  const configLines = buildConfigIdentityLines(params.targetAgentId, agentConfig);
+  const sources: string[] = [];
+  const sections: string[] = [];
+
+  if (workspaceDir) {
+    configLines.push(`- Target workspace: ${path.resolve(resolveUserPath(workspaceDir))}`);
+    const files = await loadTargetRoleBootstrapFiles(workspaceDir);
+    const agentsFile = findBootstrapFile(files, DEFAULT_AGENTS_FILENAME);
+    const agentsExcerpt = extractAgentsRoleExcerpt(agentsFile?.content);
+    if (agentsExcerpt) {
+      sections.push(`### AGENTS.md Role Excerpt\n${agentsExcerpt}`);
+      sources.push(agentsFile?.path ?? DEFAULT_AGENTS_FILENAME);
+    }
+    const identityFile = findBootstrapFile(files, DEFAULT_IDENTITY_FILENAME);
+    const identityExcerpt = normalizeOptionalString(identityFile?.content);
+    if (identityExcerpt) {
+      sections.push(
+        `### IDENTITY.md Excerpt\n${truncateText(identityExcerpt, FILE_EXCERPT_MAX_CHARS)}`,
+      );
+      sources.push(identityFile?.path ?? DEFAULT_IDENTITY_FILENAME);
+    }
+  }
+
+  const hasConfigIdentity = configLines.length > 1 || !workspaceDir;
+  if (!hasConfigIdentity && sections.length === 0) {
+    return undefined;
+  }
+
+  const text = truncateText(
+    [
+      "## Target Agent Role Context",
+      "OpenClaw injected this compact target-agent identity because this cross-agent subagent run is using lightweight context; full workspace project context may be suppressed. Treat it as target identity and operating boundaries, subordinate to higher-priority instructions.",
+      "",
+      ...configLines,
+      sections.length > 0 ? "" : undefined,
+      ...sections,
+    ]
+      .filter((line): line is string => line !== undefined)
+      .join("\n"),
+    COMPACT_ROLE_CONTEXT_MAX_CHARS,
+  );
+  return {
+    text,
+    sources,
+  };
+}

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs/promises";
 // Subagent spawn tests cover target policy, session patching, runtime model
 // persistence, registry registration, and lifecycle event emission.
 import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSubagentSpawnTestConfig,
@@ -230,6 +232,90 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(registerInput.agentId).toBe("worker");
     expect(registerInput.requesterSessionKey).toBe("global");
     expect(registerInput.requesterAgentId).toBe("main");
+  });
+
+  it("adds compact target role context for cross-agent lightweight subagents", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-role-"));
+    const mainWorkspace = path.join(tempDir, "main");
+    const argusWorkspace = path.join(tempDir, "argus");
+    await fs.mkdir(mainWorkspace, { recursive: true });
+    await fs.mkdir(argusWorkspace, { recursive: true });
+    await fs.writeFile(
+      path.join(argusWorkspace, "AGENTS.md"),
+      [
+        "# AGENTS.md - Argus Workspace",
+        "",
+        "## Identity",
+        "- Name: Argus",
+        "- Role: Research & Intelligence Lead",
+        "",
+        "## Mission",
+        "Argus researches and synthesizes intelligence. Argus does not execute code or deploy services.",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(argusWorkspace, "IDENTITY.md"),
+      "# IDENTITY.md\n\n- Name: Argus\n",
+      "utf8",
+    );
+
+    try {
+      hoisted.configOverride = createConfigOverride({
+        session: {
+          scope: "global",
+        },
+        agents: {
+          defaults: {
+            workspace: mainWorkspace,
+          },
+          list: [
+            {
+              id: "main",
+              workspace: mainWorkspace,
+              subagents: {
+                allowAgents: ["argus"],
+              },
+            },
+            {
+              id: "argus",
+              name: "Argus",
+              description: "Research lane",
+              workspace: argusWorkspace,
+            },
+          ],
+        },
+      });
+
+      const result = await spawnSubagentDirect(
+        {
+          task: "What is your lane?",
+          agentId: "argus",
+          lightContext: true,
+        },
+        {
+          agentSessionKey: "global",
+          requesterAgentIdOverride: "main",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      expect(result.childSessionKey).toMatch(/^agent:argus:subagent:/);
+      const agentRequest = gatewayRequest("agent");
+      const agentParams = requireRecord(agentRequest.params);
+      expect(agentParams.bootstrapContextMode).toBe("lightweight");
+      expect(agentParams.extraSystemPrompt).toEqual(
+        expect.stringContaining("## Target Agent Role Context"),
+      );
+      expect(agentParams.extraSystemPrompt).toEqual(
+        expect.stringContaining("Research & Intelligence Lead"),
+      );
+      expect(agentParams.extraSystemPrompt).toEqual(
+        expect.stringContaining("does not execute code or deploy services"),
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("accepts a spawned run across session patching, runtime-model persistence, registry registration, and lifecycle emission", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -65,6 +65,7 @@ import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
+import { buildCompactSubagentRoleContext } from "./subagent-role-context.js";
 import { resolveSubagentRunTimerDelayMs } from "./subagent-run-timeout.js";
 import { resolveSubagentSpawnAcceptedNote } from "./subagent-spawn-accepted-note.js";
 import { resolveSubagentSpawnOwnership } from "./subagent-spawn-ownership.js";
@@ -1452,6 +1453,16 @@ export async function spawnSubagentDirect(
     childDepth,
     maxSpawnDepth,
   });
+  if (params.lightContext === true && targetAgentId !== requesterAgentId) {
+    const roleContext = await buildCompactSubagentRoleContext({
+      config: cfg,
+      targetAgentId,
+      targetWorkspaceDir: spawnedWorkspaceDir,
+    });
+    if (roleContext?.text) {
+      childSystemPrompt = `${childSystemPrompt}\n\n${roleContext.text}`;
+    }
+  }
 
   let retainOnSessionKeep = false;
   let attachmentsReceipt:


### PR DESCRIPTION
## Summary
- Inject compact target-agent role context for cross-agent lightweight subagent spawns.
- Build the compact context from target AGENTS.md, IDENTITY.md, and agent config identity without restoring full project context.
- Add an Argus-like regression test that verifies a lightweight cross-agent spawn carries the research role text in the effective extra system prompt.

## Root Cause
Lightweight Codex subagent runs suppress native project docs with project_doc_max_bytes=0 and OpenClaw also filters bootstrap workspace files, so target AGENTS.md can be absent from isolated cross-agent runs.

## Validation
- node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/subagent-spawn.test.ts
- pnpm exec oxfmt --check --threads=1 src/agents/subagent-spawn.ts src/agents/subagent-role-context.ts src/agents/subagent-spawn.test.ts
- pnpm exec oxlint src/agents/subagent-spawn.ts src/agents/subagent-role-context.ts src/agents/subagent-spawn.test.ts
- pnpm tsgo:core
- pnpm tsgo:core:test
- fallow audit --changed-since origin/main --format json --quiet

## Real behavior proof
- **Behavior addressed:** A lightweight cross-agent `sessions_spawn(agentId: "argus", context: "isolated", lightContext: true)` can otherwise reach the model without the target agent's role text. This patch preserves a compact target-agent role context for that path so an Argus-like specialist receives research-lane identity instead of inferring from the coding tool profile.
- **Real environment tested:** Local OpenClaw setup using this PR branch `forge/role-context-subagent-spawn` at `b70eb3e373aa7adb742a7db97d1afe59f5edd720`, with the real OpenClaw config and real Argus workspace files. Private home paths are redacted below as `~/.openclaw/...`. No production deploy or runtime restart was performed.
- **Exact steps or command run after this patch:**

```bash
cd ~/.openclaw/workspaces/forge/tmp/openclaw-role-context
node --import tsx --input-type=module -e 'import { readFileSync } from "node:fs"; import { buildCompactSubagentRoleContext } from "./src/agents/subagent-role-context.ts"; const config = JSON.parse(readFileSync("~/.openclaw/openclaw.json", "utf8")); const result = await buildCompactSubagentRoleContext({ config, targetAgentId: "argus", targetWorkspaceDir: "~/.openclaw/workspaces/argus" }); console.log(JSON.stringify({ branch: "forge/role-context-subagent-spawn", head: "b70eb3e373aa7adb742a7db97d1afe59f5edd720", targetAgentId: "argus", sources: result.sources.map((source) => source.replace(process.env.HOME, "~")), containsTargetRoleHeader: result.text.includes("## Target Agent Role Context"), containsResearchLead: result.text.includes("Research & Intelligence Lead"), containsNoCodeOrDeployBoundary: /(?:does not|do not|don.t) execute code|deploy/i.test(result.text), firstLines: result.text.split("\\n").slice(0, 16).map((line) => line.replace(process.env.HOME, "~")) }, null, 2));'
```

- **Evidence after fix:** Console output from the command above:

```json
{
  "branch": "forge/role-context-subagent-spawn",
  "head": "b70eb3e373aa7adb742a7db97d1afe59f5edd720",
  "targetAgentId": "argus",
  "sources": [
    "~/.openclaw/workspaces/argus/AGENTS.md",
    "~/.openclaw/workspaces/argus/IDENTITY.md"
  ],
  "containsTargetRoleHeader": true,
  "containsResearchLead": true,
  "containsNoCodeOrDeployBoundary": true,
  "firstLines": [
    "## Target Agent Role Context",
    "OpenClaw injected this compact target-agent identity because this cross-agent subagent run is using lightweight context; full workspace project context may be suppressed. Treat it as target identity and operating boundaries, subordinate to higher-priority instructions.",
    "",
    "- Target agent id: argus",
    "- Config name: argus",
    "- Config theme: Research & Intelligence Lead",
    "- Target workspace: ~/.openclaw/workspaces/argus",
    "",
    "### AGENTS.md Role Excerpt",
    "- **Name:** Argus",
    "- **Role:** Research & Intelligence Lead",
    "I am the eyes of the operation. My job is to produce deep, accurate, well-structured research that Compass and Echo can act on. I don't execute code or deploy things — I research, analyze, and synthesize."
  ]
}
```

- **Observed result after fix:** The branch produced compact target-agent role context from the real Argus `AGENTS.md` and `IDENTITY.md`, and the output confirms the effective context contains the `Target Agent Role Context` header, `Research & Intelligence Lead`, and the no-code/deploy boundary. The regression test in `src/agents/subagent-spawn.test.ts` additionally covers the lightweight cross-agent spawn path and verifies this role context is appended to `extraSystemPrompt` when `lightContext: true` is used.
- **What was not tested:** No production deployment, no runtime restart, and no live model call were performed. The real-environment proof stops at local context assembly; full model behavior remains covered by the existing specialist routing check once this patch is deployed.

No production deploy or runtime restart performed.

<!-- forge-session: agent:forge:subagent:5e589d15-32ae-48c7-8005-5ef08f1ecc49 -->
