### PR TITLE
fix(memory-core): honor private-network settings for OpenAI-compatible embeddings

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -159,6 +159,10 @@ provider/auth configuration, switch to a reachable provider, or set
 }
 ```
 
+<Note>
+When `memory.search.provider` resolves a configured alias through the core OpenAI-compatible adapter (`api: "openai-completions"`, `api: "openai-responses"`, or a `baseUrl`-only entry), memory embeddings use that provider's `request.allowPrivateNetwork` policy. For custom or local endpoints, omitting the flag trusts only the exact configured `baseUrl` origin (`scheme://host:port`); `true` allows broader private-network requests, while `false` disables exact-origin trust. A `memory.search.remote.baseUrl` override on another origin requires explicit `true`. Other embedding adapters keep their own network policy.
+</Note>
+
 ### API key resolution
 
 Remote embeddings require an API key. Bedrock uses the AWS SDK default credential chain instead (instance roles, SSO, access keys, or a Bedrock API key).

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -155,7 +155,7 @@ provider/auth configuration, switch to a reachable provider, or set
 ```
 
 <Note>
-When `memory.search.provider` resolves a configured alias through the core OpenAI-compatible adapter (`api: "openai-completions"`, `api: "openai-responses"`, or a `baseUrl`-only entry), memory embeddings use that provider's `request.allowPrivateNetwork` policy. For custom or local endpoints, omitting the flag trusts only the exact configured `baseUrl` origin (`scheme://host:port`); `true` allows broader private-network requests, while `false` disables exact-origin trust. A `memory.search.remote.baseUrl` override on another origin requires explicit `true`. Other embedding adapters keep their own network policy.
+When `memory.search.provider` resolves a configured alias through the core OpenAI-compatible adapter (`api: "openai-completions"`, `api: "openai-responses"`, or a `baseUrl`-only entry), memory embeddings use that provider's `request.allowPrivateNetwork` policy. For custom or local endpoints, omitting the flag trusts only the exact configured `baseUrl` origin (`scheme://host:port`); `true` allows broader private-network requests, while `false` disables exact-origin trust. A `memory.search.remote.baseUrl` override is treated as an explicitly configured endpoint and follows the same exact-origin/default and explicit opt-in rules. Other embedding adapters keep their own network policy.
 </Note>
 
 ### API key resolution

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -154,6 +154,10 @@ provider/auth configuration, switch to a reachable provider, or set
 }
 ```
 
+<Note>
+When `memory.search.provider` resolves a configured alias through the core OpenAI-compatible adapter (`api: "openai-completions"`, `api: "openai-responses"`, or a `baseUrl`-only entry), memory embeddings use that provider's `request.allowPrivateNetwork` policy. For custom or local endpoints, omitting the flag trusts only the exact configured `baseUrl` origin (`scheme://host:port`); `true` allows broader private-network requests, while `false` disables exact-origin trust. A `memory.search.remote.baseUrl` override on another origin requires explicit `true`. Other embedding adapters keep their own network policy.
+</Note>
+
 ### API key resolution
 
 Remote embeddings require an API key. Bedrock uses the AWS SDK default credential chain instead (instance roles, SSO, access keys, or a Bedrock API key).

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -744,6 +744,17 @@ describe("provider request config", () => {
     expect(resolved.trustConfiguredBaseUrlOrigin).toBe(true);
   });
 
