### PR TITLE
fix(cli): accept parent options placed after lazy subcommands (#55563 regression 1) [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Lazy CLI parent options:** accept shipped parent-option ordering such as `openclaw browser tabs --browser-profile remote` after lazy command loading without stealing colliding child options. (#94431) Thanks @ml12580.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Lazy CLI parent options:** accept shipped parent-option ordering such as `openclaw browser tabs --browser-profile remote` after lazy command loading without stealing colliding child options. (#94431) Thanks @ml12580.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -180,6 +180,28 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     expect(tabsCommand.parent?.opts().json).toBe(true);
   });
 
+  it("accepts the shipped trailing browser profile order after lazy loading", async () => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    registerBrowserCli(program, [
+      "node",
+      "openclaw",
+      "browser",
+      "tabs",
+      "--browser-profile",
+      "remote",
+    ]);
+
+    await program.parseAsync(["browser", "tabs", "--browser-profile", "remote"], {
+      from: "user",
+    });
+
+    const tabsCommand = requireTrailingCommand(
+      requireFirstCall(manageMocks.tabsAction, "tabs action call"),
+      "tabs action",
+    );
+    expect(tabsCommand.parent?.opts().browserProfile).toBe("remote");
+  });
+
   it("skips browser option values when selecting the lazy command group", async () => {
     const program = new Command();
     program.name("openclaw");

--- a/src/cli/program/action-reparse.test.ts
+++ b/src/cli/program/action-reparse.test.ts
@@ -24,6 +24,25 @@ function deleteRawArgs(command: Command): void {
   delete (command as Command & { rawArgs?: string[] }).rawArgs;
 }
 
+async function expectReparseArgv(params: {
+  parent: Command;
+  action: Command;
+  argv: string[];
+  expected: string[];
+}): Promise<void> {
+  let root = params.parent;
+  while (root.parent) {
+    root = root.parent;
+  }
+  setRawArgs(root, params.argv);
+  buildParseArgvMock.mockReturnValue(params.argv);
+  const parseAsync = vi.spyOn(root, "parseAsync").mockResolvedValue(root);
+
+  await reparseProgramFromActionArgs(params.parent, [params.action]);
+
+  expect(parseAsync).toHaveBeenCalledWith(params.expected);
+}
+
 describe("reparseProgramFromActionArgs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -167,5 +186,92 @@ describe("reparseProgramFromActionArgs", () => {
       fallbackArgv: ["config", "set", "key", "value"],
     });
     expect(parseAsync).toHaveBeenCalled();
+  });
+
+  it("hoists a trailing lazy-parent option before the loaded command", async () => {
+    const root = new Command().name("openclaw");
+    const browser = root.command("browser").option("--browser-profile <name>");
+    const tabs = browser.command("tabs");
+    await expectReparseArgv({
+      parent: browser,
+      action: tabs,
+      argv: ["node", "openclaw", "browser", "tabs", "--browser-profile", "remote"],
+      expected: ["node", "openclaw", "browser", "--browser-profile", "remote", "tabs"],
+    });
+  });
+
+  it("skips root option values that match the parent command name", async () => {
+    const root = new Command().name("openclaw").option("--profile <name>");
+    const browser = root.command("browser").option("--browser-profile <name>");
+    const tabs = browser.command("tabs");
+    await expectReparseArgv({
+      parent: browser,
+      action: tabs,
+      argv: [
+        "node",
+        "openclaw",
+        "--profile",
+        "browser",
+        "browser",
+        "tabs",
+        "--browser-profile",
+        "remote",
+      ],
+      expected: [
+        "node",
+        "openclaw",
+        "--profile",
+        "browser",
+        "browser",
+        "--browser-profile",
+        "remote",
+        "tabs",
+      ],
+    });
+  });
+
+  it("hoists parent options after nested lazy commands", async () => {
+    const root = new Command().name("openclaw");
+    const browser = root.command("browser").option("--browser-profile <name>");
+    const tab = browser.command("tab");
+    tab.command("new");
+    await expectReparseArgv({
+      parent: browser,
+      action: tab,
+      argv: ["node", "openclaw", "browser", "tab", "new", "--browser-profile", "work"],
+      expected: ["node", "openclaw", "browser", "--browser-profile", "work", "tab", "new"],
+    });
+  });
+
+  it("leaves a child-owned option collision after the child command", async () => {
+    const root = new Command().name("openclaw");
+    const browser = root.command("browser").option("--json");
+    const extension = browser.command("extension");
+    extension.command("path");
+    extension.command("pair").option("--json");
+    const argv = ["node", "openclaw", "browser", "extension", "pair", "--json"];
+    await expectReparseArgv({ parent: browser, action: extension, argv, expected: argv });
+  });
+
+  it("hoists a parent option when only a sibling command owns the same flag", async () => {
+    const root = new Command().name("openclaw");
+    const browser = root.command("browser").option("--url <url>");
+    const cookies = browser.command("cookies");
+    cookies.command("list");
+    cookies.command("set").option("--url <url>");
+    await expectReparseArgv({
+      parent: browser,
+      action: cookies,
+      argv: ["node", "openclaw", "browser", "cookies", "list", "--url", "ws://gateway"],
+      expected: ["node", "openclaw", "browser", "--url", "ws://gateway", "cookies", "list"],
+    });
+  });
+
+  it("keeps a missing parent option value after the loaded command", async () => {
+    const root = new Command().name("openclaw");
+    const browser = root.command("browser").option("--browser-profile <name>");
+    const tabs = browser.command("tabs");
+    const argv = ["node", "openclaw", "browser", "tabs", "--browser-profile"];
+    await expectReparseArgv({ parent: browser, action: tabs, argv, expected: argv });
   });
 });

