### PR TITLE
fix(gateway): expose idempotencyKey in chat history metadata

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1602,6 +1602,8 @@ export function buildOversizedHistoryPlaceholder(message?: unknown): Record<stri
       : {};
   const metadataId = typeof metadata.id === "string" ? metadata.id : undefined;
   const metadataSeq = typeof metadata.seq === "number" ? metadata.seq : undefined;
+  const metadataIdempotencyKey =
+    typeof metadata.idempotencyKey === "string" ? metadata.idempotencyKey : undefined;
   return {
     role,
     timestamp,
@@ -1609,6 +1611,7 @@ export function buildOversizedHistoryPlaceholder(message?: unknown): Record<stri
     __openclaw: {
       ...(metadataId ? { id: metadataId } : {}),
       ...(metadataSeq !== undefined ? { seq: metadataSeq } : {}),
+      ...(metadataIdempotencyKey ? { idempotencyKey: metadataIdempotencyKey } : {}),
       truncated: true,
       reason: "oversized",
     },

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -43,12 +43,15 @@ function createHandler(projectSessionActive: boolean) {
   return { broadcastToConnIds, handler };
 }
 
-async function emitAssistantTranscriptUpdate(projectSessionActive: boolean) {
+async function emitAssistantTranscriptUpdate(
+  projectSessionActive: boolean,
+  message: unknown = { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+) {
   const { broadcastToConnIds, handler } = createHandler(projectSessionActive);
   handler({
     sessionFile: "/tmp/sess-main.jsonl",
     sessionKey: "agent:main:main",
-    message: { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+    message,
     messageId: "message-1",
     messageSeq: 1,
   });
@@ -77,6 +80,24 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       sessionKey: "agent:main:main",
       hasActiveRun: false,
       session: { hasActiveRun: false },
+    });
+  });
+
+  it("broadcasts user idempotency keys in session.message metadata", async () => {
+    await expect(
+      emitAssistantTranscriptUpdate(false, {
+        role: "user",
+        content: [{ type: "text", text: "Optimistic turn" }],
+        idempotencyKey: "client-turn-3",
+      }),
+    ).resolves.toMatchObject({
+      message: {
+        __openclaw: {
+          id: "message-1",
+          idempotencyKey: "client-turn-3",
+          seq: 1,
+        },
+      },
     });
   });
 });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -29,6 +29,14 @@ import {
 type SessionEventSubscribers = Pick<SessionEventSubscriberRegistry, "getAll">;
 type SessionMessageSubscribers = Pick<SessionMessageSubscriberRegistry, "get">;
 
+function readMessageIdempotencyKey(message: unknown): string | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const value = (message as Record<string, unknown>).idempotencyKey;
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
 function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string): string[] {
   // Global sessions can be subscribed through either the raw global key or the
   // default-agent scoped key; non-default agent global sessions stay scoped.
@@ -211,8 +219,10 @@ async function handleTranscriptUpdateBroadcast(
     includeSession: true,
     hasActiveRun,
   });
+  const idempotencyKey = readMessageIdempotencyKey(update.message);
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
     ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
+    ...(idempotencyKey ? { idempotencyKey } : {}),
     ...(messageSeq !== undefined ? { seq: messageSeq } : {}),
   });
   const message = projectChatDisplayMessage(rawMessage);

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -126,6 +126,33 @@ describe("SessionHistorySseState", () => {
     }
   });
 
