### PR TITLE
fix: suppress exec stderr warnings from covering channel replies (#94360)

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -643,7 +643,11 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[1]?.text).toContain("Exec");
   });
 
-  it("shows exec tool errors when assistant output claims success", () => {
+  it("suppresses exec tool warning when assistant already replied (#94360)", () => {
+    // Exec stderr is operational noise — when the assistant already has a
+    // user-facing reply, the warning covers the actual response in channel
+    // UIs. Suppress it unless verbose details are warranted or the command
+    // timed out.
     const payloads = buildPayloads({
       assistantTexts: ["The script is ready to use and saved in your workspace."],
       lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
@@ -653,14 +657,40 @@ describe("buildEmbeddedRunPayloads", () => {
       },
     });
 
-    expect(payloads).toHaveLength(2);
+    expect(payloads).toHaveLength(1);
     expect(payloads[0]?.text).toBe("The script is ready to use and saved in your workspace.");
+  });
+
+  it("shows exec tool warning when no assistant reply exists", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      lastAssistant: undefined,
+      lastToolError: {
+        toolName: "exec",
+        error: "/bin/bash: line 1: python: command not found",
+      },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Exec");
+  });
+
+  it("shows exec tool warning with details when verbose is full despite reply", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Done."],
+      lastAssistant: { stopReason: "end_turn" } as unknown as AssistantMessage,
+      verboseLevel: "full",
+      lastToolError: {
+        toolName: "exec",
+        error: "Copy-Item : failed to copy",
+      },
+    });
+
+    expect(payloads).toHaveLength(2);
     expect(payloads[1]?.isError).toBe(true);
     expect(payloads[1]?.text).toContain("Exec");
-    expect(payloads[1]?.text).not.toContain("python: command not found");
-    expect(getReplyPayloadMetadata(payloads[1] as object)?.nonTerminalToolErrorWarning).toBe(
-      undefined,
-    );
+    expect(payloads[1]?.text).toContain("Copy-Item : failed to copy");
   });
 
   it("shows mutating tool errors when assistant output does not acknowledge the failure", () => {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -202,6 +202,22 @@ function resolveToolErrorWarningPolicy(params: {
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
+    // Exec-like tools: suppress the diagnostic warning when the assistant
+    // already has a user-facing reply and verbose details are not warranted.
+    // Stderr is operational noise that covers the actual response in channel
+    // UIs such as Feishu and Telegram (#94360). The warning still fires when
+    // no reply exists (so the user is not left with silence), when
+    // includeDetails is on (verbose:full, heartbeat, cron timeout), or when
+    // the command timed out (the user needs to know it did not complete).
+    if (
+      isExecLikeToolName(params.lastToolError.toolName) &&
+      !includeDetails &&
+      params.hasUserFacingReply &&
+      !params.lastToolError.timedOut &&
+      !params.lastToolError.middlewareError
+    ) {
+      return { showWarning: false, includeDetails };
+    }
     return {
       showWarning: !params.hasUserFacingErrorReply && !params.hasUserFacingFailureAcknowledgement,
       includeDetails,


### PR DESCRIPTION
## Summary

- **Problem**: Exec tool stderr warnings (`⚠️ 🛠️ Exec failed`) are sent as user-visible reply messages to all channels (Feishu, Telegram, Discord, etc.), covering the agent's actual response.
- **Root cause**: In `resolveToolErrorWarningPolicy`, exec tools are caught by the mutating-tool branch (line 202) before reaching the exec-specific suppression (line 210), making that suppression dead code for `exec`/`bash` tools.
- **Fix**: Added an exec-specific suppression inside the mutating-tool branch that suppresses the diagnostic warning when: the assistant already has a user-facing reply, verbose details are not warranted, the command did not time out, and it is not a middleware error.
- **Preserved safety**: Exec warnings still fire when: no assistant reply exists, `verbose: full` is on, the command timed out, or it is a middleware error.
- Reviewers should focus on the policy ordering and the conditions that still allow exec warnings through.

## Linked context

Closes #94360

Related #93251 (same bug class — Telegram tool-failure message leak)

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: Exec stderr output (e.g., PowerShell `Copy-Item ... failed`) sent as a visible `⚠️` reply in Feishu, covering the agent's actual response.
- **Real environment tested**: macOS 15.5, Node 22, Vitest 4.1.7
- **Exact steps or command run after this patch**: `pnpm test -- src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts`
- **Evidence after fix**: All 92 tests pass (56 error + 36 main payload tests), including 3 new/updated exec-specific tests that verify: (1) exec warnings suppressed when assistant replied, (2) exec warnings still shown when no reply exists, (3) exec warnings with details still shown when verbose is full.
- **Observed result after fix**: `buildEmbeddedRunPayloads` returns only the assistant text payload (no `⚠️` warning) for exec errors when the assistant already has a visible reply.
- **What was not tested**: Live Feishu end-to-end delivery (no Feishu credentials in dev env). The fix is in core payload assembly, not channel-specific code.
- **Proof limitations or environment constraints**: Cannot reproduce the exact Feishu rendering issue locally without a Feishu bot setup. Fix verified through unit tests that directly exercise the payload builder.

## Tests and validation

- `pnpm test -- src/agents/embedded-agent-runner/run/payloads.errors.test.ts` — 56 passed
- `pnpm test -- src/agents/embedded-agent-runner/run/payloads.test.ts` — 36 passed
- Updated test: "suppresses exec tool warning when assistant already replied (#94360)" — verifies only assistant text is returned, no warning payload
- New test: "shows exec tool warning when no assistant reply exists" — verifies warning still fires without assistant reply
- New test: "shows exec tool warning with details when verbose is full despite reply" — verifies verbose mode still surfaces details
- Existing tests preserved: timeout warnings, middleware error warnings, non-exec mutating tool warnings all unchanged

## Risk checklist

- Did user-visible behavior change? `Yes` — exec tool failure warnings are no longer sent to external channels when the assistant already replied (unless verbose, timeout, or middleware error).
- Did config, environment, or migration behavior change? `No`
- Did security, auth, secrets, network, or tool execution behavior change? `No`
- Highest-risk area: The exec-specific suppression could hide a misleading assistant reply (assistant claims success, exec actually failed). Mitigated by: (1) the agent still sees the exec failure in its tool result and will correct in the next turn, (2) timeout and middleware errors are still surfaced, (3) users can opt into `verbose: full` to see all details.

## Current review state

- Ready for maintainer review.
- No bot or reviewer comments yet.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)