### PR TITLE
fix(gateway): deliver OAuth authorization URLs to non-terminal clients

### DIFF
--- a/extensions/chutes/index.ts
+++ b/extensions/chutes/index.ts
@@ -38,24 +38,28 @@ async function runChutesOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthRes
       })
     ).trim();
   const clientSecret = normalizeOptionalString(process.env.CHUTES_CLIENT_SECRET);
+  const presentsAuthChallenge = ctx.prompter.presentsAuthChallenge === true;
+  const collapseManualIntro = isRemote && presentsAuthChallenge;
 
-  await ctx.prompter.note(
-    isRemote
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "After signing in, paste the redirect URL back here.",
-          "",
-          `Redirect URI: ${redirectUri}`,
-        ].join("\n")
-      : [
-          "Browser will open for Chutes authentication.",
-          "If the callback doesn't auto-complete, paste the redirect URL.",
-          "",
-          `Redirect URI: ${redirectUri}`,
-        ].join("\n"),
-    "Chutes OAuth",
-  );
+  if (!collapseManualIntro) {
+    await ctx.prompter.note(
+      isRemote
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "After signing in, paste the redirect URL back here.",
+            "",
+            `Redirect URI: ${redirectUri}`,
+          ].join("\n")
+        : [
+            "Browser will open for Chutes authentication.",
+            "If the callback doesn't auto-complete, paste the redirect URL.",
+            "",
+            `Redirect URI: ${redirectUri}`,
+          ].join("\n"),
+      "Chutes OAuth",
+    );
+  }
 
   const progress = ctx.prompter.progress("Starting Chutes OAuth…");
   try {
@@ -66,6 +70,13 @@ async function runChutesOAuth(ctx: ProviderAuthContext): Promise<ProviderAuthRes
       spin: progress,
       openUrl: ctx.openUrl,
       localBrowserMessage: "Complete sign-in in browser…",
+      manualPromptMessage: collapseManualIntro
+        ? [
+            "After signing in, paste the redirect URL back here.",
+            "",
+            `Redirect URI: ${redirectUri}`,
+          ].join("\n")
+        : undefined,
     });
 
     const creds = await loginChutes({

--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -73,7 +73,11 @@ export function buildGoogleGeminiCliProvider(): ProviderPlugin {
               openUrl: ctx.openUrl,
               log: (msg) => ctx.runtime.log(msg),
               note: ctx.prompter.note,
-              prompt: async (message) => ctx.prompter.text({ message }),
+              presentsAuthChallenge: ctx.prompter.presentsAuthChallenge === true,
+              prompt: async (message) =>
+                ctx.prompter.text({
+                  message,
+                }),
               progress: spin,
             });
 

--- a/extensions/google/oauth.shared.ts
+++ b/extensions/google/oauth.shared.ts
@@ -37,6 +37,7 @@ export type GeminiCliOAuthCredentials = {
 
 export type GeminiCliOAuthContext = {
   isRemote: boolean;
+  presentsAuthChallenge?: boolean;
   openUrl: (url: string) => Promise<void>;
   log: (msg: string) => void;
   note: (message: string, title?: string) => Promise<void>;

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -2,6 +2,10 @@
 import { join, parse } from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const oauthRuntimeMocks = vi.hoisted(() => ({
+  loginGeminiCliOAuth: vi.fn(),
+}));
+
 vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
     "openclaw/plugin-sdk/runtime-env",
@@ -11,6 +15,10 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
     isWSL2Sync: () => false,
   };
 });
