### PR TITLE
fix(matrix): handle event decryption errors during sync

### DIFF
--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -74,6 +74,27 @@ describe("createMatrixMonitorSyncLifecycle", () => {
     });
   });
 
+  it("keeps the channel wait alive for Matrix missing-key decryption errors", async () => {
+    const { client, lifecycle, setStatus } = createSyncLifecycleHarness();
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    client.emit(
+      "sync.unexpected_error",
+      new Error(
+        "Error decrypting event (id=$event type=m.room.encrypted): DecryptionError[msg: The sender's device has not sent us the keys for this message.]",
+      ),
+    );
+    await Promise.resolve();
+
+    expect(
+      statusCalls(setStatus).some(
+        (status) => status.accountId === "default" && status.healthState === "error",
+      ),
+    ).toBe(false);
+    lifecycle.dispose();
+    await expect(waitPromise).resolves.toBeUndefined();
+  });
+
   it("ignores STOPPED emitted during intentional shutdown", async () => {
     const { client, lifecycle, setStatus, setStopping } = createSyncLifecycleHarness({
       withStopping: true,

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -74,25 +74,27 @@ describe("createMatrixMonitorSyncLifecycle", () => {
     });
   });
 
-  it("keeps the channel wait alive for Matrix missing-key decryption errors", async () => {
+  it("treats missing-key-shaped unexpected sync errors as fatal", async () => {
     const { client, lifecycle, setStatus } = createSyncLifecycleHarness();
 
     const waitPromise = lifecycle.waitForFatalStop();
-    client.emit(
-      "sync.unexpected_error",
-      new Error(
-        "Error decrypting event (id=$event type=m.room.encrypted): DecryptionError[msg: The sender's device has not sent us the keys for this message.]",
-      ),
+    const error = new Error(
+      "Error decrypting event (id=$event type=m.room.encrypted): DecryptionError[msg: The sender's device has not sent us the keys for this message.]",
     );
-    await Promise.resolve();
+    try {
+      client.emit("sync.unexpected_error", error);
+      await Promise.resolve();
 
-    expect(
-      statusCalls(setStatus).some(
-        (status) => status.accountId === "default" && status.healthState === "error",
-      ),
-    ).toBe(false);
-    lifecycle.dispose();
-    await expect(waitPromise).resolves.toBeUndefined();
+      expectLastStatusFields(setStatus, {
+        accountId: "default",
+        healthState: "error",
+        lastError: error.message,
+      });
+      await expect(waitPromise).rejects.toThrow(error.message);
+    } finally {
+      lifecycle.dispose();
+      await waitPromise.catch(() => undefined);
+    }
   });
 
   it("ignores STOPPED emitted during intentional shutdown", async () => {

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -17,18 +17,6 @@ function formatSyncLifecycleError(state: MatrixSyncState, error?: unknown): Erro
   return new Error(message ?? `Matrix sync entered ${state} unexpectedly`);
 }
 
-function isMatrixMissingKeyDecryptionError(error: Error): boolean {
-  const message = `${error.name} ${error.message}`.toLowerCase();
-  const decryptingEncryptedEvent =
-    message.includes("error decrypting event") && message.includes("m.room.encrypted");
-  const decryptionFailure =
-    message.includes("decryptionerror") || message.includes("megolm_unknown_inbound_session_id");
-  const missingKey =
-    message.includes("has not sent us the keys") ||
-    message.includes("megolm_unknown_inbound_session_id");
-  return decryptingEncryptedEvent && decryptionFailure && missingKey;
-}
-
 export function createMatrixMonitorSyncLifecycle(params: {
   client: MatrixClient;
   statusController: MatrixMonitorStatusController;
@@ -70,7 +58,7 @@ export function createMatrixMonitorSyncLifecycle(params: {
   };
 
   const onUnexpectedError = (error: Error) => {
-    if (params.isStopping?.() || isMatrixMissingKeyDecryptionError(error)) {
+    if (params.isStopping?.()) {
       return;
     }
     params.statusController.noteUnexpectedError(error);

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -17,6 +17,18 @@ function formatSyncLifecycleError(state: MatrixSyncState, error?: unknown): Erro
   return new Error(message ?? `Matrix sync entered ${state} unexpectedly`);
 }
 
+function isMatrixMissingKeyDecryptionError(error: Error): boolean {
+  const message = `${error.name} ${error.message}`.toLowerCase();
+  const decryptingEncryptedEvent =
+    message.includes("error decrypting event") && message.includes("m.room.encrypted");
+  const decryptionFailure =
+    message.includes("decryptionerror") || message.includes("megolm_unknown_inbound_session_id");
+  const missingKey =
+    message.includes("has not sent us the keys") ||
+    message.includes("megolm_unknown_inbound_session_id");
+  return decryptingEncryptedEvent && decryptionFailure && missingKey;
+}
+
 export function createMatrixMonitorSyncLifecycle(params: {
   client: MatrixClient;
   statusController: MatrixMonitorStatusController;
@@ -58,7 +70,7 @@ export function createMatrixMonitorSyncLifecycle(params: {
   };
 
   const onUnexpectedError = (error: Error) => {
-    if (params.isStopping?.()) {
+    if (params.isStopping?.() || isMatrixMissingKeyDecryptionError(error)) {
       return;
     }
     params.statusController.noteUnexpectedError(error);

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -243,7 +243,7 @@ type MatrixJsClientStub = {
   sendTyping: ReturnType<typeof vi.fn>;
   getRoom: ReturnType<typeof vi.fn>;
   getRooms: ReturnType<typeof vi.fn>;
-  getCrypto: ReturnType<typeof vi.fn>;
+  getCrypto: ReturnType<typeof vi.fn<() => unknown>>;
   decryptEventIfNeeded: ReturnType<typeof vi.fn>;
   relations: ReturnType<typeof vi.fn>;
 };

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -8,6 +8,7 @@ import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixTestRuntime } from "../test-runtime.js";
 import { readMatrixRecoveryKeyState } from "./crypto-state-store.js";
+import { MatrixDecryptBridge } from "./sdk/decrypt-bridge.js";
 
 function requestUrl(input: RequestInfo | URL | undefined): string {
   if (!input) {
@@ -3762,5 +3763,65 @@ describe("MatrixClient crypto bootstrapping", () => {
 
     expect(result.success).toBe(true);
     expect(result.error).toBeUndefined();
+  });
+
+  it("bounds exhausted decrypt retry rehydration on crypto signals", async () => {
+    const cryptoApi = {};
+    const bridge = new MatrixDecryptBridge({
+      client: {
+        getCrypto: () => cryptoApi,
+      },
+      toRaw: (event) => ({
+        event_id: event.getId() ?? "",
+      }),
+      emitDecryptedEvent: vi.fn(),
+      emitFailedDecryption: vi.fn(),
+      emitMessage: vi.fn(),
+    });
+    const retryStates = (
+      bridge as unknown as {
+        exhaustedDecryptRetries: Map<
+          string,
+          {
+            event: FakeMatrixEvent;
+            roomId: string;
+            eventId: string;
+            attempts: number;
+            inFlight: boolean;
+            timer: ReturnType<typeof setTimeout> | null;
+            exhaustedAt: number;
+          }
+        >;
+      }
+    ).exhaustedDecryptRetries;
+    const events = Array.from({ length: 513 }, (_unused, index) => {
+      const event = new FakeMatrixEvent({
+        roomId: "!room:example.org",
+        eventId: `$event-${index}`,
+        sender: "@alice:example.org",
+        type: "m.room.encrypted",
+        ts: Date.now(),
+        content: {},
+        decryptionFailure: true,
+      });
+      event.onAttemptDecryption(() => {});
+      retryStates.set(`!room:example.org|$event-${index}`, {
+        event,
+        roomId: "!room:example.org",
+        eventId: `$event-${index}`,
+        attempts: 8,
+        inFlight: false,
+        timer: null,
+        exhaustedAt: Date.now(),
+      });
+      return event;
+    });
+
+    bridge.retryPendingNow("test crypto signal", { includeExhausted: true });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events[0]?.attemptDecryption).not.toHaveBeenCalled();
+    expect(events.at(-1)?.attemptDecryption).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1170,6 +1170,69 @@ describe("MatrixClient event bridge", () => {
     expect(failed).toEqual(["missing room key"]);
   });
 
+  it("retries an exhausted missing-key decryption when a crypto key signal arrives", async () => {
+    vi.useFakeTimers();
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+    });
+    const delivered: string[] = [];
+    const cryptoListeners = new Map<string, (...args: unknown[]) => void>();
+
+    matrixJsClient.getCrypto = vi.fn(() => ({
+      on: vi.fn((eventName: string, listener: (...args: unknown[]) => void) => {
+        cryptoListeners.set(eventName, listener);
+      }),
+      bootstrapCrossSigning: vi.fn(async () => {}),
+      bootstrapSecretStorage: vi.fn(consumeMatrixSecretStorageKey),
+      requestOwnUserVerification: vi.fn(async () => null),
+    }));
+
+    client.on("room.message", (_roomId, event) => {
+      delivered.push(event.type);
+    });
+
+    const encrypted = new FakeMatrixEvent({
+      roomId: "!room:example.org",
+      eventId: "$event",
+      sender: "@alice:example.org",
+      type: "m.room.encrypted",
+      ts: Date.now(),
+      content: {},
+      decryptionFailure: true,
+    });
+
+    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {});
+
+    await client.start();
+    try {
+      matrixJsClient.emit("event", encrypted);
+      encrypted.emit("decrypted", encrypted, new Error("missing room key"));
+
+      await vi.advanceTimersByTimeAsync(200_000);
+      expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(8);
+
+      matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
+        encrypted.markDecrypted({
+          type: "m.room.message",
+          content: {
+            msgtype: "m.text",
+            body: "hello",
+          },
+        });
+      });
+
+      const trigger = cryptoListeners.get("crypto.keyBackupDecryptionKeyCached");
+      expect(trigger).toBeTypeOf("function");
+      trigger?.();
+      await Promise.resolve();
+
+      expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
+      expect(delivered).toEqual(["m.room.message"]);
+    } finally {
+      client.stopSyncWithoutPersist();
+    }
+  });
+
   it("does not start duplicate retries when crypto signals fire while retry is in-flight", async () => {
     vi.useFakeTimers();
     const client = new MatrixClient("https://matrix.example.org", "token", {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1172,8 +1172,11 @@ describe("MatrixClient event bridge", () => {
 
   it("retries an exhausted missing-key decryption when a crypto key signal arrives", async () => {
     vi.useFakeTimers();
+    const cryptoStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-exhausted-retry-"));
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
+      idbSnapshotPath: path.join(cryptoStateDir, "crypto-idb-snapshot.json"),
+      cryptoDatabasePrefix: path.basename(cryptoStateDir),
     });
     const delivered: string[] = [];
     const cryptoListeners = new Map<string, (...args: unknown[]) => void>();
@@ -1234,9 +1237,11 @@ describe("MatrixClient event bridge", () => {
   });
 
   it("does not start duplicate retries when crypto signals fire while retry is in-flight", async () => {
-    vi.useFakeTimers();
+    const cryptoStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-duplicate-retry-"));
     const client = new MatrixClient("https://matrix.example.org", "token", {
       encryption: true,
+      idbSnapshotPath: path.join(cryptoStateDir, "crypto-idb-snapshot.json"),
+      cryptoDatabasePrefix: path.basename(cryptoStateDir),
     });
     const delivered: string[] = [];
     const cryptoListeners = new Map<string, (...args: unknown[]) => void>();
@@ -1287,19 +1292,23 @@ describe("MatrixClient event bridge", () => {
     );
 
     await client.start();
-    matrixJsClient.emit("event", encrypted);
-    encrypted.emit("decrypted", encrypted, new Error("missing room key"));
+    try {
+      matrixJsClient.emit("event", encrypted);
+      encrypted.emit("decrypted", encrypted, new Error("missing room key"));
 
-    const trigger = cryptoListeners.get("crypto.keyBackupDecryptionKeyCached");
-    expect(trigger).toBeTypeOf("function");
-    trigger?.();
-    trigger?.();
-    await Promise.resolve();
+      const trigger = cryptoListeners.get("crypto.keyBackupDecryptionKeyCached");
+      expect(trigger).toBeTypeOf("function");
+      trigger?.();
+      trigger?.();
+      await Promise.resolve();
 
-    expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
-    releaseRetryRef.current?.();
-    await Promise.resolve();
-    expect(delivered).toEqual(["m.room.message"]);
+      expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
+      releaseRetryRef.current?.();
+      await Promise.resolve();
+      expect(delivered).toEqual(["m.room.message"]);
+    } finally {
+      client.stopSyncWithoutPersist();
+    }
   });
 
   it("emits room.invite when a membership invite targets the current user", async () => {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { CryptoEvent } from "matrix-js-sdk/lib/crypto-api/CryptoEvent.js";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixTestRuntime } from "../test-runtime.js";
@@ -3823,5 +3824,69 @@ describe("MatrixClient crypto bootstrapping", () => {
 
     expect(events[0]?.attemptDecryption).not.toHaveBeenCalled();
     expect(events.at(-1)?.attemptDecryption).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not rehydrate exhausted decrypt retries on generic device updates", async () => {
+    const listeners = new Map<string, () => void>();
+    const cryptoApi = {
+      on: vi.fn((eventName: string, listener: () => void) => {
+        listeners.set(eventName, listener);
+      }),
+    };
+    const bridge = new MatrixDecryptBridge({
+      client: {
+        getCrypto: () => cryptoApi,
+      },
+      toRaw: (event) => ({
+        event_id: event.getId() ?? "",
+      }),
+      emitDecryptedEvent: vi.fn(),
+      emitFailedDecryption: vi.fn(),
+      emitMessage: vi.fn(),
+    });
+    const event = new FakeMatrixEvent({
+      roomId: "!room:example.org",
+      eventId: "$event",
+      sender: "@alice:example.org",
+      type: "m.room.encrypted",
+      ts: Date.now(),
+      content: {},
+      decryptionFailure: true,
+    });
+    event.onAttemptDecryption(() => {});
+    (
+      bridge as unknown as {
+        exhaustedDecryptRetries: Map<
+          string,
+          {
+            event: FakeMatrixEvent;
+            roomId: string;
+            eventId: string;
+            attempts: number;
+            inFlight: boolean;
+            timer: ReturnType<typeof setTimeout> | null;
+            exhaustedAt: number;
+          }
+        >;
+      }
+    ).exhaustedDecryptRetries.set("!room:example.org|$event", {
+      event,
+      roomId: "!room:example.org",
+      eventId: "$event",
+      attempts: 8,
+      inFlight: false,
+      timer: null,
+      exhaustedAt: Date.now(),
+    });
+
+    bridge.bindCryptoRetrySignals(cryptoApi);
+    listeners.get(CryptoEvent.DevicesUpdated)?.();
+    await Promise.resolve();
+
+    expect(event.attemptDecryption).not.toHaveBeenCalled();
+    listeners.get(CryptoEvent.KeyBackupDecryptionKeyCached)?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(event.attemptDecryption).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1236,6 +1236,65 @@ describe("MatrixClient event bridge", () => {
     }
   });
 
+  it("clears exhausted decrypt retries when the bridge stops", async () => {
+    vi.useFakeTimers();
+    const cryptoStateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "matrix-sdk-stop-exhausted-retry-"),
+    );
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+      idbSnapshotPath: path.join(cryptoStateDir, "crypto-idb-snapshot.json"),
+      cryptoDatabasePrefix: path.basename(cryptoStateDir),
+    });
+    const cryptoListeners = new Map<string, (...args: unknown[]) => void>();
+
+    matrixJsClient.getCrypto = vi.fn(() => ({
+      on: vi.fn((eventName: string, listener: (...args: unknown[]) => void) => {
+        cryptoListeners.set(eventName, listener);
+      }),
+      bootstrapCrossSigning: vi.fn(async () => {}),
+      bootstrapSecretStorage: vi.fn(consumeMatrixSecretStorageKey),
+      requestOwnUserVerification: vi.fn(async () => null),
+    }));
+
+    const encrypted = new FakeMatrixEvent({
+      roomId: "!room:example.org",
+      eventId: "$event",
+      sender: "@alice:example.org",
+      type: "m.room.encrypted",
+      ts: Date.now(),
+      content: {},
+      decryptionFailure: true,
+    });
+
+    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {});
+
+    await client.start();
+    matrixJsClient.emit("event", encrypted);
+    encrypted.emit("decrypted", encrypted, new Error("missing room key"));
+
+    await vi.advanceTimersByTimeAsync(200_000);
+    expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(8);
+
+    client.stopWithoutPersist();
+    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
+      encrypted.markDecrypted({
+        type: "m.room.message",
+        content: {
+          msgtype: "m.text",
+          body: "hello",
+        },
+      });
+    });
+
+    const trigger = cryptoListeners.get("crypto.keyBackupDecryptionKeyCached");
+    expect(trigger).toBeTypeOf("function");
+    trigger?.();
+    await Promise.resolve();
+
+    expect(matrixJsClient.decryptEventIfNeeded).not.toHaveBeenCalled();
+  });
+
   it("does not start duplicate retries when crypto signals fire while retry is in-flight", async () => {
     const cryptoStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-sdk-duplicate-retry-"));
     const client = new MatrixClient("https://matrix.example.org", "token", {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -96,16 +96,24 @@ class FakeMatrixEvent extends EventEmitter {
   private readonly roomId: string;
   private readonly eventId: string;
   private readonly sender: string;
+  private readonly encrypted: boolean;
   private type: string;
   private readonly ts: number;
   private content: Record<string, unknown>;
+  private clearEvent?: { type: string; content: Record<string, unknown> };
   private readonly stateKey?: string;
   private readonly unsigned?: {
     age?: number;
     redacted_because?: unknown;
   };
-  readonly decryptionFailureReason?: string;
+  private decryptionFailureReasonValue?: string;
   private decryptionFailure: boolean;
+  private decryptAttemptHandler?: (options?: { isRetry?: boolean }) => Promise<void> | void;
+  readonly attemptDecryption = vi.fn(
+    async (_crypto: unknown, options?: { isRetry?: boolean }): Promise<void> => {
+      await this.decryptAttemptHandler?.(options);
+    },
+  );
 
   constructor(params: {
     roomId: string;
@@ -126,13 +134,18 @@ class FakeMatrixEvent extends EventEmitter {
     this.roomId = params.roomId;
     this.eventId = params.eventId;
     this.sender = params.sender;
+    this.encrypted = params.type === "m.room.encrypted";
     this.type = params.type;
     this.ts = params.ts;
     this.content = params.content;
     this.stateKey = params.stateKey;
     this.unsigned = params.unsigned;
-    this.decryptionFailureReason = params.decryptionFailureReason;
+    this.decryptionFailureReasonValue = params.decryptionFailureReason;
     this.decryptionFailure = params.decryptionFailure === true;
+  }
+
+  get decryptionFailureReason(): string | undefined {
+    return this.decryptionFailureReasonValue;
   }
 
   getRoomId(): string {
@@ -148,7 +161,7 @@ class FakeMatrixEvent extends EventEmitter {
   }
 
   getType(): string {
-    return this.type;
+    return this.clearEvent?.type ?? this.type;
   }
 
   getTs(): number {
@@ -156,7 +169,7 @@ class FakeMatrixEvent extends EventEmitter {
   }
 
   getContent(): Record<string, unknown> {
-    return this.content;
+    return this.clearEvent?.content ?? this.content;
   }
 
   getUnsigned(): { age?: number; redacted_because?: unknown } {
@@ -171,10 +184,33 @@ class FakeMatrixEvent extends EventEmitter {
     return this.decryptionFailure;
   }
 
+  shouldAttemptDecryption(): boolean {
+    return this.encrypted && this.clearEvent === undefined;
+  }
+
+  onAttemptDecryption(handler: (options?: { isRetry?: boolean }) => Promise<void> | void): void {
+    this.decryptAttemptHandler = handler;
+  }
+
+  markDecryptionFailed(reason: string): void {
+    this.clearEvent = {
+      type: "m.room.message",
+      content: {
+        msgtype: "m.bad.encrypted",
+        body: `** Unable to decrypt: ${reason} **`,
+      },
+    };
+    this.decryptionFailure = true;
+    this.decryptionFailureReasonValue ??= DecryptionFailureCode.MEGOLM_UNKNOWN_INBOUND_SESSION_ID;
+    this.emit("decrypted", this, new Error(reason));
+  }
+
   markDecrypted(params: { type: string; content: Record<string, unknown> }): void {
     this.type = params.type;
     this.content = params.content;
+    this.clearEvent = { type: params.type, content: params.content };
     this.decryptionFailure = false;
+    this.decryptionFailureReasonValue = undefined;
   }
 }
 
@@ -989,7 +1025,7 @@ describe("MatrixClient event bridge", () => {
         body: "hello",
       },
     });
-    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
+    encrypted.onAttemptDecryption(() => {
       encrypted.emit("decrypted", decrypted);
     });
 
@@ -1004,8 +1040,9 @@ describe("MatrixClient event bridge", () => {
     expect(trigger).toBeTypeOf("function");
     trigger?.();
     await Promise.resolve();
+    await Promise.resolve();
 
-    expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
+    expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(1);
     expect(delivered).toEqual(["m.room.message"]);
   });
 
@@ -1204,17 +1241,25 @@ describe("MatrixClient event bridge", () => {
       decryptionFailure: true,
     });
 
-    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {});
+    matrixJsClient.decryptEventIfNeeded = vi.fn(
+      async (event: FakeMatrixEvent, options?: { isRetry?: boolean }) => {
+        if (!event.shouldAttemptDecryption()) {
+          return;
+        }
+        await event.attemptDecryption(matrixJsClient.getCrypto(), options);
+      },
+    );
 
     await client.start();
     try {
       matrixJsClient.emit("event", encrypted);
-      encrypted.emit("decrypted", encrypted, new Error("missing room key"));
+      encrypted.markDecryptionFailed("missing room key");
 
       await vi.advanceTimersByTimeAsync(200_000);
-      expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(8);
+      expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(8);
 
-      matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
+      encrypted.attemptDecryption.mockClear();
+      encrypted.onAttemptDecryption(() => {
         encrypted.markDecrypted({
           type: "m.room.message",
           content: {
@@ -1228,8 +1273,9 @@ describe("MatrixClient event bridge", () => {
       expect(trigger).toBeTypeOf("function");
       trigger?.();
       await Promise.resolve();
+      await Promise.resolve();
 
-      expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
+      expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(1);
       expect(delivered).toEqual(["m.room.message"]);
     } finally {
       client.stopSyncWithoutPersist();
@@ -1267,17 +1313,16 @@ describe("MatrixClient event bridge", () => {
       decryptionFailure: true,
     });
 
-    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {});
-
     await client.start();
     matrixJsClient.emit("event", encrypted);
     encrypted.emit("decrypted", encrypted, new Error("missing room key"));
 
     await vi.advanceTimersByTimeAsync(200_000);
-    expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(8);
+    expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(8);
 
     client.stopWithoutPersist();
-    matrixJsClient.decryptEventIfNeeded = vi.fn(async () => {
+    encrypted.attemptDecryption.mockClear();
+    encrypted.onAttemptDecryption(() => {
       encrypted.markDecrypted({
         type: "m.room.message",
         content: {
@@ -1292,7 +1337,7 @@ describe("MatrixClient event bridge", () => {
     trigger?.();
     await Promise.resolve();
 
-    expect(matrixJsClient.decryptEventIfNeeded).not.toHaveBeenCalled();
+    expect(encrypted.attemptDecryption).not.toHaveBeenCalled();
   });
 
   it("does not start duplicate retries when crypto signals fire while retry is in-flight", async () => {
@@ -1340,7 +1385,7 @@ describe("MatrixClient event bridge", () => {
     });
 
     const releaseRetryRef: { current?: () => void } = {};
-    matrixJsClient.decryptEventIfNeeded = vi.fn(
+    encrypted.onAttemptDecryption(
       async () =>
         await new Promise<void>((resolve) => {
           releaseRetryRef.current = () => {
@@ -1361,8 +1406,9 @@ describe("MatrixClient event bridge", () => {
       trigger?.();
       await Promise.resolve();
 
-      expect(matrixJsClient.decryptEventIfNeeded).toHaveBeenCalledTimes(1);
+      expect(encrypted.attemptDecryption).toHaveBeenCalledTimes(1);
       releaseRetryRef.current?.();
+      await Promise.resolve();
       await Promise.resolve();
       expect(delivered).toEqual(["m.room.message"]);
     } finally {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -3889,4 +3889,69 @@ describe("MatrixClient crypto bootstrapping", () => {
     await Promise.resolve();
     expect(event.attemptDecryption).toHaveBeenCalledTimes(1);
   });
+
+  it("does not rearm or emit after stop while a decrypt retry is in flight", async () => {
+    let releaseDecrypt: (() => void) | undefined;
+    const emitFailedDecryption = vi.fn();
+    const emitMessage = vi.fn();
+    const bridge = new MatrixDecryptBridge({
+      client: {
+        getCrypto: () => ({}),
+      },
+      toRaw: (event) => ({
+        event_id: event.getId() ?? "",
+      }),
+      emitDecryptedEvent: vi.fn(),
+      emitFailedDecryption,
+      emitMessage,
+    });
+    const event = new FakeMatrixEvent({
+      roomId: "!room:example.org",
+      eventId: "$event",
+      sender: "@alice:example.org",
+      type: "m.room.encrypted",
+      ts: Date.now(),
+      content: {},
+      decryptionFailure: true,
+    });
+    event.onAttemptDecryption(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDecrypt = () => {
+            event.emit("decrypted", event, new Error("still missing"));
+            resolve();
+          };
+        }),
+    );
+    const retryState = {
+      event,
+      roomId: "!room:example.org",
+      eventId: "$event",
+      attempts: 1,
+      inFlight: false,
+      timer: null,
+    };
+    (
+      bridge as unknown as {
+        decryptRetries: Map<string, typeof retryState>;
+      }
+    ).decryptRetries.set("!room:example.org|$event", retryState);
+
+    bridge.retryPendingNow("test retry");
+    await Promise.resolve();
+    bridge.stop();
+    releaseDecrypt?.();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(emitFailedDecryption).not.toHaveBeenCalled();
+    expect(emitMessage).not.toHaveBeenCalled();
+    expect(
+      (
+        bridge as unknown as {
+          decryptRetries: Map<string, typeof retryState>;
+        }
+      ).decryptRetries.size,
+    ).toBe(0);
+  });
 });

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -11,6 +11,16 @@ type MatrixDecryptIfNeededClient = {
       isRetry?: boolean;
     },
   ) => Promise<void>;
+  getCrypto?: () => unknown;
+};
+
+type MatrixDecryptRetryEvent = MatrixEvent & {
+  attemptDecryption?: (
+    crypto: unknown,
+    opts?: {
+      isRetry?: boolean;
+    },
+  ) => Promise<void>;
 };
 
 type MatrixDecryptRetryState = {
@@ -334,7 +344,14 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     state.inFlight = true;
     state.timer = null;
     this.activeRetryRuns += 1;
-    const canDecrypt = typeof this.deps.client.decryptEventIfNeeded === "function";
+    const retryEvent = state.event as MatrixDecryptRetryEvent;
+    const retryCrypto = this.deps.client.getCrypto?.();
+    const canAttemptDecryption =
+      retryCrypto !== undefined &&
+      retryCrypto !== null &&
+      typeof retryEvent.attemptDecryption === "function";
+    const canDecrypt =
+      canAttemptDecryption || typeof this.deps.client.decryptEventIfNeeded === "function";
     if (!canDecrypt) {
       this.clearDecryptRetry(retryKey);
       this.activeRetryRuns = Math.max(0, this.activeRetryRuns - 1);
@@ -343,9 +360,15 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     }
 
     try {
-      await this.deps.client.decryptEventIfNeeded?.(state.event, {
-        isRetry: true,
-      });
+      if (canAttemptDecryption) {
+        await retryEvent.attemptDecryption?.(retryCrypto, {
+          isRetry: true,
+        });
+      } else {
+        await this.deps.client.decryptEventIfNeeded?.(state.event, {
+          isRetry: true,
+        });
+      }
     } catch {
       // Retry with backoff until we hit the configured retry cap.
     } finally {

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -95,6 +95,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
   private activeRetryRuns = 0;
   private readonly retryIdleResolvers = new Set<() => void>();
   private cryptoRetrySignalsBound = false;
+  private stopped = false;
 
   constructor(
     private readonly deps: {
@@ -120,6 +121,9 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
   }
 
   attachEncryptedEvent(event: MatrixEvent, roomId: string): void {
+    if (this.stopped) {
+      return;
+    }
     if (this.trackedEncryptedEvents.has(event)) {
       return;
     }
@@ -140,6 +144,9 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
   }
 
   retryPendingNow(reason: string, options?: { includeExhausted?: boolean }): void {
+    if (this.stopped) {
+      return;
+    }
     if (options?.includeExhausted) {
       this.pruneExhaustedDecryptRetries(Date.now());
       for (const [retryKey, state] of this.exhaustedDecryptRetries) {
@@ -198,6 +205,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
   }
 
   stop(): void {
+    this.stopped = true;
     for (const retryKey of this.decryptRetries.keys()) {
       this.clearDecryptRetry(retryKey);
     }
@@ -226,6 +234,9 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     decryptedEvent: MatrixEvent;
     err?: Error;
   }): void {
+    if (this.stopped) {
+      return;
+    }
     const decryptedRoomId = params.decryptedEvent.getRoomId() || params.roomId;
     const decryptedRaw = this.deps.toRaw(params.decryptedEvent);
     const retryEventId = decryptedRaw.event_id || params.encryptedEvent.getId() || "";
@@ -292,6 +303,9 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     roomId: string;
     eventId: string;
   }): void {
+    if (this.stopped) {
+      return;
+    }
     const retryKey = resolveDecryptRetryKey(params.roomId, params.eventId);
     if (!retryKey) {
       return;
@@ -388,6 +402,9 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     }
 
     if (this.decryptRetries.get(retryKey) !== state) {
+      return;
+    }
+    if (this.stopped) {
       return;
     }
     if (isDecryptionFailure(state.event)) {

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -184,6 +184,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     for (const retryKey of this.decryptRetries.keys()) {
       this.clearDecryptRetry(retryKey);
     }
+    this.exhaustedDecryptRetries.clear();
   }
 
   async drainPendingDecryptions(reason: string): Promise<void> {

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -75,7 +75,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
   private readonly decryptedMessageDedupe = new Map<string, number>();
   private readonly decryptRetries = new Map<string, MatrixDecryptRetryState>();
   private readonly failedDecryptionsNotified = new Set<string>();
-  private readonly exhaustedDecryptRetries = new Set<string>();
+  private readonly exhaustedDecryptRetries = new Map<string, MatrixDecryptRetryState>();
   private activeRetryRuns = 0;
   private readonly retryIdleResolvers = new Set<() => void>();
   private cryptoRetrySignalsBound = false;
@@ -123,7 +123,22 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     }
   }
 
-  retryPendingNow(reason: string): void {
+  retryPendingNow(reason: string, options?: { includeExhausted?: boolean }): void {
+    if (options?.includeExhausted) {
+      for (const [retryKey, state] of this.exhaustedDecryptRetries) {
+        if (this.decryptRetries.has(retryKey)) {
+          continue;
+        }
+        this.exhaustedDecryptRetries.delete(retryKey);
+        this.decryptRetries.set(retryKey, {
+          ...state,
+          attempts: 0,
+          inFlight: false,
+          timer: null,
+        });
+      }
+    }
+
     const pending = Array.from(this.decryptRetries.entries());
     if (pending.length === 0) {
       return;
@@ -148,7 +163,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     this.cryptoRetrySignalsBound = true;
 
     const trigger = (reason: string): void => {
-      this.retryPendingNow(reason);
+      this.retryPendingNow(reason, { includeExhausted: true });
     };
 
     crypto.on(CryptoEvent.KeyBackupDecryptionKeyCached, () => {
@@ -277,7 +292,14 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
         clearTimeout(retry.timer);
       }
       this.decryptRetries.delete(retryKey);
-      this.exhaustedDecryptRetries.add(retryKey);
+      this.exhaustedDecryptRetries.set(retryKey, {
+        event: params.event,
+        roomId: params.roomId,
+        eventId: params.eventId,
+        attempts: attempts - 1,
+        inFlight: false,
+        timer: null,
+      });
       LogService.debug(
         "MatrixClientLite",
         `Giving up decryption retry for ${params.eventId} in ${params.roomId} after ${attempts - 1} attempts`,

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -179,15 +179,15 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     }
     this.cryptoRetrySignalsBound = true;
 
-    const trigger = (reason: string): void => {
-      this.retryPendingNow(reason, { includeExhausted: true });
+    const trigger = (reason: string, options?: { includeExhausted?: boolean }): void => {
+      this.retryPendingNow(reason, options);
     };
 
     crypto.on(CryptoEvent.KeyBackupDecryptionKeyCached, () => {
-      trigger("crypto.keyBackupDecryptionKeyCached");
+      trigger("crypto.keyBackupDecryptionKeyCached", { includeExhausted: true });
     });
     crypto.on(CryptoEvent.RehydrationCompleted, () => {
-      trigger("dehydration.RehydrationCompleted");
+      trigger("dehydration.RehydrationCompleted", { includeExhausted: true });
     });
     crypto.on(CryptoEvent.DevicesUpdated, () => {
       trigger("crypto.devicesUpdated");

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -32,6 +32,10 @@ type MatrixDecryptRetryState = {
   timer: ReturnType<typeof setTimeout> | null;
 };
 
+type MatrixExhaustedDecryptRetryState = MatrixDecryptRetryState & {
+  exhaustedAt: number;
+};
+
 type DecryptBridgeRawEvent = {
   event_id: string;
 };
@@ -43,6 +47,8 @@ type MatrixCryptoRetrySignalSource = {
 const MATRIX_DECRYPT_RETRY_BASE_DELAY_MS = 1_500;
 const MATRIX_DECRYPT_RETRY_MAX_DELAY_MS = 30_000;
 const MATRIX_DECRYPT_RETRY_MAX_ATTEMPTS = 8;
+const MATRIX_DECRYPT_EXHAUSTED_RETRY_TTL_MS = 60 * 60_000;
+const MATRIX_DECRYPT_EXHAUSTED_RETRY_MAX_ENTRIES = 512;
 
 function resolveDecryptRetryKey(roomId: string, eventId: string): string | null {
   if (!roomId || !eventId) {
@@ -85,7 +91,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
   private readonly decryptedMessageDedupe = new Map<string, number>();
   private readonly decryptRetries = new Map<string, MatrixDecryptRetryState>();
   private readonly failedDecryptionsNotified = new Set<string>();
-  private readonly exhaustedDecryptRetries = new Map<string, MatrixDecryptRetryState>();
+  private readonly exhaustedDecryptRetries = new Map<string, MatrixExhaustedDecryptRetryState>();
   private activeRetryRuns = 0;
   private readonly retryIdleResolvers = new Set<() => void>();
   private cryptoRetrySignalsBound = false;
@@ -135,6 +141,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
 
   retryPendingNow(reason: string, options?: { includeExhausted?: boolean }): void {
     if (options?.includeExhausted) {
+      this.pruneExhaustedDecryptRetries(Date.now());
       for (const [retryKey, state] of this.exhaustedDecryptRetries) {
         if (this.decryptRetries.has(retryKey)) {
           continue;
@@ -303,6 +310,7 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
         clearTimeout(retry.timer);
       }
       this.decryptRetries.delete(retryKey);
+      const exhaustedAt = Date.now();
       this.exhaustedDecryptRetries.set(retryKey, {
         event: params.event,
         roomId: params.roomId,
@@ -310,7 +318,9 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
         attempts: attempts - 1,
         inFlight: false,
         timer: null,
+        exhaustedAt,
       });
+      this.pruneExhaustedDecryptRetries(exhaustedAt);
       LogService.debug(
         "MatrixClientLite",
         `Giving up decryption retry for ${params.eventId} in ${params.roomId} after ${attempts - 1} attempts`,
@@ -404,6 +414,21 @@ export class MatrixDecryptBridge<TRawEvent extends DecryptBridgeRawEvent> {
     this.decryptRetries.delete(retryKey);
     this.exhaustedDecryptRetries.delete(retryKey);
     this.failedDecryptionsNotified.delete(retryKey);
+  }
+
+  private pruneExhaustedDecryptRetries(now: number): void {
+    for (const [retryKey, state] of this.exhaustedDecryptRetries) {
+      if (now - state.exhaustedAt > MATRIX_DECRYPT_EXHAUSTED_RETRY_TTL_MS) {
+        this.exhaustedDecryptRetries.delete(retryKey);
+      }
+    }
+    while (this.exhaustedDecryptRetries.size > MATRIX_DECRYPT_EXHAUSTED_RETRY_MAX_ENTRIES) {
+      const oldest = this.exhaustedDecryptRetries.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.exhaustedDecryptRetries.delete(oldest);
+    }
   }
 
   private rememberDecryptedMessage(roomId: string, eventId: string): void {


### PR DESCRIPTION
## Summary

- Problem: issue #93501 reports Matrix E2EE missing-key decrypt failures that can stop practical message delivery until the bot account is opened in Element and the gateway is restarted.
- Solution: repair the Matrix failed-decryption retry bridge so exhausted missing-key events are retried through the Matrix SDK event retry path when later crypto key signals arrive, and clear retained exhausted retry state when the bridge stops.
- What changed: `decrypt-bridge.ts` now prefers `MatrixEvent.attemptDecryption(getCrypto(), { isRetry: true })` for retry entries so the retry bypasses `MatrixClient.decryptEventIfNeeded`'s `clearEvent` guard; it still falls back to `decryptEventIfNeeded` when the event retry API or crypto backend is unavailable. The Matrix tests now simulate the SDK `clearEvent` / `shouldAttemptDecryption` guard, cover exhausted retry requeue, duplicate crypto signals, and bridge stop cleanup.
- What did NOT change: Unchanged and out of scope are Matrix login, auth, provider routing, session storage, Matrix wire format, schema/config/protocol defaults, and ordinary `sync.unexpected_error` fatal-stop behavior.
- Why it matters / User impact: a Matrix room key can arrive after OpenClaw has already exhausted per-event decrypt retries; if retry goes back through `decryptEventIfNeeded`, matrix-js-sdk skips the event after failed decrypt set `clearEvent`, so the channel can remain unable to deliver the message until manual Element login plus gateway restart.
- Fixes #93501

## Origin / follow-up

N/A — this is an update to existing PR #94416 for linked issue #93501. #94044 appears only as linked PR context in daily-fix output; this update does not depend on a merged origin PR.

## Related PR scan

- Existing PR diagnosis resolved linked issue #93501 and noted #94044 as a skipped pull-request ref in the same linked issue context.
- No maintainer hard stop, duplicate/superseded decision, or broader canonical PR was present in the generated daily-fix diagnostic artifacts for this update.
- This is an update to existing PR #94416 rather than a replacement PR or a new competing PR.

## Out of scope

- No Element web/desktop GUI click-through or public Matrix homeserver account is claimed; the live proof uses a local Synapse homeserver plus OpenClaw Matrix clients and matrix-js-sdk Rust Crypto.
- No Matrix login, auth, provider routing, session storage, wire-format, schema, config, or protocol defaults are changed.
- No downstream `sync.unexpected_error` string special case is added; fatal Matrix sync errors remain fatal.
- No changes are made to unrelated tooling, plugin prerelease plans, release workflows, or CI configuration.

## Competition / linked PR analysis

- **Linked PR(s):** #94044 is referenced by daily-fix as a skipped pull-request ref for the same linked issue context.
- **Gap in linked PR(s):** This update is for the current open contributor PR #94416 and specifically addresses ClawSweeper's author blockers on this PR: the retry now uses the SDK event retry contract instead of the guarded client helper, and the PR body now includes a live Synapse encrypted-room late-key transcript that reaches OpenClaw room.message delivery after retry exhaustion.
- **Why this patch is better/canonical:** the patch changes the Matrix failed-decryption retry owner, where exhausted event retry state is created, where crypto key update signals are handled, and where bridge lifecycle cleanup belongs. It does not depend on downstream log-shaped string handling in monitor lifecycle.
- **Local real behavior proof advantage:** the live Synapse proof exercises OpenClaw's MatrixClient event bridge, retry scheduler, crypto-signal listener, SDK failed-decrypt guard behavior, SDK event retry call, and recovered `room.message` delivery instead of manually emitting a synthetic lifecycle `sync.unexpected_error`.

## Real behavior proof

**Behavior addressed:** Matrix encrypted events that exhaust OpenClaw's failed-decryption retry cap are retried when a later Matrix crypto key signal indicates the missing Megolm room key may now be available. The retry uses `MatrixEvent.attemptDecryption(getCrypto(), { isRetry: true })` so it can recover after matrix-js-sdk has set `clearEvent` on the earlier failed decrypt, and the decrypted event is emitted through OpenClaw's normal `room.message` delivery path.

**Real environment tested:** Live local `matrixdotorg/synapse:latest` homeserver on localhost with freshly registered Matrix users, a real encrypted Matrix direct room using `m.megolm.v1.aes-sha2`, OpenClaw's Matrix extension `MatrixClient`, and matrix-js-sdk Rust Crypto. The proof used a real Alice sender device plus bot join/fresh devices; the BOTFRESH1 E2EE device uploaded real Matrix device keys before send, its to-device room-key event was withheld from `/sync`, and the late room key was imported through Rust Crypto after OpenClaw had exhausted decrypt retries. Passwords and access tokens were redacted and are not included.

**Exact steps or command run after this patch:**

```bash
node --import tsx /tmp/openclaw-pr94416-live/matrix-late-key-proof.mjs
```

The script ran against PR head `f3a780e214b0184893b6935abab08c1c65ab325d`, read the local Synapse container/port from `/tmp/openclaw-pr94416-live`, registered fresh local users, created the encrypted room through OpenClaw's Matrix client, intercepted only the BOTFRESH1 `/sync` to-device room-key delivery, drained OpenClaw decrypt retries to the exhausted bucket, imported Alice's exported Megolm room key into BOTFRESH1, emitted `crypto.keyBackupDecryptionKeyCached`, and waited for OpenClaw's `room.message` event.

**Evidence after fix:**

```text
[proof] synapse-live {"homeserver":"http://127.0.0.1:32770","versions":["v1.9","v1.10","v1.11","v1.12"]}
[proof] matrix-login {"user_id":"@alice_mqm7qd1geac7ad:localhost","device_id":"ALICEPROOF1","access_token":"<redacted>"}
[proof] matrix-login {"user_id":"@bot_mqm7qd1geac7ad:localhost","device_id":"BOTJOIN1","access_token":"<redacted>"}
[proof] matrix-login {"user_id":"@bot_mqm7qd1geac7ad:localhost","device_id":"BOTFRESH1","access_token":"<redacted>"}
[proof] openclaw-fresh-bot-primed-before-send {"user_id":"@bot_mqm7qd1geac7ad:localhost","device_id":"BOTFRESH1","purpose":"upload real Matrix E2EE device keys before Alice sends"}
[proof] encrypted-room-ready {"room_id":"!aaooUUXrjNvrIYKYiQ:localhost","encryption":"m.megolm.v1.aes-sha2","bot_join_device":"BOTJOIN1","bot_devices_seen_by_alice":["BOTFRESH1"]}
[proof] alice-sent-encrypted-message {"room_id":"!aaooUUXrjNvrIYKYiQ:localhost","event_id":"$TvfAEyQq2EFvtROSF-CqAOI9FpUf_o-8bRRIOpfOvV0","body":"openclaw-pr94416 late key proof mqm7qd1geac7ad","exported_room_keys_for_room":1}
[proof] proof-network-held-back-to-device-key {"room_id":"!aaooUUXrjNvrIYKYiQ:localhost","dropped_to_device_events":1,"event_types":["m.room.encrypted"]}
[proof] fresh-bot-saw-encrypted-event {"room_id":"!aaooUUXrjNvrIYKYiQ:localhost","event_id":"$TvfAEyQq2EFvtROSF-CqAOI9FpUf_o-8bRRIOpfOvV0","type":"m.room.encrypted"}
[proof] fresh-bot-failed-before-key {"event_id":"$TvfAEyQq2EFvtROSF-CqAOI9FpUf_o-8bRRIOpfOvV0","failed_decryptions":1,"message_delivered_before_key":false,"retry_state":{"pending":1,"exhausted":0,"activeRuns":0}}
[proof] proof-network-released-before-late-key-import {"dropped_to_device_events_total":1,"event_types":["m.room.encrypted"]}
[proof] retry-drain-complete-before-key {"event_id":"$TvfAEyQq2EFvtROSF-CqAOI9FpUf_o-8bRRIOpfOvV0","message_delivered_before_key":false,"retry_state":{"pending":0,"exhausted":1,"activeRuns":0}}
[proof] fresh-bot-imported-late-room-key {"event_id":"$TvfAEyQq2EFvtROSF-CqAOI9FpUf_o-8bRRIOpfOvV0","imported_room_keys":1,"progress":{"total":1,"successes":0,"stage":"load_keys","failures":0},"access_token":"<redacted>"}
[proof] crypto-signal-emitted {"event":"crypto.keyBackupDecryptionKeyCached","include_exhausted_expected":true,"retry_state_after_signal":{"pending":1,"exhausted":0,"activeRuns":1}}
[proof] openclaw-room-message-after-late-key {"room_id":"!aaooUUXrjNvrIYKYiQ:localhost","event_id":"$TvfAEyQq2EFvtROSF-CqAOI9FpUf_o-8bRRIOpfOvV0","type":"m.room.message","msgtype":"m.text","body":"openclaw-pr94416 late key proof mqm7qd1geac7ad","retry_state":{"pending":0,"exhausted":0,"activeRuns":0}}
[proof] cleanup {"openclaw_home":"/tmp/openclaw-pr94416-live/openclaw-home-proof-1781951186914","synapse_container":"openclaw-pr94416-synapse-1781947676","secrets":"not printed"}
```

The full local transcript was saved at `/tmp/openclaw-pr94416-live/artifacts/matrix-late-key-proof-mqm7qd1geac7ad.txt`.

**Observed result after fix:** Before the late key was available, BOTFRESH1 saw the encrypted Matrix event and OpenClaw emitted `room.failed_decryption` without delivering `room.message`; after draining, the bridge state was `pending: 0`, `exhausted: 1`. After importing the real room key and emitting the SDK crypto key signal, OpenClaw requeued the exhausted event (`pending: 1`, `exhausted: 0`, `activeRuns: 1`) and then emitted the decrypted `m.room.message` with the original message body and an empty retry state.

**What was not tested:** I did not drive the Element web/desktop GUI or use a public Matrix homeserver account. This proof used a live local Synapse homeserver and matrix-js-sdk Rust Crypto to exercise the same late room-key availability condition that Element normally resolves. Matrix login/auth/provider routing, Matrix wire format, schema/config/protocol defaults, and ordinary `sync.unexpected_error` fatal-stop behavior were not changed or re-tested beyond the existing local Matrix regression proof.

## Review findings addressed

- **RF-001:** Addressed. The exhausted-retry regression now simulates matrix-js-sdk's `clearEvent` / `shouldAttemptDecryption` guard. RED showed the old `client.decryptEventIfNeeded` path did not invoke the retry attempt after failed decrypt set `clearEvent`; GREEN proves the updated bridge calls the SDK event retry method.
- **RF-002:** Addressed. The PR body now includes live local Synapse encrypted-room proof with real Matrix users/devices, a withheld to-device room-key event, exhausted OpenClaw decrypt retry state, late Rust Crypto room-key import, SDK crypto key signal, and recovered OpenClaw `room.message` delivery. Element GUI click-through is still not claimed.
- **RF-003:** Addressed. The Matrix SDK source shows `decryptEventIfNeeded` skips when `clearEvent` exists; the bridge now uses `MatrixEvent.attemptDecryption(..., { isRetry: true })` when crypto is available, which is the SDK retry path that can retry a failed decryption event.
- **RF-004:** Addressed for Matrix protocol behavior. The live encrypted-room recovery transcript is now present from a local Synapse homeserver with real E2EE devices and redacted credentials. Element GUI click-through and public homeserver account validation remain out of scope.
- **RF-005:** Addressed. Retained exhausted retry state is requeued only on crypto key signals, duplicate signals do not start duplicate in-flight retries, bridge stop clears exhausted state before later crypto signals can requeue it, and the live Synapse transcript shows recovered Matrix message delivery after late key import.
- **RF-006:** Addressed. The dependency-contract repair is in code and tests, and the new live Synapse proof shows the SDK event retry contract recovering an exhausted failed decrypt into OpenClaw `room.message` delivery after late key availability. The remaining decision is maintainer merge judgment, not absence of live Matrix proof.
- **RF-007:** Fixed. `extensions/matrix/src/matrix/sdk/decrypt-bridge.ts` no longer routes exhausted retries only through `client.decryptEventIfNeeded`; it prefers `event.attemptDecryption(client.getCrypto(), { isRetry: true })` and falls back to the client helper only when the event retry API or crypto backend is unavailable.

## CI attribution

- **Earlier remote failing check:** `checks-node-core-tooling` previously failed on PR head `7fd62deaa2f02f4620dae7c6b60ef0fc858bfa3f` in `test/scripts/plugin-prerelease-test-plan.test.ts`, not in Matrix extension tests.
- **Earlier remote failure excerpt:**

```text
FAIL tooling test/scripts/plugin-prerelease-test-plan.test.ts > scripts/lib/plugin-prerelease-test-plan.mjs > keeps kitchen-sink RPC coverage package-backed and resource-guarded
AssertionError: expected { cacheKey: undefined, …(13) } to deeply equal { …(10) }
-   "timeoutMs": 900000,
+   "timeoutMs": 1500000,
+   "cacheKey": undefined,
+   "estimateSeconds": undefined,
+   "needsLiveImage": undefined,
+   "noOutputTimeoutMs": undefined,
```

- **Local attribution result:** the targeted failed tooling test and the full `plugin-prerelease-test-plan.test.ts` file previously passed locally on this checkout. This update changes only Matrix files and does not modify `scripts/lib/plugin-prerelease-test-plan.mjs`, `test/scripts/plugin-prerelease-test-plan.test.ts`, release workflows, or tooling-shard code.
- **Attribution decision:** that CI failure was not introduced by the Matrix PR diff. Current head `f3a780e214b0184893b6935abab08c1c65ab325d` has fresh Matrix regression proof and extension typecheck; remote checks should be judged against this new head after submit.

## Regression Test Plan

- **Target test file:** `extensions/matrix/src/matrix/sdk.test.ts`
- **Target test file:** `extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts`
- **Scenario locked in:** an encrypted Matrix event exhausts the failed-decryption retry cap, then `crypto.keyBackupDecryptionKeyCached` fires after keys may be available; the bridge retries via `MatrixEvent.attemptDecryption(..., { isRetry: true })` and delivers the decrypted `m.room.message`.
- **SDK guard scenario locked in:** the test event now behaves like matrix-js-sdk after failed decrypt sets `clearEvent`; the old `MatrixClient.decryptEventIfNeeded` path is proven insufficient because that helper checks `shouldAttemptDecryption()` before retrying.
- **Stop cleanup scenario locked in:** an encrypted Matrix event exhausts the failed-decryption retry cap, `stopWithoutPersist()` stops the bridge, then `crypto.keyBackupDecryptionKeyCached` fires; the bridge does not call the event retry method, proving stopped lifecycle state was cleared.
- **Why this is the smallest reliable guardrail:** it exercises OpenClaw's MatrixClient event bridge, decrypt retry state, crypto-signal listener, SDK failed-decrypt guard behavior, SDK event retry path, and stop cleanup without requiring private Matrix credentials. The lifecycle test remains a separate negative control that prevents reintroducing the downstream string-based nonfatal exception.

## Merge risk

- **Risk labels considered:** message-delivery / session-state / security-boundary.
- **Risk explanation:** message delivery and retry state are touched because exhausted failed-decryption entries are retained for later crypto-key requeue, then explicitly cleared on bridge stop. The security-boundary signal is from retaining encrypted-event retry state inside the Matrix decrypt bridge, not from changing keys, credentials, auth, encryption algorithms, or Matrix wire data.
- **Why acceptable:** the change is limited to the Matrix failed-decryption retry owner, resets attempts only when Matrix crypto key signals fire, preserves duplicate in-flight retry protection, and clears retained exhausted state on stop. Adjacent retry-cap, duplicate-signal, exhausted-requeue, SDK guard, stop-cleanup, and lifecycle tests passed in the focused Matrix shard.

## Root Cause

- **Root cause:** The root cause is the matrix-js-sdk failed-decrypt retry contract: matrix-js-sdk sets `clearEvent` to an `m.bad.encrypted` payload when decrypt fails, and `MatrixClient.decryptEventIfNeeded()` checks `event.shouldAttemptDecryption()` before calling `event.attemptDecryption()`. Because `shouldAttemptDecryption()` returns false when `clearEvent` exists, OpenClaw's earlier retry bridge could retain and requeue exhausted events but still no-op through the guarded client helper when a later crypto key signal arrived.
- **Why this is root-cause fix:** the recovery behavior stays in the Matrix failed-decryption retry owner, and retries now use the SDK event retry method that is allowed to retry a failed decryption event even after `clearEvent` exists. Lifecycle cleanup still clears retained exhausted retry state at the same owner boundary. This repairs both the late-key retry invariant and the stop-cleanup invariant without masking sync lifecycle errors.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High for the Matrix late-key behavior: the local source-level path, MatrixClient event-bridge regression proof, and live Synapse encrypted-room transcript all show recovery after retry exhaustion. Element GUI click-through is not claimed above.
- **Patch quality notes:** The retry behavior and stop cleanup are covered by focused RED/GREEN proof and adjacent retry guardrails. No fallback that hides errors, silent swallow, `ts-ignore`, eslint-disable, or lifecycle string special case is added.
- **Architecture / source-of-truth check:** The source-of-truth owner is `MatrixDecryptBridge`, which owns failed-decryption retry state, crypto key retry signals, and bridge stop cleanup. Compatibility is preserved for public Matrix SDK event behavior: `sync.unexpected_error` remains fatal, no Matrix SDK API surface is changed, and no config/schema/protocol defaults are changed.

