### PR TITLE
fix(agents): preserve active compaction retries

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -824,6 +824,13 @@ vi.mock("../utils.js", () => ({
 }));
 
 vi.mock("./compaction-retry-aggregate-timeout.js", () => ({
+  hasActiveCompactionRetryWork: ({
+    isCompactionInFlight,
+    isSessionStreaming,
+  }: {
+    isCompactionInFlight: boolean;
+    isSessionStreaming: boolean;
+  }) => isCompactionInFlight || isSessionStreaming,
   waitForCompactionRetryWithAggregateTimeout: async () => ({
     timedOut: false,
     aborted: false,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -456,7 +456,10 @@ import {
   TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES,
 } from "./attempt.tool-search-run-plan.js";
 import { resolveAttemptTranscriptPolicy } from "./attempt.transcript-policy.js";
-import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
+import {
+  hasActiveCompactionRetryWork,
+  waitForCompactionRetryWithAggregateTimeout,
+} from "./compaction-retry-aggregate-timeout.js";
 import {
   resolveRunTimeoutDuringCompaction,
   selectCompactionTimeoutSnapshot,
@@ -4938,7 +4941,11 @@ export async function runEmbeddedAttempt(
                 waitForCompactionRetry,
                 abortable,
                 aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
-                isCompactionStillInFlight: isCompactionInFlight,
+                isCompactionRetryStillActive: () =>
+                  hasActiveCompactionRetryWork({
+                    isCompactionInFlight: isCompactionInFlight(),
+                    isSessionStreaming: activeSession.isStreaming,
+                  }),
               });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts
@@ -1,7 +1,10 @@
 // Coverage for aggregate timeout handling while waiting on compaction retry.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
-import { waitForCompactionRetryWithAggregateTimeout } from "./compaction-retry-aggregate-timeout.js";
+import {
+  hasActiveCompactionRetryWork,
+  waitForCompactionRetryWithAggregateTimeout,
+} from "./compaction-retry-aggregate-timeout.js";
 
 type AggregateTimeoutParams = Parameters<typeof waitForCompactionRetryWithAggregateTimeout>[0];
 type TimeoutCallback = NonNullable<AggregateTimeoutParams["onTimeout"]>;
@@ -42,7 +45,7 @@ function buildAggregateTimeoutParams(
     waitForCompactionRetry: overrides.waitForCompactionRetry,
     abortable: overrides.abortable ?? (async (promise) => await promise),
     aggregateTimeoutMs: overrides.aggregateTimeoutMs ?? 60_000,
-    isCompactionStillInFlight: overrides.isCompactionStillInFlight,
+    isCompactionRetryStillActive: overrides.isCompactionRetryStillActive,
     onTimeout,
   };
 }
@@ -63,23 +66,23 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
     });
   });
 