+
+vi.mock("./oauth.runtime.js", () => ({
+  loginGeminiCliOAuth: oauthRuntimeMocks.loginGeminiCliOAuth,
+}));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
@@ -756,17 +764,24 @@ describe("loginGeminiCliOAuth", () => {
 
   type LoginGeminiCliOAuthFn = (options: {
     isRemote: boolean;
+    presentsAuthChallenge?: boolean;
     openUrl: () => Promise<void>;
     log: (msg: string) => void;
-    note: () => Promise<void>;
-    prompt: () => Promise<string>;
+    note: (message: string, title?: string) => Promise<void>;
+    prompt: (message: string) => Promise<string>;
     progress: { update: () => void; stop: () => void };
   }) => Promise<{ projectId?: string }>;
 
-  async function runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth: LoginGeminiCliOAuthFn) {
+  async function runRemoteLoginWithCapturedAuthUrl(
+    loginGeminiCliOAuth: LoginGeminiCliOAuthFn,
+    options: { presentsAuthChallenge?: boolean } = {},
+  ) {
     let authUrl = "";
+    const note = vi.fn(async () => {});
+    const promptCalls: string[] = [];
     const result = await loginGeminiCliOAuth({
       isRemote: true,
+      presentsAuthChallenge: options.presentsAuthChallenge,
       openUrl: async () => {},
       log: (msg) => {
         const found = msg.match(/https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?[^\s]+/);
@@ -774,14 +789,15 @@ describe("loginGeminiCliOAuth", () => {
           authUrl = found[0];
         }
       },
-      note: async () => {},
-      prompt: async () => {
+      note,
+      prompt: async (message) => {
+        promptCalls.push(message);
         const state = new URL(authUrl).searchParams.get("state");
         return `http://localhost:8085/oauth2callback?code=oauth-code&state=${state}`;
       },
       progress: { update: () => {}, stop: () => {} },
     });
-    return { result, authUrl };
+    return { result, authUrl, note, promptCalls };
   }
 
   async function runProjectDiscoveryExpectingProjectId(projectId: string) {
@@ -894,6 +910,62 @@ describe("loginGeminiCliOAuth", () => {
       "PKCE code verifier",
     );
     expect(codeVerifier).not.toBe(authState);
+  });
+
+  it("includes the manual OAuth auth URL in the prompt message", async () => {
+    installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      return undefined;
+    });
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { authUrl, promptCalls } = await runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth);
+
+    expect(promptCalls).toEqual([
+      [
+        "Open this URL in your LOCAL browser:",
+        "",
+        authUrl,
+        "",
+        "After signing in, copy the redirect URL and paste it here:",
+      ].join("\n"),
+    ]);
+  });
+
+  it("collapses manual OAuth instructions into the auth URL prompt for auth-presenting clients", async () => {
+    installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      return undefined;
+    });
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { authUrl, note, promptCalls } = await runRemoteLoginWithCapturedAuthUrl(
+      loginGeminiCliOAuth,
+      {
+        presentsAuthChallenge: true,
+      },
+    );
+
+    expect(note).not.toHaveBeenCalled();
+    expect(promptCalls).toEqual([
+      [
+        "Open this URL in your LOCAL browser:",
+        "",
+        authUrl,
+        "",
+        "After signing in, copy the redirect URL and paste it here:",
+      ].join("\n"),
+    ]);
   });
 
   it("rejects manual callback input when the returned state does not match", async () => {
@@ -1081,5 +1153,77 @@ describe("loginGeminiCliOAuth", () => {
 
     expect(Number.isSafeInteger(result.expires)).toBe(true);
     expect(result.expires).toBeLessThanOrEqual(beforeRefresh);
+  });
+});
+
+describe("Gemini CLI provider OAuth wiring", () => {
+  beforeEach(() => {
+    oauthRuntimeMocks.loginGeminiCliOAuth.mockReset();
+  });
+
+  it("forwards manual OAuth URLs into wizard text messages", async () => {
+    const authUrl = "https://accounts.google.com/o/oauth2/v2/auth?state=abc";
+    oauthRuntimeMocks.loginGeminiCliOAuth.mockImplementation(
+      async (ctx: {
+        presentsAuthChallenge?: boolean;
+        prompt: (message: string) => Promise<string>;
+      }) => {
+        expect(ctx.presentsAuthChallenge).toBe(true);
+        await ctx.prompt(
+          [
+            "Open this URL in your LOCAL browser:",
+            "",
+            authUrl,
+            "",
+            "After signing in, copy the redirect URL and paste it here:",
+          ].join("\n"),
+        );
+        return {
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+          email: "lobster@openclaw.ai",
+        };
+      },
+    );
+
+    const { buildGoogleGeminiCliProvider } = await import("./gemini-cli-provider.js");
+    const provider = buildGoogleGeminiCliProvider();
+    const method = provider.auth?.find((candidate) => candidate.id === "oauth");
+    if (!method) {
+      throw new Error("expected Gemini CLI OAuth method");
+    }
+
+    const spin = { update: vi.fn(), stop: vi.fn() };
+    const text = vi.fn(async () => "http://localhost:8085/oauth2callback?code=oauth-code");
+
+    await method.run({
+      isRemote: true,
+      openUrl: vi.fn(async () => {}),
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn((code: number) => {
+          throw new Error(`exit:${code}`);
+        }),
+      },
+      prompter: {
+        presentsAuthChallenge: true,
+        note: vi.fn(async () => {}),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => spin),
+        text,
+      },
+    } as never);
+
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        authUrl,
+        "",
+        "After signing in, copy the redirect URL and paste it here:",
+      ].join("\n"),
+    });
   });
 });

