### PR TITLE
fix(compaction): wire aggregate retry timeout to compaction.timeoutSeconds (#94391)

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -828,6 +828,9 @@ vi.mock("./compaction-retry-aggregate-timeout.js", () => ({
     timedOut: false,
     aborted: false,
   }),
+  resolveCompactionRetryAggregateTimeoutMs: () => 60_000,
+  COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS: 60_000,
+  COMPACTION_RETRY_AGGREGATE_TIMEOUT_MARGIN_MS: 30_000,
 }));
 
 vi.mock("./compaction-timeout.js", () => ({

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -355,6 +355,7 @@ import {
   isPrimaryBootstrapRun,
   remapInjectedContextFilesToWorkspace,
 } from "./attempt.bootstrap-context.js";
+import { resolveCompactionRetryAggregateTimeoutMs } from "./compaction-retry-aggregate-timeout.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import {
@@ -4919,7 +4920,15 @@ export async function runEmbeddedAttempt(
         // Only trust snapshot if compaction wasn't running before or after capture
         const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
         const preCompactionSessionId = activeSession.sessionId;
-        const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000;
+        // Derive the outer aggregate-wait budget from the inner compaction
+        // model-call safety timeout (agents.defaults.compaction.timeoutSeconds,
+        // already resolved as `compactionTimeoutMs` above). A hardcoded 60s
+        // outer wait used to fire before slow compaction calls (~150–190s on
+        // ~200K-token sessions) finished, abandoning valid results the
+        // provider had already returned and triggering a retry storm. See
+        // https://github.com/openclaw/openclaw/issues/94391.
+        const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS =
+          resolveCompactionRetryAggregateTimeoutMs(compactionTimeoutMs);
 
         try {
           // Flush buffered block replies before waiting for compaction so the

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -1,7 +1,12 @@
 // Coverage for aggregate timeout handling while waiting on compaction retry.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
-import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
+import {
+  COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+  COMPACTION_RETRY_AGGREGATE_TIMEOUT_MARGIN_MS,
+  resolveCompactionRetryAggregateTimeoutMs,
+  waitForCompactionRetryWithAggregateTimeout,
+} from "./compaction-retry-aggregate-timeout.js";
 
 type AggregateTimeoutParams = Parameters<typeof waitForCompactionRetryWithAggregateTimeout>[0];
 type TimeoutCallback = NonNullable<AggregateTimeoutParams["onTimeout"]>;
@@ -198,6 +203,86 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
 
       await expect(waitForCompactionRetryWithAggregateTimeout(params)).rejects.toThrow("aborted");
 
+      expectClearedTimeoutState(params.onTimeout, false);
+    });
+  });
+});
+
+describe("resolveCompactionRetryAggregateTimeoutMs", () => {
+  // Regression coverage for #94391: hardcoded 60s outer wait used to abandon
+  // valid compaction results on slow ~200K-token sessions.
+  it("falls back to the historical 60s floor when no inner timeout is provided", () => {
+    expect(resolveCompactionRetryAggregateTimeoutMs(undefined)).toBe(
+      COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    );
+  });
+
+  it("falls back to the floor for non-finite or non-positive inputs", () => {
+    expect(resolveCompactionRetryAggregateTimeoutMs(0)).toBe(
+      COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    );
+    expect(resolveCompactionRetryAggregateTimeoutMs(-1_000)).toBe(
+      COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    );
+    expect(resolveCompactionRetryAggregateTimeoutMs(Number.NaN)).toBe(
+      COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    );
+    expect(resolveCompactionRetryAggregateTimeoutMs(Number.POSITIVE_INFINITY)).toBe(
+      COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    );
+  });
+
+  it("keeps the floor when the inner timeout would resolve below it", () => {
+    expect(resolveCompactionRetryAggregateTimeoutMs(15_000)).toBe(
+      COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    );
+  });
+
+  it("adds a margin on top of the inner compaction timeout", () => {
+    // Default install: compaction.timeoutSeconds=180 → outer wait covers the
+    // inner cap so a slow but still-completing compaction is consumed instead
+    // of discarded.
+    expect(resolveCompactionRetryAggregateTimeoutMs(180_000)).toBe(
+      180_000 + COMPACTION_RETRY_AGGREGATE_TIMEOUT_MARGIN_MS,
+    );
+    // Operator override: compaction.timeoutSeconds=300 → outer wait scales.
+    expect(resolveCompactionRetryAggregateTimeoutMs(300_000)).toBe(
+      300_000 + COMPACTION_RETRY_AGGREGATE_TIMEOUT_MARGIN_MS,
+    );
+  });
+
+  it("waits the full configured budget before timing out (regression: #94391)", async () => {
+    // Mirrors the field repro: compaction model call returns at ~174s while
+    // the outer wait, wired to compaction.timeoutSeconds=300, must not fire
+    // at the legacy 60s mark.
+    await withFakeTimers(async () => {
+      const aggregateTimeoutMs = resolveCompactionRetryAggregateTimeoutMs(300_000);
+      let compactionInFlight = true;
+      const waitForCompactionRetry = vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            setTimeout(() => {
+              compactionInFlight = false;
+              resolve();
+            }, 174_000);
+          }),
+      );
+      const params = buildAggregateTimeoutParams({
+        waitForCompactionRetry,
+        aggregateTimeoutMs,
+        isCompactionStillInFlight: () => compactionInFlight,
+      });
+
+      const resultPromise = waitForCompactionRetryWithAggregateTimeout(params);
+
+      // Past the legacy 60s budget: the wait must still be in flight.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(params.onTimeout).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(174_000 - 60_000);
+      const result = await resultPromise;
+
+      expect(result.timedOut).toBe(false);
       expectClearedTimeoutState(params.onTimeout, false);
     });
   });

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
@@ -4,6 +4,50 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 
 /**
+ * Lower bound on the aggregate retry-wait budget. Preserves the historical
+ * 60s floor so installs that have not raised `agents.defaults.compaction
+ * .timeoutSeconds` keep the same behavior they had before this helper existed.
+ */
+export const COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS = 60_000;
+
+/**
+ * Slack added on top of the inner compaction model-call safety timeout so the
+ * outer aggregate wait never trips before the inner timeout has had a chance
+ * to fire and surface a real error. Without this margin, a compaction call
+ * that just barely fits inside `compaction.timeoutSeconds` could still race
+ * the aggregate wait and have its result silently discarded — see #94391.
+ */
+export const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MARGIN_MS = 30_000;
+
+/**
+ * Derive the outer aggregate-wait budget from the inner compaction model-call
+ * timeout.
+ *
+ * The inner safety timeout (`agents.defaults.compaction.timeoutSeconds`,
+ * default 180s) bounds how long a single compaction model call may run. The
+ * outer aggregate wait must always be at least that large plus a small
+ * margin, otherwise the outer wait abandons valid compaction results that
+ * the provider already returned (and which the caller has already paid for).
+ *
+ * Operators who raise `compaction.timeoutSeconds` automatically pick up a
+ * matching aggregate-wait budget; installs without that override fall back
+ * to the historical 60s floor.
+ */
+export function resolveCompactionRetryAggregateTimeoutMs(compactionTimeoutMs?: number): number {
+  if (
+    typeof compactionTimeoutMs !== "number" ||
+    !Number.isFinite(compactionTimeoutMs) ||
+    compactionTimeoutMs <= 0
+  ) {
+    return COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS;
+  }
+  return Math.max(
+    COMPACTION_RETRY_AGGREGATE_TIMEOUT_FLOOR_MS,
+    compactionTimeoutMs + COMPACTION_RETRY_AGGREGATE_TIMEOUT_MARGIN_MS,
+  );
+}
+
+/**
  * Waits for compaction retry completion with an aggregate timeout so a lost
  * retry resolution cannot hold the session lane indefinitely.
  */


