### PR TITLE
fix(feishu): preserve replies before error finals

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -122,7 +122,13 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     onReplyStart?: () => Promise<void> | void;
     onIdle?: () => Promise<void> | void;
     deliver: (
-      payload: { text?: string; mediaUrl?: string; mediaUrls?: string[]; audioAsVoice?: boolean },
+      payload: {
+        text?: string;
+        mediaUrl?: string;
+        mediaUrls?: string[];
+        audioAsVoice?: boolean;
+        isError?: boolean;
+      },
       meta: { kind: string },
     ) => Promise<void> | void;
   };
@@ -712,7 +718,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  it("coalesces distinct final payloads into one streaming card until idle", async () => {
+  it("coalesces cumulative final payloads into one streaming card until idle", async () => {
     const { options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
@@ -730,6 +736,76 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("appends an independent error final without replacing the assistant answer", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.deliver({ text: "The file is ready." }, { kind: "final" });
+    await options.deliver({ text: "⚠️ Exec failed", isError: true }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "The file is ready.\n\n⚠️ Exec failed",
+      { note: "Agent: agent" },
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate the answer from a cumulative error final", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.deliver({ text: "The file is ready." }, { kind: "final" });
+    await options.deliver(
+      { text: "The file is ready.\n\n⚠️ Exec failed", isError: true },
+      { kind: "final" },
+    );
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "The file is ready.\n\n⚠️ Exec failed",
+      { note: "Agent: agent" },
+    );
+  });
+
+  it("replaces a partial preview when the first final is an error", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    result.replyOptions.onPartialReply?.({ text: "Working on it..." });
+    await options.deliver({ text: "⚠️ Exec failed", isError: true }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("⚠️ Exec failed", {
+      note: "Agent: agent",
+    });
+  });
+
+  it("falls back to chunked text when an appended error exceeds the streaming limit", async () => {
+    const runtime = getFeishuRuntimeMock();
+    runtime.channel.text.resolveTextChunkLimit.mockReturnValue(20);
+
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.deliver({ text: "123456789012345678" }, { kind: "final" });
+    await options.deliver({ text: "⚠️ Exec failed", isError: true }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].discard).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expectLastMockArgFields(sendMessageFeishuMock, "message send params", {
+      text: "123456789012345678\n\n⚠️ Exec failed",
+    });
   });
 
   it("skips exact duplicate final text after streaming close", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -34,6 +34,23 @@ function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
 }
 
+function mergeStreamingFinalText(
+  previousText: string,
+  nextText: string,
+  appendError: boolean,
+): string {
+  if (!appendError || !previousText) {
+    return nextText;
+  }
+  if (nextText.startsWith(previousText)) {
+    return nextText;
+  }
+  if (previousText.endsWith(`\n\n${nextText}`)) {
+    return previousText;
+  }
+  return `${previousText}\n\n${nextText}`;
+}
+
 /** Maximum age (ms) for a message to receive a typing indicator reaction.
  * Messages older than this are likely replays after context compaction (#30418). */
 const TYPING_INDICATOR_MAX_AGE_MS = 2 * 60_000;
@@ -249,6 +266,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let statusLine = "";
   let snapshotBaseText = "";
   let lastSnapshotTextLength = 0;
+  // Partial previews are replaceable; only committed final text may precede an error notice.
+  let hasStreamingFinalText = false;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -403,6 +422,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     statusLine = "";
     snapshotBaseText = "";
     lastSnapshotTextLength = 0;
+    hasStreamingFinalText = false;
   };
 
   const closeStreaming = async (options?: { markClosedForReply?: boolean }) => {
@@ -628,7 +648,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const payloadText =
           payload.isReasoning && payload.text ? formatReasoningMessage(payload.text) : payload.text;
         const reply = resolveSendableOutboundReplyParts({ ...payload, text: payloadText });
-        const text = reply.text;
+        const text =
+          info?.kind === "final"
+            ? mergeStreamingFinalText(
+                streamText,
+                reply.text,
+                payload.isError === true && hasStreamingFinalText,
+              )
+            : reply.text;
         const hasText = reply.hasText;
         const hasMedia = reply.hasMedia;
         const hasVoiceMedia =
@@ -708,7 +735,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta", dedupeWithLastPartial: true });
             }
             if (info?.kind === "final") {
+              // Final payloads can be cumulative snapshots or independent
+              // notices. Preserve both when the latter arrives after an answer.
               streamText = text;
+              hasStreamingFinalText = true;
               snapshotBaseText = "";
               lastSnapshotTextLength = text.length;
               flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));


### PR DESCRIPTION
## Summary

- Preserve a completed Feishu streaming-card answer when core emits a later independent error final.
- Keep cumulative final snapshots and first-error-after-partial behavior unchanged.
- Re-evaluate Feishu's text limit after merging so oversized combined output uses the existing chunked fallback.

## Linked context

Closes #94360

Related #94374
Related #94381

## Real behavior proof (required for external PRs)

- Behavior addressed: a final execution warning replaced the assistant answer in Feishu streaming cards.
- Real environment tested: Azure-backed Crabbox Linux runner using the production Feishu reply dispatcher with mocked Feishu transport boundaries.
- Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 corepack pnpm test src/agents/embedded-agent-runner/run/payloads.errors.test.ts extensions/feishu/src/reply-dispatcher.test.ts`; then the three focused multi-final/partial/limit scenarios.
- Evidence after fix: 54 core payload tests and 82 Feishu dispatcher tests passed; all 3 focused multi-final scenarios passed.
- Observed result after fix: the streaming card closes with the assistant answer followed by the independent error; cumulative snapshots do not repeat the answer; a first error replaces a partial preview; oversized merged text uses chunked delivery.
- What was not tested: a live Feishu tenant with production credentials.
- Proof limitations or environment constraints: transport calls were mocked to avoid posting into a real tenant; production dispatcher state transitions and Linux runtime were exercised.

## Tests and validation

- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/embedded-agent-runner/run/payloads.errors.test.ts extensions/feishu/src/reply-dispatcher.test.ts`
- Azure-backed Crabbox Linux: same 136 tests, plus 3 focused dispatcher scenarios.
- `pnpm format -- extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `git diff --check`
- Fresh Codex autoreview: clean after fixing three accepted edge-case findings (merged-size limit, cumulative error snapshots, partial-preview state).

Regression coverage verifies independent and cumulative error finals, partial previews, and merged text over the configured streaming limit.

## Risk checklist

Did user-visible behavior change? `Yes`

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

Highest-risk area: distinguishing committed final text from replaceable streaming previews.

Mitigation: explicit per-stream final-text state, reset with the existing streaming lifecycle, plus focused regression coverage for both shapes.

## Current review state

Ready for CI and maintainer review. No known author blocker. Live Feishu credential proof remains the only validation gap.