--- a/extensions/google/oauth.ts
+++ b/extensions/google/oauth.ts
@@ -19,20 +19,24 @@ export async function loginGeminiCliOAuth(
   ctx: GeminiCliOAuthContext,
 ): Promise<GeminiCliOAuthCredentials> {
   const needsManual = shouldUseManualOAuthFlow(ctx.isRemote);
-  await ctx.note(
-    needsManual
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "After signing in, copy the redirect URL and paste it back here.",
-        ].join("\n")
-      : [
-          "Browser will open for Google authentication.",
-          "Sign in with your Google account for Gemini CLI access.",
-          "The callback will be captured automatically on localhost:8085.",
-        ].join("\n"),
-    "Gemini CLI OAuth",
-  );
+  const presentsAuthChallenge = ctx.presentsAuthChallenge === true;
+  const collapseManualIntro = needsManual && presentsAuthChallenge;
+  if (!collapseManualIntro) {
+    await ctx.note(
+      needsManual
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "After signing in, copy the redirect URL and paste it back here.",
+          ].join("\n")
+        : [
+            "Browser will open for Google authentication.",
+            "Sign in with your Google account for Gemini CLI access.",
+            "The callback will be captured automatically on localhost:8085.",
+          ].join("\n"),
+      "Gemini CLI OAuth",
+    );
+  }
 
   const { verifier, challenge } = generatePkce();
   const state = generateOAuthState();
