### PR TITLE
feat(discord): drain pending deliveries on gateway reconnect

### DIFF
--- a/extensions/discord/src/delivery-retry.ts
+++ b/extensions/discord/src/delivery-retry.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/retry-runtime";
 import { resolveDiscordAccount } from "./accounts.js";
 import { DiscordError } from "./internal/discord.js";
+import { getGateway } from "./monitor/gateway-registry.js";
 import { parseDiscordRetryAfterBodySeconds } from "./retry-after.js";
 
 const DISCORD_DELIVERY_RETRY_DEFAULTS = {
@@ -16,9 +17,12 @@ const DISCORD_DELIVERY_RETRY_DEFAULTS = {
   jitter: 0,
 } satisfies Required<RetryConfig>;
 
-export function isRetryableDiscordDeliveryError(err: unknown): boolean {
+export function isRetryableDiscordDeliveryError(err: unknown, opts?: { gatewayDisconnected?: boolean }): boolean {
   if (err instanceof DiscordError) {
     return false;
+  }
+  if (opts?.gatewayDisconnected) {
+    return true;
   }
   const status = (err as { status?: number }).status ?? (err as { statusCode?: number }).statusCode;
   return status === 429 || (status !== undefined && status >= 500);
@@ -47,10 +51,12 @@ export async function withDiscordDeliveryRetry<T>(params: {
   fn: () => Promise<T>;
 }): Promise<T> {
   const account = resolveDiscordAccount({ cfg: params.cfg, accountId: params.accountId });
+  const gateway = getGateway(params.accountId ?? undefined);
+  const gatewayDisconnected = gateway != null && !gateway.isConnected;
   const retryConfig = resolveRetryConfig(DISCORD_DELIVERY_RETRY_DEFAULTS, account.config.retry);
   return await retryAsync(params.fn, {
     ...retryConfig,
-    shouldRetry: (err) => isRetryableDiscordDeliveryError(err),
+    shouldRetry: (err) => isRetryableDiscordDeliveryError(err, { gatewayDisconnected }),
     retryAfterMs: getDiscordDeliveryRetryAfterMs,
   });
 }

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -24,6 +24,7 @@ type MockGateway = {
 
 const {
   attachDiscordGatewayLoggingMock,
+  drainPendingDeliveriesMock,
   getDiscordGatewayEmitterMock,
   registerGatewayMock,
   stopGatewayLoggingMock,
@@ -34,6 +35,7 @@ const {
   const getDiscordGatewayEmitterMockLocal = vi.fn<() => EventEmitter | undefined>(() => undefined);
   return {
     attachDiscordGatewayLoggingMock: vi.fn(() => stopGatewayLoggingMockLocal),
+    drainPendingDeliveriesMock: vi.fn(async (_opts: unknown) => undefined),
     getDiscordGatewayEmitterMock: getDiscordGatewayEmitterMockLocal,
     waitForDiscordGatewayStopMock: vi.fn((_params: WaitForDiscordGatewayStopParams) =>
       Promise.resolve(),
@@ -46,6 +48,10 @@ const {
 
 vi.mock("../gateway-logging.js", () => ({
   attachDiscordGatewayLogging: attachDiscordGatewayLoggingMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/delivery-queue-runtime", () => ({
+  drainPendingDeliveries: drainPendingDeliveriesMock,
 }));
 
 vi.mock("../monitor.gateway.js", () => ({
@@ -73,6 +79,7 @@ describe("runDiscordGatewayLifecycle", () => {
 
   beforeEach(() => {
     attachDiscordGatewayLoggingMock.mockClear();
+    drainPendingDeliveriesMock.mockClear();
     getDiscordGatewayEmitterMock.mockClear();
     waitForDiscordGatewayStopMock.mockClear();
     registerGatewayMock.mockClear();
@@ -152,6 +159,7 @@ describe("runDiscordGatewayLifecycle", () => {
     };
     const lifecycleParams: LifecycleParams = {
       accountId: "default",
+      cfg: {} as LifecycleParams["cfg"],
       gateway: gateway ? (gateway as unknown as MutableDiscordGateway) : undefined,
       runtime,
       isDisallowedIntentsError: params?.isDisallowedIntentsError ?? (() => false),
@@ -753,6 +761,32 @@ describe("runDiscordGatewayLifecycle", () => {
           patch.lastDisconnect !== null &&
           patch.lastDisconnect?.error === "runtime-not-ready",
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it("drains pending deliveries when the gateway reconnects after an initial disconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const { emitter, gateway } = createGatewayHarness();
+      gateway.isConnected = true;
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        gateway.isConnected = false;
+        emitter.emit("debug", "Gateway websocket opened");
+        await vi.advanceTimersByTimeAsync(500);
+        gateway.isConnected = true;
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+
+      await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+      expect(drainPendingDeliveriesMock).toHaveBeenCalled();
+      const drainCall = drainPendingDeliveriesMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(drainCall.drainKey).toBe("discord:default");
+      expect(drainCall.logLabel).toBe("Discord reconnect drain");
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -1,4 +1,7 @@
 // Discord provider module implements model/runtime integration.
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
 import {
   createConnectedChannelStatusPatch,
   createTransportActivityStatusPatch,
@@ -189,6 +192,32 @@ function resolveTransportActivityAt(event: unknown): number {
   return timestampMs !== undefined && timestampMs >= 0 ? timestampMs : Date.now();
 }
 
+function drainPendingDiscordDeliveriesAfterReconnect(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  runtime: RuntimeEnv;
+}) {
+  const accountId = normalizeAccountId(params.accountId);
+  void drainPendingDeliveries({
+    drainKey: `discord:${accountId}`,
+    logLabel: "Discord reconnect drain",
+    cfg: params.cfg,
+    log: {
+      info: (message) => params.runtime.log?.(`[discord][diag] ${message}`),
+      warn: (message) => params.runtime.log?.(`[discord] ${message}`),
+      error: (message) => params.runtime.log?.(`[discord] ${message}`),
+    },
+    selectEntry: (entry) => ({
+      match: entry.channel === "discord" && normalizeAccountId(entry.accountId) === accountId,
+      bypassBackoff: false,
+    }),
+  }).catch((err: unknown) => {
+    params.runtime.error?.(
+      danger(`discord: reconnect delivery drain failed: ${String(err)}`),
+    );
+  });
+}
+
 function createGatewayStatusObserver(params: {
   gateway?: Pick<MutableDiscordGateway, "isConnected">;
   abortSignal?: AbortSignal;
@@ -196,11 +225,13 @@ function createGatewayStatusObserver(params: {
   pushStatus: (patch: Parameters<DiscordMonitorStatusSink>[0]) => void;
   isLifecycleStopping: () => boolean;
   runtimeReadyTimeoutMs: number;
+  onReconnect?: () => void;
 }) {
   let forceStopHandler: ((err: unknown) => void) | undefined;
   let queuedForceStopError: unknown;
   let readyPollId: ReturnType<typeof setInterval> | undefined;
   let readyTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  let hasConnectedOnce = false;
 
   const shouldStop = () => params.abortSignal?.aborted || params.isLifecycleStopping();
   const clearReadyWatch = () => {
@@ -239,6 +270,10 @@ function createGatewayStatusObserver(params: {
       }
       clearReadyWatch();
       pushConnectedStatus(Date.now());
+      if (hasConnectedOnce) {
+        params.onReconnect?.();
+      }
+      hasConnectedOnce = true;
     };
 
     pollConnected();
@@ -307,6 +342,9 @@ function createGatewayStatusObserver(params: {
   return {
     onGatewayDebug,
     clearReadyWatch,
+    markInitialReady: () => {
+      hasConnectedOnce = true;
+    },
     registerForceStop: (handler: (err: unknown) => void) => {
       forceStopHandler = handler;
       if (queuedForceStopError !== undefined) {
@@ -407,6 +445,7 @@ async function waitForGatewayReady(params: {
 
 export async function runDiscordGatewayLifecycle(params: {
   accountId: string;
+  cfg: OpenClawConfig;
   gateway?: MutableDiscordGateway;
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
@@ -448,6 +487,16 @@ export async function runDiscordGatewayLifecycle(params: {
     pushStatus,
     isLifecycleStopping: () => lifecycleStopping,
     runtimeReadyTimeoutMs: gatewayRuntimeReadyTimeoutMs,
+    onReconnect: () => {
+      if (lifecycleStopping || params.abortSignal?.aborted) {
+        return;
+      }
+      drainPendingDiscordDeliveriesAfterReconnect({
+        cfg: params.cfg,
+        accountId: params.accountId,
+        runtime: params.runtime,
+      });
+    },
   });
   gatewayEmitter?.on("debug", statusObserver.onGatewayDebug);
   let lastTransportActivityStatusAt: number | undefined;
@@ -524,6 +573,8 @@ export async function runDiscordGatewayLifecycle(params: {
       beforeRestart: statusObserver.clearReadyWatch,
       readyTimeoutMs: gatewayReadyTimeoutMs,
     });
+
+    statusObserver.markInitialReady();
 
     if (drainPendingGatewayErrors() === "stop") {
       return;

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -598,6 +598,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     onEarlyGatewayDebug = undefined;
     await (runDiscordGatewayLifecycleForTesting ?? runDiscordGatewayLifecycle)({
       accountId: account.accountId,
+      cfg,
       gateway: lifecycleGateway,
       runtime,
       abortSignal: opts.abortSignal,


### PR DESCRIPTION
## What changed

Add delivery queue drain on Discord gateway reconnect, bringing parity with the existing WhatsApp (`delivery-queue/failed/`) and Telegram (`drainPendingDeliveries`) mechanisms.

When the Discord gateway WebSocket disconnects and reconnects (codes 1005/1006, ~13 times/day observed), any outbound message attempted during the 2-5 second reconnect window was silently dropped. This PR queues and retries those messages after the connection is re-established.

### Changes

- **`extensions/discord/src/monitor/provider.lifecycle.ts`**: Add `drainPendingDiscordDeliveriesAfterReconnect()` that calls `drainPendingDeliveries()` with `drainKey: "discord:<accountId>"`, filtering for `channel === "discord"`. Hook into the status observer via `onReconnect`, which fires when `isConnected` transitions from `false → true` after the initial startup. Track `hasConnectedOnce` to distinguish initial startup from subsequent reconnects. Mark initial ready after `waitForGatewayReady` succeeds. Add `cfg` param to `runDiscordGatewayLifecycle`.

- **`extensions/discord/src/delivery-retry.ts`**: Extend `isRetryableDiscordDeliveryError` with `gatewayDisconnected` option. When the gateway is disconnected, all delivery errors are retryable (not just 429/5xx). Check `getGateway(accountId).isConnected` in `withDiscordDeliveryRetry` and pass `gatewayDisconnected` to `shouldRetry`.

- **`extensions/discord/src/monitor/provider.ts`**: Pass `cfg` to the `runDiscordGatewayLifecycle` call.

## Why

Discord gateway WebSocket disconnects are frequent and expected (~13/day per the issue). Unlike WhatsApp which has a `delivery-queue/failed/` mechanism, Discord had no retry/requeue for messages that fail during the reconnect window. This caused cron job reports, sub-agent completions, and other outbound messages to be permanently lost.

## Real behavior proof

### Before fix

Outbound messages sent during a Discord gateway reconnect window (WebSocket close codes 1005/1006) were silently dropped with no retry mechanism. The existing `withDiscordDeliveryRetry` only handled HTTP-level errors (429 rate limits, 5xx server errors) — network/connection errors from a disconnected gateway were not retryable.

### After fix

**Evidence type**: Terminal output / Test output

**Setup**: OpenClaw development environment, Vitest test suite

```
❯ node scripts/run-vitest.mjs extensions/discord/src/monitor/provider.lifecycle.test.ts

 ✓ |extension-discord| extensions/discord/src/monitor/provider.lifecycle.test.ts (22 tests) 10.86s
   ✓ drains pending deliveries when the gateway reconnects after an initial disconnect 9ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
```

The new test verifies that when the gateway transitions `connected → disconnected → connected`, `drainPendingDeliveries()` is called with the correct `drainKey: "discord:default"` and `logLabel: "Discord reconnect drain"`.

Fixes #56610
