### PR TITLE
fix: taxonomy coverage id cleanup

### DIFF
--- a/.agents/skills/claw-score/SKILL.md
+++ b/.agents/skills/claw-score/SKILL.md
@@ -31,6 +31,10 @@ out of this repo. If a score needs private evidence, use the redacted
 - `taxonomy.yaml` is the hand-edited source of truth for surfaces, levels,
   QA profiles, categories, feature coverage IDs, docs refs, LTS overrides, and
   completeness-instruction paths.
+- Feature `coverageIds` are conjunctive proof targets, not aliases. Prefer one
+  tightly scoped coverage ID per feature. If a taxonomy feature needs multiple
+  proofs, split it into separately named feature rows so missing proof lowers
+  coverage without hiding which behavior is absent.
 - `docs/maturity-scores.yaml` is the aggregate score source committed in this
   repo. It is the only committed score data; do not add generated inventory
   directories.
@@ -62,6 +66,11 @@ Render an evidence-enriched docs artifact from downloaded QA artifacts:
 pnpm maturity:render -- --evidence-dir .artifacts/maturity-evidence --output-dir .artifacts/maturity-docs
 ```
 
+For taxonomy-only changes in a checkout where the maturity render/check commands
+are not present yet, validate the root taxonomy plus QA scenario evidence join
+directly with the QA Lab scorecard tests and a taxonomy/scenario coverage ID
+audit.
+
 ## Scoring Workflow
 
 When asked to score or refresh a surface:
@@ -77,6 +86,8 @@ When asked to score or refresh a surface:
    public or redacted artifact evidence.
 6. Run `pnpm maturity:render`.
 7. Run `pnpm maturity:check`.
+8. For taxonomy or coverage-ID changes, also run the QA Lab scorecard tests and
+   a taxonomy/scenario coverage ID audit.
 
 For subjective score changes, make the smallest defensible edit and leave the
 evidence path in the PR or task summary. The deterministic renderer owns

--- a/.agents/skills/claw-score/SKILL.md
+++ b/.agents/skills/claw-score/SKILL.md
@@ -31,10 +31,12 @@ out of this repo. If a score needs private evidence, use the redacted
 - `taxonomy.yaml` is the hand-edited source of truth for surfaces, levels,
   QA profiles, categories, feature coverage IDs, docs refs, LTS overrides, and
   completeness-instruction paths.
-- Feature `coverageIds` are proof targets, not aliases. Keep one coverage ID
-  per feature row; split multi-proof features into distinct behavior-named rows.
-- Do not preserve old group names as `Parent - child` feature names, or repeat
-  the same coverage ID within one category.
+- Feature `coverageIds` are ANDed proof targets, not aliases. A feature may
+  list multiple IDs when each ID proves part of one capability.
+- Keep categories and feature names unique, product-shaped, and broader than raw
+  coverage IDs. Do not promote generic IDs into standalone feature names.
+- Avoid duplicate coverage-ID bundles under different feature names in one
+  category.
 - `docs/maturity-scores.yaml` is the aggregate score source committed in this
   repo. It is the only committed score data; do not add generated inventory
   directories.
@@ -66,11 +68,6 @@ Render an evidence-enriched docs artifact from downloaded QA artifacts:
 pnpm maturity:render -- --evidence-dir .artifacts/maturity-evidence --output-dir .artifacts/maturity-docs
 ```
 
-For taxonomy-only changes in a checkout where the maturity render/check commands
-are not present yet, validate the root taxonomy plus QA scenario evidence join
-directly with the QA Lab scorecard tests and a taxonomy/scenario coverage ID
-audit.
-
 ## Scoring Workflow
 
 When asked to score or refresh a surface:
@@ -86,8 +83,6 @@ When asked to score or refresh a surface:
    public or redacted artifact evidence.
 6. Run `pnpm maturity:render`.
 7. Run `pnpm maturity:check`.
-8. For taxonomy or coverage-ID changes, also run the QA Lab scorecard tests and
-   a taxonomy/scenario coverage ID audit.
 
 For subjective score changes, make the smallest defensible edit and leave the
 evidence path in the PR or task summary. The deterministic renderer owns

--- a/.agents/skills/claw-score/SKILL.md
+++ b/.agents/skills/claw-score/SKILL.md
@@ -31,10 +31,15 @@ out of this repo. If a score needs private evidence, use the redacted
 - `taxonomy.yaml` is the hand-edited source of truth for surfaces, levels,
   QA profiles, categories, feature coverage IDs, docs refs, LTS overrides, and
   completeness-instruction paths.
-- Feature `coverageIds` are conjunctive proof targets, not aliases. Prefer one
-  tightly scoped coverage ID per feature. If a taxonomy feature needs multiple
+- Feature `coverageIds` are conjunctive proof targets, not aliases. Keep one
+  tightly scoped coverage ID per feature row. If a feature needs multiple
   proofs, split it into separately named feature rows so missing proof lowers
   coverage without hiding which behavior is absent.
+- Name split feature rows for the behavior being proved, not for the old group
+  they came from. Avoid generated names like `Runtime activation - Plugin
+lifecycle`; prefer `Plugin lifecycle` or another direct behavior name.
+- Within one category, do not repeat the same coverage ID across multiple
+  feature rows. A repeated same-ID row over-counts one proof target.
 - `docs/maturity-scores.yaml` is the aggregate score source committed in this
   repo. It is the only committed score data; do not add generated inventory
   directories.

--- a/.agents/skills/claw-score/SKILL.md
+++ b/.agents/skills/claw-score/SKILL.md
@@ -31,15 +31,10 @@ out of this repo. If a score needs private evidence, use the redacted
 - `taxonomy.yaml` is the hand-edited source of truth for surfaces, levels,
   QA profiles, categories, feature coverage IDs, docs refs, LTS overrides, and
   completeness-instruction paths.
-- Feature `coverageIds` are conjunctive proof targets, not aliases. Keep one
-  tightly scoped coverage ID per feature row. If a feature needs multiple
-  proofs, split it into separately named feature rows so missing proof lowers
-  coverage without hiding which behavior is absent.
-- Name split feature rows for the behavior being proved, not for the old group
-  they came from. Avoid generated names like `Runtime activation - Plugin
-lifecycle`; prefer `Plugin lifecycle` or another direct behavior name.
-- Within one category, do not repeat the same coverage ID across multiple
-  feature rows. A repeated same-ID row over-counts one proof target.
+- Feature `coverageIds` are proof targets, not aliases. Keep one coverage ID
+  per feature row; split multi-proof features into distinct behavior-named rows.
+- Do not preserve old group names as `Parent - child` feature names, or repeat
+  the same coverage ID within one category.
 - `docs/maturity-scores.yaml` is the aggregate score source committed in this
   repo. It is the only committed score data; do not add generated inventory
   directories.

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -57,6 +57,10 @@ the resolved scenarios through `qa suite`. `--surface` and
 The resulting `qa-evidence.json` includes a profile scorecard summary with
 selected-category counts and missing coverage IDs; the individual evidence
 entries remain the source of truth for the tests, coverage roles, and results.
+Taxonomy feature rows are one-ID proof targets, not aliases for equivalent
+behaviors. Primary scenario coverage fulfills the exact matching feature ID;
+secondary coverage is advisory context and still shows as missing primary
+evidence until a scenario covers that ID as primary.
 Slim evidence omits per-entry `execution` and sets `evidenceMode: "slim"`;
 `smoke-ci` defaults to slim, and `--evidence-mode full` restores full entries:
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -57,8 +57,8 @@ the resolved scenarios through `qa suite`. `--surface` and
 The resulting `qa-evidence.json` includes a profile scorecard summary with
 selected-category counts and missing coverage IDs; the individual evidence
 entries remain the source of truth for the tests, coverage roles, and results.
-Taxonomy feature rows are exact one-ID proof targets. Primary scenario coverage
-fulfills matching IDs; secondary coverage stays advisory.
+Taxonomy feature coverage IDs are exact proof targets, not aliases. Primary
+scenario coverage fulfills matching IDs; secondary coverage stays advisory.
 Slim evidence omits per-entry `execution` and sets `evidenceMode: "slim"`;
 `smoke-ci` defaults to slim, and `--evidence-mode full` restores full entries:
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -57,10 +57,8 @@ the resolved scenarios through `qa suite`. `--surface` and
 The resulting `qa-evidence.json` includes a profile scorecard summary with
 selected-category counts and missing coverage IDs; the individual evidence
 entries remain the source of truth for the tests, coverage roles, and results.
