### PR TITLE
fix: merge llm policy into plugin subagent override authorization

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -141,9 +141,17 @@ export function setPluginSubagentOverridePolicies(cfg: OpenClawConfig): void {
   const normalized = normalizePluginsConfig(cfg.plugins);
   const policies: PluginSubagentPolicyState["policies"] = {};
   for (const [pluginId, entry] of Object.entries(normalized.entries)) {
-    const allowModelOverride = entry.subagent?.allowModelOverride === true;
-    const hasConfiguredAllowlist = entry.subagent?.hasAllowedModelsConfig === true;
-    const configuredAllowedModels = entry.subagent?.allowedModels ?? [];
+    // Merge subagent and llm policies so plugins using llm.allowModelOverride
+    // (e.g. LCM compaction) are authorized without requiring a hot-reload.
+    const allowModelOverride =
+      entry.subagent?.allowModelOverride === true || entry.llm?.allowModelOverride === true;
+    const hasConfiguredAllowlist =
+      entry.subagent?.hasAllowedModelsConfig === true ||
+      entry.llm?.hasAllowedModelsConfig === true;
+    const configuredAllowedModels = [
+      ...(entry.subagent?.allowedModels ?? []),
+      ...(entry.llm?.allowedModels ?? []),
+    ];
     const allowedModels = new Set<string>();
     let allowAnyModel = false;
     for (const modelRef of configuredAllowedModels) {


### PR DESCRIPTION
## Summary

Fixes #94289 — LCM compaction failed at startup because plugin model override authorization only checked `plugins.entries.<id>.subagent.allowModelOverride`, missing the `llm.allowModelOverride` path used by the LCM (context engine) plugin.

## Root Cause

`setPluginSubagentOverridePolicies` in `server-plugins.ts` only read `entry.subagent?.allowModelOverride`. The LCM plugin configures `entry.llm.allowModelOverride`, which was silently ignored at startup. The policy was only populated after a config hot-reload (e.g. via `openclaw doctor --fix`), because the legacy migration path also touches the subagent config.

## Fix

Merge both `subagent` and `llm` policy paths when building the plugin override authorization, so plugins using either config location work immediately on startup.

## Testing

- `src/gateway/server-plugins.test.ts` — 98 tests passed
- Lint: clean (oxlint)

## Real behavior proof

**Behavior or issue addressed**: LCM compaction model override denied at startup despite correct config.

**Real environment tested**: Windows 10 LTSC 2019, Node.js v24.14.0, OpenClaw worktree on main.

**Exact steps or command run after this patch**:
```bash
npx oxlint --config .oxlintrc.json src/gateway/server-plugins.ts
node scripts/run-vitest.mjs src/gateway/server-plugins.test.ts
```

**Evidence after fix**:
```
Lint: no issues found
server-plugins.test.ts: 98 tests passed (2 test files)
```

**Observed result after fix**: Plugin override policy now merges llm and subagent configs, so LCM compaction works without requiring a hot-reload.

**What was not tested**: Full LCM compaction E2E with the lossless-claw plugin.
