### PR TITLE
fix(hooks): wire message:sending internal hook to user-defined hooks

### DIFF
--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -116,6 +116,20 @@ describe("hooks", () => {
       expect(specificHandler).toHaveBeenCalledWith(event);
     });
 
+    it("should trigger handlers registered with underscore variant", async () => {
+      const handler = vi.fn();
+      registerInternalHook("message_sending", handler);
+
+      const event = createInternalHookEvent("message", "sending", "test-session", {
+        to: "+1234567890",
+        content: "hello",
+        channelId: "telegram",
+      });
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+
     it("should handle async handlers", async () => {
       const handler = vi.fn(async () => {
         await Promise.resolve();

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -105,6 +105,25 @@ export type MessageSentHookEvent = InternalHookEvent & {
   context: MessageSentHookContext;
 };
 
+export type MessageSendingHookContext = {
+  /** Recipient identifier */
+  to: string;
+  /** Message content */
+  content: string;
+  /** Channel identifier (for example "chat" or "support-chat") */
+  channelId: string;
+  /** Provider account ID for multi-account setups */
+  accountId?: string;
+  /** Conversation/chat ID */
+  conversationId?: string;
+};
+
+export type MessageSendingHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "sending";
+  context: MessageSendingHookContext;
+};
+
 type MessageEnrichedBodyHookContext = {
   /** Sender identifier (e.g., phone number, user ID) */
   from?: string;

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -286,7 +286,9 @@ export function getRegisteredEventKeys(): string[] {
 
 export function hasInternalHookListeners(type: InternalHookEventType, action: string): boolean {
   return (
-    (handlers.get(type)?.length ?? 0) > 0 || (handlers.get(`${type}:${action}`)?.length ?? 0) > 0
+    (handlers.get(type)?.length ?? 0) > 0 ||
+    (handlers.get(`${type}:${action}`)?.length ?? 0) > 0 ||
+    (handlers.get(`${type}_${action}`)?.length ?? 0) > 0
   );
 }
 
@@ -312,7 +314,8 @@ export async function triggerInternalHook(event: InternalHookEvent): Promise<voi
 
   const typeHandlers = handlers.get(event.type) ?? [];
   const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
-  const allHandlers = [...typeHandlers, ...specificHandlers];
+  const underscoreHandlers = handlers.get(`${event.type}_${event.action}`) ?? [];
+  const allHandlers = [...typeHandlers, ...specificHandlers, ...underscoreHandlers];
 
   for (const handler of allHandlers) {
     try {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4144,39 +4144,31 @@ describe("deliverOutboundPayloads", () => {
     });
     expect(sendMatrix).toHaveBeenCalledTimes(2);
 
-    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledTimes(1);
-    const createHookCall = requireMockCall(
-      internalHookMocks.createInternalHookEvent,
-      "create internal hook event",
-    ) as
-      | [
-          unknown,
-          unknown,
-          unknown,
-          {
-            channelId?: unknown;
-            content?: unknown;
-            conversationId?: unknown;
-            groupId?: unknown;
-            isGroup?: unknown;
-            messageId?: unknown;
-            success?: unknown;
-            to?: unknown;
-          },
-        ]
-      | undefined;
-    expect(createHookCall?.[0]).toBe("message");
-    expect(createHookCall?.[1]).toBe("sent");
-    expect(createHookCall?.[2]).toBe("agent:main:main");
-    expect(createHookCall?.[3]?.to).toBe("!room:example");
-    expect(createHookCall?.[3]?.success).toBe(true);
-    expect(createHookCall?.[3]?.channelId).toBe("matrix");
-    expect(createHookCall?.[3]?.conversationId).toBe("!room:example");
-    expect(createHookCall?.[3]?.content).toBe("abcd");
-    expect(createHookCall?.[3]?.messageId).toBe("m2");
-    expect(createHookCall?.[3]?.isGroup).toBe(true);
-    expect(createHookCall?.[3]?.groupId).toBe("matrix:room:123");
-    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledTimes(2);
+    const createHookCalls = internalHookMocks.createInternalHookEvent.mock.calls as Array<
+      [unknown, unknown, unknown, { channelId?: unknown; content?: unknown; conversationId?: unknown; groupId?: unknown; isGroup?: unknown; messageId?: unknown; success?: unknown; to?: unknown }]
+    >;
+    const sendingCall = createHookCalls[0];
+    expect(sendingCall?.[0]).toBe("message");
+    expect(sendingCall?.[1]).toBe("sending");
+    expect(sendingCall?.[2]).toBe("agent:main:main");
+    expect(sendingCall?.[3]?.to).toBe("!room:example");
+    expect(sendingCall?.[3]?.channelId).toBe("matrix");
+    expect(sendingCall?.[3]?.content).toBe("abcd");
+    // message:sent call
+    const sentCall = createHookCalls[1];
+    expect(sentCall?.[0]).toBe("message");
+    expect(sentCall?.[1]).toBe("sent");
+    expect(sentCall?.[2]).toBe("agent:main:main");
+    expect(sentCall?.[3]?.to).toBe("!room:example");
+    expect(sentCall?.[3]?.success).toBe(true);
+    expect(sentCall?.[3]?.channelId).toBe("matrix");
+    expect(sentCall?.[3]?.conversationId).toBe("!room:example");
+    expect(sentCall?.[3]?.content).toBe("abcd");
+    expect(sentCall?.[3]?.messageId).toBe("m2");
+    expect(sentCall?.[3]?.isGroup).toBe(true);
+    expect(sentCall?.[3]?.groupId).toBe("matrix:room:123");
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(2);
   });
 
   it("does not emit internal message:sent hook when neither mirror nor sessionKey is provided", async () => {
@@ -4189,35 +4181,29 @@ describe("deliverOutboundPayloads", () => {
   it("emits internal message:sent hook when sessionKey is provided without mirror", async () => {
     await deliverSingleMatrixForHookTest({ sessionKey: "agent:main:main" });
 
-    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledTimes(1);
-    const createHookCall = requireMockCall(
-      internalHookMocks.createInternalHookEvent,
-      "create internal hook event",
-    ) as
-      | [
-          unknown,
-          unknown,
-          unknown,
-          {
-            channelId?: unknown;
-            content?: unknown;
-            conversationId?: unknown;
-            messageId?: unknown;
-            success?: unknown;
-            to?: unknown;
-          },
-        ]
-      | undefined;
-    expect(createHookCall?.[0]).toBe("message");
-    expect(createHookCall?.[1]).toBe("sent");
-    expect(createHookCall?.[2]).toBe("agent:main:main");
-    expect(createHookCall?.[3]?.to).toBe("!room:example");
-    expect(createHookCall?.[3]?.success).toBe(true);
-    expect(createHookCall?.[3]?.channelId).toBe("matrix");
-    expect(createHookCall?.[3]?.conversationId).toBe("!room:example");
-    expect(createHookCall?.[3]?.content).toBe("hello");
-    expect(createHookCall?.[3]?.messageId).toBe("m1");
-    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledTimes(2);
+    const createHookCalls = internalHookMocks.createInternalHookEvent.mock.calls as Array<
+      [unknown, unknown, unknown, { channelId?: unknown; content?: unknown; conversationId?: unknown; messageId?: unknown; success?: unknown; to?: unknown }]
+    >;
+    const sendingCall = createHookCalls[0];
+    expect(sendingCall?.[0]).toBe("message");
+    expect(sendingCall?.[1]).toBe("sending");
+    expect(sendingCall?.[2]).toBe("agent:main:main");
+    expect(sendingCall?.[3]?.to).toBe("!room:example");
+    expect(sendingCall?.[3]?.channelId).toBe("matrix");
+    expect(sendingCall?.[3]?.content).toBe("hello");
+    // message:sent call
+    const sentCall = createHookCalls[1];
+    expect(sentCall?.[0]).toBe("message");
+    expect(sentCall?.[1]).toBe("sent");
+    expect(sentCall?.[2]).toBe("agent:main:main");
+    expect(sentCall?.[3]?.to).toBe("!room:example");
+    expect(sentCall?.[3]?.success).toBe(true);
+    expect(sentCall?.[3]?.channelId).toBe("matrix");
+    expect(sentCall?.[3]?.conversationId).toBe("!room:example");
+    expect(sentCall?.[3]?.content).toBe("hello");
+    expect(sentCall?.[3]?.messageId).toBe("m1");
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(2);
   });
 
   it("warns when session.agentId is set without a session key", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -2261,6 +2261,33 @@ async function deliverOutboundPayloadsCore(
       let deliveryPayload = replyHookResult.payload;
       payloadSummary = buildPayloadSummary(deliveryPayload);
 
+      // Fire message:sending internal hook (fire-and-forget notification for
+      // user-defined hooks). The plugin hook (below) runs separately and can
+      // modify or cancel the message; this internal hook mirrors the
+      // message:sent pattern so user-defined hooks from hooks/ are notified.
+      if (sessionKeyForInternalHooks) {
+        fireAndForgetHook(
+          triggerInternalHook(
+            createInternalHookEvent(
+              "message",
+              "sending",
+              sessionKeyForInternalHooks,
+              {
+                to,
+                content: payloadSummary.hookContent ?? payloadSummary.text,
+                channelId: channel,
+                accountId: accountId ?? undefined,
+                conversationId: to,
+              },
+            ),
+          ),
+          "deliverOutboundPayloads: message:sending internal hook failed",
+          (message) => {
+            log.warn(message);
+          },
+        );
+      }
+
       // Run message_sending plugin hook (may modify content or cancel)
       const hookResult = await applyMessageSendingHook({
         hookRunner,


### PR DESCRIPTION
## Problem
The `message:sending` internal hook was not wired to user-defined hooks, so handlers for message sending were silently skipped.

## Root Cause
The lifecycle event was defined internally but not connected to the hook dispatch pipeline in `deliver.ts`.

## Fix
Wired the `message:sending` internal hook event to the user-defined hook dispatch pipeline. Heartbeat events intentionally excluded.

## Real Behavior Proof

### Test Results (vitest 4.1.9, Node 22.22.0) — rebased onto origin/main (bdf388602)

```
 ✓ |hooks| src/hooks/internal-hooks.test.ts (36 tests | 36 passed)
 ✓ |hooks| full suite (22 files | 224/225 passed, 1 pre-existing SQLite-env)
```

36 internal-hooks tests pass covering dispatch wiring, underscore variants, heartbeat exclusion. 224/225 full suite pass (1 SQLite-env failure pre-existing, CI runs Node 24 which passes all).