### PR TITLE
#94249: skill_workshop apply times out on large proposals (~28KB)

### DIFF
--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -65,6 +65,10 @@ export function resolveSkillWorkshopToolApproval(params: {
     requireApproval: {
       ...text,
       allowedDecisions: ["allow-once", "deny"],
+      // Apply can involve reviewing large proposals (~28 KB); the default 2-minute
+      // plugin-approval timeout is too short for a thorough review. Raise it to 5
+      // minutes so users have adequate time to inspect and approve the change.
+      ...(action === "apply" ? { timeoutMs: 300_000 } : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary

`skill_workshop action=apply` consistently returns "Approval timed out" for large proposals (~28 KB). The default plugin-approval timeout of 120 seconds is insufficient for reviewing sizable workshop proposals.

## Linked context

Closes #94249

## Root Cause

In `src/skills/workshop/policy.ts`, `resolveSkillWorkshopToolApproval()` returns a `requireApproval` without setting a custom `timeoutMs`. The fallback defaults to `DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS = 120_000` (2 minutes). For proposals around 28 KB, users need more time to inspect the content before approving, causing the 2-minute window to expire.

## Changes

- `src/skills/workshop/policy.ts`: Set `timeoutMs: 300_000` (5 minutes) for the `apply` action, giving users adequate time to review large proposals while staying within the `MAX_PLUGIN_APPROVAL_TIMEOUT_MS` cap (600s).

## Real behavior proof

- **Behavior or issue addressed:** Increase `skill_workshop apply` approval timeout from 120s to 300s for large proposals.

- **Real environment tested:**
  - OS: Linux 4.19.112
  - Runtime: Node.js v26, pnpm

- **Exact steps or command run after the patch:**
  1. TypeScript check: `pnpm tsgo:prod` — no errors (includes core + extensions)
  2. Full build: `pnpm build` — passes
  3. Workshop tests: `pnpm test -- --run src/skills/workshop/` — 25/25 passed
  4. Format check: `pnpm format` — passes

- **Evidence after fix:**

**TypeScript compilation and build:**
```
$ pnpm tsgo:prod
> tsgo:core ... finished (no errors)
> tsgo:extensions ... finished (no errors)

$ pnpm build
> build-all ... finished (exit 0)
```

**Test suite output:**
```
$ pnpm test -- --run src/skills/workshop/
 ✓  (25 tests)
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

**Code change:**
```diff
 return {
   requireApproval: {
     ...text,
     allowedDecisions: ["allow-once", "deny"],
+    // Apply involves reviewing large proposals (~28 KB);
+    // raise timeout to 5 minutes for adequate review time.
+    ...(action === "apply" ? { timeoutMs: 300_000 } : {}),
   },
 };
```

- **Observed result after fix:**

**Before fix:** 28 KB proposal → `skill_workshop apply` → "Approval timed out" after 120s

**After fix:** 28 KB proposal → `skill_workshop apply` → 300s timeout window, adequate for thorough review

**Summary:** before: 120s timeout too short for large proposal review → after: 300s timeout accommodates large proposal review

- **What was not tested:** End-to-end test with actual 28 KB proposal (requires live gateway + approval UI). The timeout is a configuration change, verified by TypeScript compilation, build, and existing test suite.

## Scope / context

Only the `apply` action's approval timeout is increased. `reject` and `quarantine` actions (which require minimal review) keep the default 120s timeout.