-  it("keeps waiting while compaction remains in flight", async () => {
-    // The aggregate timer should not cut off active compaction work; timeout
-    // starts once compaction is no longer in flight.
+  it("keeps waiting while compaction retry work remains active", async () => {
+    // The aggregate timer should not cut off either the compaction call or its
+    // retry model run; timeout starts once both phases are idle.
     await withFakeTimers(async () => {
-      let compactionInFlight = true;
+      let retryWorkActive = true;
       const waitForCompactionRetry = vi.fn(
         async () =>
           await new Promise<void>((resolve) => {
             setTimeout(() => {
-              compactionInFlight = false;
+              retryWorkActive = false;
               resolve();
             }, 170_000);
           }),
       );
       const params = buildAggregateTimeoutParams({
         waitForCompactionRetry,
-        isCompactionStillInFlight: () => compactionInFlight,
+        isCompactionRetryStillActive: () => retryWorkActive,
       });
 
       const resultPromise = waitForCompactionRetryWithAggregateTimeout(params);
@@ -101,7 +104,7 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
       }, 90_000);
       const params = buildAggregateTimeoutParams({
         waitForCompactionRetry,
-        isCompactionStillInFlight: () => compactionInFlight,
+        isCompactionRetryStillActive: () => compactionInFlight,
       });
 
       const resultPromise = waitForCompactionRetryWithAggregateTimeout(params);
@@ -200,5 +203,23 @@ describe("waitForCompactionRetryWithAggregateTimeout", () => {
 
       expectClearedTimeoutState(params.onTimeout, false);
     });
+  });
+});
+
+describe("hasActiveCompactionRetryWork", () => {
+  it.each([
+    { isCompactionInFlight: true, isSessionStreaming: false },
+    { isCompactionInFlight: false, isSessionStreaming: true },
+  ])("returns true while either retry phase is active", (params) => {
+    expect(hasActiveCompactionRetryWork(params)).toBe(true);
+  });
+
+  it("returns false once compaction and the retry model run are idle", () => {
+    expect(
+      hasActiveCompactionRetryWork({
+        isCompactionInFlight: false,
+        isSessionStreaming: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.ts
@@ -3,6 +3,13 @@
  */
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 
+export function hasActiveCompactionRetryWork(params: {
+  isCompactionInFlight: boolean;
+  isSessionStreaming: boolean;
+}): boolean {
+  return params.isCompactionInFlight || params.isSessionStreaming;
+}
+
 /**
  * Waits for compaction retry completion with an aggregate timeout so a lost
  * retry resolution cannot hold the session lane indefinitely.
@@ -12,7 +19,7 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
   abortable: <T>(promise: Promise<T>) => Promise<T>;
   aggregateTimeoutMs: number;
   onTimeout?: () => void;
-  isCompactionStillInFlight?: () => boolean;
+  isCompactionRetryStillActive?: () => boolean;
 }): Promise<{ timedOut: boolean }> {
   const timeoutMs = resolveTimerTimeoutMs(params.aggregateTimeoutMs, 1);
 
@@ -43,9 +50,10 @@ export async function waitForCompactionRetryWithAggregateTimeout(params: {
         throw result.error;
       }
 
-      // Keep extending the timeout window while compaction is actively running.
-      // We only trigger the fallback timeout once compaction appears idle.
-      if (params.isCompactionStillInFlight?.()) {
+      // A post-compaction retry is a normal model run, so compaction itself is
+      // already idle while the provider request is still active. Only start
+      // deadlock recovery after both phases are idle.
+      if (params.isCompactionRetryStillActive?.()) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

- Preserve the existing 60-second idle recovery guard for lost compaction retry resolution.
- Treat the retry model request as active work while the agent session is streaming, so valid long-running retries are not abandoned at 60 seconds.
- Add regression coverage for active retry work and the idle fallback.

This fixes long-session compaction retries without adding a config surface or coupling retry duration to the separate compaction-call timeout.

## Linked context

Closes #94391

Related #40324

## Real behavior proof

- Behavior or issue addressed: A post-compaction retry model request lasting longer than 60 seconds was treated as idle because compaction itself had ended, so the aggregate guard discarded a still-valid result.
- Real environment tested: macOS source checkout and an isolated Azure-backed Linux test box using the repository Node/pnpm toolchain.
- Exact steps or command run after this patch: `pnpm test src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.waits-multiple-compaction-retries-before-resolving.test.ts src/agents/embedded-agent-runner/run/compaction-timeout.test.ts`; then a source-level runtime probe with a 60 ms aggregate window and a 170 ms active retry.
- Evidence after fix: 31 focused tests passed on Linux. The runtime probe printed `PASS active retry completed without timeout after 171ms`.
- Observed result after fix: The aggregate guard extends while either compaction or the retry model run is active, then retains the existing timeout once both phases are idle.
- What was not tested: A paid 200K-token Anthropic compaction session.
- Proof limitations or environment constraints: The field report already contains the real 143-187 second provider trajectories. The deterministic probe compresses the same timing relationship to milliseconds and exercises the production helper and lifecycle predicate.
- Before evidence: Current source used only the compaction-in-flight flag. During the post-compaction retry, that flag is false even though the agent session remains streaming.

## Tests and validation

- `pnpm test src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts -- --reporter=verbose`
- `pnpm test src/agents/embedded-agent-runner/run/compaction-retry-aggregate-timeout.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.waits-multiple-compaction-retries-before-resolving.test.ts src/agents/embedded-agent-runner/run/compaction-timeout.test.ts`
- Same focused suite plus the active-retry runtime probe on remote Linux: 31 tests passed; probe passed.
- `autoreview --mode local --engine codex --model gpt-5.5 --thinking high`: clean, no actionable findings.

## Risk checklist

Did user-visible behavior change? (`Yes`)

Long-running valid compaction retries are allowed to finish instead of silently falling back at 60 seconds.

Did config, environment, or migration behavior change? (`No`)

Did security, auth, secrets, network, or tool execution behavior change? (`No`)

Highest risk: extending a genuinely stuck retry. Mitigation: the retry is extended only while the session runtime reports active streaming; once idle, the original 60-second lost-resolution fallback still applies, and the enclosing run abort deadline remains authoritative.

## Current review state

Ready for CI and maintainer review. No unresolved autoreview findings.