-Taxonomy feature rows are one-ID proof targets, not aliases for equivalent
-behaviors. Primary scenario coverage fulfills the exact matching feature ID;
-secondary coverage is advisory context and still shows as missing primary
-evidence until a scenario covers that ID as primary.
+Taxonomy feature rows are exact one-ID proof targets. Primary scenario coverage
+fulfills matching IDs; secondary coverage stays advisory.
 Slim evidence omits per-entry `execution` and sets `evidenceMode: "slim"`;
 `smoke-ci` defaults to slim, and `--evidence-mode full` restores full entries:
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -473,11 +473,11 @@ describe("qa cli runtime", () => {
       expect(evidence.scorecard).not.toHaveProperty("kind");
       expect(evidence.scorecard).not.toHaveProperty("taxonomy");
       expect(evidence.scorecard).not.toHaveProperty("profile");
-      expect(evidence.scorecard?.features?.fulfilled).toBe(1);
+      expect(evidence.scorecard?.features?.fulfilled).toBe(0);
       expect(evidence.scorecard?.categoryReports?.[0]).toMatchObject({
         id: "agent-runtime-and-provider-execution.agent-turn-execution",
         features: {
-          fulfilled: 1,
+          fulfilled: 0,
         },
       });
       expect(evidence.entries?.[0]).not.toHaveProperty("execution");

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -473,11 +473,11 @@ describe("qa cli runtime", () => {
       expect(evidence.scorecard).not.toHaveProperty("kind");
       expect(evidence.scorecard).not.toHaveProperty("taxonomy");
       expect(evidence.scorecard).not.toHaveProperty("profile");
-      expect(evidence.scorecard?.features?.fulfilled).toBe(0);
+      expect(evidence.scorecard?.features?.fulfilled).toBe(1);
       expect(evidence.scorecard?.categoryReports?.[0]).toMatchObject({
         id: "agent-runtime-and-provider-execution.agent-turn-execution",
         features: {
-          fulfilled: 0,
+          fulfilled: 1,
         },
       });
       expect(evidence.entries?.[0]).not.toHaveProperty("execution");

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -19,8 +19,9 @@ title: OpenClaw QA Scenario Pack
 # - add `coverage.secondary` only when a scenario intentionally protects another behavior
 # - keep IDs behavior-shaped, broad enough to reuse, lowercase, and dotted or dashed
 # - use the exact values listed under feature `coverageIds` in `taxonomy.yaml`
-# - taxonomy feature rows use one coverage ID; scenario primary can list multiple
-#   only when this scenario is primary proof for each
+# - taxonomy feature coverage IDs are exact proof targets, not aliases
+# - scenario primary can list multiple IDs only when this scenario is primary
+#   proof for each
 # - prefer reusing an existing coverage ID over minting a scenario-shaped ID
 # - avoid copying the scenario title into coverage IDs
 # - use `pnpm openclaw qa coverage` to render the current inventory

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -19,6 +19,8 @@ title: OpenClaw QA Scenario Pack
 # - add `coverage.secondary` only when a scenario intentionally protects another behavior
 # - keep IDs behavior-shaped, broad enough to reuse, lowercase, and dotted or dashed
 # - use the exact values listed under feature `coverageIds` in `taxonomy.yaml`
+# - taxonomy feature rows should normally carry one coverage ID; scenario primary
+#   IDs may list multiple behaviors only when this scenario is primary proof for each
 # - prefer reusing an existing coverage ID over minting a scenario-shaped ID
 # - avoid copying the scenario title into coverage IDs
 # - use `pnpm openclaw qa coverage` to render the current inventory

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -19,8 +19,8 @@ title: OpenClaw QA Scenario Pack
 # - add `coverage.secondary` only when a scenario intentionally protects another behavior
 # - keep IDs behavior-shaped, broad enough to reuse, lowercase, and dotted or dashed
 # - use the exact values listed under feature `coverageIds` in `taxonomy.yaml`
-# - taxonomy feature rows should normally carry one coverage ID; scenario primary
-#   IDs may list multiple behaviors only when this scenario is primary proof for each
+# - taxonomy feature rows use one coverage ID; scenario primary can list multiple
+#   only when this scenario is primary proof for each
 # - prefer reusing an existing coverage ID over minting a scenario-shaped ID
 # - avoid copying the scenario title into coverage IDs
 # - use `pnpm openclaw qa coverage` to render the current inventory

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -175,11 +175,11 @@ surfaces:
           - name: Usage and memory APIs
             coverageIds: [usage-and-memory-apis]
             description: Usage summaries and memory readiness RPCs.
-          - name: Session APIs - Subagents
+          - name: Subagents
             coverageIds: [agents.subagents]
-          - name: Session APIs - Gateway session list
+          - name: Gateway session list
             coverageIds: [gateway.sessions-list]
-          - name: Session APIs - Session status tool
+          - name: Session status tool
             coverageIds: [tools.session-status]
           - name: Chat APIs
             coverageIds: [chat-apis]
@@ -450,11 +450,11 @@ surfaces:
           - name: Service installation
             coverageIds: [service-installation]
             description: Supervised lifecycle installation on macOS, Linux user/systemd, and native Windows task scheduling.
-          - name: Restart and stop - Restart config apply
+          - name: Restart config apply
             coverageIds: [config.restart-apply]
-          - name: Restart and stop - Plugin capabilities
+          - name: Plugin capabilities
             coverageIds: [plugins.capabilities]
-          - name: Restart and stop - Gateway restart
+          - name: Gateway restart
             coverageIds: [runtime.gateway-restart]
           - name: Service status
             coverageIds: [service-status]
@@ -462,13 +462,13 @@ surfaces:
           - name: Bind and port settings
             coverageIds: [bind-and-port-settings]
             description: Bind and port precedence across CLI flags, env vars, config, and persisted supervisor metadata.
-          - name: Config reload - Hot config apply
+          - name: Hot config apply
             coverageIds: [config.hot-apply]
-          - name: Config reload - Hot plugin reload
+          - name: Hot plugin reload
             coverageIds: [plugins.hot-reload]
-          - name: Config reload - Plugin lifecycle
+          - name: Plugin lifecycle
             coverageIds: [plugins.lifecycle]
-          - name: Config reload - Plugin skills
+          - name: Plugin skills
             coverageIds: [plugins.skills]
           - name: Multi-gateway isolation
             coverageIds: [multi-gateway-isolation]
@@ -656,11 +656,11 @@ surfaces:
           - name: Service install and control
             coverageIds: [service-install-and-control]
             description: The CLI documents install, status, start, stop, restart, and run flows for managed gateway services.
-          - name: Service auth wiring - Agent creation
+          - name: Agent creation
             coverageIds: [agents.create]
-          - name: Service auth wiring - Discord channel config
+          - name: Discord channel config
             coverageIds: [channels.discord-config]
-          - name: Service auth wiring - Crestodian setup config
+          - name: Crestodian setup config
             coverageIds: [config.crestodian-setup]
           - name: Drift and reinstall recovery
             coverageIds: [drift-and-reinstall-recovery]
@@ -926,52 +926,44 @@ surfaces:
           - name: Plugin setup
             coverageIds: [plugin-setup]
             description: Operators can run plugin setup flows without fully activating runtime behavior.
-          - name: Runtime activation - Hot config apply
+          - name: Hot config apply
             coverageIds: [config.hot-apply]
-          - name: Runtime activation - Gateway performance
+          - name: Gateway performance
             coverageIds: [gateway.performance]
-          - name: Runtime activation - Live OpenAI models
+          - name: Live OpenAI models
             coverageIds: [models.live-openai]
-          - name: Runtime activation - Before prompt build hook
+          - name: Before prompt build hook
             coverageIds: [plugins.before-prompt-build]
-          - name: Runtime activation - Before tool call hook
+          - name: Before tool call hook
             coverageIds: [plugins.before-tool-call]
-          - name: Runtime activation - Hot plugin reload
+          - name: Hot plugin reload
             coverageIds: [plugins.hot-reload]
-          - name: Runtime activation - Kitchen sink plugin
+          - name: Kitchen sink plugin
             coverageIds: [plugins.kitchen-sink]
-          - name: Runtime activation - Plugin lifecycle
+          - name: Plugin lifecycle
             coverageIds: [plugins.lifecycle]
-          - name: Runtime activation - Plugin tools
+          - name: Plugin tools
             coverageIds: [plugins.plugin-tools]
-          - name: Runtime activation - Plugin runtime
+          - name: Plugin runtime
             coverageIds: [plugins.runtime]
-          - name: Runtime activation - Plugin skills
+          - name: Plugin skills
             coverageIds: [plugins.skills]
-          - name: Runtime activation - Gateway log sentinel plugin hooks
+          - name: Gateway log sentinel plugin hooks
             coverageIds: [runtime.gateway-log-sentinel.plugin-hooks]
-          - name: Enable and disable - Hot config apply
-            coverageIds: [config.hot-apply]
-          - name: Enable and disable - Hot plugin reload
-            coverageIds: [plugins.hot-reload]
-          - name: Enable and disable - Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: Safe load failures - Plugin tool contracts
+          - name: Plugin tool contracts
             coverageIds: [plugins.contracts.tools]
-          - name: Safe load failures - Gateway log sentinel plugin contracts
+          - name: Gateway log sentinel plugin contracts
             coverageIds: [runtime.gateway-log-sentinel.plugin-contracts]
           - name: Dependency repair
             coverageIds: [dependency-repair]
             description: Runtime can detect and repair missing or stale plugin dependencies.
-          - name: Install update and uninstall - Hot plugin install
+          - name: Hot plugin install
             coverageIds: [plugins.hot-install]
-          - name: Install update and uninstall - Plugin skills
-            coverageIds: [plugins.skills]
-          - name: Install update and uninstall - Gateway restart
+          - name: Gateway restart
             coverageIds: [runtime.gateway-restart]
-          - name: Install update and uninstall - Package update runtime
+          - name: Package update runtime
             coverageIds: [runtime.package-update]
-          - name: Install update and uninstall - Update run runtime
+          - name: Update run runtime
             coverageIds: [runtime.update-run]
         docs:
           - docs/plugins/architecture.md
@@ -1019,25 +1011,25 @@ surfaces:
           - name: Provider plugins
             coverageIds: [provider-plugins]
             description: Provider plugins register models and capabilities with the runtime.
-          - name: Tool plugins - Gateway performance
+          - name: Gateway performance
             coverageIds: [gateway.performance]
-          - name: Tool plugins - Live OpenAI models
+          - name: Live OpenAI models
             coverageIds: [models.live-openai]
-          - name: Tool plugins - Before prompt build hook
+          - name: Before prompt build hook
             coverageIds: [plugins.before-prompt-build]
-          - name: Tool plugins - Before tool call hook
+          - name: Before tool call hook
             coverageIds: [plugins.before-tool-call]
-          - name: Tool plugins - Kitchen sink plugin
+          - name: Kitchen sink plugin
             coverageIds: [plugins.kitchen-sink]
-          - name: Tool plugins - Plugin lifecycle
+          - name: Plugin lifecycle
             coverageIds: [plugins.lifecycle]
-          - name: Tool plugins - MCP plugin tools
+          - name: MCP plugin tools
             coverageIds: [plugins.mcp-tools]
-          - name: Tool plugins - Plugin tools
+          - name: Plugin tools
             coverageIds: [plugins.plugin-tools]
-          - name: Tool plugins - Gateway log sentinel plugin hooks
+          - name: Gateway log sentinel plugin hooks
             coverageIds: [runtime.gateway-log-sentinel.plugin-hooks]
-          - name: Tool plugins - Tool invocation
+          - name: Tool invocation
             coverageIds: [tools.invocation]
           - name: Model catalogs
             coverageIds: [model-catalogs]
@@ -1048,21 +1040,19 @@ surfaces:
           - name: Web search and fetch
             coverageIds: [web-search-and-fetch]
             description: Provider or tool plugins can expose web search and fetch capabilities.
-          - name: Mixed plugins - Hot config apply
+          - name: Hot config apply
             coverageIds: [config.hot-apply]
-          - name: Mixed plugins - Restart config apply
+          - name: Restart config apply
             coverageIds: [config.restart-apply]
-          - name: Mixed plugins - Plugin capabilities
+          - name: Plugin capabilities
             coverageIds: [plugins.capabilities]
-          - name: Mixed plugins - Hot plugin install
+          - name: Hot plugin install
             coverageIds: [plugins.hot-install]
-          - name: Mixed plugins - Plugin runtime
+          - name: Plugin runtime
             coverageIds: [plugins.runtime]
-          - name: Mixed plugins - Plugin skills
+          - name: Plugin skills
             coverageIds: [plugins.skills]
-          - name: Mixed plugins - Tool invocation
-            coverageIds: [tools.invocation]
-          - name: Mixed plugins - Skill invocation tool
+          - name: Skill invocation tool
             coverageIds: [tools.skill-invocation]
         docs:
           - docs/plugins/sdk-provider-plugins.md
@@ -1147,9 +1137,9 @@ surfaces:
           - name: Local test environment
             coverageIds: [local-test-environment]
             description: Plugin authors can set up the local test environment and scoped helper configuration for plugin testing.
-          - name: Plugin runtime harness - Plugin tool contracts
+          - name: Plugin tool contracts
             coverageIds: [plugins.contracts.tools]
-          - name: Plugin runtime harness - Gateway log sentinel plugin contracts
+          - name: Gateway log sentinel plugin contracts
             coverageIds: [runtime.gateway-log-sentinel.plugin-contracts]
           - name: Unit and integration scaffolds
             coverageIds: [unit-and-integration-scaffolds]
@@ -1157,15 +1147,15 @@ surfaces:
           - name: Docker lifecycle suites
             coverageIds: [docker-lifecycle-suites]
             description: Docker-based end-to-end scripts validate packaged plugin lifecycle flows.
-          - name: Smoke tests - Gateway performance
+          - name: Gateway performance
             coverageIds: [gateway.performance]
-          - name: Smoke tests - Live OpenAI models
+          - name: Live OpenAI models
             coverageIds: [models.live-openai]
-          - name: Smoke tests - Kitchen sink plugin
+          - name: Kitchen sink plugin
             coverageIds: [plugins.kitchen-sink]
-          - name: Smoke tests - Plugin lifecycle
+          - name: Plugin lifecycle
             coverageIds: [plugins.lifecycle]
-          - name: Smoke tests - Plugin tools
+          - name: Plugin tools
             coverageIds: [plugins.plugin-tools]
         docs:
           - docs/plugins/sdk-testing.md
@@ -1195,61 +1185,53 @@ surfaces:
       - name: Agent Turn Execution
         id: agent-turn-execution
         features:
-          - name: Turn startup and runtime choice - Agent creation
+          - name: Agent creation
             coverageIds: [agents.create]
-          - name: Turn startup and runtime choice - Agent instructions
+          - name: Agent instructions
             coverageIds: [agents.instructions]
-          - name: Turn startup and runtime choice - Discord channel config
+          - name: Discord channel config
             coverageIds: [channels.discord-config]
-          - name: Turn startup and runtime choice - Crestodian setup config
+          - name: Crestodian setup config
             coverageIds: [config.crestodian-setup]
-          - name: Turn startup and runtime choice - First action runtime
+          - name: First action runtime
             coverageIds: [runtime.first-action]
-          - name: Turn startup and runtime choice - First-hour 20-turn runtime
+          - name: First-hour 20-turn runtime
             coverageIds: [runtime.first-hour-20]
-          - name: Turn startup and runtime choice - Long context runtime
+          - name: Long context runtime
             coverageIds: [runtime.long-context]
-          - name: Session and run coordination - Subagents
+          - name: Subagents
             coverageIds: [agents.subagents]
-          - name: Session and run coordination - Channel deduplication
+          - name: Channel deduplication
             coverageIds: [channels.dedup]
-          - name: Session and run coordination - DM channel
+          - name: DM channel
             coverageIds: [channels.dm]
-          - name: Session and run coordination - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Session and run coordination - Channel reconnect
+          - name: Channel reconnect
             coverageIds: [channels.reconnect]
-          - name: Session and run coordination - Channel streaming
+          - name: Channel streaming
             coverageIds: [channels.streaming]
-          - name: Session and run coordination - Channel threads
+          - name: Channel threads
             coverageIds: [channels.threads]
-          - name: Session and run coordination - No-target heartbeat commitments
+          - name: No-target heartbeat commitments
             coverageIds: [commitments.heartbeat-target-none]
-          - name: Session and run coordination - Commitment scope
+          - name: Commitment scope
             coverageIds: [commitments.scope]
-          - name: Session and run coordination - Personal channel replies
+          - name: Personal channel replies
             coverageIds: [personal.channel-replies]
-          - name: Session and run coordination - Codex plugin lifecycle
+          - name: Codex plugin lifecycle
             coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: Session and run coordination - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
-          - name: Session and run coordination - Fallback delivery
+          - name: Fallback delivery
             coverageIds: [runtime.fallback-delivery]
-          - name: Session and run coordination - Gateway restart
+          - name: Gateway restart
             coverageIds: [runtime.gateway-restart]
-          - name: Session and run coordination - Runtime restart recovery
+          - name: Runtime restart recovery
             coverageIds: [runtime.restart-recovery]
-          - name: Session and run coordination - Turn ordering
+          - name: Turn ordering
             coverageIds: [runtime.turn-ordering]
-          - name: Abort and terminal outcomes - Channel streaming
-            coverageIds: [channels.streaming]
-          - name: Abort and terminal outcomes - Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Abort and terminal outcomes - Fallback delivery
-            coverageIds: [runtime.fallback-delivery]
-          - name: Abort and terminal outcomes - Long context runtime
-            coverageIds: [runtime.long-context]
-          - name: Abort and terminal outcomes - 100-turn soak
+          - name: 100-turn soak
             coverageIds: [runtime.soak-100]
         docs:
           - docs/concepts/agent-loop.md
@@ -1264,24 +1246,24 @@ surfaces:
       - name: External Runtimes and Subagents
         id: external-runtimes-and-subagents
         features:
-          - name: External harness selection - OpenClaw harness agent
+          - name: OpenClaw harness agent
             coverageIds: [agents.openclaw-harness]
-          - name: External harness selection - Workspace planning
+          - name: Workspace planning
             coverageIds: [workspace.planning]
           - name: CLI runtime aliases
             coverageIds: [cli-runtime-aliases]
             description: Runtime aliases and CLI-based execution paths such as Claude CLI and Gemini CLI.
-          - name: Subagent turns - Subagents
+          - name: Subagents
             coverageIds: [agents.subagents]
-          - name: Subagent turns - Agent synthesis
+          - name: Agent synthesis
             coverageIds: [agents.synthesis]
-          - name: Subagent turns - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Subagent turns - Gateway session list
+          - name: Gateway session list
             coverageIds: [gateway.sessions-list]
-          - name: Subagent turns - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
-          - name: Subagent turns - Session spawn tool
+          - name: Session spawn tool
             coverageIds: [tools.sessions-spawn]
           - name: Runtime recovery
             coverageIds: [runtime-recovery]
@@ -1357,26 +1339,20 @@ surfaces:
       - name: Model and Runtime Selection
         id: model-and-runtime-selection
         features:
-          - name: Model reference selection - Claude CLI model
+          - name: Claude CLI model
             coverageIds: [models.claude-cli]
-          - name: Model reference selection - Provider model capabilities
+          - name: Provider model capabilities
             coverageIds: [models.provider-capabilities]
-          - name: Provider and runtime overrides - Model switching
+          - name: Model switching
             coverageIds: [models.switching]
-          - name: Provider and runtime overrides - Model thinking
+          - name: Model thinking
             coverageIds: [models.thinking]
-          - name: Provider and runtime overrides - Session continuity
+          - name: Session continuity
             coverageIds: [runtime.session-continuity]
-          - name: Provider and runtime overrides - Tool continuity
+          - name: Tool continuity
             coverageIds: [runtime.tool-continuity]
-          - name: Thinking and context settings - Model switching
-            coverageIds: [models.switching]
-          - name: Thinking and context settings - Model thinking
-            coverageIds: [models.thinking]
-          - name: Thinking and context settings - Reasoning visibility
+          - name: Reasoning visibility
             coverageIds: [runtime.reasoning-visibility]
-          - name: Thinking and context settings - Session continuity
-            coverageIds: [runtime.session-continuity]
           - name: Invalid route recovery
             coverageIds: [invalid-route-recovery]
             description: Preserving or clearing invalid route state when selections drift or fail.
@@ -1394,30 +1370,30 @@ surfaces:
       - name: Provider Auth
         id: provider-auth
         features:
-          - name: Login and API-key setup - Anthropic model
+          - name: Anthropic model
             coverageIds: [models.anthropic]
-          - name: Login and API-key setup - Provider model auth
+          - name: Provider model auth
             coverageIds: [models.provider-auth]
-          - name: Auth profile selection - Auth profiles provider selection
+          - name: Auth profiles provider selection
             coverageIds: [auth-profiles.provider-selection]
-          - name: Auth profile selection - Codex plugin auth
+          - name: Codex plugin auth
             coverageIds: [runtime.codex-plugin.auth]
-          - name: Credential health checks - Gateway performance
+          - name: Gateway performance
             coverageIds: [gateway.performance]
-          - name: Credential health checks - Live OpenAI models
+          - name: Live OpenAI models
             coverageIds: [models.live-openai]
-          - name: Credential health checks - Kitchen sink plugin
+          - name: Kitchen sink plugin
             coverageIds: [plugins.kitchen-sink]
-          - name: Credential health checks - Plugin lifecycle
+          - name: Plugin lifecycle
             coverageIds: [plugins.lifecycle]
-          - name: Credential health checks - Plugin tools
+          - name: Plugin tools
             coverageIds: [plugins.plugin-tools]
           - name: Auth failover
             coverageIds: [auth-failover]
             description: Same-provider and cross-profile auth fallback behavior.
-          - name: Provider fallback recovery - Memory failure handling
+          - name: Memory failure handling
             coverageIds: [memory.failure-handling]
-          - name: Provider fallback recovery - Runtime fallbacks
+          - name: Runtime fallbacks
             coverageIds: [runtime.fallbacks]
           - name: Rate-limit and capacity recovery
             coverageIds: [rate-limit-and-capacity-recovery]
@@ -1451,23 +1427,23 @@ surfaces:
       - name: Streaming and Progress
         id: streaming-and-progress
         features:
-          - name: Streaming replies - Channel streaming
+          - name: Channel streaming
             coverageIds: [channels.streaming]
-          - name: Streaming replies - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
-          - name: Streaming replies - Fallback delivery
+          - name: Fallback delivery
             coverageIds: [runtime.fallback-delivery]
-          - name: Progress visibility - Model thinking
+          - name: Model thinking
             coverageIds: [models.thinking]
-          - name: Progress visibility - Personal failure recovery
+          - name: Personal failure recovery
             coverageIds: [personal.failure-recovery]
-          - name: Progress visibility - Personal no fake progress
+          - name: Personal no fake progress
             coverageIds: [personal.no-fake-progress]
-          - name: Progress visibility - Personal task followthrough
+          - name: Personal task followthrough
             coverageIds: [personal.task-followthrough]
-          - name: Progress visibility - Reasoning visibility
+          - name: Reasoning visibility
             coverageIds: [runtime.reasoning-visibility]
-          - name: Progress visibility - Evidence tools
+          - name: Evidence tools
             coverageIds: [tools.evidence]
         docs:
           - docs/concepts/streaming.md
@@ -1481,56 +1457,52 @@ surfaces:
       - name: Tool Calls and Response Handling
         id: tool-calls-and-response-handling
         features:
-          - name: Tool-call handling - Model switching
+          - name: Model switching
             coverageIds: [models.switching]
-          - name: Tool-call handling - Personal no fake progress
+          - name: Personal no fake progress
             coverageIds: [personal.no-fake-progress]
-          - name: Tool-call handling - Personal task followthrough
+          - name: Personal task followthrough
             coverageIds: [personal.task-followthrough]
-          - name: Tool-call handling - Personal tool safety
+          - name: Personal tool safety
             coverageIds: [personal.tool-safety]
-          - name: Tool-call handling - Runtime approvals
+          - name: Runtime approvals
             coverageIds: [runtime.approvals]
-          - name: Tool-call handling - Codex native workspace read
+          - name: Codex native workspace read
             coverageIds: [runtime.codex-native-workspace.read]
-          - name: Tool-call handling - Runtime prompt compatibility
+          - name: Runtime prompt compatibility
             coverageIds: [runtime.prompt-compatibility]
-          - name: Tool-call handling - Tool continuity
+          - name: Tool continuity
             coverageIds: [runtime.tool-continuity]
-          - name: Tool-call handling - Apply patch tool
+          - name: Apply patch tool
             coverageIds: [tools.apply-patch]
-          - name: Tool-call handling - Edit tool
+          - name: Edit tool
             coverageIds: [tools.edit]
-          - name: Tool-call handling - Evidence tools
+          - name: Evidence tools
             coverageIds: [tools.evidence]
-          - name: Tool-call handling - Tool followthrough
+          - name: Tool followthrough
             coverageIds: [tools.followthrough]
-          - name: Tool-call handling - File list tool
+          - name: File list tool
             coverageIds: [tools.fs.list]
-          - name: Tool-call handling - File read tool
+          - name: File read tool
             coverageIds: [tools.fs.read]
-          - name: Tool-call handling - File write tool
+          - name: File write tool
             coverageIds: [tools.fs.write]
-          - name: Tool-call handling - Grep tool
+          - name: Grep tool
             coverageIds: [tools.grep]
-          - name: Tool-call handling - Workspace artifacts
+          - name: Workspace artifacts
             coverageIds: [workspace.artifacts]
-          - name: Usage and response reporting - Subagents
+          - name: Subagents
             coverageIds: [agents.subagents]
-          - name: Usage and response reporting - Agent synthesis
+          - name: Agent synthesis
             coverageIds: [agents.synthesis]
-          - name: Failure recovery - Personal failure recovery
+          - name: Personal failure recovery
             coverageIds: [personal.failure-recovery]
-          - name: Failure recovery - Personal no fake progress
-            coverageIds: [personal.no-fake-progress]
-          - name: Failure recovery - Runtime empty response recovery
+          - name: Runtime empty response recovery
             coverageIds: [runtime.empty-response-recovery]
-          - name: Failure recovery - Runtime reasoning only recovery
+          - name: Runtime reasoning only recovery
             coverageIds: [runtime.reasoning-only-recovery]
-          - name: Failure recovery - Retry policy
+          - name: Retry policy
             coverageIds: [runtime.retry-policy]
-          - name: Failure recovery - Evidence tools
-            coverageIds: [tools.evidence]
         docs:
           - docs/concepts/agent-loop.md
           - docs/providers/ollama.md
@@ -1543,40 +1515,30 @@ surfaces:
       - name: Tool Execution Controls
         id: tool-execution-controls
         features:
-          - name: Tool availability rules - QA artifact safety
+          - name: QA artifact safety
             coverageIds: [qa.artifact-safety]
-          - name: Tool availability rules - Runtime inventory
+          - name: Runtime inventory
             coverageIds: [runtime.inventory]
-          - name: Tool availability rules - Runtime tool policy
+          - name: Runtime tool policy
             coverageIds: [runtime.tool-policy]
-          - name: Tool availability rules - Security redaction
+          - name: Security redaction
             coverageIds: [security.redaction]
           - name: Sandboxed exec behavior
             coverageIds: [sandboxed-exec-behavior]
             description: Exec behavior, sandbox roots, and workspace constraints visible to operators.
-          - name: Approval flow - Personal approval denial
+          - name: Personal approval denial
             coverageIds: [personal.approval-denial]
-          - name: Approval flow - Personal tool safety
+          - name: Personal tool safety
             coverageIds: [personal.tool-safety]
-          - name: Approval flow - Runtime approvals
+          - name: Runtime approvals
             coverageIds: [runtime.approvals]
-          - name: Approval flow - Tool followthrough
+          - name: Tool followthrough
             coverageIds: [tools.followthrough]
-          - name: Approval flow - Tool safety
+          - name: Tool safety
             coverageIds: [tools.safety]
           - name: Elevated execution
             coverageIds: [elevated-execution]
             description: Elevated host execution rules and related controls.
-          - name: Tool safety controls - Personal approval denial
-            coverageIds: [personal.approval-denial]
-          - name: Tool safety controls - Personal tool safety
-            coverageIds: [personal.tool-safety]
-          - name: Tool safety controls - Runtime approvals
-            coverageIds: [runtime.approvals]
-          - name: Tool safety controls - Tool followthrough
-            coverageIds: [tools.followthrough]
-          - name: Tool safety controls - Tool safety
-            coverageIds: [tools.safety]
           - name: Delegated tool access
             coverageIds: [delegated-tool-access]
             description: Inherited or narrowed tool policy for subagents and delegated execution.
@@ -1627,26 +1589,26 @@ surfaces:
       - name: Token Management
         id: token-management
         features:
-          - name: Compaction - Runtime compaction
+          - name: Runtime compaction
             coverageIds: [runtime.compaction]
-          - name: Compaction - Runtime empty response recovery
+          - name: Runtime empty response recovery
             coverageIds: [runtime.empty-response-recovery]
-          - name: Compaction - Runtime reasoning only recovery
+          - name: Runtime reasoning only recovery
             coverageIds: [runtime.reasoning-only-recovery]
-          - name: Compaction - Retry policy
+          - name: Retry policy
             coverageIds: [runtime.retry-policy]
           - name: Pruning
             coverageIds: [pruning]
             description: Covers Pruning across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
-          - name: Token Pressure - Codex app server runtime
+          - name: Codex app server runtime
             coverageIds: [runtime.codex-app-server]
-          - name: Token Pressure - First-hour 20-turn runtime
+          - name: First-hour 20-turn runtime
             coverageIds: [runtime.first-hour-20]
-          - name: Token Pressure - Gateway log sentinel Codex progress
+          - name: Gateway log sentinel Codex progress
             coverageIds: [runtime.gateway-log-sentinel.codex-progress]
-          - name: Token Pressure - Long context runtime
+          - name: Long context runtime
             coverageIds: [runtime.long-context]
-          - name: Token Pressure - 100-turn soak
+          - name: 100-turn soak
             coverageIds: [runtime.soak-100]
         docs:
           - docs/concepts/compaction.md
@@ -1663,19 +1625,19 @@ surfaces:
       - name: Context Engine
         id: context-engine
         features:
-          - name: Context Engine - Docs discovery
+          - name: Docs discovery
             coverageIds: [docs.discovery]
-          - name: Context Engine - Workspace artifacts
+          - name: Workspace artifacts
             coverageIds: [workspace.artifacts]
-          - name: Context Engine - Long-running workspace task
+          - name: Long-running workspace task
             coverageIds: [workspace.long-running-task]
-          - name: Context Engine - Repo discovery
+          - name: Repo discovery
             coverageIds: [workspace.repo-discovery]
-          - name: Runtime Assembly - OpenClaw harness agent
+          - name: OpenClaw harness agent
             coverageIds: [agents.openclaw-harness]
-          - name: Runtime Assembly - Codex CLI model
+          - name: Codex CLI model
             coverageIds: [models.codex-cli]
-          - name: Runtime Assembly - Workspace planning
+          - name: Workspace planning
             coverageIds: [workspace.planning]
         docs:
           - docs/concepts/context.md
@@ -1691,15 +1653,15 @@ surfaces:
       - name: Cross-client History and Session Parity
         id: cross-client-history-and-session-parity
         features:
-          - name: Cross-client History - Channel threads
+          - name: Channel threads
             coverageIds: [channels.threads]
-          - name: Cross-client History - Memory thread isolation
+          - name: Memory thread isolation
             coverageIds: [memory.thread-isolation]
-          - name: Session Parity - Model switching
+          - name: Model switching
             coverageIds: [models.switching]
-          - name: Session Parity - Model thinking
+          - name: Model thinking
             coverageIds: [models.thinking]
-          - name: Session Parity - Session continuity
+          - name: Session continuity
             coverageIds: [runtime.session-continuity]
         docs:
           - docs/web/webchat.md
@@ -1721,21 +1683,21 @@ surfaces:
           - name: Session maintenance warnings
             coverageIds: [session-maintenance-warnings]
             description: Covers restart maintenance warnings, delivery queues, memory/session cleanup signals, and operator-visible maintenance state.
-          - name: Session and transcript recovery - Restart config apply
+          - name: Restart config apply
             coverageIds: [config.restart-apply]
-          - name: Session and transcript recovery - Memory failure handling
+          - name: Memory failure handling
             coverageIds: [memory.failure-handling]
-          - name: Session and transcript recovery - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
-          - name: Session and transcript recovery - Runtime fallbacks
+          - name: Runtime fallbacks
             coverageIds: [runtime.fallbacks]
-          - name: Session and transcript recovery - Gateway restart
+          - name: Gateway restart
             coverageIds: [runtime.gateway-restart]
-          - name: Session and transcript recovery - Package update runtime
+          - name: Package update runtime
             coverageIds: [runtime.package-update]
-          - name: Session and transcript recovery - Runtime restart recovery
+          - name: Runtime restart recovery
             coverageIds: [runtime.restart-recovery]
-          - name: Session and transcript recovery - Update run runtime
+          - name: Update run runtime
             coverageIds: [runtime.update-run]
         docs:
           - docs/gateway/diagnostics.md
@@ -1753,21 +1715,21 @@ surfaces:
       - name: Core Prompts and Context
         id: core-prompts-and-context
         features:
-          - name: Instruction Profile - Agent instructions
+          - name: Agent instructions
             coverageIds: [agents.instructions]
-          - name: Instruction Profile - Character persona
+          - name: Character persona
             coverageIds: [character.persona]
-          - name: Instruction Profile - First action runtime
+          - name: First action runtime
             coverageIds: [runtime.first-action]
-          - name: Instruction Profile - Workspace artifacts
+          - name: Workspace artifacts
             coverageIds: [workspace.artifacts]
-          - name: Context Visibility - Docs discovery
+          - name: Docs discovery
             coverageIds: [docs.discovery]
-          - name: Context Visibility - Codex CLI model
+          - name: Codex CLI model
             coverageIds: [models.codex-cli]
-          - name: Context Visibility - Runtime no meta leak
+          - name: Runtime no meta leak
             coverageIds: [runtime.no-meta-leak]
-          - name: Context Visibility - Repo discovery
+          - name: Repo discovery
             coverageIds: [workspace.repo-discovery]
         docs:
           - docs/concepts/context.md
@@ -1786,48 +1748,30 @@ surfaces:
           - name: Memory Backend Storage
             coverageIds: [memory-backend-storage]
             description: Covers Memory Backend Storage across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
-          - name: Embedding Search - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Embedding Search - Memory active recall
+          - name: Memory active recall
             coverageIds: [memory.active-recall]
-          - name: Embedding Search - Memory ranking
+          - name: Memory ranking
             coverageIds: [memory.ranking]
-          - name: Embedding Search - Memory recall
+          - name: Memory recall
             coverageIds: [memory.recall]
-          - name: Embedding Search - Personal memory recall
+          - name: Personal memory recall
             coverageIds: [personal.memory-recall]
-          - name: Memory Files - Memory dreaming
+          - name: Memory dreaming
             coverageIds: [memory.dreaming]
-          - name: Memory Files - Memory promotion
+          - name: Memory promotion
             coverageIds: [memory.promotion]
-          - name: Memory Files - QA artifact safety
+          - name: QA artifact safety
             coverageIds: [qa.artifact-safety]
-          - name: Memory search and store tools - Group channel messages
+          - name: Group channel messages
             coverageIds: [channels.group-messages]
-          - name: Memory search and store tools - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Memory search and store tools - Memory active recall
-            coverageIds: [memory.active-recall]
-          - name: Memory search and store tools - Memory ranking
-            coverageIds: [memory.ranking]
-          - name: Memory search and store tools - Memory recall
-            coverageIds: [memory.recall]
-          - name: Memory search and store tools - Memory tools
+          - name: Memory tools
             coverageIds: [memory.tools]
-          - name: Memory search and store tools - Personal memory recall
-            coverageIds: [personal.memory-recall]
-          - name: Memory search and store tools - Tool memory add
+          - name: Tool memory add
             coverageIds: [tools.memory.add]
-          - name: Memory search and store tools - Tool memory recall
+          - name: Tool memory recall
             coverageIds: [tools.memory.recall]
-          - name: Active Memory - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Active Memory - Memory active recall
-            coverageIds: [memory.active-recall]
-          - name: Active Memory - Memory recall
-            coverageIds: [memory.recall]
-          - name: Active Memory - Personal memory recall
-            coverageIds: [personal.memory-recall]
         docs:
           - docs/reference/memory-config.md
           - docs/concepts/memory-qmd.md
@@ -1852,11 +1796,11 @@ surfaces:
           - name: Session Routing
             coverageIds: [session-routing]
             description: Covers Session Routing across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
-          - name: Conversation routing - Webchat channel
+          - name: Webchat channel
             coverageIds: [channels.webchat]
-          - name: Conversation routing - Runtime direct reply routing
+          - name: Runtime direct reply routing
             coverageIds: [runtime.direct-reply-routing]
-          - name: Conversation routing - Tool message
+          - name: Tool message
             coverageIds: [tools.message]
         docs:
           - docs/concepts/session.md
@@ -1941,11 +1885,11 @@ surfaces:
           - name: Channel status taxonomy in channels list
             coverageIds: [channel-status-taxonomy-in-channels-list]
             description: Channel status taxonomy in channels list, channels status, and setup status output
-          - name: Setup/onboarding flows - Agent creation
+          - name: Agent creation
             coverageIds: [agents.create]
-          - name: Setup/onboarding flows - Discord channel config
+          - name: Discord channel config
             coverageIds: [channels.discord-config]
-          - name: Setup/onboarding flows - Crestodian setup config
+          - name: Crestodian setup config
             coverageIds: [config.crestodian-setup]
           - name: Install-on-demand
             coverageIds: [install-on-demand]
@@ -1967,27 +1911,23 @@ surfaces:
       - name: Group Thread and Ambient Room Behavior
         id: group-thread-and-ambient-room-behavior
         features:
-          - name: Group/channel session isolation - Group channel messages
+          - name: Group channel messages
             coverageIds: [channels.group-messages]
-          - name: Group/channel session isolation - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Group/channel session isolation - Memory tools
+          - name: Memory tools
             coverageIds: [memory.tools]
-          - name: Mention-required - Group channel visible replies
+          - name: Group channel visible replies
             coverageIds: [channels.group-visible-replies]
-          - name: Mention-required - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Mention-required - Tool message
+          - name: Tool message
             coverageIds: [tools.message]
-          - name: Native threads - DM channel
+          - name: DM channel
             coverageIds: [channels.dm]
-          - name: Native threads - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Native threads - Channel threads
+          - name: Channel threads
             coverageIds: [channels.threads]
-          - name: Native threads - Memory thread isolation
+          - name: Memory thread isolation
             coverageIds: [memory.thread-isolation]
-          - name: Native threads - Personal channel replies
+          - name: Personal channel replies
             coverageIds: [personal.channel-replies]
           - name: Broadcast groups
             coverageIds: [broadcast-groups]
@@ -2066,63 +2006,47 @@ surfaces:
       - name: Outbound Delivery and Reply Pipeline
         id: outbound-delivery-and-reply-pipeline
         features:
-          - name: Automatic final reply delivery - Subagents
+          - name: Subagents
             coverageIds: [agents.subagents]
-          - name: Automatic final reply delivery - Channel deduplication
+          - name: Channel deduplication
             coverageIds: [channels.dedup]
-          - name: Automatic final reply delivery - Direct channel visible replies
+          - name: Direct channel visible replies
             coverageIds: [channels.direct-visible-replies]
-          - name: Automatic final reply delivery - DM channel
+          - name: DM channel
             coverageIds: [channels.dm]
-          - name: Automatic final reply delivery - Group channel visible replies
+          - name: Group channel visible replies
             coverageIds: [channels.group-visible-replies]
-          - name: Automatic final reply delivery - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Automatic final reply delivery - Channel reconnect
+          - name: Channel reconnect
             coverageIds: [channels.reconnect]
-          - name: Automatic final reply delivery - Channel streaming
+          - name: Channel streaming
             coverageIds: [channels.streaming]
-          - name: Automatic final reply delivery - Channel threads
+          - name: Channel threads
             coverageIds: [channels.threads]
-          - name: Automatic final reply delivery - No-target heartbeat commitments
+          - name: No-target heartbeat commitments
             coverageIds: [commitments.heartbeat-target-none]
-          - name: Automatic final reply delivery - Commitment scope
+          - name: Commitment scope
             coverageIds: [commitments.scope]
-          - name: Automatic final reply delivery - Personal channel replies
+          - name: Personal channel replies
             coverageIds: [personal.channel-replies]
-          - name: Automatic final reply delivery - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
-          - name: Automatic final reply delivery - Fallback delivery
+          - name: Fallback delivery
             coverageIds: [runtime.fallback-delivery]
-          - name: Automatic final reply delivery - Gateway restart
+          - name: Gateway restart
             coverageIds: [runtime.gateway-restart]
-          - name: Automatic final reply delivery - Runtime restart recovery
+          - name: Runtime restart recovery
             coverageIds: [runtime.restart-recovery]
-          - name: Automatic final reply delivery - Tool message
+          - name: Tool message
             coverageIds: [tools.message]
-          - name: Durable outbound send orchestration - Channel deduplication
-            coverageIds: [channels.dedup]
-          - name: Durable outbound send orchestration - Channel reconnect
-            coverageIds: [channels.reconnect]
-          - name: Durable outbound send orchestration - Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Reply pipeline transforms - Channel message actions
+          - name: Channel message actions
             coverageIds: [channels.message-actions]
-          - name: Reply pipeline transforms - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Provider outbound adapter bridge - Direct channel visible replies
-            coverageIds: [channels.direct-visible-replies]
-          - name: Provider outbound adapter bridge - Group channel visible replies
-            coverageIds: [channels.group-visible-replies]
-          - name: Provider outbound adapter bridge - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Provider outbound adapter bridge - Webchat channel
+          - name: Webchat channel
             coverageIds: [channels.webchat]
-          - name: Provider outbound adapter bridge - Runtime direct reply routing
+          - name: Runtime direct reply routing
             coverageIds: [runtime.direct-reply-routing]
-          - name: Provider outbound adapter bridge - Tool message
-            coverageIds: [tools.message]
-          - name: Provider outbound adapter bridge - Message tool
+          - name: Message tool
             coverageIds: [tools.message-tool]
         docs:
           - docs/channels/groups.md
@@ -2139,13 +2063,13 @@ surfaces:
       - name: Conversation Routing and Delivery
         id: conversation-routing-and-delivery
         features:
-          - name: Inbound conversation routing - DM channel
+          - name: DM channel
             coverageIds: [channels.dm]
-          - name: Inbound conversation routing - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Inbound conversation routing - Channel threads
+          - name: Channel threads
             coverageIds: [channels.threads]
-          - name: Inbound conversation routing - Personal channel replies
+          - name: Personal channel replies
             coverageIds: [personal.channel-replies]
           - name: Session key construction
             coverageIds: [session-key-construction]
@@ -2159,43 +2083,35 @@ surfaces:
           - name: Thread/parent-child placement
             coverageIds: [thread-parent-child-placement]
             description: Thread/parent-child placement and provider-owned target normalization
-          - name: Plugin registry resolution - Subagents
+          - name: Subagents
             coverageIds: [agents.subagents]
-          - name: Plugin registry resolution - Direct channel visible replies
+          - name: Direct channel visible replies
             coverageIds: [channels.direct-visible-replies]
-          - name: Plugin registry resolution - DM channel
-            coverageIds: [channels.dm]
-          - name: Plugin registry resolution - Group channel messages
+          - name: Group channel messages
             coverageIds: [channels.group-messages]
-          - name: Plugin registry resolution - Group channel visible replies
+          - name: Group channel visible replies
             coverageIds: [channels.group-visible-replies]
-          - name: Plugin registry resolution - Channel message actions
+          - name: Channel message actions
             coverageIds: [channels.message-actions]
-          - name: Plugin registry resolution - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Plugin registry resolution - Channel threads
-            coverageIds: [channels.threads]
-          - name: Plugin registry resolution - Image generation media
+          - name: Image generation media
             coverageIds: [media.image-generation]
-          - name: Plugin registry resolution - Image understanding media
+          - name: Image understanding media
             coverageIds: [media.image-understanding]
-          - name: Plugin registry resolution - Memory recall
+          - name: Memory recall
             coverageIds: [memory.recall]
-          - name: Plugin registry resolution - Personal channel replies
-            coverageIds: [personal.channel-replies]
-          - name: Plugin registry resolution - Personal memory recall
+          - name: Personal memory recall
             coverageIds: [personal.memory-recall]
-          - name: Plugin registry resolution - Personal reminders
+          - name: Personal reminders
             coverageIds: [personal.reminders]
-          - name: Plugin registry resolution - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
-          - name: Plugin registry resolution - Scheduling cron
+          - name: Scheduling cron
             coverageIds: [scheduling.cron]
-          - name: Plugin registry resolution - Scheduling dedup
+          - name: Scheduling dedup
             coverageIds: [scheduling.dedup]
-          - name: Plugin registry resolution - Tool message
+          - name: Tool message
             coverageIds: [tools.message]
-          - name: Plugin registry resolution - UI control
+          - name: UI control
             coverageIds: [ui.control]
           - name: Channel account startup
             coverageIds: [channel-account-startup]
@@ -2232,11 +2148,11 @@ surfaces:
           - name: channels.status
             coverageIds: [channels-status]
             description: channels.status, probes, account snapshots, and warnings
-          - name: Channel health policy - Channel deduplication
+          - name: Channel deduplication
             coverageIds: [channels.dedup]
-          - name: Channel health policy - Channel reconnect
+          - name: Channel reconnect
             coverageIds: [channels.reconnect]
-          - name: Channel health policy - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
           - name: Operator CLI controls
             coverageIds: [operator-cli-controls]
@@ -2272,15 +2188,15 @@ surfaces:
       - name: Approval Policy and Tool Safeguards
         id: approval-policy-and-tool-safeguards
         features:
-          - name: Approval Policy - Personal approval denial
+          - name: Personal approval denial
             coverageIds: [personal.approval-denial]
-          - name: Approval Policy - Personal tool safety
+          - name: Personal tool safety
             coverageIds: [personal.tool-safety]
-          - name: Approval Policy - Runtime approvals
+          - name: Runtime approvals
             coverageIds: [runtime.approvals]
-          - name: Approval Policy - Tool followthrough
+          - name: Tool followthrough
             coverageIds: [tools.followthrough]
-          - name: Approval Policy - Tool safety
+          - name: Tool safety
             coverageIds: [tools.safety]
           - name: Dangerous Tool Safeguards
             coverageIds: [dangerous-tool-safeguards]
@@ -2457,19 +2373,19 @@ surfaces:
           - name: Secrets Storage
             coverageIds: [secrets-storage]
             description: Covers Secrets Storage across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
-          - name: Redaction - Memory dreaming
+          - name: Memory dreaming
             coverageIds: [memory.dreaming]
-          - name: Redaction - Memory promotion
+          - name: Memory promotion
             coverageIds: [memory.promotion]
-          - name: Redaction - Personal diagnostics
+          - name: Personal diagnostics
             coverageIds: [personal.diagnostics]
-          - name: Redaction - Personal redaction
+          - name: Personal redaction
             coverageIds: [personal.redaction]
-          - name: Redaction - QA artifact safety
+          - name: QA artifact safety
             coverageIds: [qa.artifact-safety]
-          - name: Redaction - Runtime tool policy
+          - name: Runtime tool policy
             coverageIds: [runtime.tool-policy]
-          - name: Redaction - Security redaction
+          - name: Security redaction
             coverageIds: [security.redaction]
           - name: Configuration Hygiene
             coverageIds: [configuration-hygiene]
@@ -2521,11 +2437,11 @@ surfaces:
           - name: Restart logging
             coverageIds: [restart-logging]
             description: Restart logging and runtime snapshot evaluation
-          - name: openclaw doctor - Codex plugin auth
+          - name: Codex plugin auth
             coverageIds: [runtime.codex-plugin.auth]
-          - name: openclaw doctor - Codex plugin lifecycle
+          - name: Codex plugin lifecycle
             coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: openclaw doctor - Runtime doctor repair
+          - name: Runtime doctor repair
             coverageIds: [runtime.doctor-repair]
           - name: Structured health checks
             coverageIds: [structured-health-checks]
@@ -2545,15 +2461,15 @@ surfaces:
           - name: Gateway RPC health
             coverageIds: [gateway-rpc-health]
             description: Gateway RPC health and status
-          - name: Cached health snapshots - Gateway performance
+          - name: Gateway performance
             coverageIds: [gateway.performance]
-          - name: Cached health snapshots - Live OpenAI models
+          - name: Live OpenAI models
             coverageIds: [models.live-openai]
-          - name: Cached health snapshots - Kitchen sink plugin
+          - name: Kitchen sink plugin
             coverageIds: [plugins.kitchen-sink]
-          - name: Cached health snapshots - Plugin lifecycle
+          - name: Plugin lifecycle
             coverageIds: [plugins.lifecycle]
-          - name: Cached health snapshots - Plugin tools
+          - name: Plugin tools
             coverageIds: [plugins.plugin-tools]
         docs:
           - docs/gateway/health.md
@@ -2615,11 +2531,11 @@ surfaces:
           - name: Chat /diagnostics
             coverageIds: [chat-diagnostics]
             description: Chat /diagnostics and /codex diagnostics approval flows
-          - name: Support zip composition - Personal diagnostics
+          - name: Personal diagnostics
             coverageIds: [personal.diagnostics]
-          - name: Support zip composition - Personal redaction
+          - name: Personal redaction
             coverageIds: [personal.redaction]
-          - name: Support zip composition - QA artifact safety
+          - name: QA artifact safety
             coverageIds: [qa.artifact-safety]
           - name: Bounded in-process stability recorder
             coverageIds: [bounded-in-process-stability-recorder]
@@ -2668,34 +2584,30 @@ surfaces:
           - name: diagnostics-otel plugin install
             coverageIds: [diagnostics-otel-plugin-install]
             description: diagnostics-otel plugin install, enablement, config, env overrides, sampling, flush interval, and preloaded SDK mode
-          - name: OTLP/HTTP traces - QA Lab harness
+          - name: QA Lab harness
             coverageIds: [harness.qa-lab]
-          - name: OTLP/HTTP traces - OTel telemetry
+          - name: OTel telemetry
             coverageIds: [telemetry.otel]
           - name: Trusted trace context
             coverageIds: [trusted-trace-context]
             description: Trusted trace context, W3C traceparent propagation to model calls, file-log correlation, content-capture controls, and redacted/bounded attributes
-          - name: Model and runtime telemetry - Docker E2E
+          - name: Docker E2E
             coverageIds: [docker.e2e]
-          - name: Model and runtime telemetry - QA Lab harness
-            coverageIds: [harness.qa-lab]
-          - name: Model and runtime telemetry - Tool trace visibility harness
+          - name: Tool trace visibility harness
             coverageIds: [harness.tool-trace-visibility]
-          - name: Model and runtime telemetry - Personal failure recovery
+          - name: Personal failure recovery
             coverageIds: [personal.failure-recovery]
-          - name: Model and runtime telemetry - Personal no fake progress
+          - name: Personal no fake progress
             coverageIds: [personal.no-fake-progress]
-          - name: Model and runtime telemetry - Personal task followthrough
+          - name: Personal task followthrough
             coverageIds: [personal.task-followthrough]
-          - name: Model and runtime telemetry - QA bus runtime
+          - name: QA bus runtime
             coverageIds: [runtime.qa-bus]
-          - name: Model and runtime telemetry - OTel telemetry
-            coverageIds: [telemetry.otel]
-          - name: Model and runtime telemetry - Telemetry prometheus
+          - name: Telemetry prometheus
             coverageIds: [telemetry.prometheus]
-          - name: Model and runtime telemetry - Evidence tools
+          - name: Evidence tools
             coverageIds: [tools.evidence]
-          - name: Model and runtime telemetry - Tool trace
+          - name: Tool trace
             coverageIds: [tools.trace]
           - name: diagnostics-prometheus plugin install
             coverageIds: [diagnostics-prometheus-plugin-install]
@@ -2703,12 +2615,6 @@ surfaces:
           - name: Gateway-authenticated GET /api/diagnostics/prometheus
             coverageIds: [gateway-authenticated-get-api-diagnostics-prometheus]
             description: Gateway-authenticated GET /api/diagnostics/prometheus behavior, status, and operator-visible verification.
-          - name: Prometheus text exposition - Docker E2E
-            coverageIds: [docker.e2e]
-          - name: Prometheus text exposition - QA Lab harness
-            coverageIds: [harness.qa-lab]
-          - name: Prometheus text exposition - Telemetry prometheus
-            coverageIds: [telemetry.prometheus]
           - name: Trusted diagnostic event subscription
             coverageIds: [trusted-diagnostic-event-subscription]
             description: Trusted diagnostic event subscription and rendering of run, model, tool, message, Talk, queue, session, liveness, payload, memory, and exporter metrics
@@ -2787,37 +2693,17 @@ surfaces:
           - name: Cron RPCs
             coverageIds: [cron-rpcs]
             description: Covers Cron RPCs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
-          - name: Agent cron tool - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Agent cron tool - Personal reminders
+          - name: Personal reminders
             coverageIds: [personal.reminders]
-          - name: Agent cron tool - Scheduling cron
+          - name: Scheduling cron
             coverageIds: [scheduling.cron]
-          - name: Manual cron runs - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Manual cron runs - Personal reminders
-            coverageIds: [personal.reminders]
-          - name: Manual cron runs - Scheduling cron
-            coverageIds: [scheduling.cron]
-          - name: Manual cron runs - Scheduling dedup
-            coverageIds: [scheduling.dedup]
-          - name: Isolated cron execution - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Isolated cron execution - Personal reminders
-            coverageIds: [personal.reminders]
-          - name: Isolated cron execution - Scheduling cron
-            coverageIds: [scheduling.cron]
-          - name: Isolated cron execution - Scheduling dedup
+          - name: Scheduling dedup
             coverageIds: [scheduling.dedup]
           - name: Model/provider preflight
             coverageIds: [model-provider-preflight]
             description: Covers Model/provider preflight across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
-          - name: Run history - QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Run history - Scheduling cron
-            coverageIds: [scheduling.cron]
-          - name: Run history - Scheduling dedup
-            coverageIds: [scheduling.dedup]
           - name: Timeout and denial diagnostics
             coverageIds: [timeout-and-denial-diagnostics]
             description: Covers Timeout and denial diagnostics across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
@@ -3062,11 +2948,11 @@ surfaces:
           - name: Due-only heartbeat tasks
             coverageIds: [due-only-heartbeat-tasks]
             description: Covers Due-only heartbeat tasks across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
-          - name: Commitment check-ins - No-target heartbeat commitments
+          - name: No-target heartbeat commitments
             coverageIds: [commitments.heartbeat-target-none]
-          - name: Commitment check-ins - Commitment scope
+          - name: Commitment scope
             coverageIds: [commitments.scope]
-          - name: Commitment check-ins - Runtime delivery
+          - name: Runtime delivery
             coverageIds: [runtime.delivery]
         docs:
           - docs/automation/index.md
@@ -3279,11 +3165,11 @@ surfaces:
           - name: Audio proxy and limit handling
             coverageIds: [audio-proxy-and-limit-handling]
             description: Covers Audio proxy and limit handling across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
-          - name: Inbound image summarization - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Inbound image summarization - Image understanding media
+          - name: Image understanding media
             coverageIds: [media.image-understanding]
-          - name: Inbound image summarization - UI control
+          - name: UI control
             coverageIds: [ui.control]
           - name: Active vision model bypass
             coverageIds: [active-vision-model-bypass]
@@ -3334,17 +3220,13 @@ surfaces:
       - name: Media Generation
         id: media-generation
         features:
-          - name: Image generation tool invocation - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Image generation tool invocation - Image generation media
+          - name: Image generation media
             coverageIds: [media.image-generation]
-          - name: Image generation tool invocation - Tool image generate
+          - name: Tool image generate
             coverageIds: [tools.image-generate]
-          - name: Image generation tool invocation - Tool native image generation
-            coverageIds: [tools.native-image-generation]
-          - name: Provider and model selection - Image generation media
-            coverageIds: [media.image-generation]
-          - name: Provider and model selection - Tool native image generation
+          - name: Tool native image generation
             coverageIds: [tools.native-image-generation]
           - name: Reference image editing
             coverageIds: [reference-image-editing]
@@ -3744,11 +3626,11 @@ surfaces:
       - name: Browser UI
         id: browser-ui
         features:
-          - name: Gateway-hosted UI - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: Gateway-hosted UI - Image understanding media
+          - name: Image understanding media
             coverageIds: [media.image-understanding]
-          - name: Gateway-hosted UI - UI control
+          - name: UI control
             coverageIds: [ui.control]
           - name: Dashboard open/auth bootstrap
             coverageIds: [dashboard-open-auth-bootstrap]
@@ -3819,17 +3701,17 @@ surfaces:
           - name: chat.history projection
             coverageIds: [chat-history-projection]
             description: Covers chat.history projection across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
-          - name: chat.send lifecycle - QA channel
+          - name: QA channel
             coverageIds: [channels.qa-channel]
-          - name: chat.send lifecycle - Webchat channel
+          - name: Webchat channel
             coverageIds: [channels.webchat]
-          - name: chat.send lifecycle - Image understanding media
+          - name: Image understanding media
             coverageIds: [media.image-understanding]
-          - name: chat.send lifecycle - Runtime direct reply routing
+          - name: Runtime direct reply routing
             coverageIds: [runtime.direct-reply-routing]
-          - name: chat.send lifecycle - Tool message
+          - name: Tool message
             coverageIds: [tools.message]
-          - name: chat.send lifecycle - UI control
+          - name: UI control
             coverageIds: [ui.control]
           - name: Abort/partial retention
             coverageIds: [abort-partial-retention]
@@ -3891,11 +3773,11 @@ surfaces:
           - name: Live log tail
             coverageIds: [live-log-tail]
             description: Covers Live log tail across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
-          - name: Update run/status - Gateway restart
+          - name: Gateway restart
             coverageIds: [runtime.gateway-restart]
-          - name: Update run/status - Package update runtime
+          - name: Package update runtime
             coverageIds: [runtime.package-update]
-          - name: Update run/status - Update run runtime
+          - name: Update run runtime
             coverageIds: [runtime.update-run]
           - name: Activity summaries
             coverageIds: [activity-summaries]
@@ -4545,19 +4427,19 @@ surfaces:
           - name: ToolSpace
             coverageIds: [toolspace]
             description: Tool discovery and invocation abstraction for external apps.
-          - name: Artifacts - Character persona
+          - name: Character persona
             coverageIds: [character.persona]
-          - name: Artifacts - Personal task followthrough
+          - name: Personal task followthrough
             coverageIds: [personal.task-followthrough]
-          - name: Artifacts - Tool followthrough
+          - name: Tool followthrough
             coverageIds: [tools.followthrough]
-          - name: Artifacts - Workspace artifacts
+          - name: Workspace artifacts
             coverageIds: [workspace.artifacts]
-          - name: Artifacts - Workspace builds
+          - name: Workspace builds
             coverageIds: [workspace.builds]
-          - name: Artifacts - Long-running workspace task
+          - name: Long-running workspace task
             coverageIds: [workspace.long-running-task]
-          - name: Artifacts - Repo discovery
+          - name: Repo discovery
             coverageIds: [workspace.repo-discovery]
           - name: Tasks
             coverageIds: [tasks]
@@ -5615,11 +5497,11 @@ surfaces:
       - name: Diagnostics and Repair
         id: diagnostics-and-repair
         features:
-          - name: openclaw doctor - Codex plugin auth
+          - name: Codex plugin auth
             coverageIds: [runtime.codex-plugin.auth]
-          - name: openclaw doctor - Codex plugin lifecycle
+          - name: Codex plugin lifecycle
             coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: openclaw doctor - Runtime doctor repair
+          - name: Runtime doctor repair
             coverageIds: [runtime.doctor-repair]
           - name: openclaw status
             coverageIds: [openclaw-status]
@@ -6780,11 +6662,11 @@ surfaces:
           - name: Docker E2E package artifact generation
             coverageIds: [docker-e2e-package-artifact-generation]
             description: Docker E2E package artifact generation and shared build helpers
-          - name: Docker E2E plan/scheduler scripts - Docker E2E
+          - name: Docker E2E
             coverageIds: [docker.e2e]
-          - name: Docker E2E plan/scheduler scripts - QA Lab harness
+          - name: QA Lab harness
             coverageIds: [harness.qa-lab]
-          - name: Docker E2E plan/scheduler scripts - Telemetry prometheus
+          - name: Telemetry prometheus
             coverageIds: [telemetry.prometheus]
           - name: Release-path install
             coverageIds: [release-path-install]
@@ -9131,18 +9013,18 @@ surfaces:
       - name: Model and Auth
         id: model-and-auth
         features:
-          - name: Canonical OpenAI Model Routing - OpenAI model
+          - name: OpenAI model
             coverageIds: [models.openai]
-          - name: Canonical OpenAI Model Routing - Tool web search
+          - name: Tool web search
             coverageIds: [tools.web-search]
           - name: Catalog
             coverageIds: [catalog]
             description: 'Covers Catalog across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
-          - name: Codex OAuth Profiles - Auth profiles provider selection
+          - name: Auth profiles provider selection
             coverageIds: [auth-profiles.provider-selection]
-          - name: Codex OAuth Profiles - Codex plugin auth
+          - name: Codex plugin auth
             coverageIds: [runtime.codex-plugin.auth]
-          - name: Codex OAuth Profiles - Runtime doctor repair
+          - name: Runtime doctor repair
             coverageIds: [runtime.doctor-repair]
           - name: Subscription Usage
             coverageIds: [subscription-usage]
@@ -9181,17 +9063,11 @@ surfaces:
           - name: Codex Responses Transport
             coverageIds: [codex-responses-transport]
             description: Covers Codex Responses Transport across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
-          - name: Payload Compatibility - Codex native workspace read
+          - name: Codex native workspace read
             coverageIds: [runtime.codex-native-workspace.read]
-          - name: Payload Compatibility - Runtime prompt compatibility
+          - name: Runtime prompt compatibility
             coverageIds: [runtime.prompt-compatibility]
-          - name: Payload Compatibility - File read tool
-            coverageIds: [tools.fs.read]
-          - name: Tool Context - Codex native workspace read
-            coverageIds: [runtime.codex-native-workspace.read]
-          - name: Tool Context - Runtime prompt compatibility
-            coverageIds: [runtime.prompt-compatibility]
-          - name: Tool Context - File read tool
+          - name: File read tool
             coverageIds: [tools.fs.read]
           - name: Capability Compatibility
             coverageIds: [capability-compatibility]
@@ -9215,29 +9091,23 @@ surfaces:
       - name: Native Codex Harness
         id: native-codex-harness
         features:
-          - name: Native Codex App-server Harness - Codex CLI model
+          - name: Codex CLI model
             coverageIds: [models.codex-cli]
-          - name: Native Codex App-server Harness - Codex app server runtime
+          - name: Codex app server runtime
             coverageIds: [runtime.codex-app-server]
-          - name: Native Codex App-server Harness - Gateway log sentinel Codex progress
+          - name: Gateway log sentinel Codex progress
             coverageIds: [runtime.gateway-log-sentinel.codex-progress]
-          - name: Native Codex App-server Harness - Long context runtime
+          - name: Long context runtime
             coverageIds: [runtime.long-context]
-          - name: Native Codex App-server Harness - Runtime no meta leak
+          - name: Runtime no meta leak
             coverageIds: [runtime.no-meta-leak]
-          - name: Native Codex App-server Harness - Workspace planning
+          - name: Workspace planning
             coverageIds: [workspace.planning]
-          - name: Thread Lifecycle - Codex app server runtime
-            coverageIds: [runtime.codex-app-server]
-          - name: Thread Lifecycle - Codex plugin lifecycle
+          - name: Codex plugin lifecycle
             coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: Thread Lifecycle - Runtime doctor repair
+          - name: Runtime doctor repair
             coverageIds: [runtime.doctor-repair]
-          - name: Thread Lifecycle - Gateway log sentinel Codex progress
-            coverageIds: [runtime.gateway-log-sentinel.codex-progress]
-          - name: Thread Lifecycle - Long context runtime
-            coverageIds: [runtime.long-context]
-          - name: Thread Lifecycle - Turn ordering
+          - name: Turn ordering
             coverageIds: [runtime.turn-ordering]
         docs:
           - docs/plugins/codex-harness.md
@@ -9359,13 +9229,13 @@ surfaces:
           - name: Bundled Claude catalog
             coverageIds: [bundled-claude-catalog]
             description: 'Covers Bundled Claude catalog across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
-          - name: Canonical anthropic refs - Anthropic model
+          - name: Anthropic model
             coverageIds: [models.anthropic]
-          - name: Canonical anthropic refs - Provider model auth
+          - name: Provider model auth
             coverageIds: [models.provider-auth]
-          - name: Claude CLI compatibility - Claude CLI model
+          - name: Claude CLI model
             coverageIds: [models.claude-cli]
-          - name: Claude CLI compatibility - Provider model capabilities
+          - name: Provider model capabilities
             coverageIds: [models.provider-capabilities]
           - name: Model picker availability
             coverageIds: [model-picker-availability]
@@ -10572,9 +10442,9 @@ surfaces:
       - name: Tool Availability and Fetch
         id: tool-availability-and-fetch
         features:
-          - name: web_search exposure - OpenAI model
+          - name: OpenAI model
             coverageIds: [models.openai]
-          - name: web_search exposure - Tool web search
+          - name: Tool web search
             coverageIds: [tools.web-search]
           - name: web_fetch exposure
             coverageIds: [tools.web-fetch]
@@ -10648,19 +10518,19 @@ surfaces:
           - name: Snapshots
             coverageIds: [snapshots]
             description: Covers Snapshots across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
-          - name: Artifacts - Character persona
+          - name: Character persona
             coverageIds: [character.persona]
-          - name: Artifacts - Personal task followthrough
+          - name: Personal task followthrough
             coverageIds: [personal.task-followthrough]
-          - name: Artifacts - Tool followthrough
+          - name: Tool followthrough
             coverageIds: [tools.followthrough]
-          - name: Artifacts - Workspace artifacts
+          - name: Workspace artifacts
             coverageIds: [workspace.artifacts]
-          - name: Artifacts - Workspace builds
+          - name: Workspace builds
             coverageIds: [workspace.builds]
-          - name: Artifacts - Long-running workspace task
+          - name: Long-running workspace task
             coverageIds: [workspace.long-running-task]
-          - name: Artifacts - Repo discovery
+          - name: Repo discovery
             coverageIds: [workspace.repo-discovery]
           - name: Browser Plugin Service
             coverageIds: [browser-plugin-service]
@@ -10703,23 +10573,23 @@ surfaces:
       - name: Tool Invocation and Execution
         id: tool-invocation-and-execution
         features:
-          - name: Exec Routing - Tool bash
+          - name: Tool bash
             coverageIds: [tools.bash]
-          - name: Exec Routing - Tool exec
+          - name: Tool exec
             coverageIds: [tools.exec]
-          - name: Process Lifecycle - Workspace artifacts
+          - name: Workspace artifacts
             coverageIds: [workspace.artifacts]
-          - name: Process Lifecycle - Workspace builds
+          - name: Workspace builds
             coverageIds: [workspace.builds]
-          - name: Process Lifecycle - Long-running workspace task
+          - name: Long-running workspace task
             coverageIds: [workspace.long-running-task]
-          - name: Process Lifecycle - Repo discovery
+          - name: Repo discovery
             coverageIds: [workspace.repo-discovery]
-          - name: Direct Tool Invoke API - MCP plugin tools
+          - name: MCP plugin tools
             coverageIds: [plugins.mcp-tools]
-          - name: Direct Tool Invoke API - Plugin skills
+          - name: Plugin skills
             coverageIds: [plugins.skills]
-          - name: Direct Tool Invoke API - Tool invocation
+          - name: Tool invocation
             coverageIds: [tools.invocation]
           - name: Node System.run
             coverageIds: [node-system-run]

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -175,9 +175,12 @@ surfaces:
           - name: Usage and memory APIs
             coverageIds: [usage-and-memory-apis]
             description: Usage summaries and memory readiness RPCs.
-          - name: Session APIs
-            coverageIds: [agents.subagents, gateway.sessions-list, tools.session-status]
-            description: '`sessions.*` RPCs.'
+          - name: Session APIs - Subagents
+            coverageIds: [agents.subagents]
+          - name: Session APIs - Gateway session list
+            coverageIds: [gateway.sessions-list]
+          - name: Session APIs - Session status tool
+            coverageIds: [tools.session-status]
           - name: Chat APIs
             coverageIds: [chat-apis]
             description: '`chat.*` and `agent.wait` RPCs.'
@@ -447,18 +450,26 @@ surfaces:
           - name: Service installation
             coverageIds: [service-installation]
             description: Supervised lifecycle installation on macOS, Linux user/systemd, and native Windows task scheduling.
-          - name: Restart and stop
-            coverageIds: [config.restart-apply, plugins.capabilities, runtime.gateway-restart]
-            description: Correct `restart` and `stop` behavior for supervised installs.
+          - name: Restart and stop - Restart config apply
+            coverageIds: [config.restart-apply]
+          - name: Restart and stop - Plugin capabilities
+            coverageIds: [plugins.capabilities]
+          - name: Restart and stop - Gateway restart
+            coverageIds: [runtime.gateway-restart]
           - name: Service status
             coverageIds: [service-status]
             description: Status behavior for supervised installs.
           - name: Bind and port settings
             coverageIds: [bind-and-port-settings]
             description: Bind and port precedence across CLI flags, env vars, config, and persisted supervisor metadata.
-          - name: Config reload
-            coverageIds: [config.hot-apply, plugins.hot-reload, plugins.lifecycle, plugins.skills]
-            description: 'Config reload modes: `off`, `hot`, `restart`, and `hybrid`.'
+          - name: Config reload - Hot config apply
+            coverageIds: [config.hot-apply]
+          - name: Config reload - Hot plugin reload
+            coverageIds: [plugins.hot-reload]
+          - name: Config reload - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Config reload - Plugin skills
+            coverageIds: [plugins.skills]
           - name: Multi-gateway isolation
             coverageIds: [multi-gateway-isolation]
             description: Multiple-gateway isolation on one host, including config/state/workspace separation.
@@ -645,9 +656,12 @@ surfaces:
           - name: Service install and control
             coverageIds: [service-install-and-control]
             description: The CLI documents install, status, start, stop, restart, and run flows for managed gateway services.
-          - name: Service auth wiring
-            coverageIds: [agents.create, channels.discord-config, config.crestodian-setup]
-            description: Gateway service installation documents how auth tokens and other sensitive values are handled.
+          - name: Service auth wiring - Agent creation
+            coverageIds: [agents.create]
+          - name: Service auth wiring - Discord channel config
+            coverageIds: [channels.discord-config]
+          - name: Service auth wiring - Crestodian setup config
+            coverageIds: [config.crestodian-setup]
           - name: Drift and reinstall recovery
             coverageIds: [drift-and-reinstall-recovery]
             description: Operators are given explicit guidance for repairing or reinstalling a broken managed gateway service.
@@ -912,21 +926,53 @@ surfaces:
           - name: Plugin setup
             coverageIds: [plugin-setup]
             description: Operators can run plugin setup flows without fully activating runtime behavior.
-          - name: Runtime activation
-            coverageIds: [config.hot-apply, gateway.performance, models.live-openai, plugins.before-prompt-build, plugins.before-tool-call, plugins.hot-reload, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools, plugins.runtime, plugins.skills, runtime.gateway-log-sentinel.plugin-hooks]
-            description: Enabled plugins activate and register runtime behavior after manifest validation succeeds.
-          - name: Enable and disable
-            coverageIds: [config.hot-apply, plugins.hot-reload, plugins.lifecycle]
-            description: Operators can enable or disable installed plugins without losing install state.
-          - name: Safe load failures
-            coverageIds: [plugins.contracts.tools, runtime.gateway-log-sentinel.plugin-contracts]
-            description: Unsafe or unsupported plugin loads are blocked with diagnosable failures before runtime execution.
+          - name: Runtime activation - Hot config apply
+            coverageIds: [config.hot-apply]
+          - name: Runtime activation - Gateway performance
+            coverageIds: [gateway.performance]
+          - name: Runtime activation - Live OpenAI models
+            coverageIds: [models.live-openai]
+          - name: Runtime activation - Before prompt build hook
+            coverageIds: [plugins.before-prompt-build]
+          - name: Runtime activation - Before tool call hook
+            coverageIds: [plugins.before-tool-call]
+          - name: Runtime activation - Hot plugin reload
+            coverageIds: [plugins.hot-reload]
+          - name: Runtime activation - Kitchen sink plugin
+            coverageIds: [plugins.kitchen-sink]
+          - name: Runtime activation - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Runtime activation - Plugin tools
+            coverageIds: [plugins.plugin-tools]
+          - name: Runtime activation - Plugin runtime
+            coverageIds: [plugins.runtime]
+          - name: Runtime activation - Plugin skills
+            coverageIds: [plugins.skills]
+          - name: Runtime activation - Gateway log sentinel plugin hooks
+            coverageIds: [runtime.gateway-log-sentinel.plugin-hooks]
+          - name: Enable and disable - Hot config apply
+            coverageIds: [config.hot-apply]
+          - name: Enable and disable - Hot plugin reload
+            coverageIds: [plugins.hot-reload]
+          - name: Enable and disable - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Safe load failures - Plugin tool contracts
+            coverageIds: [plugins.contracts.tools]
+          - name: Safe load failures - Gateway log sentinel plugin contracts
+            coverageIds: [runtime.gateway-log-sentinel.plugin-contracts]
           - name: Dependency repair
             coverageIds: [dependency-repair]
             description: Runtime can detect and repair missing or stale plugin dependencies.
-          - name: Install update and uninstall
-            coverageIds: [plugins.hot-install, plugins.skills, runtime.gateway-restart, runtime.package-update, runtime.update-run]
-            description: Install, update, and uninstall lifecycle behavior is defined and tested.
+          - name: Install update and uninstall - Hot plugin install
+            coverageIds: [plugins.hot-install]
+          - name: Install update and uninstall - Plugin skills
+            coverageIds: [plugins.skills]
+          - name: Install update and uninstall - Gateway restart
+            coverageIds: [runtime.gateway-restart]
+          - name: Install update and uninstall - Package update runtime
+            coverageIds: [runtime.package-update]
+          - name: Install update and uninstall - Update run runtime
+            coverageIds: [runtime.update-run]
         docs:
           - docs/plugins/architecture.md
           - docs/plugins/architecture-internals.md
@@ -973,9 +1019,26 @@ surfaces:
           - name: Provider plugins
             coverageIds: [provider-plugins]
             description: Provider plugins register models and capabilities with the runtime.
-          - name: Tool plugins
-            coverageIds: [gateway.performance, models.live-openai, plugins.before-prompt-build, plugins.before-tool-call, plugins.kitchen-sink, plugins.lifecycle, plugins.mcp-tools, plugins.plugin-tools, runtime.gateway-log-sentinel.plugin-hooks, tools.invocation]
-            description: Tool plugins register discoverable tools and static metadata without ambiguous runtime ownership.
+          - name: Tool plugins - Gateway performance
+            coverageIds: [gateway.performance]
+          - name: Tool plugins - Live OpenAI models
+            coverageIds: [models.live-openai]
+          - name: Tool plugins - Before prompt build hook
+            coverageIds: [plugins.before-prompt-build]
+          - name: Tool plugins - Before tool call hook
+            coverageIds: [plugins.before-tool-call]
+          - name: Tool plugins - Kitchen sink plugin
+            coverageIds: [plugins.kitchen-sink]
+          - name: Tool plugins - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Tool plugins - MCP plugin tools
+            coverageIds: [plugins.mcp-tools]
+          - name: Tool plugins - Plugin tools
+            coverageIds: [plugins.plugin-tools]
+          - name: Tool plugins - Gateway log sentinel plugin hooks
+            coverageIds: [runtime.gateway-log-sentinel.plugin-hooks]
+          - name: Tool plugins - Tool invocation
+            coverageIds: [tools.invocation]
           - name: Model catalogs
             coverageIds: [model-catalogs]
             description: Provider model catalogs are discoverable and merge cleanly into global listings.
@@ -985,9 +1048,22 @@ surfaces:
           - name: Web search and fetch
             coverageIds: [web-search-and-fetch]
             description: Provider or tool plugins can expose web search and fetch capabilities.
-          - name: Mixed plugins
-            coverageIds: [config.hot-apply, config.restart-apply, plugins.capabilities, plugins.hot-install, plugins.runtime, plugins.skills, tools.invocation, tools.skill-invocation]
-            description: Mixed provider and tool plugins are supported without ambiguous ownership.
+          - name: Mixed plugins - Hot config apply
+            coverageIds: [config.hot-apply]
+          - name: Mixed plugins - Restart config apply
+            coverageIds: [config.restart-apply]
+          - name: Mixed plugins - Plugin capabilities
+            coverageIds: [plugins.capabilities]
+          - name: Mixed plugins - Hot plugin install
+            coverageIds: [plugins.hot-install]
+          - name: Mixed plugins - Plugin runtime
+            coverageIds: [plugins.runtime]
+          - name: Mixed plugins - Plugin skills
+            coverageIds: [plugins.skills]
+          - name: Mixed plugins - Tool invocation
+            coverageIds: [tools.invocation]
+          - name: Mixed plugins - Skill invocation tool
+            coverageIds: [tools.skill-invocation]
         docs:
           - docs/plugins/sdk-provider-plugins.md
           - docs/plugins/tool-plugins.md
@@ -1071,18 +1147,26 @@ surfaces:
           - name: Local test environment
             coverageIds: [local-test-environment]
             description: Plugin authors can set up the local test environment and scoped helper configuration for plugin testing.
-          - name: Plugin runtime harness
-            coverageIds: [plugins.contracts.tools, runtime.gateway-log-sentinel.plugin-contracts]
-            description: Plugin test harnesses cover authoring and runtime integration paths.
+          - name: Plugin runtime harness - Plugin tool contracts
+            coverageIds: [plugins.contracts.tools]
+          - name: Plugin runtime harness - Gateway log sentinel plugin contracts
+            coverageIds: [runtime.gateway-log-sentinel.plugin-contracts]
           - name: Unit and integration scaffolds
             coverageIds: [unit-and-integration-scaffolds]
             description: Scoped test helpers and configuration support unit and integration testing for plugin surfaces.
           - name: Docker lifecycle suites
             coverageIds: [docker-lifecycle-suites]
             description: Docker-based end-to-end scripts validate packaged plugin lifecycle flows.
-          - name: Smoke tests
-            coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
-            description: Local and packaged smoke tests catch broken installs before release.
+          - name: Smoke tests - Gateway performance
+            coverageIds: [gateway.performance]
+          - name: Smoke tests - Live OpenAI models
+            coverageIds: [models.live-openai]
+          - name: Smoke tests - Kitchen sink plugin
+            coverageIds: [plugins.kitchen-sink]
+          - name: Smoke tests - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Smoke tests - Plugin tools
+            coverageIds: [plugins.plugin-tools]
         docs:
           - docs/plugins/sdk-testing.md
           - docs/plugins/sdk-setup.md
@@ -1111,15 +1195,62 @@ surfaces:
       - name: Agent Turn Execution
         id: agent-turn-execution
         features:
-          - name: Turn startup and runtime choice
-            coverageIds: [agents.create, agents.instructions, channels.discord-config, config.crestodian-setup, runtime.first-action, runtime.first-hour-20, runtime.long-context]
-            description: Starting an agent turn and choosing gateway versus embedded runtime execution.
-          - name: Session and run coordination
-            coverageIds: [agents.subagents, channels.dedup, channels.dm, channels.qa-channel, channels.reconnect, channels.streaming, channels.threads, commitments.heartbeat-target-none, commitments.scope, personal.channel-replies, runtime.codex-plugin.lifecycle, runtime.delivery, runtime.fallback-delivery, runtime.gateway-restart, runtime.restart-recovery, runtime.turn-ordering]
-            description: Establishing session and run ids, queue locks, and related execution coordination.
-          - name: Abort and terminal outcomes
-            coverageIds: [channels.streaming, runtime.delivery, runtime.fallback-delivery, runtime.long-context, runtime.soak-100]
-            description: Honoring aborts, timing provider/model work, and emitting terminal outcomes.
+          - name: Turn startup and runtime choice - Agent creation
+            coverageIds: [agents.create]
+          - name: Turn startup and runtime choice - Agent instructions
+            coverageIds: [agents.instructions]
+          - name: Turn startup and runtime choice - Discord channel config
+            coverageIds: [channels.discord-config]
+          - name: Turn startup and runtime choice - Crestodian setup config
+            coverageIds: [config.crestodian-setup]
+          - name: Turn startup and runtime choice - First action runtime
+            coverageIds: [runtime.first-action]
+          - name: Turn startup and runtime choice - First-hour 20-turn runtime
+            coverageIds: [runtime.first-hour-20]
+          - name: Turn startup and runtime choice - Long context runtime
+            coverageIds: [runtime.long-context]
+          - name: Session and run coordination - Subagents
+            coverageIds: [agents.subagents]
+          - name: Session and run coordination - Channel deduplication
+            coverageIds: [channels.dedup]
+          - name: Session and run coordination - DM channel
+            coverageIds: [channels.dm]
+          - name: Session and run coordination - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Session and run coordination - Channel reconnect
+            coverageIds: [channels.reconnect]
+          - name: Session and run coordination - Channel streaming
+            coverageIds: [channels.streaming]
+          - name: Session and run coordination - Channel threads
+            coverageIds: [channels.threads]
+          - name: Session and run coordination - No-target heartbeat commitments
+            coverageIds: [commitments.heartbeat-target-none]
+          - name: Session and run coordination - Commitment scope
+            coverageIds: [commitments.scope]
+          - name: Session and run coordination - Personal channel replies
+            coverageIds: [personal.channel-replies]
+          - name: Session and run coordination - Codex plugin lifecycle
+            coverageIds: [runtime.codex-plugin.lifecycle]
+          - name: Session and run coordination - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Session and run coordination - Fallback delivery
+            coverageIds: [runtime.fallback-delivery]
+          - name: Session and run coordination - Gateway restart
+            coverageIds: [runtime.gateway-restart]
+          - name: Session and run coordination - Runtime restart recovery
+            coverageIds: [runtime.restart-recovery]
+          - name: Session and run coordination - Turn ordering
+            coverageIds: [runtime.turn-ordering]
+          - name: Abort and terminal outcomes - Channel streaming
+            coverageIds: [channels.streaming]
+          - name: Abort and terminal outcomes - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Abort and terminal outcomes - Fallback delivery
+            coverageIds: [runtime.fallback-delivery]
+          - name: Abort and terminal outcomes - Long context runtime
+            coverageIds: [runtime.long-context]
+          - name: Abort and terminal outcomes - 100-turn soak
+            coverageIds: [runtime.soak-100]
         docs:
           - docs/concepts/agent-loop.md
           - docs/cli/agent.md
@@ -1133,15 +1264,25 @@ surfaces:
       - name: External Runtimes and Subagents
         id: external-runtimes-and-subagents
         features:
-          - name: External harness selection
-            coverageIds: [agents.openclaw-harness, workspace.planning]
-            description: Choosing Codex app-server, ACP, and other external runtime harnesses.
+          - name: External harness selection - OpenClaw harness agent
+            coverageIds: [agents.openclaw-harness]
+          - name: External harness selection - Workspace planning
+            coverageIds: [workspace.planning]
           - name: CLI runtime aliases
             coverageIds: [cli-runtime-aliases]
             description: Runtime aliases and CLI-based execution paths such as Claude CLI and Gemini CLI.
-          - name: Subagent turns
-            coverageIds: [agents.subagents, agents.synthesis, channels.qa-channel, gateway.sessions-list, runtime.delivery, tools.sessions-spawn]
-            description: Spawning, delivering, and announcing subagent work outside the default embedded path.
+          - name: Subagent turns - Subagents
+            coverageIds: [agents.subagents]
+          - name: Subagent turns - Agent synthesis
+            coverageIds: [agents.synthesis]
+          - name: Subagent turns - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Subagent turns - Gateway session list
+            coverageIds: [gateway.sessions-list]
+          - name: Subagent turns - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Subagent turns - Session spawn tool
+            coverageIds: [tools.sessions-spawn]
           - name: Runtime recovery
             coverageIds: [runtime-recovery]
             description: Cleanup, timeout, and liveness behavior for external runtimes and subagents.
@@ -1216,15 +1357,26 @@ surfaces:
       - name: Model and Runtime Selection
         id: model-and-runtime-selection
         features:
-          - name: Model reference selection
-            coverageIds: [models.claude-cli, models.provider-capabilities]
-            description: Selecting the model reference for an agent turn from user or configured defaults.
-          - name: Provider and runtime overrides
-            coverageIds: [models.switching, models.thinking, runtime.session-continuity, runtime.tool-continuity]
-            description: Handling provider selection and runtime overrides for a turn.
-          - name: Thinking and context settings
-            coverageIds: [models.switching, models.thinking, runtime.reasoning-visibility, runtime.session-continuity]
-            description: Resolving thinking and context settings as part of model selection.
+          - name: Model reference selection - Claude CLI model
+            coverageIds: [models.claude-cli]
+          - name: Model reference selection - Provider model capabilities
+            coverageIds: [models.provider-capabilities]
+          - name: Provider and runtime overrides - Model switching
+            coverageIds: [models.switching]
+          - name: Provider and runtime overrides - Model thinking
+            coverageIds: [models.thinking]
+          - name: Provider and runtime overrides - Session continuity
+            coverageIds: [runtime.session-continuity]
+          - name: Provider and runtime overrides - Tool continuity
+            coverageIds: [runtime.tool-continuity]
+          - name: Thinking and context settings - Model switching
+            coverageIds: [models.switching]
+          - name: Thinking and context settings - Model thinking
+            coverageIds: [models.thinking]
+          - name: Thinking and context settings - Reasoning visibility
+            coverageIds: [runtime.reasoning-visibility]
+          - name: Thinking and context settings - Session continuity
+            coverageIds: [runtime.session-continuity]
           - name: Invalid route recovery
             coverageIds: [invalid-route-recovery]
             description: Preserving or clearing invalid route state when selections drift or fail.
@@ -1242,21 +1394,31 @@ surfaces:
       - name: Provider Auth
         id: provider-auth
         features:
-          - name: Login and API-key setup
-            coverageIds: [models.anthropic, models.provider-auth]
-            description: Login, OAuth, and paste-key flows for provider access.
-          - name: Auth profile selection
-            coverageIds: [auth-profiles.provider-selection, runtime.codex-plugin.auth]
-            description: Selecting and validating provider auth profiles.
-          - name: Credential health checks
-            coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
-            description: Doctor, status, and related credential health checks and repair signals.
+          - name: Login and API-key setup - Anthropic model
+            coverageIds: [models.anthropic]
+          - name: Login and API-key setup - Provider model auth
+            coverageIds: [models.provider-auth]
+          - name: Auth profile selection - Auth profiles provider selection
+            coverageIds: [auth-profiles.provider-selection]
+          - name: Auth profile selection - Codex plugin auth
+            coverageIds: [runtime.codex-plugin.auth]
+          - name: Credential health checks - Gateway performance
+            coverageIds: [gateway.performance]
+          - name: Credential health checks - Live OpenAI models
+            coverageIds: [models.live-openai]
+          - name: Credential health checks - Kitchen sink plugin
+            coverageIds: [plugins.kitchen-sink]
+          - name: Credential health checks - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Credential health checks - Plugin tools
+            coverageIds: [plugins.plugin-tools]
           - name: Auth failover
             coverageIds: [auth-failover]
             description: Same-provider and cross-profile auth fallback behavior.
-          - name: Provider fallback recovery
-            coverageIds: [memory.failure-handling, runtime.fallbacks]
-            description: Provider and auth-profile fallback behavior when execution fails.
+          - name: Provider fallback recovery - Memory failure handling
+            coverageIds: [memory.failure-handling]
+          - name: Provider fallback recovery - Runtime fallbacks
+            coverageIds: [runtime.fallbacks]
           - name: Rate-limit and capacity recovery
             coverageIds: [rate-limit-and-capacity-recovery]
             description: Recovery paths for quota, capacity, and rate-limit failures.
@@ -1289,12 +1451,24 @@ surfaces:
       - name: Streaming and Progress
         id: streaming-and-progress
         features:
-          - name: Streaming replies
-            coverageIds: [channels.streaming, runtime.delivery, runtime.fallback-delivery]
-            description: Streaming block updates and partial assistant output before final delivery.
-          - name: Progress visibility
-            coverageIds: [models.thinking, personal.failure-recovery, personal.no-fake-progress, personal.task-followthrough, runtime.reasoning-visibility, tools.evidence]
-            description: Progress preview events and item lifecycle updates surfaced during execution.
+          - name: Streaming replies - Channel streaming
+            coverageIds: [channels.streaming]
+          - name: Streaming replies - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Streaming replies - Fallback delivery
+            coverageIds: [runtime.fallback-delivery]
+          - name: Progress visibility - Model thinking
+            coverageIds: [models.thinking]
+          - name: Progress visibility - Personal failure recovery
+            coverageIds: [personal.failure-recovery]
+          - name: Progress visibility - Personal no fake progress
+            coverageIds: [personal.no-fake-progress]
+          - name: Progress visibility - Personal task followthrough
+            coverageIds: [personal.task-followthrough]
+          - name: Progress visibility - Reasoning visibility
+            coverageIds: [runtime.reasoning-visibility]
+          - name: Progress visibility - Evidence tools
+            coverageIds: [tools.evidence]
         docs:
           - docs/concepts/streaming.md
           - docs/concepts/agent-loop.md
@@ -1307,15 +1481,56 @@ surfaces:
       - name: Tool Calls and Response Handling
         id: tool-calls-and-response-handling
         features:
-          - name: Tool-call handling
-            coverageIds: [models.switching, personal.no-fake-progress, personal.task-followthrough, personal.tool-safety, runtime.approvals, runtime.codex-native-workspace.read, runtime.prompt-compatibility, runtime.tool-continuity, tools.apply-patch, tools.edit, tools.evidence, tools.followthrough, tools.fs.list, tools.fs.read, tools.fs.write, tools.grep, workspace.artifacts]
-            description: Reliable tool-call behavior across providers, including malformed or provider-specific payload differences.
-          - name: Usage and response reporting
-            coverageIds: [agents.subagents, agents.synthesis]
-            description: Response ids and usage accounting normalized into operator-visible runtime behavior.
-          - name: Failure recovery
-            coverageIds: [personal.failure-recovery, personal.no-fake-progress, runtime.empty-response-recovery, runtime.reasoning-only-recovery, runtime.retry-policy, tools.evidence]
-            description: Failure-stream finalization and cleanup when provider output is malformed or incomplete.
+          - name: Tool-call handling - Model switching
+            coverageIds: [models.switching]
+          - name: Tool-call handling - Personal no fake progress
+            coverageIds: [personal.no-fake-progress]
+          - name: Tool-call handling - Personal task followthrough
+            coverageIds: [personal.task-followthrough]
+          - name: Tool-call handling - Personal tool safety
+            coverageIds: [personal.tool-safety]
+          - name: Tool-call handling - Runtime approvals
+            coverageIds: [runtime.approvals]
+          - name: Tool-call handling - Codex native workspace read
+            coverageIds: [runtime.codex-native-workspace.read]
+          - name: Tool-call handling - Runtime prompt compatibility
+            coverageIds: [runtime.prompt-compatibility]
+          - name: Tool-call handling - Tool continuity
+            coverageIds: [runtime.tool-continuity]
+          - name: Tool-call handling - Apply patch tool
+            coverageIds: [tools.apply-patch]
+          - name: Tool-call handling - Edit tool
+            coverageIds: [tools.edit]
+          - name: Tool-call handling - Evidence tools
+            coverageIds: [tools.evidence]
+          - name: Tool-call handling - Tool followthrough
+            coverageIds: [tools.followthrough]
+          - name: Tool-call handling - File list tool
+            coverageIds: [tools.fs.list]
+          - name: Tool-call handling - File read tool
+            coverageIds: [tools.fs.read]
+          - name: Tool-call handling - File write tool
+            coverageIds: [tools.fs.write]
+          - name: Tool-call handling - Grep tool
+            coverageIds: [tools.grep]
+          - name: Tool-call handling - Workspace artifacts
+            coverageIds: [workspace.artifacts]
+          - name: Usage and response reporting - Subagents
+            coverageIds: [agents.subagents]
+          - name: Usage and response reporting - Agent synthesis
+            coverageIds: [agents.synthesis]
+          - name: Failure recovery - Personal failure recovery
+            coverageIds: [personal.failure-recovery]
+          - name: Failure recovery - Personal no fake progress
+            coverageIds: [personal.no-fake-progress]
+          - name: Failure recovery - Runtime empty response recovery
+            coverageIds: [runtime.empty-response-recovery]
+          - name: Failure recovery - Runtime reasoning only recovery
+            coverageIds: [runtime.reasoning-only-recovery]
+          - name: Failure recovery - Retry policy
+            coverageIds: [runtime.retry-policy]
+          - name: Failure recovery - Evidence tools
+            coverageIds: [tools.evidence]
         docs:
           - docs/concepts/agent-loop.md
           - docs/providers/ollama.md
@@ -1328,21 +1543,40 @@ surfaces:
       - name: Tool Execution Controls
         id: tool-execution-controls
         features:
-          - name: Tool availability rules
-            coverageIds: [qa.artifact-safety, runtime.inventory, runtime.tool-policy, security.redaction]
-            description: Which tools are available during a turn after policy resolution and provider-based suppression.
+          - name: Tool availability rules - QA artifact safety
+            coverageIds: [qa.artifact-safety]
+          - name: Tool availability rules - Runtime inventory
+            coverageIds: [runtime.inventory]
+          - name: Tool availability rules - Runtime tool policy
+            coverageIds: [runtime.tool-policy]
+          - name: Tool availability rules - Security redaction
+            coverageIds: [security.redaction]
           - name: Sandboxed exec behavior
             coverageIds: [sandboxed-exec-behavior]
             description: Exec behavior, sandbox roots, and workspace constraints visible to operators.
-          - name: Approval flow
-            coverageIds: [personal.approval-denial, personal.tool-safety, runtime.approvals, tools.followthrough, tools.safety]
-            description: Operator approval gates for tool execution.
+          - name: Approval flow - Personal approval denial
+            coverageIds: [personal.approval-denial]
+          - name: Approval flow - Personal tool safety
+            coverageIds: [personal.tool-safety]
+          - name: Approval flow - Runtime approvals
+            coverageIds: [runtime.approvals]
+          - name: Approval flow - Tool followthrough
+            coverageIds: [tools.followthrough]
+          - name: Approval flow - Tool safety
+            coverageIds: [tools.safety]
           - name: Elevated execution
             coverageIds: [elevated-execution]
             description: Elevated host execution rules and related controls.
-          - name: Tool safety controls
-            coverageIds: [personal.approval-denial, personal.tool-safety, runtime.approvals, tools.followthrough, tools.safety]
-            description: Before-tool-call hooks and related guardrails that shape operator-visible tool behavior.
+          - name: Tool safety controls - Personal approval denial
+            coverageIds: [personal.approval-denial]
+          - name: Tool safety controls - Personal tool safety
+            coverageIds: [personal.tool-safety]
+          - name: Tool safety controls - Runtime approvals
+            coverageIds: [runtime.approvals]
+          - name: Tool safety controls - Tool followthrough
+            coverageIds: [tools.followthrough]
+          - name: Tool safety controls - Tool safety
+            coverageIds: [tools.safety]
           - name: Delegated tool access
             coverageIds: [delegated-tool-access]
             description: Inherited or narrowed tool policy for subagents and delegated execution.
@@ -1393,15 +1627,27 @@ surfaces:
       - name: Token Management
         id: token-management
         features:
-          - name: Compaction
-            coverageIds: [runtime.compaction, runtime.empty-response-recovery, runtime.reasoning-only-recovery, runtime.retry-policy]
-            description: Covers Compaction across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
+          - name: Compaction - Runtime compaction
+            coverageIds: [runtime.compaction]
+          - name: Compaction - Runtime empty response recovery
+            coverageIds: [runtime.empty-response-recovery]
+          - name: Compaction - Runtime reasoning only recovery
+            coverageIds: [runtime.reasoning-only-recovery]
+          - name: Compaction - Retry policy
+            coverageIds: [runtime.retry-policy]
           - name: Pruning
             coverageIds: [pruning]
             description: Covers Pruning across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
-          - name: Token Pressure
-            coverageIds: [runtime.codex-app-server, runtime.first-hour-20, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.soak-100]
-            description: Covers Token Pressure across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
+          - name: Token Pressure - Codex app server runtime
+            coverageIds: [runtime.codex-app-server]
+          - name: Token Pressure - First-hour 20-turn runtime
+            coverageIds: [runtime.first-hour-20]
+          - name: Token Pressure - Gateway log sentinel Codex progress
+            coverageIds: [runtime.gateway-log-sentinel.codex-progress]
+          - name: Token Pressure - Long context runtime
+            coverageIds: [runtime.long-context]
+          - name: Token Pressure - 100-turn soak
+            coverageIds: [runtime.soak-100]
         docs:
           - docs/concepts/compaction.md
           - docs/concepts/context.md
@@ -1417,12 +1663,20 @@ surfaces:
       - name: Context Engine
         id: context-engine
         features:
-          - name: Context Engine
-            coverageIds: [docs.discovery, workspace.artifacts, workspace.long-running-task, workspace.repo-discovery]
-            description: Covers Context Engine across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
-          - name: Runtime Assembly
-            coverageIds: [agents.openclaw-harness, models.codex-cli, workspace.planning]
-            description: Covers Runtime Assembly across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
+          - name: Context Engine - Docs discovery
+            coverageIds: [docs.discovery]
+          - name: Context Engine - Workspace artifacts
+            coverageIds: [workspace.artifacts]
+          - name: Context Engine - Long-running workspace task
+            coverageIds: [workspace.long-running-task]
+          - name: Context Engine - Repo discovery
+            coverageIds: [workspace.repo-discovery]
+          - name: Runtime Assembly - OpenClaw harness agent
+            coverageIds: [agents.openclaw-harness]
+          - name: Runtime Assembly - Codex CLI model
+            coverageIds: [models.codex-cli]
+          - name: Runtime Assembly - Workspace planning
+            coverageIds: [workspace.planning]
         docs:
           - docs/concepts/context.md
           - docs/concepts/context-engine.md
@@ -1437,12 +1691,16 @@ surfaces:
       - name: Cross-client History and Session Parity
         id: cross-client-history-and-session-parity
         features:
-          - name: Cross-client History
-            coverageIds: [channels.threads, memory.thread-isolation]
-            description: Covers Cross-client History across `chat.history`, `chat.send`, WebChat display projection, TUI session actions, Android chat/session selection, OpenAI-compatible history mapping, channel history windows, and history visibility across reset/restart.
-          - name: Session Parity
-            coverageIds: [models.switching, models.thinking, runtime.session-continuity]
-            description: Covers Session Parity across `chat.history`, `chat.send`, WebChat display projection, TUI session actions, Android chat/session selection, OpenAI-compatible history mapping, channel history windows, and history visibility across reset/restart.
+          - name: Cross-client History - Channel threads
+            coverageIds: [channels.threads]
+          - name: Cross-client History - Memory thread isolation
+            coverageIds: [memory.thread-isolation]
+          - name: Session Parity - Model switching
+            coverageIds: [models.switching]
+          - name: Session Parity - Model thinking
+            coverageIds: [models.thinking]
+          - name: Session Parity - Session continuity
+            coverageIds: [runtime.session-continuity]
         docs:
           - docs/web/webchat.md
           - docs/platforms/android.md
@@ -1463,9 +1721,22 @@ surfaces:
           - name: Session maintenance warnings
             coverageIds: [session-maintenance-warnings]
             description: Covers restart maintenance warnings, delivery queues, memory/session cleanup signals, and operator-visible maintenance state.
-          - name: Session and transcript recovery
-            coverageIds: [config.restart-apply, memory.failure-handling, runtime.delivery, runtime.fallbacks, runtime.gateway-restart, runtime.package-update, runtime.restart-recovery, runtime.update-run]
-            description: Covers restart recovery, orphaned subagent resume, transcript repair, and safe restoration of session state after failures.
+          - name: Session and transcript recovery - Restart config apply
+            coverageIds: [config.restart-apply]
+          - name: Session and transcript recovery - Memory failure handling
+            coverageIds: [memory.failure-handling]
+          - name: Session and transcript recovery - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Session and transcript recovery - Runtime fallbacks
+            coverageIds: [runtime.fallbacks]
+          - name: Session and transcript recovery - Gateway restart
+            coverageIds: [runtime.gateway-restart]
+          - name: Session and transcript recovery - Package update runtime
+            coverageIds: [runtime.package-update]
+          - name: Session and transcript recovery - Runtime restart recovery
+            coverageIds: [runtime.restart-recovery]
+          - name: Session and transcript recovery - Update run runtime
+            coverageIds: [runtime.update-run]
         docs:
           - docs/gateway/diagnostics.md
           - docs/reference/session-management-compaction.md
@@ -1482,12 +1753,22 @@ surfaces:
       - name: Core Prompts and Context
         id: core-prompts-and-context
         features:
-          - name: Instruction Profile
-            coverageIds: [agents.instructions, character.persona, runtime.first-action, workspace.artifacts]
-            description: Covers Instruction Profile across `AGENTS.md`, `USER.md`, `IDENTITY.md`, `SOUL.md`, project context injection, bootstrap truncation, untrusted supplemental context, context visibility config, and runtime-context leakage prevention.
-          - name: Context Visibility
-            coverageIds: [docs.discovery, models.codex-cli, runtime.no-meta-leak, workspace.repo-discovery]
-            description: Covers Context Visibility across `AGENTS.md`, `USER.md`, `IDENTITY.md`, `SOUL.md`, project context injection, bootstrap truncation, untrusted supplemental context, context visibility config, and runtime-context leakage prevention.
+          - name: Instruction Profile - Agent instructions
+            coverageIds: [agents.instructions]
+          - name: Instruction Profile - Character persona
+            coverageIds: [character.persona]
+          - name: Instruction Profile - First action runtime
+            coverageIds: [runtime.first-action]
+          - name: Instruction Profile - Workspace artifacts
+            coverageIds: [workspace.artifacts]
+          - name: Context Visibility - Docs discovery
+            coverageIds: [docs.discovery]
+          - name: Context Visibility - Codex CLI model
+            coverageIds: [models.codex-cli]
+          - name: Context Visibility - Runtime no meta leak
+            coverageIds: [runtime.no-meta-leak]
+          - name: Context Visibility - Repo discovery
+            coverageIds: [workspace.repo-discovery]
         docs:
           - docs/concepts/context.md
           - docs/reference/transcript-hygiene.md
@@ -1505,18 +1786,48 @@ surfaces:
           - name: Memory Backend Storage
             coverageIds: [memory-backend-storage]
             description: Covers Memory Backend Storage across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
-          - name: Embedding Search
-            coverageIds: [channels.qa-channel, memory.active-recall, memory.ranking, memory.recall, personal.memory-recall]
-            description: Covers Embedding Search across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
-          - name: Memory Files
-            coverageIds: [memory.dreaming, memory.promotion, qa.artifact-safety]
-            description: Covers Memory Files across root memory files, active memory, memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
-          - name: Memory search and store tools
-            coverageIds: [channels.group-messages, channels.qa-channel, memory.active-recall, memory.ranking, memory.recall, memory.tools, personal.memory-recall, tools.memory.add, tools.memory.recall]
-            description: Covers memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
-          - name: Active Memory
-            coverageIds: [channels.qa-channel, memory.active-recall, memory.recall, personal.memory-recall]
-            description: Covers Active Memory across root memory files, active memory, memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
+          - name: Embedding Search - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Embedding Search - Memory active recall
+            coverageIds: [memory.active-recall]
+          - name: Embedding Search - Memory ranking
+            coverageIds: [memory.ranking]
+          - name: Embedding Search - Memory recall
+            coverageIds: [memory.recall]
+          - name: Embedding Search - Personal memory recall
+            coverageIds: [personal.memory-recall]
+          - name: Memory Files - Memory dreaming
+            coverageIds: [memory.dreaming]
+          - name: Memory Files - Memory promotion
+            coverageIds: [memory.promotion]
+          - name: Memory Files - QA artifact safety
+            coverageIds: [qa.artifact-safety]
+          - name: Memory search and store tools - Group channel messages
+            coverageIds: [channels.group-messages]
+          - name: Memory search and store tools - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Memory search and store tools - Memory active recall
+            coverageIds: [memory.active-recall]
+          - name: Memory search and store tools - Memory ranking
+            coverageIds: [memory.ranking]
+          - name: Memory search and store tools - Memory recall
+            coverageIds: [memory.recall]
+          - name: Memory search and store tools - Memory tools
+            coverageIds: [memory.tools]
+          - name: Memory search and store tools - Personal memory recall
+            coverageIds: [personal.memory-recall]
+          - name: Memory search and store tools - Tool memory add
+            coverageIds: [tools.memory.add]
+          - name: Memory search and store tools - Tool memory recall
+            coverageIds: [tools.memory.recall]
+          - name: Active Memory - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Active Memory - Memory active recall
+            coverageIds: [memory.active-recall]
+          - name: Active Memory - Memory recall
+            coverageIds: [memory.recall]
+          - name: Active Memory - Personal memory recall
+            coverageIds: [personal.memory-recall]
         docs:
           - docs/reference/memory-config.md
           - docs/concepts/memory-qmd.md
@@ -1541,9 +1852,12 @@ surfaces:
           - name: Session Routing
             coverageIds: [session-routing]
             description: Covers Session Routing across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
-          - name: Conversation routing
-            coverageIds: [channels.webchat, runtime.direct-reply-routing, tools.message]
-            description: Covers Conversation Binding across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
+          - name: Conversation routing - Webchat channel
+            coverageIds: [channels.webchat]
+          - name: Conversation routing - Runtime direct reply routing
+            coverageIds: [runtime.direct-reply-routing]
+          - name: Conversation routing - Tool message
+            coverageIds: [tools.message]
         docs:
           - docs/concepts/session.md
           - docs/channels/channel-routing.md
@@ -1627,9 +1941,12 @@ surfaces:
           - name: Channel status taxonomy in channels list
             coverageIds: [channel-status-taxonomy-in-channels-list]
             description: Channel status taxonomy in channels list, channels status, and setup status output
-          - name: Setup/onboarding flows
-            coverageIds: [agents.create, channels.discord-config, config.crestodian-setup]
-            description: Setup/onboarding flows, including first-run channel selection and channel account setup
+          - name: Setup/onboarding flows - Agent creation
+            coverageIds: [agents.create]
+          - name: Setup/onboarding flows - Discord channel config
+            coverageIds: [channels.discord-config]
+          - name: Setup/onboarding flows - Crestodian setup config
+            coverageIds: [config.crestodian-setup]
           - name: Install-on-demand
             coverageIds: [install-on-demand]
             description: Install-on-demand, downloadable, bundled, official external, local, npm, and ClawHub distinctions
@@ -1650,15 +1967,28 @@ surfaces:
       - name: Group Thread and Ambient Room Behavior
         id: group-thread-and-ambient-room-behavior
         features:
-          - name: Group/channel session isolation
-            coverageIds: [channels.group-messages, channels.qa-channel, memory.tools]
-            description: Group/channel session isolation and group history context
-          - name: Mention-required
-            coverageIds: [channels.group-visible-replies, channels.qa-channel, tools.message]
-            description: Mention-required, always-on, and ambient room-event modes
-          - name: Native threads
-            coverageIds: [channels.dm, channels.qa-channel, channels.threads, memory.thread-isolation, personal.channel-replies]
-            description: Native threads, topics, parent-child bindings, and thread spawn behavior
+          - name: Group/channel session isolation - Group channel messages
+            coverageIds: [channels.group-messages]
+          - name: Group/channel session isolation - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Group/channel session isolation - Memory tools
+            coverageIds: [memory.tools]
+          - name: Mention-required - Group channel visible replies
+            coverageIds: [channels.group-visible-replies]
+          - name: Mention-required - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Mention-required - Tool message
+            coverageIds: [tools.message]
+          - name: Native threads - DM channel
+            coverageIds: [channels.dm]
+          - name: Native threads - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Native threads - Channel threads
+            coverageIds: [channels.threads]
+          - name: Native threads - Memory thread isolation
+            coverageIds: [memory.thread-isolation]
+          - name: Native threads - Personal channel replies
+            coverageIds: [personal.channel-replies]
           - name: Broadcast groups
             coverageIds: [broadcast-groups]
             description: Broadcast groups and multi-agent group routing
@@ -1736,18 +2066,64 @@ surfaces:
       - name: Outbound Delivery and Reply Pipeline
         id: outbound-delivery-and-reply-pipeline
         features:
-          - name: Automatic final reply delivery
-            coverageIds: [agents.subagents, channels.dedup, channels.direct-visible-replies, channels.dm, channels.group-visible-replies, channels.qa-channel, channels.reconnect, channels.streaming, channels.threads, commitments.heartbeat-target-none, commitments.scope, personal.channel-replies, runtime.delivery, runtime.fallback-delivery, runtime.gateway-restart, runtime.restart-recovery, tools.message]
-            description: Automatic final reply delivery and strict message-tool-only visible delivery
-          - name: Durable outbound send orchestration
-            coverageIds: [channels.dedup, channels.reconnect, runtime.delivery]
-            description: Durable outbound send orchestration, receipts, partial failures, and fallback paths
-          - name: Reply pipeline transforms
-            coverageIds: [channels.message-actions, channels.qa-channel]
-            description: Reply pipeline transforms, typing callbacks, draft streaming, and status reactions
-          - name: Provider outbound adapter bridge
-            coverageIds: [channels.direct-visible-replies, channels.group-visible-replies, channels.qa-channel, channels.webchat, runtime.direct-reply-routing, tools.message, tools.message-tool]
-            description: Provider outbound adapter bridge and message capabilities
+          - name: Automatic final reply delivery - Subagents
+            coverageIds: [agents.subagents]
+          - name: Automatic final reply delivery - Channel deduplication
+            coverageIds: [channels.dedup]
+          - name: Automatic final reply delivery - Direct channel visible replies
+            coverageIds: [channels.direct-visible-replies]
+          - name: Automatic final reply delivery - DM channel
+            coverageIds: [channels.dm]
+          - name: Automatic final reply delivery - Group channel visible replies
+            coverageIds: [channels.group-visible-replies]
+          - name: Automatic final reply delivery - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Automatic final reply delivery - Channel reconnect
+            coverageIds: [channels.reconnect]
+          - name: Automatic final reply delivery - Channel streaming
+            coverageIds: [channels.streaming]
+          - name: Automatic final reply delivery - Channel threads
+            coverageIds: [channels.threads]
+          - name: Automatic final reply delivery - No-target heartbeat commitments
+            coverageIds: [commitments.heartbeat-target-none]
+          - name: Automatic final reply delivery - Commitment scope
+            coverageIds: [commitments.scope]
+          - name: Automatic final reply delivery - Personal channel replies
+            coverageIds: [personal.channel-replies]
+          - name: Automatic final reply delivery - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Automatic final reply delivery - Fallback delivery
+            coverageIds: [runtime.fallback-delivery]
+          - name: Automatic final reply delivery - Gateway restart
+            coverageIds: [runtime.gateway-restart]
+          - name: Automatic final reply delivery - Runtime restart recovery
+            coverageIds: [runtime.restart-recovery]
+          - name: Automatic final reply delivery - Tool message
+            coverageIds: [tools.message]
+          - name: Durable outbound send orchestration - Channel deduplication
+            coverageIds: [channels.dedup]
+          - name: Durable outbound send orchestration - Channel reconnect
+            coverageIds: [channels.reconnect]
+          - name: Durable outbound send orchestration - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Reply pipeline transforms - Channel message actions
+            coverageIds: [channels.message-actions]
+          - name: Reply pipeline transforms - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Provider outbound adapter bridge - Direct channel visible replies
+            coverageIds: [channels.direct-visible-replies]
+          - name: Provider outbound adapter bridge - Group channel visible replies
+            coverageIds: [channels.group-visible-replies]
+          - name: Provider outbound adapter bridge - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Provider outbound adapter bridge - Webchat channel
+            coverageIds: [channels.webchat]
+          - name: Provider outbound adapter bridge - Runtime direct reply routing
+            coverageIds: [runtime.direct-reply-routing]
+          - name: Provider outbound adapter bridge - Tool message
+            coverageIds: [tools.message]
+          - name: Provider outbound adapter bridge - Message tool
+            coverageIds: [tools.message-tool]
         docs:
           - docs/channels/groups.md
           - docs/channels/ambient-room-events.md
@@ -1763,9 +2139,14 @@ surfaces:
       - name: Conversation Routing and Delivery
         id: conversation-routing-and-delivery
         features:
-          - name: Inbound conversation routing
-            coverageIds: [channels.dm, channels.qa-channel, channels.threads, personal.channel-replies]
-            description: Inbound and command conversation resolution across sessions, threads, and provider-owned targets.
+          - name: Inbound conversation routing - DM channel
+            coverageIds: [channels.dm]
+          - name: Inbound conversation routing - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Inbound conversation routing - Channel threads
+            coverageIds: [channels.threads]
+          - name: Inbound conversation routing - Personal channel replies
+            coverageIds: [personal.channel-replies]
           - name: Session key construction
             coverageIds: [session-key-construction]
             description: Session key construction and session metadata recording
@@ -1778,9 +2159,44 @@ surfaces:
           - name: Thread/parent-child placement
             coverageIds: [thread-parent-child-placement]
             description: Thread/parent-child placement and provider-owned target normalization
-          - name: Plugin registry resolution
-            coverageIds: [agents.subagents, channels.direct-visible-replies, channels.dm, channels.group-messages, channels.group-visible-replies, channels.message-actions, channels.qa-channel, channels.threads, media.image-generation, media.image-understanding, memory.recall, personal.channel-replies, personal.memory-recall, personal.reminders, runtime.delivery, scheduling.cron, scheduling.dedup, tools.message, ui.control]
-            description: Plugin registry resolution and scoped channel runtime creation
+          - name: Plugin registry resolution - Subagents
+            coverageIds: [agents.subagents]
+          - name: Plugin registry resolution - Direct channel visible replies
+            coverageIds: [channels.direct-visible-replies]
+          - name: Plugin registry resolution - DM channel
+            coverageIds: [channels.dm]
+          - name: Plugin registry resolution - Group channel messages
+            coverageIds: [channels.group-messages]
+          - name: Plugin registry resolution - Group channel visible replies
+            coverageIds: [channels.group-visible-replies]
+          - name: Plugin registry resolution - Channel message actions
+            coverageIds: [channels.message-actions]
+          - name: Plugin registry resolution - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Plugin registry resolution - Channel threads
+            coverageIds: [channels.threads]
+          - name: Plugin registry resolution - Image generation media
+            coverageIds: [media.image-generation]
+          - name: Plugin registry resolution - Image understanding media
+            coverageIds: [media.image-understanding]
+          - name: Plugin registry resolution - Memory recall
+            coverageIds: [memory.recall]
+          - name: Plugin registry resolution - Personal channel replies
+            coverageIds: [personal.channel-replies]
+          - name: Plugin registry resolution - Personal memory recall
+            coverageIds: [personal.memory-recall]
+          - name: Plugin registry resolution - Personal reminders
+            coverageIds: [personal.reminders]
+          - name: Plugin registry resolution - Runtime delivery
+            coverageIds: [runtime.delivery]
+          - name: Plugin registry resolution - Scheduling cron
+            coverageIds: [scheduling.cron]
+          - name: Plugin registry resolution - Scheduling dedup
+            coverageIds: [scheduling.dedup]
+          - name: Plugin registry resolution - Tool message
+            coverageIds: [tools.message]
+          - name: Plugin registry resolution - UI control
+            coverageIds: [ui.control]
           - name: Channel account startup
             coverageIds: [channel-account-startup]
             description: Channel account startup, shutdown, logout, abort, and manual-stop state
@@ -1816,9 +2232,12 @@ surfaces:
           - name: channels.status
             coverageIds: [channels-status]
             description: channels.status, probes, account snapshots, and warnings
-          - name: Channel health policy
-            coverageIds: [channels.dedup, channels.reconnect, runtime.delivery]
-            description: Channel health policy, health monitor restarts, stale socket detection, cooldowns, and restart caps
+          - name: Channel health policy - Channel deduplication
+            coverageIds: [channels.dedup]
+          - name: Channel health policy - Channel reconnect
+            coverageIds: [channels.reconnect]
+          - name: Channel health policy - Runtime delivery
+            coverageIds: [runtime.delivery]
           - name: Operator CLI controls
             coverageIds: [operator-cli-controls]
             description: Operator CLI controls for start, stop, logout, status, restart, and troubleshoot
@@ -1853,9 +2272,16 @@ surfaces:
       - name: Approval Policy and Tool Safeguards
         id: approval-policy-and-tool-safeguards
         features:
-          - name: Approval Policy
-            coverageIds: [personal.approval-denial, personal.tool-safety, runtime.approvals, tools.followthrough, tools.safety]
-            description: Covers Approval Policy across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
+          - name: Approval Policy - Personal approval denial
+            coverageIds: [personal.approval-denial]
+          - name: Approval Policy - Personal tool safety
+            coverageIds: [personal.tool-safety]
+          - name: Approval Policy - Runtime approvals
+            coverageIds: [runtime.approvals]
+          - name: Approval Policy - Tool followthrough
+            coverageIds: [tools.followthrough]
+          - name: Approval Policy - Tool safety
+            coverageIds: [tools.safety]
           - name: Dangerous Tool Safeguards
             coverageIds: [dangerous-tool-safeguards]
             description: Covers Dangerous Tool Safeguards across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
@@ -2031,9 +2457,20 @@ surfaces:
           - name: Secrets Storage
             coverageIds: [secrets-storage]
             description: Covers Secrets Storage across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
-          - name: Redaction
-            coverageIds: [memory.dreaming, memory.promotion, personal.diagnostics, personal.redaction, qa.artifact-safety, runtime.tool-policy, security.redaction]
-            description: Covers Redaction across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
+          - name: Redaction - Memory dreaming
+            coverageIds: [memory.dreaming]
+          - name: Redaction - Memory promotion
+            coverageIds: [memory.promotion]
+          - name: Redaction - Personal diagnostics
+            coverageIds: [personal.diagnostics]
+          - name: Redaction - Personal redaction
+            coverageIds: [personal.redaction]
+          - name: Redaction - QA artifact safety
+            coverageIds: [qa.artifact-safety]
+          - name: Redaction - Runtime tool policy
+            coverageIds: [runtime.tool-policy]
+          - name: Redaction - Security redaction
+            coverageIds: [security.redaction]
           - name: Configuration Hygiene
             coverageIds: [configuration-hygiene]
             description: Covers Configuration Hygiene across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
@@ -2084,9 +2521,12 @@ surfaces:
           - name: Restart logging
             coverageIds: [restart-logging]
             description: Restart logging and runtime snapshot evaluation
-          - name: openclaw doctor
-            coverageIds: [runtime.codex-plugin.auth, runtime.codex-plugin.lifecycle, runtime.doctor-repair]
-            description: openclaw doctor, openclaw doctor --fix, --repair, --yes, --non-interactive, --deep, and --lint
+          - name: openclaw doctor - Codex plugin auth
+            coverageIds: [runtime.codex-plugin.auth]
+          - name: openclaw doctor - Codex plugin lifecycle
+            coverageIds: [runtime.codex-plugin.lifecycle]
+          - name: openclaw doctor - Runtime doctor repair
+            coverageIds: [runtime.doctor-repair]
           - name: Structured health checks
             coverageIds: [structured-health-checks]
             description: Structured health checks, findings, repair results, check selection, JSON lint output, severity filtering, and exit behavior
@@ -2105,9 +2545,16 @@ surfaces:
           - name: Gateway RPC health
             coverageIds: [gateway-rpc-health]
             description: Gateway RPC health and status
-          - name: Cached health snapshots
-            coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
-            description: Cached health snapshots, live probe refresh, sensitive fields gated by operator admin scope, and event-loop health attachment
+          - name: Cached health snapshots - Gateway performance
+            coverageIds: [gateway.performance]
+          - name: Cached health snapshots - Live OpenAI models
+            coverageIds: [models.live-openai]
+          - name: Cached health snapshots - Kitchen sink plugin
+            coverageIds: [plugins.kitchen-sink]
+          - name: Cached health snapshots - Plugin lifecycle
+            coverageIds: [plugins.lifecycle]
+          - name: Cached health snapshots - Plugin tools
+            coverageIds: [plugins.plugin-tools]
         docs:
           - docs/gateway/health.md
           - docs/channels/telegram.md
@@ -2168,9 +2615,12 @@ surfaces:
           - name: Chat /diagnostics
             coverageIds: [chat-diagnostics]
             description: Chat /diagnostics and /codex diagnostics approval flows
-          - name: Support zip composition
-            coverageIds: [personal.diagnostics, personal.redaction, qa.artifact-safety]
-            description: Support zip composition, safe relative paths, sanitized config/status/health/log/stability files, and privacy manifest
+          - name: Support zip composition - Personal diagnostics
+            coverageIds: [personal.diagnostics]
+          - name: Support zip composition - Personal redaction
+            coverageIds: [personal.redaction]
+          - name: Support zip composition - QA artifact safety
+            coverageIds: [qa.artifact-safety]
           - name: Bounded in-process stability recorder
             coverageIds: [bounded-in-process-stability-recorder]
             description: Bounded in-process stability recorder and diagnostics.stability RPC
@@ -2218,24 +2668,47 @@ surfaces:
           - name: diagnostics-otel plugin install
             coverageIds: [diagnostics-otel-plugin-install]
             description: diagnostics-otel plugin install, enablement, config, env overrides, sampling, flush interval, and preloaded SDK mode
-          - name: OTLP/HTTP traces
-            coverageIds: [harness.qa-lab, telemetry.otel]
-            description: OTLP/HTTP traces, metrics, and logs
+          - name: OTLP/HTTP traces - QA Lab harness
+            coverageIds: [harness.qa-lab]
+          - name: OTLP/HTTP traces - OTel telemetry
+            coverageIds: [telemetry.otel]
           - name: Trusted trace context
             coverageIds: [trusted-trace-context]
             description: Trusted trace context, W3C traceparent propagation to model calls, file-log correlation, content-capture controls, and redacted/bounded attributes
-          - name: Model and runtime telemetry
-            coverageIds: [docker.e2e, harness.qa-lab, harness.tool-trace-visibility, personal.failure-recovery, personal.no-fake-progress, personal.task-followthrough, runtime.qa-bus, telemetry.otel, telemetry.prometheus, tools.evidence, tools.trace]
-            description: Model, tool, message, session, queue, Talk, exec, webhook, context assembly, harness, and exporter-health signals
+          - name: Model and runtime telemetry - Docker E2E
+            coverageIds: [docker.e2e]
+          - name: Model and runtime telemetry - QA Lab harness
+            coverageIds: [harness.qa-lab]
+          - name: Model and runtime telemetry - Tool trace visibility harness
+            coverageIds: [harness.tool-trace-visibility]
+          - name: Model and runtime telemetry - Personal failure recovery
+            coverageIds: [personal.failure-recovery]
+          - name: Model and runtime telemetry - Personal no fake progress
+            coverageIds: [personal.no-fake-progress]
+          - name: Model and runtime telemetry - Personal task followthrough
+            coverageIds: [personal.task-followthrough]
+          - name: Model and runtime telemetry - QA bus runtime
+            coverageIds: [runtime.qa-bus]
+          - name: Model and runtime telemetry - OTel telemetry
+            coverageIds: [telemetry.otel]
+          - name: Model and runtime telemetry - Telemetry prometheus
+            coverageIds: [telemetry.prometheus]
+          - name: Model and runtime telemetry - Evidence tools
+            coverageIds: [tools.evidence]
+          - name: Model and runtime telemetry - Tool trace
+            coverageIds: [tools.trace]
           - name: diagnostics-prometheus plugin install
             coverageIds: [diagnostics-prometheus-plugin-install]
             description: diagnostics-prometheus plugin install and enablement
           - name: Gateway-authenticated GET /api/diagnostics/prometheus
             coverageIds: [gateway-authenticated-get-api-diagnostics-prometheus]
             description: Gateway-authenticated GET /api/diagnostics/prometheus behavior, status, and operator-visible verification.
-          - name: Prometheus text exposition
-            coverageIds: [docker.e2e, harness.qa-lab, telemetry.prometheus]
-            description: Prometheus text exposition, counters, gauges, histograms, label policy, series cap, and overflow metric
+          - name: Prometheus text exposition - Docker E2E
+            coverageIds: [docker.e2e]
+          - name: Prometheus text exposition - QA Lab harness
+            coverageIds: [harness.qa-lab]
+          - name: Prometheus text exposition - Telemetry prometheus
+            coverageIds: [telemetry.prometheus]
           - name: Trusted diagnostic event subscription
             coverageIds: [trusted-diagnostic-event-subscription]
             description: Trusted diagnostic event subscription and rendering of run, model, tool, message, Talk, queue, session, liveness, payload, memory, and exporter metrics
@@ -2314,21 +2787,37 @@ surfaces:
           - name: Cron RPCs
             coverageIds: [cron-rpcs]
             description: Covers Cron RPCs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
-          - name: Agent cron tool
-            coverageIds: [channels.qa-channel, personal.reminders, scheduling.cron]
-            description: Covers Agent cron tool across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
-          - name: Manual cron runs
-            coverageIds: [channels.qa-channel, personal.reminders, scheduling.cron, scheduling.dedup]
-            description: Covers Manual cron runs across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
-          - name: Isolated cron execution
-            coverageIds: [channels.qa-channel, personal.reminders, scheduling.cron, scheduling.dedup]
-            description: Covers Isolated cron execution across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Agent cron tool - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Agent cron tool - Personal reminders
+            coverageIds: [personal.reminders]
+          - name: Agent cron tool - Scheduling cron
+            coverageIds: [scheduling.cron]
+          - name: Manual cron runs - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Manual cron runs - Personal reminders
+            coverageIds: [personal.reminders]
+          - name: Manual cron runs - Scheduling cron
+            coverageIds: [scheduling.cron]
+          - name: Manual cron runs - Scheduling dedup
+            coverageIds: [scheduling.dedup]
+          - name: Isolated cron execution - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Isolated cron execution - Personal reminders
+            coverageIds: [personal.reminders]
+          - name: Isolated cron execution - Scheduling cron
+            coverageIds: [scheduling.cron]
+          - name: Isolated cron execution - Scheduling dedup
+            coverageIds: [scheduling.dedup]
           - name: Model/provider preflight
             coverageIds: [model-provider-preflight]
             description: Covers Model/provider preflight across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
-          - name: Run history
-            coverageIds: [channels.qa-channel, scheduling.cron, scheduling.dedup]
-            description: Covers Run history across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Run history - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Run history - Scheduling cron
+            coverageIds: [scheduling.cron]
+          - name: Run history - Scheduling dedup
+            coverageIds: [scheduling.dedup]
           - name: Timeout and denial diagnostics
             coverageIds: [timeout-and-denial-diagnostics]
             description: Covers Timeout and denial diagnostics across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
@@ -2573,9 +3062,12 @@ surfaces:
           - name: Due-only heartbeat tasks
             coverageIds: [due-only-heartbeat-tasks]
             description: Covers Due-only heartbeat tasks across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
-          - name: Commitment check-ins
-            coverageIds: [commitments.heartbeat-target-none, commitments.scope, runtime.delivery]
-            description: Covers Commitment check-ins across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
+          - name: Commitment check-ins - No-target heartbeat commitments
+            coverageIds: [commitments.heartbeat-target-none]
+          - name: Commitment check-ins - Commitment scope
+            coverageIds: [commitments.scope]
+          - name: Commitment check-ins - Runtime delivery
+            coverageIds: [runtime.delivery]
         docs:
           - docs/automation/index.md
           - docs/gateway/heartbeat.md
@@ -2787,9 +3279,12 @@ surfaces:
           - name: Audio proxy and limit handling
             coverageIds: [audio-proxy-and-limit-handling]
             description: Covers Audio proxy and limit handling across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
-          - name: Inbound image summarization
-            coverageIds: [channels.qa-channel, media.image-understanding, ui.control]
-            description: Covers Inbound image summarization across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
+          - name: Inbound image summarization - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Inbound image summarization - Image understanding media
+            coverageIds: [media.image-understanding]
+          - name: Inbound image summarization - UI control
+            coverageIds: [ui.control]
           - name: Active vision model bypass
             coverageIds: [active-vision-model-bypass]
             description: Covers Active vision model bypass across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
@@ -2839,12 +3334,18 @@ surfaces:
       - name: Media Generation
         id: media-generation
         features:
-          - name: Image generation tool invocation
-            coverageIds: [channels.qa-channel, media.image-generation, tools.image-generate, tools.native-image-generation]
-            description: Covers Image generation tool invocation across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
-          - name: Provider and model selection
-            coverageIds: [media.image-generation, tools.native-image-generation]
-            description: Covers Provider and model selection across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Image generation tool invocation - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Image generation tool invocation - Image generation media
+            coverageIds: [media.image-generation]
+          - name: Image generation tool invocation - Tool image generate
+            coverageIds: [tools.image-generate]
+          - name: Image generation tool invocation - Tool native image generation
+            coverageIds: [tools.native-image-generation]
+          - name: Provider and model selection - Image generation media
+            coverageIds: [media.image-generation]
+          - name: Provider and model selection - Tool native image generation
+            coverageIds: [tools.native-image-generation]
           - name: Reference image editing
             coverageIds: [reference-image-editing]
             description: Covers Reference image editing across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
@@ -3243,9 +3744,12 @@ surfaces:
       - name: Browser UI
         id: browser-ui
         features:
-          - name: Gateway-hosted UI
-            coverageIds: [channels.qa-channel, media.image-understanding, ui.control]
-            description: Covers Gateway-hosted UI across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
+          - name: Gateway-hosted UI - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: Gateway-hosted UI - Image understanding media
+            coverageIds: [media.image-understanding]
+          - name: Gateway-hosted UI - UI control
+            coverageIds: [ui.control]
           - name: Dashboard open/auth bootstrap
             coverageIds: [dashboard-open-auth-bootstrap]
             description: Covers Dashboard open/auth bootstrap across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
@@ -3315,9 +3819,18 @@ surfaces:
           - name: chat.history projection
             coverageIds: [chat-history-projection]
             description: Covers chat.history projection across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
-          - name: chat.send lifecycle
-            coverageIds: [channels.qa-channel, channels.webchat, media.image-understanding, runtime.direct-reply-routing, tools.message, ui.control]
-            description: Covers chat.send lifecycle across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
+          - name: chat.send lifecycle - QA channel
+            coverageIds: [channels.qa-channel]
+          - name: chat.send lifecycle - Webchat channel
+            coverageIds: [channels.webchat]
+          - name: chat.send lifecycle - Image understanding media
+            coverageIds: [media.image-understanding]
+          - name: chat.send lifecycle - Runtime direct reply routing
+            coverageIds: [runtime.direct-reply-routing]
+          - name: chat.send lifecycle - Tool message
+            coverageIds: [tools.message]
+          - name: chat.send lifecycle - UI control
+            coverageIds: [ui.control]
           - name: Abort/partial retention
             coverageIds: [abort-partial-retention]
             description: Covers Abort/partial retention across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
@@ -3378,9 +3891,12 @@ surfaces:
           - name: Live log tail
             coverageIds: [live-log-tail]
             description: Covers Live log tail across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
-          - name: Update run/status
-            coverageIds: [runtime.gateway-restart, runtime.package-update, runtime.update-run]
-            description: Covers Update run/status across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
+          - name: Update run/status - Gateway restart
+            coverageIds: [runtime.gateway-restart]
+          - name: Update run/status - Package update runtime
+            coverageIds: [runtime.package-update]
+          - name: Update run/status - Update run runtime
+            coverageIds: [runtime.update-run]
           - name: Activity summaries
             coverageIds: [activity-summaries]
             description: Covers Activity summaries across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
@@ -4029,9 +4545,20 @@ surfaces:
           - name: ToolSpace
             coverageIds: [toolspace]
             description: Tool discovery and invocation abstraction for external apps.
-          - name: Artifacts
-            coverageIds: [character.persona, personal.task-followthrough, tools.followthrough, workspace.artifacts, workspace.builds, workspace.long-running-task, workspace.repo-discovery]
-            description: Artifact summaries, retention metadata, and download behavior.
+          - name: Artifacts - Character persona
+            coverageIds: [character.persona]
+          - name: Artifacts - Personal task followthrough
+            coverageIds: [personal.task-followthrough]
+          - name: Artifacts - Tool followthrough
+            coverageIds: [tools.followthrough]
+          - name: Artifacts - Workspace artifacts
+            coverageIds: [workspace.artifacts]
+          - name: Artifacts - Workspace builds
+            coverageIds: [workspace.builds]
+          - name: Artifacts - Long-running workspace task
+            coverageIds: [workspace.long-running-task]
+          - name: Artifacts - Repo discovery
+            coverageIds: [workspace.repo-discovery]
           - name: Tasks
             coverageIds: [tasks]
             description: SDK helpers around Gateway task APIs.
@@ -5088,9 +5615,12 @@ surfaces:
       - name: Diagnostics and Repair
         id: diagnostics-and-repair
         features:
-          - name: openclaw doctor
-            coverageIds: [runtime.codex-plugin.auth, runtime.codex-plugin.lifecycle, runtime.doctor-repair]
-            description: openclaw doctor and repair/migration for WSL2 Gateway
+          - name: openclaw doctor - Codex plugin auth
+            coverageIds: [runtime.codex-plugin.auth]
+          - name: openclaw doctor - Codex plugin lifecycle
+            coverageIds: [runtime.codex-plugin.lifecycle]
+          - name: openclaw doctor - Runtime doctor repair
+            coverageIds: [runtime.doctor-repair]
           - name: openclaw status
             coverageIds: [openclaw-status]
             description: openclaw status, status --all, and Gateway service/runtime summary
@@ -6250,9 +6780,12 @@ surfaces:
           - name: Docker E2E package artifact generation
             coverageIds: [docker-e2e-package-artifact-generation]
             description: Docker E2E package artifact generation and shared build helpers
-          - name: Docker E2E plan/scheduler scripts
-            coverageIds: [docker.e2e, harness.qa-lab, telemetry.prometheus]
-            description: Docker E2E plan/scheduler scripts, lane metadata, targeted grouping, package artifact generation, and GitHub hydration action
+          - name: Docker E2E plan/scheduler scripts - Docker E2E
+            coverageIds: [docker.e2e]
+          - name: Docker E2E plan/scheduler scripts - QA Lab harness
+            coverageIds: [harness.qa-lab]
+          - name: Docker E2E plan/scheduler scripts - Telemetry prometheus
+            coverageIds: [telemetry.prometheus]
           - name: Release-path install
             coverageIds: [release-path-install]
             description: Release-path install, update, upgrade survivor, live-provider, plugin, Open WebUI, and cleanup scenario planning
@@ -8598,15 +9131,19 @@ surfaces:
       - name: Model and Auth
         id: model-and-auth
         features:
-          - name: Canonical OpenAI Model Routing
-            coverageIds: [models.openai, tools.web-search]
-            description: 'Covers Canonical OpenAI Model Routing across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
+          - name: Canonical OpenAI Model Routing - OpenAI model
+            coverageIds: [models.openai]
+          - name: Canonical OpenAI Model Routing - Tool web search
+            coverageIds: [tools.web-search]
           - name: Catalog
             coverageIds: [catalog]
             description: 'Covers Catalog across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
-          - name: Codex OAuth Profiles
-            coverageIds: [auth-profiles.provider-selection, runtime.codex-plugin.auth, runtime.doctor-repair]
-            description: Covers Codex OAuth Profiles across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
+          - name: Codex OAuth Profiles - Auth profiles provider selection
+            coverageIds: [auth-profiles.provider-selection]
+          - name: Codex OAuth Profiles - Codex plugin auth
+            coverageIds: [runtime.codex-plugin.auth]
+          - name: Codex OAuth Profiles - Runtime doctor repair
+            coverageIds: [runtime.doctor-repair]
           - name: Subscription Usage
             coverageIds: [subscription-usage]
             description: Covers Subscription Usage across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
@@ -8644,12 +9181,18 @@ surfaces:
           - name: Codex Responses Transport
             coverageIds: [codex-responses-transport]
             description: Covers Codex Responses Transport across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
-          - name: Payload Compatibility
-            coverageIds: [runtime.codex-native-workspace.read, runtime.prompt-compatibility, tools.fs.read]
-            description: Covers Payload Compatibility across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
-          - name: Tool Context
-            coverageIds: [runtime.codex-native-workspace.read, runtime.prompt-compatibility, tools.fs.read]
-            description: Covers Tool Context across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
+          - name: Payload Compatibility - Codex native workspace read
+            coverageIds: [runtime.codex-native-workspace.read]
+          - name: Payload Compatibility - Runtime prompt compatibility
+            coverageIds: [runtime.prompt-compatibility]
+          - name: Payload Compatibility - File read tool
+            coverageIds: [tools.fs.read]
+          - name: Tool Context - Codex native workspace read
+            coverageIds: [runtime.codex-native-workspace.read]
+          - name: Tool Context - Runtime prompt compatibility
+            coverageIds: [runtime.prompt-compatibility]
+          - name: Tool Context - File read tool
+            coverageIds: [tools.fs.read]
           - name: Capability Compatibility
             coverageIds: [capability-compatibility]
             description: Covers Capability Compatibility across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
@@ -8672,12 +9215,30 @@ surfaces:
       - name: Native Codex Harness
         id: native-codex-harness
         features:
-          - name: Native Codex App-server Harness
-            coverageIds: [models.codex-cli, runtime.codex-app-server, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.no-meta-leak, workspace.planning]
-            description: Covers Native Codex App-server Harness across native Codex app-server runtime path used by OpenAI agent turns when the Codex harness owns thread identity, native model loop, compaction, native tools, and native app-server controls.
-          - name: Thread Lifecycle
-            coverageIds: [runtime.codex-app-server, runtime.codex-plugin.lifecycle, runtime.doctor-repair, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.turn-ordering]
-            description: Covers Thread Lifecycle across native Codex app-server runtime path used by OpenAI agent turns when the Codex harness owns thread identity, native model loop, compaction, native tools, and native app-server controls.
+          - name: Native Codex App-server Harness - Codex CLI model
+            coverageIds: [models.codex-cli]
+          - name: Native Codex App-server Harness - Codex app server runtime
+            coverageIds: [runtime.codex-app-server]
+          - name: Native Codex App-server Harness - Gateway log sentinel Codex progress
+            coverageIds: [runtime.gateway-log-sentinel.codex-progress]
+          - name: Native Codex App-server Harness - Long context runtime
+            coverageIds: [runtime.long-context]
+          - name: Native Codex App-server Harness - Runtime no meta leak
+            coverageIds: [runtime.no-meta-leak]
+          - name: Native Codex App-server Harness - Workspace planning
+            coverageIds: [workspace.planning]
+          - name: Thread Lifecycle - Codex app server runtime
+            coverageIds: [runtime.codex-app-server]
+          - name: Thread Lifecycle - Codex plugin lifecycle
+            coverageIds: [runtime.codex-plugin.lifecycle]
+          - name: Thread Lifecycle - Runtime doctor repair
+            coverageIds: [runtime.doctor-repair]
+          - name: Thread Lifecycle - Gateway log sentinel Codex progress
+            coverageIds: [runtime.gateway-log-sentinel.codex-progress]
+          - name: Thread Lifecycle - Long context runtime
+            coverageIds: [runtime.long-context]
+          - name: Thread Lifecycle - Turn ordering
+            coverageIds: [runtime.turn-ordering]
         docs:
           - docs/plugins/codex-harness.md
           - docs/plugins/codex-harness-runtime.md
@@ -8798,12 +9359,14 @@ surfaces:
           - name: Bundled Claude catalog
             coverageIds: [bundled-claude-catalog]
             description: 'Covers Bundled Claude catalog across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
-          - name: Canonical anthropic refs
-            coverageIds: [models.anthropic, models.provider-auth]
-            description: 'Covers Canonical anthropic refs across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
-          - name: Claude CLI compatibility
-            coverageIds: [models.claude-cli, models.provider-capabilities]
-            description: 'Covers Claude CLI compatibility across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Canonical anthropic refs - Anthropic model
+            coverageIds: [models.anthropic]
+          - name: Canonical anthropic refs - Provider model auth
+            coverageIds: [models.provider-auth]
+          - name: Claude CLI compatibility - Claude CLI model
+            coverageIds: [models.claude-cli]
+          - name: Claude CLI compatibility - Provider model capabilities
+            coverageIds: [models.provider-capabilities]
           - name: Model picker availability
             coverageIds: [model-picker-availability]
             description: 'Covers Model picker availability across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
@@ -10009,9 +10572,10 @@ surfaces:
       - name: Tool Availability and Fetch
         id: tool-availability-and-fetch
         features:
-          - name: web_search exposure
-            coverageIds: [models.openai, tools.web-search]
-            description: Defines web_search exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
+          - name: web_search exposure - OpenAI model
+            coverageIds: [models.openai]
+          - name: web_search exposure - Tool web search
+            coverageIds: [tools.web-search]
           - name: web_fetch exposure
             coverageIds: [tools.web-fetch]
             description: Defines web_fetch exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
@@ -10084,9 +10648,20 @@ surfaces:
           - name: Snapshots
             coverageIds: [snapshots]
             description: Covers Snapshots across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
-          - name: Artifacts
-            coverageIds: [character.persona, personal.task-followthrough, tools.followthrough, workspace.artifacts, workspace.builds, workspace.long-running-task, workspace.repo-discovery]
-            description: Covers Artifacts across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
+          - name: Artifacts - Character persona
+            coverageIds: [character.persona]
+          - name: Artifacts - Personal task followthrough
+            coverageIds: [personal.task-followthrough]
+          - name: Artifacts - Tool followthrough
+            coverageIds: [tools.followthrough]
+          - name: Artifacts - Workspace artifacts
+            coverageIds: [workspace.artifacts]
+          - name: Artifacts - Workspace builds
+            coverageIds: [workspace.builds]
+          - name: Artifacts - Long-running workspace task
+            coverageIds: [workspace.long-running-task]
+          - name: Artifacts - Repo discovery
+            coverageIds: [workspace.repo-discovery]
           - name: Browser Plugin Service
             coverageIds: [browser-plugin-service]
             description: Covers Browser Plugin Service across bundled browser plugin activation, browser CLI registration, `browser.request` Gateway routing, control-service startup, and related browser plugin service and profiles behavior.
@@ -10128,15 +10703,24 @@ surfaces:
       - name: Tool Invocation and Execution
         id: tool-invocation-and-execution
         features:
-          - name: Exec Routing
-            coverageIds: [tools.bash, tools.exec]
-            description: Covers Exec Routing across `exec` foreground and background execution, `yieldMs`, timeouts, PTY, and related exec routing and process lifecycle behavior.
-          - name: Process Lifecycle
-            coverageIds: [workspace.artifacts, workspace.builds, workspace.long-running-task, workspace.repo-discovery]
-            description: Covers Process Lifecycle across `exec` foreground and background execution, `yieldMs`, timeouts, PTY, and related exec routing and process lifecycle behavior.
-          - name: Direct Tool Invoke API
-            coverageIds: [plugins.mcp-tools, plugins.skills, tools.invocation]
-            description: Covers Direct Tool Invoke API across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.
+          - name: Exec Routing - Tool bash
+            coverageIds: [tools.bash]
+          - name: Exec Routing - Tool exec
+            coverageIds: [tools.exec]
+          - name: Process Lifecycle - Workspace artifacts
+            coverageIds: [workspace.artifacts]
+          - name: Process Lifecycle - Workspace builds
+            coverageIds: [workspace.builds]
+          - name: Process Lifecycle - Long-running workspace task
+            coverageIds: [workspace.long-running-task]
+          - name: Process Lifecycle - Repo discovery
+            coverageIds: [workspace.repo-discovery]
+          - name: Direct Tool Invoke API - MCP plugin tools
+            coverageIds: [plugins.mcp-tools]
+          - name: Direct Tool Invoke API - Plugin skills
+            coverageIds: [plugins.skills]
+          - name: Direct Tool Invoke API - Tool invocation
+            coverageIds: [tools.invocation]
           - name: Node System.run
             coverageIds: [node-system-run]
             description: Covers Node System.run across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -2842,9 +2842,9 @@ surfaces:
           - name: Image generation tool invocation
             coverageIds: [channels.qa-channel, media.image-generation, tools.image-generate, tools.native-image-generation]
             description: Covers Image generation tool invocation across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
-          - name: Provider and model selection
+          - name: Image generation provider routing
             coverageIds: [media.image-generation, tools.native-image-generation]
-            description: Covers Provider and model selection across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+            description: Covers image generation provider and model routing across `image_generate`, provider registration, provider capability listing, and related image generation tool behavior.
           - name: Reference image editing
             coverageIds: [reference-image-editing]
             description: Covers Reference image editing across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
@@ -2857,9 +2857,9 @@ surfaces:
           - name: Music generation tool invocation
             coverageIds: [music-generation-tool-invocation]
             description: Covers Music generation tool invocation across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
-          - name: Provider and model selection
-            coverageIds: [provider-and-model-selection-2]
-            description: Covers Provider and model selection across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
+          - name: Music generation provider controls
+            coverageIds: [music-generation-provider-controls]
+            description: Covers music generation provider and model controls across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation routing behavior.
           - name: Lyrics, instrumental, duration, and format controls
             coverageIds: [lyrics-instrumental-duration-and-format-controls]
             description: Covers Lyrics, instrumental, duration, and format controls across `music_generate`, provider/model config, lyrics/instrumental/duration/format controls, image reference inputs where supported, and related music generation tool and provider routing behavior.
@@ -2898,7 +2898,7 @@ surfaces:
           - docs/tools/video-generation.md
         search_anchors:
           - Image generation tool invocation
-          - Provider and model selection
+          - Image generation provider routing
           - Reference image editing
           - Generated image task lifecycle
           - Generated image persistence and delivery
@@ -2906,6 +2906,7 @@ surfaces:
           - Provider + CLI fallback
           - Mention detection in groups
           - Music generation tool invocation
+          - Music generation provider controls
           - Lyrics, instrumental, duration, and format controls
           - Reference inputs where supported
           - Music task lifecycle and duplicate status
@@ -6197,7 +6198,7 @@ surfaces:
           - name: Container update/rebuild/restart guidance for Docker
             coverageIds: [container-update-rebuild-restart-guidance-for-docker]
             description: Container update/rebuild/restart guidance for Docker and Podman hosts
-          - name: Docker Compose
+          - name: Docker Compose mounts and secrets
             coverageIds: [docker-compose]
             description: Docker Compose and Podman config/workspace/auth-profile secret mounts
           - name: Gateway token generation
@@ -6206,8 +6207,8 @@ surfaces:
           - name: Ownership
             coverageIds: [ownership]
             description: Ownership, permissions, SELinux mount behavior, and state survival across container replacement
-          - name: Docker Compose
-            coverageIds: [docker-compose-2]
+          - name: Docker Compose network access
+            coverageIds: [docker-compose-network-access]
             description: Docker Compose and Podman port publishing, bind mode, host local provider access, Bonjour, Tailscale, and Control UI origins
           - name: Container health endpoints
             coverageIds: [container-health-endpoints]
@@ -8500,85 +8501,77 @@ surfaces:
       - name: Channel Setup and Operations
         id: channel-setup-and-operations
         features:
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel]
-            description: Cli, Gateway Rpc, and Agent Tool
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel-2]
+          - name: Voice call CLI, RPC, and agent tool
+            coverageIds: [voice-call-cli-rpc-agent-tool]
+            description: CLI, Gateway RPC, and agent tool
+          - name: Voice call setup smoke
+            coverageIds: [voice-call-setup-smoke]
             description: Setup, Configuration, and Smoke
         docs:
           - docs/cli/voicecall.md
           - docs/plugins/voice-call.md
           - docs/gateway/protocol.md
         search_anchors:
-          - 'voice call channel voice call channel: cli, gateway rpc, and agent tool'
-          - 'voice call channel: cli, gateway rpc, and agent tool'
-          - 'voice call channel voice call channel: setup, configuration, and smoke'
-          - 'voice call channel: setup, configuration, and smoke'
+          - voice call CLI, RPC, and agent tool
+          - voice call setup smoke
         category_note: setup-configuration-and-smoke.md
         human_lts_override: false
       - name: Access and Identity
         id: access-and-identity
         features:
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel]
+          - name: Voice call webhook security
+            coverageIds: [voice-call-webhook-security]
             description: Webhook Exposure and Security
         docs:
           - docs/plugins/voice-call.md
           - docs/cli/voicecall.md
         search_anchors:
-          - 'voice call channel voice call channel: webhook exposure and security'
-          - 'voice call channel: webhook exposure and security'
+          - voice call webhook security
         category_note: webhook-exposure-and-security.md
         human_lts_override: false
       - name: Conversation Routing and Delivery
         id: conversation-routing-and-delivery
         features:
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel]
+          - name: Voice call inbound routing
+            coverageIds: [voice-call-inbound-routing]
             description: Inbound Routing, Sessions, and Lifecycle
         docs:
           - docs/plugins/voice-call.md
         search_anchors:
