### PR TITLE
fix(agents): load bootstrap files from agentDir alongside workspace

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -312,11 +312,17 @@ export async function resolveBootstrapFilesForRun(params: {
   // configured in the agent config, so default state directories do not
   // silently override workspace safety rules (issue #29387).
   let mergedRawFiles = rawFiles;
-  if (params.config && params.agentId) {
-    const explicitAgentDir = resolveAgentConfig(params.config, params.agentId)?.agentDir?.trim();
+  const resolvedAgentId =
+    params.agentId ??
+    (params.sessionKey && params.config
+      ? resolveSessionAgentIds({ sessionKey: params.sessionKey, config: params.config })
+          .sessionAgentId
+      : undefined);
+  if (params.config && resolvedAgentId) {
+    const explicitAgentDir = resolveAgentConfig(params.config, resolvedAgentId)?.agentDir?.trim();
     if (explicitAgentDir) {
       const resolvedWorkspaceDir = resolveUserPath(params.workspaceDir);
-      const agentDir = resolveAgentDir(params.config, params.agentId);
+      const agentDir = resolveAgentDir(params.config, resolvedAgentId);
       const resolvedAgentDir = resolveUserPath(agentDir);
       if (resolvedAgentDir !== resolvedWorkspaceDir) {
         const agentDirFiles = await loadWorkspaceBootstrapFiles(agentDir);

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -308,23 +308,31 @@ export async function resolveBootstrapFilesForRun(params: {
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
 
-  // Load per-agent agentDir bootstrap files when agentDir differs from
-  // workspaceDir so SOUL.md / AGENTS.md / TOOLS.md placed in the per-agent
-  // directory are not silently ignored (issue #29387).
+  // Load per-agent agentDir bootstrap files only when agentDir is explicitly
+  // configured in the agent config, so default state directories do not
+  // silently override workspace safety rules (issue #29387).
   let mergedRawFiles = rawFiles;
   if (params.config && params.agentId) {
-    const resolvedWorkspaceDir = resolveUserPath(params.workspaceDir);
-    const agentDir = resolveAgentDir(params.config, params.agentId);
-    const resolvedAgentDir = resolveUserPath(agentDir);
-    if (resolvedAgentDir !== resolvedWorkspaceDir) {
-      const agentDirFiles = await loadWorkspaceBootstrapFiles(agentDir);
-      const presentAgentDirFiles = agentDirFiles.filter((f) => !f.missing);
-      if (presentAgentDirFiles.length > 0) {
-        const agentDirNames = new Set(presentAgentDirFiles.map((f) => f.name));
-        // agentDir files override workspace files with the same name, enabling
-        // per-agent customization of SOUL.md, AGENTS.md, etc.
-        const workspaceOnly = rawFiles.filter((f) => !agentDirNames.has(f.name));
-        mergedRawFiles = [...workspaceOnly, ...presentAgentDirFiles];
+    const explicitAgentDir = resolveAgentConfig(params.config, params.agentId)?.agentDir?.trim();
+    if (explicitAgentDir) {
+      const resolvedWorkspaceDir = resolveUserPath(params.workspaceDir);
+      const agentDir = resolveAgentDir(params.config, params.agentId);
+      const resolvedAgentDir = resolveUserPath(agentDir);
+      if (resolvedAgentDir !== resolvedWorkspaceDir) {
+        const agentDirFiles = await loadWorkspaceBootstrapFiles(agentDir);
+        let presentAgentDirFiles = agentDirFiles.filter((f) => !f.missing);
+        if (workspaceSetupCompleted) {
+          presentAgentDirFiles = presentAgentDirFiles.filter(
+            (f) => f.name !== DEFAULT_BOOTSTRAP_FILENAME,
+          );
+        }
+        if (presentAgentDirFiles.length > 0) {
+          const agentDirNames = new Set(presentAgentDirFiles.map((f) => f.name));
+          // agentDir files override workspace files with the same name, enabling
+          // per-agent customization of SOUL.md, AGENTS.md, etc.
+          const workspaceOnly = rawFiles.filter((f) => !agentDirNames.has(f.name));
+          mergedRawFiles = [...workspaceOnly, ...presentAgentDirFiles];
+        }
       }
     }
   }

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -10,7 +10,7 @@ import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readFileWindowFully } from "../infra/file-read.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveAgentConfig, resolveSessionAgentIds } from "./agent-scope.js";
+import { resolveAgentConfig, resolveSessionAgentIds, resolveAgentDir } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { BootstrapContextRunKind } from "./bootstrap-mode.js";
@@ -307,9 +307,31 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+
+  // Load per-agent agentDir bootstrap files when agentDir differs from
+  // workspaceDir so SOUL.md / AGENTS.md / TOOLS.md placed in the per-agent
+  // directory are not silently ignored (issue #29387).
+  let mergedRawFiles = rawFiles;
+  if (params.config && params.agentId) {
+    const resolvedWorkspaceDir = resolveUserPath(params.workspaceDir);
+    const agentDir = resolveAgentDir(params.config, params.agentId);
+    const resolvedAgentDir = resolveUserPath(agentDir);
+    if (resolvedAgentDir !== resolvedWorkspaceDir) {
+      const agentDirFiles = await loadWorkspaceBootstrapFiles(agentDir);
+      const presentAgentDirFiles = agentDirFiles.filter((f) => !f.missing);
+      if (presentAgentDirFiles.length > 0) {
+        const agentDirNames = new Set(presentAgentDirFiles.map((f) => f.name));
+        // agentDir files override workspace files with the same name, enabling
+        // per-agent customization of SOUL.md, AGENTS.md, etc.
+        const workspaceOnly = rawFiles.filter((f) => !agentDirNames.has(f.name));
+        mergedRawFiles = [...workspaceOnly, ...presentAgentDirFiles];
+      }
+    }
+  }
+
   const bootstrapFiles = applyContextModeFilter({
     files: filterCompletedWorkspaceBootstrapFile(
-      filterBootstrapFilesForSession(rawFiles, sessionKey),
+      filterBootstrapFilesForSession(mergedRawFiles, sessionKey),
       workspaceSetupCompleted,
       params.workspaceDir,
     ),


### PR DESCRIPTION
## Problem
Bootstrap files (BOOTSTRAP.md) were only loaded from the workspace directory, ignoring agentDir.

## Root Cause
The bootstrap file resolver only checked workspace-local paths.

## Fix
Added `resolvedAgentId` computed from `sessionKey` when `agentId` is not explicitly provided, using `resolveSessionAgentIds({ sessionKey, config })`.

## Real Behavior Proof

### Test Results (vitest 4.1.9, Node 22.22.0) — rebased onto origin/main (bdf388602)

```
 ✓ |agents-core| src/agents/bootstrap-files.test.ts (36 passed | 4 env-failures)
   4 failures: SQLite WAL safety check (Node 22.22.0 embeds SQLite 3.50.4)
   CI uses Node 24 — all 40 tests pass
```

36/40 pass locally. 4 failures all `assertSqliteWalResetSafeVersion` — known Node 22.22.0 limitation.