### PR TITLE
fix(agents): preserve pending subagent completion announces

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -4526,6 +4526,44 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("preserves pending completion announce delivery without media fallback", async () => {
+    const callGateway = createGatewayMock({
+      runId: "subagent:child:ok",
+      status: "accepted",
+      acceptedAt: Date.now(),
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      sessionId: "requester-session-channel",
+      isActive: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-channel-completion-pending",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "channel completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("does not fail stale channel subagent completions only because the parent stayed private", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1495,18 +1495,6 @@ async function sendSubagentAnnounceDirectly(params: {
 
     const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
     if (directAnnounceStillPending) {
-      if (
-        params.expectsCompletionMessage &&
-        expectedMediaUrls.length === 0 &&
-        !requiresMessageToolDelivery
-      ) {
-        return {
-          delivered: false,
-          path: "direct",
-          reason: "completion_handoff_pending",
-          error: "completion agent handoff is still pending",
-        };
-      }
       return {
         delivered: true,
         path: "direct",


### PR DESCRIPTION
## Summary

Fixes #93323 by treating non-terminal direct announce responses as accepted delivery for subagent completion handoffs.

Previously `subagent-announce-delivery` mapped `accepted` / `started` / `in_flight` gateway responses to `delivered: false` for the plain completion-message branch, which let the registry retry budget exhaust and abandon the announce. The fix removes that inconsistent special case so pending direct announces return `delivered: true` consistently with the existing media completion path.

## Root cause

`sendSubagentAnnounceDirectly` already classifies gateway `accepted`, `started`, and `in_flight` as non-terminal pending states. For completion handoffs with no media and no required message-tool delivery, it nevertheless returned `completion_handoff_pending` as a failed delivery. That turned a healthy accepted gateway run into a retryable/final failure at the registry layer.

## Changes

- Remove the `completion_handoff_pending` failure branch for non-terminal direct announce responses.
- Add a regression test for pending plain completion announce delivery without media fallback.

## Real behavior proof

Behavior addressed: Subagent completion announce delivery no longer treats a non-terminal gateway response as a failed delivery when there are no media URLs and no message-tool delivery requirement.

Real environment tested: Direct AWS Crabbox on Linux, provider `aws`, lease `cbx_7b5a3efee072` (`violet-shrimp`), run `run_ee5d6664b84e`, portal https://crabbox.openclaw.ai/portal/runs/run_ee5d6664b84e. The run synced the production-only PR head `021466b57025fef7e1b7677ef9cfc945b650c750` and ran the QA Lab scenario against a real Gateway child with `provider-mode live-frontier`, `openai/gpt-5.5`, `qa-channel`, and fast mode enabled.

Exact steps or command run after this patch:

```text
node scripts/crabbox-wrapper.mjs run --provider aws --allow-env OPENAI_API_KEY --idle-timeout 90m --ttl 240m --timing-json --full-resync --artifact-glob '.artifacts/qa-e2e/pr-94349-live-proof/**' --shell -- 'set -u
RUN_DIR=.artifacts/qa-e2e/pr-94349-live-proof
rm -rf "$RUN_DIR"
mkdir -p "$RUN_DIR"
export OPENCLAW_BUILD_PRIVATE_QA=1
export OPENCLAW_ENABLE_PRIVATE_QA_CLI=1
export OPENCLAW_LOG_LEVEL=debug
export OPENCLAW_QA_REDACT_PUBLIC_METADATA=1
printf "%s\n" "021466b57025fef7e1b7677ef9cfc945b650c750" | tee "$RUN_DIR/head.txt"
printf "%s\n" "issue-93323-ci" | tee "$RUN_DIR/branch.txt"
node scripts/run-node.mjs qa suite --provider-mode live-frontier --scenario subagent-completion-direct-fallback --fast --concurrency 1 --output-dir "$RUN_DIR" 2>&1 | tee "$RUN_DIR/qa-suite.log"'
```

Evidence after fix:

```text
[qa-suite] provider start: live-frontier
[qa-suite] provider ready: live
[qa-suite] gateway start
[qa-suite] gateway ready: http://127.0.0.1:45907
[qa-suite] scenario start (1/1): subagent-completion-direct-fallback
[qa-suite] scenario pass (1/1): subagent-completion-direct-fallback
[qa-suite] run complete: passed=1 failed=0 total=1

Scenario: Subagent completion direct fallback
Step: yielded parent receives child completion through direct fallback
Details: Native subagent completed with:

`QA-SUBAGENT-DIRECT-FALLBACK-OK`

Run summary: provider=aws lease=cbx_7b5a3efee072 slug=violet-shrimp run=run_ee5d6664b84e exitCode=0 totalMs=224578
Artifact bundle: .crabbox/runs/run_ee5d6664b84e/run_ee5d6664b84e-artifacts.tgz
```

Observed result after fix: The live QA scenario ran through QA Lab, a real Gateway child, `qa-channel`, and live OpenAI frontier model routing. The parent launched a native subagent, yielded, and the requester received the child completion marker `QA-SUBAGENT-DIRECT-FALLBACK-OK` through the completion fallback path. The focused regression still covers the exact pending direct-announce branch by asserting a gateway `accepted` response now reports `delivered: true` and does not trigger direct fallback delivery for the plain completion-handoff branch.

What was not tested: Mantis Telegram proof remains unreliable for this PR, and this does not claim to close the broader delivery-loss trackers in #44925 or #52249. The live proof targets the implicated Gateway/subagent completion path for #93323.

## Additional verification

```text
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
# passed locally after final rebase

node scripts/run-vitest.mjs src/agents/subagent-announce-delivery.test.ts -- --reporter=verbose
# passed locally after final rebase

node scripts/run-vitest.mjs extensions/qa-lab/src/providers/mock-openai/server.test.ts
# passed locally while diagnosing the stale mock QA fixture; QA-lab fixture changes are intentionally left out of this PR and should be handled as follow-up testing debt.
```

## Notes

No agent transcript is included in this PR body.