### PR TITLE
fix(codex): keep root memory in bootstrap context

### DIFF
--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -100,7 +100,7 @@ Bootstrap files are resolved from the active workspace and routed to the prompt 
 - `BOOTSTRAP.md` (only on brand-new workspaces)
 - `MEMORY.md` when present
 
-On the native Codex harness, OpenClaw avoids repeating stable workspace files in every user turn. Codex loads `AGENTS.md`, including its `## Tools` section, through native project-doc discovery. `SOUL.md`, `IDENTITY.md`, and `USER.md` are forwarded as turn-scoped collaboration developer instructions so native Codex sub-agents do not inherit them. `MEMORY.md` content is not pasted into every native Codex turn either: when memory tools are available for the workspace, Codex turns get a small workspace-memory note directing the model to `memory_search` or `memory_get`. If tools are disabled, memory search is unavailable, or the active workspace differs from the agent memory workspace, `MEMORY.md` falls back to the normal bounded turn-context path. `BOOTSTRAP.md` keeps the normal turn-context role.
+On the native Codex harness, OpenClaw avoids repeating stable workspace files in every user turn. Codex loads `AGENTS.md`, including its `## Tools` section, through native project-doc discovery. `SOUL.md`, `IDENTITY.md`, and `USER.md` are forwarded as turn-scoped collaboration developer instructions so native Codex sub-agents do not inherit them. `HEARTBEAT.md` content is not injected directly; heartbeat turns receive collaboration-mode guidance and monitor scratch is appended only to heartbeat prompts. `MEMORY.md` content from the configured agent workspace uses the normal bounded turn-context path for native Codex turns, even when memory tools are available for that workspace. The injected root memory is intended for sparse bootstrap facts; Codex should still use `memory_search` or `memory_get` when durable memory is relevant beyond that bounded bootstrap context. `BOOTSTRAP.md` keeps the normal turn-context role.
 
 Heartbeat monitor scratch is not a bootstrap file. The heartbeat runner appends it only to heartbeat turns; normal turns do not receive it. The default agent's system prompt automatically includes heartbeat guidance while its cadence is enabled, with no independent heartbeat setting to hide that section.
 
@@ -120,7 +120,7 @@ Large files are truncated with a marker:
 
 Missing files inject a short missing-file marker. Detailed raw/injected counts stay in diagnostics such as `/context`, `/status`, doctor, and logs.
 
-For memory files, truncation is not data loss: the file stays intact on disk. On native Codex, `MEMORY.md` is read on demand through memory tools when available, with bounded prompt fallback otherwise. On other harnesses, the model only sees the shortened injected copy until it reads or searches memory directly. If `MEMORY.md` is repeatedly truncated, distill it into a shorter durable summary, move detailed history into `memory/*.md`, or intentionally raise the bootstrap limits.
+For memory files, truncation is not data loss: the file stays intact on disk. Native Codex and other harnesses only see the shortened injected root `MEMORY.md` copy until they read or search memory directly. If `MEMORY.md` is repeatedly truncated, distill it into a shorter durable summary, move detailed history into `memory/*.md`, or intentionally raise the bootstrap limits.
 
 Sub-agent sessions only inject `AGENTS.md` (other bootstrap files are filtered out to keep sub-agent context small).
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -744,14 +744,12 @@ For OpenClaw workspace parity, local tool notes live in the `## Tools` section o
 - Heartbeat turns receive generic initiative guidance through collaboration
   mode. Monitor cron scratch is appended to the heartbeat prompt instead of
   injected as workspace context.
