### PR TITLE
feat(plugins): persist plugin allow-always approvals

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -202,6 +202,7 @@ type BeforeToolCallResult = {
     timeoutMs?: number;
     timeoutBehavior?: "allow" | "deny";
     allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
+    allowAlwaysKey?: string;
     pluginId?: string;
     onResolution?: (
       decision: "allow-once" | "allow-always" | "deny" | "timeout" | "cancelled",
@@ -223,6 +224,9 @@ Hook guard behavior for typed lifecycle hooks:
   requested approval.
 - `onResolution` receives the resolved approval decision - `allow-once`,
   `allow-always`, `deny`, `timeout`, or `cancelled`.
+- `allowAlwaysKey` makes `allow-always` durable for later requests from the same
+  plugin and tool name. Keep the key stable for the exact future action scope
+  being trusted, and do not include secrets.
 
 See [Plugin permission requests](/plugins/plugin-permission-requests) for
 approval routing, decision behavior, and when to use `requireApproval` instead

--- a/docs/plugins/plugin-permission-requests.md
+++ b/docs/plugins/plugin-permission-requests.md
@@ -52,6 +52,8 @@ export default definePluginEntry({
 
       const environment =
         typeof event.params.environment === "string" ? event.params.environment : "unknown";
+      const allowAlwaysKey =
+        environment === "production" ? undefined : `deploy_service:${environment}`;
 
       return {
         requireApproval: {
@@ -62,6 +64,7 @@ export default definePluginEntry({
             environment === "production"
               ? ["allow-once", "deny"]
               : ["allow-once", "allow-always", "deny"],
+          allowAlwaysKey,
           timeoutMs: 120_000,
           timeoutBehavior: "deny",
           onResolution(decision) {
@@ -86,27 +89,30 @@ Write prompt text for the person who will approve the action:
   cause production damage or data loss.
 - Use `allowedDecisions: ["allow-once", "deny"]` when persistent trust is
   unsafe for that action.
+- Set `allowAlwaysKey` when you offer `allow-always` and want OpenClaw to
+  remember it. The key is scoped by plugin id and tool name, hashed before
+  storage, and should name the exact future action scope, such as
+  `deploy_service:staging`. Do not put secrets in it.
 
 ## Decision behavior
 
 OpenClaw creates a pending approval with a `plugin:` ID, delivers it to the
 available approval surfaces, and waits for a decision.
 
-| Decision          | Result                                                                    |
-| ----------------- | ------------------------------------------------------------------------- |
-| `allow-once`      | The current call continues.                                               |
-| `allow-always`    | The current call continues and the decision is passed to the plugin.      |
-| `deny`            | The call is blocked with a denied tool result.                            |
-| Timeout           | The call is blocked unless `timeoutBehavior` is `"allow"`.                |
-| Cancellation      | The call is blocked when the run is aborted.                              |
-| No approval route | The call is blocked because no connected approval surface can resolve it. |
+| Decision          | Result                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `allow-once`      | The current call continues.                                                               |
+| `allow-always`    | The current call continues. With `allowAlwaysKey`, matching future requests auto-approve. |
+| `deny`            | The call is blocked with a denied tool result.                                            |
+| Timeout           | The call is blocked unless `timeoutBehavior` is `"allow"`.                                |
+| Cancellation      | The call is blocked when the run is aborted.                                              |
+| No approval route | The call is blocked because no connected approval surface can resolve it.                 |
 
-`allow-always` is only durable when the requesting plugin or runtime implements
-that persistence. For ordinary `before_tool_call.requireApproval` hooks,
-OpenClaw treats `allow-once` and `allow-always` as approval decisions for the
-current call and passes the resolved value to `onResolution`. If your plugin
-offers `allow-always`, document and implement exactly what future calls it
-trusts.
+For ordinary `before_tool_call.requireApproval` hooks, OpenClaw persists
+`allow-always` when the request includes `allowAlwaysKey`. Later requests with
+the same plugin id, tool name, and key return `allow-always` immediately without
+creating a pending approval. Without `allowAlwaysKey`, `allow-always` is only a
+decision for the current call and is passed to `onResolution`.
 
 If the hook also returns `params`, OpenClaw applies those parameter changes only
 after the approval succeeds. A lower-priority hook can still block after a

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -12,6 +12,7 @@ import { NonEmptyString } from "./primitives.js";
 const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 256;
+const PLUGIN_APPROVAL_ALLOW_ALWAYS_KEY_MAX_LENGTH = 512;
 
 /** Approval request raised by a plugin before a sensitive tool action proceeds. */
 export const PluginApprovalRequestParamsSchema = Type.Object(
@@ -22,6 +23,9 @@ export const PluginApprovalRequestParamsSchema = Type.Object(
     severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
     toolName: Type.Optional(Type.String()),
     toolCallId: Type.Optional(Type.String()),
+    allowAlwaysKey: Type.Optional(
+      Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_ALLOW_ALWAYS_KEY_MAX_LENGTH }),
+    ),
     allowedDecisions: Type.Optional(
       Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
         minItems: 1,

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -1410,6 +1410,7 @@ describe("before_tool_call requireApproval handling", () => {
         title: "Sensitive",
         description: "Sensitive op",
         pluginId: "sage",
+        allowAlwaysKey: "sage:bash:rm",
       },
     });
 
@@ -1429,7 +1430,10 @@ describe("before_tool_call requireApproval handling", () => {
     const requestCall = requireGatewayCall(0);
     expect(requestCall[0]).toBe("plugin.approval.request");
     requireRecord(requestCall[1], "approval request gateway client");
-    expect(requireRecord(requestCall[2], "approval request params").twoPhase).toBe(true);
+    expectRecordFields(requireRecord(requestCall[2], "approval request params"), {
+      allowAlwaysKey: "sage:bash:rm",
+      twoPhase: true,
+    });
     expect(requestCall[3]).toEqual({ expectFinal: false });
     const waitCall = requireGatewayCall(1);
     expect(waitCall[0]).toBe("plugin.approval.waitDecision");

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -3,6 +3,9 @@
  * Ensures gateway approval requests use non-blocking semantics and preserve
  * plugin hook decisions.
  */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -67,8 +70,16 @@ function requireBeforeToolCall(
 describe("runBeforeToolCallHook — embedded mode approvals", () => {
   let hookRunner: Pick<HookRunner, "hasHooks" | "runBeforeToolCall">;
   let runBeforeToolCallMock: ReturnType<typeof vi.fn<HookRunner["runBeforeToolCall"]>>;
+  let previousStateDir: string | undefined;
+  let stateDir = "";
+  let workspaceDir = "";
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-approval-test-"));
+    workspaceDir = path.join(stateDir, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    process.env.OPENCLAW_STATE_DIR = stateDir;
     runBeforeToolCallMock = vi.fn<HookRunner["runBeforeToolCall"]>();
     hookRunner = {
       hasHooks: vi.fn<HookRunner["hasHooks"]>().mockReturnValue(true),
@@ -79,9 +90,15 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     setActivePluginRegistry(createEmptyPluginRegistry());
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     setEmbeddedMode(false);
     setActivePluginRegistry(createEmptyPluginRegistry());
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await fs.rm(stateDir, { recursive: true, force: true });
   });
 
   it("blocks approval-required tools in embedded mode when no gateway approval route exists", async () => {
@@ -329,6 +346,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
       toolCallId: "call-skill-apply",
       ctx: {
+        workspaceDir,
         agentId: "main",
         sessionKey: "main",
         config: {
@@ -353,7 +371,10 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       "Apply a pending workspace skill proposal into live workspace skills.",
     );
     expect(approvalCall.request.severity).toBe("warning");
-    expect(approvalCall.request.allowedDecisions).toEqual(["allow-once", "deny"]);
+    expect(approvalCall.request.allowedDecisions).toEqual(["allow-once", "allow-always", "deny"]);
+    expect(approvalCall.request.allowAlwaysKey).toBe(
+      `skill-workshop:lifecycle:apply:${workspaceDir}`,
+    );
     expect(approvalCall.request.toolName).toBe("skill_workshop");
     expect(approvalCall.request.toolCallId).toBe("call-skill-apply");
     expect(runBeforeToolCallMock).toHaveBeenCalledTimes(1);
@@ -374,6 +395,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
         params: { action: "inspect", proposal_id: "weather-20260530-a1b2c3d4e5" },
         toolCallId: "call-skill-hook-apply",
         ctx: {
+          workspaceDir,
           config: {
             skills: {
               workshop: {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -669,6 +669,7 @@ async function requestPluginToolApproval(params: {
         description: approval.description,
         severity: approval.severity,
         allowedDecisions: approval.allowedDecisions,
+        allowAlwaysKey: approval.allowAlwaysKey,
         toolName: params.toolName,
         toolCallId: params.toolCallId,
         agentId: params.ctx?.agentId,
@@ -887,6 +888,8 @@ async function resolveSkillWorkshopApprovalForFinalParams(params: {
     toolName: params.toolName,
     toolParams: isPlainObject(params.params) ? params.params : {},
     ...(params.ctx?.config ? { config: params.ctx.config } : {}),
+    ...(params.ctx?.workspaceDir ? { workspaceDir: params.ctx.workspaceDir } : {}),
+    ...(params.ctx?.cwd ? { cwd: params.ctx.cwd } : {}),
   });
   return await resolveBeforeToolCallApprovalOutcome({
     result,
@@ -1119,6 +1122,8 @@ export async function runBeforeToolCallHook(args: {
       toolName,
       toolParams: normalizedParams,
       ...(args.ctx?.config ? { config: args.ctx.config } : {}),
+      ...(args.ctx?.workspaceDir ? { workspaceDir: args.ctx.workspaceDir } : {}),
+      ...(args.ctx?.cwd ? { cwd: args.ctx.cwd } : {}),
     });
     if (!initialCorePolicyResult && !shouldRunTrustedPolicies && !hasBeforeToolCallHooks) {
       return { blocked: false, params };

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -121,11 +121,19 @@ function createDemoPolicy(handle: NodeInvokePolicyHandler): NodeInvokePolicyRegi
 
 function createApprovalRequestPolicy(params?: {
   timeoutMs?: number;
+  toolName?: string;
+  allowAlwaysKey?: string;
+  allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
 }): NodeInvokePolicyRegistration {
   return createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
     const approval = await ctx.approvals?.request({
       title: "Sensitive action",
       description: "Needs approval",
+      ...(params?.toolName === undefined ? {} : { toolName: params.toolName }),
+      ...(params?.allowAlwaysKey === undefined ? {} : { allowAlwaysKey: params.allowAlwaysKey }),
+      ...(params?.allowedDecisions === undefined
+        ? {}
+        : { allowedDecisions: params.allowedDecisions }),
       ...(params?.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
     });
     return { ok: true, payload: approval ?? null };
@@ -283,6 +291,38 @@ describe("applyPluginNodeInvokePolicy", () => {
 
     const record = await expectSinglePendingApproval(manager);
     expect(record.expiresAtMs - record.createdAtMs).toBe(MAX_PLUGIN_APPROVAL_TIMEOUT_MS);
+
+    await expectApprovalResolution(resultPromise, manager, record);
+  });
+
+  it("passes allow-always scope fields into plugin policy approval requests", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    setDangerousDemoCommandRegistry([
+      createApprovalRequestPolicy({
+        toolName: "node.invoke.demo",
+        allowAlwaysKey: "node.invoke.demo:/tmp/x",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+      }),
+    ]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([
+        createApprovalClient({
+          connId: "conn-owner-approval",
+          clientId: "client-owner",
+          deviceId: "device-owner",
+        }),
+      ]),
+    });
+    const resultPromise = invokeDemoPolicy(context, createOperatorClient());
+
+    const record = await expectSinglePendingApproval(manager);
+    expect(record.request).toMatchObject({
+      pluginId: DEMO_PLUGIN_ID,
+      toolName: "node.invoke.demo",
+      allowAlwaysKey: "node.invoke.demo:/tmp/x",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
 
     await expectApprovalResolution(resultPromise, manager, record);
   });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -2,8 +2,12 @@
 // Lets plugin policies gate dangerous node commands before transport dispatch.
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolvePluginApprovalAllowAlwaysReuse } from "../infra/plugin-approval-allow-always.js";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
-import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
+import {
+  resolvePluginApprovalRequestAllowedDecisions,
+  resolvePluginApprovalTimeoutMs,
+} from "../infra/plugin-approvals.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type {
@@ -68,9 +72,27 @@ function createApprovalRuntime(params: {
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
+        allowAlwaysKey: normalizeOptionalString(input.allowAlwaysKey) ?? null,
+        ...(Array.isArray(input.allowedDecisions)
+          ? {
+              allowedDecisions: resolvePluginApprovalRequestAllowedDecisions({
+                allowedDecisions: input.allowedDecisions,
+              }),
+            }
+          : {}),
         agentId: normalizeOptionalString(input.agentId) ?? null,
         sessionKey: normalizeOptionalString(input.sessionKey) ?? null,
       };
+      try {
+        const reuse = resolvePluginApprovalAllowAlwaysReuse(request);
+        if (reuse) {
+          return { id: reuse.id, decision: reuse.decision };
+        }
+      } catch (err) {
+        params.context.logGateway?.error?.(
+          `plugin approvals: allow-always lookup failed: ${String(err)}`,
+        );
+      }
       const record = manager.create(request, timeoutMs, `plugin:${randomUUID()}`);
       record.requestedByConnId = params.client?.connId ?? null;
       record.requestedByDeviceId = params.client?.connect?.device?.id ?? null;

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -1,7 +1,11 @@
 // Plugin approval tests cover requested/resolved plugin approval events,
 // requester visibility, broadcast behavior, and approval manager integration.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
+import { resetPluginStateStoreForTests } from "../../plugin-state/plugin-state-store.js";
 import { ExecApprovalManager } from "../exec-approval-manager.js";
 import { createPluginApprovalHandlers } from "./plugin-approval.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
@@ -250,14 +254,29 @@ const invalidRequestCases = [
 
 describe("createPluginApprovalHandlers", () => {
   let manager: ExecApprovalManager<PluginApprovalRequestPayload>;
+  let tempStateDirs: string[];
 
   beforeEach(() => {
     manager = createManager();
+    tempStateDirs = [];
   });
 
   afterEach(() => {
+    resetPluginStateStoreForTests();
+    vi.unstubAllEnvs();
+    for (const dir of tempStateDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
     vi.restoreAllMocks();
   });
+
+  function useTempStateDir(): string {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-approval-"));
+    tempStateDirs.push(stateDir);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    resetPluginStateStoreForTests();
+    return stateDir;
+  }
 
   it("returns handlers for every plugin approval method", () => {
     const handlers = createPluginApprovalHandlers(manager);
@@ -459,6 +478,125 @@ describe("createPluginApprovalHandlers", () => {
       ]);
       manager.resolve(approvalId, "deny");
       await handlerPromise;
+    });
+
+    it("persists allow-always by plugin, tool, and allowAlwaysKey", async () => {
+      useTempStateDir();
+      const handlers = createPluginApprovalHandlers(manager);
+      const firstRespond = vi.fn();
+      const requestParams = {
+        pluginId: "deploy-plugin",
+        title: "Deploy service",
+        description: "Deploy service to staging",
+        toolName: "deploy_service",
+        allowAlwaysKey: "deploy_service:staging",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        twoPhase: true,
+      };
+      const firstOpts = createMockOptions("plugin.approval.request", requestParams, {
+        respond: firstRespond,
+      });
+
+      const firstRequest = handlers["plugin.approval.request"](firstOpts);
+      const approvalId = await waitForAcceptedApproval(firstRespond);
+      await handlers["plugin.approval.resolve"](
+        createMockOptions("plugin.approval.resolve", {
+          id: approvalId,
+          decision: "allow-always",
+        }),
+      );
+      await firstRequest;
+
+      const secondRespond = vi.fn();
+      await handlers["plugin.approval.request"](
+        createMockOptions("plugin.approval.request", requestParams, {
+          respond: secondRespond,
+          context: createNoExecApprovalContext(),
+        }),
+      );
+
+      const result = expectResponseOk(secondRespond);
+      expect(result.id).toMatch(/^plugin:allow-always:[0-9a-f]{24}$/);
+      expect(result.decision).toBe("allow-always");
+      expect(manager.listPendingRecords()).toHaveLength(0);
+    });
+
+    it("does not reuse allow-always across different plugin approval scopes", async () => {
+      useTempStateDir();
+      const handlers = createPluginApprovalHandlers(manager);
+      const baseParams = {
+        pluginId: "deploy-plugin",
+        title: "Deploy service",
+        description: "Deploy service to staging",
+        toolName: "deploy_service",
+        allowAlwaysKey: "deploy_service:staging",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        twoPhase: true,
+      };
+      const firstRespond = vi.fn();
+      const firstRequest = handlers["plugin.approval.request"](
+        createMockOptions("plugin.approval.request", baseParams, { respond: firstRespond }),
+      );
+      const approvalId = await waitForAcceptedApproval(firstRespond);
+      await handlers["plugin.approval.resolve"](
+        createMockOptions("plugin.approval.resolve", {
+          id: approvalId,
+          decision: "allow-always",
+        }),
+      );
+      await firstRequest;
+
+      const changedScopeCases = [
+        { ...baseParams, pluginId: "other-plugin" },
+        { ...baseParams, toolName: "rollback_service" },
+        { ...baseParams, allowAlwaysKey: "deploy_service:production" },
+      ];
+
+      for (const requestParams of changedScopeCases) {
+        const respond = vi.fn();
+        const request = handlers["plugin.approval.request"](
+          createMockOptions("plugin.approval.request", requestParams, { respond }),
+        );
+        const scopedApprovalId = await waitForAcceptedApproval(respond);
+        expect(scopedApprovalId).toMatch(/^plugin:/);
+        expect(scopedApprovalId).not.toContain("allow-always");
+        manager.resolve(scopedApprovalId, "deny");
+        await request;
+      }
+    });
+
+    it("does not persist allow-always when allowAlwaysKey is omitted", async () => {
+      useTempStateDir();
+      const handlers = createPluginApprovalHandlers(manager);
+      const requestParams = {
+        pluginId: "deploy-plugin",
+        title: "Deploy service",
+        description: "Deploy service to staging",
+        toolName: "deploy_service",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        twoPhase: true,
+      };
+      const firstRespond = vi.fn();
+      const firstRequest = handlers["plugin.approval.request"](
+        createMockOptions("plugin.approval.request", requestParams, { respond: firstRespond }),
+      );
+      const approvalId = await waitForAcceptedApproval(firstRespond);
+      await handlers["plugin.approval.resolve"](
+        createMockOptions("plugin.approval.resolve", {
+          id: approvalId,
+          decision: "allow-always",
+        }),
+      );
+      await firstRequest;
+
+      const secondRespond = vi.fn();
+      const secondRequest = handlers["plugin.approval.request"](
+        createMockOptions("plugin.approval.request", requestParams, { respond: secondRespond }),
+      );
+      const secondApprovalId = await waitForAcceptedApproval(secondRespond);
+      expect(secondApprovalId).not.toContain("allow-always");
+      manager.resolve(secondApprovalId, "deny");
+      await secondRequest;
     });
   });
 

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -9,6 +9,10 @@ import {
   validatePluginApprovalResolveParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
+import {
+  rememberPluginApprovalResolvedAllowAlways,
+  resolvePluginApprovalAllowAlwaysReuse,
+} from "../../infra/plugin-approval-allow-always.js";
 import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
 import {
   resolvePluginApprovalRequestAllowedDecisions,
@@ -57,6 +61,7 @@ export function createPluginApprovalHandlers(
         severity?: string | null;
         toolName?: string | null;
         toolCallId?: string | null;
+        allowAlwaysKey?: string | null;
         allowedDecisions?: string[] | null;
         agentId?: string | null;
         sessionKey?: string | null;
@@ -80,6 +85,7 @@ export function createPluginApprovalHandlers(
         severity: (p.severity as PluginApprovalRequestPayload["severity"]) ?? null,
         toolName: p.toolName ?? null,
         toolCallId: p.toolCallId ?? null,
+        allowAlwaysKey: normalizeTrimmedString(p.allowAlwaysKey),
         ...(Array.isArray(p.allowedDecisions)
           ? {
               allowedDecisions: resolvePluginApprovalRequestAllowedDecisions({
@@ -94,6 +100,16 @@ export function createPluginApprovalHandlers(
         turnSourceAccountId: normalizeTrimmedString(p.turnSourceAccountId),
         turnSourceThreadId: p.turnSourceThreadId ?? null,
       };
+
+      try {
+        const reuse = resolvePluginApprovalAllowAlwaysReuse(request);
+        if (reuse) {
+          respond(true, reuse, undefined);
+          return;
+        }
+      } catch (err) {
+        context.logGateway?.error?.(`plugin approvals: allow-always lookup failed: ${String(err)}`);
+      }
 
       // Always server-generate the ID — never accept plugin-provided IDs.
       // Kind-prefix so /approve routing can distinguish plugin vs exec IDs deterministically.
@@ -193,6 +209,14 @@ export function createPluginApprovalHandlers(
         forwardResolved: (resolvedEvent) =>
           opts?.forwarder?.handlePluginApprovalResolved?.(resolvedEvent),
         forwardResolvedErrorLabel: "plugin approvals: forward resolve failed",
+        extraResolvedHandlers: [
+          {
+            run: (resolvedEvent) => {
+              rememberPluginApprovalResolvedAllowAlways(resolvedEvent);
+            },
+            errorLabel: "plugin approvals: allow-always persistence failed",
+          },
+        ],
       });
     },
   };

--- a/src/infra/plugin-approval-allow-always.ts
+++ b/src/infra/plugin-approval-allow-always.ts
@@ -1,0 +1,126 @@
+// Generic allow-always persistence for plugin approval requests.
+import { createHash } from "node:crypto";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
+import type { ExecApprovalDecision } from "./exec-approvals.js";
+import type { PluginApprovalRequestPayload, PluginApprovalResolved } from "./plugin-approvals.js";
+import { resolvePluginApprovalRequestAllowedDecisions } from "./plugin-approvals.js";
+
+const PLUGIN_APPROVAL_ALLOW_ALWAYS_OWNER_ID = "core:plugin-approvals";
+const PLUGIN_APPROVAL_ALLOW_ALWAYS_NAMESPACE = "allow-always";
+const MAX_PLUGIN_APPROVAL_ALLOW_ALWAYS_ENTRIES = 10_000;
+
+type PluginApprovalAllowAlwaysScope = {
+  pluginId: string;
+  toolName: string;
+  allowAlwaysKey: string;
+};
+
+type PluginApprovalAllowAlwaysEntry = {
+  version: 1;
+  pluginId: string;
+  toolName: string;
+  approvedAtMs: number;
+};
+
+export type PluginApprovalAllowAlwaysReuse = {
+  id: string;
+  decision: Extract<ExecApprovalDecision, "allow-always">;
+  createdAtMs: number;
+  expiresAtMs: number;
+};
+
+const allowAlwaysStore = createCorePluginStateSyncKeyedStore<PluginApprovalAllowAlwaysEntry>({
+  ownerId: PLUGIN_APPROVAL_ALLOW_ALWAYS_OWNER_ID,
+  namespace: PLUGIN_APPROVAL_ALLOW_ALWAYS_NAMESPACE,
+  maxEntries: MAX_PLUGIN_APPROVAL_ALLOW_ALWAYS_ENTRIES,
+});
+
+function resolvePluginApprovalAllowAlwaysScope(
+  request: PluginApprovalRequestPayload,
+): PluginApprovalAllowAlwaysScope | null {
+  const pluginId = normalizeOptionalString(request.pluginId);
+  const toolName = normalizeOptionalString(request.toolName);
+  const allowAlwaysKey = normalizeOptionalString(request.allowAlwaysKey);
+  if (!pluginId || !toolName || !allowAlwaysKey) {
+    return null;
+  }
+  return { pluginId, toolName, allowAlwaysKey };
+}
+
+function requestOffersAllowAlways(request: PluginApprovalRequestPayload): boolean {
+  return resolvePluginApprovalRequestAllowedDecisions(request).includes("allow-always");
+}
+
+function fingerprintPluginApprovalAllowAlwaysScope(scope: PluginApprovalAllowAlwaysScope): string {
+  const hash = createHash("sha256");
+  hash.update("openclaw:plugin-approval:allow-always:v1");
+  hash.update("\0");
+  hash.update(JSON.stringify(scope));
+  return hash.digest("hex");
+}
+
+function resolvePluginApprovalAllowAlwaysFingerprint(
+  request: PluginApprovalRequestPayload,
+): { fingerprint: string; scope: PluginApprovalAllowAlwaysScope } | null {
+  if (!requestOffersAllowAlways(request)) {
+    return null;
+  }
+  const scope = resolvePluginApprovalAllowAlwaysScope(request);
+  if (!scope) {
+    return null;
+  }
+  return {
+    fingerprint: fingerprintPluginApprovalAllowAlwaysScope(scope),
+    scope,
+  };
+}
+
+function buildPluginApprovalAllowAlwaysReuseId(fingerprint: string): string {
+  return `plugin:allow-always:${fingerprint.slice(0, 24)}`;
+}
+
+/** Return an immediate allow-always decision when a matching durable approval exists. */
+export function resolvePluginApprovalAllowAlwaysReuse(
+  request: PluginApprovalRequestPayload,
+  nowMs = Date.now(),
+): PluginApprovalAllowAlwaysReuse | null {
+  const resolved = resolvePluginApprovalAllowAlwaysFingerprint(request);
+  if (!resolved) {
+    return null;
+  }
+  const entry = allowAlwaysStore.lookup(resolved.fingerprint);
+  if (!entry || entry.version !== 1) {
+    return null;
+  }
+  return {
+    id: buildPluginApprovalAllowAlwaysReuseId(resolved.fingerprint),
+    decision: "allow-always",
+    createdAtMs: nowMs,
+    expiresAtMs: nowMs,
+  };
+}
+
+/** Persist allow-always for future requests with the same plugin/tool/key scope. */
+export function rememberPluginApprovalAllowAlways(request: PluginApprovalRequestPayload): void {
+  const resolved = resolvePluginApprovalAllowAlwaysFingerprint(request);
+  if (!resolved) {
+    return;
+  }
+  allowAlwaysStore.register(resolved.fingerprint, {
+    version: 1,
+    pluginId: resolved.scope.pluginId,
+    toolName: resolved.scope.toolName,
+    approvedAtMs: Date.now(),
+  });
+}
+
+/** Persist a resolved plugin approval only when it actually chose allow-always. */
+export function rememberPluginApprovalResolvedAllowAlways(
+  resolved: Pick<PluginApprovalResolved, "decision" | "request">,
+): void {
+  if (resolved.decision !== "allow-always" || !resolved.request) {
+    return;
+  }
+  rememberPluginApprovalAllowAlways(resolved.request);
+}

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -20,6 +20,7 @@ export type PluginApprovalRequestPayload = {
   severity?: "info" | "warning" | "critical" | null;
   toolName?: string | null;
   toolCallId?: string | null;
+  allowAlwaysKey?: string | null;
   allowedDecisions?: readonly ExecApprovalDecision[] | null;
   actions?: readonly PluginApprovalActionView[] | null;
   agentId?: string | null;

--- a/src/plugins/hook-before-tool-call-result.ts
+++ b/src/plugins/hook-before-tool-call-result.ts
@@ -20,6 +20,7 @@ export type PluginHookBeforeToolCallResult = {
     timeoutMs?: number;
     timeoutBehavior?: "allow" | "deny";
     allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
+    allowAlwaysKey?: string;
     pluginId?: string;
     onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;
   };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2226,6 +2226,8 @@ export type OpenClawPluginNodeInvokePolicyApprovalRuntime = {
     severity?: "info" | "warning" | "critical";
     toolName?: string;
     toolCallId?: string;
+    allowAlwaysKey?: string;
+    allowedDecisions?: OpenClawPluginNodeInvokeApprovalDecision[];
     agentId?: string;
     sessionKey?: string;
     timeoutMs?: number;

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -1,5 +1,7 @@
 // Workshop policy helpers validate generated skill drafts against workspace policy.
+import path from "node:path";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
@@ -43,11 +45,28 @@ function lifecycleApprovalText(action: SkillWorkshopLifecycleAction): {
   };
 }
 
+function resolveLifecycleApprovalWorkspaceScope(params: {
+  workspaceDir?: string;
+  cwd?: string;
+}): string | undefined {
+  const workspaceDir = normalizeOptionalString(params.workspaceDir ?? params.cwd);
+  return workspaceDir ? path.resolve(workspaceDir) : undefined;
+}
+
+function buildLifecycleApprovalAllowAlwaysKey(params: {
+  action: SkillWorkshopLifecycleAction;
+  workspaceDir: string;
+}): string {
+  return `skill-workshop:lifecycle:${params.action}:${params.workspaceDir}`;
+}
+
 /** Returns approval policy for skill workshop lifecycle tool calls. */
 export function resolveSkillWorkshopToolApproval(params: {
   toolName: string;
   toolParams: unknown;
   config?: OpenClawConfig;
+  workspaceDir?: string;
+  cwd?: string;
 }): PluginHookBeforeToolCallResult | undefined {
   if (params.toolName !== "skill_workshop") {
     return undefined;
@@ -60,11 +79,23 @@ export function resolveSkillWorkshopToolApproval(params: {
   if (config.approvalPolicy === "auto") {
     return undefined;
   }
+  const workspaceScope = resolveLifecycleApprovalWorkspaceScope(params);
   const text = lifecycleApprovalText(action);
+  const allowedDecisions = workspaceScope
+    ? (["allow-once", "allow-always", "deny"] as const)
+    : (["allow-once", "deny"] as const);
   return {
     requireApproval: {
       ...text,
-      allowedDecisions: ["allow-once", "deny"],
+      allowedDecisions: [...allowedDecisions],
+      ...(workspaceScope
+        ? {
+            allowAlwaysKey: buildLifecycleApprovalAllowAlwaysKey({
+              action,
+              workspaceDir: workspaceScope,
+            }),
+          }
+        : {}),
     },
   };
 }


### PR DESCRIPTION
## Summary
- add a generic allowAlwaysKey contract to plugin approval requests, before_tool_call approvals, and node.invoke plugin policy approvals
- persist allow-always decisions by hashed plugin id, tool name, and key in the shared SQLite-backed core plugin state namespace
- make Skill Workshop only opt into the generic backend mechanism by supplying a lifecycle approval key
- document the durable allow-always contract for plugin authors

## Verification
- pnpm docs:list
- pnpm format -- packages/gateway-protocol/src/schema/plugin-approvals.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/agents/agent-tools.before-tool-call.ts src/gateway/node-invoke-plugin-policy.test.ts src/gateway/node-invoke-plugin-policy.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/plugin-approval.ts src/infra/plugin-approval-allow-always.ts src/infra/plugin-approvals.ts src/plugins/hook-before-tool-call-result.ts src/plugins/types.ts src/skills/workshop/policy.ts
- pnpm format:docs -- docs/plugins/hooks.md docs/plugins/plugin-permission-requests.md
- git diff --check
- pnpm test src/gateway/server-methods/plugin-approval.test.ts src/gateway/node-invoke-plugin-policy.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
- pnpm build

## Real behavior proof
Behavior addressed: Plugin approval allow-always can now be durable without a feature-specific persistence store.
Real environment tested: Local OpenClaw source checkout on macOS after rebasing onto origin/main.
Exact steps or command run after this patch: The Verification commands above were run after the patch; focused tests and build were rerun after the rebase.
Evidence after fix: Focused tests passed across 3 Vitest shards; pnpm build completed successfully.
Observed result after fix: A resolved allow-always plugin approval is stored by plugin/tool/key and later matching requests return allow-always immediately instead of creating a pending approval.
What was not tested: Full GitHub CI and live desktop approval UI were not run for this backend-focused PR.
