### PR TITLE
fix(tui): handle /status and /compact in local mode instead of falling through to model (fixes #71592)

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -541,6 +541,32 @@ describe("tui command handlers", () => {
     });
   });
 
+  it("shows system message for /status in local mode instead of sending to model", async () => {
+    const { handleCommand, sendChat, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/status");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith(
+      "/status is not supported in local TUI mode — use gateway-connected TUI for this command",
+    );
+  });
+
+  it("shows system message for /compact in local mode instead of sending to model", async () => {
+    const { handleCommand, sendChat, addSystem } = createHarness({
+      opts: { local: true },
+    });
+
+    await handleCommand("/compact");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith(
+      "/compact is not supported in local TUI mode — use gateway-connected TUI for this command",
+    );
+  });
+
   it("keeps gateway diagnostics on /gateway-status", async () => {
     const { handleCommand, getGatewayStatus, addSystem, addUser, sendChat } = createHarness({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -709,6 +709,16 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "quit":
         requestExit();
         break;
+      case "status":
+      case "compact":
+        if (opts.local === true) {
+          chatLog.addSystem(
+            `/${name} is not supported in local TUI mode — use gateway-connected TUI for this command`,
+          );
+        } else {
+          await sendMessage(raw);
+        }
+        break;
       default:
         await sendMessage(raw);
         break;


### PR DESCRIPTION
## What

Handle `/status` and `/compact` in TUI local mode instead of falling through to `sendMessage(raw)`, which sends the command text as a user message to the model.

When `opts.local === true`, the TUI now shows a system message explaining that these commands are not supported in local mode. In gateway-connected mode, behavior is unchanged — the commands are forwarded to the gateway as before.

Fixes #71592

## Why

The TUI slash command switch in `tui-command-handlers.ts` had no `case` for `status` or `compact`. These parsed commands fell through to the `default` branch (`await sendMessage(raw)`), appearing as user turns that started a local embedded agent run. The commands are advertised by TUI autocomplete but had no local-mode handler.

## How

Added `case "status":` and `case "compact":` to the command switch, between `quit` and `default`. When `opts.local === true`, the handler calls `chatLog.addSystem()` with a clear message. Otherwise, it forwards to the gateway via `sendMessage(raw)` — preserving existing non-local behavior.

## How to Test

Run the TUI command handler verification suite:

```
node scripts/run-vitest.mjs run src/tui/tui-command-handlers.test.ts
```

## Real behavior proof

- **Behavior addressed:** `/status` and `/compact` slash commands in local TUI mode fall through to the model instead of being handled locally
- **Environment tested:** macOS, Node.js, OpenClaw upstream/main at 0a6736af
- **Steps run after the patch:**
  1. Applied the case handler fix to `src/tui/tui-command-handlers.ts`
  2. Added two test cases for local-mode `/status` and `/compact`
  3. Ran `node scripts/run-vitest.mjs run src/tui/tui-command-handlers.test.ts`
  4. Ran TypeScript type check
- **Evidence after fix:**

```
$ grep -n 'case "status"\|case "compact"\|local TUI mode' src/tui/tui-command-handlers.ts
712:      case "status":
713:      case "compact":
716:            `/${name} is not supported in local TUI mode — use gateway-connected TUI for this command`,

$ node scripts/run-vitest.mjs run src/tui/tui-command-handlers.test.ts
 ✓  tui  src/tui/tui-command-handlers.test.ts (61 tests) 61ms
 Test Files  1 passed (1)
      Tests  61 passed (61)
```

- **Observed result after fix:** `/status` and `/compact` in local mode show a system message instead of starting a model run. All 61 tests pass including the 2 new local-mode tests.
- **What was not tested:** Live TUI session with `openclaw tui --local` (only static analysis and test harness verification).
