### PR TITLE
Add stdin and file message inputs to agent CLI

### DIFF
--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -34,7 +34,9 @@ export function registerAgentTurnCommand(
   program
     .command("agent")
     .description("Run an agent turn via the Gateway (use --local for embedded)")
-    .requiredOption("-m, --message <text>", "Message body for the agent")
+    .option("-m, --message <text>", "Message body for the agent")
+    .option("--message-file <path>", "Read the message body from a UTF-8 file")
+    .option("--message-stdin", "Read the message body from stdin", false)
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-key <key>", "Explicit session key (agent:<id>:<key>, or scoped to --agent)")
     .option("--session-id <id>", "Use an explicit session id")
@@ -71,6 +73,8 @@ ${theme.heading("Examples:")}
 ${formatHelpExamples([
   ['openclaw agent --to +15555550123 --message "status update"', "Start a new session."],
   ['openclaw agent --agent ops --message "Summarize logs"', "Use a specific agent."],
+  ["cat prompt.txt | openclaw agent --agent ops --message-stdin", "Read a message from stdin."],
+  ["openclaw agent --agent ops --message-file prompt.txt", "Read a message from a file."],
   [
     'openclaw agent --session-key agent:ops:incident-42 --message "Summarize status"',
     "Target an exact session key.",

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -105,6 +105,19 @@ describe("registerAgentCommands", () => {
     expect(deps).toBeUndefined();
   });
 
+  it("forwards file and stdin message input options", async () => {
+    await runCli(["agent", "--message-file", "/tmp/prompt.txt", "--agent", "ops"]);
+
+    const [fileOptions] = commandCall(agentCliCommandMock, 0);
+    expect((fileOptions as { messageFile?: string }).messageFile).toBe("/tmp/prompt.txt");
+    expect((fileOptions as { messageStdin?: boolean }).messageStdin).toBe(false);
+
+    await runCli(["agent", "--message-stdin", "--agent", "ops"]);
+
+    const [stdinOptions] = commandCall(agentCliCommandMock, 1);
+    expect((stdinOptions as { messageStdin?: boolean }).messageStdin).toBe(true);
+  });
+
   it("runs agent command with verbose disabled for --verbose off", async () => {
     await runCli(["agent", "--message", "hi", "--verbose", "off"]);
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -308,6 +308,50 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("reads the gateway message from a UTF-8 file", async () => {
+    await withTempStore(async ({ dir }) => {
+      mockGatewaySuccessReply();
+      const messagePath = path.join(dir, "prompt.txt");
+      fs.writeFileSync(messagePath, "  file hello  \n", "utf8");
+
+      await agentCliCommand({ messageFile: messagePath, to: "+1555" }, runtime);
+
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      const params = requireRecord(request.params, "gateway request params");
+      expect(params.message).toBe("file hello");
+    });
+  });
+
+  it("requires exactly one message input source", async () => {
+    await withTempStore(async ({ dir }) => {
+      const messagePath = path.join(dir, "prompt.txt");
+      fs.writeFileSync(messagePath, "file hello", "utf8");
+
+      await expect(
+        agentCliCommand({ message: "hi", messageFile: messagePath, to: "+1555" }, runtime),
+      ).rejects.toThrow(
+        "Choose exactly one message input: --message, --message-file, or --message-stdin.",
+      );
+
+      await expect(agentCliCommand({ to: "+1555" }, runtime)).rejects.toThrow(
+        "Choose exactly one message input: --message, --message-file, or --message-stdin.",
+      );
+      expect(callGateway).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects empty file message input", async () => {
+    await withTempStore(async ({ dir }) => {
+      const messagePath = path.join(dir, "prompt.txt");
+      fs.writeFileSync(messagePath, " \n\t ", "utf8");
+
+      await expect(
+        agentCliCommand({ messageFile: messagePath, to: "+1555" }, runtime),
+      ).rejects.toThrow("Missing message.");
+      expect(callGateway).not.toHaveBeenCalled();
+    });
+  });
+
   it.each(["/new", "/RESET", "/reset check status"] as const)(
     "uses backend admin authority for %s gateway commands",
     async (message) => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,5 +1,6 @@
 // Gateway-first agent CLI implementation with embedded fallback for local/runtime failures.
 import { randomUUID } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -62,9 +63,12 @@ const EMBEDDED_FALLBACK_META = {
 } as const;
 const GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX = "gateway-fallback-";
 const GATEWAY_TRANSIENT_CONNECT_RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 15_000] as const;
+const MAX_AGENT_MESSAGE_INPUT_BYTES = 10 * 1024 * 1024;
 
 type AgentCliOpts = {
-  message: string;
+  message?: string;
+  messageFile?: string;
+  messageStdin?: boolean;
   agent?: string;
   model?: string;
   to?: string;
@@ -94,6 +98,7 @@ type AgentCliProcessLike = {
 type AgentCliDeps = CliDeps & {
   process?: AgentCliProcessLike;
 };
+type ResolvedAgentCliOpts = AgentCliOpts & { message: string };
 type AgentGatewayCallIdentity = Pick<
   Parameters<typeof callGateway>[0],
   "clientName" | "mode" | "scopes"
@@ -192,6 +197,86 @@ function resolveGatewayAgentTimeoutMs(timeoutSeconds: number): number {
   return resolveTimerTimeoutMs((timeoutSeconds + 30) * 1000, 10_000, 10_000);
 }
 
+function formatMissingMessageError(): string {
+  return `Missing message. Use ${formatCliCommand('openclaw agent --message "..." --agent <id>')}, --message-file <path>, or --message-stdin.`;
+}
+
+function formatMessageInputSizeError(source: string): string {
+  return `Message input from ${source} exceeds ${MAX_AGENT_MESSAGE_INPUT_BYTES} bytes. Use a smaller prompt or split the request.`;
+}
+
+function assertAgentMessageInputSize(value: string, source: string): void {
+  if (Buffer.byteLength(value, "utf8") > MAX_AGENT_MESSAGE_INPUT_BYTES) {
+    throw new Error(formatMessageInputSizeError(source));
+  }
+}
+
+function readAgentMessageFile(filePath: string): string {
+  const stat = statSync(filePath);
+  if (stat.size > MAX_AGENT_MESSAGE_INPUT_BYTES) {
+    throw new Error(formatMessageInputSizeError("--message-file"));
+  }
+  const value = readFileSync(filePath, "utf8");
+  assertAgentMessageInputSize(value, "--message-file");
+  return value;
+}
+
+async function readAgentMessageStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new Error(
+      "--message-stdin requires piped input. Pipe a prompt on stdin or use --message-file <path>.",
+    );
+  }
+  const chunks: string[] = [];
+  let byteLength = 0;
+  process.stdin.setEncoding("utf8");
+  for await (const chunk of process.stdin) {
+    const text =
+      typeof chunk === "string" ? chunk : Buffer.from(chunk as Uint8Array).toString("utf8");
+    byteLength += Buffer.byteLength(text, "utf8");
+    if (byteLength > MAX_AGENT_MESSAGE_INPUT_BYTES) {
+      throw new Error(formatMessageInputSizeError("--message-stdin"));
+    }
+    chunks.push(text);
+  }
+  return chunks.join("");
+}
+
+async function resolveAgentCliMessageInput(opts: AgentCliOpts): Promise<ResolvedAgentCliOpts> {
+  const messageFile = normalizeOptionalString(opts.messageFile);
+  const modes = [
+    typeof opts.message === "string",
+    Boolean(messageFile),
+    opts.messageStdin === true,
+  ].filter(Boolean);
+  if (modes.length !== 1) {
+    throw new Error(
+      "Choose exactly one message input: --message, --message-file, or --message-stdin.",
+    );
+  }
+
+  let rawMessage = "";
+  if (typeof opts.message === "string") {
+    rawMessage = opts.message;
+    assertAgentMessageInputSize(rawMessage, "--message");
+  } else if (messageFile) {
+    rawMessage = readAgentMessageFile(messageFile);
+  } else {
+    rawMessage = await readAgentMessageStdin();
+  }
+
+  const message = rawMessage.trim();
+  if (!message) {
+    throw new Error(formatMissingMessageError());
+  }
+  return {
+    ...opts,
+    message,
+    messageFile: undefined,
+    messageStdin: undefined,
+  };
+}
+
 async function getGatewayDispatchConfig(options?: {
   skipShellEnvFallback?: boolean;
 }): Promise<OpenClawConfig> {
@@ -231,7 +316,7 @@ function isGatewayAgentTimeoutError(err: unknown): boolean {
   return err instanceof Error && err.message.includes("gateway request timeout for agent");
 }
 
-function isControlCommandThatMustNotFallback(opts: Pick<AgentCliOpts, "message">): boolean {
+function isControlCommandThatMustNotFallback(opts: Pick<ResolvedAgentCliOpts, "message">): boolean {
   const normalized = opts.message.trim().toLowerCase();
   return normalized === "/compact" || normalized.startsWith("/compact ");
 }
@@ -288,7 +373,7 @@ function validateExplicitSessionKeyForDispatch(
   }
 }
 
-async function normalizeSessionKeyOptsForDispatch(opts: AgentCliOpts): Promise<AgentCliOpts> {
+async function normalizeSessionKeyOptsForDispatch<T extends AgentCliOpts>(opts: T): Promise<T> {
   const rawSessionKey = opts.sessionKey?.trim();
   const rawTo = opts.to?.trim();
   if (!rawSessionKey && !opts.sessionId?.trim() && classifySessionKeyShape(rawTo) === "agent") {
@@ -620,17 +705,15 @@ function formatInFlightGatewayAgentMessage(response: GatewayAgentResponse): stri
 }
 
 async function agentViaGatewayCommand(
-  opts: AgentCliOpts,
+  opts: ResolvedAgentCliOpts,
   runtime: RuntimeEnv,
   signalBridge: ReturnType<typeof createAgentCliSignalBridge>,
 ) {
   protectJsonStdout(opts);
-  const body = (opts.message ?? "").trim();
+  const body = opts.message.trim();
   const explicitSessionKey = opts.sessionKey?.trim();
   if (!body) {
-    throw new Error(
-      `Missing message. Use ${formatCliCommand('openclaw agent --message "..." --agent <id>')} or pass --to/--session-key/--session-id for an existing conversation.`,
-    );
+    throw new Error(formatMissingMessageError());
   }
   if (!opts.to && !opts.sessionId && !opts.agent && !explicitSessionKey) {
     throw new Error(
@@ -806,7 +889,7 @@ async function agentViaGatewayCommand(
 }
 
 async function agentViaGatewayCommandWithTransientRetries(
-  opts: AgentCliOpts,
+  opts: ResolvedAgentCliOpts,
   runtime: RuntimeEnv,
   signalBridge: ReturnType<typeof createAgentCliSignalBridge>,
 ) {
@@ -839,7 +922,8 @@ export async function agentCliCommand(
   deps?: AgentCliDeps,
 ) {
   protectJsonStdout(opts);
-  const dispatchOpts = await normalizeSessionKeyOptsForDispatch(opts);
+  const resolvedOpts = await resolveAgentCliMessageInput(opts);
+  const dispatchOpts = await normalizeSessionKeyOptsForDispatch(resolvedOpts);
   validateExplicitSessionKeyForDispatch(dispatchOpts);
   const gatewayDispatchOpts = dispatchOpts.runId
     ? dispatchOpts


### PR DESCRIPTION
## Summary
- add `openclaw agent --message-stdin` and `--message-file <path>`
- enforce exactly one message input source across inline, file, and stdin
- reject empty file/stdin input and keep size limits before dispatch

## Verification
- `node scripts/test-projects.mjs src/cli/program/register.agent.test.ts src/commands/agent-via-gateway.test.ts`
- `pnpm tsgo:core`
- `pnpm build`
- isolated CLI smokes for `--message-stdin` and `--message-file` reached expected no-target validation
