### PR TITLE
fix(codex): preserve MEMORY.md in bootstrap context when memory tools available

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -117,6 +117,58 @@ describe("Codex app-server attempt context", () => {
     expect(context.memoryToolRouted).toBe(false);
   });
 
+  // FIX #94295: MEMORY.md should remain injected even when memory tools are available
+  it("keeps MEMORY.md injected when memory tools are available (FIX #94295)", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-memory-fix-workspace-"));
+    const memorySummary = "Project-specific operational facts for memory recall.";
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), memorySummary);
+
+    const context = await buildCodexWorkspaceBootstrapContext({
+      params: {
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        config: {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+            },
+          },
+        },
+      } as EmbeddedRunAttemptParams,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sessionKey: "agent:main:session-1",
+      sessionAgentId: "main",
+      memoryToolNames: ["memory_search", "memory_get"],
+    });
+
+    // When workspaces match, memory tools can be routed
+    expect(context.memoryToolRouted).toBe(true);
+
+    // FIX #94295: MEMORY.md should still be in prompt context (not filtered out)
+    expect(context.promptContext).toContain(memorySummary);
+
+    // Verify the system prompt report shows non-zero injected chars for MEMORY.md
+    const report = buildCodexSystemPromptReport({
+      attempt: {
+        sessionId: "session-1",
+        provider: "codex",
+        modelId: "gpt-5.4-codex",
+      } as EmbeddedRunAttemptParams,
+      sessionKey: "agent:main:session-1",
+      workspaceDir,
+      developerInstructions: "test instructions",
+      workspaceBootstrapContext: context,
+      skillsPrompt: "",
+      tools: [] as CodexDynamicToolSpec[],
+    });
+
+    const memoryFile = report.injectedWorkspaceFiles.find((f) => f.name === "MEMORY.md");
+    expect(memoryFile).toBeDefined();
+    expect(memoryFile?.injectedChars).toBeGreaterThan(0);
+    expect(memoryFile?.rawChars).toBeGreaterThan(0);
+  });
+
   it("remaps Codex bootstrap files under dot-prefixed workspace directories", () => {
     expect(
       remapCodexContextFilePath({

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -174,8 +174,9 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
         agentId: params.params.agentId ?? params.sessionAgentId,
         workspaceDir: params.effectiveWorkspace,
       });
-    // Native Codex turns should read workspace MEMORY.md through tools when
-    // possible; pasting it into every prompt turns durable memory into policy.
+    // FIX #94295: MEMORY.md provides sparse long-lived bootstrap facts that agents
+    // need to know which memory queries to run. Memory tools offer deeper recall,
+    // but should not suppress root bootstrap memory that contains operational facts.
     const bootstrapFiles = await resolveBootstrapFilesForRun({
       workspaceDir: params.resolvedWorkspace,
       config: params.params.config,
@@ -199,30 +200,22 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
         targetWorkspaceDir: params.effectiveWorkspace,
       }),
     );
-    const contextFiles = buildBootstrapContextForFiles(
-      memoryToolsAvailable
-        ? bootstrapFiles.filter(
-            (file) =>
-              !isCodexWorkspaceRootMemoryBootstrapFile({
-                file,
-                workspaceDir: params.resolvedWorkspace,
-              }),
-          )
-        : bootstrapFiles,
-      {
-        config: params.params.config,
-        agentId: params.params.agentId ?? params.sessionAgentId,
-        warn: (message) => embeddedAgentLog.warn(message),
-      },
-    ).map((file) =>
+    // FIX #94295: Always include MEMORY.md in bootstrap context when present.
+    // Memory tools provide an additional deeper-recall path, not a replacement.
+    const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, {
+      config: params.params.config,
+      agentId: params.params.agentId ?? params.sessionAgentId,
+      warn: (message) => embeddedAgentLog.warn(message),
+    }).map((file) =>
       remapCodexContextFilePath({
         file,
         sourceWorkspaceDir: params.resolvedWorkspace,
         targetWorkspaceDir: params.effectiveWorkspace,
       }),
     );
+    // FIX #94295: Include MEMORY.md in prompt context files regardless of memory tools availability.
     const promptContextFiles = selectCodexWorkspacePromptContextFiles(contextFiles, {
-      excludeMemory: memoryToolsAvailable,
+      excludeMemory: false,
       memoryWorkspaceDir: params.effectiveWorkspace,
     });
     const developerInstructionFiles = shouldInjectCodexOpenClawPromptContext(params.params)
@@ -418,28 +411,17 @@ function buildCodexBootstrapInjectionStats(params: {
   const developerInstructionIndex = indexCodexContextFileContent(
     params.developerInstructionFiles ?? [],
   );
-  const memoryToolRoutedPaths = new Set(
-    (params.memoryToolRoutedBootstrapFiles ?? [])
-      .map((file) => readNonEmptyString(file.path))
-      .filter(isNonEmptyString)
-      .map(normalizeCodexContextFilePath),
-  );
   return params.bootstrapFiles.map((file) => {
     const fileName = readNonEmptyString(file.name);
     const pathValue = readNonEmptyString(file.path) ?? fileName ?? "";
     const displayName = (fileName ?? getCodexContextFileDisplayBasename(pathValue)) || pathValue;
     const baseName = getCodexContextFileBasename(pathValue || fileName || "");
     const rawChars = file.missing ? 0 : (file.content ?? "").trimEnd().length;
-    const memoryToolRoutedFile =
-      baseName === CODEX_MEMORY_CONTEXT_BASENAME &&
-      params.memoryToolRouted === true &&
-      memoryToolRoutedPaths.has(normalizeCodexContextFilePath(pathValue));
-    const injected = memoryToolRoutedFile
-      ? undefined
-      : (readCodexIndexedContextFileContent(injectedIndex, pathValue, fileName) ??
-        readCodexIndexedContextFileContent(developerInstructionIndex, pathValue, fileName));
-    let injectedChars = memoryToolRoutedFile ? 0 : (injected?.length ?? 0);
-    let truncated = memoryToolRoutedFile ? false : !file.missing && injectedChars < rawChars;
+    const injected =
+      readCodexIndexedContextFileContent(injectedIndex, pathValue, fileName) ??
+      readCodexIndexedContextFileContent(developerInstructionIndex, pathValue, fileName);
+    let injectedChars = injected?.length ?? 0;
+    let truncated = !file.missing && injectedChars < rawChars;
     if (injected === undefined) {
       if (CODEX_NATIVE_PROJECT_DOC_BASENAMES.has(baseName)) {
         injectedChars = rawChars;
@@ -805,18 +787,18 @@ export function renderCodexWorkspaceMemoryReference(params: {
   return lines.join("\n").trim();
 }
 
+// FIX #94295: MEMORY.md stays in bootstrap prompt context; memory tools are an additional path.
 function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
   files: EmbeddedContextFile[];
   toolNames: readonly string[];
   memoryToolRouted: boolean;
   citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
 }): string | undefined {
-  const memoryRecallInstructions = params.memoryToolRouted
-    ? renderCodexMemoryRecallInstructions({
-        toolNames: params.toolNames,
-        citationsMode: params.citationsMode,
-      })
-    : undefined;
+  const memoryRecallInstructions = renderCodexMemoryRecallInstructions({
+    toolNames: params.toolNames,
+    citationsMode: params.citationsMode,
+    memoryInjectedInPrompt: !params.memoryToolRouted,
+  });
   const memoryReferenceInstructions = renderCodexWorkspaceMemoryReference({
     files: params.files,
     toolNames: params.toolNames,
@@ -828,6 +810,7 @@ function renderCodexWorkspaceMemoryCollaborationInstructions(params: {
 function renderCodexMemoryRecallInstructions(params: {
   toolNames: readonly string[];
   citationsMode?: Parameters<typeof buildMemorySystemPromptAddition>[0]["citationsMode"];
+  memoryInjectedInPrompt?: boolean;
 }): string | undefined {
   const availableTools = new Set(params.toolNames);
   const memoryPrompt = buildMemorySystemPromptAddition({
@@ -840,7 +823,15 @@ function renderCodexMemoryRecallInstructions(params: {
     return undefined;
   }
   const toolSearchBridge = renderCodexMemoryToolSearchBridge(params.toolNames);
-  return [memoryPrompt, toolSearchBridge].filter(isNonEmptyString).join("\n").trim();
+  // FIX #94295: Add guidance about MEMORY.md being in prompt vs only accessible through tools
+  const memoryLocationGuidance =
+    params.memoryInjectedInPrompt === false
+      ? " Note: Workspace MEMORY.md is not pasted into this turn's prompt; use memory tools when durable memory context may be relevant."
+      : " Note: Workspace MEMORY.md is included in this turn's bootstrap prompt context; memory tools provide additional deeper recall when needed.";
+  return [memoryPrompt + memoryLocationGuidance, toolSearchBridge]
+    .filter(isNonEmptyString)
+    .join("\n")
+    .trim();
 }
 
 function renderCodexMemoryToolSearchBridge(toolNames: readonly string[]): string | undefined {
@@ -926,7 +917,9 @@ function isCodexWorkspaceRootMemoryPath(params: {
   const absolutePath = path.isAbsolute(filePath)
     ? path.resolve(filePath)
     : path.resolve(params.workspaceDir, filePath);
-  return absolutePath === path.join(path.resolve(params.workspaceDir), "MEMORY.md");
+  return (
+    absolutePath === path.join(path.resolve(params.workspaceDir), CODEX_MEMORY_CONTEXT_BASENAME)
+  );
 }
 
 function isSameCodexWorkspacePath(left: string, right: string): boolean {


### PR DESCRIPTION
## Summary

Fix issue where Native Codex turns incorrectly filter out root MEMORY.md when memory tools are available. This causes persistent bootstrap facts to not appear in the prompt context, making agents appear to "forget" known project/user rules.

Fixes #94295

## Real behavior proof (required for external PRs)

**Behavior addressed**: 
When MEMORY.md exists at the workspace root with non-empty content and memory-core plugin's memory_search/memory_get tools are available, MEMORY.md is filtered out from the bootstrap context, causing the `/context` command output to show `injected 0 chars`.

**Real environment tested**:
- **Runtime**: Node 22.19+, pnpm test framework with Vitest
- **Test environment**: extensions/codex/src/app-server/attempt-context.test.ts

**Exact steps or command run after this patch**:

```bash
pnpm test extensions/codex/src/app-server/attempt-context.test.ts
```

**Evidence after fix**:

```
 RUN  v4.1.8 /home/0668000603/workspace/openclaw-worktrees/issue-94295

 ✓ extensions/codex/src/app-server/attempt-context.test.ts (5 tests) 86ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  75.84s
```

**Observed result after the fix**: 
New test case `keeps MEMORY.md injected when memory tools are available (FIX #94295)` verifies:
1. When memory tools are available (`memoryToolRouted = true`)
2. MEMORY.md remains included in prompt context (`promptContext` contains MEMORY.md content)
3. System prompt report shows `injectedChars > 0` for MEMORY.md
4. `rawChars > 0` indicates the file exists and is loaded

**What was not tested**: 
- Full integration tests in actual Codex harness runtime (requires Crabbox/Testbox for broader validation)
- Behavior differences across different memory plugins (third-party memory tools may have different recall strategies)

## Tests and validation

✅ Unit tests: 5/5 passed (including new FIX #94295 test)
✅ Regression tests: All existing tests passed
✅ Type checking: No type errors
✅ Lint: No warnings

## Risk checklist

Did user-visible behavior change? `Yes`
- MEMORY.md now correctly injects into Native Codex turns' prompt context
- `/context` command reports correct `injectedChars` (non-zero values)

Did config, environment, or migration behavior change? `No`
- No configuration changes
- No environment variable changes
- No migration requirements

Did security, auth, secrets, network, or tool execution behavior change? `No`
- Only affects prompt context building logic
- Does not involve security, authentication, or network behavior

What is the highest-risk area?
- Prompt size may increase slightly (MEMORY.md is typically small and subject to bootstrap budget limits)

How is that risk mitigated?
- MEMORY.md is usually a sparse long-lived memory file with minimal content
- Bootstrap max/file and max/total limits still apply
- Memory tools remain available as an additional deeper-recall path

## Current review state

What is the next action?
- Maintainer review
