### PR TITLE
fix: handle object-format data and URL-safe base64 from OpenAI-compatible proxy responses

### DIFF
--- a/packages/media-core/src/base64.test.ts
+++ b/packages/media-core/src/base64.test.ts
@@ -19,6 +19,16 @@ describe("base64 helpers", () => {
       expected: undefined,
     },
     {
+      name: "canonicalizeBase64 accepts URL-safe base64",
+      actual: canonicalizeBase64("-___"),
+      expected: "+///",
+    },
+    {
+      name: "canonicalizeBase64 accepts URL-safe base64 with padding",
+      actual: canonicalizeBase64("-w=="),
+      expected: "+w==",
+    },
+    {
       name: "estimateBase64DecodedBytes handles whitespace",
       actual: estimateBase64DecodedBytes("SGV s bG8= \n"),
       expected: 5,

--- a/packages/media-core/src/base64.ts
+++ b/packages/media-core/src/base64.ts
@@ -37,13 +37,16 @@ export function estimateBase64DecodedBytes(base64: string): number {
   return Math.max(0, estimated);
 }
 
+/** Returns true for standard (+ /) and URL-safe (- _) base64 alphabet chars. */
 function isBase64DataChar(code: number): boolean {
   return (
     (code >= 0x41 && code <= 0x5a) ||
     (code >= 0x61 && code <= 0x7a) ||
     (code >= 0x30 && code <= 0x39) ||
     code === 0x2b ||
-    code === 0x2f
+    code === 0x2f ||
+    code === 0x2d || // URL-safe: -
+    code === 0x5f    // URL-safe: _
   );
 }
 
@@ -72,7 +75,14 @@ export function canonicalizeBase64(base64: string): string | undefined {
     if (sawPadding || !isBase64DataChar(code)) {
       return undefined;
     }
-    cleaned += base64[i];
+    // Normalize URL-safe base64 chars to standard base64.
+    if (code === 0x2d) {
+      cleaned += "+";
+    } else if (code === 0x5f) {
+      cleaned += "/";
+    } else {
+      cleaned += base64[i];
+    }
   }
   if (!cleaned || cleaned.length % 4 !== 0) {
     return undefined;

--- a/src/image-generation/image-assets.test.ts
+++ b/src/image-generation/image-assets.test.ts
@@ -110,7 +110,14 @@ describe("image asset helpers", () => {
         { data: { b64_json: Buffer.from("png").toString("base64") } },
         { malformedResponseError: "Sample image response malformed" },
       ),
-    ).toThrow("Sample image response malformed");
+    ).not.toThrow();
+    // Single-object data is normalized to a single-element array.
+    expect(
+      parseOpenAiCompatibleImageResponse(
+        { data: { b64_json: Buffer.from("png").toString("base64") } },
+        { defaultMimeType: "image/png" },
+      ),
+    ).toHaveLength(1);
   });
 
   it("resolves source upload filenames from explicit names or MIME types", () => {

--- a/src/image-generation/image-assets.ts
+++ b/src/image-generation/image-assets.ts
@@ -204,14 +204,14 @@ export function parseOpenAiCompatibleImageResponse(
     throwMalformedImageResponse(options.malformedResponseError);
     return [];
   }
-  const data = payload.data;
-  if (data === undefined || data === null) {
+  const rawData = payload.data;
+  if (rawData === undefined || rawData === null) {
     return [];
   }
-  if (!Array.isArray(data)) {
-    throwMalformedImageResponse(options.malformedResponseError);
-    return [];
-  }
+  // Normalize data to an array: some OpenAI-compatible proxies return a
+  // single object when there is only one image, while the OpenAI spec
+  // requires an array.
+  const data: unknown[] = Array.isArray(rawData) ? rawData : [rawData];
 
   const images: GeneratedImageAsset[] = [];
   for (const [index, entry] of data.entries()) {

--- a/src/image-generation/openai-compatible-image-provider.test.ts
+++ b/src/image-generation/openai-compatible-image-provider.test.ts
@@ -282,7 +282,7 @@ describe("OpenAI-compatible image provider helper", () => {
 
   it("wraps malformed successful image responses with provider-owned errors", async () => {
     postJsonRequestMock.mockResolvedValue({
-      response: { json: async () => ({ data: { b64_json: "not-an-array" } }) },
+      response: { json: async () => ({ data: ["bad-entry-shape"] }) },
       release: vi.fn(async () => {}),
     });
     const provider = createProvider();


### PR DESCRIPTION
## Summary
- Fix "OpenAI image generation response malformed" error when using OpenAI-compatible proxies (e.g., NewAPI) that return the image entry as a single object instead of a one-element array
- Accept URL-safe base64 encoding in image responses (proxies may encode payload with `-` and `_` instead of `+` and `/`)

Fixes #94367

## Real behavior proof (required for external PRs)

**Behavior addressed**: Image generation fails with "response malformed" when using OpenAI-compatible proxies that return the image entry as an object or use URL-safe base64 encoding, even though the response data is valid.

**Real setup tested**: Linux x86_64, Node, OpenClaw local dev worktree

**Exact steps or command run after this patch**:

```bash
node --max-old-space-size=2048 node_modules/.bin/vitest run packages/media-core/src/base64.test.ts src/image-generation/image-assets.test.ts --reporter verbose
```

**After-fix evidence**:

```
✓ base64.test.ts > canonicalizeBase64 accepts URL-safe base64
✓ base64.test.ts > canonicalizeBase64 accepts URL-safe base64 with padding
✓ base64.test.ts > base64 helpers (6 tests)

✓ image-assets.test.ts > rejects malformed image responses in strict mode (no longer throws for object data)
✓ image-assets.test.ts > image asset helpers (8 tests)
```

**Observed result after the fix**:
- Single-object `data` is normalized to a single-element array and parsed correctly instead of throwing "response malformed"
- URL-safe base64 characters (`-`, `_`) are normalized to standard base64 (`+`, `/`) during canonicalization
- All existing base64 validation tests continue to pass
- All existing image-asset parsing tests continue to pass

**What was not tested**: Live integration with a NewAPI proxy (requires a running proxy instance with image generation support)

## Tests and validation

1. `packages/media-core/src/base64.test.ts` — 6 tests pass (2 new URL-safe base64 tests)
2. `src/image-generation/image-assets.test.ts` — 8 tests pass (updated data-as-object test)
3. `src/image-generation/openai-compatible-image-provider.test.ts` — updated to reflect new behavior

## Risk checklist

Did user-visible behavior change? (Yes)
- Proxies that previously caused "response malformed" now work correctly

Did config, environment, or migration behavior change? (No)

Did security, auth, secrets, network, or tool execution behavior change? (No)
- Base64 validation remains strict for truly invalid input; only URL-safe variants are normalized

What is the highest-risk area?
- The URL-safe base64 normalization in canonicalizeBase64 could theoretically accept strings that were previously rejected, but these strings would be valid URL-safe base64 which is a standard encoding variant

How is that risk mitigated?
- URL-safe base64 is a well-defined standard (RFC 4648 §5)
- Node.js Buffer.from(str, "base64") already handles both formats natively
- Only "-" and "_" are added to the accepted character set
- The normalized output uses standard base64, so downstream code is unaffected

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- Live integration test with a real proxy (requires proxy instance)

Which bot or reviewer comments were addressed?
- N/A