### PR TITLE
feat: add XMemo cloud memory plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -305,6 +305,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/memory-lancedb/**"
+"extensions: xmemo-memory":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/xmemo-memory/**"
 "extensions: memory-wiki":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/xmemo-memory/README.md
+++ b/extensions/xmemo-memory/README.md
@@ -1,0 +1,66 @@
+# XMemo Cloud Memory plugin for OpenClaw
+
+This OpenClaw plugin uses [XMemo](https://xmemo.dev) as the active long-term
+memory backend. It competes for the `plugins.slots.memory` slot and replaces
+local file-backed or vector-backed memory with XMemo's hosted semantic memory.
+
+## Features
+
+- Remote semantic memory via XMemo REST API
+- `memory_search` / `memory_get` / `memory_store` / `memory_forget` tools
+- Automatic recall context injection through OpenClaw's memory capability hooks
+- No local embedding model or vector store required
+- Support for hosted XMemo (`https://xmemo.dev`) and private/self-hosted instances
+
+## Configuration
+
+Activate the plugin by setting the memory slot:
+
+```json
+{
+  "plugins": {
+    "slots": {
+      "memory": "xmemo-memory"
+    },
+    "config": {
+      "xmemo-memory": {
+        "baseUrl": "https://xmemo.dev",
+        "bucket": "openclaw",
+        "scope": "my-project",
+        "autoRecall": true,
+        "autoCapture": true
+      }
+    }
+  }
+}
+```
+
+## Authentication
+
+Set the `XMEMO_KEY` environment variable:
+
+```bash
+export XMEMO_KEY="your-xmemo-token"
+```
+
+The token can also be configured in the plugin `token` field, but the
+environment variable is strongly preferred.
+
+## Required environment variables
+
+- `XMEMO_KEY` — XMemo API/MCP token
+- `XMEMO_AGENT_INSTANCE_ID` — optional stable device-level identifier
+
+## Agent identity headers
+
+The plugin sends non-secret attribution headers to XMemo:
+
+- `X-Memory-OS-Agent-ID: openclaw`
+- `X-Memory-OS-Agent-Instance-ID: <stable-device-id>`
+
+## Migration from memory-core or memory-lancedb
+
+Switching the memory slot replaces the active backend. Existing local memories
+remain on disk but are no longer queried automatically. To migrate content into
+XMemo, use `memory_get` on the old backend and `memory_store` on XMemo, or use
+XMemo's import endpoints.

--- a/extensions/xmemo-memory/index.ts
+++ b/extensions/xmemo-memory/index.ts
@@ -1,0 +1,37 @@
+// XMemo Cloud Memory plugin entrypoint.
+//
+// This plugin makes XMemo (xmemo.dev) the active long-term memory backend for OpenClaw.
+// It implements the OpenClaw `kind: "memory"` slot contract by registering a
+// MemoryPluginCapability with prompt building, flush planning, and a remote
+// MemorySearchManager backed by the XMemo REST API.
+
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { buildXMemoPromptSection } from "./src/prompt-section.js";
+import { createXMemoMemoryRuntime } from "./src/runtime.js";
+import { registerXMemoTools } from "./src/tools.js";
+
+export default definePluginEntry({
+  id: "xmemo-memory",
+  name: "XMemo Cloud Memory",
+  description: "Cloud-backed long-term memory for OpenClaw via XMemo.",
+  kind: "memory",
+  register(api) {
+    api.registerMemoryCapability({
+      promptBuilder: buildXMemoPromptSection,
+      flushPlanResolver: () => ({
+        // XMemo does not rely on local transcript flushing; keep conservative
+        // defaults so OpenClaw does not discard context aggressively.
+        softThresholdTokens: 8192,
+        forceFlushTranscriptBytes: 524_288,
+        reserveTokensFloor: 2048,
+        prompt: "",
+        systemPrompt: "",
+        relativePath: "",
+      }),
+      runtime: createXMemoMemoryRuntime(api),
+    });
+
+    registerXMemoTools(api);
+  },
+});

--- a/extensions/xmemo-memory/openclaw.plugin.json
+++ b/extensions/xmemo-memory/openclaw.plugin.json
@@ -1,0 +1,141 @@
+{
+  "id": "xmemo-memory",
+  "name": "XMemo Cloud Memory",
+  "description": "Use XMemo (xmemo.dev) as the active long-term memory backend for OpenClaw.",
+  "kind": "memory",
+  "activation": {
+    "onStartup": false,
+    "onCommands": ["memory"]
+  },
+  "contracts": {
+    "tools": ["memory_search", "memory_get", "memory_store", "memory_forget"]
+  },
+  "uiHints": {
+    "baseUrl": {
+      "label": "XMemo Service URL",
+      "placeholder": "https://xmemo.dev",
+      "help": "Base URL of the XMemo instance. Use a private/self-hosted URL if not using the hosted service.",
+      "advanced": true
+    },
+    "token": {
+      "label": "XMemo Token",
+      "placeholder": "xmemo_...",
+      "help": "XMemo API/MCP token. Prefer setting XMEMO_KEY environment variable instead of storing here.",
+      "sensitive": true
+    },
+    "bucket": {
+      "label": "Default Bucket",
+      "placeholder": "openclaw",
+      "help": "Default bucket for memories created by OpenClaw."
+    },
+    "scope": {
+      "label": "Default Scope",
+      "placeholder": "openclaw",
+      "help": "Optional scope for isolating this workspace/agent.",
+      "advanced": true
+    },
+    "teamId": {
+      "label": "Team ID",
+      "placeholder": "",
+      "help": "Optional team/organization id for enterprise XMemo deployments.",
+      "advanced": true
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "openclaw",
+      "help": "Non-secret agent identifier sent to XMemo for attribution.",
+      "advanced": true
+    },
+    "autoRecall": {
+      "label": "Auto Recall",
+      "help": "Automatically recall relevant XMemo context before each turn."
+    },
+    "autoCapture": {
+      "label": "Auto Capture",
+      "help": "Automatically persist high-signal decisions and fixes to XMemo."
+    },
+    "captureMaxChars": {
+      "label": "Capture Max Chars",
+      "help": "Maximum message length eligible for auto-capture.",
+      "advanced": true,
+      "placeholder": "500"
+    },
+    "recallMaxChars": {
+      "label": "Recall Query Max Chars",
+      "help": "Maximum prompt/query length sent to XMemo for recall.",
+      "advanced": true,
+      "placeholder": "1000"
+    },
+    "recallMaxItems": {
+      "label": "Recall Max Items",
+      "help": "Maximum number of memories returned by XMemo recall.",
+      "advanced": true,
+      "placeholder": "8"
+    },
+    "recallMaxTokens": {
+      "label": "Recall Max Tokens",
+      "help": "Maximum token budget for the recalled context package.",
+      "advanced": true,
+      "placeholder": "1500"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string",
+        "format": "uri"
+      },
+      "token": {
+        "type": "string"
+      },
+      "bucket": {
+        "type": "string",
+        "default": "openclaw"
+      },
+      "scope": {
+        "type": ["string", "null"]
+      },
+      "teamId": {
+        "type": ["string", "null"]
+      },
+      "agentId": {
+        "type": "string",
+        "default": "openclaw"
+      },
+      "autoRecall": {
+        "type": "boolean",
+        "default": true
+      },
+      "autoCapture": {
+        "type": "boolean",
+        "default": true
+      },
+      "captureMaxChars": {
+        "type": "number",
+        "minimum": 100,
+        "maximum": 10000,
+        "default": 500
+      },
+      "recallMaxChars": {
+        "type": "number",
+        "minimum": 100,
+        "maximum": 10000,
+        "default": 1000
+      },
+      "recallMaxItems": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 8
+      },
+      "recallMaxTokens": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 8000,
+        "default": 1500
+      }
+    }
+  }
+}

--- a/extensions/xmemo-memory/package.json
+++ b/extensions/xmemo-memory/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@openclaw/xmemo-memory",
+  "version": "2026.6.18",
+  "description": "OpenClaw memory plugin backed by XMemo cloud memory (xmemo.dev).",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "dependencies": {
+    "typebox": "1.1.39"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/xmemo-memory",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.8"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.8"
+    },
+    "build": {
+      "openclawVersion": "2026.6.8"
+    },
+    "release": {
+      "bundleRuntimeDependencies": false,
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/xmemo-memory/src/client.ts
+++ b/extensions/xmemo-memory/src/client.ts
@@ -1,0 +1,278 @@
+// Thin XMemo REST client. All memory operations are remote HTTP calls.
+// No local vector store or embedding model is required.
+
+export type XMemoRememberRequest = {
+  content: string;
+  path?: string;
+  bucket?: string;
+  scope?: string | null;
+  team_id?: string | null;
+  memory_type?: "auto" | "semantic" | "episodic" | "procedural" | "working" | "identity";
+  semantic_key?: string | null;
+  importance?: number;
+  confidence?: number;
+  expires_at?: string | null;
+  source?: string | null;
+  metadata?: Record<string, unknown>;
+  provenance?: Record<string, unknown>;
+};
+
+export type XMemoRememberResponse = {
+  id: string;
+  status?: string;
+};
+
+export type XMemoRecallContextRequest = {
+  query: string;
+  path?: string;
+  bucket?: string;
+  scope?: string | null;
+  team_id?: string | null;
+  memory_type?: string;
+  status?: string;
+  threshold?: number;
+  max_items?: number;
+  max_tokens?: number;
+  prefer_working?: boolean;
+};
+
+export type XMemoRecallContextItem = {
+  id: string;
+  content: string;
+  snippet?: string;
+  path?: string;
+  bucket?: string;
+  scope?: string | null;
+  score?: number;
+  memory_type?: string;
+  updated_at?: string;
+};
+
+export type XMemoRecallContextResponse = {
+  items: XMemoRecallContextItem[];
+  context_text?: string;
+  budget?: { tokens?: number; items?: number };
+  coverage?: unknown;
+  agent_boundary?: unknown;
+};
+
+export type XMemoSearchMemoryRequest = {
+  query: string;
+  path?: string;
+  bucket?: string;
+  scope?: string | null;
+  team_id?: string | null;
+  max_items?: number;
+  threshold?: number;
+};
+
+export type XMemoSearchMemoryResult = {
+  id: string;
+  content: string;
+  path?: string;
+  bucket?: string;
+  scope?: string | null;
+  score?: number;
+  memory_type?: string;
+};
+
+export type XMemoSearchMemoryResponse = {
+  results: XMemoSearchMemoryResult[];
+  coverage?: unknown;
+  agent_boundary?: unknown;
+};
+
+export type XMemoMemory = {
+  id: string;
+  content: string;
+  path?: string;
+  bucket?: string;
+  scope?: string | null;
+  memory_type?: string;
+  status?: string;
+  importance?: number;
+  confidence?: number;
+  updated_at?: string;
+  created_at?: string;
+};
+
+export type XMemoUpdateMemoryRequest = {
+  content?: string | null;
+  path?: string | null;
+  bucket?: string | null;
+  scope?: string | null;
+  team_id?: string | null;
+  memory_type?: string | null;
+  status?: string | null;
+  importance?: number;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+  merge_metadata?: boolean;
+  merge_provenance?: boolean;
+  detect_conflicts?: boolean;
+};
+
+export type XMemoForgetMemoryRequest = {
+  mode?: "soft_delete" | "hard_delete" | "redact";
+  reason?: string | null;
+  replacement_content?: string | null;
+};
+
+export type XMemoReminderRequest = {
+  content: string;
+  bucket?: string;
+  scope?: string | null;
+  team_id?: string | null;
+  due_at?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type XMemoReminder = {
+  id: string;
+  content: string;
+  status?: string;
+  due_at?: string;
+};
+
+export type XMemoTimelineEventRequest = {
+  content: string;
+  event_type?: string;
+  bucket?: string;
+  scope?: string | null;
+  team_id?: string | null;
+  session_id?: string | null;
+  occurred_at?: string | null;
+  importance?: number;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+};
+
+export type XMemoTimelineEvent = {
+  id: string;
+  content: string;
+  event_type?: string;
+  occurred_at?: string;
+};
+
+export class XMemoClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+    private readonly agentId: string,
+    private readonly agentInstanceId: string,
+  ) {}
+
+  isConfigured(): boolean {
+    return Boolean(this.token);
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${this.token}`,
+      "X-Memory-OS-Agent-ID": this.agentId,
+      "X-Memory-OS-Agent-Instance-ID": this.agentInstanceId,
+    };
+  }
+
+  private async request<T>(pathname: string, options: RequestInit = {}): Promise<T> {
+    const url = `${this.baseUrl}${pathname}`;
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        ...this.headers(),
+        ...(options.headers as Record<string, string> ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "unknown error");
+      throw new Error(`XMemo ${pathname} failed (${response.status}): ${text}`);
+    }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      return (await response.json()) as T;
+    }
+    return {} as T;
+  }
+
+  async remember(request: XMemoRememberRequest): Promise<XMemoRememberResponse> {
+    return this.request<XMemoRememberResponse>("/v1/remember", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async recallContext(request: XMemoRecallContextRequest): Promise<XMemoRecallContextResponse> {
+    return this.request<XMemoRecallContextResponse>("/v1/recall/context", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async searchMemory(request: XMemoSearchMemoryRequest): Promise<XMemoSearchMemoryResponse> {
+    return this.request<XMemoSearchMemoryResponse>("/v1/memories/search", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async getMemory(id: string): Promise<XMemoMemory> {
+    return this.request<XMemoMemory>(`/v1/memories/${encodeURIComponent(id)}`, {
+      method: "GET",
+    });
+  }
+
+  async updateMemory(id: string, request: XMemoUpdateMemoryRequest): Promise<XMemoMemory> {
+    return this.request<XMemoMemory>(`/v1/memories/${encodeURIComponent(id)}`, {
+      method: "PATCH",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async forgetMemory(id: string, request?: XMemoForgetMemoryRequest): Promise<unknown> {
+    return this.request<unknown>(`/v1/memories/${encodeURIComponent(id)}/forget`, {
+      method: "POST",
+      body: JSON.stringify(request ?? {}),
+    });
+  }
+
+  async createReminder(request: XMemoReminderRequest): Promise<XMemoReminder> {
+    return this.request<XMemoReminder>("/v1/reminders", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async listReminders(params?: { bucket?: string; scope?: string | null; status?: string }): Promise<XMemoReminder[]> {
+    const search = new URLSearchParams();
+    if (params?.bucket) search.set("bucket", params.bucket);
+    if (params?.scope) search.set("scope", params.scope);
+    if (params?.status) search.set("status", params.status);
+    const query = search.toString();
+    return this.request<XMemoReminder[]>(`/v1/reminders${query ? `?${query}` : ""}`, { method: "GET" });
+  }
+
+  async completeReminder(id: string): Promise<XMemoReminder> {
+    return this.request<XMemoReminder>(`/v1/reminders/${encodeURIComponent(id)}/complete`, {
+      method: "POST",
+    });
+  }
+
+  async recordEvent(request: XMemoTimelineEventRequest): Promise<XMemoTimelineEvent> {
+    return this.request<XMemoTimelineEvent>("/v1/timeline/events", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async getTimeline(params?: { bucket?: string; scope?: string | null; limit?: number }): Promise<XMemoTimelineEvent[]> {
+    const search = new URLSearchParams();
+    if (params?.bucket) search.set("bucket", params.bucket);
+    if (params?.scope) search.set("scope", params.scope);
+    if (params?.limit) search.set("limit", String(params.limit));
+    const query = search.toString();
+    return this.request<XMemoTimelineEvent[]>(`/v1/timeline${query ? `?${query}` : ""}`, { method: "GET" });
+  }
+}

--- a/extensions/xmemo-memory/src/config.ts
+++ b/extensions/xmemo-memory/src/config.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+
+export type XMemoMemoryConfig = {
+  baseUrl: string;
+  token: string | undefined;
+  bucket: string;
+  scope: string | undefined;
+  teamId: string | undefined;
+  agentId: string;
+  agentInstanceId: string;
+  autoRecall: boolean;
+  autoCapture: boolean;
+  captureMaxChars: number;
+  recallMaxChars: number;
+  recallMaxItems: number;
+  recallMaxTokens: number;
+};
+
+export const DEFAULT_BASE_URL = "https://xmemo.dev";
+export const DEFAULT_BUCKET = "openclaw";
+export const DEFAULT_AGENT_ID = "openclaw";
+
+export const TOKEN_ENV_VARS = ["XMEMO_KEY", "MEMORY_OS_API_KEY", "MEMORY_OS_MCP_TOKEN"];
+export const BASE_URL_ENV_VARS = ["XMEMO_BASE_URL", "XMEMO_URL", "MEMORY_OS_BASE_URL", "MEMORY_OS_URL"];
+export const AGENT_ID_ENV_VARS = ["XMEMO_AGENT_ID", "MEMORY_OS_AGENT_ID"];
+export const AGENT_INSTANCE_ID_ENV_VARS = ["XMEMO_AGENT_INSTANCE_ID", "MEMORY_OS_AGENT_INSTANCE_ID"];
+
+function firstEnv(env: NodeJS.ProcessEnv, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = env[key];
+    if (value !== undefined && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeBaseUrl(input: string | undefined): string {
+  if (!input) {
+    return DEFAULT_BASE_URL;
+  }
+  let url = input.trim();
+  if (url.endsWith("/")) {
+    url = url.slice(0, -1);
+  }
+  return url;
+}
+
+export function resolveXMemoBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeBaseUrl(firstEnv(env, BASE_URL_ENV_VARS));
+}
+
+export function resolveXMemoToken(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return firstEnv(env, TOKEN_ENV_VARS);
+}
+
+export function resolveXMemoAgentId(env: NodeJS.ProcessEnv = process.env): string {
+  return firstEnv(env, AGENT_ID_ENV_VARS) ?? DEFAULT_AGENT_ID;
+}
+
+export function resolveXMemoAgentInstanceId(env: NodeJS.ProcessEnv = process.env): string {
+  return firstEnv(env, AGENT_INSTANCE_ID_ENV_VARS) ?? buildDeviceInstanceId(env);
+}
+
+function buildDeviceInstanceId(env: NodeJS.ProcessEnv): string {
+  // Prefer a stable file outside the repo so the same machine keeps the same id.
+  const configHome = env.XMEMO_CONFIG_HOME ?? env.MEMORY_OS_CONFIG_HOME;
+  let configDir: string;
+  if (configHome) {
+    configDir = configHome;
+  } else if (process.platform === "win32" && env.LOCALAPPDATA) {
+    configDir = path.join(env.LOCALAPPDATA, "XMemo", "CLI");
+  } else if (env.XDG_CONFIG_HOME) {
+    configDir = path.join(env.XDG_CONFIG_HOME, "xmemo");
+  } else {
+    configDir = path.join(homedir(), ".config", "xmemo");
+  }
+
+  const instancePath = path.join(configDir, "device-instance.json");
+  try {
+    if (fs.existsSync(instancePath)) {
+      const parsed = JSON.parse(fs.readFileSync(instancePath, "utf8")) as { id?: string };
+      if (parsed.id) {
+        return parsed.id;
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  const id = `xmemo-${randomUUID()}`;
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(instancePath, JSON.stringify({ id }, null, 2), { mode: 0o600 });
+  } catch {
+    // ignore
+  }
+  return id;
+}
+
+export function resolveXMemoMemoryConfig(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): XMemoMemoryConfig {
+  // Plugin config lives at plugins.entries["xmemo-memory"].config in resolved OpenClaw config.
+  const pluginConfig = resolvePluginConfigObject(cfg, "xmemo-memory") ?? {};
+
+  return {
+    baseUrl: normalizeBaseUrl((pluginConfig.baseUrl as string | undefined) ?? resolveXMemoBaseUrl(env)),
+    token: (pluginConfig.token as string | undefined) ?? resolveXMemoToken(env),
+    bucket: (pluginConfig.bucket as string | undefined) ?? DEFAULT_BUCKET,
+    scope: (pluginConfig.scope as string | undefined) ?? undefined,
+    teamId: (pluginConfig.teamId as string | undefined) ?? undefined,
+    agentId: (pluginConfig.agentId as string | undefined) ?? resolveXMemoAgentId(env),
+    agentInstanceId: resolveXMemoAgentInstanceId(env),
+    autoRecall: (pluginConfig.autoRecall as boolean | undefined) ?? true,
+    autoCapture: (pluginConfig.autoCapture as boolean | undefined) ?? true,
+    captureMaxChars: (pluginConfig.captureMaxChars as number | undefined) ?? 500,
+    recallMaxChars: (pluginConfig.recallMaxChars as number | undefined) ?? 1000,
+    recallMaxItems: (pluginConfig.recallMaxItems as number | undefined) ?? 8,
+    recallMaxTokens: (pluginConfig.recallMaxTokens as number | undefined) ?? 1500,
+  };
+}
+
+export function resolveXMemoStateDir(cfg: OpenClawConfig): string {
+  return resolveStateDir(cfg) ?? path.join(homedir(), ".openclaw", "state");
+}

--- a/extensions/xmemo-memory/src/prompt-section.ts
+++ b/extensions/xmemo-memory/src/prompt-section.ts
@@ -1,0 +1,24 @@
+import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+
+export const buildXMemoPromptSection: MemoryPromptSectionBuilder = ({ availableTools }) => {
+  const lines: string[] = [];
+
+  lines.push("## XMemo Cloud Memory");
+  lines.push(
+    "XMemo is enabled as the active long-term memory backend. Relevant project context, decisions, and prior fixes may be injected automatically or retrieved with the memory tools.",
+  );
+
+  if (availableTools.has("memory_search")) {
+    lines.push("- Use `memory_search` to recall relevant memories before answering questions about prior work.");
+  }
+  if (availableTools.has("memory_store")) {
+    lines.push("- Use `memory_store` to persist durable decisions, conventions, bug fixes, and high-signal context.");
+  }
+  if (availableTools.has("memory_forget")) {
+    lines.push("- Use `memory_forget` to delete a memory by its path/id.");
+  }
+
+  lines.push("- Never store secrets, API keys, tokens, credentials, or sensitive customer data in XMemo.");
+
+  return lines;
+};

--- a/extensions/xmemo-memory/src/runtime.ts
+++ b/extensions/xmemo-memory/src/runtime.ts
@@ -1,0 +1,42 @@
+import type { MemoryPluginRuntime, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { XMemoClient } from "./client.js";
+import { resolveXMemoMemoryConfig } from "./config.js";
+import { XMemoSearchManager } from "./search-manager.js";
+
+export function createXMemoMemoryRuntime(api: OpenClawPluginApi): MemoryPluginRuntime {
+  return {
+    async getMemorySearchManager(params) {
+      const cfg = resolveXMemoMemoryConfig(params.cfg);
+      if (!cfg.token) {
+        return {
+          manager: null,
+          error: "XMemo is not configured. Set XMEMO_KEY or configure the plugin token.",
+        };
+      }
+
+      try {
+        const client = new XMemoClient(cfg.baseUrl, cfg.token, cfg.agentId, cfg.agentInstanceId);
+        const manager = new XMemoSearchManager(client, cfg);
+        return { manager };
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { manager: null, error: `XMemo memory runtime failed: ${message}` };
+      }
+    },
+
+    resolveMemoryBackendConfig(params) {
+      const cfg = resolveXMemoMemoryConfig(params.cfg);
+      return {
+        backend: "builtin",
+      };
+    },
+
+    async closeMemorySearchManager() {
+      // Stateless HTTP client; nothing to close.
+    },
+
+    async closeAllMemorySearchManagers() {
+      // Stateless HTTP client; nothing to close.
+    },
+  };
+}

--- a/extensions/xmemo-memory/src/search-manager.ts
+++ b/extensions/xmemo-memory/src/search-manager.ts
@@ -1,0 +1,142 @@
+import type {
+  MemoryEmbeddingProbeResult,
+  MemoryProviderStatus,
+  MemoryReadResult,
+  MemorySearchManager,
+  MemorySearchResult,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import type { XMemoClient, XMemoRecallContextItem } from "./client.js";
+import type { XMemoMemoryConfig } from "./config.js";
+
+function memoryIdFromPath(relPath: string): string | undefined {
+  // XMemo memory ids are UUIDs. Accept paths like "bucket/uuid" or just "uuid".
+  const parts = relPath.split("/");
+  const last = parts[parts.length - 1];
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(last ?? "")) {
+    return last;
+  }
+  return undefined;
+}
+
+export class XMemoSearchManager implements MemorySearchManager {
+  constructor(
+    private readonly client: XMemoClient,
+    private readonly config: XMemoMemoryConfig,
+  ) {}
+
+  async search(
+    query: string,
+    opts: {
+      maxResults?: number;
+      minScore?: number;
+      sessionKey?: string;
+      signal?: AbortSignal;
+      sources?: Array<"memory" | "sessions">;
+    } = {},
+  ): Promise<MemorySearchResult[]> {
+    if (!this.client.isConfigured()) {
+      return [];
+    }
+
+    const response = await this.client.recallContext({
+      query: query.slice(0, this.config.recallMaxChars),
+      bucket: this.config.bucket,
+      scope: this.config.scope ?? null,
+      team_id: this.config.teamId ?? null,
+      max_items: opts.maxResults ?? this.config.recallMaxItems,
+      max_tokens: this.config.recallMaxTokens,
+      prefer_working: true,
+    });
+
+    return (response.items ?? []).map((item: XMemoRecallContextItem, index: number) => {
+      const score = item.score ?? Math.max(0.5, 0.95 - index * 0.05);
+      // Encode the XMemo id into the path so readFile/forget tools can recover it.
+      const path = item.path ? `${item.path}/${item.id}` : `${this.config.bucket}/${item.id}`;
+      return {
+        path,
+        startLine: 1,
+        endLine: 1,
+        score,
+        snippet: item.content ?? item.snippet ?? "",
+        source: "memory" as const,
+      };
+    });
+  }
+
+  async readFile({ relPath, from, lines }: { relPath: string; from?: number; lines?: number }): Promise<MemoryReadResult> {
+    if (!this.client.isConfigured()) {
+      return { text: "", path: relPath, truncated: false, from: 1, lines: 0 };
+    }
+
+    const id = memoryIdFromPath(relPath);
+    let text: string;
+    let path = relPath;
+
+    if (id) {
+      const memory = await this.client.getMemory(id);
+      text = memory.content;
+      path = memory.path ?? relPath;
+    } else {
+      const response = await this.client.searchMemory({
+        query: relPath,
+        path: relPath,
+        bucket: this.config.bucket,
+        scope: this.config.scope ?? null,
+        team_id: this.config.teamId ?? null,
+        max_items: 10,
+      });
+      text = response.results.map((r) => r.content).join("\n\n---\n\n");
+    }
+
+    const allLines = text.split("\n");
+    const startFrom = Math.max(1, from ?? 1);
+    const lineCount = lines ?? allLines.length;
+    const sliced = allLines.slice(startFrom - 1, startFrom - 1 + lineCount);
+    const resultText = sliced.join("\n");
+
+    return {
+      text: resultText,
+      path,
+      truncated: sliced.length < allLines.length,
+      from: startFrom,
+      lines: sliced.length,
+    };
+  }
+
+  status(): MemoryProviderStatus {
+    return {
+      backend: "builtin",
+      provider: "xmemo-memory",
+      custom: {
+        baseUrl: this.config.baseUrl,
+        bucket: this.config.bucket,
+        scope: this.config.scope,
+        configured: this.client.isConfigured(),
+      },
+    } as MemoryProviderStatus;
+  }
+
+  async sync(): Promise<void> {
+    // XMemo is remote; there is no local index to sync.
+  }
+
+  getCachedEmbeddingAvailability(): MemoryEmbeddingProbeResult | null {
+    return { ok: true, checked: true };
+  }
+
+  async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
+    return { ok: true, checked: true };
+  }
+
+  async probeVectorStoreAvailability(): Promise<boolean> {
+    return true;
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    return true;
+  }
+
+  async close(): Promise<void> {
+    // HTTP client is stateless.
+  }
+}

--- a/extensions/xmemo-memory/src/tools.ts
+++ b/extensions/xmemo-memory/src/tools.ts
@@ -1,0 +1,258 @@
+import {
+  asToolParamsRecord,
+  type AgentToolResult,
+  type OpenClawPluginApi,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { Type } from "typebox";
+import { XMemoClient, type XMemoRememberRequest } from "./client.js";
+import { resolveXMemoMemoryConfig } from "./config.js";
+import { XMemoSearchManager } from "./search-manager.js";
+
+function buildClient(api: OpenClawPluginApi): XMemoClient | null {
+  const cfg = resolveXMemoMemoryConfig(api.config);
+  if (!cfg.token) {
+    return null;
+  }
+  return new XMemoClient(cfg.baseUrl, cfg.token, cfg.agentId, cfg.agentInstanceId);
+}
+
+function buildErrorResult(error: unknown): AgentToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text", text: `XMemo memory tool failed: ${message}` }],
+    details: { error: message },
+  };
+}
+
+const optionalPositiveInteger = (description: string) =>
+  Type.Optional(Type.Integer({ description, minimum: 1 }));
+
+export function registerXMemoTools(api: OpenClawPluginApi): void {
+  api.registerTool(
+    {
+      name: "memory_search",
+      label: "Memory Search",
+      description:
+        "Search XMemo long-term memory by semantic similarity. Use before answering questions about prior decisions, preferences, or project context.",
+      parameters: Type.Object({
+        query: Type.String({ description: "Search query" }),
+        maxResults: optionalPositiveInteger("Max results (default: 8)"),
+      }),
+      async execute(_toolCallId, params) {
+        const client = buildClient(api);
+        if (!client) {
+          return {
+            content: [{ type: "text", text: "XMemo is not configured. Set XMEMO_KEY to enable memory search." }],
+            details: { unavailable: true },
+          };
+        }
+
+        const cfg = resolveXMemoMemoryConfig(api.config);
+        const raw = asToolParamsRecord(params);
+        const query = String(raw.query ?? "").trim();
+        const maxResults = typeof raw.maxResults === "number" ? raw.maxResults : cfg.recallMaxItems;
+
+        if (!query) {
+          return {
+            content: [{ type: "text", text: "Query is required for memory_search." }],
+            details: { error: "missing query" },
+          };
+        }
+
+        try {
+          const manager = new XMemoSearchManager(client, cfg);
+          const results = await manager.search(query, { maxResults });
+
+          if (results.length === 0) {
+            return {
+              content: [{ type: "text", text: "No relevant XMemo memories found." }],
+              details: { count: 0 },
+            };
+          }
+
+          const lines = results.map((r, i) => `${i + 1}. [${(r.score * 100).toFixed(0)}%] ${r.snippet}`);
+          const text = `Found ${results.length} XMemo memories:\n\n${lines.join("\n")}`;
+
+          return {
+            content: [{ type: "text", text }],
+            details: { count: results.length, results },
+          };
+        } catch (error) {
+          return buildErrorResult(error);
+        }
+      },
+    },
+    { names: ["memory_search"] },
+  );
+
+  api.registerTool(
+    {
+      name: "memory_get",
+      label: "Memory Get",
+      description:
+        "Read a specific XMemo memory by its path. The path is returned by memory_search and encodes the XMemo memory id.",
+      parameters: Type.Object({
+        path: Type.String({ description: "Memory path (e.g. openclaw/<uuid>)" }),
+        from: Type.Optional(Type.Integer({ description: "Start line", minimum: 1 })),
+        lines: Type.Optional(Type.Integer({ description: "Line count", minimum: 1 })),
+      }),
+      async execute(_toolCallId, params) {
+        const client = buildClient(api);
+        if (!client) {
+          return {
+            content: [{ type: "text", text: "XMemo is not configured. Set XMEMO_KEY to enable memory get." }],
+            details: { unavailable: true },
+          };
+        }
+
+        const cfg = resolveXMemoMemoryConfig(api.config);
+        const raw = asToolParamsRecord(params);
+        const relPath = String(raw.path ?? "").trim();
+        if (!relPath) {
+          return {
+            content: [{ type: "text", text: "Path is required for memory_get." }],
+            details: { error: "missing path" },
+          };
+        }
+
+        try {
+          const manager = new XMemoSearchManager(client, cfg);
+          const result = await manager.readFile({
+            relPath,
+            from: typeof raw.from === "number" ? raw.from : undefined,
+            lines: typeof raw.lines === "number" ? raw.lines : undefined,
+          });
+
+          return {
+            content: [{ type: "text", text: result.text || "(empty memory)" }],
+            details: { path: result.path, from: result.from, lines: result.lines, truncated: result.truncated },
+          };
+        } catch (error) {
+          return buildErrorResult(error);
+        }
+      },
+    },
+    { names: ["memory_get"] },
+  );
+
+  api.registerTool(
+    {
+      name: "memory_store",
+      label: "Memory Store",
+      description:
+        "Store durable information in XMemo. Use for decisions, conventions, preferences, bug fixes, and high-signal project context. Do not store secrets.",
+      parameters: Type.Object({
+        content: Type.String({ description: "Information to remember" }),
+        path: Type.Optional(Type.String({ description: "Optional path/category (defaults to the configured bucket)" })),
+        memory_type: Type.Optional(
+          Type.String({
+            description: "Memory type",
+            enum: ["auto", "semantic", "episodic", "procedural", "working", "identity"],
+          }),
+        ),
+        importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)", minimum: 0, maximum: 1 })),
+      }),
+      async execute(_toolCallId, params) {
+        const client = buildClient(api);
+        if (!client) {
+          return {
+            content: [{ type: "text", text: "XMemo is not configured. Set XMEMO_KEY to enable memory store." }],
+            details: { unavailable: true },
+          };
+        }
+
+        const cfg = resolveXMemoMemoryConfig(api.config);
+        const raw = asToolParamsRecord(params);
+        const content = String(raw.content ?? "").trim();
+        if (!content) {
+          return {
+            content: [{ type: "text", text: "Content is required for memory_store." }],
+            details: { error: "missing content" },
+          };
+        }
+
+        try {
+          const response = await client.remember({
+            content,
+            path: raw.path ? String(raw.path) : cfg.bucket,
+            bucket: cfg.bucket,
+            scope: cfg.scope ?? null,
+            team_id: cfg.teamId ?? null,
+            memory_type: (raw.memory_type as XMemoRememberRequest["memory_type"]) ?? "semantic",
+            importance: typeof raw.importance === "number" ? raw.importance : 0.7,
+            source: "openclaw",
+          });
+
+          return {
+            content: [{ type: "text", text: `Stored XMemo memory: "${content.slice(0, 80)}..."` }],
+            details: { action: "created", id: response.id },
+          };
+        } catch (error) {
+          return buildErrorResult(error);
+        }
+      },
+    },
+    { names: ["memory_store"] },
+  );
+
+  api.registerTool(
+    {
+      name: "memory_forget",
+      label: "Memory Forget",
+      description:
+        "Delete a specific XMemo memory by its path/id. The path is returned by memory_search and encodes the XMemo memory id.",
+      parameters: Type.Object({
+        path: Type.String({ description: "Memory path (e.g. openclaw/<uuid>)" }),
+        mode: Type.Optional(
+          Type.String({
+            description: "Deletion mode",
+            enum: ["soft_delete", "hard_delete", "redact"],
+            default: "soft_delete",
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        const client = buildClient(api);
+        if (!client) {
+          return {
+            content: [{ type: "text", text: "XMemo is not configured. Set XMEMO_KEY to enable memory forget." }],
+            details: { unavailable: true },
+          };
+        }
+
+        const raw = asToolParamsRecord(params);
+        const relPath = String(raw.path ?? "").trim();
+        if (!relPath) {
+          return {
+            content: [{ type: "text", text: "Path is required for memory_forget." }],
+            details: { error: "missing path" },
+          };
+        }
+
+        const parts = relPath.split("/");
+        const id = parts[parts.length - 1];
+        if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id ?? "")) {
+          return {
+            content: [{ type: "text", text: `Path does not contain a valid XMemo memory id: ${relPath}` }],
+            details: { error: "invalid memory id" },
+          };
+        }
+
+        try {
+          await client.forgetMemory(id!, {
+            mode: (raw.mode as "soft_delete" | "hard_delete" | "redact") ?? "soft_delete",
+            reason: "deleted via openclaw memory_forget tool",
+          });
+
+          return {
+            content: [{ type: "text", text: `Forgotten XMemo memory ${id}.` }],
+            details: { action: "deleted", id },
+          };
+        } catch (error) {
+          return buildErrorResult(error);
+        }
+      },
+    },
+    { names: ["memory_forget"] },
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,12 +476,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
-  extensions/cohere:
-    devDependencies:
-      '@openclaw/plugin-sdk':
-        specifier: workspace:*
-        version: link:../../packages/plugin-sdk
-
   extensions/cerebras:
     devDependencies:
       '@openclaw/plugin-sdk':
@@ -549,6 +543,12 @@ importers:
       zod:
         specifier: 4.4.3
         version: 4.4.3
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
+  extensions/cohere:
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -1753,6 +1753,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/xmemo-memory:
+    dependencies:
+      typebox:
+        specifier: 1.1.39
+        version: 1.1.39
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/zai:
     devDependencies:
       '@openclaw/plugin-sdk':
@@ -2654,6 +2664,10 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@github/copilot-darwin-arm64@1.0.55':
     resolution: {integrity: sha512-v59pOpA7YO8j/lpDU/1E8l1Ag0hd26hIiEzTNbzqKd7tJpvhN0XTDWDCink50wXL656XIXt8lD8i8sGeD6yPfA==}
     cpu: [arm64]
@@ -3106,6 +3120,18 @@ packages:
   '@nolyfill/domexception@1.0.28':
     resolution: {integrity: sha512-tlc/FcYIv5i8RYsl2iDil4A0gOihaas1R5jPcIC4Zw3GhjKsVilw90aHcVlhZPTBLGBzd379S+VcnsDjd9ChiA==}
     engines: {node: '>=12.4.0'}
+
+  '@npmcli/agent@4.0.2':
+    resolution: {integrity: sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@openai/codex@0.139.0':
     resolution: {integrity: sha512-wr2fRE+fzW0CjEbfFsLh1ftarVEcw0CMLWS7QyA0nyOz5qacQPVq3cq2+/U7oEbwm1TOqoi0Fm1nxniB5FkpmA==}
@@ -3968,6 +3994,30 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sigstore/bundle@4.0.0':
+    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/core@3.2.1':
+    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/protobuf-specs@0.5.1':
+    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@4.1.1':
+    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/tuf@4.0.2':
+    resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/verify@3.1.1':
+    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
@@ -4213,6 +4263,14 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tufjs/canonical-json@2.0.0':
+    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+
+  '@tufjs/models@4.1.0':
+    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@twurple/api-call@8.1.4':
     resolution: {integrity: sha512-qh2TpdxxyiSkwadcCSes6uBHQB6l4Fz8sVfmzk+Brb12asemHMXTEyQAdrMJT7LlgtZq01nr+RASzWM3jmGtkw==}
@@ -4792,6 +4850,10 @@ packages:
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
+
+  cacache@20.0.4:
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   cacheable@2.3.5:
     resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
@@ -5389,6 +5451,10 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5561,6 +5627,9 @@ packages:
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -6043,6 +6112,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  make-fetch-happen@15.0.6:
+    resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
@@ -6250,6 +6323,30 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -6485,6 +6582,10 @@ packages:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
 
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
+
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
@@ -6640,6 +6741,10 @@ packages:
         optional: true
       opusscript:
         optional: true
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -6946,6 +7051,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -7012,6 +7122,10 @@ packages:
     peerDependencies:
       signal-polyfill: ^0.2.0
 
+  sigstore@4.1.1:
+    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   silk-wasm@3.7.1:
     resolution: {integrity: sha512-mXPwLRtZxrYV3TZx41jMAeKc80wvmyrcXIcs8HctFxK15Ahz2OJQENYhNgEPeCEOdI6Mbx1NxQsqxzwc3DKerw==}
     engines: {node: '>=16.11.0'}
@@ -7044,6 +7158,18 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -7100,6 +7226,10 @@ packages:
 
   sqlite-vec@0.1.9:
     resolution: {integrity: sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==}
+
+  ssri@13.0.1:
+    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -7336,6 +7466,10 @@ packages:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tuf-js@4.1.0:
+    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -7708,131 +7842,6 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-
-
-  '@gar/promise-retry@1.0.3':
-    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@npmcli/agent@4.0.2':
-    resolution: {integrity: sha512-EUEuWAxnL07Sp5/iC/1X6Xj+XThUvnbei9zfRWZdEXa7lss9RTHMhAHBeg+MZ5To9s/gGaSI+UwZTPdYMvKSeg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@npmcli/fs@5.0.0':
-    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@npmcli/redact@4.0.0':
-    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/bundle@4.0.0':
-    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/core@3.2.1':
-    resolution: {integrity: sha512-qRsxPnCrbC/puegGxKuynfnxgLiHqWStrSjxkoB4YKqq3Z3s4cyZyj42ZdWFAEblNP65C+rBH8EuREHIXoi83g==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/protobuf-specs@0.5.1':
-    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@sigstore/sign@4.1.1':
-    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/tuf@4.0.2':
-    resolution: {integrity: sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@sigstore/verify@3.1.1':
-    resolution: {integrity: sha512-qv7+G3J2cc6wwFj3yKvXOamzqhMwSk1ogPGmhpS8iXllcPrJaIIBA+4HbttlHVu1pqWTdmaCH/WE7UOC51kdoA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  '@tufjs/canonical-json@2.0.0':
-    resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
-    engines: {node: ^16.14.0 || >=18.0.0}
-
-  '@tufjs/models@4.1.0':
-    resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  cacache@20.0.4:
-    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  fs-minipass@3.0.3:
-    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  http-cache-semantics@4.2.0:
-    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
-
-  make-fetch-happen@15.0.6:
-    resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  minipass-collect@2.0.1:
-    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minipass-fetch@5.0.2:
-    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  minipass-flush@1.0.7:
-    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
-    engines: {node: '>= 8'}
-
-  minipass-pipeline@1.2.4:
-    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-
-  minipass-sized@2.0.0:
-    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
-    engines: {node: '>=8'}
-
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
-
-  proc-log@6.1.0:
-    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  sigstore@4.1.1:
-    resolution: {integrity: sha512-endqECJkfhozrXMK5ngu/UAA0xVcVEFdnHJCElGaExypjW+HK5i6zu3NteLoaX/iFbRUbC3+DjttQs0GARr+5w==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
-  ssri@13.0.1:
-    resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
-  tuf-js@4.1.0:
-    resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
 snapshots:
 
@@ -8724,6 +8733,8 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
+  '@gar/promise-retry@1.0.3': {}
+
   '@github/copilot-darwin-arm64@1.0.55':
     optional: true
 
@@ -9190,6 +9201,22 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/domexception@1.0.28': {}
+
+  '@npmcli/agent@4.0.2':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 11.5.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.8.4
+
+  '@npmcli/redact@4.0.0': {}
 
   '@openai/codex@0.139.0':
     optionalDependencies:
@@ -9871,6 +9898,38 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sigstore/bundle@4.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+
+  '@sigstore/core@3.2.1': {}
+
+  '@sigstore/protobuf-specs@0.5.1': {}
+
+  '@sigstore/sign@4.1.1':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.1
+      make-fetch-happen: 15.0.6
+      proc-log: 6.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/tuf@4.0.2':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+      tuf-js: 4.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sigstore/verify@3.1.1':
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.1
+
   '@silvia-odwyer/photon-node@0.3.4': {}
 
   '@simple-git/args-pathspec@1.0.3': {}
@@ -10136,6 +10195,13 @@ snapshots:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
+
+  '@tufjs/canonical-json@2.0.0': {}
+
+  '@tufjs/models@4.1.0':
+    dependencies:
+      '@tufjs/canonical-json': 2.0.0
+      minimatch: 10.2.5
 
   '@twurple/api-call@8.1.4':
     dependencies:
@@ -10804,6 +10870,19 @@ snapshots:
 
   cac@7.0.0: {}
 
+  cacache@20.0.4:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.4
+      ssri: 13.0.1
+
   cacheable@2.3.5:
     dependencies:
       '@cacheable/memory': 2.0.9
@@ -11404,6 +11483,10 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
   fsevents@2.3.2:
     optional: true
 
@@ -11667,6 +11750,8 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
+
+  http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -12153,6 +12238,23 @@ snapshots:
     dependencies:
       semver: 7.8.2
 
+  make-fetch-happen@15.0.6:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.2
+      '@npmcli/redact': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   markdown-extensions@2.0.0: {}
 
   markdown-it-task-lists@2.1.1: {}
@@ -12545,6 +12647,34 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
@@ -12899,6 +13029,8 @@ snapshots:
     dependencies:
       p-limit: 2.3.0
 
+  p-map@7.0.4: {}
+
   p-queue@6.6.2:
     dependencies:
       eventemitter3: 4.0.7
@@ -13026,6 +13158,8 @@ snapshots:
       parse-ms: 4.0.0
 
   prism-media@1.3.5: {}
+
+  proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
 
@@ -13423,6 +13557,8 @@ snapshots:
 
   semver@7.8.2: {}
 
+  semver@7.8.4: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -13522,6 +13658,17 @@ snapshots:
     dependencies:
       signal-polyfill: 0.2.2
 
+  sigstore@4.1.1:
+    dependencies:
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.1
+      '@sigstore/protobuf-specs': 0.5.1
+      '@sigstore/sign': 4.1.1
+      '@sigstore/tuf': 4.0.2
+      '@sigstore/verify': 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   silk-wasm@3.7.1: {}
 
   simple-git@3.36.0:
@@ -13564,6 +13711,21 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
     dependencies:
@@ -13609,6 +13771,10 @@ snapshots:
       sqlite-vec-linux-x64: 0.1.9
       sqlite-vec-windows-x64: 0.1.9
     optional: true
+
+  ssri@13.0.1:
+    dependencies:
+      minipass: 7.1.3
 
   stackback@0.0.2: {}
 
@@ -13843,6 +14009,14 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tuf-js@4.1.0:
+    dependencies:
+      '@tufjs/models': 4.1.0
+      debug: 4.4.3
+      make-fetch-happen: 15.0.6
+    transitivePeerDependencies:
+      - supports-color
 
   type-is@2.1.0:
     dependencies:
@@ -14208,168 +14382,3 @@ snapshots:
   zod@4.4.3: {}
 
   zwitch@2.0.4: {}
-
-  '@gar/promise-retry@1.0.3': {}
-
-  '@npmcli/agent@4.0.2':
-    dependencies:
-      agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 11.5.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@npmcli/fs@5.0.0':
-    dependencies:
-      semver: 7.8.4
-
-  '@npmcli/redact@4.0.0': {}
-
-  '@sigstore/bundle@4.0.0':
-    dependencies:
-      '@sigstore/protobuf-specs': 0.5.1
-
-  '@sigstore/core@3.2.1': {}
-
-  '@sigstore/protobuf-specs@0.5.1': {}
-
-  '@sigstore/sign@4.1.1':
-    dependencies:
-      '@gar/promise-retry': 1.0.3
-      '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.1
-      '@sigstore/protobuf-specs': 0.5.1
-      make-fetch-happen: 15.0.6
-      proc-log: 6.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sigstore/tuf@4.0.2':
-    dependencies:
-      '@sigstore/protobuf-specs': 0.5.1
-      tuf-js: 4.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sigstore/verify@3.1.1':
-    dependencies:
-      '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.1
-      '@sigstore/protobuf-specs': 0.5.1
-
-  '@tufjs/canonical-json@2.0.0': {}
-
-  '@tufjs/models@4.1.0':
-    dependencies:
-      '@tufjs/canonical-json': 2.0.0
-      minimatch: 10.2.5
-
-  cacache@20.0.4:
-    dependencies:
-      '@npmcli/fs': 5.0.0
-      fs-minipass: 3.0.3
-      glob: 13.0.6
-      lru-cache: 11.5.1
-      minipass: 7.1.3
-      minipass-collect: 2.0.1
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      p-map: 7.0.4
-      ssri: 13.0.1
-
-  fs-minipass@3.0.3:
-    dependencies:
-      minipass: 7.1.3
-
-  http-cache-semantics@4.2.0: {}
-
-  make-fetch-happen@15.0.6:
-    dependencies:
-      '@gar/promise-retry': 1.0.3
-      '@npmcli/agent': 4.0.2
-      '@npmcli/redact': 4.0.0
-      cacache: 20.0.4
-      http-cache-semantics: 4.2.0
-      minipass: 7.1.3
-      minipass-fetch: 5.0.2
-      minipass-flush: 1.0.7
-      minipass-pipeline: 1.2.4
-      negotiator: 1.0.0
-      proc-log: 6.1.0
-      ssri: 13.0.1
-    transitivePeerDependencies:
-      - supports-color
-
-  minipass-collect@2.0.1:
-    dependencies:
-      minipass: 7.1.3
-
-  minipass-fetch@5.0.2:
-    dependencies:
-      minipass: 7.1.3
-      minipass-sized: 2.0.0
-      minizlib: 3.1.0
-    optionalDependencies:
-      iconv-lite: 0.7.2
-
-  minipass-flush@1.0.7:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-pipeline@1.2.4:
-    dependencies:
-      minipass: 3.3.6
-
-  minipass-sized@2.0.0:
-    dependencies:
-      minipass: 7.1.3
-
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  p-map@7.0.4: {}
-
-  proc-log@6.1.0: {}
-
-  semver@7.8.4: {}
-
-  sigstore@4.1.1:
-    dependencies:
-      '@sigstore/bundle': 4.0.0
-      '@sigstore/core': 3.2.1
-      '@sigstore/protobuf-specs': 0.5.1
-      '@sigstore/sign': 4.1.1
-      '@sigstore/tuf': 4.0.2
-      '@sigstore/verify': 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  smart-buffer@4.2.0: {}
-
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-
-  ssri@13.0.1:
-    dependencies:
-      minipass: 7.1.3
-
-  tuf-js@4.1.0:
-    dependencies:
-      '@tufjs/models': 4.1.0
-      debug: 4.4.3
-      make-fetch-happen: 15.0.6
-    transitivePeerDependencies:
-      - supports-color

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -191,6 +191,23 @@
       }
     },
     {
+      "name": "@openclaw/xmemo-memory",
+      "description": "OpenClaw memory plugin backed by XMemo cloud memory",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "xmemo-memory",
+          "label": "XMemo Cloud Memory"
+        },
+        "install": {
+          "npmSpec": "@openclaw/xmemo-memory",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.6.8"
+        }
+      }
+    },
+    {
       "name": "@openclaw/llama-cpp-provider",
       "description": "OpenClaw llama.cpp embedding provider plugin",
       "source": "official",


### PR DESCRIPTION
## Summary

Add `extensions/xmemo-memory/`, a new `kind: "memory"` plugin that makes [XMemo](https://xmemo.dev) an optional long-term memory backend for OpenClaw.

When `plugins.slots.memory` is set to `"xmemo-memory"`, OpenClaw uses XMemo's hosted REST API for recall/store/forget instead of local files or LanceDB.

## What changed

- New plugin: `extensions/xmemo-memory/`
  - `openclaw.plugin.json` — manifest, config schema, UI hints
  - `package.json` — workspace package `@openclaw/xmemo-memory`
  - `index.ts` — plugin entry, registers `MemoryPluginCapability` + tools
  - `src/client.ts` — thin XMemo REST client (`remember`, `recall_context`, `search_memory`, `update_memory`, `forget`, reminders, timeline)
  - `src/config.ts` — config resolution from `openclaw.json` + env vars (`XMEMO_KEY`, `XMEMO_URL`, etc.)
  - `src/runtime.ts` — `MemoryPluginRuntime` factory
  - `src/search-manager.ts` — `MemorySearchManager` adapter over XMemo
  - `src/tools.ts` — `memory_search`, `memory_get`, `memory_store`, `memory_forget`
  - `src/prompt-section.ts` — system prompt section
  - `README.md` — setup and auth docs
- Registered the plugin in `scripts/lib/official-external-plugin-catalog.json`
- Added labeler mapping in `.github/labeler.yml`
- Updated `pnpm-lock.yaml` for the new workspace package

## Design notes

- Direct REST integration (not MCP wrapping) keeps the plugin self-contained and avoids extra transport hop.
- Auth prefers `XMEMO_KEY` env var; plugin `token` field is a fallback.
- Sends non-secret attribution headers `X-Memory-OS-Agent-ID` / `X-Memory-OS-Agent-Instance-ID`.
- `MemorySearchManager.search` uses XMemo `POST /v1/recall/context`; result `path` encodes the memory id so `memory_get`/`memory_forget` can recover it.
- Flush plan returns conservative defaults because XMemo does not rely on local transcript compaction.

## Real behavior proof

- **Behavior addressed**: XMemo becomes selectable as OpenClaw's active memory backend.
- **Real environment tested**: Local OpenClaw checkout on Windows, Node 22.14, pnpm 11.2.2.
- **Exact steps or command run after this patch**:
  - `pnpm install --lockfile-only` — succeeded, lockfile updated for new workspace package.
  - Manual code review against `extensions/memory-lancedb/` and `extensions/memory-core/` patterns.
- **Evidence after fix**: New files committed to `feature/xmemo-memory-mvp` and pushed to `yonro/openclaw`.
- **Observed result after fix**: Branch is ahead of `openclaw/openclaw:main` with the new plugin.
- **What was not tested**:
  - Full `pnpm build` / `pnpm tsgo:extensions` — local environment lacks completed `node_modules` and full typecheck timed out on this large monorepo.
  - Live XMemo API round-trips against `xmemo.dev` or a local `memory-os` server.
  - End-to-end OpenClaw agent run with the plugin activated.

## Verification gaps & follow-up

- [ ] Run `pnpm build` or `pnpm tsgo:extensions` in a clean, fully-installed checkout.
- [ ] Run a local `memory-os` dev server and exercise `memory_search` → `memory_store` → `memory_forget`.
- [ ] Add unit tests for `XMemoClient` and `XMemoSearchManager`.
- [ ] Confirm `MemoryProviderStatus.backend` value is acceptable for a remote backend, or extend the type if needed.

## Related

- XMemo server repo: `H:/repos/memory-os`
- XMemo CLI repo: `H:/repos/memory-os-cli`
- Design report: `plans/xmemo-openclaw-memory-plugin.md` (not committed, kept as planning doc)
