### PR TITLE
fix #86957: drain worker-spooled Telegram updates immediately

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -903,6 +903,79 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("drains worker-spooled updates without waiting for the next drain interval", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const handleUpdate = vi.fn(async () => {
+      abort.abort();
+    });
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    let onMessage: WorkerMessageListener | undefined;
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const ackSpooledUpdate = vi.fn();
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn((listener: WorkerMessageListener) => {
+        onMessage = listener;
+        return () => undefined;
+      }),
+      ackSpooledUpdate,
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 60_000,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(onMessage).toBeDefined());
+      onMessage?.({
+        type: "update",
+        requestId: "write-1",
+        update: { update_id: 42, message: { text: "hello" } },
+        queued: 1,
+      });
+
+      await vi.waitFor(() =>
+        expect(ackSpooledUpdate).toHaveBeenCalledWith("write-1", { ok: true, updateId: 42 }),
+      );
+      onMessage?.({ type: "spooled", updateId: 42, queued: 1 });
+      await vi.waitFor(() =>
+        expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } }),
+      );
+      await vi.waitFor(async () => expect(await pendingUpdateIds(tempDir, "all")).toEqual([]));
+      stopWorker?.();
+      await runPromise;
+    } finally {
+      abort.abort();
+      stopWorker?.();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("drains existing isolated ingress spool entries below the persisted offset", async () => {
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -1000,6 +1000,7 @@ export class TelegramPollingSession {
       forceCycleResolve = resolve;
     });
     const stalledBacklogKeys = new Set<string>();
+    let requestImmediateDrain: () => void = () => undefined;
     const unsubscribe = worker.onMessage((message) => {
       const ackSpooledUpdate = (
         requestId: string,
@@ -1053,6 +1054,7 @@ export class TelegramPollingSession {
         }).then(
           (updateId) => {
             ackSpooledUpdate(message.requestId, { ok: true, updateId });
+            requestImmediateDrain();
           },
           (err: unknown) => {
             ackSpooledUpdate(message.requestId, {
@@ -1065,6 +1067,7 @@ export class TelegramPollingSession {
       }
       if (message.type === "spooled") {
         liveness.noteGetUpdatesActivity();
+        requestImmediateDrain();
       }
     });
     const stopOnAbort = () => {
@@ -1152,6 +1155,9 @@ export class TelegramPollingSession {
       } finally {
         drainActive = false;
       }
+    };
+    requestImmediateDrain = () => {
+      void drainOnce();
     };
     await drainOnce();
     const drainTimer = setInterval(() => {


### PR DESCRIPTION
## Summary
- Wake the Telegram isolated polling drain immediately after a worker-spooled update is written to `channel_ingress_events`.
- Keep the existing durable queue, claim, completion, and interval-drain behavior unchanged.
- Add a regression test covering worker-spooled inbound delivery without waiting for the next drain interval.

## Issue
Fixes #86957.

## Root Cause
- **Root cause:** The root source of this state lifecycle bug is that the isolated Telegram ingress worker asks the main polling session to write inbound updates into `channel_ingress_events`, but the main session only drained that spool at cycle start and on the periodic drain timer. Because the worker-write lifecycle did not wake the queue drain, a subsequent worker-spooled inbound update could remain `pending` with `attempts = 0`, `claim_owner = null`, and no delivery queue entry until a later timer-driven drain.
- **Why this is root-cause fix:** The missing invariant was that a successful worker write must wake the production drain path that claims, dispatches, and completes the queued update. This patch requests a drain immediately after the main session persists a worker update, and again when the worker reports the update as spooled; the existing `drainActive`, abort, restart, claim, and completion guards still own ordering and concurrency.
- **Fix classification:** Minimal root-cause fix in the Telegram isolated ingress dispatcher wakeup path.
- **Maintainer-ready confidence:** High. The diff is limited to `extensions/telegram/src/polling-session.ts` and a focused regression in `extensions/telegram/src/polling-session.test.ts`; it does not change queue schema, channel policy, outbound Telegram behavior, access control, provider routing, or token handling.

## Why it matters / User impact
Issue #86957 reports Telegram inbound routing wedging after a successful first Telegram turn: outbound Telegram still works, polling still starts, and the next inbound row reaches `channel_ingress_events`, but it stays pending/unclaimed with no delivery queue entry.

## Verification
- The fix adds `requestImmediateDrain()` calls in the `update` and `spooled` message handlers of the isolated ingress cycle, and wires `requestImmediateDrain` to `drainOnce()` before the initial drain.
- A regression test with `drainIntervalMs: 60_000` verifies that a worker-spooled update is drained and handled without waiting 60s.
- Existing CI test suite covers the unchanged queue schema, claim, completion, restart, and concurrency guards.

## Patch quality notes
Minimal surgical fix: 6 lines of production code changed, 73 lines of focused regression test. No schema, config, or behavior changes outside the drain wakeup path.