### PR TITLE
fix(chrome): probe IPv4 loopback in ensurePortAvailable to match Chrome CDP bind

### DIFF
--- a/src/infra/ports.ts
+++ b/src/infra/ports.ts
@@ -39,7 +39,7 @@ export async function describePortOwner(port: number): Promise<string | undefine
 export async function ensurePortAvailable(port: number): Promise<void> {
   // Detect EADDRINUSE early with a friendly message.
   try {
-    await tryListenOnPort({ port });
+    await tryListenOnPort({ port, host: "127.0.0.1" });
   } catch (err) {
     if (isErrno(err) && err.code === "EADDRINUSE") {
       throw new PortInUseError(port);


### PR DESCRIPTION
## Summary

Fixes #94379

`ensurePortAvailable()` used bare `net.listen({port})` which binds the IPv6 wildcard on dual-stack hosts, missing IPv4-only loopback occupants. Chrome CDP binds on `127.0.0.1`, so the pre-flight guard was silently bypassed. Chrome then fails with `bind() failed: Address already in use` but the user sees a misleading `HTTP 401`.

## Root Cause

The address family the pre-flight probes (`::`) does not match the address family Chrome binds (`127.0.0.1`). An IPv4-only occupant goes undetected.

## Change

`src/infra/ports.ts` — 1 line

```diff
- await tryListenOnPort({ port });
+ await tryListenOnPort({ port, host: "127.0.0.1" });
```

Probe `127.0.0.1` explicitly to match Chrome's CDP bind address family. The sibling `checkPortInUse` already probes all 4 loopback families — this aligns `ensurePortAvailable` with that pattern.

## Testing

pnpm not available in local environment — relying on CI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)