-          - 'voice call channel voice call channel: inbound routing, sessions, and lifecycle'
-          - 'voice call channel: inbound routing, sessions, and lifecycle'
+          - voice call inbound routing, sessions, and lifecycle
         category_note: inbound-routing-sessions-and-lifecycle.md
         human_lts_override: false
       - name: Media and Rich Content
         id: media-and-rich-content
         features:
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel]
+          - name: Voice call provider transports
+            coverageIds: [voice-call-provider-transports]
             description: Provider Transports and Call Control
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel-2]
-            description: Telephony Tts, Playback, Dtmf, and Audio
+          - name: Voice call telephony audio
+            coverageIds: [voice-call-telephony-audio]
+            description: Telephony TTS, playback, DTMF, and audio
         docs:
           - docs/plugins/voice-call.md
           - docs/plugins/plugin-inventory.md
         search_anchors:
-          - 'voice call channel voice call channel: provider transports and call control'
-          - 'voice call channel: provider transports and call control'
-          - 'voice call channel voice call channel: telephony tts, playback, dtmf, and audio'
-          - 'voice call channel: telephony tts, playback, dtmf, and audio'
+          - voice call provider transports and call control
+          - voice call telephony TTS, playback, DTMF, and audio
         category_note: provider-transports-and-call-control.md
         human_lts_override: false
       - name: Realtime Voice and Calls
         id: realtime-voice-and-calls
         features:
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel]
+          - name: Voice call realtime consult
+            coverageIds: [voice-call-realtime-consult]
             description: Realtime Voice and Agent Consult
