### PR TITLE
fix(feishu): render streaming card footer

### DIFF
--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -171,6 +171,14 @@
           },
           "streaming": { "type": "boolean" },
           "blockStreaming": { "type": "boolean" },
+          "footer": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "elapsed": { "type": "boolean" },
+              "status": { "type": "boolean" }
+            }
+          },
           "replyInThread": {
             "type": "string",
             "enum": ["disabled", "enabled"]
@@ -208,6 +216,14 @@
       },
       "streaming": { "type": "boolean" },
       "blockStreaming": { "type": "boolean" },
+      "footer": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "elapsed": { "type": "boolean" },
+          "status": { "type": "boolean" }
+        }
+      },
       "replyInThread": {
         "type": "string",
         "enum": ["disabled", "enabled"]

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -221,6 +221,32 @@ describe("FeishuConfigSchema optimization flags", () => {
     expect(result.accounts?.main?.blockStreaming).toBe(false);
   });
 
+  it("accepts top-level and account-level streaming footer options", () => {
+    const result = FeishuConfigSchema.parse({
+      footer: {
+        elapsed: true,
+        status: true,
+      },
+      accounts: {
+        main: {
+          footer: {
+            elapsed: false,
+            status: true,
+          },
+        },
+      },
+    });
+
+    expect(result.footer).toEqual({
+      elapsed: true,
+      status: true,
+    });
+    expect(result.accounts?.main?.footer).toEqual({
+      elapsed: false,
+      status: true,
+    });
+  });
+
   it("accepts account-level optimization flags", () => {
     const result = FeishuConfigSchema.parse({
       accounts: {

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -71,6 +71,14 @@ const RenderModeSchema = z.enum(["auto", "raw", "card"]).optional();
 const StreamingModeSchema = z.boolean().optional();
 const BlockStreamingSchema = z.boolean().optional();
 
+const FooterSchema = z
+  .object({
+    elapsed: z.boolean().optional(),
+    status: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 const BlockStreamingCoalesceSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -199,6 +207,7 @@ const FeishuSharedConfigShape = {
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
+  footer: FooterSchema,
   tools: FeishuToolsConfigSchema,
   actions: ChannelActionsSchema,
   replyInThread: ReplyInThreadSchema,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1489,6 +1489,41 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("passes configured streaming footer options to streaming cards", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: true,
+        footer: {
+          elapsed: true,
+          status: true,
+        },
+      },
+    });
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expectStreamingStartOptions(0, {
+      footer: {
+        elapsed: true,
+        status: true,
+      },
+      note: "Agent: agent",
+    });
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```ts\nconst x = 1\n```", {
+      footerStatus: "completed",
+      note: "Agent: agent",
+    });
+  });
+
   it("uses streaming cards for thread replies and keeps topic metadata", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -25,7 +25,12 @@ import {
 } from "./reply-dispatcher-runtime-api.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
-import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
+import {
+  FeishuStreamingSession,
+  mergeStreamingText,
+  type StreamingFooterConfig,
+  type StreamingFooterStatus,
+} from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -112,6 +117,16 @@ function resolveCardNote(
     parts.push(`Provider: ${prefixCtx.provider}`);
   }
   return parts.join(" | ");
+}
+
+function resolveStreamingFooterConfig(config: {
+  footer?: StreamingFooterConfig;
+}): StreamingFooterConfig | undefined {
+  const footer = config.footer;
+  if (footer?.elapsed !== true && footer?.status !== true) {
+    return undefined;
+  }
+  return footer;
 }
 
 type CreateFeishuReplyDispatcherParams = {
@@ -241,6 +256,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const streamingEnabled = account.config?.streaming !== false && renderMode !== "raw";
   const coreBlockStreamingEnabled = account.config?.blockStreaming === true;
   const reasoningPreviewEnabled = streamingEnabled && params.allowReasoningPreview === true;
+  const streamingFooter = resolveStreamingFooterConfig(account.config);
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
@@ -378,6 +394,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           rootId,
           header: cardHeader,
           note: cardNote,
+          ...(streamingFooter ? { footer: streamingFooter } : {}),
         });
         streamingStartBackoffUntilByAccount.delete(account.accountId);
       } catch (error) {
@@ -405,7 +422,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     lastSnapshotTextLength = 0;
   };
 
-  const closeStreaming = async (options?: { markClosedForReply?: boolean }) => {
+  const closeStreaming = async (options?: {
+    markClosedForReply?: boolean;
+    footerStatus?: Exclude<StreamingFooterStatus, "running">;
+  }) => {
     try {
       if (streamingStartPromise) {
         await streamingStartPromise;
@@ -415,7 +435,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         statusLine = "";
         const text = buildCombinedStreamText(reasoningText, streamText);
         const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-        const contentVisible = await streaming.close(text, { note: finalNote });
+        const contentVisible = await streaming.close(text, {
+          note: finalNote,
+          ...(streamingFooter ? { footerStatus: options?.footerStatus ?? "completed" } : {}),
+        });
         // Track the raw streamed text so the duplicate-final check in deliver()
         // can skip the redundant text delivery that arrives after onIdle closes
         // the streaming card.
@@ -582,7 +605,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     return true;
   };
 
-  const queueIdleSideEffects = (options?: { markClosedForReply?: boolean }): Promise<void> => {
+  const queueIdleSideEffects = (options?: {
+    markClosedForReply?: boolean;
+    footerStatus?: Exclude<StreamingFooterStatus, "running">;
+  }): Promise<void> => {
     const nextIdleSideEffects = idleSideEffectsPromise.then(async () => {
       await closeStreaming(options);
       typingCallbacks?.onIdle?.();
@@ -777,7 +803,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        await queueIdleSideEffects({ markClosedForReply: false });
+        await queueIdleSideEffects({ markClosedForReply: false, footerStatus: "error" });
       },
       onIdle: () => queueIdleSideEffects(),
       onCleanup: () => {

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -20,6 +20,12 @@ type StreamingSessionState = {
   currentText: string;
   sentText: string;
   hasNote: boolean;
+  hasFooter?: boolean;
+  footer?: {
+    elapsed?: boolean;
+    status?: boolean;
+  };
+  startedAtMs?: number;
 };
 
 function setStreamingSessionInternals(
@@ -151,6 +157,99 @@ describe("FeishuStreamingSession", () => {
     } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
     return { authTokens, client };
   }
+
+  it("renders configured status and elapsed footers on streaming cards", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-16T12:00:00.000Z"));
+    const createBodies: string[] = [];
+    const footerBodies: string[] = [];
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockImplementation(
+      async ({ url, init }: { url: string; init?: { body?: string } }) => {
+        if (url.includes("/auth/")) {
+          return {
+            response: {
+              ok: true,
+              json: async () => ({
+                code: 0,
+                msg: "ok",
+                tenant_access_token: "token",
+                expire: 7200,
+              }),
+            },
+            release,
+          };
+        }
+        if (url.endsWith("/cardkit/v1/cards")) {
+          createBodies.push(init?.body ?? "");
+          return {
+            response: {
+              ok: true,
+              json: async () => ({ code: 0, msg: "ok", data: { card_id: "card_footer" } }),
+            },
+            release,
+          };
+        }
+        if (url.includes("/elements/footer/content")) {
+          footerBodies.push(init?.body ?? "");
+        }
+        return {
+          response: {
+            ok: true,
+            json: async () => ({ code: 0, msg: "ok" }),
+          },
+          release,
+        };
+      },
+    );
+    const client = {
+      im: {
+        message: {
+          create: vi.fn(async () => ({ code: 0, msg: "ok", data: { message_id: "om_footer" } })),
+        },
+      },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+
+    const session = new FeishuStreamingSession(client, {
+      appId: "app_footer",
+      appSecret: "secret",
+    });
+
+    await session.start("chat_id", "chat_id", {
+      footer: {
+        elapsed: true,
+        status: true,
+      },
+      note: "Agent: agent",
+    });
+    vi.setSystemTime(new Date("2026-06-16T12:00:01.250Z"));
+    await session.close("final answer", { footerStatus: "completed" });
+
+    const createPayload = JSON.parse(createBodies[0] ?? "{}") as { data?: string };
+    const cardJson = JSON.parse(createPayload.data ?? "{}") as {
+      body?: { elements?: unknown[] };
+    };
+    expect(cardJson.body?.elements).toEqual([
+      { tag: "markdown", content: "", element_id: "content" },
+      { tag: "hr" },
+      {
+        tag: "markdown",
+        content: "<font color='grey'>Agent: agent</font>",
+        element_id: "note",
+      },
+      {
+        tag: "markdown",
+        content: "<font color='grey'>生成中</font>",
+        element_id: "footer",
+      },
+    ]);
+    expect(footerBodies).toHaveLength(1);
+    expect(JSON.parse(footerBodies[0] ?? "{}")).toEqual({
+      content: "<font color='grey'>已完成 | 耗时 1.3s</font>",
+      sequence: 3,
+      uuid: "f_card_footer_3",
+    });
+  });
 
   it("flushes throttled pending text after the throttle window", async () => {
     vi.useFakeTimers();

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -22,7 +22,17 @@ type CardState = {
   currentText: string;
   sentText: string;
   hasNote: boolean;
+  hasFooter: boolean;
+  footer?: StreamingFooterConfig;
+  startedAtMs: number;
 };
+
+export type StreamingFooterConfig = {
+  elapsed?: boolean;
+  status?: boolean;
+};
+
+export type StreamingFooterStatus = "running" | "completed" | "error" | "stopped";
 
 /** Options for customising the initial streaming card appearance. */
 type StreamingCardOptions = {
@@ -30,6 +40,8 @@ type StreamingCardOptions = {
   header?: CardHeaderConfig;
   /** Optional grey note footer text. */
   note?: string;
+  /** Optional grey status/elapsed footer. */
+  footer?: StreamingFooterConfig;
 };
 
 /** Optional header for streaming cards (title bar with color template) */
@@ -49,6 +61,12 @@ type StreamingStartOptions = {
 const STREAMING_UPDATE_THROTTLE_MS = 160;
 const STREAMING_SIGNIFICANT_DELTA_CHARS = 18;
 const FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS = 7200;
+const STREAMING_FOOTER_STATUS_LABELS: Record<StreamingFooterStatus, string> = {
+  running: "生成中",
+  completed: "已完成",
+  error: "出错",
+  stopped: "已停止",
+};
 
 // Token cache (keyed by domain + appId)
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
@@ -141,6 +159,37 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
+function hasStreamingFooter(
+  footer: StreamingFooterConfig | undefined,
+): footer is StreamingFooterConfig {
+  return footer?.elapsed === true || footer?.status === true;
+}
+
+function formatStreamingElapsedMs(startedAtMs: number, nowMs: number): string {
+  const elapsedMs = Math.max(0, nowMs - startedAtMs);
+  return `${(elapsedMs / 1000).toFixed(1)}s`;
+}
+
+function formatStreamingFooterText(
+  footer: StreamingFooterConfig,
+  status: StreamingFooterStatus,
+  startedAtMs: number,
+  nowMs = Date.now(),
+): string {
+  const parts: string[] = [];
+  if (footer.status) {
+    parts.push(STREAMING_FOOTER_STATUS_LABELS[status]);
+  }
+  if (footer.elapsed && status !== "running") {
+    parts.push(`耗时 ${formatStreamingElapsedMs(startedAtMs, nowMs)}`);
+  }
+  return parts.join(" | ");
+}
+
+function formatGreyFooter(text: string): string {
+  return `<font color='grey'>${text}</font>`;
+}
+
 function hasNaturalStreamingBoundary(text: string): boolean {
   return /[\n。！？!?；;：:]$/.test(text);
 }
@@ -230,15 +279,26 @@ export class FeishuStreamingSession {
     }
 
     const apiBase = resolveApiBase(this.creds.domain);
+    const startedAtMs = Date.now();
+    const footer = hasStreamingFooter(options?.footer) ? options.footer : undefined;
     const elements: Record<string, unknown>[] = [
       { tag: "markdown", content: "", element_id: "content" },
     ];
-    if (options?.note) {
+    if (options?.note || footer) {
       elements.push({ tag: "hr" });
+    }
+    if (options?.note) {
       elements.push({
         tag: "markdown",
-        content: `<font color='grey'>${options.note}</font>`,
+        content: formatGreyFooter(options.note),
         element_id: "note",
+      });
+    }
+    if (footer) {
+      elements.push({
+        tag: "markdown",
+        content: formatGreyFooter(formatStreamingFooterText(footer, "running", startedAtMs)),
+        element_id: "footer",
       });
     }
     const cardJson: Record<string, unknown> = {
@@ -346,6 +406,9 @@ export class FeishuStreamingSession {
       currentText: "",
       sentText: "",
       hasNote: Boolean(options?.note),
+      hasFooter: Boolean(footer),
+      ...(footer ? { footer } : {}),
+      startedAtMs,
     };
     this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
   }
@@ -511,7 +574,7 @@ export class FeishuStreamingSession {
           "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({
-          content: `<font color='grey'>${note}</font>`,
+          content: formatGreyFooter(note),
           sequence: this.state.sequence,
           uuid: `n_${this.state.cardId}_${this.state.sequence}`,
         }),
@@ -525,7 +588,41 @@ export class FeishuStreamingSession {
       .catch((e: unknown) => this.log?.(`Note update failed: ${String(e)}`));
   }
 
-  async close(finalText?: string, options?: { note?: string }): Promise<boolean> {
+  private async updateFooterContent(status: StreamingFooterStatus): Promise<void> {
+    if (!this.state || !this.state.hasFooter || !this.state.footer) {
+      return;
+    }
+    const apiBase = resolveApiBase(this.creds.domain);
+    this.state.sequence += 1;
+    const footerText = formatStreamingFooterText(this.state.footer, status, this.state.startedAtMs);
+    await fetchWithSsrFGuard({
+      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/footer/content`,
+      init: {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${await getToken(this.creds)}`,
+          "Content-Type": "application/json",
+          "User-Agent": getFeishuUserAgent(),
+        },
+        body: JSON.stringify({
+          content: formatGreyFooter(footerText),
+          sequence: this.state.sequence,
+          uuid: `f_${this.state.cardId}_${this.state.sequence}`,
+        }),
+      },
+      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+      auditContext: "feishu.streaming-card.footer-update",
+    })
+      .then(async ({ release }) => {
+        await release();
+      })
+      .catch((e: unknown) => this.log?.(`Footer update failed: ${String(e)}`));
+  }
+
+  async close(
+    finalText?: string,
+    options?: { note?: string; footerStatus?: Exclude<StreamingFooterStatus, "running"> },
+  ): Promise<boolean> {
     if (!this.state || this.closed) {
       return false;
     }
@@ -556,6 +653,9 @@ export class FeishuStreamingSession {
     // Update note with final model/provider info
     if (options?.note) {
       await this.updateNoteContent(options.note);
+    }
+    if (this.state.hasFooter) {
+      await this.updateFooterContent(options?.footerStatus ?? "completed");
     }
 
     // Close streaming mode


### PR DESCRIPTION
## Summary

- Fixes the built-in Feishu channel ignoring `channels.feishu.footer.elapsed/status` for streaming cards.
- Adds explicit Feishu footer config metadata and passes enabled footer options into the streaming card session.
- Streaming cards now create a footer element while running and update it on close with `已完成`/`出错` plus elapsed time when configured.
- Out of scope: changing `discard()` behavior for media/oversized-message fallbacks; those paths still delete the streaming preview instead of rendering a stopped card.

## Linked context

Closes #93667

Related #93667

This was selected from the public issue queue as an external contributor fix.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `channels.feishu.footer.elapsed/status` was accepted by the built-in Feishu channel metadata but was not consumed by the streaming card path, so users could not see completion status or elapsed time in Feishu streaming card footers.
- Real environment tested: Local OpenClaw source checkout plus live Feishu group `zengwen-konw` using the built-in Feishu streaming CardKit path.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs extensions/feishu/src/config-schema.test.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/reply-dispatcher.test.ts
pnpm tsgo:extensions
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
node --import tsx contrib/feishu-live-footer-proof.mjs
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

Terminal output from focused local validation:

```text
[test] passed 1 Vitest shard in 16.39s
pnpm tsgo:extensions exited 0
git diff --check exited 0
autoreview clean: no accepted/actionable findings reported
```

Live Feishu output from the patched streaming card path:

```text
[streaming-card] Started streaming: cardId=7652608618333064142, messageId=om_x100b6c0c3ee3d0a4b1ae3d44a288ddd
[streaming-card] Closed streaming: cardId=7652608618333064142
Live Feishu streaming footer proof sent. visible=true
```

- Observed result after fix:

The Feishu streaming card payload now includes a `footer` markdown element when `footer.elapsed/status` is enabled, and close updates that element to:

```text
<font color='grey'>已完成 | 耗时 1.3s</font>
```

The dispatcher also passes `{ footerStatus: "completed" }` on the normal close path and `{ footerStatus: "error" }` on reply errors.

- What was not tested: Feishu/Lark client screenshot proof and the external `@larksuite/openclaw-lark` package.
- Proof limitations or environment constraints: The live proof used a test Feishu group and redacted app credentials. It proves OpenClaw created, sent, updated, and closed a real Feishu CardKit streaming card with the new footer path; it does not include a client screenshot.
- Before evidence (optional but encouraged): The red TDD run failed because `FeishuConfigSchema` rejected `footer`, dispatcher start options had `footer: undefined`, and the streaming card payload lacked a `footer` element.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/feishu/src/config-schema.test.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `pnpm tsgo:extensions`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

Regression coverage added:

- config schema accepts top-level and account-level `footer.elapsed/status`
- reply dispatcher passes configured footer options into `FeishuStreamingSession`
- streaming card CardKit payload creates and updates the footer element with status and elapsed text

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `Yes`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: Feishu CardKit streaming card payload shape.

How is that risk mitigated? The change is gated behind `footer.elapsed/status`; existing no-footer paths keep their prior card shape, and focused tests assert the new CardKit payload.

## Current review state

Next action: maintainer review and CI.

Waiting on: maintainer review.

AI-assisted (Codex). Proof above was run manually.
