### PR TITLE
docs: add ClawHub namespace claims to sidebar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1387,6 +1387,7 @@
                   "clawhub/http-api",
                   "clawhub/acceptable-usage",
                   "clawhub/moderation",
+                  "clawhub/namespace-claims",
                   "clawhub/security",
                   "clawhub/security-audits",
                   "clawhub/content-rights",


### PR DESCRIPTION
## Summary
- add `clawhub/namespace-claims` to the ClawHub API/trust sidebar group
- pairs with the merged ClawHub source docs page in openclaw/clawhub#2720

## Verification
- `pnpm docs:list`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/.codex/worktrees/757f/clawhub pnpm docs:check-links`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/.codex/worktrees/757f/clawhub pnpm docs:check-mdx`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/.codex/worktrees/757f/clawhub pnpm check:docs`

## Real behavior proof
Behavior addressed: the ClawHub docs sidebar now has a standalone `Org and Namespace Claims` route target after the ClawHub source docs page was added in openclaw/clawhub#2720.
Real environment tested: local OpenClaw docs checkout with ClawHub docs mirrored from `/Users/patrickerichsen/.codex/worktrees/757f/clawhub`.
Exact steps or command run after this patch: `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/Users/patrickerichsen/.codex/worktrees/757f/clawhub pnpm check:docs`.
Evidence after fix: docs sync mirrored 21 ClawHub assets, docs MDX passed, markdownlint passed, docs formatting passed, i18n glossary passed, and link audit reported `checked_internal_links=4564` with `broken_links=0`.
Observed result after fix: `docs/docs.json` includes `clawhub/namespace-claims` in the ClawHub API/trust sidebar group, and the mirrored ClawHub source contains that route.
What was not tested: the hosted `docs.openclaw.ai` page after merge/deploy; this PR has not landed yet.
