### PR TITLE
fix(plugin-sdk): export approval handler runtime event types

### DIFF
--- a/src/infra/approval-handler-runtime.ts
+++ b/src/infra/approval-handler-runtime.ts
@@ -55,6 +55,9 @@ export {
   createLazyChannelApprovalNativeRuntimeAdapter,
 };
 export type {
+  ApprovalRequest,
+  ApprovalResolved,
+  ChannelApprovalKind,
   ChannelApprovalCapabilityHandlerContext,
   ChannelApprovalNativeAvailabilityAdapter,
   ChannelApprovalNativeFinalAction,

--- a/src/plugin-sdk/approval-handler-runtime.ts
+++ b/src/plugin-sdk/approval-handler-runtime.ts
@@ -9,6 +9,8 @@ export {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
   type ApprovalActionView,
   type ApprovalMetadataView,
+  type ApprovalRequest,
+  type ApprovalResolved,
   type ApprovalViewModel,
   type ExecApprovalExpiredView,
   type ExecApprovalPendingView,
@@ -24,6 +26,7 @@ export {
   type ChannelApprovalHandler,
   type ChannelApprovalHandlerAdapter,
   type ChannelApprovalCapabilityHandlerContext,
+  type ChannelApprovalKind,
   type ExpiredApprovalView,
   type PendingApprovalView,
   type PluginApprovalExpiredView,
@@ -33,11 +36,11 @@ export {
 } from "../infra/approval-handler-runtime.js";
 export { resolveApprovalOverGateway } from "./approval-gateway-runtime.js";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
+import type { ApprovalRequest, ApprovalResolved } from "../infra/approval-handler-runtime.js";
 import type {
   ExpiredApprovalView,
   ResolvedApprovalView,
 } from "../infra/approval-view-model.types.js";
-import type { ExecApprovalRequest, ExecApprovalResolved } from "../infra/exec-approvals.js";
 import {
   buildPluginApprovalExpiredMessage,
   buildPluginApprovalResolvedMessage,
@@ -45,9 +48,6 @@ import {
   type PluginApprovalResolved,
 } from "../infra/plugin-approvals.js";
 import { buildApprovalResolvedReplyPayload } from "./approval-renderers.js";
-
-type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
 
 /** Builds channel-visible resolved approval text for exec and plugin approvals. */
 export function buildChannelApprovalResolvedText(params: {


### PR DESCRIPTION
## Summary
- Export `ApprovalRequest`, `ApprovalResolved`, and `ChannelApprovalKind` from the approval handler runtime SDK surface.
- Reuse the exported approval event types in `plugin-sdk/approval-handler-runtime` instead of maintaining local unions.

## Reasoning
Channel-native approval runtimes already operate on generic OpenClaw approval events, not channel-specific request shapes. The internal runtime types define those shared unions, but the public `openclaw/plugin-sdk/approval-handler-runtime` subpath did not expose them. That leaves downstream channel adapters unable to name the callback request/resolution types from the same SDK surface that provides `ChannelApprovalNativeRuntimeAdapter` and related helpers.

This showed up while implementing a RovoClaw native approval adapter: the adapter needed to type an approval request as exec-or-plugin, so it had to recreate a local `ExecApprovalRequest | PluginApprovalRequest` alias. Exporting the existing internal union avoids that duplication and keeps plugin authors on the supported SDK contract.

This is intentionally a type-surface change only. It does not change approval creation, delivery, resolution, fallback behavior, or any RovoClaw/ACP-specific logic.

## Test
- `pnpm tsgo:core`