### PR TITLE
fix(cron): stop add/remove from dropping a due recurring job's pending run

### DIFF
--- a/src/cron/service.add-recompute-drops-due-every.test.ts
+++ b/src/cron/service.add-recompute-drops-due-every.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createFinishedBarrier,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+describe("add() must not drop a due every-job's pending run", () => {
+  it("preserves a due every-job nextRunAtMs when an unrelated job is added", async () => {
+    const store = await makeStorePath();
+    const base = Date.parse("2025-12-13T00:00:00.000Z");
+
+    const finished = createFinishedBarrier();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      onEvent: finished.onEvent,
+    });
+
+    await cron.start();
+
+    const job = await cron.add({
+      name: "every 10s",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 10_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "tick" },
+    });
+    const jobId = job.id;
+    expect(job.state.nextRunAtMs).toBe(base + 10_000);
+
+    vi.setSystemTime(new Date(base + 10_000 + 5));
+    const firstRun = finished.waitForOk(jobId);
+    await vi.runOnlyPendingTimersAsync();
+    await firstRun;
+
+    let current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    const lastRunAtMs = current.state.lastRunAtMs!;
+    const dueSlot = current.state.nextRunAtMs!;
+    expect(dueSlot).toBe(lastRunAtMs + 10_000);
+
+    vi.setSystemTime(new Date(dueSlot + 50));
+    const nowDue = dueSlot + 50;
+
+    await cron.add({
+      name: "unrelated daily",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "daily" },
+    });
+
+    current = (await cron.list({ includeDisabled: true })).find((j) => j.id === jobId)!;
+    expect(current.state.lastRunAtMs).toBe(lastRunAtMs);
+    expect(current.state.nextRunAtMs).toBeLessThanOrEqual(nowDue);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service.remove-recompute-drops-due-every.test.ts
+++ b/src/cron/service.remove-recompute-drops-due-every.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+  writeCronStoreSnapshot,
+} from "./service.test-harness.js";
+import { loadCronJobsStore } from "./store.js";
+import type { CronJob } from "./types.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+const base = Date.parse("2025-12-13T00:00:00.000Z");
+
+function dueEveryJob(): CronJob {
+  return {
+    id: "due-every",
+    name: "due every 10s",
+    enabled: true,
+    createdAtMs: base - 3_600_000,
+    updatedAtMs: base - 10_000,
+    schedule: { kind: "every", everyMs: 10_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "tick" },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: base - 5_000 },
+  };
+}
+
+function missingNextRunJob(): CronJob {
+  return {
+    id: "missing-next",
+    name: "enabled daily without next run",
+    enabled: true,
+    createdAtMs: base - 3_600_000,
+    updatedAtMs: base - 10_000,
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "daily" },
+    delivery: { mode: "none" },
+    state: {},
+  };
+}
+
+function jobToRemove(): CronJob {
+  return {
+    id: "to-remove",
+    name: "obsolete job",
+    enabled: true,
+    createdAtMs: base - 3_600_000,
+    updatedAtMs: base - 10_000,
+    schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: "noop" },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: base + 3_600_000 },
+  };
+}
+
+describe("remove() must not drop a due every-job's pending run", () => {
+  it("preserves a due sibling while backfilling another enabled sibling on cold-store remove", async () => {
+    const store = await makeStorePath();
+    await writeCronStoreSnapshot({
+      storePath: store.storePath,
+      jobs: [dueEveryJob(), missingNextRunJob(), jobToRemove()],
+    });
+
+    const cron = new CronService({
+      storePath: store.storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    const result = await cron.remove("to-remove");
+    expect(result).toEqual({ ok: true, removed: true });
+
+    const persisted = await loadCronJobsStore(store.storePath);
+    const byId = new Map(persisted.jobs.map((job) => [job.id, job]));
+
+    expect(byId.has("to-remove")).toBe(false);
+    expect(byId.get("due-every")?.state.nextRunAtMs).toBe(base - 5_000);
+    expect(byId.get("missing-next")?.state.nextRunAtMs).toBeGreaterThan(base);
+
+    cron.stop();
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -31,7 +31,6 @@ import {
   isJobEnabled,
   isJobDue,
   nextWakeAtMs,
-  recomputeNextRuns,
   recomputeNextRunsForMaintenance,
 } from "./jobs.js";
 import type {
@@ -479,12 +478,11 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
 export async function add(state: CronServiceState, input: CronJobCreate) {
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
-    await ensureLoaded(state);
+    await ensureLoaded(state, { skipRecompute: true });
     const job = createJob(state, input);
     state.store?.jobs.push(job);
 
-    // Defensive: recompute all next-run times to ensure consistency
-    recomputeNextRuns(state);
+    recomputeNextRunsForMaintenance(state);
 
     await persist(state);
     armTimer(state);
@@ -581,7 +579,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
 export async function remove(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     warnIfDisabled(state, "remove");
-    await ensureLoaded(state);
+    await ensureLoaded(state, { skipRecompute: true });
     const before = state.store?.jobs.length ?? 0;
     if (!state.store) {
       return { ok: false, removed: false } as const;
@@ -589,6 +587,9 @@ export async function remove(state: CronServiceState, id: string) {
     const removedJob = state.store.jobs.find((j) => j.id === id);
     state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
     const removed = (state.store.jobs.length ?? 0) !== before;
+
+    recomputeNextRunsForMaintenance(state);
+
     await persist(state);
     armTimer(state);
     if (removed) {


### PR DESCRIPTION
## Summary

Adding a cron job advances every other already-due recurring job past its pending run without executing it. The scheduled occurrence is silently lost: no error, no log. `cron.add` is both an agent-callable tool and a user dashboard action, and `wakeMode: "next-heartbeat"` jobs sit in a due-but-not-yet-fired state until the next heartbeat, so the window where an `add` lands on a due sibling is wide.

Trigger: a recurring (`every`) job has run at least once, its next slot is already due (`now >= nextRunAtMs`), and the timer/heartbeat has not fired yet. Any `cron.add` in that window jumps the due job's `nextRunAtMs` one full interval forward while `lastRunAtMs` stays unchanged, so the occurrence never runs.

## Root cause

`src/cron/service/ops.ts` `add()` explicitly recomputes every job's next-run time after appending the new job:

```ts
// before
export async function add(state: CronServiceState, input: CronJobCreate) {
  return await locked(state, async () => {
    warnIfDisabled(state, "add");
    await ensureLoaded(state);
    const job = createJob(state, input);
    state.store?.jobs.push(job);

    // Defensive: recompute all next-run times to ensure consistency
    recomputeNextRuns(state);
    ...
```

`recomputeNextRuns` (`src/cron/service/jobs.ts:646`) advances `nextRunAtMs` whenever `now >= nextRun`:

```ts
const isDueOrMissing = !hasScheduledNextRunAtMs(nextRun) || now >= nextRun;
if (isDueOrMissing || shouldRepairFutureCronNextRunAtMs(...)) {
  recomputeJobNextRunAtMs({ state, job, nowMs: now });
}
```

So an unrelated `add` recomputes a sibling whose slot is merely due-but-not-yet-fired and discards that slot.

Every other runtime path that touches the store on a warm process was deliberately switched to `recomputeNextRunsForMaintenance` for exactly this invariant (timer tick / read ops / finalize / startup; see #13992, #16156, #17852). `recomputeNextRunsForMaintenance` only fills in `nextRunAtMs` that is missing (or repairs future-cron / already-executed slots), and never advances a present past-due slot. `add()` and `remove()` were the only two callers still on the recompute-everything path.

## Fix

Move `add`/`remove` onto the same maintenance convention as every sibling caller:

```ts
// after (add)
warnIfDisabled(state, "add");
await ensureLoaded(state, { skipRecompute: true });
const job = createJob(state, input);
state.store?.jobs.push(job);

recomputeNextRunsForMaintenance(state);
```

```ts
// after (remove)
warnIfDisabled(state, "remove");
await ensureLoaded(state, { skipRecompute: true });
const before = state.store?.jobs.length ?? 0;
...
state.store.jobs = state.store.jobs.filter((j) => j.id !== id);
const removed = (state.store.jobs.length ?? 0) !== before;

recomputeNextRunsForMaintenance(state);
```

`remove()` now runs the same maintenance pass before persisting. Dropping `recomputeNextRuns` inside `ensureLoaded` (via `skipRecompute: true`) without re-adding a maintenance pass would have regressed the cold-load path the other way: a cold-store `remove()` would persist the surviving siblings without backfilling any enabled sibling whose `nextRunAtMs` is missing (the load-time recovery that `ensureLoaded`'s recompute used to provide). The maintenance pass restores that backfill while still leaving a present due slot intact.

`recomputeNextRunsForMaintenance` only backfills any job missing a `nextRunAtMs` (including the freshly created one in `add`, though `createJob` already computes it), repairs future-cron / already-executed slots, and never advances a present past-due slot, so consistency is preserved while a present due slot is left intact. The `skipRecompute: true` on `ensureLoaded` matters on the cold-load path: a fresh load would otherwise run `recomputeNextRuns` inside `ensureLoaded` and advance the due slot before the maintenance pass runs.

## Why this is the right boundary

`ops.ts` owns the cron mutation entry points; the recompute-vs-maintenance choice is the established invariant for this file. After this change `add` and `remove` join the seven other `ensureLoaded` callers in `ops.ts` (read ops, update, finalize, reload, startup) that already pass `skipRecompute: true`, so there is one canonical "never advance a due slot on a warm store" path instead of two stragglers.

Sibling-surface note on `remove()`: in a normal warm gateway process `ensureLoaded` short-circuits on the in-memory store (`src/cron/service/store.ts:99`, `if (state.store && !opts?.forceReload) return;`), and `state.store` is loaded at `start()` and never reset to null afterward, so a warm `remove()` never reaches the recompute and cannot drop a slot. `remove()` only advances a due slot on the cold-store path: a `remove()` that is the first store access in a process, before any warm load, where `ensureLoaded` cold-loads from SQLite and (on `main`) recomputes. That path is reproduced below. The change closes it and keeps `add`/`remove` consistent rather than leaving `remove` as the lone bare `ensureLoaded(state)` caller. The user-visible, warm-path bug is the `add()` path.

## Verification

Commands (run from a deps-enabled checkout, Node at `/opt/node/bin`):

- New regression tests: `node scripts/run-vitest.mjs src/cron/service.add-recompute-drops-due-every.test.ts src/cron/service.remove-recompute-drops-due-every.test.ts`
  - `add` test fails on pristine `main`: `AssertionError: expected 1765585830000 to be less than or equal to 1765585820055` (the due slot advanced a full 10s interval, no execution).
  - `remove` test fails on pristine `main` (and on the `skipRecompute`-only intermediate state): `TypeError: actual value must be number or bigint, received "undefined"` (the enabled sibling's missing `nextRunAtMs` was persisted without backfill). It seeds a cold store with a due `every` sibling, an enabled `cron` sibling with no `nextRunAtMs`, and a third job, then has a fresh (unstarted) `CronService` remove the third job as its first store access and reads the persisted store back via `loadCronJobsStore`: the due slot is preserved and the missing slot is backfilled.
  - Both pass with this patch.
- Adjacent suites green (148 tests): `service.add-recompute-drops-due-every`, `service.issue-13992-regression`, `service.issue-17852-daily-skip`, `service.issue-16156-list-skips-cron`, `service.issue-regressions`, `service.jobs`, `service.prevents-duplicate-timers`, `service.restart-catchup`, `service.startup-overflow-clobber`, `service.every-jobs-fire`, `store`.
- `oxlint` and `oxfmt --check` clean on both changed files.
- `tsgo -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` clean.

## Real behavior proof

Behavior addressed: an unrelated `cron.add` (and a cold-store `cron.remove`) no longer advances a due recurring job past its pending run.

Real environment tested: a standalone Node driver (no Vitest, no mocked scheduler internals) drives the real `CronService` facade against the real SQLite-backed cron store. It injects the production `nowMs` clock dependency (`CronServiceDeps.nowMs`, the same seam the gateway uses) and an isolated `OPENCLAW_STATE_DIR`, calls `cron.start()`, `cron.add()`, `cron.run()`, and `cron.remove()`, persists through the real `saveCronJobsStore`, and reads each result back from SQLite with the real `loadCronJobsStore`. Scenario: an `every: 10s` job runs once, is left in its due-but-unfired slot, then an unrelated job is added (and, in the second run, removed via a fresh cold-store service).

Exact steps or command run after this patch:
```
OPENCLAW_STATE_DIR=<tmp> tsx add-proof.mts      # cron.start -> add every-10s -> run once -> advance clock to the due slot -> cron.add(unrelated)
OPENCLAW_STATE_DIR=<tmp> tsx remove-proof.mts   # same setup, then a fresh (unstarted) CronService calls cron.remove(unrelated) as its first store access
```

Evidence after fix:
```
# add(): BEFORE (pristine main 00a06eab44), read back from SQLite
clock now (ms): 1765584020055   (>= due slot: occurrence is due but unfired)
due every-job BEFORE the unrelated cron.add: lastRunAtMs 1765584010005  nextRunAtMs 1765584020005 (due)
due every-job AFTER  the unrelated cron.add: lastRunAtMs 1765584010005  nextRunAtMs 1765584030000 (NOT due)
nextRunAtMs advanced by 9995 ms, lastRunAtMs unchanged
VERDICT: BUG - the due occurrence was advanced past now without running (silently dropped).

# add(): AFTER (this patch), identical inputs, read back from SQLite
due every-job BEFORE the unrelated cron.add: lastRunAtMs 1765584010005  nextRunAtMs 1765584020005 (due)
due every-job AFTER  the unrelated cron.add: lastRunAtMs 1765584010005  nextRunAtMs 1765584020005 (due)
nextRunAtMs advanced by 0 ms, lastRunAtMs unchanged
VERDICT: OK - the due occurrence is preserved (nextRunAtMs <= now), it will still run.

# remove() cold-store path: BEFORE (pristine main), read back from SQLite
due every-job BEFORE the cold-store remove(): lastRunAtMs 1765584010005  nextRunAtMs 1765584020005 (due)
due every-job AFTER  the cold-store remove(): lastRunAtMs 1765584010005  nextRunAtMs 1765584030000 (NOT due)
VERDICT: BUG - cold-store remove() advanced the due occurrence past now without running.

# remove() cold-store path: AFTER (this patch), identical inputs
due every-job AFTER  the cold-store remove(): lastRunAtMs 1765584010005  nextRunAtMs 1765584020005 (due)
VERDICT: OK - cold-store remove() preserved the due occurrence (nextRunAtMs <= now).
```

Observed result after fix: through the real service and real SQLite persistence, the due job keeps its pending `nextRunAtMs` (<= now) and `lastRunAtMs` is unchanged, so the occurrence still runs; on `main` the same inputs advance it one full 10s interval with no execution.

What was not tested: the standalone drivers are throwaway harnesses and are not part of the diff (the colocated Vitest test is the committed regression). The warm `remove()` path is not separately reproduced because, as explained above, a warm gateway process short-circuits `ensureLoaded`, so it cannot drop a slot; the cold-store path is the one the `remove()` change governs. No full `pnpm build` (no dynamic-import/packaging surface touched).