--- a/src/cli/program/action-reparse.ts
+++ b/src/cli/program/action-reparse.ts
@@ -1,15 +1,14 @@
 // Reparse support for lazy commands after their placeholder has been replaced.
-import type { Command } from "commander";
+import type { Command, Option } from "commander";
 import { buildParseArgv } from "../argv.js";
 import { resolveActionArgs, resolveCommandOptionArgs } from "./helpers.js";
 
-function getCommandPathFromRoot(command: Command | undefined): string[] {
-  const path: string[] = [];
+function getCommandPathFromRoot(command: Command | undefined): Command[] {
+  const path: Command[] = [];
   let current = command;
   while (current?.parent) {
-    const name = current.name();
-    if (name) {
-      path.unshift(name);
+    if (current.name()) {
+      path.unshift(current);
     }
     current = current.parent;
   }
@@ -20,7 +19,7 @@ function buildFallbackArgv(program: Command, actionCommand: Command | undefined)
   const actionArgsList = resolveActionArgs(actionCommand);
   const parentOptionArgs =
     actionCommand?.parent === program ? resolveCommandOptionArgs(program) : [];
-  const commandPath = getCommandPathFromRoot(actionCommand);
+  const commandPath = getCommandPathFromRoot(actionCommand).map((command) => command.name());
   if (commandPath.length === 0) {
     return [...parentOptionArgs, ...actionArgsList];
   }
@@ -40,6 +39,151 @@ function findRootCommand(cmd: Command): Command {
   return current;
 }
 
+function findOption(command: Command, token: string): Option | undefined {
+  const equalsIndex = token.indexOf("=");
+  const flag = equalsIndex === -1 ? token : token.slice(0, equalsIndex);
+  return command.options.find(
+    (candidate) =>
+      (candidate.short === flag || candidate.long === flag) &&
+      (equalsIndex === -1 || candidate.required || candidate.optional),
+  );
+}
+
+function findNearestOption(commands: readonly Command[], token: string): Option | undefined {
+  for (let index = commands.length - 1; index >= 0; index -= 1) {
+    const command = commands[index];
+    const option = command ? findOption(command, token) : undefined;
+    if (option) {
+      return option;
+    }
+  }
+  return undefined;
+}
+
+function matchesCommandName(command: Command, token: string): boolean {
+  return command.name() === token || command.aliases().includes(token);
+}
+
+// Returns 0 for a missing required value, otherwise the number of consumed tokens.
+function optionTokenCount(option: Option, argv: readonly string[], index: number): number {
+  const token = argv[index] ?? "";
+  if (token.includes("=") || (!option.required && !option.optional)) {
+    return 1;
+  }
+  const next = argv[index + 1];
+  if (option.required) {
+    return next === undefined ? 0 : 2;
+  }
+  const optionalValue = next && (!next.startsWith("-") || /^-\d/.test(next));
+  return optionalValue ? 2 : 1;
+}
+
+function findCommandPathEnd(argv: readonly string[], command: Command): number {
+  const path = getCommandPathFromRoot(command);
+  const root = path[0]?.parent;
+  if (!root) {
+    return -1;
+  }
+  const selectedCommands = [root];
+  let pathIndex = 0;
+  for (let index = 2; index < argv.length; index += 1) {
+    const token = argv[index] ?? "";
+    const option = findNearestOption(selectedCommands, token);
+    if (option) {
+      const count = optionTokenCount(option, argv, index);
+      if (count === 0) {
+        return -1;
+      }
+      index += count - 1;
+      continue;
+    }
+    const nextCommand = path[pathIndex];
+    if (!nextCommand || !matchesCommandName(nextCommand, token)) {
+      return -1;
+    }
+    selectedCommands.push(nextCommand);
+    pathIndex += 1;
+    if (pathIndex === path.length) {
+      return index + 1;
+    }
+  }
+  return -1;
+}
+
+/** Restore parent-option placement without stealing options owned by the loaded child command. */
+function hoistLazyParentOptions(
+  argv: string[],
+  parentCommand: Command,
+  lazyCommandName: string,
+): string[] {
+  let lazyCommandIndex = findCommandPathEnd(argv, parentCommand);
+  if (lazyCommandIndex === -1) {
+    return argv;
+  }
+  while (lazyCommandIndex < argv.length) {
+    const option = findOption(parentCommand, argv[lazyCommandIndex] ?? "");
+    if (!option) {
+      break;
+    }
+    const count = optionTokenCount(option, argv, lazyCommandIndex);
+    if (count === 0) {
+      return argv;
+    }
+    lazyCommandIndex += count;
+  }
+  if (argv[lazyCommandIndex] !== lazyCommandName) {
+    return argv;
+  }
+
+  const lazyCommand = parentCommand.commands.find((command) =>
+    matchesCommandName(command, lazyCommandName),
+  );
+  if (!lazyCommand) {
+    return argv;
+  }
+  let selectedCommand = lazyCommand;
+  const selectedCommands = [selectedCommand];
+
+  const hoisted: string[] = [];
+  const remaining: string[] = [];
+  let acceptsSubcommands = true;
+  for (let index = lazyCommandIndex + 1; index < argv.length; index += 1) {
+    const token = argv[index] ?? "";
+    if (token === "--") {
+      remaining.push(...argv.slice(index));
+      break;
+    }
+    const childOption = findNearestOption(selectedCommands, token);
+    const parentOption = findOption(parentCommand, token);
+    const option = childOption ?? parentOption;
+    if (option) {
+      const count = optionTokenCount(option, argv, index);
+      if (count === 0) {
+        return argv;
+      }
+      const tokens = argv.slice(index, index + count);
+      (childOption ? remaining : hoisted).push(...tokens);
+      index += count - 1;
+      continue;
+    }
+    if (acceptsSubcommands && !token.startsWith("-")) {
+      const nextCommand: Command | undefined = selectedCommand.commands.find((command) =>
+        matchesCommandName(command, token),
+      );
+      if (nextCommand) {
+        selectedCommand = nextCommand;
+        selectedCommands.push(nextCommand);
+      } else {
+        acceptsSubcommands = false;
+      }
+    }
+    remaining.push(token);
+  }
+  return hoisted.length === 0
+    ? argv
+    : [...argv.slice(0, lazyCommandIndex), ...hoisted, lazyCommandName, ...remaining];
+}
+
 /** Rebuild argv from Commander action args and re-run parsing after lazy registration. */
 export async function reparseProgramFromActionArgs(
   program: Command,
@@ -57,5 +201,8 @@ export async function reparseProgramFromActionArgs(
     rawArgs,
     fallbackArgv,
   });
-  await rootProgram.parseAsync(parseArgv);
+  const normalizedArgv = actionCommand
+    ? hoistLazyParentOptions(parseArgv, program, actionCommand.name())
+    : parseArgv;
+  await rootProgram.parseAsync(normalizedArgv);
 }


### PR DESCRIPTION
> [AI-assisted] Original contribution by @ml12580; maintainer rewrite and validation by @steipete.

## What Problem This Solves

OpenClaw v2026.3.24 enabled Commander's positional-option mode. That made this previously shipped and documented invocation fail during lazy command reparse:

```text
openclaw browser tabs --browser-profile remote
error: unknown option '--browser-profile'
```

`--browser-profile` belongs to the `browser` parent, but the second parse happens only after `tabs` has replaced its lazy placeholder. Positional mode then treats the trailing flag as a `tabs` option. This is Regression 1 of #55563 and breaks existing WSL2/remote-CDP troubleshooting commands. Regression 2 in that issue (`doctor --fix` gateway cycling) is separate and intentionally untouched.

## Why This Change Was Made

The contributor patch established the right normalization point. I rewrote it around one invariant: after the real lazy subtree loads, restore parent-option placement only when the selected child path does not own the same flag.

The final parser:

- walks the real Commander hierarchy and consumes ancestor option values, so command-looking values do not confuse path selection;
- moves only options owned by the lazy parent;
- preserves collisions on the selected child, including `browser extension pair --json` and cookie `--url`;
- ignores collisions that exist only on an unselected sibling;
- preserves aliases, option values, missing required values, and the `--` terminator.

Simply disabling positional options on `browser` was rejected: Commander 15 would make the parent steal colliding leaf flags. That would fix the reported command by breaking currently valid child behavior.

## User Impact

Both supported orderings work again:

```text
openclaw browser --browser-profile remote tabs
openclaw browser tabs --browser-profile remote
```

The same repair applies to nested lazy commands such as `browser tab new --browser-profile remote`. Existing child-option ownership remains unchanged. No config, protocol, auth, network, or migration surface changes.

## Evidence

Dependency contract checked directly against Commander 15.0.0 source and types: positional parent options after a subcommand are intentionally disabled, and disabling positional mode would restore parent capture at the cost of child collisions.

Blacksmith Testbox provider/id: `blacksmith-testbox` / `tbx_01kwxpxmb3x1g1prnaa9cs4230`.

- `pnpm test src/cli/program/action-reparse.test.ts src/cli/program/register.subclis.test.ts` — 32 passed.
- `pnpm test extensions/browser/src/cli/browser-cli.lazy.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts extensions/browser/src/cli/browser-cli-state.option-collisions.test.ts` — 26 passed.
- `pnpm check:changed -- CHANGELOG.md src/cli/program/action-reparse.ts src/cli/program/action-reparse.test.ts extensions/browser/src/cli/browser-cli.lazy.test.ts` — passed all selected type, lint, docs, and repository guards before the release-owned changelog line was removed by the landing guard.
- `pnpm build` — passed, including CLI bootstrap/import guards, runtime postbuild, plugin assets, and Control UI build.
- Black-box built-CLI contract — 7/7 clauses passed: both parent-option orders were observably identical; nested order worked; selected-child collision, sibling collision, terminator, and missing-value behavior were preserved.
- Fresh structured autoreview — clean, no accepted/actionable findings.

Release-note context and contributor credit are retained here. Root `CHANGELOG.md` is release-owned, so the native landing guard correctly kept it out of this normal PR.
