### PR TITLE
feat(skills-mcp): implement skills MCP bridge with configuration and handler

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -41,6 +41,7 @@ import {
 import type { PreauthConnectionBudget } from "./server/preauth-connection-budget.js";
 import type { ReadinessChecker } from "./server/readiness.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
+import { resolveSkillsMcpConfig } from "./skills-mcp.config.js";
 
 type PluginHttpRequestHandler = (
   req: IncomingMessage,
@@ -90,6 +91,7 @@ let httpAuthUtilsModulePromise: Promise<typeof import("./http-auth-utils.js")> |
 let pluginRouteRuntimeScopesModulePromise:
   | Promise<typeof import("./server/plugin-route-runtime-scopes.js")>
   | undefined;
+let skillsMcpHttpModulePromise: Promise<typeof import("./skills-mcp.handler.js")> | undefined;
 
 function getIdentityAvatarModule() {
   identityAvatarModulePromise ??= import("../agents/identity-avatar.js");
@@ -154,6 +156,13 @@ function getHttpAuthUtilsModule() {
 function getPluginRouteRuntimeScopesModule() {
   pluginRouteRuntimeScopesModulePromise ??= import("./server/plugin-route-runtime-scopes.js");
   return pluginRouteRuntimeScopesModulePromise;
+}
+
+// Lazy-load the skills MCP handler so the agent/skill runtime stack only loads
+// when the bridge is enabled and a matching `/mcp` request actually arrives.
+function getSkillsMcpHttpModule() {
+  skillsMcpHttpModulePromise ??= import("./skills-mcp.handler.js");
+  return skillsMcpHttpModulePromise;
 }
 
 const GATEWAY_PROBE_STATUS_BY_PATH = new Map<string, "live" | "ready">([
@@ -604,6 +613,17 @@ export function createGatewayHttpServer(opts: {
           run: () => handleHooksRequest(req, res),
         },
       ];
+      const skillsMcpConfig = resolveSkillsMcpConfig();
+      if (skillsMcpConfig.enabled && scopedRequestPath === skillsMcpConfig.path) {
+        requestStages.push({
+          name: "skills-mcp",
+          run: async () =>
+            (await getSkillsMcpHttpModule()).handleSkillsMcpHttpRequest(req, res, {
+              cfg: configSnapshot,
+              runtimeCfg: skillsMcpConfig,
+            }),
+        });
+      }
       if (openAiCompatEnabled && isOpenAiModelsPath(scopedRequestPath)) {
         requestStages.push({
           name: "models",

--- a/src/gateway/skills-mcp.config.ts
+++ b/src/gateway/skills-mcp.config.ts
@@ -1,0 +1,59 @@
+// Skills MCP bridge configuration.
+// Resolves the env-driven runtime config for the optional `/mcp` skills bridge.
+// The bridge is a network entry point, so it stays disabled unless a bearer
+// token is configured; an empty token can never expose an unauthenticated route.
+import { isTruthyEnvValue } from "../infra/env.js";
+
+const DEFAULT_SKILLS_MCP_PATH = "/mcp";
+
+/** Resolved runtime config for the skills MCP bridge. */
+export type SkillsMcpRuntimeConfig = {
+  enabled: boolean;
+  path: string;
+  token: string;
+  /** Agent whose workspace skills are exposed; defaults to the default agent. */
+  agentId?: string;
+  /** Allow-list of skill names; empty means every eligible skill is exposed. */
+  allow: string[];
+  /** Deny-list of skill names; takes precedence over the allow-list. */
+  deny: string[];
+};
+
+function parseCsvEnv(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function normalizePath(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return DEFAULT_SKILLS_MCP_PATH;
+  }
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+/**
+ * Resolves the skills MCP bridge config from the environment. Returns
+ * `enabled: false` whenever the toggle is off or no bearer token is set so
+ * callers can cheaply skip the route without exposing an open endpoint.
+ */
+export function resolveSkillsMcpConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): SkillsMcpRuntimeConfig {
+  const token = env.OPENCLAW_SKILLS_MCP_TOKEN?.trim() ?? "";
+  const agentId = env.OPENCLAW_SKILLS_MCP_AGENT?.trim();
+  const enabled = isTruthyEnvValue(env.OPENCLAW_SKILLS_MCP_ENABLED) && token.length > 0;
+  return {
+    enabled,
+    path: normalizePath(env.OPENCLAW_SKILLS_MCP_PATH),
+    token,
+    agentId: agentId && agentId.length > 0 ? agentId : undefined,
+    allow: parseCsvEnv(env.OPENCLAW_SKILLS_MCP_SKILLS),
+    deny: parseCsvEnv(env.OPENCLAW_SKILLS_MCP_DENY),
+  };
+}

--- a/src/gateway/skills-mcp.handler.ts
+++ b/src/gateway/skills-mcp.handler.ts
@@ -1,0 +1,197 @@
+// Skills MCP bridge HTTP handler.
+// Serves the bearer-authenticated `/mcp` JSON-RPC endpoint that exposes the
+// agent's workspace skills as MCP tools. Reuses the loopback MCP protocol and
+// body helpers; auth is a dedicated bridge token, independent of gateway
+// operator credentials, so external callers never gain gateway control.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { safeEqualSecret } from "../security/secret-equal.js";
+import { getHeader } from "./http-auth-utils.js";
+import {
+  jsonRpcError,
+  jsonRpcResult,
+  MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS,
+  type JsonRpcRequest,
+} from "./mcp-http.protocol.js";
+import {
+  isMcpHttpBodyTimeoutError,
+  isMcpHttpBodyTooLargeError,
+  readMcpHttpBody,
+  resolveMcpHttpBodyTimeoutMs,
+} from "./mcp-http.request.js";
+import type { SkillsMcpRuntimeConfig } from "./skills-mcp.config.js";
+import {
+  buildSkillsMcpTools,
+  type SkillsMcpTool,
+  type SkillsMcpToolSchemaEntry,
+} from "./skills-mcp.tools.js";
+
+const SKILLS_MCP_SERVER_NAME = "openclaw-skills";
+const SKILLS_MCP_SERVER_VERSION = "0.1.0";
+
+type SkillsMcpDispatchContext = {
+  tools: Map<string, SkillsMcpTool>;
+  toolSchema: SkillsMcpToolSchemaEntry[];
+};
+
+function readJsonRpcId(message: unknown): string | number | null | undefined {
+  if (!isRecord(message)) {
+    return null;
+  }
+  const id = message.id;
+  return typeof id === "string" || typeof id === "number" || id === null ? id : undefined;
+}
+
+function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
+  return isRecord(message) && message.jsonrpc === "2.0" && typeof message.method === "string";
+}
+
+function negotiateProtocolVersion(requested: unknown): string {
+  const supported = MCP_LOOPBACK_SUPPORTED_PROTOCOL_VERSIONS as readonly string[];
+  if (typeof requested === "string" && supported.includes(requested)) {
+    return requested;
+  }
+  return supported[0];
+}
+
+async function handleToolCall(
+  id: ReturnType<typeof readJsonRpcId>,
+  params: Record<string, unknown> | undefined,
+  tools: Map<string, SkillsMcpTool>,
+): Promise<object> {
+  const name = isRecord(params) && typeof params.name === "string" ? params.name : "";
+  const args = isRecord(params) && isRecord(params.arguments) ? params.arguments : {};
+  const tool = tools.get(name);
+  if (!tool) {
+    return jsonRpcResult(id, {
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
+      isError: true,
+    });
+  }
+  try {
+    const text = await tool.execute(args);
+    return jsonRpcResult(id, { content: [{ type: "text", text }], isError: false });
+  } catch (error) {
+    return jsonRpcResult(id, {
+      content: [{ type: "text", text: formatErrorMessage(error) }],
+      isError: true,
+    });
+  }
+}
+
+async function dispatchSkillsMcpMessage(
+  message: JsonRpcRequest,
+  ctx: SkillsMcpDispatchContext,
+): Promise<object | null> {
+  const id = message.id;
+  switch (message.method) {
+    case "initialize":
+      return jsonRpcResult(id, {
+        protocolVersion: negotiateProtocolVersion(message.params?.protocolVersion),
+        capabilities: { tools: {} },
+        serverInfo: { name: SKILLS_MCP_SERVER_NAME, version: SKILLS_MCP_SERVER_VERSION },
+      });
+    case "ping":
+      return jsonRpcResult(id, {});
+    case "tools/list":
+      return jsonRpcResult(id, { tools: ctx.toolSchema });
+    case "tools/call":
+      return await handleToolCall(id, message.params, ctx.tools);
+    default:
+      // Notifications carry no id and never expect a reply.
+      if (message.method.startsWith("notifications/")) {
+        return null;
+      }
+      return jsonRpcError(id, -32601, `Method not found: ${message.method}`);
+  }
+}
+
+function endJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function handleBodyReadFailure(res: ServerResponse, error: unknown): void {
+  if (res.headersSent) {
+    return;
+  }
+  if (isMcpHttpBodyTooLargeError(error)) {
+    endJson(res, 413, { error: "payload_too_large" });
+    return;
+  }
+  if (isMcpHttpBodyTimeoutError(error)) {
+    endJson(res, 408, { error: "request_body_timeout" });
+    return;
+  }
+  endJson(res, 400, jsonRpcError(null, -32700, "Parse error"));
+}
+
+/**
+ * Handles a `/mcp` skills-bridge request. Returns `false` when the bridge is
+ * disabled so the request falls through to the rest of the gateway router;
+ * otherwise it fully answers the request and returns `true`.
+ */
+export async function handleSkillsMcpHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: { cfg: OpenClawConfig; runtimeCfg: SkillsMcpRuntimeConfig },
+): Promise<boolean> {
+  const { cfg, runtimeCfg } = opts;
+  if (!runtimeCfg.enabled) {
+    return false;
+  }
+
+  if (req.method !== "POST") {
+    res.writeHead(405, { Allow: "POST", "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "method_not_allowed" }));
+    return true;
+  }
+
+  const authHeader = getHeader(req, "authorization") ?? "";
+  if (!safeEqualSecret(authHeader, `Bearer ${runtimeCfg.token}`)) {
+    endJson(res, 401, { error: "unauthorized" });
+    return true;
+  }
+
+  const contentType = getHeader(req, "content-type") ?? "";
+  if (!contentType.startsWith("application/json")) {
+    endJson(res, 415, { error: "unsupported_media_type" });
+    return true;
+  }
+
+  let parsed: JsonRpcRequest | JsonRpcRequest[];
+  try {
+    const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
+    parsed = JSON.parse(body) as JsonRpcRequest | JsonRpcRequest[];
+  } catch (error) {
+    handleBodyReadFailure(res, error);
+    return true;
+  }
+
+  const { tools, toolSchema } = buildSkillsMcpTools(cfg, runtimeCfg);
+  const messages = Array.isArray(parsed) ? parsed : [parsed];
+  const responses: object[] = [];
+  for (const message of messages) {
+    if (!isJsonRpcRequest(message)) {
+      responses.push(jsonRpcError(readJsonRpcId(message), -32600, "Invalid Request"));
+      continue;
+    }
+    const response = await dispatchSkillsMcpMessage(message, { tools, toolSchema });
+    if (response !== null) {
+      responses.push(response);
+    }
+  }
+
+  if (responses.length === 0) {
+    res.writeHead(202);
+    res.end();
+    return true;
+  }
+
+  const payload = Array.isArray(parsed) ? JSON.stringify(responses) : JSON.stringify(responses[0]);
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(payload);
+  return true;
+}

--- a/src/gateway/skills-mcp.tools.ts
+++ b/src/gateway/skills-mcp.tools.ts
@@ -1,0 +1,428 @@
+// Skills MCP bridge tool registry.
+// Enumerates the agent's workspace skills as MCP tools and runs each one as a
+// background, one-shot agent turn. Tool calls return quickly with a job handle;
+// the `skill-result` meta tool fetches the final output once the run settles.
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { agentCommandFromIngress } from "../agents/agent-command.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { resolveSandboxPath } from "../agents/sandbox-paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { defaultRuntime } from "../runtime.js";
+import type { SkillEntry } from "../skills/types.js";
+import {
+  filterWorkspaceSkillEntries,
+  loadWorkspaceSkillEntries,
+} from "../skills/loading/workspace.js";
+import type { SkillsMcpRuntimeConfig } from "./skills-mcp.config.js";
+
+/** Meta tool always present (independent of allow/deny) to drain background jobs. */
+const SKILL_RESULT_TOOL_NAME = "skill-result";
+/** Grace window so very fast skills can return inline on the first tool call. */
+const INLINE_WAIT_MS = 2_500;
+/** Default and ceiling blocking wait for `skill-result` polling. */
+const DEFAULT_RESULT_WAIT_MS = 30_000;
+const MAX_RESULT_WAIT_MS = 50_000;
+/** Background jobs are process-local and expire so the map cannot grow forever. */
+const JOB_TTL_MS = 60 * 60 * 1000;
+/** Workspace subdir that holds per-job uploaded files; removed after the run. */
+const UPLOAD_DIR_NAME = ".skills-mcp-uploads";
+/** Upload guards for this network entry: bound count and total decoded size. */
+const MAX_UPLOAD_FILES = 50;
+const MAX_UPLOAD_TOTAL_BYTES = 25 * 1024 * 1024;
+
+type SkillUploadFile = { path: string; content: string; encoding: "utf8" | "base64" };
+
+type SkillJobStatus = "running" | "done" | "error";
+
+type SkillJob = {
+  id: string;
+  status: SkillJobStatus;
+  result: string;
+  error: string;
+  createdAt: number;
+  controller: AbortController;
+  settled: Promise<void>;
+  markSettled: () => void;
+};
+
+const jobs = new Map<string, SkillJob>();
+
+/** JSON Schema fragment advertised to MCP clients for one tool. */
+export type SkillsMcpToolSchemaEntry = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+};
+
+/** Executable tool bound to a resolved skill (or the result meta tool). */
+export type SkillsMcpTool = {
+  name: string;
+  schema: SkillsMcpToolSchemaEntry;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+};
+
+function pruneExpiredJobs(now: number): void {
+  for (const [id, job] of jobs) {
+    if (now - job.createdAt > JOB_TTL_MS) {
+      jobs.delete(id);
+    }
+  }
+}
+
+function createSkillJob(): SkillJob {
+  const now = Date.now();
+  pruneExpiredJobs(now);
+  let markSettled: () => void = () => {};
+  const settled = new Promise<void>((resolve) => {
+    markSettled = resolve;
+  });
+  const job: SkillJob = {
+    id: randomUUID(),
+    status: "running",
+    result: "",
+    error: "",
+    createdAt: now,
+    controller: new AbortController(),
+    settled,
+    markSettled,
+  };
+  jobs.set(job.id, job);
+  return job;
+}
+
+// Mirrors the OpenAI-compatible handler's payload-to-text projection so a skill
+// run's final assistant text is what the MCP caller receives.
+function resolveAgentResultText(result: unknown): string {
+  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
+  if (!Array.isArray(payloads)) {
+    return "";
+  }
+  return payloads
+    .map((entry) => (typeof entry.text === "string" ? entry.text : ""))
+    .filter((text) => text.length > 0)
+    .join("\n\n");
+}
+
+function buildSkillMessage(skillName: string, input: string, uploadedPaths: string[]): string {
+  const parts = [
+    `Use the "${skillName}" skill to complete the request. ` +
+      "Read its SKILL.md first, then follow its instructions.",
+  ];
+  if (uploadedPaths.length > 0) {
+    parts.push(
+      `Uploaded files are available at these absolute paths:\n${uploadedPaths
+        .map((filePath) => `- ${filePath}`)
+        .join("\n")}`,
+    );
+  }
+  const trimmed = input.trim();
+  if (trimmed) {
+    parts.push(`Input:\n${trimmed}`);
+  }
+  return parts.join("\n\n");
+}
+
+function parseUploadFiles(value: unknown): SkillUploadFile[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('"files" must be an array of { path, content, encoding? } objects.');
+  }
+  if (value.length > MAX_UPLOAD_FILES) {
+    throw new Error(`Too many files: ${value.length} (max ${MAX_UPLOAD_FILES}).`);
+  }
+  const files: SkillUploadFile[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      throw new Error('Each "files" entry must be an object.');
+    }
+    const filePath = typeof entry.path === "string" ? entry.path.trim() : "";
+    if (!filePath) {
+      throw new Error('Each file requires a non-empty "path".');
+    }
+    if (typeof entry.content !== "string") {
+      throw new Error(`File "${filePath}" requires a string "content".`);
+    }
+    const encoding = entry.encoding === "base64" ? "base64" : "utf8";
+    files.push({ path: filePath, content: entry.content, encoding });
+  }
+  return files;
+}
+
+// Stage uploaded files under a per-job workspace subdir. Paths are sandbox-checked
+// (no absolute paths, no `..` escape) because the bridge is a network entry, and
+// the absolute on-disk paths are handed to the skill run via the prompt.
+async function stageUploadedFiles(params: {
+  workspaceDir: string;
+  jobId: string;
+  files: SkillUploadFile[];
+}): Promise<{ dir: string; paths: string[] }> {
+  const root = path.join(params.workspaceDir, UPLOAD_DIR_NAME, params.jobId);
+  await mkdir(root, { recursive: true });
+  const paths: string[] = [];
+  let totalBytes = 0;
+  try {
+    for (const file of params.files) {
+      const { resolved } = resolveSandboxPath({ filePath: file.path, cwd: root, root });
+      const buffer = Buffer.from(file.content, file.encoding);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > MAX_UPLOAD_TOTAL_BYTES) {
+        throw new Error(`Uploaded files exceed ${MAX_UPLOAD_TOTAL_BYTES} bytes total.`);
+      }
+      await mkdir(path.dirname(resolved), { recursive: true });
+      await writeFile(resolved, buffer);
+      paths.push(resolved);
+    }
+  } catch (error) {
+    await rm(root, { recursive: true, force: true }).catch(() => {});
+    throw error;
+  }
+  return { dir: root, paths };
+}
+
+function startSkillRun(params: {
+  job: SkillJob;
+  agentId: string;
+  skillName: string;
+  message: string;
+  uploadDir?: string;
+}) {
+  const { job, agentId, skillName, message, uploadDir } = params;
+  // The run uses its own AbortController so it survives the short HTTP request
+  // that started it; the session key must carry the agent prefix or the run is
+  // rejected for an agent/session mismatch.
+  void agentCommandFromIngress(
+    {
+      message,
+      agentId,
+      sessionKey: `agent:${agentId}:skills-mcp-${skillName}`,
+      deliver: false,
+      disableMessageTool: true,
+      senderIsOwner: false,
+      allowModelOverride: false,
+      cleanupBundleMcpOnRunEnd: true,
+      abortSignal: job.controller.signal,
+    },
+    defaultRuntime,
+  )
+    .then((result) => {
+      job.result = resolveAgentResultText(result);
+      job.status = "done";
+    })
+    .catch((error: unknown) => {
+      job.error = error instanceof Error ? error.message : String(error);
+      job.status = "error";
+    })
+    .finally(() => {
+      // Staged uploads only live for the duration of the run; remove them once it
+      // settles so per-job upload dirs do not accumulate in the workspace.
+      if (uploadDir) {
+        void rm(uploadDir, { recursive: true, force: true }).catch(() => {});
+      }
+      job.markSettled();
+    });
+}
+
+async function waitForJobSettlement(job: SkillJob, timeoutMs: number): Promise<void> {
+  if (job.status !== "running" || timeoutMs <= 0) {
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([job.settled, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function formatRunningResponse(jobId: string): string {
+  return JSON.stringify({
+    status: "running",
+    job_id: jobId,
+    message:
+      `Skill is still running. Call the "${SKILL_RESULT_TOOL_NAME}" tool with ` +
+      `{ "job_id": "${jobId}" } to fetch the result.`,
+  });
+}
+
+// Done -> final text; error -> throw so the caller marks the MCP result as an
+// error; still running -> a JSON handle the client can poll with skill-result.
+function resolveJobOutput(job: SkillJob): string {
+  if (job.status === "done") {
+    return job.result;
+  }
+  if (job.status === "error") {
+    throw new Error(job.error || "Skill run failed.");
+  }
+  return formatRunningResponse(job.id);
+}
+
+function clampResultWaitMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_RESULT_WAIT_MS;
+  }
+  return Math.min(MAX_RESULT_WAIT_MS, Math.max(0, Math.floor(value)));
+}
+
+function buildSkillToolSchema(entry: SkillEntry): SkillsMcpToolSchemaEntry {
+  return {
+    name: entry.skill.name,
+    description: entry.skill.description || `Run the ${entry.skill.name} skill.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        input: {
+          type: "string",
+          description: "Task input or instructions forwarded to the skill.",
+        },
+        files: {
+          type: "array",
+          description:
+            "Optional files staged on disk before the skill runs; their absolute " +
+            "paths are provided to the skill.",
+          items: {
+            type: "object",
+            properties: {
+              path: {
+                type: "string",
+                description: "Relative destination path (no absolute paths or '..').",
+              },
+              content: { type: "string", description: "File content." },
+              encoding: {
+                type: "string",
+                enum: ["utf8", "base64"],
+                description: "Content encoding; defaults to utf8. Use base64 for binary files.",
+              },
+            },
+            required: ["path", "content"],
+          },
+        },
+      },
+      required: [],
+    },
+  };
+}
+
+function buildSkillResultToolSchema(): SkillsMcpToolSchemaEntry {
+  return {
+    name: SKILL_RESULT_TOOL_NAME,
+    description:
+      "Fetch the result of a previously started skill run by its job_id, " +
+      "blocking up to wait_ms for completion.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        job_id: { type: "string", description: "Job id returned by a skill tool call." },
+        wait_ms: {
+          type: "number",
+          description: `Max blocking wait in ms (default ${DEFAULT_RESULT_WAIT_MS}, max ${MAX_RESULT_WAIT_MS}).`,
+        },
+      },
+      required: ["job_id"],
+    },
+  };
+}
+
+function createSkillResultTool(): SkillsMcpTool {
+  const schema = buildSkillResultToolSchema();
+  return {
+    name: SKILL_RESULT_TOOL_NAME,
+    schema,
+    execute: async (args) => {
+      const jobId = typeof args.job_id === "string" ? args.job_id.trim() : "";
+      if (!jobId) {
+        throw new Error(`${SKILL_RESULT_TOOL_NAME} requires a "job_id" string argument.`);
+      }
+      const job = jobs.get(jobId);
+      if (!job) {
+        throw new Error(`Unknown job_id: ${jobId}`);
+      }
+      await waitForJobSettlement(job, clampResultWaitMs(args.wait_ms));
+      return resolveJobOutput(job);
+    },
+  };
+}
+
+/**
+ * Builds the MCP tool set exposed by the bridge: one tool per eligible workspace
+ * skill (after allow/deny filtering) plus the always-present `skill-result`
+ * meta tool. Tools are sorted by name for deterministic `tools/list` output.
+ */
+export function buildSkillsMcpTools(
+  cfg: OpenClawConfig,
+  runtimeCfg: SkillsMcpRuntimeConfig,
+): { tools: Map<string, SkillsMcpTool>; toolSchema: SkillsMcpToolSchemaEntry[] } {
+  const agentId = runtimeCfg.agentId ?? resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  const entries = filterWorkspaceSkillEntries(
+    loadWorkspaceSkillEntries(workspaceDir, { config: cfg, agentId }),
+    cfg,
+  );
+  const allow = new Set(runtimeCfg.allow);
+  const deny = new Set(runtimeCfg.deny);
+
+  const tools = new Map<string, SkillsMcpTool>();
+  const sorted = [...entries].sort((a, b) => a.skill.name.localeCompare(b.skill.name));
+  for (const entry of sorted) {
+    const name = entry.skill.name;
+    if (name === SKILL_RESULT_TOOL_NAME || tools.has(name)) {
+      continue;
+    }
+    if (deny.has(name)) {
+      continue;
+    }
+    if (allow.size > 0 && !allow.has(name)) {
+      continue;
+    }
+    const schema = buildSkillToolSchema(entry);
+    tools.set(name, {
+      name,
+      schema,
+      execute: async (args) => {
+        const input = typeof args.input === "string" ? args.input : "";
+        const files = parseUploadFiles(args.files);
+        const job = createSkillJob();
+        let uploadDir: string | undefined;
+        let uploadedPaths: string[] = [];
+        if (files.length > 0) {
+          try {
+            const staged = await stageUploadedFiles({ workspaceDir, jobId: job.id, files });
+            uploadDir = staged.dir;
+            uploadedPaths = staged.paths;
+          } catch (error) {
+            // Staging failed before the run started; drop the job so it is not
+            // left dangling as "running" until TTL prune.
+            jobs.delete(job.id);
+            job.markSettled();
+            throw error;
+          }
+        }
+        startSkillRun({
+          job,
+          agentId,
+          skillName: name,
+          message: buildSkillMessage(name, input, uploadedPaths),
+          uploadDir,
+        });
+        await waitForJobSettlement(job, INLINE_WAIT_MS);
+        return resolveJobOutput(job);
+      },
+    });
+  }
+
+  const resultTool = createSkillResultTool();
+  tools.set(resultTool.name, resultTool);
+
+  const toolSchema = [...tools.values()].map((tool) => tool.schema);
+  return { tools, toolSchema };
+}


### PR DESCRIPTION
- Added `skills-mcp.config.ts` for environment-driven configuration of the skills MCP bridge.
- Introduced `skills-mcp.handler.ts` to handle JSON-RPC requests for agent skills.
- Implemented lazy-loading of the skills MCP handler in `server-http.ts`.
- Created `skills-mcp.tools.ts` to manage skills as MCP tools, including job handling and file uploads.
- Enhanced the gateway HTTP server to support the `/mcp` endpoint based on configuration.

This feature enables a new skills bridge for agents, allowing for dynamic skill execution and management.