-          - name: Voice Call Channel
-            coverageIds: [voice-call-channel-2]
+          - name: Voice call streaming transcription
+            coverageIds: [voice-call-streaming-transcription]
             description: Streaming Transcription and Auto-response
         docs:
           - docs/plugins/voice-call.md
         search_anchors:
-          - 'voice call channel voice call channel: realtime voice and agent consult'
-          - 'voice call channel: realtime voice and agent consult'
-          - 'voice call channel voice call channel: streaming transcription and auto-response'
-          - 'voice call channel: streaming transcription and auto-response'
+          - voice call realtime voice and agent consult
+          - voice call streaming transcription and auto-response
         category_note: realtime-voice-and-agent-consult.md
         human_lts_override: false
     last_score_run:
@@ -9080,15 +9073,15 @@ surfaces:
           - name: Usage and stop reasons
             coverageIds: [usage-and-stop-reasons]
             description: 'Covers Usage and stop reasons across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
-          - name: Thought-signature replay
-            coverageIds: [thought-signature-replay]
-            description: 'Covers Thought-signature replay across direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct gemini api behavior.'
+          - name: Direct Gemini transport payloads
+            coverageIds: [direct-gemini-transport-payloads]
+            description: 'Covers direct `google-generative-ai` Gemini transport and shared Google message/stream conversion: request URL construction, request config, text/image/audio/video/tool payload conversion, function response handling, and related direct Gemini API behavior.'
           - name: Thinking-level mapping
             coverageIds: [thinking-level-mapping]
             description: Covers Thinking-level mapping across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
