### PR TITLE
fix: dedupe duplicate non-streaming final replies

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1509,3 +1509,21 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads[0]?.text).toBe("hello world!");
   });
 });
+
+// #84623 premise: when block streaming is disabled, a single turn can resolve
+// two byte-identical finals (e.g. a provider that resends full content on
+// text_end). The assembly does NOT collapse them, so the per-turn dedupe owner
+// is the shared dispatcher (see dispatch-from-config.reply-dispatch.test.ts),
+// not buildReplyPayloads.
+describe("buildReplyPayloads non-streaming identical-final premise (#84623)", () => {
+  it("keeps both identical media finals for a provider-resend shape", async () => {
+    const dup = { text: "generated image", mediaUrl: "https://example.com/gen.png" };
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: false,
+      payloads: [{ ...dup }, { ...dup }],
+    });
+
+    expect(replyPayloads).toHaveLength(2);
+  });
+});

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearAgentHarnesses } from "../../agents/harness/registry.js";
 import type { PluginHookReplyDispatchResult } from "../../plugins/hooks.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
 import {
   acpManagerRuntimeMocks,
   acpMocks,
@@ -301,6 +302,116 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(sessionStoreMocks.currentEntry?.pendingFinalDelivery).toBe(true);
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryText).toBe("durable reply");
     expect(sessionStoreMocks.currentEntry?.pendingFinalDeliveryCreatedAt).toBe(1);
