### PR TITLE
fix(subagent): recover terminal transcript before lost context

### DIFF
--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -2399,6 +2399,108 @@ describe("subagent registry seam flow", () => {
     expect(run?.cleanupCompletedAt).toBeTypeOf("number");
   });
 
+  it("reconciles stale active runs from the current private terminal transcript", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return { status: "pending" };
+      }
+      return {};
+    });
+
+    const startedAt = Date.parse("2026-03-24T11:58:00Z");
+    const endedAt = startedAt + 222;
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-private-transcript-"));
+    try {
+      const transcriptFile = path.join(tmpDir, "child-run.jsonl");
+      await fs.writeFile(
+        transcriptFile,
+        [
+          JSON.stringify({ type: "session", version: 1, id: "sess-child" }),
+          JSON.stringify({
+            message: {
+              role: "assistant",
+              content: "stale copied result",
+              stopReason: "stop",
+              timestamp: startedAt - 1,
+            },
+          }),
+          JSON.stringify({
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "private transcript result" }],
+              stopReason: "stop",
+              timestamp: endedAt,
+            },
+          }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      mod.addSubagentRunForTests({
+        runId: "run-private-terminal",
+        childSessionKey: "agent:main:subagent:child",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        task: "settle from private transcript state",
+        cleanup: "keep",
+        expectsCompletionMessage: true,
+        createdAt: startedAt,
+        startedAt,
+        execution: {
+          status: "running",
+          startedAt,
+          transcriptFile,
+        },
+        completion: {
+          required: true,
+        },
+      });
+
+      vi.setSystemTime(new Date("2026-03-24T12:02:00Z"));
+      await mod.testing.sweepOnceForTests();
+
+      await waitForFast(() => {
+        const announceParams = findRecordCallArg(
+          mocks.runSubagentAnnounceFlow,
+          0,
+          "private transcript announce",
+          (record) => record.childRunId === "run-private-terminal",
+        );
+        expectRecordFields(
+          announceParams.outcome,
+          { status: "ok", endedAt },
+          "private transcript announce outcome",
+        );
+      });
+
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-private-terminal");
+      expect(run?.endedAt).toBe(endedAt);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "ok",
+          startedAt,
+          endedAt,
+          elapsedMs: 222,
+        },
+        "private transcript run outcome",
+      );
+      expect(run?.completion?.resultText).toBe("private transcript result");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("uses session-store start time when sweeping stale explicit-timeout runs", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -47,6 +47,7 @@ import {
 import {
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
+  capFrozenResultText,
   reconcileOrphanedRestoredRuns,
   reconcileOrphanedRun,
   resolveAnnounceRetryDelayMs,
@@ -85,6 +86,7 @@ import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import {
   loadSubagentSessionEntry,
   resolveCompletionFromSessionEntry,
+  resolveCompletionFromCurrentRunTranscript,
   resolveSubagentSessionCompletion,
   resolveSubagentSessionStartedAt,
   type SubagentSessionStoreCache,
@@ -956,6 +958,38 @@ async function sweepSubagentRuns() {
 
           if (sessionEntry?.abortedLastRun === true) {
             scheduleSubagentOrphanRecovery({ delayMs: 1_000 });
+            continue;
+          }
+
+          const transcriptCompletion = await resolveCompletionFromCurrentRunTranscript({
+            childSessionKey: entry.childSessionKey,
+            transcriptFile: entry.execution?.transcriptFile,
+            fallbackEndedAt: now,
+            notBeforeMs: entry.startedAt ?? entry.createdAt,
+            startedAt: entry.startedAt,
+          });
+          if (transcriptCompletion) {
+            const completionState = ensureCompletionState(entry);
+            if (
+              transcriptCompletion.resultText !== undefined &&
+              completionState.resultText === undefined
+            ) {
+              completionState.resultText = capFrozenResultText(transcriptCompletion.resultText);
+              completionState.capturedAt = now;
+            }
+            await completeSubagentRunWithRecovery(
+              {
+                runId,
+                startedAt: transcriptCompletion.startedAt,
+                endedAt: transcriptCompletion.endedAt,
+                outcome: transcriptCompletion.outcome,
+                reason: transcriptCompletion.reason,
+                sendFarewell: true,
+                accountId: entry.requesterOrigin?.accountId,
+                triggerCleanup: true,
+              },
+              "sweeper-current-run-transcript-completion",
+            );
             continue;
           }
 

--- a/src/agents/subagent-session-reconciliation.test.ts
+++ b/src/agents/subagent-session-reconciliation.test.ts
@@ -1,0 +1,120 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveCompletionFromCurrentRunTranscript } from "./subagent-session-reconciliation.js";
+
+describe("subagent session reconciliation", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-reconcile-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeTranscript(events: unknown[]): Promise<string> {
+    const transcriptFile = path.join(tmpDir, "child-run.jsonl");
+    await fs.writeFile(
+      transcriptFile,
+      `${events.map((event) => JSON.stringify(event)).join("\n")}\n`,
+      "utf-8",
+    );
+    return transcriptFile;
+  }
+
+  it("recovers completion from the current run private terminal stop turn", async () => {
+    const startedAt = Date.parse("2026-03-24T12:00:00Z");
+    const endedAt = startedAt + 1_234;
+    const transcriptFile = await writeTranscript([
+      { type: "session", version: 1, id: "sess-child" },
+      {
+        message: {
+          role: "assistant",
+          content: "stale copied answer",
+          stopReason: "stop",
+          timestamp: startedAt - 1,
+        },
+      },
+      {
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "current child result" }],
+          stopReason: "stop",
+          timestamp: endedAt,
+        },
+      },
+    ]);
+
+    await expect(
+      resolveCompletionFromCurrentRunTranscript({
+        childSessionKey: "agent:main:subagent:child",
+        transcriptFile,
+        fallbackEndedAt: endedAt + 10_000,
+        notBeforeMs: startedAt,
+        startedAt,
+      }),
+    ).resolves.toEqual({
+      startedAt,
+      endedAt,
+      outcome: { status: "ok" },
+      reason: "subagent-complete",
+      resultText: "current child result",
+    });
+  });
+
+  it("does not recover stale copied output from before the current run", async () => {
+    const startedAt = Date.parse("2026-03-24T12:00:00Z");
+    const transcriptFile = await writeTranscript([
+      { type: "session", version: 1, id: "sess-child" },
+      {
+        message: {
+          role: "assistant",
+          content: "old child result",
+          stopReason: "stop",
+          timestamp: startedAt - 1,
+        },
+      },
+    ]);
+
+    await expect(
+      resolveCompletionFromCurrentRunTranscript({
+        childSessionKey: "agent:main:subagent:child",
+        transcriptFile,
+        fallbackEndedAt: startedAt + 1_000,
+        notBeforeMs: startedAt,
+        startedAt,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it.each(["error", "aborted", "toolUse"])(
+    "does not recover a non-success terminal turn with stopReason=%s",
+    async (stopReason) => {
+      const startedAt = Date.parse("2026-03-24T12:00:00Z");
+      const transcriptFile = await writeTranscript([
+        { type: "session", version: 1, id: "sess-child" },
+        {
+          message: {
+            role: "assistant",
+            content: "partial child text",
+            stopReason,
+            timestamp: startedAt + 1,
+          },
+        },
+      ]);
+
+      await expect(
+        resolveCompletionFromCurrentRunTranscript({
+          childSessionKey: "agent:main:subagent:child",
+          transcriptFile,
+          fallbackEndedAt: startedAt + 10_000,
+          notBeforeMs: startedAt,
+          startedAt,
+        }),
+      ).resolves.toBeNull();
+    },
+  );
+});

--- a/src/agents/subagent-session-reconciliation.ts
+++ b/src/agents/subagent-session-reconciliation.ts
@@ -12,6 +12,8 @@ import {
   type SessionEntry,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
+import { extractTextFromChatContent } from "../shared/chat-content.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -29,6 +31,13 @@ export type SubagentSessionCompletion = {
   outcome: SubagentRunOutcome;
   reason: SubagentLifecycleEndedReason;
 };
+
+/** Completion proven by the current run's private transcript terminal turn. */
+export type SubagentTranscriptCompletion = SubagentSessionCompletion & {
+  resultText?: string;
+};
+
+const SUCCESSFUL_TERMINAL_STOP_REASONS = new Set(["stop", "end_turn"]);
 
 function finiteTimestamp(value: number | undefined): number | undefined {
   return asFiniteNumber(value);
@@ -72,6 +81,115 @@ function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: 
     }
   }
   return undefined;
+}
+
+function coerceTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function isAssistantMessage(message: unknown): message is Record<string, unknown> {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    !Array.isArray(message) &&
+    (message as { role?: unknown }).role === "assistant"
+  );
+}
+
+function readAssistantText(message: Record<string, unknown>): string | undefined {
+  const text = extractTextFromChatContent(message.content, {
+    joinWith: "\n",
+    normalizeText: (value) => value.trim(),
+  })?.trim();
+  return text || undefined;
+}
+
+function isFreshAssistantTurn(params: {
+  message: Record<string, unknown>;
+  notBeforeMs?: number;
+}): boolean {
+  if (params.notBeforeMs === undefined) {
+    return true;
+  }
+  const timestamp = coerceTimestamp(params.message.timestamp);
+  return timestamp !== undefined && timestamp >= params.notBeforeMs;
+}
+
+function latestCurrentRunAssistantTurn(
+  messages: unknown[],
+  notBeforeMs: number | undefined,
+): Record<string, unknown> | undefined {
+  let latest: Record<string, unknown> | undefined;
+  for (const message of messages) {
+    if (!isAssistantMessage(message)) {
+      continue;
+    }
+    if (!isFreshAssistantTurn({ message, notBeforeMs })) {
+      continue;
+    }
+    latest = message;
+  }
+  return latest;
+}
+
+/**
+ * Resolve a completed child run from the private transcript owned by the
+ * current registry row. This intentionally ignores chat.history/display output:
+ * recovery is accepted only when the current run's latest assistant turn has an
+ * explicit successful terminal stop reason.
+ */
+export async function resolveCompletionFromCurrentRunTranscript(params: {
+  childSessionKey: string;
+  transcriptFile?: string;
+  fallbackEndedAt: number;
+  notBeforeMs?: number;
+  startedAt?: number;
+}): Promise<SubagentTranscriptCompletion | null> {
+  const transcriptFile = params.transcriptFile?.trim();
+  if (!transcriptFile) {
+    return null;
+  }
+  try {
+    const messages = await readSessionMessagesAsync(
+      {
+        sessionFile: transcriptFile,
+        sessionId: params.childSessionKey,
+      },
+      {
+        mode: "recent",
+        maxMessages: 100,
+        maxBytes: 1024 * 1024,
+      },
+    );
+    const latest = latestCurrentRunAssistantTurn(messages, params.notBeforeMs);
+    if (!latest) {
+      return null;
+    }
+    const stopReason = typeof latest.stopReason === "string" ? latest.stopReason.trim() : undefined;
+    if (!stopReason || !SUCCESSFUL_TERMINAL_STOP_REASONS.has(stopReason)) {
+      return null;
+    }
+    const endedAt = coerceTimestamp(latest.timestamp) ?? params.fallbackEndedAt;
+    const resultText = readAssistantText(latest);
+    return {
+      ...(typeof params.startedAt === "number" && Number.isFinite(params.startedAt)
+        ? { startedAt: params.startedAt }
+        : {}),
+      endedAt,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      ...(resultText ? { resultText } : {}),
+    };
+  } catch {
+    return null;
+  }
 }
 
 /** Load a child session entry using the agent-specific session store path. */


### PR DESCRIPTION
Fixes #90299.

## Summary

This keeps the lost-context sweeper from reporting a failed subagent when the current run already wrote a successful terminal assistant turn to its private transcript.

The new path is deliberately narrower than display-output recovery: it reads only `entry.execution.transcriptFile`, ignores copied stale history before the registry run start, and accepts only an explicit successful terminal `stopReason` (`stop`/`end_turn`). `error`, `aborted`, and `toolUse` turns still fall through to the existing recovery/error paths.

## Real behavior proof

Behavior addressed:
When the subagent registry sweeper loses the in-memory run context, it now checks the current run's private transcript before emitting `subagent run lost active execution context`. A successful recovery requires a current-run assistant terminal turn, not merely visible/displayed output.

Real environment tested:
Local OpenClaw worktree on macOS after `pnpm install --frozen-lockfile`. The live proof below ran OpenClaw source through `tsx`, wrote an actual private JSONL transcript on disk, and invoked the real transcript-reader-backed `resolveCompletionFromCurrentRunTranscript` helper outside Vitest/CI.

Exact steps or command run after this patch:
- Ran a local `pnpm exec tsx -e '...'` script that created a private child transcript containing one stale copied assistant result before `startedAt` and one current assistant turn with `stopReason: "stop"`, then called `resolveCompletionFromCurrentRunTranscript` against that file.
- Ran `node scripts/run-vitest.mjs src/agents/subagent-session-reconciliation.test.ts src/agents/subagent-registry.test.ts`.
- Ran `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false`.
- Ran `pnpm exec oxfmt --check --threads=1 src/agents/subagent-session-reconciliation.ts src/agents/subagent-registry.ts src/agents/subagent-session-reconciliation.test.ts src/agents/subagent-registry.test.ts`.
- Ran `node scripts/run-oxlint.mjs src/agents/subagent-session-reconciliation.ts src/agents/subagent-registry.ts src/agents/subagent-session-reconciliation.test.ts src/agents/subagent-registry.test.ts`.

Evidence after fix:
Copied terminal output from the local OpenClaw live proof command:

```text
[openclaw live proof] command=resolveCompletionFromCurrentRunTranscript
[openclaw live proof] transcriptFile=$TMPDIR/openclaw-real-proof-EfMJfc/child-run.jsonl
[openclaw live proof] recoveredStatus=ok
[openclaw live proof] recoveredReason=subagent-complete
[openclaw live proof] recoveredResult=current private terminal result
[openclaw live proof] staleCopiedOutputIgnored=true
[openclaw live proof] endedAtMatchedTerminalTurn=true
```

Observed result after fix:
The real transcript reader recovered `status=ok` from the current private terminal turn, ignored the stale copied pre-run output, and used the terminal turn timestamp instead of the fallback lost-context time. The focused registry regression also completes the stale active run as `ok` and preserves `private transcript result` instead of emitting the lost-context error.

What was not tested:
No live Agent Teams UI/gateway conversation was run manually. The live proof covers the private transcript recovery boundary directly, and the focused registry test covers the sweeper path with the session store still reporting `status: running`.

## Validation

- `node scripts/run-vitest.mjs src/agents/subagent-session-reconciliation.test.ts src/agents/subagent-registry.test.ts` -> 2 files passed, 71 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false` -> exited 0.
- `pnpm exec oxfmt --check --threads=1 ...` -> all matched files use the correct format.
- `node scripts/run-oxlint.mjs ...` -> exited 0.