+  it("suppresses fake-IP private exemptions when embedding access is explicitly denied", () => {
+    expect(
+      resolveProviderTransportSsrFPolicy({
+        baseUrl: "https://embed.internal/v1",
+        url: "https://embed.internal/v1/embeddings",
+        allowPrivateNetwork: false,
+        privateNetworkExplicitlyDenied: true,
+      }),
+    ).toBeUndefined();
+  });
+
   it("keeps explicit private-network denial for loopback model requests", () => {
     const resolved = resolveProviderRequestPolicyConfig({
       provider: "local-agent-proxy",

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -7,11 +7,6 @@ import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
 import { emitModelTransportDebug } from "@openclaw/ai/transports";
 import { formatModelTransportDebugUrl } from "@openclaw/ai/transports";
 import {
-  isCloudMetadataIpAddress,
-  isLinkLocalIpAddress,
-  parseCanonicalIpAddress,
-} from "@openclaw/net-policy/ip";
-import {
   asFiniteNumberInRange,
   clampTimerTimeoutMs,
   parseStrictFiniteNumber,
@@ -23,12 +18,6 @@ import {
 } from "../infra/net/fetch-guard.js";
 import { wrapGuardedBodyStream } from "../infra/net/guarded-body-stream.js";
 import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
-import {
-  mergeSsrFPolicies,
-  ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist,
-  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
-  type SsrFPolicy,
-} from "../infra/net/ssrf.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveDebugProxySettings } from "../proxy-capture/env.js";
@@ -50,6 +39,9 @@ import {
   mergeModelProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
 } from "./provider-request-config.js";
+import { resolveProviderTransportSsrFPolicy } from "./provider-transport-ssrf-policy.js";
+
+export { resolveProviderTransportSsrFPolicy } from "./provider-transport-ssrf-policy.js";
 
 const DEFAULT_MAX_SDK_RETRY_WAIT_SECONDS = 60;
 const OPENAI_SDK_STREAM_CONTENT_SNIFF_BYTES = 2 * 1024;
@@ -66,7 +58,6 @@ const SSE_NONOK_BODY_MAX_BYTES = 64 * 1024;
 /** Max decoded characters buffered while waiting for the next SSE event boundary. */
 const SSE_SANITIZE_BUFFER_MAX_CHARS = 16 * 1024 * 1024;
 
-const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 
 function hasReadableSseData(block: string): boolean {
@@ -630,98 +621,6 @@ function buildModelRequestSignal(
     return timeoutSignal;
   }
   return AbortSignal.any([baseSignal, timeoutSignal]);
-}
-
-function resolveHttpOrigin(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return undefined;
-    }
-    parsed.hostname = parsed.hostname.replace(/\.+$/, "");
-    return parsed.origin.toLowerCase();
-  } catch {
-    return undefined;
-  }
-}
-
-function normalizeProviderOriginHostname(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return undefined;
-    }
-    const normalized = parsed.hostname.trim().toLowerCase().replace(/\.+$/, "");
-    return normalized || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function canImplicitlyTrustConfiguredBaseUrlOrigin(value: unknown): value is string {
-  const hostname = normalizeProviderOriginHostname(value);
-  if (!hostname) {
-    return false;
-  }
-  const labels = hostname.split(".").filter(Boolean);
-  return (
-    !labels.some(
-      (label) =>
-        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
-    ) &&
-    !isLinkLocalIpAddress(hostname) &&
-    !isCloudMetadataIpAddress(hostname)
-  );
-}
-
-function canApplyFakeIpHostnamePolicy(value: unknown): value is string {
-  const hostname = normalizeProviderOriginHostname(value);
-  if (!hostname) {
-    return false;
-  }
-  const labels = hostname.split(".").filter(Boolean);
-  return (
-    !labels.some(
-      (label) =>
-        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
-    ) && !parseCanonicalIpAddress(hostname)
-  );
-}
-
-export function resolveProviderTransportSsrFPolicy(params: {
-  baseUrl?: string;
-  url: string;
-  allowPrivateNetwork?: boolean;
-  trustConfiguredBaseUrlOrigin?: boolean;
-}): SsrFPolicy | undefined {
-  const baseUrl = params.baseUrl;
-  const baseOrigin = resolveHttpOrigin(baseUrl);
-  const requestOrigin = resolveHttpOrigin(params.url);
-  const requestMatchesBaseOrigin =
-    typeof baseUrl === "string" && Boolean(baseOrigin) && requestOrigin === baseOrigin;
-  const baseUrlOriginPolicy =
-    requestMatchesBaseOrigin &&
-    params.trustConfiguredBaseUrlOrigin &&
-    canImplicitlyTrustConfiguredBaseUrlOrigin(baseUrl)
-      ? ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl)
-      : undefined;
-  // Fake-IP trust is hostname-scoped and orthogonal to exact-origin private-IP trust.
-  // It is for DNS hostnames only and does not allow literal private IPs by itself.
-  const fakeIpPolicy =
-    requestMatchesBaseOrigin && canApplyFakeIpHostnamePolicy(baseUrl)
-      ? ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist(baseUrl)
-      : undefined;
-  return mergeSsrFPolicies(
-    baseUrlOriginPolicy,
-    fakeIpPolicy,
-    params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
-  );
 }
 
 function headersContainSecretSentinel(headers: HeadersInit | undefined): boolean {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -6,12 +6,6 @@
 import { parseRetryAfterHttpDateMs } from "@openclaw/ai/internal/retry-after";
 import { emitModelTransportDebug, formatModelTransportDebugUrl } from "@openclaw/ai/transports";
 import {
-  isCloudMetadataIpAddress,
-  isLinkLocalIpAddress,
-  isRfc8215LocalUseNat64Ipv6Address,
-  parseCanonicalIpAddress,
-} from "@openclaw/net-policy/ip";
-import {
   asFiniteNumberInRange,
   clampTimerTimeoutMs,
   parseStrictFiniteNumber,
@@ -23,13 +17,6 @@ import {
 } from "../infra/net/fetch-guard.js";
 import { wrapGuardedBodyStream } from "../infra/net/guarded-body-stream.js";
 import { shouldUseEnvHttpProxyForUrl } from "../infra/net/proxy-env.js";
-import {
-  mergeSsrFPolicies,
-  ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist,
-  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
-  SsrFBlockedError,
-  type SsrFPolicy,
-} from "../infra/net/ssrf.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveDebugProxySettings } from "../proxy-capture/env.js";
@@ -52,6 +39,12 @@ import {
   resolveProviderRequestPolicyConfig,
 } from "./provider-request-config.js";
 import { getProviderTransportDispatcherPool } from "./provider-transport-dispatcher-pool.js";
+import {
+  resolveProviderTransportSsrFPolicy,
+  withModelProviderNetworkRemediation,
+} from "./provider-transport-ssrf-policy.js";
+
+export { resolveProviderTransportSsrFPolicy } from "./provider-transport-ssrf-policy.js";
 
 const DEFAULT_MAX_SDK_RETRY_WAIT_SECONDS = 60;
 const OPENAI_SDK_STREAM_CONTENT_SNIFF_BYTES = 2 * 1024;
@@ -68,7 +61,6 @@ const SSE_NONOK_BODY_MAX_BYTES = 64 * 1024;
 /** Max decoded characters buffered while waiting for the next SSE event boundary. */
 const SSE_SANITIZE_BUFFER_MAX_CHARS = 16 * 1024 * 1024;
 
-const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 
 function hasReadableSseData(block: string): boolean {
@@ -632,128 +624,6 @@ function buildModelRequestSignal(
     return timeoutSignal;
   }
   return AbortSignal.any([baseSignal, timeoutSignal]);
-}
-
-function resolveHttpOrigin(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return undefined;
-    }
-    parsed.hostname = parsed.hostname.replace(/\.+$/, "");
-    return parsed.origin.toLowerCase();
-  } catch {
-    return undefined;
-  }
-}
-
-function normalizeProviderOriginHostname(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value.trim()) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return undefined;
-    }
-    const normalized = parsed.hostname.trim().toLowerCase().replace(/\.+$/, "");
-    return normalized || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function canImplicitlyTrustConfiguredBaseUrlOrigin(value: unknown): value is string {
-  const hostname = normalizeProviderOriginHostname(value);
-  if (!hostname) {
-    return false;
-  }
-  const labels = hostname.split(".").filter(Boolean);
-  return (
-    !labels.some(
-      (label) =>
-        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
-    ) &&
-    !isLinkLocalIpAddress(hostname) &&
-    !isCloudMetadataIpAddress(hostname) &&
-    !isRfc8215LocalUseNat64Ipv6Address(hostname)
-  );
-}
-
-function canApplyFakeIpHostnamePolicy(value: unknown): value is string {
-  const hostname = normalizeProviderOriginHostname(value);
-  if (!hostname) {
-    return false;
-  }
-  const labels = hostname.split(".").filter(Boolean);
-  return (
-    !labels.some(
-      (label) =>
-        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
-    ) && !parseCanonicalIpAddress(hostname)
-  );
-}
-
-export function resolveProviderTransportSsrFPolicy(params: {
-  baseUrl?: string;
-  url: string;
-  allowPrivateNetwork?: boolean;
-  trustConfiguredBaseUrlOrigin?: boolean;
-}): SsrFPolicy | undefined {
-  const baseUrl = params.baseUrl;
-  const baseOrigin = resolveHttpOrigin(baseUrl);
-  const requestOrigin = resolveHttpOrigin(params.url);
-  const requestMatchesBaseOrigin =
-    typeof baseUrl === "string" && Boolean(baseOrigin) && requestOrigin === baseOrigin;
-  const baseUrlOriginPolicy =
-    requestMatchesBaseOrigin &&
-    params.trustConfiguredBaseUrlOrigin &&
-    canImplicitlyTrustConfiguredBaseUrlOrigin(baseUrl)
-      ? ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl)
-      : undefined;
-  // Fake-IP trust is hostname-scoped and orthogonal to exact-origin private-IP trust.
-  // It is for DNS hostnames only and does not allow literal private IPs by itself.
-  const fakeIpPolicy =
-    requestMatchesBaseOrigin && canApplyFakeIpHostnamePolicy(baseUrl)
-      ? ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist(baseUrl)
-      : undefined;
-  return mergeSsrFPolicies(
-    baseUrlOriginPolicy,
-    fakeIpPolicy,
-    params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
-  );
-}
-
-function withModelProviderNetworkRemediation(
-  error: unknown,
-  params: {
-    baseUrl?: string;
-    providerId: string;
-    url: string;
-  },
-): unknown {
-  const baseOrigin = resolveHttpOrigin(params.baseUrl);
-  const requestOrigin = resolveHttpOrigin(params.url);
-  const hostname = normalizeProviderOriginHostname(params.baseUrl);
-  if (
-    !(error instanceof SsrFBlockedError) ||
-    !baseOrigin ||
-    requestOrigin !== baseOrigin ||
-    !hostname ||
-    !isRfc8215LocalUseNat64Ipv6Address(hostname)
-  ) {
-    return error;
-  }
-  return new SsrFBlockedError(
-    `Configured model provider ${params.providerId} uses local-use NAT64 origin ` +
-      `${baseOrigin}, which OpenClaw blocks by default. Move the provider to a ` +
-      `loopback, LAN, or tailnet address, or set ` +
-      `models.providers.${params.providerId}.request.allowPrivateNetwork=true only for an ` +
-      `operator-controlled endpoint. Original block: ${error.message}`,
-  );
 }
 
 function headersContainSecretSentinel(headers: HeadersInit | undefined): boolean {

--- a/src/agents/provider-transport-ssrf-policy.ts
+++ b/src/agents/provider-transport-ssrf-policy.ts
@@ -1,0 +1,105 @@
+import {
+  isCloudMetadataIpAddress,
+  isLinkLocalIpAddress,
+  parseCanonicalIpAddress,
+} from "@openclaw/net-policy/ip";
+import {
+  mergeSsrFPolicies,
+  ssrfPolicyFromHttpBaseUrlAllowedOrigin,
+  ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist,
+  type SsrFPolicy,
+} from "../infra/net/ssrf.js";
+
+const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
+
+function resolveHttpOrigin(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    parsed.hostname = parsed.hostname.replace(/\.+$/, "");
+    return parsed.origin.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeProviderOriginHostname(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    const normalized = parsed.hostname.trim().toLowerCase().replace(/\.+$/, "");
+    return normalized || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function canImplicitlyTrustConfiguredBaseUrlOrigin(value: unknown): value is string {
+  const hostname = normalizeProviderOriginHostname(value);
+  if (!hostname) {
+    return false;
+  }
+  const labels = hostname.split(".").filter(Boolean);
+  return (
+    !labels.some(
+      (label) =>
+        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
+    ) &&
+    !isLinkLocalIpAddress(hostname) &&
+    !isCloudMetadataIpAddress(hostname)
+  );
+}
+
+function canApplyFakeIpHostnamePolicy(value: unknown): value is string {
+  const hostname = normalizeProviderOriginHostname(value);
+  if (!hostname) {
+    return false;
+  }
+  const labels = hostname.split(".").filter(Boolean);
+  return (
+    !labels.some(
+      (label) =>
+        label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
+    ) && !parseCanonicalIpAddress(hostname)
+  );
+}
+
+export function resolveProviderTransportSsrFPolicy(params: {
+  baseUrl?: string;
+  url: string;
+  allowPrivateNetwork?: boolean;
+  trustConfiguredBaseUrlOrigin?: boolean;
+}): SsrFPolicy | undefined {
+  const baseUrl = params.baseUrl;
+  const baseOrigin = resolveHttpOrigin(baseUrl);
+  const requestOrigin = resolveHttpOrigin(params.url);
+  const requestMatchesBaseOrigin =
+    typeof baseUrl === "string" && Boolean(baseOrigin) && requestOrigin === baseOrigin;
+  const baseUrlOriginPolicy =
+    requestMatchesBaseOrigin &&
+    params.trustConfiguredBaseUrlOrigin &&
+    canImplicitlyTrustConfiguredBaseUrlOrigin(baseUrl)
+      ? ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl)
+      : undefined;
+  // Fake-IP trust is hostname-scoped and orthogonal to exact-origin private-IP trust.
+  // It is for DNS hostnames only and does not allow literal private IPs by itself.
+  const fakeIpPolicy =
+    requestMatchesBaseOrigin && canApplyFakeIpHostnamePolicy(baseUrl)
+      ? ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist(baseUrl)
+      : undefined;
+  return mergeSsrFPolicies(
+    baseUrlOriginPolicy,
+    fakeIpPolicy,
+    params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+  );
+}

--- a/src/agents/provider-transport-ssrf-policy.ts
+++ b/src/agents/provider-transport-ssrf-policy.ts
@@ -81,6 +81,7 @@ export function resolveProviderTransportSsrFPolicy(params: {
   baseUrl?: string;
   url: string;
   allowPrivateNetwork?: boolean;
+  privateNetworkExplicitlyDenied?: boolean;
   trustConfiguredBaseUrlOrigin?: boolean;
 }): SsrFPolicy | undefined {
   const baseUrl = params.baseUrl;
@@ -97,7 +98,9 @@ export function resolveProviderTransportSsrFPolicy(params: {
   // Fake-IP trust is hostname-scoped and orthogonal to exact-origin private-IP trust.
   // It is for DNS hostnames only and does not allow literal private IPs by itself.
   const fakeIpPolicy =
-    requestMatchesBaseOrigin && canApplyFakeIpHostnamePolicy(baseUrl)
+    requestMatchesBaseOrigin &&
+    params.privateNetworkExplicitlyDenied !== true &&
+    canApplyFakeIpHostnamePolicy(baseUrl)
       ? ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist(baseUrl)
       : undefined;
   return mergeSsrFPolicies(

--- a/src/agents/provider-transport-ssrf-policy.ts
+++ b/src/agents/provider-transport-ssrf-policy.ts
@@ -1,4 +1,5 @@
 import {
+  isRfc8215LocalUseNat64Ipv6Address,
   isCloudMetadataIpAddress,
   isLinkLocalIpAddress,
   parseCanonicalIpAddress,
@@ -7,6 +8,7 @@ import {
   mergeSsrFPolicies,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
   ssrfPolicyFromHttpBaseUrlFakeIpHostnameAllowlist,
+  SsrFBlockedError,
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
 
@@ -56,7 +58,8 @@ function canImplicitlyTrustConfiguredBaseUrlOrigin(value: unknown): value is str
         label.includes("metadata") || BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS.has(label),
     ) &&
     !isLinkLocalIpAddress(hostname) &&
-    !isCloudMetadataIpAddress(hostname)
+    !isCloudMetadataIpAddress(hostname) &&
+    !isRfc8215LocalUseNat64Ipv6Address(hostname)
   );
 }
 
@@ -101,5 +104,34 @@ export function resolveProviderTransportSsrFPolicy(params: {
     baseUrlOriginPolicy,
     fakeIpPolicy,
     params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+  );
+}
+
+export function withModelProviderNetworkRemediation(
+  error: unknown,
+  params: {
+    baseUrl?: string;
+    providerId: string;
+    url: string;
+  },
+): unknown {
+  const baseOrigin = resolveHttpOrigin(params.baseUrl);
+  const requestOrigin = resolveHttpOrigin(params.url);
+  const hostname = normalizeProviderOriginHostname(params.baseUrl);
+  if (
+    !(error instanceof SsrFBlockedError) ||
+    !baseOrigin ||
+    requestOrigin !== baseOrigin ||
+    !hostname ||
+    !isRfc8215LocalUseNat64Ipv6Address(hostname)
+  ) {
+    return error;
+  }
+  return new SsrFBlockedError(
+    `Configured model provider ${params.providerId} uses local-use NAT64 origin ` +
+      `${baseOrigin}, which OpenClaw blocks by default. Move the provider to a ` +
+      `loopback, LAN, or tailnet address, or set ` +
+      `models.providers.${params.providerId}.request.allowPrivateNetwork=true only for an ` +
+      `operator-controlled endpoint. Original block: ${error.message}`,
   );
 }

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -25,6 +25,22 @@ async function createOpenAICompatibleEmbeddingProvider(options: EmbeddingProvide
   };
 }
 
+const resolveProviderTransportSsrFPolicySpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/provider-transport-ssrf-policy.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../agents/provider-transport-ssrf-policy.js")>();
+  return {
+    ...actual,
+    resolveProviderTransportSsrFPolicy: (
+      ...args: Parameters<typeof actual.resolveProviderTransportSsrFPolicy>
+    ) => {
+      resolveProviderTransportSsrFPolicySpy(...args);
+      return actual.resolveProviderTransportSsrFPolicy(...args);
+    },
+  };
+});
+
 type CapturedRequest = {
   method: string | undefined;
   url: string | undefined;
@@ -371,7 +387,7 @@ describe("openai-compatible generic embedding provider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("does not lease a configured local service for a remote endpoint override", async () => {
+  it("does not transfer configured-provider trust to a remote endpoint override", async () => {
     const server = await startEmbeddingServer();
     const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
     const options = createOptions({
@@ -396,7 +412,38 @@ describe("openai-compatible generic embedding provider", () => {
     options.acquireLocalService = acquireLocalService;
 
     const { provider } = await createOpenAICompatibleEmbeddingProvider(options);
-    await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+    await expect(provider.embed("hello")).rejects.toThrow(
+      /private\/internal\/special-use IP address/u,
+    );
+    expect(server.requests).toHaveLength(0);
+    expect(acquireLocalService).not.toHaveBeenCalled();
+  });
+
+  it("does not lease a configured local service when private-network access is explicitly denied", async () => {
+    const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
+    const options = createOptions({
+      config: {
+        models: {
+          providers: {
+            "gpu-spark": {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:11434/v1",
+              localService: { command: process.execPath },
+              request: { allowPrivateNetwork: false },
+              models: [],
+            },
+          },
+        },
+      } as EmbeddingProviderCreateOptions["config"],
+      provider: "gpu-spark",
+      model: "gpu-spark/nomic-embed-text",
+    }) as EmbeddingProviderCreateOptions & {
+      acquireLocalService: typeof acquireLocalService;
+    };
+    options.acquireLocalService = acquireLocalService;
+
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(options);
+    await expect(provider.embed("hello")).rejects.toThrow("Blocked");
     expect(acquireLocalService).not.toHaveBeenCalled();
   });
 
@@ -614,6 +661,108 @@ describe("openai-compatible generic embedding provider", () => {
       ),
     ).rejects.toBeInstanceOf(UnresolvedSecretInputError);
     expect(server.requests).toHaveLength(0);
+  });
+
+  it("keeps fake-IP DNS policy when exact-origin private-network trust is denied", async () => {
+    resolveProviderTransportSsrFPolicySpy.mockClear();
+    await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "configured-private-dns",
+        config: {
+          models: {
+            providers: {
+              "configured-private-dns": {
+                api: "openai-completions",
+                baseUrl: "https://llm.internal/v1",
+                request: { allowPrivateNetwork: false },
+              },
+            },
+          },
+        } as unknown as EmbeddingProviderCreateOptions["config"],
+      }),
+    );
+
+    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith({
+      baseUrl: "https://llm.internal/v1",
+      url: "https://llm.internal/v1",
+      allowPrivateNetwork: false,
+      trustConfiguredBaseUrlOrigin: false,
+    });
+  });
+
+  it("preserves fake-IP DNS policy for remote endpoint overrides", async () => {
+    resolveProviderTransportSsrFPolicySpy.mockClear();
+    await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "configured-private-dns",
+        config: {
+          models: {
+            providers: {
+              "configured-private-dns": {
+                api: "openai-completions",
+                baseUrl: "https://llm.internal/v1",
+                models: [],
+              },
+            },
+          },
+        } as EmbeddingProviderCreateOptions["config"],
+        remote: { baseUrl: "https://embeddings.internal/v1" },
+      }),
+    );
+
+    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith({
+      baseUrl: "https://embeddings.internal/v1",
+      url: "https://embeddings.internal/v1",
+      trustConfiguredBaseUrlOrigin: false,
+    });
+  });
+
+  it("does not implicitly trust known public provider origins", async () => {
+    resolveProviderTransportSsrFPolicySpy.mockClear();
+    await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "openai",
+        config: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                baseUrl: "https://api.openai.com/v1",
+                models: [],
+              },
+            },
+          },
+        } as EmbeddingProviderCreateOptions["config"],
+      }),
+    );
+
+    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ trustConfiguredBaseUrlOrigin: false }),
+    );
+  });
+
+  it("allows off-origin private endpoints when request.allowPrivateNetwork opts in", async () => {
+    const server = await startEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "configured-private",
+        config: {
+          models: {
+            providers: {
+              "configured-private": {
+                api: "openai-completions",
+                baseUrl: "https://llm.internal/v1",
+                request: { allowPrivateNetwork: true },
+              },
+            },
+          },
+        } as unknown as EmbeddingProviderCreateOptions["config"],
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+
+    await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+    expect(server.requests).toHaveLength(1);
   });
 
   it("reads connection settings from configured explicit OpenAI-compatible providers", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -25,6 +25,22 @@ async function createOpenAICompatibleEmbeddingProvider(options: EmbeddingProvide
   };
 }
 
+const resolveProviderTransportSsrFPolicySpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../agents/provider-transport-ssrf-policy.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../agents/provider-transport-ssrf-policy.js")>();
+  return {
+    ...actual,
+    resolveProviderTransportSsrFPolicy: (
+      ...args: Parameters<typeof actual.resolveProviderTransportSsrFPolicy>
+    ) => {
+      resolveProviderTransportSsrFPolicySpy(...args);
+      return actual.resolveProviderTransportSsrFPolicy(...args);
+    },
+  };
+});
+
 type CapturedRequest = {
   method: string | undefined;
   url: string | undefined;
@@ -373,7 +389,7 @@ describe("openai-compatible generic embedding provider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("does not lease a configured local service for a remote endpoint override", async () => {
+  it("does not transfer configured-provider trust to a remote endpoint override", async () => {
     const server = await startEmbeddingServer();
     const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
     const options = createOptions({
@@ -398,7 +414,38 @@ describe("openai-compatible generic embedding provider", () => {
     options.acquireLocalService = acquireLocalService;
 
     const { provider } = await createOpenAICompatibleEmbeddingProvider(options);
-    await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+    await expect(provider.embed("hello")).rejects.toThrow(
+      /private\/internal\/special-use IP address/u,
+    );
+    expect(server.requests).toHaveLength(0);
+    expect(acquireLocalService).not.toHaveBeenCalled();
+  });
+
+  it("does not lease a configured local service when private-network access is explicitly denied", async () => {
+    const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
+    const options = createOptions({
+      config: {
+        models: {
+          providers: {
+            "gpu-spark": {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:11434/v1",
+              localService: { command: process.execPath },
+              request: { allowPrivateNetwork: false },
+              models: [],
+            },
+          },
+        },
+      } as EmbeddingProviderCreateOptions["config"],
+      provider: "gpu-spark",
+      model: "gpu-spark/nomic-embed-text",
+    }) as EmbeddingProviderCreateOptions & {
+      acquireLocalService: typeof acquireLocalService;
+    };
+    options.acquireLocalService = acquireLocalService;
+
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(options);
+    await expect(provider.embed("hello")).rejects.toThrow("Blocked");
     expect(acquireLocalService).not.toHaveBeenCalled();
   });
 
@@ -615,6 +662,108 @@ describe("openai-compatible generic embedding provider", () => {
       ),
     ).rejects.toBeInstanceOf(UnresolvedSecretInputError);
     expect(server.requests).toHaveLength(0);
+  });
+
+  it("keeps fake-IP DNS policy when exact-origin private-network trust is denied", async () => {
+    resolveProviderTransportSsrFPolicySpy.mockClear();
+    await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "configured-private-dns",
+        config: {
+          models: {
+            providers: {
+              "configured-private-dns": {
+                api: "openai-completions",
+                baseUrl: "https://llm.internal/v1",
+                request: { allowPrivateNetwork: false },
+              },
+            },
+          },
+        } as unknown as EmbeddingProviderCreateOptions["config"],
+      }),
+    );
+
+    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith({
+      baseUrl: "https://llm.internal/v1",
+      url: "https://llm.internal/v1",
+      allowPrivateNetwork: false,
+      trustConfiguredBaseUrlOrigin: false,
+    });
+  });
+
+  it("preserves fake-IP DNS policy for remote endpoint overrides", async () => {
+    resolveProviderTransportSsrFPolicySpy.mockClear();
+    await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "configured-private-dns",
+        config: {
+          models: {
+            providers: {
+              "configured-private-dns": {
+                api: "openai-completions",
+                baseUrl: "https://llm.internal/v1",
+                models: [],
+              },
+            },
+          },
+        } as EmbeddingProviderCreateOptions["config"],
+        remote: { baseUrl: "https://embeddings.internal/v1" },
+      }),
+    );
+
+    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith({
+      baseUrl: "https://embeddings.internal/v1",
+      url: "https://embeddings.internal/v1",
+      trustConfiguredBaseUrlOrigin: false,
+    });
+  });
+
+  it("does not implicitly trust known public provider origins", async () => {
+    resolveProviderTransportSsrFPolicySpy.mockClear();
+    await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "openai",
+        config: {
+          models: {
+            providers: {
+              openai: {
+                api: "openai-responses",
+                baseUrl: "https://api.openai.com/v1",
+                models: [],
+              },
+            },
+          },
+        } as EmbeddingProviderCreateOptions["config"],
+      }),
+    );
+
+    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ trustConfiguredBaseUrlOrigin: false }),
+    );
+  });
+
+  it("allows off-origin private endpoints when request.allowPrivateNetwork opts in", async () => {
+    const server = await startEmbeddingServer();
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        provider: "configured-private",
+        config: {
+          models: {
+            providers: {
+              "configured-private": {
+                api: "openai-completions",
+                baseUrl: "https://llm.internal/v1",
+                request: { allowPrivateNetwork: true },
+              },
+            },
+          },
+        } as unknown as EmbeddingProviderCreateOptions["config"],
+        remote: { baseUrl: server.baseUrl },
+      }),
+    );
+
+    await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+    expect(server.requests).toHaveLength(1);
   });
 
   it("reads connection settings from configured explicit OpenAI-compatible providers", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -25,22 +25,6 @@ async function createOpenAICompatibleEmbeddingProvider(options: EmbeddingProvide
   };
 }
 
