### PR TITLE
fix: #94391 将 compaction aggregate timeout 从硬编码 60s 改为读取 compaction.timeoutSeconds 配置

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4919,8 +4919,6 @@ export async function runEmbeddedAttempt(
         // Only trust snapshot if compaction wasn't running before or after capture
         const preCompactionSnapshot = wasCompactingBefore || wasCompactingAfter ? null : snapshot;
         const preCompactionSessionId = activeSession.sessionId;
-        const COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS = 60_000;
-
         try {
           // Flush buffered block replies before waiting for compaction so the
           // user receives the assistant response immediately.  Without this,
@@ -4937,14 +4935,14 @@ export async function runEmbeddedAttempt(
             : await waitForCompactionRetryWithAggregateTimeout({
                 waitForCompactionRetry,
                 abortable,
-                aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
+                aggregateTimeoutMs: compactionTimeoutMs,
                 isCompactionStillInFlight: isCompactionInFlight,
               });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;
             if (!isProbeSession) {
               log.warn(
-                `compaction retry aggregate timeout (${COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS}ms): ` +
+                `compaction retry aggregate timeout (${compactionTimeoutMs}ms): ` +
                   `proceeding with pre-compaction state runId=${params.runId} sessionId=${params.sessionId}`,
               );
             }


### PR DESCRIPTION
## 变更说明

将 `COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS` 硬编码常量（60000ms）替换为从 `agents.defaults.compaction.timeoutSeconds` 配置读取的 `compactionTimeoutMs`（默认 180000ms）。

### 根因

在 ~200K token 的大 session 中，compaction 模型调用（anthropic/claude-sonnet-4-6）需要 **143-187s** 完成，但硬编码的 **60s** aggregate timeout 在模型调用完成前就丢弃了有效结果：

| 后果 | 详情 |
|------|------|
| 结果丢弃 | compaction 完成（`aborted=False`）但被 60s 标记 incomplete |
| 重试风暴 | 每轮失败触发新的 compaction 重试（观察到连续 6 次失败） |
| API 费用浪费 | 每次失败都白烧一次完整的 ~200K token provider 调用 |
| 静默失败 | 用户无任何错误提示，session 卡在 overflow 上限无法自动恢复 |

### 修复方案

将 aggregate timeout 关联到已有的 `agents.defaults.compaction.timeoutSeconds` 配置项：
- **默认值**：180s（原 60s），覆盖正常 compaction 调用的 143-187s 范围
- **已调高配置的用户**：自动获得修复，无需额外配置
- **不改配置面**：不加新配置项，复用已有字段

### 对比竞品 PR #94403

`#94403` 只是把硬编码从 60000 改成 300000，仍然硬编码。本 PR 将其接入已有配置体系，用户可以自行调整。

## 关联 Issue

Closes #94391

## 变更类型

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Code refactor
- [ ] Test update
- [ ] Dependency update

## 风险等级

low — 改动范围极小（删除 2 行、修改 2 行），复用已有的 `compactionTimeoutMs` 变量和 `resolveCompactionTimeoutMs()` 配置解析逻辑。

## 测试情况

- `compaction-retry-aggregate-timeout.test.ts`：16/16 通过
- 改动不涉及函数签名变更，mock 层无需适配

🤖 Generated with [Claude Code](https://claude.com/claude-code)