-- `MEMORY.md` content from the configured agent workspace is not pasted into
-  native Codex turn input when memory tools are available for that
-  workspace; when it exists, the harness adds a small workspace-memory
-  pointer to turn-scoped collaboration developer instructions and Codex
-  should use `memory_search` or `memory_get` when durable memory is relevant.
-  If tools are disabled, memory search is unavailable, or the active
-  workspace differs from the agent memory workspace, `MEMORY.md` uses the
-  normal bounded turn-context path instead.
+- `MEMORY.md` content from the configured agent workspace uses the normal
+  bounded turn-context path for native Codex turns, even when memory tools
+  are available for that workspace. The injected root memory is intended
+  for sparse bootstrap facts; Codex should still use `memory_search` or
+  `memory_get` when durable memory is relevant beyond that bounded
+  bootstrap context.
 - `BOOTSTRAP.md`, when present, is forwarded as OpenClaw turn input reference
   context.
 

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -50,10 +50,12 @@ OpenClaw runs (for example cron) still suppress project-doc loading.
 
 OpenClaw developer instructions cover OpenClaw runtime concerns: source-channel
 delivery, OpenClaw dynamic tools, ACP delegation, adapter context, and the
-active agent workspace profile files. Skill catalogs and tool-routed
-`MEMORY.md` pointers are projected as turn-scoped collaboration developer
-instructions. When memory tools are unavailable, active `BOOTSTRAP.md` content
-and full `MEMORY.md` fall back to plain turn input context instead.
+active agent workspace profile files. OpenClaw skill catalogs are projected as
+turn-scoped collaboration developer instructions for native Codex. Root
+`MEMORY.md` uses bounded turn input reference context when present, even when
+memory tools are available; Codex should use memory tools for deeper durable
+recall beyond that sparse bootstrap context. Active `BOOTSTRAP.md` content also
+uses turn input reference context.
 
 When `openclaw_direct.sessions_yield` is available, those instructions also
 tell a native Codex parent to end the current turn when a child's result should

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -26,12 +26,12 @@ OpenClaw assembles its own system prompt on every run. It includes:
   `agents.defaults.bootstrapMaxChars` (default: `20000`); total bootstrap
   injection is capped by `agents.defaults.bootstrapTotalMaxChars` (default:
   `60000`).
-  - Native Codex turns do not paste raw `MEMORY.md` when memory tools are
-    available for that workspace; they get a small memory pointer in
-    turn-scoped collaboration developer instructions instead and use memory
-    tools on demand. If tools are disabled, memory search is unavailable, or
-    the active workspace differs from the agent memory workspace, `MEMORY.md`
-    falls back to the normal bounded turn-context path.
+  - Native Codex turns paste root `MEMORY.md` from the configured agent
+    workspace through the normal bounded turn-context path, even when
+    memory tools are available for that workspace. The injected root memory
+    is intended for sparse bootstrap facts; Codex should still use memory
+    tools on demand for durable memory beyond that bounded bootstrap
+    context.
   - Lowercase root `memory.md` is never injected. It is legacy repair input
     for `openclaw doctor --fix`, which migrates it into `MEMORY.md`.
   - `memory/*.md` daily files are not part of the normal bootstrap prompt;

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -175,8 +175,10 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
         agentId: params.params.agentId ?? params.sessionAgentId,
         workspaceDir: params.effectiveWorkspace,
       });
-    // Native Codex turns should read workspace MEMORY.md through tools when
-    // possible; pasting it into every prompt turns durable memory into policy.
+    // Keep root MEMORY.md in the bounded bootstrap prompt even when memory
+    // tools are available. The tools remain available for deeper recall, but
+    // sparse bootstrap memory carries ambient operating facts Codex must see
+    // without having to know to ask first.
     const bootstrapFiles = await resolveBootstrapFilesForRun({
       workspaceDir: params.resolvedWorkspace,
       config: params.params.config,
@@ -187,35 +189,18 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       contextMode: params.params.bootstrapContextMode,
       runKind: params.params.bootstrapContextRunKind,
     });
