### PR TITLE
fix(zai): fall back to default baseUrl when template lacks one for catalog models

### DIFF
--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -34,7 +34,7 @@ import { fetchZaiUsage } from "openclaw/plugin-sdk/provider-usage";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
-import { buildZaiModelDefinition } from "./model-definitions.js";
+import { buildZaiModelDefinition, ZAI_GLOBAL_BASE_URL } from "./model-definitions.js";
 import { applyZaiConfig, applyZaiProviderConfig, resolveZaiModelId } from "./onboard.js";
 
 const PROVIDER_ID = "zai";
@@ -104,7 +104,7 @@ function resolveGlm5ForwardCompatModel(
     ...template,
     id: def.id,
     name: def.name,
-    baseUrl: ctx.providerConfig?.baseUrl ?? template?.baseUrl,
+    baseUrl: ctx.providerConfig?.baseUrl ?? template?.baseUrl ?? ZAI_GLOBAL_BASE_URL,
     api: "openai-completions",
     provider: PROVIDER_ID,
     reasoning: def.reasoning,


### PR DESCRIPTION
> **AI-assisted PR.** Implemented and verified with Claude (Claude Code). I have reviewed and understand the change and own the final diff.

## Summary

- **What**: Z.ai static catalog models (e.g. `zai/glm-5-turbo`) resolve without a baseUrl at runtime, causing the OpenAI-compatible transport to fall back to OpenAI's default API host. Users see confusing 401 errors from api.openai.com instead of expected Z.ai API calls.
- **Root cause**: The `resolveGlm5ForwardCompatModel` function in the Z.ai plugin resolves `baseUrl` as `ctx.providerConfig?.baseUrl ?? template?.baseUrl`. When there is no user config for the zai provider and the template model from the registry also lacks a per-model baseUrl (manifest catalog models only set baseUrl at the provider level), the resolved model ends up with `baseUrl: undefined`.
- **How**: Added `?? ZAI_GLOBAL_BASE_URL` as the final fallback so catalog models always resolve with their expected base URL.

Fixes #94269

## Real behavior proof (required for external PRs)

**Behavior addressed**:
Z.ai catalog models (glm-5-turbo, glm-5.1, glm-5.2, etc.) properly resolve with `https://api.z.ai/api/paas/v4` as their baseUrl when the user has not configured a custom provider config.

**Real environment tested**:
Code analysis + provider tests: 27/27 Z.ai provider tests pass.

**Before-fix evidence**:
```
resolveGlm5ForwardCompatModel for "zai/glm-5-turbo":
  ctx.providerConfig = undefined              // no user config
  template?.baseUrl = undefined               // manifest model entry has no per-model baseUrl
  → baseUrl: undefined                        // ← BUG: falls through to OpenAI default
```

**Exact steps or command run after this patch**:
```bash
# Run Z.ai provider test suite
$ node scripts/test-projects.mjs extensions/zai/ -- --run
 Test Files  5 passed (5)
      Tests  27 passed (27)
```

**After-fix evidence**:
```
resolveGlm5ForwardCompatModel for "zai/glm-5-turbo":
  ctx.providerConfig = undefined              // no user config
  template?.baseUrl = undefined               // manifest model entry has no per-model baseUrl
  ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4"
  → baseUrl: "https://api.z.ai/api/paas/v4"   // ✅ Fixed: falls back to known Z.ai base URL
```

**Observed result after the fix**:
Z.ai catalog models always resolve with the correct base URL. The three-tier fallback ensures:
1. User-configured `models.providers.zai.baseURL` takes highest priority
2. Template model baseUrl from the registry takes second priority
3. `ZAI_GLOBAL_BASE_URL` ("https://api.z.ai/api/paas/v4") is the final default

**What was not tested**:
- End-to-end test with a live Z.ai API key
- The CN endpoint case (users targeting open.bigmodel.cn should configure the endpoint explicitly)

## Tests and validation

```bash
node scripts/test-projects.mjs extensions/zai/ -- --run
# 27 tests passed across 5 test files:
# - index.test.ts (provider plugin wiring)
# - detect.test.ts (endpoint detection)
# - onboard.test.ts (configuration)
# - model-definitions.test.ts (metadata)
# - provider-runtime.contract.test.ts (runtime contract)
```

All existing tests pass without modification. No new tests needed — the fix is a single nullish coalescing fallback in the baseUrl resolution.

## Risk / scope

- 用户可见行为变化: Yes — Z.ai models without user config now correctly use api.z.ai instead of falling back to OpenAI. This is a bugfix, not a feature change.
- 配置/环境/迁移变化: No — existing user configs with explicit baseURL continue to take priority.
- 安全/凭据/网络变化: No — same API endpoint as the manifest-defined provider.
- 最高风险点: Users who explicitly configured a different baseUrl via `models.providers.zai.baseURL` are unaffected (their config takes priority).
- 缓解措施: The three-tier fallback (user config → template → default constant) ensures the most specific value wins.