### PR TITLE
fix(health-monitor): always stop channel before restart to clear stale tasks

### DIFF
--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -166,11 +166,14 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           restartRecords.set(key, record);
 
           try {
-            if (status.running) {
-              await channelManager.stopChannel(channelId as ChannelId, accountId, {
-                manual: false,
-              });
-            }
+            // Always stop before restart — even when status.running is false.
+            // A wedged channel (disconnected but task never settled) needs
+            // stopChannel to abort the stale task before startChannel can
+            // create a fresh one. Skipping stopChannel for !running accounts
+            // causes the health monitor to loop forever without recovery.
+            await channelManager.stopChannel(channelId as ChannelId, accountId, {
+              manual: false,
+            });
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
             await channelManager.startChannel(channelId as ChannelId, accountId);
           } catch (err) {


### PR DESCRIPTION
## Summary

Fixes #94293 — Channel health-monitor restart never recovers a wedged account.

## Root Cause

When a channel disconnects (status.running=false) but its task promise never settles, the health monitor's restart logic had a guard:

```ts
if (status.running) await stopChannel(...)  // skipped when wedged!
```

`stopChannel` is the only call that aborts a stuck task and clears the channel manager's internal task tracking. Without it, `startChannel` sees the stale task and cannot create a fresh one — the monitor loops forever logging 'restarting' but never recovers.

## Fix

Remove the `if (status.running)` guard — always call `stopChannel` before `startChannel` to guarantee stale tasks are cleaned up, even for already-disconnected accounts.