### PR TITLE
fix(memory): refresh stale index handles after cli reindex

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -14,6 +14,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import "./test-runtime-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
 import { closeAllMemorySearchManagers, getMemorySearchManager } from "./index.js";
+import { moveMemoryIndexFiles, removeMemoryIndexFiles } from "./manager-atomic-reindex.js";
 import { splitSourceWideEmbeddingChunks } from "./manager-embedding-ops.js";
 import { LOCAL_EMBEDDING_WORKER_ERROR_CODES } from "./manager-local-worker-errors.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
@@ -972,7 +973,53 @@ describe("memory index", () => {
     }
   });
 
-  it("rebuilds missing metadata with existing chunks before search", async () => {
+  it("reopens a stale live handle after CLI reindex swaps the store", async () => {
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
+    const dbPath = path.join(workspaceDir, "index-cli-repair-refresh.sqlite");
+    const repairedDbPath = path.join(workspaceDir, "index-cli-repair-refresh-rebuilt.sqlite");
+    const ftsOnlyCfg = createCfg({
+      storePath: dbPath,
+      provider: "none",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const ftsOnlyManager = await getFreshManager(ftsOnlyCfg);
+    await ftsOnlyManager.sync({ reason: "test", force: true });
+    await ftsOnlyManager.close?.();
+
+    const geminiCfg = createCfg({
+      storePath: dbPath,
+      provider: "gemini",
+      model: "gemini-embedding-001",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const liveManager = await getFreshManager(geminiCfg);
+    managersForCleanup.add(liveManager);
+    expect(liveManager.status().custom?.indexIdentity).toEqual({
+      status: "mismatched",
+      reason: "index was built for model fts-only, expected gemini-embedding-001",
+    });
+
+    const repairCfg = createCfg({
+      storePath: repairedDbPath,
+      provider: "gemini",
+      model: "gemini-embedding-001",
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const cliManager = await getFreshManager(repairCfg, "cli");
+    await cliManager.sync({ reason: "cli", force: true });
+    await cliManager.close?.();
+    await removeMemoryIndexFiles(dbPath);
+    await moveMemoryIndexFiles(repairedDbPath, dbPath);
+
+    const status = liveManager.status();
+    expect(status.provider).toBe("gemini");
+    expect(status.model).toBe("gemini-embedding-001");
+    expect(status.custom?.indexIdentity).toEqual({ status: "valid" });
+    const results = await liveManager.search("alpha");
+    expect(results[0]?.path).toContain("memory/2026-01-12.md");
+  });
+
+  it("rebuilds missing metadata with existing chunks on gateway sync", async () => {
     const dbPath = path.join(workspaceDir, "index-missing-meta-cutover.sqlite");
     const cfg = createCfg({
       storePath: dbPath,

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -141,6 +141,13 @@ type MemoryReindexRetryState = {
   sessionDeltas: Map<string, MemorySessionDeltaState>;
 };
 
+type MemoryDatabaseFileIdentity = {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+};
+
 const META_KEY = "memory_index_meta_v1";
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
@@ -303,6 +310,7 @@ export abstract class MemoryManagerSyncOps {
   protected vectorDegradedWriteWarningShown = false;
   protected embeddingCacheMirrorDb: DatabaseSync | null = null;
   private lastMetaSerialized: string | null = null;
+  private dbFileIdentity: MemoryDatabaseFileIdentity | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
   protected abstract db: DatabaseSync;
@@ -685,7 +693,68 @@ export abstract class MemoryManagerSyncOps {
 
   protected openDatabase(): DatabaseSync {
     const dbPath = resolveUserPath(this.settings.store.path);
-    return openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
+    const db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
+    this.dbFileIdentity = this.readDatabaseFileIdentity(dbPath);
+    return db;
+  }
+
+  private readDatabaseFileIdentity(dbPath: string): MemoryDatabaseFileIdentity | null {
+    try {
+      const stat = fsSync.statSync(dbPath);
+      return {
+        dev: stat.dev,
+        ino: stat.ino,
+        size: stat.size,
+        mtimeMs: stat.mtimeMs,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private databaseFileIdentityChanged(
+    current: MemoryDatabaseFileIdentity,
+    opened: MemoryDatabaseFileIdentity,
+  ): boolean {
+    return (
+      current.dev !== opened.dev ||
+      current.ino !== opened.ino ||
+      current.size !== opened.size ||
+      current.mtimeMs !== opened.mtimeMs
+    );
+  }
+
+  protected reopenDatabaseIfStoreFileChanged(): boolean {
+    const dbPath = resolveUserPath(this.settings.store.path);
+    const currentIdentity = this.readDatabaseFileIdentity(dbPath);
+    // CLI/status reindex publishes by atomic SQLite file replacement. A live
+    // Gateway manager can hold the old inode, so invalid identity checks must
+    // reopen before surfacing stale metadata to memory_search.
+    if (
+      !currentIdentity ||
+      !this.dbFileIdentity ||
+      !this.databaseFileIdentityChanged(currentIdentity, this.dbFileIdentity)
+    ) {
+      return false;
+    }
+
+    const oldDb = this.db;
+    const nextDb = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled, false);
+    this.db = nextDb;
+    this.dbFileIdentity = currentIdentity;
+    this.lastMetaSerialized = null;
+    this.resetVectorState();
+    this.fts.available = false;
+    this.fts.loadError = undefined;
+    this.ensureSchema();
+    const meta = this.readMeta();
+    this.vector.dims = meta?.vectorDims;
+    try {
+      closeMemoryDatabase(oldDb);
+    } catch (err) {
+      log.warn(`failed to close replaced memory database handle: ${formatErrorMessage(err)}`);
+    }
+    return true;
   }
 
   private async seedEmbeddingCache(sourceDb: DatabaseSync): Promise<void> {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -570,7 +570,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     }
   }
 
-  private refreshIndexIdentityDirty(params?: { providerKeyKnown?: boolean }) {
+  private refreshIndexIdentityDirty(params?: {
+    providerKeyKnown?: boolean;
+  }): MemoryIndexIdentityState {
     const provider =
       this.settings.provider === "none"
         ? null
@@ -583,6 +585,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       ...(provider !== undefined ? { provider } : {}),
       providerKeyKnown: params?.providerKeyKnown,
     });
+    if (state.status !== "valid" && this.reopenDatabaseIfStoreFileChanged()) {
+      return this.refreshIndexIdentityDirty(params);
+    }
     this.indexIdentityState = state;
     this.indexIdentityDirty =
       state.status === "mismatched" ||


### PR DESCRIPTION
Summary:
- Refresh a live memory-core manager's SQLite handle when an invalid index identity may be stale after an atomic CLI/status reindex swapped the store file.
- Preserve the existing hot-path behavior by only checking file identity after metadata is already missing or mismatched.
- Add a regression that builds an fts-only index, keeps a Gemini live manager open, replaces the store with a repaired Gemini index, then verifies the original manager sees valid metadata and can search again.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: live `memory_search` can keep reading stale `fts-only` index metadata from an old SQLite handle after `openclaw memory status --index` / CLI repair rebuilds the on-disk index for `gemini-embedding-001`.
- Real environment tested: rebased OpenClaw checkout on `klaw/openclaw-memory-search-stale-index-metadata`, using the actual local OpenClaw memory stores for CLI status and the memory-core runtime regression for the stale open-handle path.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts`
  - `pnpm openclaw memory status --index`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts
[test] starting test/vitest/vitest.extension-memory.config.ts

 Test Files  1 passed (1)
      Tests  52 passed (52)
   Start at  22:58:23
   Duration  8.29s (transform 4.72s, setup 501ms, import 5.37s, tests 2.33s, environment 0ms)

[test] passed 1 Vitest shard in 14.53s

$ pnpm openclaw memory status --index
Memory index complete.
Memory Search (main)
Provider: gemini (requested: gemini)
Model: gemini-embedding-001
Sources: memory
Indexed: 39/39 files · 1540 chunks
Dirty: no
Store: ~/.openclaw/memory/main.sqlite
Workspace: ~/.openclaw/workspace
Embeddings: ready
Vector store: ready
Semantic vectors: ready
Vector dims: 3072
FTS: ready

Memory index complete.
Memory Search (codex-worker)
Provider: gemini (requested: gemini)
Model: gemini-embedding-001
Sources: memory
Indexed: 39/39 files · 1540 chunks
Dirty: no
Store: ~/.openclaw/memory/codex-worker.sqlite
Workspace: ~/.openclaw/workspace
Embeddings: ready
Vector store: ready
Semantic vectors: ready
Vector dims: 3072
FTS: ready
```

- Observed result after fix: the regression keeps a live manager open on stale `fts-only` metadata, externally replaces the store with a Gemini-built index, then `status()` reports `{ status: "valid" }` and `search("alpha")` returns the expected memory result. The real CLI status command also reports the current `main` and `codex-worker` stores as clean Gemini indexes with semantic vectors and FTS ready.
- What was not tested: I did not hot-patch Khalil's already-running Telegram/Gateway process with this unmerged branch; if that process has the old code loaded, it still needs the normal deploy/restart path to pick up this fix.
- Proof limitations or environment constraints: local CLI status ran from the PR checkout and reported healthy real stores; the exact long-lived Gateway `memory_search` tool behavior is covered by the regression because the live process cannot load an unmerged PR without deployment.

Tests and validation:
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/index.test.ts`
- `git diff --check`
- `pnpm openclaw memory status --index`

Known gaps:
- `.agents/skills/autoreview/scripts/autoreview --mode local` could not run because the codex reviewer executable is not installed in this worker environment.
- The already-running production/local Gateway process must load this merged code before its `memory_search` tool can benefit from the stale-handle reopen path.
