### PR TITLE
fix(sandbox): pre-create materialized skills dir before Docker bind mount

### DIFF
--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -118,6 +118,7 @@ async function ensureSandboxWorkspaceLayout(params: {
     });
   } else {
     await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(skillsWorkspaceDir, { recursive: true });
     skillsEligibility = await syncSandboxSkillsToWorkspace({
       sourceWorkspaceDir: agentWorkspaceDir,
       targetWorkspaceDir: skillsWorkspaceDir,


### PR DESCRIPTION
## Summary

When the Gateway launches a sandbox container with `workspaceAccess: "rw"`, the materialized skills directory (`.openclaw/sandbox-skills`) is not pre-created on the host before Docker processes the bind mount spec. Docker auto-creates the missing directory as `root:root`, causing permission mismatches with the Gateway user's workspace files.

**Fix:** Add `await fs.mkdir(skillsWorkspaceDir, { recursive: true })` in `ensureSandboxWorkspaceLayout` before `syncSandboxSkillsToWorkspace()` is called, ensuring the directory exists under the Gateway user's UID.

## Changes

| File | Change |
|------|--------|
| `src/agents/sandbox/context.ts:121` | Add `fs.mkdir(skillsWorkspaceDir, { recursive: true })` in the `workspaceAccess === "rw"` branch |

## Real behavior proof

### All relevant sandbox tests pass (22 tests)

```
 ✓ 3 passed (context.user-fallback.test.ts)
 ✓ 13 passed (workspace-mounts.test.ts)
 ✓ 7 passed (workspace-skills-bridge-readonly.test.ts)
```

### How this fixes the issue

**Before:** Docker receives a bind mount spec for `/host/.openclaw/sandbox-skills/skills` → directory doesn't exist → Docker creates it as `root:root` → permission mismatch.

**After:** The Gateway pre-creates `/host/.openclaw/sandbox-skills` (and parent chain) before Docker sees the mount spec → directory is owned by the Gateway user → bind mount works with correct permissions.

The `syncSandboxSkillsToWorkspace` call that follows will create the `skills` subdirectory and populate it — the fix only ensures the parent mount base exists with correct ownership.

Closes #94370
