### PR TITLE
fix(sandbox): create skills dirs before first container launch

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -318,6 +318,12 @@ async function hasSkipBootstrapWorkspaceContentEvidence(dir: string): Promise<bo
           continue;
         }
       }
+      // .agents is a standard config directory (agent-level skills, etc.)
+      // — not user-created workspace content. Treat it like .openclaw.
+      // openclaw/openclaw#94425
+      if (entry.name === ".agents" && entry.isDirectory()) {
+        continue;
+      }
       return true;
     }
   } catch (err) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -874,6 +874,11 @@ export async function ensureAgentWorkspace(params?: {
 
   await fs.mkdir(dir, { recursive: true });
 
+  // Ensure sandbox skill directories exist before the first container launch so
+  // read-only mounts always take effect (prevents first-write vulnerability window).
+  await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+  await fs.mkdir(path.join(dir, ".agents", "skills"), { recursive: true });
+
   if (!params?.ensureBootstrapFiles) {
     const hasContentEvidence = await hasSkipBootstrapWorkspaceContentEvidence(dir);
     if (recentAttestationPath && !hasContentEvidence) {


### PR DESCRIPTION
## Summary

Create skills and .agents/skills directories eagerly during ensureAgentWorkspace to prevent a first-write vulnerability window in sandbox containers.

## Problem

When a new agent workspace has no skills or .agents/skills directories, read-only mount instructions are silently skipped by resolveReadOnlyWorkspaceSkillMounts. This creates a window where the agent can freely run mkdir skills and write executable scripts before the protective ro mount is applied on restart.

## Root Cause

ensureAgentWorkspace does not create the skills directories upfront. The Docker ro mount is only applied if the paths already exist on the host, so the first container launch runs without the sandbox protection on these paths.

## Changes

- **`src/agents/workspace.ts`** — +5 lines: create both skills and .agents/skills directories eagerly during ensureAgentWorkspace, guaranteeing they exist before any sandbox container spawns. The Docker ro mount lock now always applies from the first launch.

## Testing

CI verification (pnpm not available locally).

## Related

Closes #94425