### PR DESCRIPTION
Fixes #94391

## Root cause

In-turn compaction on ~200K-token sessions silently failed because the outer aggregate wait was a hardcoded `COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000` const inside `runEmbeddedAttempt` ([`src/agents/embedded-agent-runner/run/attempt.ts`](https://github.com/openclaw/openclaw/blob/main/src/agents/embedded-agent-runner/run/attempt.ts)). On `anthropic/claude-sonnet-4-6` the summary model call runs ~143–187s. The 60s outer wait fired first, marked the attempt incomplete, and discarded the result — even though the trajectory shows `model.completed aborted=False externalAbort=False timedOut=False` at 174s/143s/187s with valid output the provider had already been paid for.

Subsequent retries then collided with the still-running model call holding the session write lock (`DEFAULT_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS` = 60s) and gave up — the "self-compounding retry storm" Path 2 in the issue.

The inner safety wrapper `agents.defaults.compaction.timeoutSeconds` (default 180s, configurable; reporter set 300s) already governs how long a single compaction model call may run. The outer aggregate wait was simply not wired to it.

## Fix

Adopt the reporter's proposed approach: derive the outer aggregate-wait budget from the inner compaction model-call timeout instead of adding a new config surface.

- New helper `resolveCompactionRetryAggregateTimeoutMs(compactionTimeoutMs)` in `compaction-retry-aggregate-timeout.ts` returns `max(60s floor, compactionTimeoutMs + 30s margin)`.
- `attempt.ts` already resolves `compactionTimeoutMs = resolveCompactionTimeoutMs(params.config)` earlier in the function for the lock-hold/grace logic; the new outer wait reuses that value, no extra plumbing.
- 60s historical floor preserved as a fallback when the inner timeout is missing/non-finite — installs that don't touch `compaction.timeoutSeconds` get the same behavior they had before.

Behavior matrix:

| `compaction.timeoutSeconds` | Old outer wait | New outer wait |
|---|---|---|
| unset (default 180) | 60s ❌ | 210s ✅ |
| 300 (reporter's install) | 60s ❌ | 330s ✅ |
| 30 (below floor) | 60s | 60s (floor) |

The +30s margin guarantees the inner safety timeout always fires first when a compaction call genuinely hangs — the outer wait never preempts a still-completing call (Path 1 cause), which in turn eliminates the lock contention next-retry sees (Path 2 effect).

## Backwards compatibility

- No config schema change. `agents.defaults.compaction.timeoutSeconds` is already a documented public knob (used by `compaction-safety-timeout.ts`).
- Default install behavior changes from "60s outer wait abandons valid 150s+ compactions" to "210s outer wait waits for the inner cap to decide" — that is the intended fix; sessions that previously failed silently now succeed.
- `isCompactionStillInFlight` extension behavior is unchanged: while compaction is still running, the timer is restarted on each idle iteration just like before.

## Cancellation on abandon

The reporter also flagged that abandoning the wait without cancelling the model call wastes the API call. The existing inner wrapper `compactWithSafetyTimeout` already wires through an `AbortSignal` that fires when the inner timeout trips, and that signal is threaded into the underlying `compact()` call. With this PR the outer wait now waits long enough for that inner signal to be the one that fires on a true hang, so abandons happen with a real cancel rather than the outer timer leaving the call orphaned. Wiring an explicit cancel into the outer aggregate-wait abandon path would require crossing the `waitForCompactionRetry` abstraction (it does not currently expose a cancel) and is left for a follow-up if that path proves still reachable in practice.

## Tests

- New unit coverage in `compaction-retry-aggregate-timeout.test.ts` for `resolveCompactionRetryAggregateTimeoutMs`:
  - Floor when no/invalid inner timeout
  - Floor when inner timeout < 60s
  - Margin added on top of 180s default and 300s operator override
- Regression test mirroring the field repro from #94391: compaction model call returning at 174s with `compaction.timeoutSeconds=300` must no longer trip the 60s legacy budget; the wait must complete cleanly with `timedOut=false`.

`pnpm vitest run src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts` — 13 tests pass (was 8).

## Related

- #92043 — sibling family, different constant (`EMBEDDED_COMPACTION_TIMEOUT_MS` inner cap). Not a dup.
- #88919 — lock mechanism PR, secondary; this fix removes the upstream cause (Path 1) that triggers the lock contention (Path 2) #88919 targets independently.
- #30411 — early compaction threshold; this PR's calibration data (174s at ~200K tokens) supports the discussion there.