-    const memoryToolRoutedBootstrapFiles = memoryToolsAvailable
-      ? selectCodexWorkspaceMemoryReferenceFiles({
-          bootstrapFiles,
-          workspaceDir: params.resolvedWorkspace,
-        })
-      : [];
-    const memoryReferenceFiles = memoryToolRoutedBootstrapFiles.map((file) =>
-      remapCodexContextFilePath({
-        file: toCodexEmbeddedContextFile(file),
-        sourceWorkspaceDir: params.resolvedWorkspace,
-        targetWorkspaceDir: params.effectiveWorkspace,
-      }),
-    );
-    const contextFiles = buildBootstrapContextForFiles(
-      memoryToolsAvailable
-        ? bootstrapFiles.filter(
-            (file) =>
-              !isCodexWorkspaceRootMemoryBootstrapFile({
-                file,
-                workspaceDir: params.resolvedWorkspace,
-              }),
-          )
-        : bootstrapFiles,
-      {
-        config: params.params.config,
-        agentId: params.params.agentId ?? params.sessionAgentId,
-        warn: (message) => embeddedAgentLog.warn(message),
-      },
-    ).map((file) =>
+    const memoryToolRoutedBootstrapFiles: CodexBootstrapFile[] = [];
+    const memoryReferenceFiles: EmbeddedContextFile[] = [];
+    const codexBootstrapFiles = prioritizeCodexRootMemoryBootstrapFile({
+      bootstrapFiles,
+      memoryToolsAvailable,
+      workspaceDir: params.resolvedWorkspace,
+    });
+    const contextFiles = buildBootstrapContextForFiles(codexBootstrapFiles, {
+      config: params.params.config,
+      agentId: params.params.agentId ?? params.sessionAgentId,
+      warn: (message) => embeddedAgentLog.warn(message),
+    }).map((file) =>
       remapCodexContextFilePath({
         file,
         sourceWorkspaceDir: params.resolvedWorkspace,
@@ -223,7 +208,7 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       }),
     );
     const promptContextFiles = selectCodexWorkspacePromptContextFiles(contextFiles, {
-      excludeMemory: memoryToolsAvailable,
+      excludeMemory: false,
       memoryWorkspaceDir: params.effectiveWorkspace,
     });
     const turnScopedDeveloperInstructionFiles = shouldInjectCodexOpenClawPromptContext(
@@ -260,6 +245,37 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
     embeddedAgentLog.warn("failed to load codex workspace bootstrap instructions", { error });
     return { bootstrapFiles: [], contextFiles: [] };
   }
+}
+
+function prioritizeCodexRootMemoryBootstrapFile(params: {
+  bootstrapFiles: CodexBootstrapFile[];
+  memoryToolsAvailable: boolean;
+  workspaceDir: string;
+}): CodexBootstrapFile[] {
+  if (!params.memoryToolsAvailable) {
+    return params.bootstrapFiles;
+  }
+  const rootMemoryIndex = params.bootstrapFiles.findIndex(
+    (file) =>
+      !file.missing &&
+      readNonEmptyString(file.path) &&
+      isCodexWorkspaceRootMemoryPath({
+        filePath: file.path,
+        workspaceDir: params.workspaceDir,
+      }),
+  );
+  if (rootMemoryIndex <= 0) {
+    return params.bootstrapFiles;
+  }
+  const rootMemoryBootstrapFile = params.bootstrapFiles[rootMemoryIndex];
+  if (!rootMemoryBootstrapFile) {
+    return params.bootstrapFiles;
+  }
+  return [
+    rootMemoryBootstrapFile,
+    ...params.bootstrapFiles.slice(0, rootMemoryIndex),
+    ...params.bootstrapFiles.slice(rootMemoryIndex + 1),
+  ];
 }
 
 /**
@@ -768,27 +784,8 @@ function renderCodexWorkspaceDeveloperInstructions(params: {
   return lines.join("\n").trim();
 }
 
-function selectCodexWorkspaceMemoryReferenceFiles(params: {
-  bootstrapFiles: CodexBootstrapFile[];
-  workspaceDir: string;
-}): CodexBootstrapFile[] {
-  return params.bootstrapFiles
-    .filter((file) => {
-      return (
-        isCodexWorkspaceRootMemoryBootstrapFile({
-          file,
-          workspaceDir: params.workspaceDir,
-        }) &&
-        !file.missing &&
-        (file.content ?? "").trim().length > 0
-      );
-    })
-    .toSorted(compareCodexBootstrapFiles);
-}
-
 /**
- * Renders a memory-file reference that points Codex at memory tools instead of
- * embedding MEMORY.md contents.
+ * Renders a supplemental memory-file reference for deeper recall through tools.
  */
 function renderCodexWorkspaceMemoryReference(params: {
   files: EmbeddedContextFile[];
@@ -803,7 +800,7 @@ function renderCodexWorkspaceMemoryReference(params: {
   const lines = [
     "## OpenClaw Workspace Memory",
     "",
-    `MEMORY.md exists in the active agent workspace as a memory file, not an instruction file. OpenClaw does not paste its contents into native Codex turns; use ${toolNames.join(" or ")} when durable memory is relevant and the tools are available.`,
+    `MEMORY.md is injected through the bounded workspace context when present. Use ${toolNames.join(" or ")} for deeper durable memory beyond the injected bootstrap context.`,
     "",
   ];
   for (const file of params.files) {
@@ -899,23 +896,6 @@ function isMissingCodexBootstrapContextFile(file: EmbeddedContextFile): boolean 
   return file.content.trimStart().startsWith("[MISSING] Expected at:");
 }
 
-function toCodexEmbeddedContextFile(file: CodexBootstrapFile): EmbeddedContextFile {
-  return {
-    path: readNonEmptyString(file.path) ?? readNonEmptyString(file.name) ?? "",
-    content: file.content ?? "",
-  };
-}
-
-function isCodexWorkspaceRootMemoryBootstrapFile(params: {
-  file: CodexBootstrapFile;
-  workspaceDir: string;
-}): boolean {
-  return isCodexWorkspaceRootMemoryPath({
-    filePath: readNonEmptyString(params.file.path) ?? readNonEmptyString(params.file.name) ?? "",
-    workspaceDir: params.workspaceDir,
-  });
-}
-
 function isCodexWorkspaceRootMemoryContextFile(params: {
   file: EmbeddedContextFile;
   workspaceDir?: string;
@@ -993,13 +973,6 @@ function compareCodexContextFiles(left: EmbeddedContextFile, right: EmbeddedCont
     return leftBase.localeCompare(rightBase);
   }
   return leftPath.localeCompare(rightPath);
-}
-
-function compareCodexBootstrapFiles(left: CodexBootstrapFile, right: CodexBootstrapFile): number {
-  return compareCodexContextFiles(
-    toCodexEmbeddedContextFile(left),
-    toCodexEmbeddedContextFile(right),
-  );
 }
 
 function normalizeCodexContextFilePath(filePath: string): string {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3045,7 +3045,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(secondInputText).toContain("continue from there");
   });
 
-  it("routes AGENTS.md natively and MEMORY.md through tools", async () => {
+  it("routes AGENTS.md natively and keeps MEMORY.md in bounded context", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const agentsGuidance = "Follow AGENTS guidance.";
     const soulGuidance = "Soul voice goes here.";
@@ -3090,10 +3090,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(collaborationInstructions).toContain(userProfile);
     expect(collaborationInstructions).toContain("## Memory Recall");
     expect(collaborationInstructions).toContain("MEMORY.md + memory/*.md");
-    expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
-    expect(collaborationInstructions).toContain(
-      "MEMORY.md exists in the active agent workspace as a memory file, not an instruction file",
-    );
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).toContain("memory_search");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).toContain(
@@ -3103,20 +3100,19 @@ describe("runCodexAppServerAttempt", () => {
       "If the needed memory tool is deferred and not currently callable, use `tool_search` to load it, then call that memory tool.",
     );
     expect(collaborationInstructions).not.toContain(memorySummary);
-    expect(inputText).not.toContain("OpenClaw runtime context for this turn:");
-    expect(inputText).not.toContain("does not override Codex system/developer instructions");
-    expect(inputText).not.toContain("not developer policy");
+    expect(inputText).toContain("OpenClaw runtime context for this turn:");
+    expect(inputText).toContain("OpenClaw Workspace Context");
     expect(inputText).not.toContain(soulGuidance);
     expect(inputText).not.toContain(identityGuidance);
     expect(inputText).not.toContain(userProfile);
-    expect(inputText).not.toContain(memorySummary);
+    expect(inputText).toContain(memorySummary);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("MEMORY.md exists in the active agent workspace");
     expect(inputText).not.toContain("memory_search");
     expect(inputText).not.toContain("memory_get");
-    expect(inputText).not.toContain("Codex loads AGENTS.md natively");
+    expect(inputText).toContain("Codex loads AGENTS.md natively");
     expect(inputText).not.toContain(agentsGuidance);
-    expect(inputText).toBe("hello");
+    expect(inputText).not.toBe("hello");
     expect(systemPromptReport.systemPrompt.chars).toBe(
       [threadDeveloperInstructions, collaborationInstructions].join("\n\n").length,
     );
@@ -3140,7 +3136,7 @@ describe("runCodexAppServerAttempt", () => {
     });
     expect(fileStats.get("MEMORY.md")).toMatchObject({
       rawChars: memorySummary.length,
-      injectedChars: 0,
+      injectedChars: memorySummary.length,
       truncated: false,
     });
     expect(fileStats.get("AGENTS.md")).toMatchObject({
@@ -3197,11 +3193,11 @@ describe("runCodexAppServerAttempt", () => {
       workspaceDir,
     );
     expect(collaborationInstructions).not.toContain("## Memory Recall");
-    expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).not.toContain("Use `tool_search` first");
     expect(collaborationInstructions).not.toContain(memorySummary);
-    expect(inputText).toBe("hello");
-    expect(inputText).not.toContain(memorySummary);
+    expect(inputText).not.toBe("hello");
+    expect(inputText).toContain(memorySummary);
   });
   it("sends turn-scoped workspace instructions through Codex app-server payloads", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
@@ -3290,7 +3286,7 @@ describe("runCodexAppServerAttempt", () => {
       truncated: false,
     });
   });
-  it("routes MEMORY.md through memory_get when search is unavailable", async () => {
+  it("keeps MEMORY.md injected when search is unavailable", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const memorySummary = "Memory summary goes here.";
     await fs.mkdir(workspaceDir, { recursive: true });
@@ -3307,9 +3303,9 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
     expect(inputText).not.toContain("memory_get");
     expect(inputText).not.toContain("memory_search");
-    expect(inputText).not.toContain(memorySummary);
+    expect(inputText).toContain(memorySummary);
     expect(collaborationInstructions).toContain("## Memory Recall");
-    expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).toContain("memory_get");
     expect(collaborationInstructions).not.toContain("memory_search");
     expect(collaborationInstructions).not.toContain(memorySummary);
@@ -3318,7 +3314,7 @@ describe("runCodexAppServerAttempt", () => {
     );
     expect(fileStats.get("MEMORY.md")).toMatchObject({
       rawChars: memorySummary.length,
-      injectedChars: 0,
+      injectedChars: memorySummary.length,
       truncated: false,
     });
   });
@@ -3356,7 +3352,56 @@ describe("runCodexAppServerAttempt", () => {
       truncated: true,
     });
   });
-  it("keeps MEMORY.md out of the Codex workspace context budget", async () => {
+  it("prioritizes root MEMORY.md with memory tools inside the shared bootstrap cap", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    const memorySummary = "Memory summary survives the Codex bootstrap cap.";
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Soul guidance ".repeat(120));
+    await fs.writeFile(path.join(workspaceDir, "TOOLS.md"), "Tool guidance ".repeat(120));
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "User profile ".repeat(120));
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+    registerMemoryPromptForTest();
+    testing.setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("memory_search"),
+      createRuntimeDynamicTool("memory_get"),
+    ]);
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    setCodexTestModelSupportsTools(params, true);
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.config = {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          bootstrapMaxChars: 1000,
+          bootstrapTotalMaxChars: 2000,
+        },
+      },
+    } as EmbeddedRunAttemptParams["config"];
+    setAgentWorkspaceForTest(params, workspaceDir);
+
+    const { inputText, systemPromptReport } = await buildCodexTurnContextForTest(
+      params,
+      workspaceDir,
+    );
+
+    expect(inputText).toContain(memorySummary);
+    const fileStats = new Map(
+      systemPromptReport.injectedWorkspaceFiles.map((file) => [file.name, file]),
+    );
+    expect(fileStats.get("MEMORY.md")).toMatchObject({
+      rawChars: memorySummary.length,
+      injectedChars: memorySummary.length,
+      truncated: false,
+    });
+    const injectedChars = systemPromptReport.injectedWorkspaceFiles.reduce(
+      (sum, file) => sum + file.injectedChars,
+      0,
+    );
+    expect(injectedChars).toBeLessThanOrEqual(2000);
+  });
+
+  it("keeps MEMORY.md bounded inside the Codex workspace context budget", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const memorySummary = "Memory summary ".repeat(300);
     const hookContext = "Hook context survives the memory budget.";
@@ -3397,18 +3442,19 @@ describe("runCodexAppServerAttempt", () => {
     const { collaborationInstructions, inputText, systemPromptReport } =
       await buildCodexTurnContextForTest(params, workspaceDir);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
-    expect(inputText).not.toContain(memorySummary);
+    expect(inputText).toContain("Memory summary");
     expect(inputText).toContain(hookContext);
-    expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).not.toContain(memorySummary);
     const fileStats = new Map(
       systemPromptReport.injectedWorkspaceFiles.map((file) => [file.name, file]),
     );
     expect(fileStats.get("MEMORY.md")).toMatchObject({
       rawChars: memorySummary.trimEnd().length,
-      injectedChars: 0,
-      truncated: false,
+      truncated: true,
     });
+    expect(fileStats.get("MEMORY.md")?.injectedChars).toBeGreaterThan(0);
+    expect(fileStats.get("MEMORY.md")?.injectedChars).toBeLessThanOrEqual(1000);
     expect(fileStats.get("ZZZ.md")).toMatchObject({
       rawChars: hookContext.length,
       injectedChars: hookContext.length,
@@ -3418,7 +3464,7 @@ describe("runCodexAppServerAttempt", () => {
 
   it("keeps extra MEMORY.md bootstrap files in Codex workspace context", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
-    const rootMemory = "Root memory should stay tool-routed.";
+    const rootMemory = "Root memory should stay injected.";
     const nestedMemory = "Nested package memory remains prompt context.";
     const nestedMemoryPath = path.join(workspaceDir, "packages/pkg/MEMORY.md");
     await fs.mkdir(path.dirname(nestedMemoryPath), { recursive: true });
@@ -3450,9 +3496,9 @@ describe("runCodexAppServerAttempt", () => {
     const { collaborationInstructions, inputText, systemPromptReport } =
       await buildCodexTurnContextForTest(params, workspaceDir);
     expect(inputText).not.toContain("OpenClaw Workspace Memory");
-    expect(inputText).not.toContain(rootMemory);
+    expect(inputText).toContain(rootMemory);
     expect(inputText).toContain(nestedMemory);
-    expect(collaborationInstructions).toContain("OpenClaw Workspace Memory");
+    expect(collaborationInstructions).not.toContain("OpenClaw Workspace Memory");
     expect(collaborationInstructions).not.toContain(rootMemory);
     expect(collaborationInstructions).not.toContain(nestedMemory);
     const files = systemPromptReport.injectedWorkspaceFiles;
@@ -3462,7 +3508,7 @@ describe("runCodexAppServerAttempt", () => {
     const nestedMemoryStats = files.find((file) => file.path === nestedMemoryPath);
     expect(rootMemoryStats).toMatchObject({
       rawChars: rootMemory.length,
-      injectedChars: 0,
+      injectedChars: rootMemory.length,
       truncated: false,
     });
     expect(nestedMemoryStats).toMatchObject({


### PR DESCRIPTION
## 2026-07-20 refresh

- Exact head d658c04bfa8abb91daa2670f995a2aa873495ab6 merges upstream main bf6961d33efc1bc0883fd4fce898bb680ed7ba87.
- Exact-head GitHub CI and the post-body proof workflows completed with no failures. Current-main integration exposed one strict indexed-access error; the pushed fail-safe guard repairs it.
- The older Raspberry Pi receipt below remains historical behavior evidence. The remaining gate is maintainer acceptance of bounded root MEMORY.md injection when memory tools are available.

## Summary

Fixes #94295.

Native Codex currently suppresses root workspace `MEMORY.md` when memory tools are available, causing `/context` to show the file as present but injected with `0` chars. That makes sparse bootstrap memory unavailable unless the model already knows to ask memory tools for the right fact.

This PR keeps root `MEMORY.md` in the bounded workspace bootstrap prompt context and leaves memory tools available for deeper recall.

## Changes

- Stop selecting root `MEMORY.md` as a tool-routed bootstrap file for native Codex turns.
- Stop filtering root `MEMORY.md` out of `buildBootstrapContextForFiles(...)` when memory tools are present.
- Stop excluding root memory from Codex prompt-context selection.
- Update Codex app-server tests to expect nonzero `MEMORY.md` injection unless normal bootstrap budget truncation applies.
- Update the Codex harness reference, Codex harness runtime, token-use, and system-prompt docs for the new native Codex `MEMORY.md` default.

## Why

`MEMORY.md` is the sparse long-term bootstrap memory surface. It can contain ambient operating facts that the model needs before it can know which memory query to run. Tool-based recall is useful, but it should not replace bootstrap memory by default.

Related broader routing work: #83612. This PR is intentionally narrower and addresses the direct `MEMORY.md injected 0 chars` regression.

## Validation

Focused local validation on the Raspberry Pi checkout at `385b6f50a17a62555ce1abd30c28c9c9b8fa2978`:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts extensions/codex/src/app-server/attempt-context.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt.config.ts extensions/codex/src/app-server/run-attempt.test.ts -t "keeps MEMORY.md in bounded context"
git diff --check
rg -n 'not pasted into every native Codex|not pasted into native Codex|do not paste raw `MEMORY\.md`|workspace-memory note|read on demand through memory tools|tool-routed `MEMORY\.md`|MEMORY\.md` pointers|fallback injection' docs/concepts/system-prompt.md docs/plugins/codex-harness-reference.md docs/plugins/codex-harness-runtime.md docs/reference/token-use.md || true
```

Results:

- `attempt-context.test.ts`: 4 passed.
- Focused `run-attempt.test.ts` memory case: 1 passed, 104 skipped by `-t`.
- `git diff --check`: no output.
- Stale-doc wording scan: no output.

## Real behavior proof

**After-fix real behavior proof from Nick's Raspberry Pi OpenClaw host:**

- **Behavior or issue addressed:** Native Codex was suppressing root workspace `MEMORY.md` when memory tools were available, causing `/context` to show the file as present but injected with `0` chars. The fix keeps root `MEMORY.md` in the bounded workspace bootstrap prompt context while retaining memory tools for deeper recall.
- **Real environment tested:** Nick's real Raspberry Pi 5 OpenClaw host, running the installed OpenClaw package reported as `OpenClaw 2026.6.6 (8c802aa)`. The installed runtime bundle patched in-place was `/home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js`.
- **Exact steps or command run after this patch:**

```bash
openclaw --version
rg -n "MEMORY.md is injected|OpenClaw does not paste|memoryToolRoutedBootstrapFiles = \\[\\]|excludeMemory: false" \
  /home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js \
  /home/rpiuser_nick/projects/active/openclaw-pr81185-rebase/extensions/codex/src/app-server/attempt-context.ts
node --check /home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js
openclaw config validate
git -C /home/rpiuser_nick/projects/active/openclaw-pr81185-rebase diff --check -- \
  extensions/codex/src/app-server/attempt-context.ts \
  extensions/codex/src/app-server/run-attempt.test.ts
```

- **Evidence after fix:** Actual terminal output from the real OpenClaw host after patching:

```text
$ openclaw --version
OpenClaw 2026.6.6 (8c802aa)

$ rg -n "MEMORY.md is injected|OpenClaw does not paste|memoryToolRoutedBootstrapFiles = \\[\\]|excludeMemory: false" \
  /home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js \
  /home/rpiuser_nick/projects/active/openclaw-pr81185-rebase/extensions/codex/src/app-server/attempt-context.ts
/home/rpiuser_nick/projects/active/openclaw-pr81185-rebase/extensions/codex/src/app-server/attempt-context.ts:207:      excludeMemory: false,
/home/rpiuser_nick/projects/active/openclaw-pr81185-rebase/extensions/codex/src/app-server/attempt-context.ts:762:    `MEMORY.md is injected through the bounded workspace context when present. Use ${toolNames.join(" or ")} for deeper durable memory beyond the injected bootstrap context.`,
/home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js:274:        const memoryToolRoutedBootstrapFiles = [];
/home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js:286:          excludeMemory: false,
/home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js:630:        `MEMORY.md is injected through the bounded workspace context when present. Use ${(params.toolNames?.length ? params.toolNames : Array.from(CODEX_MEMORY_TOOL_NAMES)).join(" or ")} for deeper durable memory beyond the injected bootstrap context.`,

$ node --check /home/rpiuser_nick/.npm-global/lib/node_modules/openclaw/dist/run-attempt-BtRhrKv-.js
# no output, exit 0

$ openclaw config validate
Config valid: $OPENCLAW_HOME/.openclaw/openclaw.json

$ git -C /home/rpiuser_nick/projects/active/openclaw-pr81185-rebase diff --check -- extensions/codex/src/app-server/attempt-context.ts extensions/codex/src/app-server/run-attempt.test.ts
# no output, exit 0
```

- **Observed result after fix:** The installed native Codex runtime path no longer contains the suppressing `OpenClaw does not paste` behavior, no longer filters root `MEMORY.md` out of prompt context when memory tools are available, and now routes `MEMORY.md` through normal bounded bootstrap context (`excludeMemory: false`) while keeping memory tools available for deeper recall.


- **What was not tested:** A restarted-production-Gateway live `/context` screenshot or transcript was not captured in this PR body because Gateway restarts are held behind the normal operator approval gate. The after-fix evidence above covers the patched native Codex runtime path and validation commands on the real Pi host.

Hosted proof gate previously passed on the updated PR with: `External PR includes after-fix real behavior proof.`

## Maintainer note

This intentionally changes the native Codex prompt-memory default: root `MEMORY.md` is now automatically model-visible through bounded workspace context when present, even when memory tools are available. Memory tools remain the path for deeper durable recall beyond sparse bootstrap facts.

## Not yet captured

A redacted live `/context` screenshot/output from a restarted production Gateway has not been captured here. Restarting the production Gateway is held behind the normal operator approval gate.