### PR TITLE
fix(claude-cli): route native tool use through operator approver when ask is configured

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -2213,7 +2213,7 @@ ${JSON.stringify({
     }
   });
 
-  it("answers Claude live control_request can_use_tool with deny when exec policy is restrictive", async () => {
+  it("answers Claude live control_request can_use_tool with ask when exec policy is restrictive but operator approval is configured (on-miss)", async () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const writes: string[] = [];
     const stdin = {
@@ -2223,22 +2223,22 @@ ${JSON.stringify({
           stdoutListener?.(
             `${JSON.stringify({
               type: "control_request",
-              request_id: "req-deny",
+              request_id: "req-ask-onmiss",
               request: {
                 subtype: "can_use_tool",
                 tool_name: "Bash",
-                tool_use_id: "tool-deny-1",
+                tool_use_id: "tool-ask-onmiss-1",
                 input: { command: "rm -rf /" },
               },
             })}
 ${JSON.stringify({
   type: "system",
   subtype: "init",
-  session_id: "live-control-deny",
+  session_id: "live-control-ask-onmiss",
 })}
 ${JSON.stringify({
   type: "result",
-  session_id: "live-control-deny",
+  session_id: "live-control-ask-onmiss",
   result: "ok",
 })}
 `,
@@ -2252,7 +2252,7 @@ ${JSON.stringify({
       const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
       stdoutListener = input.onStdout;
       return {
-        runId: "live-run-deny",
+        runId: "live-run-ask-onmiss",
         pid: 3002,
         startedAtMs: Date.now(),
         stdin,
@@ -2265,7 +2265,7 @@ ${JSON.stringify({
       buildPreparedCliRunContext({
         provider: "claude-cli",
         model: "sonnet",
-        runId: "run-control-deny",
+        runId: "run-control-ask-onmiss",
         prompt: "hello",
         backend: { liveSession: "claude-stdio" },
         config: {
@@ -2281,11 +2281,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; message: string; decisionClassification: string };
+        response: { behavior: string; message: string; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("deny");
-    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.behavior).toBe("ask");
     expect(parsed.response.response.message).toContain("security=allowlist");
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
@@ -2422,7 +2421,7 @@ ${JSON.stringify({
     expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
   });
 
-  it("answers Claude live control_request can_use_tool with deny when approval defaults are restrictive", async () => {
+  it("answers Claude live control_request can_use_tool with ask when approval defaults are restrictive but operator approval is configured (on-miss)", async () => {
     await withTempExecApprovalsFile(
       {
         version: 1,
@@ -2439,22 +2438,22 @@ ${JSON.stringify({
               stdoutListener?.(
                 `${JSON.stringify({
                   type: "control_request",
-                  request_id: "req-approval-default-deny",
+                  request_id: "req-approval-default-ask",
                   request: {
                     subtype: "can_use_tool",
                     tool_name: "Bash",
-                    tool_use_id: "tool-approval-default-deny-1",
+                    tool_use_id: "tool-approval-default-ask-1",
                     input: { command: "ls" },
                   },
                 })}
 ${JSON.stringify({
   type: "system",
   subtype: "init",
-  session_id: "live-control-approval-default-deny",
+  session_id: "live-control-approval-default-ask",
 })}
 ${JSON.stringify({
   type: "result",
-  session_id: "live-control-approval-default-deny",
+  session_id: "live-control-approval-default-ask",
   result: "ok",
 })}
 `,
@@ -2468,7 +2467,7 @@ ${JSON.stringify({
           const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
           stdoutListener = input.onStdout;
           return {
-            runId: "live-run-approval-default-deny",
+            runId: "live-run-approval-default-ask",
             pid: 3005,
             startedAtMs: Date.now(),
             stdin,
@@ -2481,7 +2480,7 @@ ${JSON.stringify({
           buildPreparedCliRunContext({
             provider: "claude-cli",
             model: "sonnet",
-            runId: "run-control-approval-default-deny",
+            runId: "run-control-approval-default-ask",
             prompt: "hello",
             backend: {
               liveSession: "claude-stdio",
@@ -2500,11 +2499,10 @@ ${JSON.stringify({
         expect(controlResponse, "control_response written to stdin").toBeDefined();
         const parsed = JSON.parse((controlResponse ?? "").trim()) as {
           response: {
-            response: { behavior: string; message: string; decisionClassification: string };
+            response: { behavior: string; message: string; toolUseID?: string };
           };
         };
-        expect(parsed.response.response.behavior).toBe("deny");
-        expect(parsed.response.response.decisionClassification).toBe("user_reject");
+        expect(parsed.response.response.behavior).toBe("ask");
         expect(parsed.response.response.message).toContain("security=allowlist");
         const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
         expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");
@@ -2512,7 +2510,7 @@ ${JSON.stringify({
     );
   });
 
-  it("answers Claude live control_request can_use_tool with deny when session exec ask is restrictive", async () => {
+  it("answers Claude live control_request can_use_tool with ask when session exec ask overrides to always", async () => {
     let stdoutListener: ((chunk: string) => void) | undefined;
     const writes: string[] = [];
     const stdin = {
@@ -2522,22 +2520,22 @@ ${JSON.stringify({
           stdoutListener?.(
             `${JSON.stringify({
               type: "control_request",
-              request_id: "req-session-ask-deny",
+              request_id: "req-session-ask-always",
               request: {
                 subtype: "can_use_tool",
                 tool_name: "Bash",
-                tool_use_id: "tool-session-ask-deny-1",
+                tool_use_id: "tool-session-ask-always-1",
                 input: { command: "ls" },
               },
             })}
 ${JSON.stringify({
   type: "system",
   subtype: "init",
-  session_id: "live-control-session-ask-deny",
+  session_id: "live-control-session-ask-always",
 })}
 ${JSON.stringify({
   type: "result",
-  session_id: "live-control-session-ask-deny",
+  session_id: "live-control-session-ask-always",
   result: "ok",
 })}
 `,
@@ -2551,7 +2549,7 @@ ${JSON.stringify({
       const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
       stdoutListener = input.onStdout;
       return {
-        runId: "live-run-session-ask-deny",
+        runId: "live-run-session-ask-always",
         pid: 3006,
         startedAtMs: Date.now(),
         stdin,
@@ -2564,7 +2562,7 @@ ${JSON.stringify({
       buildPreparedCliRunContext({
         provider: "claude-cli",
         model: "sonnet",
-        runId: "run-control-session-ask-deny",
+        runId: "run-control-session-ask-always",
         prompt: "hello",
         backend: {
           liveSession: "claude-stdio",
@@ -2581,11 +2579,10 @@ ${JSON.stringify({
     expect(controlResponse, "control_response written to stdin").toBeDefined();
     const parsed = JSON.parse((controlResponse ?? "").trim()) as {
       response: {
-        response: { behavior: string; message: string; decisionClassification: string };
+        response: { behavior: string; message: string; toolUseID?: string };
       };
     };
-    expect(parsed.response.response.behavior).toBe("deny");
-    expect(parsed.response.response.decisionClassification).toBe("user_reject");
+    expect(parsed.response.response.behavior).toBe("ask");
     expect(parsed.response.response.message).toContain("ask=always");
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("default");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -868,22 +868,37 @@ function handleClaudeLiveControlRequest(
     return;
   }
   const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
-  const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
+  const { security, ask } = turn.execPermission;
+  // Full-bypass: security=full + ask=off → allow all native tools immediately.
+  const bypassAll = security === "full" && ask === "off";
+  // When exec is not explicitly denied and the operator is configured to
+  // approve (ask != "off"), route native tool use through the active
+  // approver instead of hard-denying. This fixes the "on-miss never asks"
+  // dead-end reported in #93661.
+  const deferToApprover =
+    !bypassAll && security !== "deny" && ask !== "off";
+  const allowed = bypassAll || deferToApprover;
   writeClaudeLiveControlResponse(session, {
     type: "control_response",
     response: {
       subtype: "success",
       request_id: requestId,
-      response: allowed
+      response: bypassAll
         ? {
             behavior: "allow",
             ...(toolUseId ? { toolUseID: toolUseId } : {}),
           }
-        : {
-            behavior: "deny",
-            decisionClassification: "user_reject",
-            message: `OpenClaw exec policy denied Claude native tool use (security=${turn.execPermission.security}, ask=${turn.execPermission.ask}).`,
-          },
+        : deferToApprover
+          ? {
+              behavior: "ask",
+              ...(toolUseId ? { toolUseID: toolUseId } : {}),
+              message: `OpenClaw exec policy requests operator approval for Claude native tool use (security=${security}, ask=${ask}).`,
+            }
+          : {
+              behavior: "deny",
+              decisionClassification: "user_reject",
+              message: `OpenClaw exec policy denied Claude native tool use (security=${security}, ask=${ask}).`,
+            },
     },
   });
 }


### PR DESCRIPTION
## Summary

- Claude native tool use (Write/Edit/Read) was hard-denied for all exec policies except `security="full" + ask="off"`
- With `ask="on-miss"` or `ask="always"`, operators were never actually asked — native tool use was silently denied
- This fix routes native tool `can_use_tool` requests through the configured operator approver (`behavior: "ask"`) when `ask !== "off"` and `security !== "deny"`
- `security="deny"` still produces a hard deny, preserving the existing contract

## Change Type

- [x] Bug fix

## Scope

- [x] CLI Runtime / Claude Code agent

## Real behavior proof

**Behavior addressed:** Native Claude tool `can_use_tool` control requests now use `behavior: "ask"` instead of `behavior: "deny"` when operator approval is configured.

**Environment tested:** Node 22.x on Linux, openclaw upstream/main at 2ef0589b76.

**Steps run after the patch:**

```bash
git show HEAD:src/agents/cli-runner/claude-live-session.ts | grep -n -A15 "bypassAll\|deferToApprover\|behavior.*ask"
```

**Evidence after fix:**

```typescript
873:  const bypassAll = security === "full" && ask === "off";
878:  const deferToApprover =
879:    !bypassAll && security !== "deny" && ask !== "off";
880:  const allowed = bypassAll || deferToApprover;
886:      response: bypassAll
887-        ? {
888:            behavior: "allow",
889-            ...(toolUseId ? { toolUseID: toolUseId } : {}),
890-          }
891:        : deferToApprover
892-          ? {
893:              behavior: "ask",
894-              ...(toolUseId ? { toolUseID: toolUseId } : {}),
895-              message: `...operator approval...`,
896-            }
897-          : {
898:              behavior: "deny",
899-              decisionClassification: "user_reject",
900-              message: `...denied Claude native tool use...`,
901-            },
```

Before (binary check, no "ask" path):
```typescript
const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
response: allowed ? { behavior: "allow" } : { behavior: "deny" }
```

After (three-way: allow / ask / deny):
```typescript
const bypassAll = security === "full" && ask === "off";
const deferToApprover = !bypassAll && security !== "deny" && ask !== "off";
response: bypassAll ? { behavior: "allow" } : deferToApprover ? { behavior: "ask" } : { behavior: "deny" }
```

**Observed result:** Three decision paths now exist: full bypass (allow), operator approval (ask), and explicit deny (deny). The `deferToApprover` guard correctly excludes `security="deny"` so fully locked-down deployments remain unchanged. Unit tests confirm: 65/65 pass, with the three updated tests now correctly expecting `behavior: "ask"` for on-miss/always configurations.

**Not tested:** Live Claude Code session with Telegram/Discord approver routing — the end-to-end `behavior: "ask"` approval flow requires a real messaging channel and Claude Code instance.

## Verification

- `node scripts/run-vitest.mjs run src/agents/cli-runner.spawn.test.ts` → 65/65 passed

## Root Cause

- Root cause: Binary permission check `security === "full" && ask === "off"` hard-denied all native tool use outside the full-bypass path, with no `behavior: "ask"` path
- Missing guardrail: `on-miss` and `always` ask configurations had no code path — they fell through to the deny branch

Closes #93661
