### PR TITLE
docs(media): clarify legacy MEDIA line formatting

### DIFF
--- a/docs/reference/rich-output-protocol.md
+++ b/docs/reference/rich-output-protocol.md
@@ -35,6 +35,31 @@ Legacy final assistant reply text may still be normalized for compatibility, but
 it is not a general plugin/tool protocol.
 </Warning>
 
+### Legacy `MEDIA:` lines
+
+Legacy final assistant replies can still attach local media with a plain
+standalone `MEDIA:` line. The parser only recognizes lines whose trimmed text
+starts with `MEDIA:` outside Markdown wrappers and code fences.
+
+Valid legacy final reply:
+
+```text
+Here is the generated image.
+
+MEDIA:/workspace/image.png
+```
+
+These remain ordinary text and do not attach media:
+
+```text
+**MEDIA:/workspace/image.png**
+`MEDIA:/workspace/image.png`
+Here is your image: MEDIA:/workspace/image.png
+```
+
+Prefer structured `mediaUrl` / `mediaUrls` fields for tools, plugins, browser
+output, streaming blocks, and message actions.
+
 Plain Markdown image syntax stays text by default. Channels that intentionally
 map Markdown image replies to media attachments opt in at their outbound
 adapter; Telegram does this so `![alt](url)` can still become a media reply.

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -207,6 +207,12 @@ Outbound attachments from the agent use structured media fields on the message t
 
 OpenClaw sends structured media alongside the text. Legacy final assistant replies may still be normalized for compatibility, but tool output, browser output, streaming blocks, and message actions do not parse text as attachment commands.
 
+If you must use a legacy final-reply `MEDIA:` line, keep it as standalone plain
+text. Markdown wrappers, code fences, and inline prose such as
+`**MEDIA:/path.png**`, `` `MEDIA:/path.png` ``, or
+`Here is the image: MEDIA:/path.png` stay text and do not attach media. See
+[Rich output protocol](/reference/rich-output-protocol#legacy-media-lines).
+
 Local-path behavior follows the same file-read trust model as the agent:
 
 - If `tools.fs.workspaceOnly` is `true`, outbound local media paths stay restricted to the OpenClaw temp root, the media cache, agent workspace paths, and sandbox-generated files.


### PR DESCRIPTION
Summary:
- Document that legacy final-reply `MEDIA:` attachments must be standalone plain-text lines.
- Add valid and invalid examples for Markdown-wrapped or inline `MEDIA:` text.
- Add a short start-page warning with a link to the rich output protocol details.

Verification:
- `git diff --no-index --check -- work/78495/docs/reference/rich-output-protocol.md.upstream work/78495/docs/reference/rich-output-protocol.md`
- `git diff --no-index --check -- work/78495/docs/start/openclaw.md.upstream work/78495/docs/start/openclaw.md`
- Not run: `pnpm docs:list`, `pnpm docs:check-mdx`, `pnpm format:docs:check` (this workspace is using API-created patches rather than a full local checkout)

Real behavior proof:
- Docs-only change; source review in #78495 shows the parser only recognizes `MEDIA:` at the start of a plain text line outside Markdown/code formatting.

Fixes #78495