@@ -82,7 +86,15 @@ async function manualFlow(
   ctx.progress.update("OAuth URL ready");
   ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
   ctx.progress.update("Waiting for you to paste the callback URL...");
-  const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
+  const callbackInput = await ctx.prompt(
+    [
+      "Open this URL in your LOCAL browser:",
+      "",
+      authUrl,
+      "",
+      "After signing in, copy the redirect URL and paste it here:",
+    ].join("\n"),
+  );
   const parsed = parseCallbackInput(callbackInput);
   if ("error" in parsed) {
     throw new Error(parsed.error, cause ? { cause } : undefined);

--- a/extensions/msteams/src/oauth.ts
+++ b/extensions/msteams/src/oauth.ts
@@ -111,7 +111,15 @@ async function manualFlow(
   ctx.progress.update("OAuth URL ready");
   ctx.log(`\nOpen this URL in your LOCAL browser:\n\n${authUrl}\n`);
   ctx.progress.update("Waiting for you to paste the callback URL...");
-  const callbackInput = await ctx.prompt("Paste the redirect URL here: ");
+  const callbackInput = await ctx.prompt(
+    [
+      "Open this URL in your LOCAL browser:",
+      "",
+      authUrl,
+      "",
+      "After signing in, copy the redirect URL and paste it here:",
+    ].join("\n"),
+  );
   const parsed = parseCallbackInput(callbackInput, state);
   if ("error" in parsed) {
     throw new Error(parsed.error, cause ? { cause } : undefined);

--- a/extensions/openai/openai-chatgpt-oauth.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth.runtime.test.ts
@@ -1,10 +1,18 @@
 // Openai tests cover openai chatgpt oauth plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { testing } from "./openai-chatgpt-oauth.runtime.js";
+
+const loginOpenAICodexMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./openai-chatgpt-oauth-flow.runtime.js", () => ({
+  loginOpenAICodex: loginOpenAICodexMock,
+}));
+
+import { loginOpenAICodexOAuth, testing } from "./openai-chatgpt-oauth.runtime.js";
 
 describe("OpenAI Codex OAuth runtime", () => {
   afterEach(() => {
+    loginOpenAICodexMock.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -21,5 +29,49 @@ describe("OpenAI Codex OAuth runtime", () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses auth-presenting instructions into the redirect paste prompt", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 302 }));
+    const note = vi.fn(async () => {});
+    const createVpsAwareHandlers = vi.fn(() => ({
+      onAuth: vi.fn(),
+      onPrompt: vi.fn(async () => "http://localhost:1455/auth/callback?code=test"),
+    }));
+    loginOpenAICodexMock.mockResolvedValueOnce({
+      access: "access-token",
+      refresh: "refresh-token",
+      expires: Date.now() + 60_000,
+    });
+
+    await loginOpenAICodexOAuth({
+      isRemote: true,
+      openUrl: vi.fn(async () => {}),
+      prompter: {
+        presentsAuthChallenge: true,
+        note,
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      } as never,
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+      } as never,
+      oauth: {
+        createVpsAwareHandlers,
+      },
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(note).not.toHaveBeenCalled();
+    expect(createVpsAwareHandlers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        manualPromptMessage: [
+          "After signing in, paste the authorization code or full redirect URL here.",
+          "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
+        ].join("\n"),
+      }),
+    );
   });
 });

--- a/extensions/openai/openai-chatgpt-oauth.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth.runtime.ts
@@ -267,6 +267,8 @@ export async function loginOpenAICodexOAuth(params: {
   localBrowserMessage?: string;
 }): Promise<OAuthCredentials | null> {
   const { prompter, runtime, isRemote, openUrl, localBrowserMessage } = params;
+  const presentsAuthChallenge = prompter.presentsAuthChallenge === true;
+  const collapseManualIntro = isRemote && presentsAuthChallenge;
 
   ensureGlobalUndiciEnvProxyDispatcher();
 
@@ -278,21 +280,23 @@ export async function loginOpenAICodexOAuth(params: {
     throw new Error(`OpenAI Codex OAuth prerequisites failed: ${preflight.message}`);
   }
 
-  await prompter.note(
-    isRemote
-      ? [
-          "You are running in a remote/VPS environment.",
-          "A URL will be shown for you to open in your LOCAL browser.",
-          "Open it, sign in, then paste the redirect URL here.",
-          "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
-        ].join("\n")
-      : [
-          "Browser will open for OpenAI authentication.",
-          "If the callback doesn't auto-complete, paste the redirect URL.",
-          "OpenAI OAuth uses localhost:1455 for the callback.",
-        ].join("\n"),
-    "OpenAI Codex OAuth",
-  );
+  if (!collapseManualIntro) {
+    await prompter.note(
+      isRemote
+        ? [
+            "You are running in a remote/VPS environment.",
+            "A URL will be shown for you to open in your LOCAL browser.",
+            "Open it, sign in, then paste the redirect URL here.",
+            "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
+          ].join("\n")
+        : [
+            "Browser will open for OpenAI authentication.",
+            "If the callback doesn't auto-complete, paste the redirect URL.",
+            "OpenAI OAuth uses localhost:1455 for the callback.",
+          ].join("\n"),
+      "OpenAI Codex OAuth",
+    );
+  }
 
   const spin = prompter.progress("Starting OAuth flow...");
   let progressActive = true;
@@ -320,7 +324,12 @@ export async function loginOpenAICodexOAuth(params: {
       spin,
       openUrl,
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser...",
-      manualPromptMessage: manualInputPromptMessage,
+      manualPromptMessage: collapseManualIntro
+        ? [
+            "After signing in, paste the authorization code or full redirect URL here.",
+            "If this OpenClaw process can receive the browser callback, sign-in may finish automatically before you paste.",
+          ].join("\n")
+        : manualInputPromptMessage,
     });
     const onAuth = (event: Parameters<typeof baseOnAuth>[0]) => {
       browserAuthStarted = true;

--- a/extensions/openrouter/oauth.test.ts
+++ b/extensions/openrouter/oauth.test.ts
@@ -196,11 +196,10 @@ describe("OpenRouter OAuth", () => {
 
     expect(openUrl).not.toHaveBeenCalled();
     expect(log.mock.calls[0]?.[0]).toContain("https://openrouter.ai/auth?");
-    expect(text).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Paste the OpenRouter redirect URL",
-      }),
-    );
+    const prompt = text.mock.calls[0]?.[0];
+    expect(prompt?.message).toContain("Open this URL in your LOCAL browser:");
+    expect(prompt?.message).toContain("https://openrouter.ai/auth?");
+    expect(prompt?.message).toContain("After signing in, paste the OpenRouter redirect URL here:");
     expect(result.defaultModel).toBe("openrouter/auto");
     expect(result.profiles).toEqual([
       {

--- a/extensions/openrouter/oauth.ts
+++ b/extensions/openrouter/oauth.ts
@@ -296,9 +296,18 @@ export async function waitForOpenRouterOAuthCallback(params: {
 async function promptForOpenRouterRedirect(
   ctx: ProviderAuthContext,
   expectedState: string,
+  authorizeUrl?: string,
 ): Promise<string> {
   const input = await ctx.prompter.text({
-    message: "Paste the OpenRouter redirect URL",
+    message: authorizeUrl
+      ? [
+          "Open this URL in your LOCAL browser:",
+          "",
+          authorizeUrl,
+          "",
+          "After signing in, paste the OpenRouter redirect URL here:",
+        ].join("\n")
+      : "Paste the OpenRouter redirect URL",
     placeholder: `${OPENROUTER_OAUTH_REDIRECT_URI}?state=...&code=...`,
     validate: (value: string) => (value.trim().length > 0 ? undefined : "Required"),
   });
@@ -333,14 +342,17 @@ async function resolveOpenRouterOAuthCode(
 
   if (ctx.isRemote) {
     ctx.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${params.authorizeUrl}\n`);
-    return await promptForOpenRouterRedirect(ctx, params.state);
+    return await promptForOpenRouterRedirect(ctx, params.state, params.authorizeUrl);
   }
 
   const callbackPromise = params
     .waitForCallback({ expectedState: params.state, onProgress: params.onProgress })
     .catch(async () => {
       params.onProgress("OAuth callback not detected; waiting for redirect URL...");
-      return { code: await promptForOpenRouterRedirect(ctx, params.state), state: params.state };
+      return {
+        code: await promptForOpenRouterRedirect(ctx, params.state, params.authorizeUrl),
+        state: params.state,
+      };
     });
   void callbackPromise.catch(() => undefined);
 

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -617,6 +617,32 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(result.defaultModel).toBe("google/gemini-3.1-pro-preview");
   });
 
+  it("treats auth-presenting prompters as remote provider auth clients", async () => {
+    let receivedIsRemote: boolean | undefined;
+    const method: ProviderAuthMethod = {
+      id: "oauth",
+      label: "OAuth",
+      kind: "oauth",
+      run: async (ctx) => {
+        receivedIsRemote = ctx.isRemote;
+        return { profiles: [] };
+      },
+    };
+
+    await runProviderPluginAuthMethod({
+      config: {},
+      runtime: {} as ApplyAuthChoiceParams["runtime"],
+      prompter: {
+        presentsAuthChallenge: true,
+        note: vi.fn(async () => {}),
+      } as unknown as ApplyAuthChoiceParams["prompter"],
+      method,
+    });
+
+    expect(isRemoteEnvironment).toHaveBeenCalledOnce();
+    expect(receivedIsRemote).toBe(true);
+  });
+
   it("replaces provider-owned default model maps during auth migrations", async () => {
     const method: ProviderAuthMethod = {
       id: "local",

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -286,7 +286,7 @@ export async function runProviderPluginAuthMethod(params: {
     opts: params.opts,
     secretInputMode: params.secretInputMode,
     allowSecretRefPrompt: params.allowSecretRefPrompt,
-    isRemote: isRemoteEnvironment(),
+    isRemote: isRemoteEnvironment() || params.prompter.presentsAuthChallenge === true,
     openUrl: async (url) => {
       await openUrl(url);
     },

--- a/src/plugins/provider-oauth-flow.test.ts
+++ b/src/plugins/provider-oauth-flow.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
+
+const AUTH_URL = "https://auth.example.test/oauth/authorize?state=abc";
+
+function createOAuthHarness(params: { isRemote: boolean; presentsAuthChallenge?: boolean }) {
+  const spin = { update: vi.fn(), stop: vi.fn() };
+  const text = vi.fn(async () => "http://localhost/callback?code=test");
+  const prompter = {
+    text,
+    presentsAuthChallenge: params.presentsAuthChallenge,
+  } as unknown as WizardPrompter;
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit:${code}`);
+    }),
+  } satisfies RuntimeEnv;
+  const openUrl = vi.fn(async () => {});
+  const handlers = createVpsAwareOAuthHandlers({
+    isRemote: params.isRemote,
+    prompter,
+    runtime,
+    spin,
+    openUrl,
+    localBrowserMessage: "Complete sign-in in browser...",
+    manualPromptMessage: "Paste the redirect URL",
+  });
+  return { handlers, text, openUrl };
+}
+
+describe("createVpsAwareOAuthHandlers", () => {
+  it("includes the authorization URL in remote OAuth text prompts", async () => {
+    const { handlers, text } = createOAuthHarness({
+      isRemote: true,
+    });
+
+    await handlers.onAuth({ url: AUTH_URL });
+
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        AUTH_URL,
+        "",
+        "Paste the redirect URL",
+      ].join("\n"),
+      validate: expect.any(Function),
+    });
+  });
+
+  it("includes the authorization URL in local fallback prompts", async () => {
+    const { handlers, text } = createOAuthHarness({
+      isRemote: false,
+    });
+
+    await handlers.onAuth({ url: AUTH_URL });
+    await handlers.onPrompt({ message: "Paste the redirect URL", placeholder: "http://localhost" });
+
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        AUTH_URL,
+        "",
+        "Paste the redirect URL",
+      ].join("\n"),
+      placeholder: "http://localhost",
+      validate: expect.any(Function),
+    });
+  });
+
+  it("keeps local fallback prompts unchanged before an auth URL is available", async () => {
+    const { handlers, text } = createOAuthHarness({ isRemote: false });
+
+    await handlers.onPrompt({ message: "Paste the redirect URL" });
+
+    expect(text).toHaveBeenCalledWith({
+      message: "Paste the redirect URL",
+      validate: expect.any(Function),
+    });
+  });
+
+  it("surfaces the URL in-band for a local auth-presenting client without opening the gateway browser", async () => {
+    // A companion driving a local gateway over RPC cannot use a browser opened
+    // on the gateway host, so the URL must arrive in the prompt instead.
+    const { handlers, text, openUrl } = createOAuthHarness({
+      isRemote: false,
+      presentsAuthChallenge: true,
+    });
+
+    await handlers.onAuth({ url: AUTH_URL });
+
+    expect(openUrl).not.toHaveBeenCalled();
+    expect(text).toHaveBeenCalledWith({
+      message: [
+        "Open this URL in your LOCAL browser:",
+        "",
+        AUTH_URL,
+        "",
+        "Paste the redirect URL",
+      ].join("\n"),
+      validate: expect.any(Function),
+    });
+  });
+
+  it("always delivers the authorization URL in-band to auth-presenting clients", async () => {
+    // Contract guardrail: an auth-presenting client must never be left to find
+    // the URL only in runtime.log or a gateway-opened browser, regardless of
+    // whether the host is otherwise classified as remote.
+    for (const isRemote of [true, false]) {
+      const { handlers, text } = createOAuthHarness({ isRemote, presentsAuthChallenge: true });
+
+      await handlers.onAuth({ url: AUTH_URL });
+
+      expect(text).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining(AUTH_URL) }),
+      );
+    }
+  });
+});