-          - name: Thought-signature replay
-            coverageIds: [thought-signature-replay-2]
-            description: Covers Thought-signature replay across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
+          - name: Thought-signature replay policy
+            coverageIds: [thought-signature-replay]
+            description: Covers Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
           - name: Tool turn ordering
             coverageIds: [tool-turn-ordering]
             description: Covers Tool turn ordering across Gemini thinking-level mapping, adaptive thinking request shape, `thoughtSignature` capture/replay/sanitization, Google replay policy, and related thinking and turn recovery behavior.
@@ -9105,8 +9098,9 @@ surfaces:
           - Multimodal inputs
           - Tool-call streaming
           - Usage and stop reasons
-          - Thought-signature replay
+          - Direct Gemini transport payloads
           - Thinking-level mapping
+          - Thought-signature replay policy
           - Tool turn ordering
           - Incomplete-turn recovery
         category_note: direct-gemini-api-transport-streaming-and-multimodal-payloads.md

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -3691,15 +3691,15 @@ surfaces:
       - name: Catalog Discovery
         id: catalog-discovery
         features:
-          - name: openclaw plugins search as the ClawHub
+          - name: Plugin catalog search
             coverageIds: [openclaw-plugins-search-as-the-clawhub]
-            description: openclaw plugins search as the ClawHub plugin lookup command
+            description: OpenClaw plugin search resolves ClawHub package lookup results.
           - name: Search result metadata
             coverageIds: [search-result-metadata]