+  test("carries inline user idempotency keys into history metadata", () => {
+    const state = newState([]);
+
+    const appended = state.appendInlineMessage({
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "optimistic turn" }],
+        idempotencyKey: "client-turn-2",
+      },
+      messageId: "message-user-2",
+      messageSeq: 2,
+    });
+
+    expect(appended?.messageSeq).toBe(2);
+    expect(
+      (
+        appended?.message as {
+          __openclaw?: { id?: string; idempotencyKey?: string; seq?: number };
+        }
+      )["__openclaw"],
+    ).toMatchObject({
+      id: "message-user-2",
+      idempotencyKey: "client-turn-2",
+      seq: 2,
+    });
+  });
+
   test("reuses one canonical array for items and messages", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [assistantTextMessage("first", 1), assistantTextMessage("second", 2)],

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -139,10 +139,11 @@ describe("SessionHistorySseState", () => {
       messageSeq: 2,
     });
 
+    expect(appended).toBeDefined();
     expect(appended?.messageSeq).toBe(2);
     expect(
       (
-        appended?.message as {
+        appended!.message as {
           __openclaw?: { id?: string; idempotencyKey?: string; seq?: number };
         }
       )["__openclaw"],

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -16,6 +16,7 @@ import {
 // raw messages are projected for display, paginated by transcript seq, then
 // incrementally updated until cursor/window semantics require a full refresh.
 type SessionHistoryTranscriptMeta = {
+  idempotencyKey?: string;
   seq?: number;
 };
 
@@ -54,6 +55,14 @@ type SessionHistoryRawSnapshot = {
   totalRawMessages?: number;
   transcriptPath?: string;
 };
+
+function readMessageIdempotencyKey(message: unknown): string | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const value = (message as Record<string, unknown>).idempotencyKey;
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
 
 /** Computes an oversized raw transcript tail window for projected chat history. */
 export function resolveSessionHistoryTailReadOptions(limit: number): {
@@ -257,8 +266,10 @@ export class SessionHistorySseState {
     } else {
       this.rawTranscriptSeq += 1;
     }
+    const idempotencyKey = readMessageIdempotencyKey(update.message);
     const nextMessage = attachOpenClawTranscriptMeta(update.message, {
       ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
+      ...(idempotencyKey ? { idempotencyKey } : {}),
       seq: this.rawTranscriptSeq,
     });
     // Projection can split, drop, or rewrite raw transcript messages. When one

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -690,6 +690,32 @@ describe("readSessionMessages", () => {
     });
   });
 
+  test("surfaces persisted user idempotency keys in __openclaw metadata (#79844)", async () => {
+    const sessionId = "test-session-idempotency-key";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        id: "entry-user-1",
+        message: {
+          role: "user",
+          content: "pending optimistic turn",
+          idempotencyKey: "client-turn-1",
+        },
+      },
+    ]);
+
+    const result = await readRecentSessionMessagesAsync(sessionId, storePath, undefined, {
+      maxMessages: 5,
+      maxBytes: 2048,
+    });
+
+    expect(result).toHaveLength(1);
+    expectMessageFields(result[0], {
+      content: "pending optimistic turn",
+      openclaw: { id: "entry-user-1", idempotencyKey: "client-turn-1" },
+    });
+  });
+
   test("honors byte caps for async recent-message reads", async () => {
     const sessionId = "test-session-recent-async-byte-cap";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -154,6 +154,14 @@ export function attachOpenClawTranscriptMeta(
   };
 }
 
+function readTranscriptMessageIdempotencyKey(message: unknown): string | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const value = (message as Record<string, unknown>).idempotencyKey;
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
 /** Read all visible transcript messages for a session from the first existing candidate file. */
 export function readSessionMessages(
   sessionId: string,
@@ -849,8 +857,10 @@ function parsedSessionEntryToMessage(parsed: unknown, seq: number): unknown {
         : typeof entry.timestamp === "number"
           ? entry.timestamp
           : Number.NaN;
+    const idempotencyKey = readTranscriptMessageIdempotencyKey(entry.message);
     return attachOpenClawTranscriptMeta(entry.message, {
       ...(typeof entry.id === "string" ? { id: entry.id } : {}),
+      ...(idempotencyKey ? { idempotencyKey } : {}),
       ...(Number.isFinite(recordTimestampMs) ? { recordTimestampMs } : {}),
       seq,
     });


### PR DESCRIPTION
## Summary
- carry persisted user-message idempotencyKey into `__openclaw` transcript metadata during history hydration
- preserve the key for live history appends, `session.message` broadcasts, and oversized history placeholders
- add focused regression coverage for transcript reads, inline history updates, and live session message events

Fixes #79844.

## Verification

- `node scripts/run-vitest.mjs run src/gateway/session-history-state.test.ts src/gateway/session-utils.fs.test.ts src/gateway/server-session-events.test.ts --reporter=verbose`
- `git diff --check`

## Real behavior proof

Behavior addressed: Clients can correlate optimistic user bubbles with hydrated or live Gateway messages via `__openclaw.idempotencyKey` instead of text/FIFO heuristics.

Real environment tested: Local OpenClaw checkout on this PR branch (`codex/chat-history-idempotency-key-79844-reopen-20260618`) with repository dependencies available, exercising Gateway transcript hydration, inline history, and `session.message` broadcast paths through the repository gateway test harness.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs run src/gateway/session-history-state.test.ts src/gateway/session-utils.fs.test.ts src/gateway/server-session-events.test.ts --reporter=verbose
git diff --check
```

Evidence after fix: Terminal capture from the local OpenClaw Gateway run showed the changed metadata behavior:

```text
✓ |gateway-core| ../../src/gateway/session-utils.fs.test.ts > readSessionMessages > surfaces persisted user idempotency keys in __openclaw metadata (#79844)
✓ |gateway-core| ../../src/gateway/session-history-state.test.ts > SessionHistorySseState > carries inline user idempotency keys into history metadata
✓ |gateway-methods| ../../src/gateway/server-session-events.test.ts > createTranscriptUpdateBroadcastHandler > broadcasts user idempotency keys in session.message metadata

Test Files  10 passed (10)
Tests  458 passed (458)
[test] passed 1 Vitest shard in 11.47s
```

Observed result after fix: The focused Gateway tests verify persisted user `idempotencyKey` values are surfaced in hydrated `__openclaw` metadata, carried through inline SSE history state, and broadcast in `session.message` metadata. `git diff --check` produced no output.

What was not tested: A live Gateway client session was not started in this environment; the focused Gateway transcript/history/broadcast test paths above exercise the affected runtime projection logic.

---
Reopened after active-PR limit cleanup. Supersedes closed PR #94398.

## What Problem This Solves
Clients that optimistically render user messages need the persisted user-message idempotency key to appear in hydrated `chat.history` responses and live Gateway `session.message` metadata. Without that key in `__openclaw`, clients have to fall back to text ordering or FIFO heuristics to correlate optimistic bubbles with server messages.

## Evidence
After this patch, the focused Gateway transcript/history/broadcast tests show the persisted user `idempotencyKey` being surfaced in hydrated `__openclaw` metadata, carried through inline SSE history state, and broadcast in `session.message` metadata. Local validation also ran `git diff --check` successfully. The detailed terminal evidence remains in the Real behavior proof section above.
