### PR TITLE
fix(ui): scroll to cron run history

### DIFF
--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -900,4 +900,40 @@ describe("cron view", () => {
       "cron-thinking-suggestions",
     ]);
   });
+
+  it("scrolls the run history card into view when History is clicked", () => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    try {
+      const container = document.createElement("div");
+      const onLoadRuns = vi.fn();
+      render(
+        renderCron(
+          createProps({
+            jobs: [createJob("job-1")],
+            onLoadRuns,
+          }),
+        ),
+        container,
+      );
+
+      const runHistory = getElement(container, "[data-run-history]", HTMLElement);
+      const scrollIntoView = vi.fn();
+      Object.defineProperty(runHistory, "scrollIntoView", {
+        configurable: true,
+        value: scrollIntoView,
+      });
+
+      getButtonByText(container, "History").dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+
+      expect(onLoadRuns).toHaveBeenCalledWith("job-1");
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -906,8 +906,9 @@ describe("cron view", () => {
       callback(0);
       return 1;
     });
+    const container = document.createElement("div");
+    document.body.append(container);
     try {
-      const container = document.createElement("div");
       const onLoadRuns = vi.fn();
       render(
         renderCron(
@@ -933,6 +934,7 @@ describe("cron view", () => {
       expect(onLoadRuns).toHaveBeenCalledWith("job-1");
       expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
     } finally {
+      container.remove();
       vi.unstubAllGlobals();
     }
   });

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -629,7 +629,7 @@ export function renderCron(props: CronProps) {
             : nothing}
         </section>
 
-        <section class="card">
+        <section class="card" data-run-history>
           <div
             class="row"
             style="justify-content: space-between; align-items: flex-start; gap: 12px;"
@@ -1687,6 +1687,15 @@ function renderJob(job: CronJob, props: CronProps) {
             @click=${(event: Event) => {
               event.stopPropagation();
               props.onLoadRuns(job.id);
+              requestAnimationFrame(() => {
+                const runHistory = document.querySelector("[data-run-history]");
+                if (
+                  runHistory instanceof HTMLElement &&
+                  typeof runHistory.scrollIntoView === "function"
+                ) {
+                  runHistory.scrollIntoView({ behavior: "smooth", block: "start" });
+                }
+              });
             }}
           >
             ${t("cron.jobList.history")}


### PR DESCRIPTION
## Summary

- Mark the existing Run history card as the scroll target on the cron page.
- After clicking a job's History button, keep loading that job's runs and scroll the Run history card into view.
- Add a focused cron view test for the visible-feedback behavior.

Closes #59902

## Verification

- `node scripts/run-vitest.mjs run ui/src/ui/views/cron.test.ts --reporter=verbose`
- `git diff --check`

## Real behavior proof

Behavior addressed: On `/cron`, clicking a job's History button gives visible feedback by scrolling the existing Run history card into view after loading that job's runs.

Real environment tested: Local OpenClaw checkout on this PR branch (`codex/cron-history-scroll-59902-20260618`) at `6c36d6a193a6d27f1f4c65a727dc12629eabb14a`, rendered in Chromium through the local Vite UI using the PR branch's real `renderCron` implementation.

Exact steps or command run after this patch:

```text
1. Start local Vite UI for this PR branch.
2. Render a long cron page with 18 jobs in Chromium at 1280x720.
3. Measure the Run history card before clicking History.
4. Click the first job's History button.
5. Measure the Run history card again and capture the after-click screenshot.
```

Evidence after fix: Browser screenshot and live output artifact: https://gist.github.com/leno23/29d7faf2fb4c95b2f803d5b8369e66f8

```json
{
  "before": {
    "scrollY": 0,
    "runHistoryTop": 4478,
    "runHistoryBottom": 4829,
    "runHistoryVisible": false,
    "selectedRunsJobId": null,
    "proofLog": []
  },
  "after": {
    "scrollY": 4071,
    "runHistoryTop": 407,
    "runHistoryBottom": 758,
    "runHistoryVisible": true,
    "selectedRunsJobId": "job-01",
    "proofLog": ["onLoadRuns(job-01)"]
  }
}
```

Observed result after fix: The browser scrolled from `scrollY=0` to `scrollY=4071`; the Run history card moved from below the viewport (`top=4478`) into the viewport (`top=407`); clicking History loaded the selected job history via `onLoadRuns(job-01)`. The linked artifact includes the after-click browser screenshot showing the Run history card visible in the viewport.

What was not tested: No additional gaps.

Supplemental local checks:

```text
node scripts/run-vitest.mjs run ui/src/ui/views/cron.test.ts --reporter=verbose
git diff --check
```


## What Problem This Solves
On the cron page, clicking a job's History button loaded run data but did not provide visible feedback by bringing the existing Run history card into view. Users could miss that the action succeeded on long cron pages.

## Evidence
The linked browser artifact in the Real behavior proof section shows a real Chromium run: after clicking History, `scrollY` changed from `0` to `4071`, the Run history card moved into the viewport, `selectedRunsJobId` became `job-01`, and `onLoadRuns(job-01)` was recorded. Supplemental local checks also passed: `node scripts/run-vitest.mjs run ui/src/ui/views/cron.test.ts --reporter=verbose` and `git diff --check`.