-            description: package name, family, channel, version, summary, and
-          - name: Distinction between plugin search
+            description: Search results include package identity, channel, version, summary, compatibility, and source metadata.
+          - name: Plugin and skill search separation
             coverageIds: [distinction-between-plugin-search]
-            description: Distinction between plugin search and skill search
+            description: Plugin search and skill search stay distinct even when both use ClawHub metadata.
           - name: Catalog lookup failure
             coverageIds: [catalog-lookup-failure]
             description: Catalog lookup failure and empty-result behavior
@@ -3782,8 +3782,8 @@ surfaces:
         features:
           - name: Source prefixes
             coverageIds: [source-prefixes]
-            description: Source prefixes and shorthand resolution for clawhub:, npm:,
-          - name: Bare package behavior during the launch
+            description: Source prefixes and shorthand resolution cover ClawHub, npm, local, archive, and marketplace plugin sources.
+          - name: Bare package launch behavior
             coverageIds: [bare-package-behavior-during-the-launch]
             description: Bare package behavior during the launch cutover
           - name: Explicit pinned versions
@@ -3819,7 +3819,7 @@ surfaces:
           - name: Uninstall config/index/policy/file cleanup
             coverageIds: [uninstall-config-index-policy-file-cleanup]
             description: Evidence scope for Uninstall config/index/policy/file cleanup.
-          - name: Gateway restart/reload requirements after
+          - name: Gateway restart and reload requirements
             coverageIds: [gateway-restart-reload-requirements-after]
             description: Gateway restart/reload requirements after install/update/uninstall
           - name: Per-plugin managed npm project
@@ -3837,15 +3837,15 @@ surfaces:
           - name: Legacy dependency root cleanup
             coverageIds: [legacy-dependency-root-cleanup]
             description: Legacy dependency root cleanup and doctor repair
-          - name: plugins list
+          - name: Plugin inventory commands
             coverageIds: [plugins-list]
-            description: plugins list, plugins inspect, runtime inspect, plugins doctor, and
+            description: Plugin list, inspect, runtime inspect, and doctor commands expose operator inventory and diagnostics.
           - name: Local plugin index
             coverageIds: [local-plugin-index]
             description: Local plugin index and persisted cold registry state
           - name: Troubleshooting stale config
             coverageIds: [troubleshooting-stale-config]
-            description: Troubleshooting stale config, blocked paths, dependencies, missing plugins,
+            description: Troubleshooting covers stale config, blocked paths, dependencies, missing plugins, and repair guidance.
           - name: Runtime verification after Gateway
             coverageIds: [runtime-verification-after-gateway]
             description: Runtime verification after Gateway restart

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -175,12 +175,9 @@ surfaces:
           - name: Usage and memory APIs
             coverageIds: [usage-and-memory-apis]
             description: Usage summaries and memory readiness RPCs.
-          - name: Subagents
-            coverageIds: [agents.subagents]
-          - name: Gateway session list
-            coverageIds: [gateway.sessions-list]
-          - name: Session status tool
-            coverageIds: [tools.session-status]
+          - name: Session APIs
+            coverageIds: [agents.subagents, gateway.sessions-list, tools.session-status]
+            description: '`sessions.*` RPCs.'
           - name: Chat APIs
             coverageIds: [chat-apis]
             description: '`chat.*` and `agent.wait` RPCs.'
@@ -450,26 +447,18 @@ surfaces:
           - name: Service installation
             coverageIds: [service-installation]
             description: Supervised lifecycle installation on macOS, Linux user/systemd, and native Windows task scheduling.
-          - name: Restart config apply
-            coverageIds: [config.restart-apply]
-          - name: Plugin capabilities
-            coverageIds: [plugins.capabilities]
-          - name: Gateway restart
-            coverageIds: [runtime.gateway-restart]
+          - name: Restart and stop
+            coverageIds: [config.restart-apply, plugins.capabilities, runtime.gateway-restart]
+            description: Correct `restart` and `stop` behavior for supervised installs.
           - name: Service status
             coverageIds: [service-status]
             description: Status behavior for supervised installs.
           - name: Bind and port settings
             coverageIds: [bind-and-port-settings]
             description: Bind and port precedence across CLI flags, env vars, config, and persisted supervisor metadata.
-          - name: Hot config apply
-            coverageIds: [config.hot-apply]
-          - name: Hot plugin reload
-            coverageIds: [plugins.hot-reload]
-          - name: Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: Plugin skills
-            coverageIds: [plugins.skills]
+          - name: Config reload
+            coverageIds: [config.hot-apply, plugins.hot-reload, plugins.lifecycle, plugins.skills]
+            description: 'Config reload modes: `off`, `hot`, `restart`, and `hybrid`.'
           - name: Multi-gateway isolation
             coverageIds: [multi-gateway-isolation]
             description: Multiple-gateway isolation on one host, including config/state/workspace separation.
@@ -656,12 +645,9 @@ surfaces:
           - name: Service install and control
             coverageIds: [service-install-and-control]
             description: The CLI documents install, status, start, stop, restart, and run flows for managed gateway services.
-          - name: Agent creation
-            coverageIds: [agents.create]
-          - name: Discord channel config
-            coverageIds: [channels.discord-config]
-          - name: Crestodian setup config
-            coverageIds: [config.crestodian-setup]
+          - name: Service auth wiring
+            coverageIds: [agents.create, channels.discord-config, config.crestodian-setup]
+            description: Gateway service installation documents how auth tokens and other sensitive values are handled.
           - name: Drift and reinstall recovery
             coverageIds: [drift-and-reinstall-recovery]
             description: Operators are given explicit guidance for repairing or reinstalling a broken managed gateway service.
@@ -926,45 +912,21 @@ surfaces:
           - name: Plugin setup
             coverageIds: [plugin-setup]
             description: Operators can run plugin setup flows without fully activating runtime behavior.
-          - name: Hot config apply
-            coverageIds: [config.hot-apply]
-          - name: Gateway performance
-            coverageIds: [gateway.performance]
-          - name: Live OpenAI models
-            coverageIds: [models.live-openai]
-          - name: Before prompt build hook
-            coverageIds: [plugins.before-prompt-build]
-          - name: Before tool call hook
-            coverageIds: [plugins.before-tool-call]
-          - name: Hot plugin reload
-            coverageIds: [plugins.hot-reload]
-          - name: Kitchen sink plugin
-            coverageIds: [plugins.kitchen-sink]
-          - name: Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: Plugin tools
-            coverageIds: [plugins.plugin-tools]
-          - name: Plugin runtime
-            coverageIds: [plugins.runtime]
-          - name: Plugin skills
-            coverageIds: [plugins.skills]
-          - name: Gateway log sentinel plugin hooks
-            coverageIds: [runtime.gateway-log-sentinel.plugin-hooks]
-          - name: Plugin tool contracts
-            coverageIds: [plugins.contracts.tools]
-          - name: Gateway log sentinel plugin contracts
-            coverageIds: [runtime.gateway-log-sentinel.plugin-contracts]
+          - name: Runtime activation
+            coverageIds: [config.hot-apply, gateway.performance, models.live-openai, plugins.before-prompt-build, plugins.before-tool-call, plugins.hot-reload, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools, plugins.runtime, plugins.skills, runtime.gateway-log-sentinel.plugin-hooks]
+            description: Enabled plugins activate and register runtime behavior after manifest validation succeeds.
+          - name: Enable and disable
+            coverageIds: [config.hot-apply, plugins.hot-reload, plugins.lifecycle]
+            description: Operators can enable or disable installed plugins without losing install state.
+          - name: Safe load failures
+            coverageIds: [plugins.contracts.tools, runtime.gateway-log-sentinel.plugin-contracts]
+            description: Unsafe or unsupported plugin loads are blocked with diagnosable failures before runtime execution.
           - name: Dependency repair
             coverageIds: [dependency-repair]
             description: Runtime can detect and repair missing or stale plugin dependencies.
-          - name: Hot plugin install
-            coverageIds: [plugins.hot-install]
-          - name: Gateway restart
-            coverageIds: [runtime.gateway-restart]
-          - name: Package update runtime
-            coverageIds: [runtime.package-update]
-          - name: Update run runtime
-            coverageIds: [runtime.update-run]
+          - name: Install update and uninstall
+            coverageIds: [plugins.hot-install, plugins.skills, runtime.gateway-restart, runtime.package-update, runtime.update-run]
+            description: Install, update, and uninstall lifecycle behavior is defined and tested.
         docs:
           - docs/plugins/architecture.md
           - docs/plugins/architecture-internals.md
@@ -1011,26 +973,9 @@ surfaces:
           - name: Provider plugins
             coverageIds: [provider-plugins]
             description: Provider plugins register models and capabilities with the runtime.
-          - name: Gateway performance
-            coverageIds: [gateway.performance]
-          - name: Live OpenAI models
-            coverageIds: [models.live-openai]
-          - name: Before prompt build hook
-            coverageIds: [plugins.before-prompt-build]
-          - name: Before tool call hook
-            coverageIds: [plugins.before-tool-call]
-          - name: Kitchen sink plugin
-            coverageIds: [plugins.kitchen-sink]
-          - name: Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: MCP plugin tools
-            coverageIds: [plugins.mcp-tools]
-          - name: Plugin tools
-            coverageIds: [plugins.plugin-tools]
-          - name: Gateway log sentinel plugin hooks
-            coverageIds: [runtime.gateway-log-sentinel.plugin-hooks]
-          - name: Tool invocation
-            coverageIds: [tools.invocation]
+          - name: Tool plugins
+            coverageIds: [gateway.performance, models.live-openai, plugins.before-prompt-build, plugins.before-tool-call, plugins.kitchen-sink, plugins.lifecycle, plugins.mcp-tools, plugins.plugin-tools, runtime.gateway-log-sentinel.plugin-hooks, tools.invocation]
+            description: Tool plugins register discoverable tools and static metadata without ambiguous runtime ownership.
           - name: Model catalogs
             coverageIds: [model-catalogs]
             description: Provider model catalogs are discoverable and merge cleanly into global listings.
@@ -1040,20 +985,9 @@ surfaces:
           - name: Web search and fetch
             coverageIds: [web-search-and-fetch]
             description: Provider or tool plugins can expose web search and fetch capabilities.
-          - name: Hot config apply
-            coverageIds: [config.hot-apply]
-          - name: Restart config apply
-            coverageIds: [config.restart-apply]
-          - name: Plugin capabilities
-            coverageIds: [plugins.capabilities]
-          - name: Hot plugin install
-            coverageIds: [plugins.hot-install]
-          - name: Plugin runtime
-            coverageIds: [plugins.runtime]
-          - name: Plugin skills
-            coverageIds: [plugins.skills]
-          - name: Skill invocation tool
-            coverageIds: [tools.skill-invocation]
+          - name: Mixed plugins
+            coverageIds: [config.hot-apply, config.restart-apply, plugins.capabilities, plugins.hot-install, plugins.runtime, plugins.skills, tools.invocation, tools.skill-invocation]
+            description: Mixed provider and tool plugins are supported without ambiguous ownership.
         docs:
           - docs/plugins/sdk-provider-plugins.md
           - docs/plugins/tool-plugins.md
@@ -1137,26 +1071,18 @@ surfaces:
           - name: Local test environment
             coverageIds: [local-test-environment]
             description: Plugin authors can set up the local test environment and scoped helper configuration for plugin testing.
-          - name: Plugin tool contracts
-            coverageIds: [plugins.contracts.tools]
-          - name: Gateway log sentinel plugin contracts
-            coverageIds: [runtime.gateway-log-sentinel.plugin-contracts]
+          - name: Plugin runtime harness
+            coverageIds: [plugins.contracts.tools, runtime.gateway-log-sentinel.plugin-contracts]
+            description: Plugin test harnesses cover authoring and runtime integration paths.
           - name: Unit and integration scaffolds
             coverageIds: [unit-and-integration-scaffolds]
             description: Scoped test helpers and configuration support unit and integration testing for plugin surfaces.
           - name: Docker lifecycle suites
             coverageIds: [docker-lifecycle-suites]
             description: Docker-based end-to-end scripts validate packaged plugin lifecycle flows.
-          - name: Gateway performance
-            coverageIds: [gateway.performance]
-          - name: Live OpenAI models
-            coverageIds: [models.live-openai]
-          - name: Kitchen sink plugin
-            coverageIds: [plugins.kitchen-sink]
-          - name: Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: Plugin tools
-            coverageIds: [plugins.plugin-tools]
+          - name: Smoke tests
+            coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
+            description: Local and packaged smoke tests catch broken installs before release.
         docs:
           - docs/plugins/sdk-testing.md
           - docs/plugins/sdk-setup.md
@@ -1185,54 +1111,15 @@ surfaces:
       - name: Agent Turn Execution
         id: agent-turn-execution
         features:
