### PR TITLE
fix(cron): skip stored delivery context for delivery.mode=none sessions

### DIFF
--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -47,6 +47,7 @@ async function resolveCronAnnounceDelivery(params: {
   agentId: string;
   jobId: string;
   target: CronAnnounceTarget;
+  deliveryMode?: string;
 }): Promise<
   | {
       ok: true;
@@ -63,6 +64,7 @@ async function resolveCronAnnounceDelivery(params: {
     to: params.target.to,
     accountId: params.target.accountId,
     sessionKey: params.target.sessionKey,
+    deliveryMode: params.deliveryMode,
   });
 
   if (!resolvedTarget.ok) {

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -1288,6 +1288,40 @@ describe("resolveDeliveryTarget", () => {
     });
   });
 
+  it("skips stored deliveryContext when delivery.mode=none so none-mode sessions are never used as fallback delivery vehicles (#94164)", async () => {
+    // Stored delivery context is set to channel "alpha" — it should be IGNORED
+    // because delivery.mode=none jobs must never auto-announce.
+    extractDeliveryInfoMock.mockReturnValueOnce({
+      deliveryContext: {
+        channel: "alpha",
+        to: "stored-room",
+        accountId: "primary",
+        threadId: "thread-stored",
+      },
+      threadId: "thread-stored",
+    });
+    setMainSessionEntry({
+      sessionId: "main",
+      updatedAt: 2000,
+      lastChannel: "alpha",
+      lastTo: "session-room",
+    });
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "last",
+      sessionKey: "agent:test:thread:42",
+      to: undefined,
+      deliveryMode: "none",
+    });
+
+    // When delivery.mode=none the stored delivery context MUST be skipped,
+    // so extractDeliveryInfo should never have been called for the session key.
+    // The result should fall back to the main session entry ("session-room")
+    // instead of using the stored context ("stored-room").
+    expect(extractDeliveryInfoMock).not.toHaveBeenCalled();
+    expect(result.to).toBe("session-room");
+  });
+
   it("scopes unqualified stored delivery lookups to the job agent", async () => {
     extractDeliveryInfoMock.mockImplementation((sessionKey: string) =>
       sessionKey === "agent:agent-b:main"

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -142,10 +142,17 @@ export async function resolveDeliveryTarget(
     /** Explicit accountId from job.delivery — overrides session-derived and binding-derived values. */
     accountId?: string;
     sessionKey?: string;
+    /**
+     * When `delivery.mode=none` the job explicitly opts out of auto-announce.
+     * Stored delivery context from such sessions MUST NOT be used as a
+     * fallback delivery vehicle (see #94164).
+     */
+    deliveryMode?: string;
   },
   options?: { dryRun?: boolean },
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
+  const deliveryModeNone = jobPayload.deliveryMode === "none";
   const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
   const allowMismatchedLastTo = requestedChannel === "last";
   const deliveryTargetRuntime = await loadDeliveryTargetRuntime();
@@ -165,10 +172,13 @@ export async function resolveDeliveryTarget(
         cfg,
       })
     : undefined;
-  const storedDeliveryContext = resolveCronStoredDeliveryContext({
-    cfg,
-    sessionKey: threadSessionKey,
-  });
+  const storedDeliveryContext =
+    deliveryModeNone
+      ? undefined
+      : resolveCronStoredDeliveryContext({
+          cfg,
+          sessionKey: threadSessionKey,
+        });
   const storedDeliveryEntry = storedDeliveryContext
     ? ({
         sessionId: threadSessionKey ?? mainSessionKey,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -418,6 +418,7 @@ async function resolveCronDeliveryContext(params: {
     threadId: deliveryPlan.threadId,
     accountId: deliveryPlan.accountId,
     sessionKey: params.job.sessionKey,
+    deliveryMode: deliveryPlan.mode,
   });
   return {
     deliveryPlan,


### PR DESCRIPTION
## Summary

- Cron jobs with `delivery.mode=none` explicitly opt out of auto-announce delivery
- When resolving delivery targets, the stored delivery context from `none`-mode cron sessions was still being used as a fallback delivery vehicle
- This caused duplicate messages arriving via alternating channels

## Change Type

- [x] Bug fix

## Scope

- [x] Cron / Delivery

## Real behavior proof

**Behavior addressed:** Skip `resolveCronStoredDeliveryContext` when `delivery.mode=none` so sessions that opted out are never used as delivery vehicles.

**Environment tested:** Node 22.x on Linux, openclaw upstream/main at 2ef0589b76, pnpm test.

**Steps run after the patch:**

```bash
# Production code verification
git diff 45d7167e..HEAD -- src/cron/isolated-agent/delivery-target.ts

# Regression test
node scripts/run-vitest.mjs run src/cron/isolated-agent/delivery-target.test.ts
```

**Evidence after fix:**

Production code change in `resolveDeliveryTarget` (delivery-target.ts):

```diff
+    /**
+     * When `delivery.mode=none` the job explicitly opts out of auto-announce.
+     * Stored delivery context from such sessions MUST NOT be used as a
+     * fallback delivery vehicle (see #94164).
+     */
+    deliveryMode?: string;
   },
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
+  const deliveryModeNone = jobPayload.deliveryMode === "none";
   ...
-  const storedDeliveryContext = resolveCronStoredDeliveryContext({
-    cfg,
-    sessionKey: threadSessionKey,
-  });
+  const storedDeliveryContext =
+    deliveryModeNone
+      ? undefined
+      : resolveCronStoredDeliveryContext({
+          cfg,
+          sessionKey: threadSessionKey,
+        });
```

Test output:

```text
Test Files  1 passed (1)
     Tests  54 passed (54)
```

**Observed result:** When `deliveryMode === "none"`, `resolveCronStoredDeliveryContext` is never called — `storedDeliveryContext` is `undefined`. The regression test verifies `extractDeliveryInfo` is never invoked for none-mode sessions.

**Not tested:** Live cron fleet with multiple `delivery.mode=none` sessions and a failing primary delivery path.

## Root Cause

- `resolveDeliveryTarget` used `resolveCronStoredDeliveryContext` unconditionally, without checking the cron job's `delivery.mode`

Closes #94164