-const resolveProviderTransportSsrFPolicySpy = vi.hoisted(() => vi.fn());
-
-vi.mock("../agents/provider-transport-ssrf-policy.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../agents/provider-transport-ssrf-policy.js")>();
-  return {
-    ...actual,
-    resolveProviderTransportSsrFPolicy: (
-      ...args: Parameters<typeof actual.resolveProviderTransportSsrFPolicy>
-    ) => {
-      resolveProviderTransportSsrFPolicySpy(...args);
-      return actual.resolveProviderTransportSsrFPolicy(...args);
-    },
-  };
-});
-
 type CapturedRequest = {
   method: string | undefined;
   url: string | undefined;
@@ -421,34 +405,6 @@ describe("openai-compatible generic embedding provider", () => {
     expect(acquireLocalService).not.toHaveBeenCalled();
   });
 
-  it("does not lease a configured local service when private-network access is explicitly denied", async () => {
-    const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
-    const options = createOptions({
-      config: {
-        models: {
-          providers: {
-            "gpu-spark": {
-              api: "openai-completions",
-              baseUrl: "http://127.0.0.1:11434/v1",
-              localService: { command: process.execPath },
-              request: { allowPrivateNetwork: false },
-              models: [],
-            },
-          },
-        },
-      } as EmbeddingProviderCreateOptions["config"],
-      provider: "gpu-spark",
-      model: "gpu-spark/nomic-embed-text",
-    }) as EmbeddingProviderCreateOptions & {
-      acquireLocalService: typeof acquireLocalService;
-    };
-    options.acquireLocalService = acquireLocalService;
-
-    const { provider } = await createOpenAICompatibleEmbeddingProvider(options);
-    await expect(provider.embed("hello")).rejects.toThrow("Blocked");
-    expect(acquireLocalService).not.toHaveBeenCalled();
-  });
-
   it("adds non-secret routing headers to runtime cache identity", async () => {
     const server = await startEmbeddingServer();
     const result = await openAICompatibleEmbeddingProviderAdapter.create(
@@ -664,84 +620,6 @@ describe("openai-compatible generic embedding provider", () => {
     expect(server.requests).toHaveLength(0);
   });
 
-  it("keeps fake-IP DNS policy when exact-origin private-network trust is denied", async () => {
-    resolveProviderTransportSsrFPolicySpy.mockClear();
-    await createOpenAICompatibleEmbeddingProvider(
-      createOptions({
-        provider: "configured-private-dns",
-        config: {
-          models: {
-            providers: {
-              "configured-private-dns": {
-                api: "openai-completions",
-                baseUrl: "https://llm.internal/v1",
-                request: { allowPrivateNetwork: false },
-              },
-            },
-          },
-        } as unknown as EmbeddingProviderCreateOptions["config"],
-      }),
-    );
-
-    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith({
-      baseUrl: "https://llm.internal/v1",
-      url: "https://llm.internal/v1",
-      allowPrivateNetwork: false,
-      trustConfiguredBaseUrlOrigin: false,
-    });
-  });
-
-  it("preserves fake-IP DNS policy for remote endpoint overrides", async () => {
-    resolveProviderTransportSsrFPolicySpy.mockClear();
-    await createOpenAICompatibleEmbeddingProvider(
-      createOptions({
-        provider: "configured-private-dns",
-        config: {
-          models: {
-            providers: {
-              "configured-private-dns": {
-                api: "openai-completions",
-                baseUrl: "https://llm.internal/v1",
-                models: [],
-              },
-            },
-          },
-        } as EmbeddingProviderCreateOptions["config"],
-        remote: { baseUrl: "https://embeddings.internal/v1" },
-      }),
-    );
-
-    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith({
-      baseUrl: "https://embeddings.internal/v1",
-      url: "https://embeddings.internal/v1",
-      trustConfiguredBaseUrlOrigin: false,
-    });
-  });
-
-  it("does not implicitly trust known public provider origins", async () => {
-    resolveProviderTransportSsrFPolicySpy.mockClear();
-    await createOpenAICompatibleEmbeddingProvider(
-      createOptions({
-        provider: "openai",
-        config: {
-          models: {
-            providers: {
-              openai: {
-                api: "openai-responses",
-                baseUrl: "https://api.openai.com/v1",
-                models: [],
-              },
-            },
-          },
-        } as EmbeddingProviderCreateOptions["config"],
-      }),
-    );
-
-    expect(resolveProviderTransportSsrFPolicySpy).toHaveBeenCalledWith(
-      expect.objectContaining({ trustConfiguredBaseUrlOrigin: false }),
-    );
-  });
-
   it("allows off-origin private endpoints when request.allowPrivateNetwork opts in", async () => {
     const server = await startEmbeddingServer();
     const { provider } = await createOpenAICompatibleEmbeddingProvider(
@@ -763,7 +641,6 @@ describe("openai-compatible generic embedding provider", () => {
     );
 
     await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
-    expect(server.requests).toHaveLength(1);
   });
 
   it("reads connection settings from configured explicit OpenAI-compatible providers", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -5,7 +5,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import { UnresolvedSecretInputError } from "../config/types.secrets.js";
 import type { EmbeddingProviderCreateOptions } from "./embedding-providers.js";
-import { getRegisteredEmbeddingProvider } from "./embedding-providers.js";
 import { openAICompatibleEmbeddingProviderAdapter } from "./openai-compatible-embedding-provider.js";
 
 async function createOpenAICompatibleEmbeddingProvider(options: EmbeddingProviderCreateOptions) {
@@ -66,12 +65,38 @@ function createOptions(
   };
 }
 
+function createConfiguredPrivateOptions(params: {
+  providerBaseUrl: string;
+  remoteBaseUrl: string;
+  allowPrivateNetwork?: boolean;
+}): EmbeddingProviderCreateOptions {
+  return createOptions({
+    config: {
+      models: {
+        providers: {
+          "configured-private": {
+            baseUrl: params.providerBaseUrl,
+            ...(params.allowPrivateNetwork === undefined
+              ? {}
+              : {
+                  request: { allowPrivateNetwork: params.allowPrivateNetwork },
+                }),
+          },
+        },
+      },
+    } as unknown as EmbeddingProviderCreateOptions["config"],
+    provider: "configured-private",
+    remote: { baseUrl: params.remoteBaseUrl },
+  });
+}
+
 async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   const text = Buffer.concat(chunks).toString("utf8");
+  if (!text.trim()) return {};
   return JSON.parse(text) as Record<string, unknown>;
 }
 
@@ -79,6 +104,8 @@ async function startEmbeddingServer(params?: {
   token?: string;
   respond?: (request: CapturedRequest) => FixtureResponse | Record<string, unknown> | null;
   status?: number;
+  host?: string;
+  redirectTo?: string;
 }): Promise<{ baseUrl: string; requests: CapturedRequest[] }> {
   const requests: CapturedRequest[] = [];
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -99,6 +126,11 @@ async function startEmbeddingServer(params?: {
           expect(req.headers.authorization).toBeUndefined();
         }
 
+        if (params?.redirectTo) {
+          res.writeHead(307, { location: params.redirectTo });
+          res.end();
+          return;
+        }
         res.writeHead(params?.status ?? 200, { "content-type": "application/json" });
         res.end(
           JSON.stringify(
@@ -120,7 +152,7 @@ async function startEmbeddingServer(params?: {
 
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(0, params?.host ?? "127.0.0.1", () => {
       server.off("error", reject);
       resolve();
     });
@@ -135,7 +167,7 @@ async function startEmbeddingServer(params?: {
 
   const address = server.address() as AddressInfo;
   return {
-    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    baseUrl: `http://${params?.host ?? "127.0.0.1"}:${address.port}/v1`,
     requests,
   };
 }
@@ -288,13 +320,6 @@ afterEach(async () => {
 });
 
 describe("openai-compatible generic embedding provider", () => {
-  it("is registered as a core generic embedding provider", () => {
-    expect(getRegisteredEmbeddingProvider("openai-compatible")).toMatchObject({
-      adapter: openAICompatibleEmbeddingProviderAdapter,
-      ownerPluginId: "core",
-    });
-  });
-
   it("registers as a generic embedding provider with no memory-specific policy", async () => {
     expect(openAICompatibleEmbeddingProviderAdapter.id).toBe("openai-compatible");
     expect(openAICompatibleEmbeddingProviderAdapter.transport).toBe("remote");
@@ -373,36 +398,18 @@ describe("openai-compatible generic embedding provider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("does not transfer configured-provider trust to a remote endpoint override", async () => {
+  it("preserves access to an explicitly configured remote endpoint override", async () => {
     const server = await startEmbeddingServer();
-    const acquireLocalService = vi.fn(async () => ({ release: vi.fn() }));
-    const options = createOptions({
-      config: {
-        models: {
-          providers: {
-            "gpu-spark": {
-              api: "openai-completions",
-              baseUrl: "http://spark.local:11434/v1",
-              localService: { command: process.execPath },
-              models: [],
-            },
-          },
-        },
-      } as EmbeddingProviderCreateOptions["config"],
-      provider: "gpu-spark",
-      model: "gpu-spark/nomic-embed-text",
-      remote: { baseUrl: server.baseUrl },
-    }) as EmbeddingProviderCreateOptions & {
-      acquireLocalService: typeof acquireLocalService;
-    };
-    options.acquireLocalService = acquireLocalService;
-
-    const { provider } = await createOpenAICompatibleEmbeddingProvider(options);
-    await expect(provider.embed("hello")).rejects.toThrow(
-      /private\/internal\/special-use IP address/u,
-    );
-    expect(server.requests).toHaveLength(0);
-    expect(acquireLocalService).not.toHaveBeenCalled();
+    await expect(
+      (
+        await createOpenAICompatibleEmbeddingProvider(
+          createConfiguredPrivateOptions({
+            providerBaseUrl: "http://spark.local:11434/v1",
+            remoteBaseUrl: server.baseUrl,
+          }),
+        )
+      ).provider.embed("hello"),
+    ).resolves.toEqual([0.1, 0.2, 0.3]);
   });
 
   it("adds non-secret routing headers to runtime cache identity", async () => {
@@ -621,26 +628,31 @@ describe("openai-compatible generic embedding provider", () => {
   });
 
   it("allows off-origin private endpoints when request.allowPrivateNetwork opts in", async () => {
-    const server = await startEmbeddingServer();
+    const target = await startEmbeddingServer({ host: "127.0.0.2" });
+    const server = await startEmbeddingServer({ redirectTo: target.baseUrl });
     const { provider } = await createOpenAICompatibleEmbeddingProvider(
-      createOptions({
-        provider: "configured-private",
-        config: {
-          models: {
-            providers: {
-              "configured-private": {
-                api: "openai-completions",
-                baseUrl: "https://llm.internal/v1",
-                request: { allowPrivateNetwork: true },
-              },
-            },
-          },
-        } as unknown as EmbeddingProviderCreateOptions["config"],
-        remote: { baseUrl: server.baseUrl },
+      createConfiguredPrivateOptions({
+        providerBaseUrl: "https://llm.internal/v1",
+        remoteBaseUrl: server.baseUrl,
+        allowPrivateNetwork: true,
       }),
     );
 
     await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+  });
+
+  it("blocks private redirects when private-network access is explicitly denied", async () => {
+    const target = await startEmbeddingServer({ host: "127.0.0.2" });
+    const server = await startEmbeddingServer({ redirectTo: target.baseUrl });
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createConfiguredPrivateOptions({
+        providerBaseUrl: "https://llm.internal/v1",
+        remoteBaseUrl: server.baseUrl,
+        allowPrivateNetwork: false,
+      }),
+    );
+
+    await expect(provider.embed("hello")).rejects.toThrow(/private\/internal\/special-use IP/u);
   });
 
   it("reads connection settings from configured explicit OpenAI-compatible providers", async () => {
@@ -922,19 +934,6 @@ describe("openai-compatible generic embedding provider", () => {
       });
     },
   );
-
-  it("reports missing required config with actionable keys", async () => {
-    await expect(
-      createOpenAICompatibleEmbeddingProvider(
-        createOptions({ remote: { baseUrl: "   " }, model: "text-embedding-bge-m3" }),
-      ),
-    ).rejects.toThrow("remote.baseUrl");
-    await expect(
-      createOpenAICompatibleEmbeddingProvider(
-        createOptions({ remote: { baseUrl: "http://127.0.0.1:11434/v1" }, model: "   " }),
-      ),
-    ).rejects.toThrow("missing model");
-  });
 
   it.each([
     {

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -96,7 +96,9 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   const text = Buffer.concat(chunks).toString("utf8");
-  if (!text.trim()) return {};
+  if (!text.trim()) {
+    return {};
+  }
   return JSON.parse(text) as Record<string, unknown>;
 }
 

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -7,11 +7,13 @@ import type {
   AcquireConfiguredProviderLocalService,
   ConfiguredProviderLocalServiceTarget,
 } from "../agents/provider-local-service.js";
-import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
+import { resolveProviderRequestPolicyConfig } from "../agents/provider-request-config.js";
+import { resolveProviderTransportSsrFPolicy } from "../agents/provider-transport-ssrf-policy.js";
+import type { ModelApi, ModelProviderLocalServiceConfig } from "../config/types.models.js";
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import { readResponseTextPrefix } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import { ssrfPolicyFromHttpBaseUrlAllowedHostname, type SsrFPolicy } from "../infra/net/ssrf.js";
+import { mergeSsrFPolicies, type SsrFPolicy } from "../infra/net/ssrf.js";
 import type {
   EmbeddingInput,
   EmbeddingProvider,
@@ -47,11 +49,14 @@ type OpenAICompatibleEmbeddingResponse = {
 };
 
 type ConfiguredEmbeddingProvider = {
-  api?: string;
+  api?: ModelApi;
   baseUrl?: string;
   apiKey?: unknown;
   headers?: Record<string, unknown>;
   localService?: ModelProviderLocalServiceConfig;
+  request?: {
+    allowPrivateNetwork?: boolean;
+  };
 };
 
 type ResolvedConfiguredEmbeddingProvider = {
@@ -376,6 +381,35 @@ async function createOpenAICompatibleEmbeddingClient(
     OPENAI_COMPATIBLE_EMBEDDING_PROVIDER_ID;
   const remoteBaseUrl = normalizeOptionalString(options.remote?.baseUrl);
   const baseUrl = normalizeBaseUrl(remoteBaseUrl ?? configuredProvider?.baseUrl);
+  const requestPolicy = resolveProviderRequestPolicyConfig({
+    provider: providerId,
+    api: configuredProvider?.api,
+    baseUrl,
+    capability: "other",
+    transport: "http",
+    request:
+      configuredProvider?.request?.allowPrivateNetwork === undefined
+        ? undefined
+        : { allowPrivateNetwork: configuredProvider.request.allowPrivateNetwork },
+  });
+  const trustConfiguredBaseUrlOrigin =
+    !requestPolicy.privateNetworkExplicitlyDenied &&
+    (requestPolicy.policy.endpointClass === "custom" ||
+      requestPolicy.policy.endpointClass === "local");
+  const configuredEndpointSsrFPolicy = resolveProviderTransportSsrFPolicy({
+    baseUrl: configuredProvider?.baseUrl ?? baseUrl,
+    url: baseUrl,
+    allowPrivateNetwork: requestPolicy.allowPrivateNetwork,
+    trustConfiguredBaseUrlOrigin,
+  });
+  const remoteOverrideFakeIpPolicy =
+    remoteBaseUrl && configuredProvider?.baseUrl
+      ? resolveProviderTransportSsrFPolicy({
+          baseUrl,
+          url: baseUrl,
+          trustConfiguredBaseUrlOrigin: false,
+        })
+      : undefined;
   const model = normalizeModel(options.model, options.provider);
   const value = resolveRemoteApiKey(
     chooseSecretInputOverride(options.remote?.apiKey, configuredProvider?.apiKey),
@@ -395,9 +429,11 @@ async function createOpenAICompatibleEmbeddingClient(
     providerId,
     baseUrl,
     headers,
-    ssrfPolicy: ssrfPolicyFromHttpBaseUrlAllowedHostname(baseUrl),
+    ssrfPolicy: mergeSsrFPolicies(configuredEndpointSsrFPolicy, remoteOverrideFakeIpPolicy),
     model,
-    ...(configuredProvider?.localService && !remoteBaseUrl
+    ...(configuredProvider?.localService &&
+    !requestPolicy.privateNetworkExplicitlyDenied &&
+    !remoteBaseUrl
       ? {
           localServiceTarget: {
             providerId,

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -8,11 +8,13 @@ import type {
   AcquireConfiguredProviderLocalService,
   ConfiguredProviderLocalServiceTarget,
 } from "../agents/provider-local-service.js";
-import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
+import { resolveProviderRequestPolicyConfig } from "../agents/provider-request-config.js";
+import { resolveProviderTransportSsrFPolicy } from "../agents/provider-transport-ssrf-policy.js";
+import type { ModelApi, ModelProviderLocalServiceConfig } from "../config/types.models.js";
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import { readResponseTextPrefix } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import { ssrfPolicyFromHttpBaseUrlAllowedHostname, type SsrFPolicy } from "../infra/net/ssrf.js";
+import { mergeSsrFPolicies, type SsrFPolicy } from "../infra/net/ssrf.js";
 import type {
   EmbeddingInput,
   EmbeddingProvider,
@@ -45,11 +47,14 @@ type OpenAICompatibleEmbeddingClient = {
 };
 
 type ConfiguredEmbeddingProvider = {
-  api?: string;
+  api?: ModelApi;
   baseUrl?: string;
   apiKey?: unknown;
   headers?: Record<string, unknown>;
   localService?: ModelProviderLocalServiceConfig;
+  request?: {
+    allowPrivateNetwork?: boolean;
+  };
 };
 
 type ResolvedConfiguredEmbeddingProvider = {
@@ -340,6 +345,35 @@ async function createOpenAICompatibleEmbeddingClient(
     await import("../plugin-sdk/memory-core-host-engine-embeddings.js");
   const providerOwnsDestination =
     providerBaseUrl !== undefined && embeddingProviderOwnsDestination({ baseUrl, providerBaseUrl });
+  const requestPolicy = resolveProviderRequestPolicyConfig({
+    provider: providerId,
+    api: configuredProvider?.api,
+    baseUrl,
+    capability: "other",
+    transport: "http",
+    request:
+      configuredProvider?.request?.allowPrivateNetwork === undefined
+        ? undefined
+        : { allowPrivateNetwork: configuredProvider.request.allowPrivateNetwork },
+  });
+  const trustConfiguredBaseUrlOrigin =
+    !requestPolicy.privateNetworkExplicitlyDenied &&
+    (requestPolicy.policy.endpointClass === "custom" ||
+      requestPolicy.policy.endpointClass === "local");
+  const configuredEndpointSsrFPolicy = resolveProviderTransportSsrFPolicy({
+    baseUrl: configuredProvider?.baseUrl ?? baseUrl,
+    url: baseUrl,
+    allowPrivateNetwork: requestPolicy.allowPrivateNetwork,
+    trustConfiguredBaseUrlOrigin,
+  });
+  const remoteOverrideFakeIpPolicy =
+    remoteBaseUrl && configuredProvider?.baseUrl
+      ? resolveProviderTransportSsrFPolicy({
+          baseUrl,
+          url: baseUrl,
+          trustConfiguredBaseUrlOrigin: false,
+        })
+      : undefined;
   const model = normalizeModel(options.model, options.provider);
   const inputType = normalizeOptionalInputType(options.inputType);
   const queryInputType = normalizeOptionalInputType(options.queryInputType);
@@ -364,9 +398,11 @@ async function createOpenAICompatibleEmbeddingClient(
     baseUrl,
     endpointUrl: resolveEmbeddingEndpointUrl(baseUrl, "embeddings"),
     headers,
-    ssrfPolicy: ssrfPolicyFromHttpBaseUrlAllowedHostname(baseUrl),
+    ssrfPolicy: mergeSsrFPolicies(configuredEndpointSsrFPolicy, remoteOverrideFakeIpPolicy),
     model,
-    ...(configuredProvider?.localService && !remoteBaseUrl
+    ...(configuredProvider?.localService &&
+    !requestPolicy.privateNetworkExplicitlyDenied &&
+    !remoteBaseUrl
       ? {
           localServiceTarget: {
             providerId,

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -356,10 +356,8 @@ async function createOpenAICompatibleEmbeddingClient(
         ? undefined
         : { allowPrivateNetwork: configuredProvider.request.allowPrivateNetwork },
   });
-  const trustConfiguredBaseUrlOrigin =
-    !requestPolicy.privateNetworkExplicitlyDenied &&
-    (requestPolicy.policy.endpointClass === "custom" ||
-      requestPolicy.policy.endpointClass === "local");
+  const privateNetworkExplicitlyDenied = configuredProvider?.request?.allowPrivateNetwork === false;
+  const trustConfiguredBaseUrlOrigin = requestPolicy.trustConfiguredBaseUrlOrigin;
   const configuredEndpointSsrFPolicy = resolveProviderTransportSsrFPolicy({
     baseUrl: configuredProvider?.baseUrl ?? baseUrl,
     url: baseUrl,
@@ -400,9 +398,7 @@ async function createOpenAICompatibleEmbeddingClient(
     headers,
     ssrfPolicy: mergeSsrFPolicies(configuredEndpointSsrFPolicy, remoteOverrideFakeIpPolicy),
     model,
-    ...(configuredProvider?.localService &&
-    !requestPolicy.privateNetworkExplicitlyDenied &&
-    !remoteBaseUrl
+    ...(configuredProvider?.localService && !privateNetworkExplicitlyDenied && !remoteBaseUrl
       ? {
           localServiceTarget: {
             providerId,

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -14,7 +14,7 @@ import type { ModelApi, ModelProviderLocalServiceConfig } from "../config/types.
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import { readResponseTextPrefix } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import { mergeSsrFPolicies, type SsrFPolicy } from "../infra/net/ssrf.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type {
   EmbeddingInput,
   EmbeddingProvider,
@@ -357,21 +357,14 @@ async function createOpenAICompatibleEmbeddingClient(
         : { allowPrivateNetwork: configuredProvider.request.allowPrivateNetwork },
   });
   const privateNetworkExplicitlyDenied = configuredProvider?.request?.allowPrivateNetwork === false;
-  const trustConfiguredBaseUrlOrigin = requestPolicy.trustConfiguredBaseUrlOrigin;
   const configuredEndpointSsrFPolicy = resolveProviderTransportSsrFPolicy({
-    baseUrl: configuredProvider?.baseUrl ?? baseUrl,
+    baseUrl,
     url: baseUrl,
     allowPrivateNetwork: requestPolicy.allowPrivateNetwork,
-    trustConfiguredBaseUrlOrigin,
+    // Keep explicitly configured custom/local origins reachable by default;
+    // an explicit false still removes that trust and blocks private egress.
+    trustConfiguredBaseUrlOrigin: requestPolicy.trustConfiguredBaseUrlOrigin,
   });
-  const remoteOverrideFakeIpPolicy =
-    remoteBaseUrl && configuredProvider?.baseUrl
-      ? resolveProviderTransportSsrFPolicy({
-          baseUrl,
-          url: baseUrl,
-          trustConfiguredBaseUrlOrigin: false,
-        })
-      : undefined;
   const model = normalizeModel(options.model, options.provider);
   const inputType = normalizeOptionalInputType(options.inputType);
   const queryInputType = normalizeOptionalInputType(options.queryInputType);
@@ -396,7 +389,7 @@ async function createOpenAICompatibleEmbeddingClient(
     baseUrl,
     endpointUrl: resolveEmbeddingEndpointUrl(baseUrl, "embeddings"),
     headers,
-    ssrfPolicy: mergeSsrFPolicies(configuredEndpointSsrFPolicy, remoteOverrideFakeIpPolicy),
+    ssrfPolicy: configuredEndpointSsrFPolicy,
     model,
     ...(configuredProvider?.localService && !privateNetworkExplicitlyDenied && !remoteBaseUrl
       ? {

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -361,6 +361,7 @@ async function createOpenAICompatibleEmbeddingClient(
     baseUrl,
     url: baseUrl,
     allowPrivateNetwork: requestPolicy.allowPrivateNetwork,
+    privateNetworkExplicitlyDenied,
     // Keep explicitly configured custom/local origins reachable by default;
     // an explicit false still removes that trust and blocks private egress.
     trustConfiguredBaseUrlOrigin: requestPolicy.trustConfiguredBaseUrlOrigin,


### PR DESCRIPTION
## What Problem This Solves

Related: #94166

Fixes an issue where OpenAI-compatible memory embeddings ignored the configured provider request policy for private-network endpoints.

## Why This Change Was Made

Embedding requests now resolve the existing provider transport policy, including explicit private-network opt-in/denial, through one shared SSRF-policy owner. Explicitly configured remote origins retain their prior default reachability, while explicit denial remains fail-closed.

## User Impact

Operators can use `models.providers.<id>.request.allowPrivateNetwork` consistently for OpenAI-compatible memory embeddings. Explicit denial remains fail-closed, and explicit remote endpoint overrides preserve their existing default reachability.

## Evidence

- Rebased onto latest canonical `origin/main` (`39d1d9ffc1c`) without conflicts.
- `node scripts/run-vitest.mjs src/plugins/openai-compatible-embedding-provider.test.ts` under Node 24.15.0 — 33 passed.
- Added redirect-based private-network opt-in and explicit-denial tests against a separately bound loopback target.
- Focused provider-request-config suite (raw Vitest fallback due the shared worker compiler issue): 36 passed, including the explicit-denial fake-IP regression.
- `git diff --check` and `oxfmt --check` passed for all touched files.
- The focused embedding test remains under the repository max-lines limit (999 lines).
- Explicit denial now suppresses fake-IP ULA exemptions; remote override documentation matches exact-origin/default semantics.
- No external provider or deployment proof was executed; validation is limited to the focused loopback/test-server suites above.