-          - name: Agent creation
-            coverageIds: [agents.create]
-          - name: Agent instructions
-            coverageIds: [agents.instructions]
-          - name: Discord channel config
-            coverageIds: [channels.discord-config]
-          - name: Crestodian setup config
-            coverageIds: [config.crestodian-setup]
-          - name: First action runtime
-            coverageIds: [runtime.first-action]
-          - name: First-hour 20-turn runtime
-            coverageIds: [runtime.first-hour-20]
-          - name: Long context runtime
-            coverageIds: [runtime.long-context]
-          - name: Subagents
-            coverageIds: [agents.subagents]
-          - name: Channel deduplication
-            coverageIds: [channels.dedup]
-          - name: DM channel
-            coverageIds: [channels.dm]
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Channel reconnect
-            coverageIds: [channels.reconnect]
-          - name: Channel streaming
-            coverageIds: [channels.streaming]
-          - name: Channel threads
-            coverageIds: [channels.threads]
-          - name: No-target heartbeat commitments
-            coverageIds: [commitments.heartbeat-target-none]
-          - name: Commitment scope
-            coverageIds: [commitments.scope]
-          - name: Personal channel replies
-            coverageIds: [personal.channel-replies]
-          - name: Codex plugin lifecycle
-            coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Fallback delivery
-            coverageIds: [runtime.fallback-delivery]
-          - name: Gateway restart
-            coverageIds: [runtime.gateway-restart]
-          - name: Runtime restart recovery
-            coverageIds: [runtime.restart-recovery]
-          - name: Turn ordering
-            coverageIds: [runtime.turn-ordering]
-          - name: 100-turn soak
-            coverageIds: [runtime.soak-100]
+          - name: Turn startup and runtime choice
+            coverageIds: [agents.create, agents.instructions, channels.discord-config, config.crestodian-setup, runtime.first-action, runtime.first-hour-20, runtime.long-context]
+            description: Starting an agent turn and choosing gateway versus embedded runtime execution.
+          - name: Session and run coordination
+            coverageIds: [agents.subagents, channels.dedup, channels.dm, channels.qa-channel, channels.reconnect, channels.streaming, channels.threads, commitments.heartbeat-target-none, commitments.scope, personal.channel-replies, runtime.codex-plugin.lifecycle, runtime.delivery, runtime.fallback-delivery, runtime.gateway-restart, runtime.restart-recovery, runtime.turn-ordering]
+            description: Establishing session and run ids, queue locks, and related execution coordination.
+          - name: Abort and terminal outcomes
+            coverageIds: [channels.streaming, runtime.delivery, runtime.fallback-delivery, runtime.long-context, runtime.soak-100]
+            description: Honoring aborts, timing provider/model work, and emitting terminal outcomes.
         docs:
           - docs/concepts/agent-loop.md
           - docs/cli/agent.md
@@ -1246,25 +1133,15 @@ surfaces:
       - name: External Runtimes and Subagents
         id: external-runtimes-and-subagents
         features:
-          - name: OpenClaw harness agent
-            coverageIds: [agents.openclaw-harness]
-          - name: Workspace planning
-            coverageIds: [workspace.planning]
+          - name: External harness selection
+            coverageIds: [agents.openclaw-harness, workspace.planning]
+            description: Choosing Codex app-server, ACP, and other external runtime harnesses.
           - name: CLI runtime aliases
             coverageIds: [cli-runtime-aliases]
             description: Runtime aliases and CLI-based execution paths such as Claude CLI and Gemini CLI.
-          - name: Subagents
-            coverageIds: [agents.subagents]
-          - name: Agent synthesis
-            coverageIds: [agents.synthesis]
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Gateway session list
-            coverageIds: [gateway.sessions-list]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Session spawn tool
-            coverageIds: [tools.sessions-spawn]
+          - name: Subagent turns
+            coverageIds: [agents.subagents, agents.synthesis, channels.qa-channel, gateway.sessions-list, runtime.delivery, tools.sessions-spawn]
+            description: Spawning, delivering, and announcing subagent work outside the default embedded path.
           - name: Runtime recovery
             coverageIds: [runtime-recovery]
             description: Cleanup, timeout, and liveness behavior for external runtimes and subagents.
@@ -1339,20 +1216,15 @@ surfaces:
       - name: Model and Runtime Selection
         id: model-and-runtime-selection
         features:
-          - name: Claude CLI model
-            coverageIds: [models.claude-cli]
-          - name: Provider model capabilities
-            coverageIds: [models.provider-capabilities]
-          - name: Model switching
-            coverageIds: [models.switching]
-          - name: Model thinking
-            coverageIds: [models.thinking]
-          - name: Session continuity
-            coverageIds: [runtime.session-continuity]
-          - name: Tool continuity
-            coverageIds: [runtime.tool-continuity]
-          - name: Reasoning visibility
-            coverageIds: [runtime.reasoning-visibility]
+          - name: Model reference selection
+            coverageIds: [models.claude-cli, models.provider-capabilities]
+            description: Selecting the model reference for an agent turn from user or configured defaults.
+          - name: Provider and runtime overrides
+            coverageIds: [models.switching, models.thinking, runtime.session-continuity, runtime.tool-continuity]
+            description: Handling provider selection and runtime overrides for a turn.
+          - name: Thinking and context settings
+            coverageIds: [models.switching, models.thinking, runtime.reasoning-visibility, runtime.session-continuity]
+            description: Resolving thinking and context settings as part of model selection.
           - name: Invalid route recovery
             coverageIds: [invalid-route-recovery]
             description: Preserving or clearing invalid route state when selections drift or fail.
@@ -1370,31 +1242,21 @@ surfaces:
       - name: Provider Auth
         id: provider-auth
         features:
-          - name: Anthropic model
-            coverageIds: [models.anthropic]
-          - name: Provider model auth
-            coverageIds: [models.provider-auth]
-          - name: Auth profiles provider selection
-            coverageIds: [auth-profiles.provider-selection]
-          - name: Codex plugin auth
-            coverageIds: [runtime.codex-plugin.auth]
-          - name: Gateway performance
-            coverageIds: [gateway.performance]
-          - name: Live OpenAI models
-            coverageIds: [models.live-openai]
-          - name: Kitchen sink plugin
-            coverageIds: [plugins.kitchen-sink]
-          - name: Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: Plugin tools
-            coverageIds: [plugins.plugin-tools]
+          - name: Login and API-key setup
+            coverageIds: [models.anthropic, models.provider-auth]
+            description: Login, OAuth, and paste-key flows for provider access.
+          - name: Auth profile selection
+            coverageIds: [auth-profiles.provider-selection, runtime.codex-plugin.auth]
+            description: Selecting and validating provider auth profiles.
+          - name: Credential health checks
+            coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
+            description: Doctor, status, and related credential health checks and repair signals.
           - name: Auth failover
             coverageIds: [auth-failover]
             description: Same-provider and cross-profile auth fallback behavior.
-          - name: Memory failure handling
-            coverageIds: [memory.failure-handling]
-          - name: Runtime fallbacks
-            coverageIds: [runtime.fallbacks]
+          - name: Provider fallback recovery
+            coverageIds: [memory.failure-handling, runtime.fallbacks]
+            description: Provider and auth-profile fallback behavior when execution fails.
           - name: Rate-limit and capacity recovery
             coverageIds: [rate-limit-and-capacity-recovery]
             description: Recovery paths for quota, capacity, and rate-limit failures.
@@ -1427,24 +1289,12 @@ surfaces:
       - name: Streaming and Progress
         id: streaming-and-progress
         features:
-          - name: Channel streaming
-            coverageIds: [channels.streaming]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Fallback delivery
-            coverageIds: [runtime.fallback-delivery]
-          - name: Model thinking
-            coverageIds: [models.thinking]
-          - name: Personal failure recovery
-            coverageIds: [personal.failure-recovery]
-          - name: Personal no fake progress
-            coverageIds: [personal.no-fake-progress]
-          - name: Personal task followthrough
-            coverageIds: [personal.task-followthrough]
-          - name: Reasoning visibility
-            coverageIds: [runtime.reasoning-visibility]
-          - name: Evidence tools
-            coverageIds: [tools.evidence]
+          - name: Streaming replies
+            coverageIds: [channels.streaming, runtime.delivery, runtime.fallback-delivery]
+            description: Streaming block updates and partial assistant output before final delivery.
+          - name: Progress visibility
+            coverageIds: [models.thinking, personal.failure-recovery, personal.no-fake-progress, personal.task-followthrough, runtime.reasoning-visibility, tools.evidence]
+            description: Progress preview events and item lifecycle updates surfaced during execution.
         docs:
           - docs/concepts/streaming.md
           - docs/concepts/agent-loop.md
@@ -1457,52 +1307,15 @@ surfaces:
       - name: Tool Calls and Response Handling
         id: tool-calls-and-response-handling
         features:
-          - name: Model switching
-            coverageIds: [models.switching]
-          - name: Personal no fake progress
-            coverageIds: [personal.no-fake-progress]
-          - name: Personal task followthrough
-            coverageIds: [personal.task-followthrough]
-          - name: Personal tool safety
-            coverageIds: [personal.tool-safety]
-          - name: Runtime approvals
-            coverageIds: [runtime.approvals]
-          - name: Codex native workspace read
-            coverageIds: [runtime.codex-native-workspace.read]
-          - name: Runtime prompt compatibility
-            coverageIds: [runtime.prompt-compatibility]
-          - name: Tool continuity
-            coverageIds: [runtime.tool-continuity]
-          - name: Apply patch tool
-            coverageIds: [tools.apply-patch]
-          - name: Edit tool
-            coverageIds: [tools.edit]
-          - name: Evidence tools
-            coverageIds: [tools.evidence]
-          - name: Tool followthrough
-            coverageIds: [tools.followthrough]
-          - name: File list tool
-            coverageIds: [tools.fs.list]
-          - name: File read tool
-            coverageIds: [tools.fs.read]
-          - name: File write tool
-            coverageIds: [tools.fs.write]
-          - name: Grep tool
-            coverageIds: [tools.grep]
-          - name: Workspace artifacts
-            coverageIds: [workspace.artifacts]
-          - name: Subagents
-            coverageIds: [agents.subagents]
-          - name: Agent synthesis
-            coverageIds: [agents.synthesis]
-          - name: Personal failure recovery
-            coverageIds: [personal.failure-recovery]
-          - name: Runtime empty response recovery
-            coverageIds: [runtime.empty-response-recovery]
-          - name: Runtime reasoning only recovery
-            coverageIds: [runtime.reasoning-only-recovery]
-          - name: Retry policy
-            coverageIds: [runtime.retry-policy]
+          - name: Tool-call handling
+            coverageIds: [models.switching, personal.no-fake-progress, personal.task-followthrough, personal.tool-safety, runtime.approvals, runtime.codex-native-workspace.read, runtime.prompt-compatibility, runtime.tool-continuity, tools.apply-patch, tools.edit, tools.evidence, tools.followthrough, tools.fs.list, tools.fs.read, tools.fs.write, tools.grep, workspace.artifacts]
+            description: Reliable tool-call behavior across providers, including malformed or provider-specific payload differences.
+          - name: Usage and response reporting
+            coverageIds: [agents.subagents, agents.synthesis]
+            description: Response ids and usage accounting normalized into operator-visible runtime behavior.
+          - name: Failure recovery
+            coverageIds: [personal.failure-recovery, personal.no-fake-progress, runtime.empty-response-recovery, runtime.reasoning-only-recovery, runtime.retry-policy, tools.evidence]
+            description: Failure-stream finalization and cleanup when provider output is malformed or incomplete.
         docs:
           - docs/concepts/agent-loop.md
           - docs/providers/ollama.md
@@ -1515,30 +1328,21 @@ surfaces:
       - name: Tool Execution Controls
         id: tool-execution-controls
         features:
-          - name: QA artifact safety
-            coverageIds: [qa.artifact-safety]
-          - name: Runtime inventory
-            coverageIds: [runtime.inventory]
-          - name: Runtime tool policy
-            coverageIds: [runtime.tool-policy]
-          - name: Security redaction
-            coverageIds: [security.redaction]
+          - name: Tool availability rules
+            coverageIds: [qa.artifact-safety, runtime.inventory, runtime.tool-policy, security.redaction]
+            description: Which tools are available during a turn after policy resolution and provider-based suppression.
           - name: Sandboxed exec behavior
             coverageIds: [sandboxed-exec-behavior]
             description: Exec behavior, sandbox roots, and workspace constraints visible to operators.
-          - name: Personal approval denial
-            coverageIds: [personal.approval-denial]
-          - name: Personal tool safety
-            coverageIds: [personal.tool-safety]
-          - name: Runtime approvals
-            coverageIds: [runtime.approvals]
-          - name: Tool followthrough
-            coverageIds: [tools.followthrough]
-          - name: Tool safety
-            coverageIds: [tools.safety]
+          - name: Approval flow
+            coverageIds: [personal.approval-denial, runtime.approvals, tools.followthrough]
+            description: Operator approval gates for tool execution.
           - name: Elevated execution
             coverageIds: [elevated-execution]
             description: Elevated host execution rules and related controls.
+          - name: Tool safety controls
+            coverageIds: [personal.tool-safety, tools.safety]
+            description: Before-tool-call hooks and related guardrails that shape operator-visible tool behavior.
           - name: Delegated tool access
             coverageIds: [delegated-tool-access]
             description: Inherited or narrowed tool policy for subagents and delegated execution.
@@ -1589,27 +1393,15 @@ surfaces:
       - name: Token Management
         id: token-management
         features:
-          - name: Runtime compaction
-            coverageIds: [runtime.compaction]
-          - name: Runtime empty response recovery
-            coverageIds: [runtime.empty-response-recovery]
-          - name: Runtime reasoning only recovery
-            coverageIds: [runtime.reasoning-only-recovery]
-          - name: Retry policy
-            coverageIds: [runtime.retry-policy]
+          - name: Compaction
+            coverageIds: [runtime.compaction, runtime.empty-response-recovery, runtime.reasoning-only-recovery, runtime.retry-policy]
+            description: Covers Compaction across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
           - name: Pruning
             coverageIds: [pruning]
             description: Covers Pruning across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
-          - name: Codex app server runtime
-            coverageIds: [runtime.codex-app-server]
-          - name: First-hour 20-turn runtime
-            coverageIds: [runtime.first-hour-20]
-          - name: Gateway log sentinel Codex progress
-            coverageIds: [runtime.gateway-log-sentinel.codex-progress]
-          - name: Long context runtime
-            coverageIds: [runtime.long-context]
-          - name: 100-turn soak
-            coverageIds: [runtime.soak-100]
+          - name: Token Pressure
+            coverageIds: [runtime.codex-app-server, runtime.first-hour-20, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.soak-100]
+            description: Covers Token Pressure across manual and automatic compaction, preemptive overflow checks, context-window estimation, session pruning, tool-result trimming, compaction providers, retry/timeout behavior, and compacted transcript checkpoints.
         docs:
           - docs/concepts/compaction.md
           - docs/concepts/context.md
@@ -1625,20 +1417,12 @@ surfaces:
       - name: Context Engine
         id: context-engine
         features:
-          - name: Docs discovery
-            coverageIds: [docs.discovery]
-          - name: Workspace artifacts
-            coverageIds: [workspace.artifacts]
-          - name: Long-running workspace task
-            coverageIds: [workspace.long-running-task]
-          - name: Repo discovery
-            coverageIds: [workspace.repo-discovery]
-          - name: OpenClaw harness agent
-            coverageIds: [agents.openclaw-harness]
-          - name: Codex CLI model
-            coverageIds: [models.codex-cli]
-          - name: Workspace planning
-            coverageIds: [workspace.planning]
+          - name: Context Engine
+            coverageIds: [docs.discovery, workspace.artifacts, workspace.long-running-task, workspace.repo-discovery]
+            description: Covers Context Engine across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
+          - name: Runtime Assembly
+            coverageIds: [agents.openclaw-harness, models.codex-cli, workspace.planning]
+            description: Covers Runtime Assembly across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
         docs:
           - docs/concepts/context.md
           - docs/concepts/context-engine.md
@@ -1653,16 +1437,12 @@ surfaces:
       - name: Cross-client History and Session Parity
         id: cross-client-history-and-session-parity
         features:
-          - name: Channel threads
-            coverageIds: [channels.threads]
-          - name: Memory thread isolation
-            coverageIds: [memory.thread-isolation]
-          - name: Model switching
-            coverageIds: [models.switching]
-          - name: Model thinking
-            coverageIds: [models.thinking]
-          - name: Session continuity
-            coverageIds: [runtime.session-continuity]
+          - name: Cross-client History
+            coverageIds: [channels.threads, memory.thread-isolation]
+            description: Covers Cross-client History across `chat.history`, `chat.send`, WebChat display projection, TUI session actions, Android chat/session selection, OpenAI-compatible history mapping, channel history windows, and history visibility across reset/restart.
+          - name: Session Parity
+            coverageIds: [models.switching, models.thinking, runtime.session-continuity]
+            description: Covers Session Parity across `chat.history`, `chat.send`, WebChat display projection, TUI session actions, Android chat/session selection, OpenAI-compatible history mapping, channel history windows, and history visibility across reset/restart.
         docs:
           - docs/web/webchat.md
           - docs/platforms/android.md
@@ -1683,22 +1463,9 @@ surfaces:
           - name: Session maintenance warnings
             coverageIds: [session-maintenance-warnings]
             description: Covers restart maintenance warnings, delivery queues, memory/session cleanup signals, and operator-visible maintenance state.
-          - name: Restart config apply
-            coverageIds: [config.restart-apply]
-          - name: Memory failure handling
-            coverageIds: [memory.failure-handling]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Runtime fallbacks
-            coverageIds: [runtime.fallbacks]
-          - name: Gateway restart
-            coverageIds: [runtime.gateway-restart]
-          - name: Package update runtime
-            coverageIds: [runtime.package-update]
-          - name: Runtime restart recovery
-            coverageIds: [runtime.restart-recovery]
-          - name: Update run runtime
-            coverageIds: [runtime.update-run]
+          - name: Session and transcript recovery
+            coverageIds: [config.restart-apply, memory.failure-handling, runtime.delivery, runtime.fallbacks, runtime.gateway-restart, runtime.package-update, runtime.restart-recovery, runtime.update-run]
+            description: Covers restart recovery, orphaned subagent resume, transcript repair, and safe restoration of session state after failures.
         docs:
           - docs/gateway/diagnostics.md
           - docs/reference/session-management-compaction.md
@@ -1715,22 +1482,12 @@ surfaces:
       - name: Core Prompts and Context
         id: core-prompts-and-context
         features:
-          - name: Agent instructions
-            coverageIds: [agents.instructions]
-          - name: Character persona
-            coverageIds: [character.persona]
-          - name: First action runtime
-            coverageIds: [runtime.first-action]
-          - name: Workspace artifacts
-            coverageIds: [workspace.artifacts]
-          - name: Docs discovery
-            coverageIds: [docs.discovery]
-          - name: Codex CLI model
-            coverageIds: [models.codex-cli]
-          - name: Runtime no meta leak
-            coverageIds: [runtime.no-meta-leak]
-          - name: Repo discovery
-            coverageIds: [workspace.repo-discovery]
+          - name: Instruction Profile
+            coverageIds: [agents.instructions, character.persona, runtime.first-action, workspace.artifacts]
+            description: Covers Instruction Profile across `AGENTS.md`, `USER.md`, `IDENTITY.md`, `SOUL.md`, project context injection, bootstrap truncation, untrusted supplemental context, context visibility config, and runtime-context leakage prevention.
+          - name: Context Visibility
+            coverageIds: [docs.discovery, models.codex-cli, runtime.no-meta-leak, workspace.repo-discovery]
+            description: Covers Context Visibility across `AGENTS.md`, `USER.md`, `IDENTITY.md`, `SOUL.md`, project context injection, bootstrap truncation, untrusted supplemental context, context visibility config, and runtime-context leakage prevention.
         docs:
           - docs/concepts/context.md
           - docs/reference/transcript-hygiene.md
@@ -1748,30 +1505,18 @@ surfaces:
           - name: Memory Backend Storage
             coverageIds: [memory-backend-storage]
             description: Covers Memory Backend Storage across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Memory active recall
-            coverageIds: [memory.active-recall]
-          - name: Memory ranking
-            coverageIds: [memory.ranking]
-          - name: Memory recall
-            coverageIds: [memory.recall]
-          - name: Personal memory recall
-            coverageIds: [personal.memory-recall]
-          - name: Memory dreaming
-            coverageIds: [memory.dreaming]
-          - name: Memory promotion
-            coverageIds: [memory.promotion]
-          - name: QA artifact safety
-            coverageIds: [qa.artifact-safety]
-          - name: Group channel messages
-            coverageIds: [channels.group-messages]
-          - name: Memory tools
-            coverageIds: [memory.tools]
-          - name: Tool memory add
-            coverageIds: [tools.memory.add]
-          - name: Tool memory recall
-            coverageIds: [tools.memory.recall]
+          - name: Embedding Search
+            coverageIds: [channels.qa-channel, memory.active-recall, memory.ranking, memory.recall, personal.memory-recall]
+            description: Covers Embedding Search across memory backend config, SQLite schema, vector acceleration, embedding provider selection, remote embedding fetch, QMD process/query parsing, session transcript indexing for search, extra paths, and backend security boundaries.
+          - name: Memory Files
+            coverageIds: [memory.dreaming, memory.promotion, qa.artifact-safety]
+            description: Covers Memory Files across root memory files, active memory, memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
+          - name: Memory search and store tools
+            coverageIds: [channels.group-messages, channels.qa-channel, memory.active-recall, memory.ranking, memory.recall, memory.tools, personal.memory-recall, tools.memory.add, tools.memory.recall]
+            description: Covers memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
+          - name: Active Memory
+            coverageIds: [channels.qa-channel, memory.active-recall, memory.recall, personal.memory-recall]
+            description: Covers Active Memory across root memory files, active memory, memory search/get/store tool exposure, memory prompt sections, memory flush plans, session-memory hook behavior, and memory plugin capability registration visible to agents.
         docs:
           - docs/reference/memory-config.md
           - docs/concepts/memory-qmd.md
@@ -1796,12 +1541,9 @@ surfaces:
           - name: Session Routing
             coverageIds: [session-routing]
             description: Covers Session Routing across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
-          - name: Webchat channel
-            coverageIds: [channels.webchat]
-          - name: Runtime direct reply routing
-            coverageIds: [runtime.direct-reply-routing]
-          - name: Tool message
-            coverageIds: [tools.message]
+          - name: Conversation routing
+            coverageIds: [channels.webchat, runtime.direct-reply-routing, tools.message]
+            description: Covers Conversation Binding across `sessionKey` construction, target resolution, conversation bindings, session labels, per-conversation isolation, thread binding, model selection continuity tied to sessions, and agent/workspace store targeting.
         docs:
           - docs/concepts/session.md
           - docs/channels/channel-routing.md
@@ -1885,12 +1627,9 @@ surfaces:
           - name: Channel status taxonomy in channels list
             coverageIds: [channel-status-taxonomy-in-channels-list]
             description: Channel status taxonomy in channels list, channels status, and setup status output
-          - name: Agent creation
-            coverageIds: [agents.create]
-          - name: Discord channel config
-            coverageIds: [channels.discord-config]
-          - name: Crestodian setup config
-            coverageIds: [config.crestodian-setup]
+          - name: Setup/onboarding flows
+            coverageIds: [agents.create, channels.discord-config, config.crestodian-setup]
+            description: Setup/onboarding flows, including first-run channel selection and channel account setup
           - name: Install-on-demand
             coverageIds: [install-on-demand]
             description: Install-on-demand, downloadable, bundled, official external, local, npm, and ClawHub distinctions
@@ -1911,24 +1650,15 @@ surfaces:
       - name: Group Thread and Ambient Room Behavior
         id: group-thread-and-ambient-room-behavior
         features:
-          - name: Group channel messages
-            coverageIds: [channels.group-messages]
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Memory tools
-            coverageIds: [memory.tools]
-          - name: Group channel visible replies
-            coverageIds: [channels.group-visible-replies]
-          - name: Tool message
-            coverageIds: [tools.message]
-          - name: DM channel
-            coverageIds: [channels.dm]
-          - name: Channel threads
-            coverageIds: [channels.threads]
-          - name: Memory thread isolation
-            coverageIds: [memory.thread-isolation]
-          - name: Personal channel replies
-            coverageIds: [personal.channel-replies]
+          - name: Group/channel session isolation
+            coverageIds: [channels.group-messages, channels.qa-channel, memory.tools]
+            description: Group/channel session isolation and group history context
+          - name: Mention-required
+            coverageIds: [channels.group-visible-replies, channels.qa-channel, tools.message]
+            description: Mention-required, always-on, and ambient room-event modes
+          - name: Native threads
+            coverageIds: [channels.dm, channels.qa-channel, channels.threads, memory.thread-isolation, personal.channel-replies]
+            description: Native threads, topics, parent-child bindings, and thread spawn behavior
           - name: Broadcast groups
             coverageIds: [broadcast-groups]
             description: Broadcast groups and multi-agent group routing
@@ -2006,48 +1736,18 @@ surfaces:
       - name: Outbound Delivery and Reply Pipeline
         id: outbound-delivery-and-reply-pipeline
         features:
-          - name: Subagents
-            coverageIds: [agents.subagents]
-          - name: Channel deduplication
-            coverageIds: [channels.dedup]
-          - name: Direct channel visible replies
-            coverageIds: [channels.direct-visible-replies]
-          - name: DM channel
-            coverageIds: [channels.dm]
-          - name: Group channel visible replies
-            coverageIds: [channels.group-visible-replies]
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Channel reconnect
-            coverageIds: [channels.reconnect]
-          - name: Channel streaming
-            coverageIds: [channels.streaming]
-          - name: Channel threads
-            coverageIds: [channels.threads]
-          - name: No-target heartbeat commitments
-            coverageIds: [commitments.heartbeat-target-none]
-          - name: Commitment scope
-            coverageIds: [commitments.scope]
-          - name: Personal channel replies
-            coverageIds: [personal.channel-replies]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Fallback delivery
-            coverageIds: [runtime.fallback-delivery]
-          - name: Gateway restart
-            coverageIds: [runtime.gateway-restart]
-          - name: Runtime restart recovery
-            coverageIds: [runtime.restart-recovery]
-          - name: Tool message
-            coverageIds: [tools.message]
-          - name: Channel message actions
-            coverageIds: [channels.message-actions]
-          - name: Webchat channel
-            coverageIds: [channels.webchat]
-          - name: Runtime direct reply routing
-            coverageIds: [runtime.direct-reply-routing]
-          - name: Message tool
-            coverageIds: [tools.message-tool]
+          - name: Automatic final reply delivery
+            coverageIds: [agents.subagents, channels.dedup, channels.direct-visible-replies, channels.dm, channels.group-visible-replies, channels.qa-channel, channels.reconnect, channels.streaming, channels.threads, commitments.heartbeat-target-none, commitments.scope, personal.channel-replies, runtime.delivery, runtime.fallback-delivery, runtime.gateway-restart, runtime.restart-recovery, tools.message]
+            description: Automatic final reply delivery and strict message-tool-only visible delivery
+          - name: Durable outbound send orchestration
+            coverageIds: [channels.dedup, channels.reconnect, runtime.delivery]
+            description: Durable outbound send orchestration, receipts, partial failures, and fallback paths
+          - name: Reply pipeline transforms
+            coverageIds: [channels.message-actions, channels.qa-channel]
+            description: Reply pipeline transforms, typing callbacks, draft streaming, and status reactions
+          - name: Provider outbound adapter bridge
+            coverageIds: [channels.direct-visible-replies, channels.group-visible-replies, channels.qa-channel, channels.webchat, runtime.direct-reply-routing, tools.message, tools.message-tool]
+            description: Provider outbound adapter bridge and message capabilities
         docs:
           - docs/channels/groups.md
           - docs/channels/ambient-room-events.md
@@ -2063,14 +1763,9 @@ surfaces:
       - name: Conversation Routing and Delivery
         id: conversation-routing-and-delivery
         features:
-          - name: DM channel
-            coverageIds: [channels.dm]
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Channel threads
-            coverageIds: [channels.threads]
-          - name: Personal channel replies
-            coverageIds: [personal.channel-replies]
+          - name: Inbound conversation routing
+            coverageIds: [channels.dm, channels.qa-channel, channels.threads, personal.channel-replies]
+            description: Inbound and command conversation resolution across sessions, threads, and provider-owned targets.
           - name: Session key construction
             coverageIds: [session-key-construction]
             description: Session key construction and session metadata recording
@@ -2083,36 +1778,9 @@ surfaces:
           - name: Thread/parent-child placement
             coverageIds: [thread-parent-child-placement]
             description: Thread/parent-child placement and provider-owned target normalization
