### PR TITLE
fix(agents): render identity name in runtime prompt

### DIFF
--- a/src/agents/cli-runner/helpers.system-prompt.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt.test.ts
@@ -95,6 +95,11 @@ describe("buildCliAgentSystemPrompt", () => {
   it("includes session identity in runtime when provided", () => {
     const prompt = buildCliAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      config: {
+        agents: {
+          list: [{ id: "main", identity: { name: "Runt" } }],
+        },
+      },
       tools: [],
       modelDisplay: "test/model",
       agentId: "main",
@@ -102,7 +107,8 @@ describe("buildCliAgentSystemPrompt", () => {
       sessionId: "session-123",
     });
 
-    expect(prompt).toContain("agent=main");
+    expect(prompt).toContain("agent=Runt");
+    expect(prompt).toContain("agentId=main");
     expect(prompt).toContain("session=agent:main:telegram:direct:peer");
     expect(prompt).toContain("sessionId=session-123");
   });

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -123,4 +123,28 @@ describe("buildSystemPromptParams", () => {
     expect(runtimeInfo.sessionKey).toBe("agent:main:main");
     expect(runtimeInfo.sessionId).toBe("23ae7fce-3c27-4a51-b58e-d800d8ca091f");
   });
+
+  it("resolves configured identity name for the active agent", () => {
+    const { runtimeInfo } = buildSystemPromptParams({
+      config: {
+        agents: {
+          list: [
+            { id: "main", identity: { name: "Runt" } },
+            { id: "coder", identity: { name: "Builder" } },
+          ],
+        },
+      },
+      agentId: "main",
+      runtime: {
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(runtimeInfo.agentId).toBe("main");
+    expect(runtimeInfo.identityName).toBe("Runt");
+  });
 });

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -19,6 +19,7 @@ import {
 
 type RuntimeInfoInput = {
   agentId?: string;
+  identityName?: string;
   sessionKey?: string;
   sessionId?: string;
   host: string;
@@ -47,7 +48,7 @@ type SystemPromptRuntimeParams = {
 export function buildSystemPromptParams(params: {
   config?: OpenClawConfig;
   agentId?: string;
-  runtime: Omit<RuntimeInfoInput, "agentId">;
+  runtime: Omit<RuntimeInfoInput, "agentId" | "identityName">;
   workspaceDir?: string;
   cwd?: string;
 }): SystemPromptRuntimeParams {
@@ -62,6 +63,7 @@ export function buildSystemPromptParams(params: {
   return {
     runtimeInfo: {
       agentId: params.agentId,
+      identityName: resolveAgentIdentityName(params.config, params.agentId),
       ...params.runtime,
       repoRoot,
     },
@@ -69,6 +71,18 @@ export function buildSystemPromptParams(params: {
     userTime,
     userTimeFormat,
   };
+}
+
+function resolveAgentIdentityName(
+  config: OpenClawConfig | undefined,
+  agentId: string | undefined,
+): string | undefined {
+  if (!agentId) {
+    return undefined;
+  }
+  const agent = config?.agents?.list?.find((entry) => entry.id === agentId);
+  const name = agent?.identity?.name?.trim();
+  return name || undefined;
 }
 
 function resolveRepoRoot(params: {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1217,6 +1217,7 @@ describe("buildAgentSystemPrompt", () => {
       workspaceDir: "/tmp/openclaw",
       runtimeInfo: {
         agentId: "work",
+        identityName: "Runt",
         sessionKey: "agent:main:main",
         sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
         host: "host",
@@ -1227,7 +1228,8 @@ describe("buildAgentSystemPrompt", () => {
       },
     });
 
-    expect(prompt).toContain("agent=work");
+    expect(prompt).toContain("agent=Runt");
+    expect(prompt).toContain("agentId=work");
     expect(prompt).toContain("session=agent:main:main");
     expect(prompt).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
   });
@@ -1247,6 +1249,7 @@ describe("buildAgentSystemPrompt", () => {
     const line = buildRuntimeLine(
       {
         agentId: "work",
+        identityName: "Runt",
         sessionKey: "agent:main:subagent:runtime-check",
         sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
         host: "host",
@@ -1262,7 +1265,8 @@ describe("buildAgentSystemPrompt", () => {
       "low",
     );
 
-    expect(line).toContain("agent=work");
+    expect(line).toContain("agent=Runt");
+    expect(line).toContain("agentId=work");
     expect(line).toContain("session=agent:main:subagent:runtime-check");
     expect(line).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
     expect(line).toContain("host=host");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -723,6 +723,7 @@ export function buildAgentSystemPrompt(params: {
   nativeCommandGuidanceLines?: string[];
   runtimeInfo?: {
     agentId?: string;
+    identityName?: string;
     sessionKey?: string;
     sessionId?: string;
     host?: string;
@@ -1378,6 +1379,7 @@ function buildActiveProcessSessionReferenceLines(
 export function buildRuntimeLine(
   runtimeInfo?: {
     agentId?: string;
+    identityName?: string;
     sessionKey?: string;
     sessionId?: string;
     host?: string;
@@ -1395,8 +1397,12 @@ export function buildRuntimeLine(
   defaultThinkLevel?: ThinkLevel,
 ): string {
   const normalizedRuntimeCapabilities = normalizePromptCapabilityIds(runtimeCapabilities);
+  const identityName = runtimeInfo?.identityName?.trim();
+  const agentLabel = identityName || runtimeInfo?.agentId;
+  const includeAgentId = runtimeInfo?.agentId && identityName && identityName !== runtimeInfo.agentId;
   return `Runtime: ${[
-    runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
+    agentLabel ? `agent=${sanitizeForPromptLiteral(agentLabel)}` : "",
+    includeAgentId ? `agentId=${sanitizeForPromptLiteral(runtimeInfo.agentId)}` : "",
     runtimeInfo?.sessionKey ? `session=${sanitizeForPromptLiteral(runtimeInfo.sessionKey)}` : "",
     runtimeInfo?.sessionId ? `sessionId=${sanitizeForPromptLiteral(runtimeInfo.sessionId)}` : "",
     runtimeInfo?.host ? `host=${runtimeInfo.host}` : "",


### PR DESCRIPTION
## Summary
- resolve the active agent identity.name into system prompt runtime metadata
- render the configured identity as `agent=...` while keeping the technical slot id as `agentId=...` for debugging
- add focused coverage for prompt params, runtime rendering, and CLI prompt assembly

Fixes #81269.

## Real behavior proof
Behavior addressed: Runtime prompt metadata now prefers the configured agent identity name over the technical slot id, avoiding repeated `agent=main` persona drift when `identity.name` is set.

Verification: `git diff --no-index --check` on the five touched files.

Not run: official vitest/oxfmt/oxlint/tsgo commands, because this workspace is not a full OpenClaw checkout and earlier clone attempts disconnected during fetch.