--- a/src/plugins/provider-oauth-flow.ts
+++ b/src/plugins/provider-oauth-flow.ts
@@ -7,6 +7,10 @@ export type OAuthPrompt = { message: string; placeholder?: string };
 
 const validateRequiredInput = (value: string) => (value.trim().length > 0 ? undefined : "Required");
 
+function withOAuthUrl(message: string, url: string): string {
+  return ["Open this URL in your LOCAL browser:", "", url, "", message].join("\n");
+}
+
 /** Creates OAuth callbacks that use local browser auth locally and manual code entry on VPS hosts. */
 export function createVpsAwareOAuthHandlers(params: {
   isRemote: boolean;
@@ -20,17 +24,25 @@ export function createVpsAwareOAuthHandlers(params: {
   onAuth: (event: { url: string }) => Promise<void>;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
 } {
-  const manualPromptMessage = params.manualPromptMessage ?? "Paste the redirect URL";
-  // Remote hosts cannot open the user's browser, so auth starts in onAuth and finishes in onPrompt.
+  const manualPromptMessage =
+    params.manualPromptMessage ?? "After signing in, paste the redirect URL here.";
+  // Remote/headless hosts cannot open the user's browser, and a client that
+  // presents the auth challenge in-band (e.g. the Windows companion over RPC)
+  // cannot use a browser opened on the gateway host either. In both cases the
+  // authorization URL must be surfaced in the prompt rather than auto-opened.
+  const surfaceUrlInBand = params.isRemote || params.prompter.presentsAuthChallenge === true;
+  // Manual flow starts in onAuth and finishes in onPrompt.
   let manualCodePromise: Promise<string> | undefined;
+  let lastAuthUrl: string | undefined;
 
   return {
     onAuth: async ({ url }) => {
-      if (params.isRemote) {
+      lastAuthUrl = url;
+      if (surfaceUrlInBand) {
         params.spin.stop("OAuth URL ready");
         params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
         manualCodePromise = params.prompter.text({
-          message: manualPromptMessage,
+          message: withOAuthUrl(manualPromptMessage, url),
           validate: validateRequiredInput,
         });
         return;
@@ -45,7 +57,7 @@ export function createVpsAwareOAuthHandlers(params: {
         return manualCodePromise;
       }
       const code = await params.prompter.text({
-        message: prompt.message,
+        message: lastAuthUrl ? withOAuthUrl(prompt.message, lastAuthUrl) : prompt.message,
         placeholder: prompt.placeholder,
         validate: validateRequiredInput,
       });

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -40,6 +40,12 @@ export type WizardProgress = {
 };
 
 export type WizardPrompter = {
+  // True when the client renders auth challenges (OAuth URLs, device codes)
+  // in-band itself — e.g. an RPC wizard client like the Windows companion that
+  // receives wizard steps rather than the gateway's stdout/browser. Providers
+  // use this to surface the authorization URL inside the prompt instead of
+  // relying on a browser opened on the gateway host or terminal-only logging.
+  presentsAuthChallenge?: boolean;
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -131,4 +131,14 @@ describe("WizardSession", () => {
     }
     await session.answer(plainStep.id, "alice");
   });
+
+  test("marks RPC prompters as auth-presenting clients", async () => {
+    const session = new WizardSession(async (prompter) => {
+      expect(prompter.presentsAuthChallenge).toBe(true);
+      await prompter.note("ready");
+    });
+
+    const step = await session.next();
+    expect(step.step?.type).toBe("note");
+  });
 });

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -49,6 +49,8 @@ function createDeferred<T>(): Deferred<T> {
 }
 
 class WizardSessionPrompter implements WizardPrompter {
+  readonly presentsAuthChallenge = true;
+
   constructor(private session: WizardSession) {}
 
   async intro(title: string): Promise<void> {


### PR DESCRIPTION
## Summary

OAuth redirect-paste setup over the RPC wizard only printed the authorization URL to gateway **stdout**, so non-terminal clients (e.g. the Windows companion app) never received the link the user needs to sign in. This carries the generated authorization URL **in-band** in the wizard text prompt via a `presentsAuthChallenge` prompter capability. Terminal CLI logging is preserved.

Covers the shared OAuth helper plus Google, OpenAI ChatGPT/Codex, OpenRouter, Chutes, and MS Teams provider paths, with focused tests.

> Clean re-open of #92234 on top of latest `main`. The previous branch was based on an older `main` and conflicted with `refactor(wizard): hide prompt session types` (f3ae525211), which made `WizardTextParams` non-exported. This version reconciles `WizardSessionPrompter.text()` with the current inline param type. **Supersedes #92234.**

## Change type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Auth / tokens
- [x] Integrations
- [x] UI / DX

## Real behavior proof

Behavior addressed: RPC wizard OAuth setup now shows the generated authorization URL in the same text prompt that asks for the redirect URL, so non-terminal clients can complete sign-in.
Real environment tested: Windows companion app driving an OpenClaw gateway wizard OAuth flow, plus the local Windows OpenClaw worktree on latest `main`.
Exact steps or command run after this patch: Opened the Windows companion against the patched gateway, started a provider OAuth wizard flow that uses redirect-URL paste, confirmed the wizard prompt displayed the authorization URL before the redirect input, opened it in a browser, and completed the redirect paste step. Also ran, cold-cache, on latest `main`: `pnpm tsgo:core`; `pnpm tsgo:core:test`; `node scripts/check-extension-package-tsc-boundary.mjs`; `node scripts/run-vitest.mjs run src/wizard/session.test.ts src/plugins/provider-oauth-flow.test.ts extensions/google/oauth.test.ts extensions/openai/openai-chatgpt-oauth.runtime.test.ts extensions/openrouter/oauth.test.ts src/commands/auth-choice.apply.plugin-provider.test.ts`.
Evidence after fix: Human verification confirmed the Windows companion wizard showed the OAuth authorization URL inline with the redirect paste prompt. Local checks on latest `main`: `tsgo:core` and `tsgo:core:test` exit 0; extension package boundary check passed (114 plugins) exit 0; focused Vitest passed 5 shards, including `forwards manual OAuth URLs into wizard text messages`.
Observed result after fix: The Windows companion flow exposed the authorization URL in the wizard prompt and the redirect paste step could be completed.
What was not tested: Full-repository `pnpm check` and `pnpm test`, and every provider's live OAuth service.

## Compatibility

- Backward compatible? Yes — terminal logging is unchanged and the `presentsAuthChallenge` capability is additive.
- Config/env changes? No.
- Migration needed? No.

## Security impact

The authorization URL was already intentionally shown/logged for user action; this carries the same non-secret authorization URL in the wizard prompt message. The secret-bearing redirect URL remains user input. No new permissions, secrets handling, network calls, or execution surface.

AI-assisted: Yes.
