### PR TITLE
Allow WhatsApp observe-only message hooks

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts
@@ -469,6 +469,75 @@ describe("processMessage group system prompt wiring", () => {
     expect(internalReceived).not.toHaveBeenCalled();
   });
 
+  it("emits observe-only message_received hooks without reply dispatch side effects", async () => {
+    const internalReceived = vi.fn();
+    registerInternalHook("message:received", internalReceived);
+    resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
+    buildContextMock.mockImplementationOnce(() => ({
+      Body: "disabled inbound",
+      BodyForCommands: "disabled inbound",
+      RawBody: "disabled inbound",
+      CommandBody: "disabled inbound",
+      From: GROUP_JID,
+      To: "+15550001111",
+      SessionKey: baseRoute.sessionKey,
+      AccountId: "default",
+      MessageSid: "observe-msg-1",
+      SenderId: "+15550002222",
+      SenderName: "Alice",
+      SenderE164: "+15550002222",
+      Timestamp: 1710000000,
+      Provider: "whatsapp",
+      Surface: "whatsapp",
+      OriginatingChannel: "whatsapp",
+      OriginatingTo: GROUP_JID,
+    }));
+
+    const result = await callProcessMessage({
+      cfg: {
+        channels: {
+          whatsapp: {
+            pluginHooks: {
+              messageReceived: true,
+            },
+          },
+        },
+      },
+      msg: createTestWebInboundMessage({
+        event: {
+          id: "observe-msg-1",
+          timestamp: 1710000000,
+        },
+        admission: {
+          ingress: {
+            admission: "observe",
+            decision: "allow",
+            reasonCode: "dm_policy_disabled",
+          },
+          senderAccess: {
+            allowed: false,
+            decision: "block",
+            reasonCode: "dm_policy_disabled",
+          },
+          activationAccess: {
+            ran: true,
+            allowed: true,
+            shouldSkip: false,
+            reasonCode: "dm_policy_disabled",
+          },
+        },
+      }),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result).toBe(false);
+    expect(runMessageReceivedMock).toHaveBeenCalledTimes(1);
+    expect(internalReceived).toHaveBeenCalledTimes(1);
+    expect(trackBackgroundTaskMock).not.toHaveBeenCalled();
+    expect(dispatchBufferedReplyMock).not.toHaveBeenCalled();
+  });
+
   it("tracks session metadata writes as connection background tasks", async () => {
     resolvePolicyMock.mockReturnValue(makePolicy(makeAccount()));
     buildContextMock.mockImplementationOnce(() => ({

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -510,6 +510,9 @@ export async function processMessage(params: {
     accountId: params.route.accountId,
     sessionKey: params.route.sessionKey,
   });
+  if (admission.ingress.admission === "observe") {
+    return false;
+  }
 
   const pinnedMainDmRecipient = resolvePinnedMainDmRecipient({
     cfg: params.cfg,

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -301,6 +301,92 @@ describe("checkInboundAccessControl admission contract", () => {
     expect(result.allowed).toBe(false);
     expect("admission" in result).toBe(false);
   });
+
+  it("observes disabled DMs without read receipts when message_received hooks are enabled", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          dmPolicy: "disabled",
+          pluginHooks: {
+            messageReceived: true,
+          },
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
+
+    const result = await checkInboundAccessControl({
+      cfg: getAccessControlTestConfig() as never,
+      accountId: "default",
+      from: "+15550001111",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: false,
+      pushName: "Sam",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550001111@s.whatsapp.net",
+    });
+
+    expectAccepted(result);
+    expect(result.shouldMarkRead).toBe(false);
+    expect(result.admission.ingress).toMatchObject({
+      admission: "observe",
+      decision: "allow",
+      reasonCode: "dm_policy_disabled",
+    });
+    expect(result.admission.senderAccess).toMatchObject({
+      allowed: false,
+      decision: "block",
+      reasonCode: "dm_policy_disabled",
+    });
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("observes disabled groups without read receipts when account message_received hooks are enabled", async () => {
+    const groupJid = "120363401234567890@g.us";
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "disabled",
+          accounts: {
+            default: {
+              pluginHooks: {
+                messageReceived: true,
+              },
+            },
+          },
+        },
+      },
+    };
+    setAccessControlTestConfig(cfg);
+
+    const result = await checkInboundAccessControl({
+      cfg: getAccessControlTestConfig() as never,
+      accountId: "default",
+      from: groupJid,
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: true,
+      pushName: "Sam",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: groupJid,
+    });
+
+    expectAccepted(result);
+    expect(result.shouldMarkRead).toBe(false);
+    expect(result.admission.ingress).toMatchObject({
+      admission: "observe",
+      decision: "allow",
+      reasonCode: "group_policy_disabled",
+    });
+    expect(result.admission.senderAccess).toMatchObject({
+      allowed: false,
+      decision: "block",
+      reasonCode: "group_policy_disabled",
+    });
+  });
 });
 
 describe("checkInboundAccessControl pairing grace", () => {

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -17,7 +17,7 @@ export type BlockedInboundAccessControlResult = {
 
 export type AcceptedInboundAccessControlResult = {
   allowed: true;
-  shouldMarkRead: true;
+  shouldMarkRead: boolean;
   isSelfChat: boolean;
   resolvedAccountId: string;
   admission: WhatsAppInboundAdmission;
@@ -44,6 +44,75 @@ function blockedInboundAccess(
     shouldMarkRead: false,
     isSelfChat: policy.isSelfChat,
     resolvedAccountId: policy.account.accountId,
+  };
+}
+
+type WhatsAppMessageReceivedHookConfig = {
+  pluginHooks?: {
+    messageReceived?: boolean;
+  };
+  accounts?: Record<string, unknown>;
+};
+
+function readWhatsAppMessageReceivedHookOptIn(value: unknown): boolean | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const pluginHooks = (value as WhatsAppMessageReceivedHookConfig).pluginHooks;
+  if (pluginHooks?.messageReceived === undefined) {
+    return undefined;
+  }
+  return pluginHooks.messageReceived;
+}
+
+function shouldObserveBlockedInbound(params: { cfg: OpenClawConfig; accountId: string }): boolean {
+  const channelConfig = params.cfg.channels?.whatsapp as
+    | WhatsAppMessageReceivedHookConfig
+    | undefined;
+  const accountConfig =
+    params.accountId && channelConfig?.accounts
+      ? channelConfig.accounts[params.accountId]
+      : undefined;
+
+  return (
+    readWhatsAppMessageReceivedHookOptIn(accountConfig) ??
+    readWhatsAppMessageReceivedHookOptIn(channelConfig) ??
+    false
+  );
+}
+
+function observeOnlyInboundAccess(params: {
+  policy: ReturnType<typeof resolveWhatsAppInboundPolicy>;
+  access: Awaited<ReturnType<typeof resolveWhatsAppIngressAccess>>;
+  isGroup: boolean;
+  conversationId: string;
+  senderId: string;
+}): AcceptedInboundAccessControlResult {
+  return {
+    allowed: true,
+    shouldMarkRead: false,
+    isSelfChat: params.policy.isSelfChat,
+    resolvedAccountId: params.policy.account.accountId,
+    admission: buildWhatsAppInboundAdmission({
+      policy: params.policy,
+      access: {
+        ...params.access,
+        ingress: {
+          ...params.access.ingress,
+          admission: "observe",
+          decision: "allow",
+        },
+        activationAccess: {
+          ...params.access.activationAccess,
+          ran: true,
+          allowed: true,
+          shouldSkip: false,
+        },
+      },
+      isGroup: params.isGroup,
+      conversationId: params.conversationId,
+      senderId: params.senderId,
+    }),
   };
 }
 
@@ -107,6 +176,15 @@ export async function checkInboundAccessControl(params: {
   if (params.group && senderAccess.decision !== "allow") {
     if (senderAccess.reasonCode === "group_policy_disabled") {
       logWhatsAppVerbose(params.verbose, "Blocked group message (groupPolicy: disabled)");
+      if (shouldObserveBlockedInbound({ cfg: params.cfg, accountId: policy.account.accountId })) {
+        return observeOnlyInboundAccess({
+          policy,
+          access,
+          isGroup: params.group,
+          conversationId,
+          senderId: admissionSenderId,
+        });
+      }
     } else if (senderAccess.reasonCode === "group_policy_empty_allowlist") {
       logWhatsAppVerbose(
         params.verbose,
@@ -129,6 +207,15 @@ export async function checkInboundAccessControl(params: {
     }
     if (senderAccess.decision === "block" && senderAccess.reasonCode === "dm_policy_disabled") {
       logWhatsAppVerbose(params.verbose, "Blocked dm (dmPolicy: disabled)");
+      if (shouldObserveBlockedInbound({ cfg: params.cfg, accountId: policy.account.accountId })) {
+        return observeOnlyInboundAccess({
+          policy,
+          access,
+          isGroup: params.group,
+          conversationId,
+          senderId: admissionSenderId,
+        });
+      }
       return blockedInboundAccess(policy);
     }
     if (senderAccess.decision === "pairing" && !policy.isSamePhone(params.from)) {


### PR DESCRIPTION
## Summary
- let WhatsApp disabled DM/group policy paths become observe-only when `pluginHooks.messageReceived=true`
- keep observe-only messages unread by returning `shouldMarkRead=false`
- stop observe-only messages immediately after message_received hooks fire, before reply dispatch/session side effects

## Real behavior proof

- Behavior or issue addressed: WhatsApp currently drops disabled DM/group messages before the `message_received` hooks can feed observe-only Comms triage. This change lets disabled-policy messages become observe-only when the hook is explicitly enabled, while keeping replies and read receipts off.
- Real environment tested: Local OpenClaw source checkout on macOS, branch `dex/whatsapp-observe-only-hooks`, commit `d11e891a`, using the real WhatsApp extension source and OpenClaw test/runtime tooling.
- Exact steps or command run after this patch:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/inbound/access-control.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts`
  - `corepack pnpm tsgo:extensions`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
RUN  v4.1.8 /Users/chai/.openclaw/workspace/projects/openclaw-source

Test Files  2 passed (2)
     Tests  25 passed (25)
  Start at  21:06:01
  Duration  14.16s (transform 11.12s, setup 369ms, import 13.11s, tests 569ms, environment 0ms)

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
```

- Observed result after fix: The after-fix WhatsApp extension behavior now covers disabled DM and disabled group messages as observe-only admissions with `shouldMarkRead=false`, emits `message_received` hooks, and returns before reply dispatch/background reply side effects.
- What was not tested: A live inbound WhatsApp message through an officially released trusted `@openclaw/whatsapp` package was not tested because this PR is the upstream source patch required before that trusted package can be released.
- Proof limitations or environment constraints: Live Comms ingest remains intentionally blocked until this patch lands in the official trusted WhatsApp package and James updates/reinstalls that package. No installed OpenClaw package files were hot-patched for this proof.
- Before evidence (optional but encouraged): On the current official trusted package, disabled WhatsApp DM/group messages are blocked before the hook, so Comms stays empty; that is why this PR changes the source package rather than the local installed artifact.

## Safety
- preserves disabled DM/group reply policy
- does not add any outbound Comms send path
- does not mark observe-only messages read

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/inbound/access-control.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts`
- `corepack pnpm tsgo:extensions`