+  });
+
+  it("deduplicates identical final replies while preserving distinct finals", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const dispatcher = createDispatcher();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => [
+        { text: "generated image", mediaUrl: "file:///tmp/generated.png" },
+        { text: "generated image", mediaUrl: "file:///tmp/generated.png" },
+        { text: "follow-up note" },
+      ],
+    });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
+    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(1, {
+      text: "generated image",
+      mediaUrl: "file:///tmp/generated.png",
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(2, {
+      text: "follow-up note",
+    });
+  });
+
+  it("keeps final replies with different delivery presentation", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const dispatcher = createDispatcher();
+
+    await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => [
+        { text: "audio", mediaUrl: "file:///tmp/audio.ogg", audioAsVoice: true },
+        { text: "audio", mediaUrl: "file:///tmp/audio.ogg", audioAsVoice: false },
+      ],
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps final replies with different reply threading explicitness", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const dispatcher = createDispatcher();
+    const explicitReply = setReplyPayloadMetadata(
+      { text: "threaded", replyToId: "message-1" },
+      { replyToIdExplicit: true },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => [{ text: "threaded", replyToId: "message-1" }, explicitReply],
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps final replies with different reply threading flags", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const dispatcher = createDispatcher();
+
+    await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => [
+        { text: "threaded", replyToCurrent: true },
+        { text: "threaded", replyToCurrent: false },
+      ],
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps final replies with different transcript mirror identities", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    const dispatcher = createDispatcher();
+    const firstMirror = setReplyPayloadMetadata(
+      { text: "mirrored source reply" },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:test:session",
+          idempotencyKey: "source-reply:first",
+        },
+      },
+    );
+    const secondMirror = setReplyPayloadMetadata(
+      { text: "mirrored source reply" },
+      {
+        sourceReplyTranscriptMirror: {
+          sessionKey: "agent:test:session",
+          idempotencyKey: "source-reply:second",
+        },
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => [firstMirror, secondMirror],
+    });
+
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
   });
 
   it("delivers a generated final reply before queued follow-up admission", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -203,6 +203,33 @@ function isDispatchReplyOperationAbortedError(
   return error instanceof DispatchReplyOperationAbortedError;
 }
 
+function createFinalReplyDispatchKey(payload: ReplyPayload): string {
+  const reply = resolveSendableOutboundReplyParts(payload);
+  const metadata = getReplyPayloadMetadata(payload);
+  return JSON.stringify({
+    text: reply.trimmedText,
+    mediaList: reply.mediaUrls,
+    trustedLocalMedia: payload.trustedLocalMedia === true,
+    sensitiveMedia: payload.sensitiveMedia === true,
+    presentation: payload.presentation ?? null,
+    delivery: payload.delivery ?? null,
+    interactive: payload.interactive ?? null,
+    btwQuestion: payload.btw?.question ?? null,
+    replyToId: payload.replyToId ?? null,
+    replyToTag: payload.replyToTag === true,
+    replyToCurrent: payload.replyToCurrent === true,
+    metadata: metadata ?? null,
+    audioAsVoice: payload.audioAsVoice === true,
+    spokenText: payload.spokenText ?? null,
+    ttsSupplement: payload.ttsSupplement ?? null,
+    isError: payload.isError === true,
+    isCompactionNotice: payload.isCompactionNotice === true,
+    isFallbackNotice: payload.isFallbackNotice === true,
+    isStatusNotice: isReplyPayloadStatusNotice(payload),
+    channelData: payload.channelData ?? null,
+  });
+}
+
 function composeAbortSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
   const activeSignals: AbortSignal[] = [];
   for (const signal of signals) {
@@ -3261,6 +3288,7 @@ export async function dispatchReplyFromConfig(
     let routedFinalCount = 0;
     let attemptedFinalDelivery = false;
     let finalDeliveryFailed = false;
+    const deliveredFinalPayloadKeys = new Set<string>();
     // Explicit command turns (native or authorized text-slash like /compact) are
     // user-initiated, so a marked terminal reply for the command bypasses
     // room_event suppression. Ambient marked notices (no CommandTurn) stay
@@ -3296,6 +3324,11 @@ export async function dispatchReplyFromConfig(
         }
         continue;
       }
+      const finalPayloadKey = createFinalReplyDispatchKey(reply);
+      if (deliveredFinalPayloadKeys.has(finalPayloadKey)) {
+        continue;
+      }
+      deliveredFinalPayloadKeys.add(finalPayloadKey);
       attemptedFinalDelivery = true;
       const finalReply = await sendFinalPayload(reply, { deliveryId: String(replyIndex) });
       queuedFinal = finalReply.queuedFinal || queuedFinal;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -203,6 +203,14 @@ function isDispatchReplyOperationAbortedError(
   return error instanceof DispatchReplyOperationAbortedError;
 }
 
+// Identity for collapsing byte-identical final payloads within one turn (#84623):
+// a non-streaming resolution can carry the same final twice (e.g. a provider
+// resends full content on text_end while block streaming is disabled), and each
+// copy would otherwise be delivered — re-uploading media — once per entry. The
+// key spans every delivery-visible field plus the internal identity that keeps
+// same-text finals intentionally distinct (threading explicitness, reply policy
+// /route, transcript-mirror identity, assistant message index). Too broad drops
+// a legitimately distinct final; too narrow fails to dedupe the real duplicate.
 function createFinalReplyDispatchKey(payload: ReplyPayload): string {
   const reply = resolveSendableOutboundReplyParts(payload);
   const metadata = getReplyPayloadMetadata(payload);
@@ -218,7 +226,12 @@ function createFinalReplyDispatchKey(payload: ReplyPayload): string {
     replyToId: payload.replyToId ?? null,
     replyToTag: payload.replyToTag === true,
     replyToCurrent: payload.replyToCurrent === true,
-    metadata: metadata ?? null,
+    assistantMessageIndex: metadata?.assistantMessageIndex ?? null,
+    assistantTranscriptOwned: metadata?.assistantTranscriptOwned === true,
+    replyToIdExplicit: metadata?.replyToIdExplicit === true,
+    replyDelivery: metadata?.replyDelivery ?? null,
+    replyDeliverySource: metadata?.replyDeliverySource ?? null,
+    sourceReplyTranscriptMirror: metadata?.sourceReplyTranscriptMirror ?? null,
     audioAsVoice: payload.audioAsVoice === true,
     spokenText: payload.spokenText ?? null,
     ttsSupplement: payload.ttsSupplement ?? null,
@@ -3324,6 +3337,9 @@ export async function dispatchReplyFromConfig(
         }
         continue;
       }
+      // Skip a final already delivered in this turn so duplicate resolver
+      // entries ship (and upload media) once. Runs after suppression so a
+      // suppressed copy never seeds the key set and blocks a later real send.
       const finalPayloadKey = createFinalReplyDispatchKey(reply);
       if (deliveredFinalPayloadKeys.has(finalPayloadKey)) {
         continue;


### PR DESCRIPTION
## Summary

- Fixes duplicate final reply delivery when non-streaming `dispatchReplyFromConfig` resolves identical final payload entries for one turn (#84623).
- Adds a per-turn final-dispatch dedupe key + `Set` guard so an exact duplicate final ships (and uploads its media) once, at the shared dispatcher choke point that every channel and resolver flows through.
- Hardens the dedupe key to a deterministic, explicit identity: it spans every delivery-visible field plus the internal identity that keeps same-text finals intentionally distinct (threading explicitness, reply policy/route, transcript-mirror identity, assistant message index). It no longer serializes the whole metadata object (whose merged key order was non-deterministic) and no longer keys on internal-only flags that should not split visibly-identical finals.
- Preserves intentional distinct final replies when visible content matches but delivery presentation, reply threading metadata, or transcript-mirror identity differs.
- Leaves message-tool dedupe, direct-block dedupe, block streaming, and channel-specific delivery code unchanged.

## Root cause

With `disableBlockStreaming: true`, the non-streaming resolution returned by `getReplyFromConfig` can carry the **same final payload twice** for a single agent turn (e.g. a provider that resends full content on `text_end` while block streaming is off). `dispatchReplyFromConfig` then iterates the final list and calls `sendFinalReply` once per entry, awaiting each send — which matches the reporter's "~1.1 s apart, second right after the first completes" symptom and the WeChat plugin uploading the same image twice.

The existing payload dedupe (`reply-payloads-dedupe.ts`) only dedupes assistant payloads against **message-tool sends** on the same route; it does not collapse two identical entries within the same final list. The shared dispatcher is the single choke point all final deliveries pass through (a custom `replyResolver` bypasses `buildReplyPayloads` entirely but still flows through the dispatch loop), and ClawSweeper triage identified it as the desired repair point, so the per-turn dedupe lives there.

## Linked context

Closes #84623

Was this requested by a maintainer or owner? No direct maintainer request. Narrow fix for an open P2 issue with ClawSweeper source-level triage.

## Real behavior proof

- Behavior addressed: non-streaming `dispatchReplyFromConfig` delivered an identical final reply payload twice for one turn; media was uploaded/sent twice.
- Real environment tested: local OpenClaw source checkout on WSL2/Linux, Node 24. Proof spans three real paths — (1) a **live agent turn** on a real provider, (2) the **real non-streaming assembly** (`buildReplyPayloads`), and (3) the **real dispatcher** (`dispatchReplyFromConfig`). Live WeChat/openclaw-weixin credentials were not available and are not needed: the fix is at the channel-agnostic dispatcher and the duplicate-collapse is observable from the dispatcher's delivery count.
- Exact steps or command run after this patch:
  - Live turn: `pnpm openclaw agent --local --json --session-key repro84623 --message "Reply with exactly: real deepseek turn ok"`
  - Assembly premise: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts`
  - Dispatcher fix: `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`

- Evidence after fix: copied live output / console output captured from a real OpenClaw setup (a live `pnpm openclaw agent` turn) plus before/after console output from the production dispatcher.

  1. Live agent turn — copied live console output from a real run of `pnpm openclaw agent --local` (real provider `deepseek/deepseek-v4-pro`, embedded runner; exercises the real non-streaming pipeline with the patched dispatcher in the hot path):

  ```
  $ pnpm openclaw agent --local --json --session-key repro84623 \
      --message "Reply with exactly: real deepseek turn ok"
  "finalAssistantVisibleText": "real deepseek turn ok"
  "winnerProvider": "deepseek"   "winnerModel": "deepseek-v4-pro"
  "runner": "embedded"   "result": "success"   "stopReason": "stop"
  ```

  2. Real assembly premise — with block streaming disabled, two byte-identical finals (provider-resend shape) survive the real `buildReplyPayloads` unchanged, so the assembly is not the right dedupe owner:

  ```
  buildReplyPayloads non-streaming identical-final premise (#84623)
    ✓ keeps both identical media finals for a provider-resend shape   (replyPayloads.length === 2)
  ```

  3. Real dispatcher fix (before/after on production `dispatchReplyFromConfig`) — temporarily neutralizing the `deliveredFinalPayloadKeys.has(...)` guard reproduces the bug, restoring it fixes it:

  ```
  guard removed: AssertionError: expected "vi.fn()" to be called 2 times, but got 3 times
                 ([image, image, follow-up] -> sendFinalReply x3, duplicate delivered)
  guard present: 12 passed -> sendFinalReply called exactly 2 times
                 (image once + distinct follow-up once)
  ```

- Observed result after fix: the duplicated identical final is delivered exactly once; distinct finals (different text/media, audio-as-voice presentation, reply-threading explicitness/flags, or transcript-mirror identity) are still delivered separately.
- What was not tested: live WeChat/openclaw-weixin delivery and live media upload against the specific provider that resends content on `text_end` (no local credentials for that channel/provider); local DeepSeek does not exhibit the resend quirk, so the duplicate is reproduced through the real assembly + dispatcher data path rather than a live WeChat turn.

## Tests and validation

- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts` (12 passed)
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts` (66 passed — includes the new non-streaming identical-final premise test)
- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.test.ts` (92 passed)
- Before/after proof: temporarily neutralizing the `deliveredFinalPayloadKeys.has(...)` guard makes the dedupe regression test fail (3 calls); restoring it returns 2 calls.
- `./node_modules/.bin/oxfmt --check --threads=1 src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts`
- `git diff --check`

Regression coverage:

- Duplicate identical final payload entries are delivered once.
- Distinct final payloads still deliver when text/media differ.
- Same visible content still delivers separately when `audioAsVoice`, reply threading explicitness/flags, or transcript-mirror identity differs.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: final reply delivery could suppress a legitimate repeated reply if the dedupe identity were too broad.

Mitigation: the key includes delivery-visible payload fields plus the internal identity (threading explicitness, reply policy/route, transcript-mirror identity, assistant message index) that makes two same-text finals intentionally distinct; regression tests cover the same-content finals that must remain distinct. The key was also made deterministic so logically-equal metadata cannot hash differently and skip a real duplicate.

## Notes

AI-assisted. Proof above was run manually on a local checkout.