-          - name: Subagents
-            coverageIds: [agents.subagents]
-          - name: Direct channel visible replies
-            coverageIds: [channels.direct-visible-replies]
-          - name: Group channel messages
-            coverageIds: [channels.group-messages]
-          - name: Group channel visible replies
-            coverageIds: [channels.group-visible-replies]
-          - name: Channel message actions
-            coverageIds: [channels.message-actions]
-          - name: Image generation media
-            coverageIds: [media.image-generation]
-          - name: Image understanding media
-            coverageIds: [media.image-understanding]
-          - name: Memory recall
-            coverageIds: [memory.recall]
-          - name: Personal memory recall
-            coverageIds: [personal.memory-recall]
-          - name: Personal reminders
-            coverageIds: [personal.reminders]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
-          - name: Scheduling cron
-            coverageIds: [scheduling.cron]
-          - name: Scheduling dedup
-            coverageIds: [scheduling.dedup]
-          - name: Tool message
-            coverageIds: [tools.message]
-          - name: UI control
-            coverageIds: [ui.control]
+          - name: Plugin registry resolution
+            coverageIds: [agents.subagents, channels.direct-visible-replies, channels.dm, channels.group-messages, channels.group-visible-replies, channels.message-actions, channels.qa-channel, channels.threads, media.image-generation, media.image-understanding, memory.recall, personal.channel-replies, personal.memory-recall, personal.reminders, runtime.delivery, scheduling.cron, scheduling.dedup, tools.message, ui.control]
+            description: Plugin registry resolution and scoped channel runtime creation
           - name: Channel account startup
             coverageIds: [channel-account-startup]
             description: Channel account startup, shutdown, logout, abort, and manual-stop state
@@ -2148,12 +1816,9 @@ surfaces:
           - name: channels.status
             coverageIds: [channels-status]
             description: channels.status, probes, account snapshots, and warnings
-          - name: Channel deduplication
-            coverageIds: [channels.dedup]
-          - name: Channel reconnect
-            coverageIds: [channels.reconnect]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
+          - name: Channel health policy
+            coverageIds: [channels.dedup, channels.reconnect, runtime.delivery]
+            description: Channel health policy, health monitor restarts, stale socket detection, cooldowns, and restart caps
           - name: Operator CLI controls
             coverageIds: [operator-cli-controls]
             description: Operator CLI controls for start, stop, logout, status, restart, and troubleshoot
@@ -2188,16 +1853,9 @@ surfaces:
       - name: Approval Policy and Tool Safeguards
         id: approval-policy-and-tool-safeguards
         features:
-          - name: Personal approval denial
-            coverageIds: [personal.approval-denial]
-          - name: Personal tool safety
-            coverageIds: [personal.tool-safety]
-          - name: Runtime approvals
-            coverageIds: [runtime.approvals]
-          - name: Tool followthrough
-            coverageIds: [tools.followthrough]
-          - name: Tool safety
-            coverageIds: [tools.safety]
+          - name: Approval Policy
+            coverageIds: [personal.approval-denial, personal.tool-safety, runtime.approvals, tools.followthrough, tools.safety]
+            description: Covers Approval Policy across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
           - name: Dangerous Tool Safeguards
             coverageIds: [dangerous-tool-safeguards]
             description: Covers Dangerous Tool Safeguards across exec approval policy, host-local approval stores, allowlist and ask modes, dangerous tool safeguards, native/chat approval routing, plugin approval routing, approval decisions, approval binding, and operator-facing CLI management.
@@ -2373,20 +2031,9 @@ surfaces:
           - name: Secrets Storage
             coverageIds: [secrets-storage]
             description: Covers Secrets Storage across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
-          - name: Memory dreaming
-            coverageIds: [memory.dreaming]
-          - name: Memory promotion
-            coverageIds: [memory.promotion]
-          - name: Personal diagnostics
-            coverageIds: [personal.diagnostics]
-          - name: Personal redaction
-            coverageIds: [personal.redaction]
-          - name: QA artifact safety
-            coverageIds: [qa.artifact-safety]
-          - name: Runtime tool policy
-            coverageIds: [runtime.tool-policy]
-          - name: Security redaction
-            coverageIds: [security.redaction]
+          - name: Redaction
+            coverageIds: [memory.dreaming, memory.promotion, personal.diagnostics, personal.redaction, qa.artifact-safety, runtime.tool-policy, security.redaction]
+            description: Covers Redaction across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
           - name: Configuration Hygiene
             coverageIds: [configuration-hygiene]
             description: Covers Configuration Hygiene across SecretRef contract and providers, runtime secret snapshots, gateway auth SecretRefs, auth-profile and generated model residues, and related secrets storage, redaction, and configuration hygiene behavior.
@@ -2437,12 +2084,9 @@ surfaces:
           - name: Restart logging
             coverageIds: [restart-logging]
             description: Restart logging and runtime snapshot evaluation
-          - name: Codex plugin auth
-            coverageIds: [runtime.codex-plugin.auth]
-          - name: Codex plugin lifecycle
-            coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: Runtime doctor repair
-            coverageIds: [runtime.doctor-repair]
+          - name: openclaw doctor
+            coverageIds: [runtime.codex-plugin.auth, runtime.codex-plugin.lifecycle, runtime.doctor-repair]
+            description: openclaw doctor, openclaw doctor --fix, --repair, --yes, --non-interactive, --deep, and --lint
           - name: Structured health checks
             coverageIds: [structured-health-checks]
             description: Structured health checks, findings, repair results, check selection, JSON lint output, severity filtering, and exit behavior
@@ -2461,16 +2105,9 @@ surfaces:
           - name: Gateway RPC health
             coverageIds: [gateway-rpc-health]
             description: Gateway RPC health and status
-          - name: Gateway performance
-            coverageIds: [gateway.performance]
-          - name: Live OpenAI models
-            coverageIds: [models.live-openai]
-          - name: Kitchen sink plugin
-            coverageIds: [plugins.kitchen-sink]
-          - name: Plugin lifecycle
-            coverageIds: [plugins.lifecycle]
-          - name: Plugin tools
-            coverageIds: [plugins.plugin-tools]
+          - name: Cached health snapshots
+            coverageIds: [gateway.performance, models.live-openai, plugins.kitchen-sink, plugins.lifecycle, plugins.plugin-tools]
+            description: Cached health snapshots, live probe refresh, sensitive fields gated by operator admin scope, and event-loop health attachment
         docs:
           - docs/gateway/health.md
           - docs/channels/telegram.md
@@ -2531,12 +2168,9 @@ surfaces:
           - name: Chat /diagnostics
             coverageIds: [chat-diagnostics]
             description: Chat /diagnostics and /codex diagnostics approval flows
-          - name: Personal diagnostics
-            coverageIds: [personal.diagnostics]
-          - name: Personal redaction
-            coverageIds: [personal.redaction]
-          - name: QA artifact safety
-            coverageIds: [qa.artifact-safety]
+          - name: Support zip composition
+            coverageIds: [personal.diagnostics, personal.redaction, qa.artifact-safety]
+            description: Support zip composition, safe relative paths, sanitized config/status/health/log/stability files, and privacy manifest
           - name: Bounded in-process stability recorder
             coverageIds: [bounded-in-process-stability-recorder]
             description: Bounded in-process stability recorder and diagnostics.stability RPC
@@ -2584,37 +2218,24 @@ surfaces:
           - name: diagnostics-otel plugin install
             coverageIds: [diagnostics-otel-plugin-install]
             description: diagnostics-otel plugin install, enablement, config, env overrides, sampling, flush interval, and preloaded SDK mode
-          - name: QA Lab harness
-            coverageIds: [harness.qa-lab]
-          - name: OTel telemetry
-            coverageIds: [telemetry.otel]
+          - name: OTLP/HTTP traces
+            coverageIds: [harness.qa-lab, telemetry.otel]
+            description: OTLP/HTTP traces, metrics, and logs
           - name: Trusted trace context
             coverageIds: [trusted-trace-context]
             description: Trusted trace context, W3C traceparent propagation to model calls, file-log correlation, content-capture controls, and redacted/bounded attributes
-          - name: Docker E2E
-            coverageIds: [docker.e2e]
-          - name: Tool trace visibility harness
-            coverageIds: [harness.tool-trace-visibility]
-          - name: Personal failure recovery
-            coverageIds: [personal.failure-recovery]
-          - name: Personal no fake progress
-            coverageIds: [personal.no-fake-progress]
-          - name: Personal task followthrough
-            coverageIds: [personal.task-followthrough]
-          - name: QA bus runtime
-            coverageIds: [runtime.qa-bus]
-          - name: Telemetry prometheus
-            coverageIds: [telemetry.prometheus]
-          - name: Evidence tools
-            coverageIds: [tools.evidence]
-          - name: Tool trace
-            coverageIds: [tools.trace]
+          - name: Model and runtime telemetry
+            coverageIds: [docker.e2e, harness.qa-lab, harness.tool-trace-visibility, personal.failure-recovery, personal.no-fake-progress, personal.task-followthrough, runtime.qa-bus, telemetry.otel, telemetry.prometheus, tools.evidence, tools.trace]
+            description: Model, tool, message, session, queue, Talk, exec, webhook, context assembly, harness, and exporter-health signals
           - name: diagnostics-prometheus plugin install
             coverageIds: [diagnostics-prometheus-plugin-install]
             description: diagnostics-prometheus plugin install and enablement
           - name: Gateway-authenticated GET /api/diagnostics/prometheus
             coverageIds: [gateway-authenticated-get-api-diagnostics-prometheus]
             description: Gateway-authenticated GET /api/diagnostics/prometheus behavior, status, and operator-visible verification.
+          - name: Prometheus text exposition
+            coverageIds: [docker.e2e, harness.qa-lab, telemetry.prometheus]
+            description: Prometheus text exposition, counters, gauges, histograms, label policy, series cap, and overflow metric
           - name: Trusted diagnostic event subscription
             coverageIds: [trusted-diagnostic-event-subscription]
             description: Trusted diagnostic event subscription and rendering of run, model, tool, message, Talk, queue, session, liveness, payload, memory, and exporter metrics
@@ -2693,17 +2314,21 @@ surfaces:
           - name: Cron RPCs
             coverageIds: [cron-rpcs]
             description: Covers Cron RPCs across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Personal reminders
-            coverageIds: [personal.reminders]
-          - name: Scheduling cron
+          - name: Agent cron tool
+            coverageIds: [channels.qa-channel, personal.reminders, scheduling.cron]
+            description: Covers Agent cron tool across cron job creation, listing, inspection, editing, and related cron job lifecycle behavior.
+          - name: Manual cron runs
             coverageIds: [scheduling.cron]
-          - name: Scheduling dedup
-            coverageIds: [scheduling.dedup]
+            description: Covers Manual cron runs across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Isolated cron execution
+            coverageIds: [scheduling.cron, scheduling.dedup]
+            description: Covers Isolated cron execution across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
           - name: Model/provider preflight
             coverageIds: [model-provider-preflight]
             description: Covers Model/provider preflight across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
+          - name: Run history
+            coverageIds: [channels.qa-channel, scheduling.cron, scheduling.dedup]
+            description: Covers Run history across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
           - name: Timeout and denial diagnostics
             coverageIds: [timeout-and-denial-diagnostics]
             description: Covers Timeout and denial diagnostics across scheduler dispatch, timer arming, manual/due runs, isolated agent execution, and related cron runs and diagnostics behavior.
@@ -2948,12 +2573,9 @@ surfaces:
           - name: Due-only heartbeat tasks
             coverageIds: [due-only-heartbeat-tasks]
             description: Covers Due-only heartbeat tasks across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
-          - name: No-target heartbeat commitments
-            coverageIds: [commitments.heartbeat-target-none]
-          - name: Commitment scope
-            coverageIds: [commitments.scope]
-          - name: Runtime delivery
-            coverageIds: [runtime.delivery]
+          - name: Commitment check-ins
+            coverageIds: [commitments.heartbeat-target-none, commitments.scope, runtime.delivery]
+            description: Covers Commitment check-ins across periodic heartbeat runs, active-hours and variable schedule behavior, wake/cooldown handling, heartbeat prompts and due-only task mode, and related heartbeat and commitments behavior.
         docs:
           - docs/automation/index.md
           - docs/gateway/heartbeat.md
@@ -3165,12 +2787,9 @@ surfaces:
           - name: Audio proxy and limit handling
             coverageIds: [audio-proxy-and-limit-handling]
             description: Covers Audio proxy and limit handling across batch audio/STT media understanding, local CLI fallbacks, provider transcription, voice-note preflight before mention gates, and related audio transcription and voice note understanding behavior.
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Image understanding media
-            coverageIds: [media.image-understanding]
-          - name: UI control
-            coverageIds: [ui.control]
+          - name: Inbound image summarization
+            coverageIds: [channels.qa-channel, media.image-understanding, ui.control]
+            description: Covers Inbound image summarization across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
           - name: Active vision model bypass
             coverageIds: [active-vision-model-bypass]
             description: Covers Active vision model bypass across image summarization before reply routing, active-model vision skip behavior, text-only model offload through `MediaPaths`/`media://inbound`, image-model fallback resolution, and related image understanding and vision routing behavior.
@@ -3220,14 +2839,12 @@ surfaces:
       - name: Media Generation
         id: media-generation
         features:
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Image generation media
-            coverageIds: [media.image-generation]
-          - name: Tool image generate
-            coverageIds: [tools.image-generate]
-          - name: Tool native image generation
-            coverageIds: [tools.native-image-generation]
+          - name: Image generation tool invocation
+            coverageIds: [channels.qa-channel, media.image-generation, tools.image-generate, tools.native-image-generation]
+            description: Covers Image generation tool invocation across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
+          - name: Provider and model selection
+            coverageIds: [media.image-generation, tools.native-image-generation]
+            description: Covers Provider and model selection across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
           - name: Reference image editing
             coverageIds: [reference-image-editing]
             description: Covers Reference image editing across `image_generate`, model selection, provider registration, provider capability listing, and related image generation tool and provider routing behavior.
@@ -3626,12 +3243,9 @@ surfaces:
       - name: Browser UI
         id: browser-ui
         features:
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Image understanding media
-            coverageIds: [media.image-understanding]
-          - name: UI control
-            coverageIds: [ui.control]
+          - name: Gateway-hosted UI
+            coverageIds: [channels.qa-channel, media.image-understanding, ui.control]
+            description: Covers Gateway-hosted UI across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
           - name: Dashboard open/auth bootstrap
             coverageIds: [dashboard-open-auth-bootstrap]
             description: Covers Dashboard open/auth bootstrap across serving the Control UI bundle from the Gateway, root and base-path routing, static asset MIME/cache behavior, public PWA assets, and related control ui shell and routing behavior.
@@ -3701,18 +3315,9 @@ surfaces:
           - name: chat.history projection
             coverageIds: [chat-history-projection]
             description: Covers chat.history projection across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
-          - name: QA channel
-            coverageIds: [channels.qa-channel]
-          - name: Webchat channel
-            coverageIds: [channels.webchat]
-          - name: Image understanding media
-            coverageIds: [media.image-understanding]
-          - name: Runtime direct reply routing
-            coverageIds: [runtime.direct-reply-routing]
-          - name: Tool message
-            coverageIds: [tools.message]
-          - name: UI control
-            coverageIds: [ui.control]
+          - name: chat.send lifecycle
+            coverageIds: [channels.qa-channel, channels.webchat, media.image-understanding, runtime.direct-reply-routing, tools.message, ui.control]
+            description: Covers chat.send lifecycle across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
           - name: Abort/partial retention
             coverageIds: [abort-partial-retention]
             description: Covers Abort/partial retention across Gateway WebChat RPC/runtime contract, durable transcript projection, active run lifecycle, abort and partial retention, and related webchat runtime and session continuity behavior.
@@ -3773,12 +3378,9 @@ surfaces:
           - name: Live log tail
             coverageIds: [live-log-tail]
             description: Covers Live log tail across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
-          - name: Gateway restart
-            coverageIds: [runtime.gateway-restart]
-          - name: Package update runtime
-            coverageIds: [runtime.package-update]
-          - name: Update run runtime
-            coverageIds: [runtime.update-run]
+          - name: Update run/status
+            coverageIds: [runtime.gateway-restart, runtime.package-update, runtime.update-run]
+            description: Covers Update run/status across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
           - name: Activity summaries
             coverageIds: [activity-summaries]
             description: Covers Activity summaries across Debug, Logs, Update, Activity, and related diagnostics, logs, update, and activity behavior.
@@ -4427,20 +4029,9 @@ surfaces:
           - name: ToolSpace
             coverageIds: [toolspace]
             description: Tool discovery and invocation abstraction for external apps.
-          - name: Character persona
-            coverageIds: [character.persona]
-          - name: Personal task followthrough
-            coverageIds: [personal.task-followthrough]
-          - name: Tool followthrough
-            coverageIds: [tools.followthrough]
-          - name: Workspace artifacts
-            coverageIds: [workspace.artifacts]
-          - name: Workspace builds
-            coverageIds: [workspace.builds]
-          - name: Long-running workspace task
-            coverageIds: [workspace.long-running-task]
-          - name: Repo discovery
-            coverageIds: [workspace.repo-discovery]
+          - name: Artifacts
+            coverageIds: [character.persona, personal.task-followthrough, tools.followthrough, workspace.artifacts, workspace.builds, workspace.long-running-task, workspace.repo-discovery]
+            description: Artifact summaries, retention metadata, and download behavior.
           - name: Tasks
             coverageIds: [tasks]
             description: SDK helpers around Gateway task APIs.
@@ -5497,12 +5088,9 @@ surfaces:
       - name: Diagnostics and Repair
         id: diagnostics-and-repair
         features:
-          - name: Codex plugin auth
-            coverageIds: [runtime.codex-plugin.auth]
-          - name: Codex plugin lifecycle
-            coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: Runtime doctor repair
-            coverageIds: [runtime.doctor-repair]
+          - name: openclaw doctor
+            coverageIds: [runtime.codex-plugin.auth, runtime.codex-plugin.lifecycle, runtime.doctor-repair]
+            description: openclaw doctor and repair/migration for WSL2 Gateway
           - name: openclaw status
             coverageIds: [openclaw-status]
             description: openclaw status, status --all, and Gateway service/runtime summary
@@ -6662,12 +6250,9 @@ surfaces:
           - name: Docker E2E package artifact generation
             coverageIds: [docker-e2e-package-artifact-generation]
             description: Docker E2E package artifact generation and shared build helpers
-          - name: Docker E2E
-            coverageIds: [docker.e2e]
-          - name: QA Lab harness
-            coverageIds: [harness.qa-lab]
-          - name: Telemetry prometheus
-            coverageIds: [telemetry.prometheus]
+          - name: Docker E2E plan/scheduler scripts
+            coverageIds: [docker.e2e, harness.qa-lab, telemetry.prometheus]
+            description: Docker E2E plan/scheduler scripts, lane metadata, targeted grouping, package artifact generation, and GitHub hydration action
           - name: Release-path install
             coverageIds: [release-path-install]
             description: Release-path install, update, upgrade survivor, live-provider, plugin, Open WebUI, and cleanup scenario planning
@@ -9013,19 +8598,15 @@ surfaces:
       - name: Model and Auth
         id: model-and-auth
         features:
-          - name: OpenAI model
-            coverageIds: [models.openai]
-          - name: Tool web search
-            coverageIds: [tools.web-search]
+          - name: Canonical OpenAI Model Routing
+            coverageIds: [models.openai, tools.web-search]
+            description: 'Covers Canonical OpenAI Model Routing across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
           - name: Catalog
             coverageIds: [catalog]
             description: 'Covers Catalog across user/operator-facing model route contract: canonical `openai/gpt-*` refs, legacy `openai-codex/*` model refs, model catalog rows, context limits, and related canonical openai model routing and catalog behavior.'
-          - name: Auth profiles provider selection
-            coverageIds: [auth-profiles.provider-selection]
-          - name: Codex plugin auth
-            coverageIds: [runtime.codex-plugin.auth]
-          - name: Runtime doctor repair
-            coverageIds: [runtime.doctor-repair]
+          - name: Codex OAuth Profiles
+            coverageIds: [auth-profiles.provider-selection, runtime.codex-plugin.auth, runtime.doctor-repair]
+            description: Covers Codex OAuth Profiles across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
           - name: Subscription Usage
             coverageIds: [subscription-usage]
             description: Covers Subscription Usage across `openai-codex` auth profiles, profile ordering, profile metadata repair, token refresh, account-id propagation, usage/cooldown handling, and auth selection for Codex-backed OpenAI agent turns.
@@ -9063,12 +8644,12 @@ surfaces:
           - name: Codex Responses Transport
             coverageIds: [codex-responses-transport]
             description: Covers Codex Responses Transport across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
-          - name: Codex native workspace read
-            coverageIds: [runtime.codex-native-workspace.read]
-          - name: Runtime prompt compatibility
-            coverageIds: [runtime.prompt-compatibility]
-          - name: File read tool
-            coverageIds: [tools.fs.read]
+          - name: Payload Compatibility
+            coverageIds: [runtime.prompt-compatibility, tools.fs.read]
+            description: Covers Payload Compatibility across low-level provider request/streaming path for `openai-codex-responses` and the shared OpenAI Responses conversion code used by direct OpenAI and Codex-auth compatibility routes.
+          - name: Tool Context
+            coverageIds: [runtime.codex-native-workspace.read, tools.fs.read]
+            description: Covers Tool Context across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
           - name: Capability Compatibility
             coverageIds: [capability-compatibility]
             description: Covers Capability Compatibility across provider-facing tools, context injection, media inputs, native-vs-client tool ownership, OpenAI Responses compatibility, and how OpenAI/Codex models receive OpenClaw runtime context.
@@ -9091,24 +8672,12 @@ surfaces:
       - name: Native Codex Harness
         id: native-codex-harness
         features:
-          - name: Codex CLI model
-            coverageIds: [models.codex-cli]
-          - name: Codex app server runtime
-            coverageIds: [runtime.codex-app-server]
-          - name: Gateway log sentinel Codex progress
-            coverageIds: [runtime.gateway-log-sentinel.codex-progress]
-          - name: Long context runtime
-            coverageIds: [runtime.long-context]
-          - name: Runtime no meta leak
-            coverageIds: [runtime.no-meta-leak]
-          - name: Workspace planning
-            coverageIds: [workspace.planning]
-          - name: Codex plugin lifecycle
-            coverageIds: [runtime.codex-plugin.lifecycle]
-          - name: Runtime doctor repair
-            coverageIds: [runtime.doctor-repair]
-          - name: Turn ordering
-            coverageIds: [runtime.turn-ordering]
+          - name: Native Codex App-server Harness
+            coverageIds: [models.codex-cli, runtime.codex-app-server, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.no-meta-leak, workspace.planning]
+            description: Covers Native Codex App-server Harness across native Codex app-server runtime path used by OpenAI agent turns when the Codex harness owns thread identity, native model loop, compaction, native tools, and native app-server controls.
+          - name: Thread Lifecycle
+            coverageIds: [runtime.codex-app-server, runtime.codex-plugin.lifecycle, runtime.doctor-repair, runtime.gateway-log-sentinel.codex-progress, runtime.long-context, runtime.turn-ordering]
+            description: Covers Thread Lifecycle across native Codex app-server runtime path used by OpenAI agent turns when the Codex harness owns thread identity, native model loop, compaction, native tools, and native app-server controls.
         docs:
           - docs/plugins/codex-harness.md
           - docs/plugins/codex-harness-runtime.md
@@ -9229,14 +8798,12 @@ surfaces:
           - name: Bundled Claude catalog
             coverageIds: [bundled-claude-catalog]
             description: 'Covers Bundled Claude catalog across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
-          - name: Anthropic model
-            coverageIds: [models.anthropic]
-          - name: Provider model auth
-            coverageIds: [models.provider-auth]
-          - name: Claude CLI model
-            coverageIds: [models.claude-cli]
-          - name: Provider model capabilities
-            coverageIds: [models.provider-capabilities]
+          - name: Canonical anthropic refs
+            coverageIds: [models.anthropic, models.provider-auth]
+            description: 'Covers Canonical anthropic refs across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
+          - name: Claude CLI compatibility
+            coverageIds: [models.claude-cli, models.provider-capabilities]
+            description: 'Covers Claude CLI compatibility across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
           - name: Model picker availability
             coverageIds: [model-picker-availability]
             description: 'Covers Model picker availability across Anthropic model catalog and policy layer: bundled model rows, model aliases, current and future Claude model id normalization, runtime-provider selection, and related model catalog and policy behavior.'
@@ -10442,10 +10009,9 @@ surfaces:
       - name: Tool Availability and Fetch
         id: tool-availability-and-fetch
         features:
-          - name: OpenAI model
-            coverageIds: [models.openai]
-          - name: Tool web search
-            coverageIds: [tools.web-search]
+          - name: web_search exposure
+            coverageIds: [models.openai, tools.web-search]
+            description: Defines web_search exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
           - name: web_fetch exposure
             coverageIds: [tools.web-fetch]
             description: Defines web_fetch exposure setup, credential, configuration, and operator verification behavior for Tool Availability and Policy.
@@ -10518,20 +10084,9 @@ surfaces:
           - name: Snapshots
             coverageIds: [snapshots]
             description: Covers Snapshots across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
-          - name: Character persona
-            coverageIds: [character.persona]
-          - name: Personal task followthrough
-            coverageIds: [personal.task-followthrough]
-          - name: Tool followthrough
-            coverageIds: [tools.followthrough]
-          - name: Workspace artifacts
+          - name: Artifacts
             coverageIds: [workspace.artifacts]
-          - name: Workspace builds
-            coverageIds: [workspace.builds]
-          - name: Long-running workspace task
-            coverageIds: [workspace.long-running-task]
-          - name: Repo discovery
-            coverageIds: [workspace.repo-discovery]
+            description: Covers Artifacts across browser tool action schemas, navigate/act/snapshot/screenshot operations, AI/role/ARIA snapshot formats, action ref storage, and related browser actions, snapshots, and artifacts behavior.
           - name: Browser Plugin Service
             coverageIds: [browser-plugin-service]
             description: Covers Browser Plugin Service across bundled browser plugin activation, browser CLI registration, `browser.request` Gateway routing, control-service startup, and related browser plugin service and profiles behavior.
@@ -10573,24 +10128,15 @@ surfaces:
       - name: Tool Invocation and Execution
         id: tool-invocation-and-execution
         features:
-          - name: Tool bash
-            coverageIds: [tools.bash]
-          - name: Tool exec
-            coverageIds: [tools.exec]
-          - name: Workspace artifacts
-            coverageIds: [workspace.artifacts]
-          - name: Workspace builds
-            coverageIds: [workspace.builds]
-          - name: Long-running workspace task
+          - name: Exec Routing
+            coverageIds: [tools.bash, tools.exec]
+            description: Covers Exec Routing across `exec` foreground and background execution, `yieldMs`, timeouts, PTY, and related exec routing and process lifecycle behavior.
+          - name: Process Lifecycle
             coverageIds: [workspace.long-running-task]
-          - name: Repo discovery
-            coverageIds: [workspace.repo-discovery]
-          - name: MCP plugin tools
-            coverageIds: [plugins.mcp-tools]
-          - name: Plugin skills
-            coverageIds: [plugins.skills]
-          - name: Tool invocation
-            coverageIds: [tools.invocation]
+            description: Covers Process Lifecycle across `exec` foreground and background execution, `yieldMs`, timeouts, PTY, and related exec routing and process lifecycle behavior.
+          - name: Direct Tool Invoke API
+            coverageIds: [plugins.mcp-tools, tools.invocation]
+            description: Covers Direct Tool Invoke API across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.
           - name: Node System.run
             coverageIds: [node-system-run]
             description: Covers Node System.run across HTTP `POST /tools/invoke`, Gateway RPC `tools.invoke`, request body and auth semantics, shared-secret operator scope restoration, and related direct tool invoke api and node system.run behavior.

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -4029,9 +4029,9 @@ surfaces:
           - name: ToolSpace
             coverageIds: [toolspace]
             description: Tool discovery and invocation abstraction for external apps.
-          - name: Artifacts
-            coverageIds: [character.persona, personal.task-followthrough, tools.followthrough, workspace.artifacts, workspace.builds, workspace.long-running-task, workspace.repo-discovery]
-            description: Artifact summaries, retention metadata, and download behavior.
+          - name: Artifact resources
+            coverageIds: [workspace.artifacts, workspace.builds]
+            description: SDK helpers for workspace artifact summaries, generated build outputs, retention metadata, and downloads.
           - name: Tasks
             coverageIds: [tasks]
             description: SDK helpers around Gateway task APIs.


### PR DESCRIPTION
## Summary

- Keep taxonomy categories and features product-shaped while documenting that feature `coverageIds` are ANDed proof targets, not aliases.
- Remove ambiguous duplicate coverage bundles that made distinct features look equivalent.
- Narrow browser/tool invocation and SDK artifact bundles so generic IDs like repo discovery, workspace builds, and plugin skills are not promoted as standalone feature proof.
- Rename duplicate feature rows and placeholder `*-2` coverage IDs into behavior-shaped feature names and coverage IDs.
- Keep QA scenario coverage mappings intact; the renamed placeholder IDs were taxonomy-only and not referenced by scenarios.

## Taxonomy/Scenario Audit

- Taxonomy coverage IDs: 1666
- QA scenario coverage IDs: 160
- QA scenario IDs missing from taxonomy: 0
- Multi-ID taxonomy features: 89
- Duplicate feature names within a category: 0
- Duplicate coverage-ID bundles within a category: 0
- `Parent - child` feature names: 0
- Placeholder numeric suffix IDs: 0
- Numeric suffix IDs intentionally kept: `runtime.first-hour-20`, `runtime.soak-100` because they are scenario-backed duration/count coverage IDs

## Verification

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/coverage-report.test.ts extensions/qa-lab/src/cli.runtime.test.ts`
- `node scripts/run-node.mjs qa coverage --json --output /tmp/openclaw-qa-coverage-id-cleanup.json`
- taxonomy/scenario coverage-ID audit script from the PR summary counts above
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Scope: PR 94304 taxonomy cleanup follow-up..."` clean, no accepted/actionable findings
