### PR TITLE
fix(ports): probe all address families in ensurePortAvailable

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -634,7 +634,7 @@ async function tryListenOnHost(port: number, host: string): Promise<PortUsageSta
   }
 }
 
-async function checkPortInUse(port: number): Promise<PortUsageStatus> {
+export async function checkPortInUse(port: number): Promise<PortUsageStatus> {
   const hosts = ["127.0.0.1", "0.0.0.0", "::1", "::"];
   let sawUnknown = false;
   for (const host of hosts) {

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -110,6 +110,15 @@ describe("ports helpers", () => {
     }
   });
 
+  it("regression: #94415 — ensurePortAvailable fails fast when availability cannot be verified", async () => {
+    // An out-of-range port makes every bind probe reject with a non-EADDRINUSE
+    // error (ERR_SOCKET_BAD_PORT), so checkPortInUse reports "unknown". The
+    // preflight must rethrow rather than silently treat an unverifiable port as
+    // free (the pre-refactor bare-listen path rethrew non-EADDRINUSE errors).
+    await expect(ensurePortAvailable(99999)).rejects.toThrow();
+    await expect(ensurePortAvailable(99999)).rejects.not.toBeInstanceOf(PortInUseError);
+  });
+
   it("handlePortError exits nicely on EADDRINUSE", async () => {
     const runtime = {
       error: vi.fn(),

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -78,7 +78,20 @@ describe("ports helpers", () => {
     });
   });
 
-  it("ensurePortAvailable rejects an IPv4-only occupant on a dual-stack host", async () => {
+  it("ensurePortAvailable resolves when the port is free", async () => {
+    const server = net.createServer();
+    const address = await listenServer(server, 0);
+    if (!address) {
+      return;
+    }
+    const port = address.port;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    await expect(ensurePortAvailable(port)).resolves.toBeUndefined();
+  });
+
+  it("regression: #94379 — ensurePortAvailable detects an IPv4-only occupant on a dual-stack host", async () => {
     // A bare listen binds the IPv6 wildcard and would miss this 127.0.0.1-only
     // occupant; the preflight must probe all address families (regression for
     // the misleading Chrome CDP 401 collision).

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -78,6 +78,25 @@ describe("ports helpers", () => {
     });
   });
 
+  it("ensurePortAvailable rejects an IPv4-only occupant on a dual-stack host", async () => {
+    // A bare listen binds the IPv6 wildcard and would miss this 127.0.0.1-only
+    // occupant; the preflight must probe all address families (regression for
+    // the misleading Chrome CDP 401 collision).
+    const blocker = net.createServer();
+    const address = await listenServer(blocker, 0, "127.0.0.1");
+    if (!address) {
+      return;
+    }
+    const port = address.port;
+    try {
+      await expect(ensurePortAvailable(port)).rejects.toBeInstanceOf(PortInUseError);
+    } finally {
+      await new Promise<void>((resolve) => {
+        blocker.close(() => resolve());
+      });
+    }
+  });
+
   it("handlePortError exits nicely on EADDRINUSE", async () => {
     const runtime = {
       error: vi.fn(),

--- a/src/infra/ports.ts
+++ b/src/infra/ports.ts
@@ -5,8 +5,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { isErrno } from "./errors.js";
 import { formatPortDiagnostics } from "./ports-format.js";
-import { inspectPortUsage } from "./ports-inspect.js";
-import { tryListenOnPort } from "./ports-probe.js";
+import { checkPortInUse, inspectPortUsage } from "./ports-inspect.js";
 import type {
   PortConnection,
   PortConnections,
@@ -37,14 +36,11 @@ export async function describePortOwner(port: number): Promise<string | undefine
 }
 
 export async function ensurePortAvailable(port: number): Promise<void> {
-  // Detect EADDRINUSE early with a friendly message.
-  try {
-    await tryListenOnPort({ port });
-  } catch (err) {
-    if (isErrno(err) && err.code === "EADDRINUSE") {
-      throw new PortInUseError(port);
-    }
-    throw err;
+  // Probe every address family: a bare listen binds the IPv6 wildcard on
+  // dual-stack hosts and misses an IPv4-only occupant, letting Chrome later
+  // collide on 127.0.0.1 and surface a misleading CDP 401.
+  if ((await checkPortInUse(port)) === "busy") {
+    throw new PortInUseError(port);
   }
 }
 

--- a/src/infra/ports.ts
+++ b/src/infra/ports.ts
@@ -39,8 +39,16 @@ export async function ensurePortAvailable(port: number): Promise<void> {
   // Probe every address family: a bare listen binds the IPv6 wildcard on
   // dual-stack hosts and misses an IPv4-only occupant, letting Chrome later
   // collide on 127.0.0.1 and surface a misleading CDP 401.
-  if ((await checkPortInUse(port)) === "busy") {
+  const status = await checkPortInUse(port);
+  if (status === "busy") {
     throw new PortInUseError(port);
+  }
+  if (status === "unknown") {
+    // A bind probe failed with something other than EADDRINUSE (e.g. EACCES on
+    // a privileged port, EINVAL on an out-of-range port). The original
+    // bare-listen path rethrew here; preserve that fail-fast instead of
+    // silently treating an unverifiable port as available.
+    throw new Error(`Port ${port} availability could not be verified.`);
   }
 }
 


### PR DESCRIPTION
## Summary

`ensurePortAvailable` did its preflight with a bare `tryListenOnPort`, which binds the **IPv6 wildcard** (`::`) on dual-stack hosts. An occupant listening only on `127.0.0.1` (IPv4-only) is invisible to that probe, so the preflight reports a busy port as **free**.

Downstream, Chrome takes that "free" port via `--remote-debugging-port` and binds `127.0.0.1` for real, collides with the existing IPv4-only occupant, and the CDP HTTP endpoint never comes up — surfacing as a misleading **CDP 401** handshake failure (the symptom behind #94379).

The fix routes the preflight through `checkPortInUse`, which probes all four address endpoints — `127.0.0.1`, `0.0.0.0`, `::1`, `::` — so an occupant on **any** family is caught early with a proper `PortInUseError`. The heavy `lsof`/`ss` diagnostics in `inspectPortUsage` stay where they were: in `handlePortError`, on failure only. Net cost is one new export and four lightweight socket probes at startup.

## Root cause

- **Probe before:** single `listen()` on the IPv6 wildcard `::`
- **Miss:** an IPv4-only occupant bound to `127.0.0.1` does not conflict with a `::` bind on a dual-stack host
- **Consequence:** preflight returns "free" → Chrome binds `127.0.0.1` → EADDRINUSE at the socket layer → CDP endpoint fails → misleading 401

## Real behavior proof

- **Behavior or issue addressed:** On a dual-stack host the old preflight binds the IPv6 wildcard `::` and never notices an occupant bound only to `127.0.0.1`, so it green-lights a port that is actually taken. Chrome then binds `127.0.0.1` via `--remote-debugging-port`, collides, and the CDP endpoint fails its handshake with a misleading 401 (#94379).
- **Real environment tested:** macOS Darwin 25.4.0 (arm64), Node v26.0.0, dual-stack loopback. Reproduced by binding a real IPv4-only occupant on `127.0.0.1`, then exercising the old probe (`listen ::`) and the new probe (`listen 127.0.0.1`, one of the address families `checkPortInUse` now covers) against that same port.
- **Exact steps or command run after this patch:** `node /tmp/repro-94379.mjs` — bind an IPv4-only occupant on `127.0.0.1:<p>`, then attempt the old-style `::` wildcard bind and the new-style `127.0.0.1` bind on `<p>`, printing what each returns.
- **Evidence after fix:** copied live terminal output from that run:
```
occupant bound IPv4-only on 127.0.0.1:61780
OLD preflight (listen ::):           SUCCEEDED -> reports port 61780 FREE  [FALSE NEGATIVE]
NEW preflight (listen 127.0.0.1):    EADDRINUSE -> detected as BUSY -> PortInUseError  [CORRECT]
```
- **Observed result after fix:** the new preflight probes `127.0.0.1` (among all families) and gets `EADDRINUSE` against the IPv4-only occupant → classifies the port as busy → throws `PortInUseError`, so the taken port is no longer let through. The old logic bound `::` successfully on the same scenario and wrongly reported the port free.
- **What was not tested:** did not drive a full end-to-end Chrome `--remote-debugging-port` launch (the root cause lives at the socket address-family layer and is reproduced/fixed there). The sibling `isPortBusy` in `src/cli/ports.ts` shares the same flaw and is left for a separate follow-up.

## Scope note

A sibling `isPortBusy` (`src/cli/ports.ts`, the `gateway --force` kill-port guard) shares the same bare-listen flaw but on a different surface (force-kill flow, not CDP preflight) with lower harm. Left untouched to keep this PR scoped to #94379; happy to follow up separately.

Fixes #94379
