### PR TITLE
fix(agents): keep post-compaction user re-issue of a kept-tail prompt during compaction rotation

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.post-compaction-duplicate-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.post-compaction-duplicate-prompt.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
+import { afterEach, describe, expect, it } from "vitest";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { rotateTranscriptAfterCompaction } from "./compaction-successor-transcript.js";
+import { readTranscriptFileState } from "./transcript-file-state.js";
+
+let tmpDir: string | undefined;
+afterEach(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+    tmpDir = undefined;
+  }
+});
+
+function makeAssistant(text: string, timestamp: number) {
+  return makeAgentAssistantMessage({ content: [{ type: "text", text }], timestamp });
+}
+
+function readUserTexts(entries: { type: string; message?: unknown }[]): string[] {
+  return entries
+    .filter(
+      (entry) =>
+        entry.type === "message" &&
+        (entry.message as { role?: unknown } | undefined)?.role === "user",
+    )
+    .map((entry) => {
+      const content = (entry.message as { content?: unknown } | undefined)?.content;
+      if (typeof content === "string") {
+        return content;
+      }
+      if (Array.isArray(content)) {
+        return content.map((block) => (block as { text?: string })?.text ?? "").join("");
+      }
+      return "";
+    });
+}
+
+const PROMPT = "Run the deployment script for staging now";
+
+describe("rotateTranscriptAfterCompaction post-compaction duplicate", () => {
+  it("keeps a real post-compaction user turn that repeats a kept-tail prompt", async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "successor-dup-post-"));
+    const manager = SessionManager.create(tmpDir, tmpDir);
+
+    manager.appendMessage({ role: "user", content: "set up the project", timestamp: 1000 });
+    manager.appendMessage(makeAssistant("Project ready.", 1001));
+
+    const firstKeptId = manager.appendMessage({
+      role: "user",
+      content: PROMPT,
+      timestamp: 2000,
+    });
+    manager.appendMessage(makeAssistant("Deploying to staging.", 2001));
+    manager.appendCompaction("Summary of project setup.", firstKeptId, 2050);
+
+    manager.appendMessage({ role: "user", content: PROMPT, timestamp: 2080 });
+    manager.appendMessage(makeAssistant("Redeploying to staging (second run).", 2081));
+
+    const sessionFile = manager.getSessionFile();
+    if (!sessionFile) {
+      throw new Error("no session file");
+    }
+
+    const result = await rotateTranscriptAfterCompaction({ sessionManager: manager, sessionFile });
+    expect(result.rotated).toBe(true);
+    const successorFile = result.sessionFile;
+    if (!successorFile) {
+      throw new Error("no successor file");
+    }
+
+    const successor = await readTranscriptFileState(successorFile);
+    const userPromptTexts = readUserTexts(
+      successor.getEntries() as { type: string; message?: unknown }[],
+    );
+
+    const occurrences = userPromptTexts.filter((text) => text.includes(PROMPT)).length;
+    expect(occurrences).toBe(2);
+  });
+});

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -143,9 +143,14 @@ function buildSuccessorEntries(params: {
   }
 
   const removedIds = new Set<string>();
-  const keptBranchEntries = branch.filter((entry) => !summarizedBranchIds.has(entry.id));
-  const duplicateUserMessageIds =
-    collectDuplicateUserMessageEntryIdsForCompaction(keptBranchEntries);
+  const keptPreCompactionEntries = branch
+    .slice(0, latestCompactionIndex)
+    .filter((entry) => !summarizedBranchIds.has(entry.id));
+  const postCompactionEntries = branch.slice(latestCompactionIndex + 1);
+  const duplicateUserMessageIds = new Set<string>([
+    ...collectDuplicateUserMessageEntryIdsForCompaction(keptPreCompactionEntries),
+    ...collectDuplicateUserMessageEntryIdsForCompaction(postCompactionEntries),
+  ]);
   for (const entry of allEntries) {
     if (
       (summarizedBranchIds.has(entry.id) && entry.type === "message") ||


### PR DESCRIPTION
## Summary

With `agents.defaults.compaction.truncateAfterCompaction` enabled, OpenClaw rotates the compacted session into a successor transcript. A genuine post-compaction user instruction that repeats a prompt kept in the pre-compaction tail, and arrives within the 60s duplicate window, is deleted from the rotated transcript. Its assistant reply is left orphaned (two consecutive assistant messages with no parent user turn), so the user instruction is lost and the turn structure is corrupted, which strict providers reject on the next request.

Trigger: compaction keeps a tail user prompt P; within 60s the user (or a cron/heartbeat/retry loop) re-issues P and the agent does new work; on rotation the post-compaction copy of P is dropped.

## Root cause

`src/agents/embedded-agent-runner/compaction-successor-transcript.ts` ran one duplicate-user dedup window across both the kept pre-compaction tail and all post-compaction entries:

```ts
// before
const keptBranchEntries = branch.filter((entry) => !summarizedBranchIds.has(entry.id));
const duplicateUserMessageIds =
  collectDuplicateUserMessageEntryIdsForCompaction(keptBranchEntries);
```

`collectDuplicateUserMessageEntryIdsForCompaction` keeps the first occurrence of a user prompt and drops later repeats within 60s. Because `keptBranchEntries` spans the compaction boundary, a kept-tail prompt becomes the dedup "first seen" and suppresses a real post-compaction re-issue of the same text. The post-compaction turn is genuine new work, not a pre-compaction retry, so it must survive rotation.

This is a regression of #93732. That PR correctly narrowed the dedup input from the full `branch` to `keptBranchEntries = branch.filter(!summarized)` to fix the summarized+kept double-removal case, but the narrowed set still crosses the boundary.

## Fix

Dedup the pre-compaction kept tail and the post-compaction tail independently, resetting the window at the boundary:

```ts
// after
const keptPreCompactionEntries = branch
  .slice(0, latestCompactionIndex)
  .filter((entry) => !summarizedBranchIds.has(entry.id));
const postCompactionEntries = branch.slice(latestCompactionIndex + 1);
const duplicateUserMessageIds = new Set<string>([
  ...collectDuplicateUserMessageEntryIdsForCompaction(keptPreCompactionEntries),
  ...collectDuplicateUserMessageEntryIdsForCompaction(postCompactionEntries),
]);
```

Each side still removes its own intra-window duplicate retries (the behavior #93732 and the existing dedup test protect), but a kept-tail prompt no longer reaches across the boundary to suppress a real post-compaction turn.

## Why this is the right boundary

The defect is in how the successor builder feeds entries to the dedup helper, so the fix stays in `buildSuccessorEntries`; the helper itself is unchanged and reused. The compaction index is already computed (`latestCompactionIndex`), so splitting at it adds no new lookup. The only behavior change is that the dedup window resets at the compaction boundary, matching the semantic boundary between summarized history and new work. This is distinct from #84139 (compaction safeguard over-keeping duplicates on sessions_send, the opposite direction) and from #93732's own summarized+kept case.

## Verification

From a deps-enabled worktree, against the changed files:

- `node scripts/run-vitest.mjs compaction-successor-transcript.post-compaction-duplicate-prompt.test.ts` plus the adjacent suites `compaction-successor-transcript.test.ts`, `compaction-duplicate-user-messages.test.ts`, `compaction-successor-transcript.duplicate-prompt-loss.test.ts`: all pass with the patch.
- The existing intended-dedup test ("drops duplicate user messages from the rotated active branch tail") stays green; both of its duplicates are post-compaction and are still deduped by the post-compaction window.
- New regression test fails on pristine `main` and passes with the patch.
- `oxlint` and `oxfmt --check` clean on both changed files; `tsgo` core and core-test lanes clean.

## Real behavior proof

Behavior addressed: post-compaction user re-issue of a kept-tail prompt is dropped from the rotated successor transcript under `truncateAfterCompaction`.
Real environment tested: drove the real `rotateTranscriptAfterCompaction` end to end over a real `SessionManager` transcript (summarized prefix, kept-tail prompt P, compaction entry, then a post-compaction re-issue of P inside the 60s window with a new assistant reply), then read the rotated successor file back with `readTranscriptFileState` and counted surviving copies of P.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compaction-successor-transcript.post-compaction-duplicate-prompt.test.ts`
Evidence after fix:
```
# BEFORE (pristine main b02b05d134)
AssertionError: expected 1 to be 2
  surviving copies of the post-compaction prompt P in the successor transcript: 1
  (post-compaction re-issue dropped; its assistant reply orphaned)

# AFTER (this patch, identical inputs)
 Test Files  1 passed (1)
      Tests  1 passed (1)
  surviving copies of the post-compaction prompt P in the successor transcript: 2
```
Observed result after fix: both the kept-tail prompt and the real post-compaction re-issue survive rotation; no orphaned assistant turn.
What was not tested: no live strict-provider request was issued against the corrupted-vs-fixed transcript; the orphaned-turn rejection is the documented consequence, not separately reproduced here. Full `pnpm build` was not run (no dynamic-import or packaging surface touched).

Note: open PR #90641 touches the same region for a different concern (assistant boundary replies) and is based pre-#93732; if it lands first this branch rebases cleanly since the changes are adjacent, not overlapping.
