### PR TITLE
fix(sandbox): ensure skills directories exist before sandbox container spawn (fixes #94425)

### DIFF
--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
+import {
+  appendWorkspaceMountArgs,
+  resolveReadOnlyWorkspaceSkillMounts,
+} from "./workspace-mounts.js";
+import { ensureSandboxWorkspace } from "./workspace.js";
 
 const tmpDirs: string[] = [];
 
@@ -247,6 +251,35 @@ describe("appendWorkspaceMountArgs", () => {
     expect(mounts).toEqual([`${sandboxWorkspaceDir}:/workspace:ro,z`]);
     expect(mounts).not.toContain(
       `${path.join(sandboxWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+    );
+  });
+
+  it("creates skills directories so read-only overlays are always resolved", async () => {
+    // When a new sandbox workspace is created without pre-existing skills
+    // directories, ensureSandboxWorkspace must create them so that
+    // resolveReadOnlyWorkspaceSkillMounts finds existing sources.
+    const agentWorkspaceDir = makeTempWorkspace();
+
+    await ensureSandboxWorkspace(agentWorkspaceDir, undefined, true);
+
+    // Directories must exist after workspace setup.
+    const skillsDir = path.join(agentWorkspaceDir, "skills");
+    const agentsSkillsDir = path.join(agentWorkspaceDir, ".agents", "skills");
+    expect(fs.existsSync(skillsDir)).toBe(true);
+    expect(fs.existsSync(agentsSkillsDir)).toBe(true);
+
+    // Mount resolution must find them and include the read-only overlays.
+    const mounts = resolveReadOnlyWorkspaceSkillMounts({
+      workspaceDir: agentWorkspaceDir,
+      agentWorkspaceDir,
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+    });
+    expect(mounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ containerPath: "/workspace/skills" }),
+        expect.objectContaining({ containerPath: "/workspace/.agents/skills" }),
+      ]),
     );
   });
 });

--- a/src/agents/sandbox/workspace.ts
+++ b/src/agents/sandbox/workspace.ts
@@ -70,4 +70,11 @@ export async function ensureSandboxWorkspace(
     ensureBootstrapFiles: !skipBootstrap,
     skipOptionalBootstrapFiles,
   });
+
+  // Ensure skills directories exist on the host so the read-only mount overlay is
+  // always applied. Without this, resolveReadOnlyWorkspaceSkillMounts silently skips
+  // the mount when the host directory is missing, leaving skills paths writable in the
+  // sandbox (reported as #94425).
+  await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+  await fs.mkdir(path.join(workspaceDir, ".agents", "skills"), { recursive: true });
 }


### PR DESCRIPTION
### Summary

- **Problem**: Sandbox 'skills' directory lacks initial read-only protection if host directory is missing upon agent creation. When `resolveReadOnlyWorkspaceSkillMounts` is called for a new agent whose workspace has no pre-existing `skills` or `.agents/skills` directories, `isExistingWorkspaceSkillMountSource` returns false and the read-only mount is silently skipped. The sandbox container then starts with those paths as writable sub-directories of the `/workspace` mount.
- **Root Cause**: `ensureSandboxWorkspace` (and `ensureAgentWorkspace`) create the workspace directory and bootstrap files but never ensure that `skills` and `.agents/skills` subdirectories exist. When these directories are missing, `isExistingWorkspaceSkillMountSource` catches `ENOENT` from `lstatSync` and returns false, causing the read-only overlay to be omitted.
- **Fix**: Create `skills` and `.agents/skills` directories in `ensureSandboxWorkspace` before the container spawns, so the read-only mount resolution always finds existing source directories.
- **What changed**:
  - `src/agents/sandbox/workspace.ts` — ensure `skills` and `.agents/skills` directories are created before sandbox container spawn
  - `src/agents/sandbox/workspace-mounts.test.ts` — add test verifying that read-only mounts are resolved even when directories did not pre-exist
- **What did NOT change (scope boundary)**:
  - No change to the mount resolution logic in `resolveReadOnlyWorkspaceSkillMounts` or `isExistingWorkspaceSkillMountSource`
  - No change to the Docker spawn or container management code
  - No change to the security policy or sandbox permission model

### Reproduction

1. Create a new agent workspace without pre-existing `skills` or `.agents/skills` directories.
2. Call `ensureSandboxWorkspace(workspaceDir)` to set up the workspace.
3. Call `resolveReadOnlyWorkspaceSkillMounts(...)` to compute read-only mounts.
4. **Before this PR**: The returned mount list is empty — the missing directories cause `isExistingWorkspaceSkillMountSource` to return false, silently skipping the read-only overlay. The sandbox starts with writable skills paths.
5. **After this PR**: The returned mount list includes the read-only skill overlays — `ensureSandboxWorkspace` creates the directories first, so `isExistingWorkspaceSkillMountSource` finds them and includes the mounts.

### Real behavior proof

**Behavior or issue addressed**: When a new sandbox agent is created without pre-existing `skills` or `.agents/skills` directories on the host, the read-only mount overlay is silently skipped (issue #94425), leaving those paths writable inside the sandbox. The fix ensures those directories are created during workspace setup so the read-only overlay is always applied.

**Real environment tested**: Linux, Node 22 — Vitest with real filesystem (tmpdir) against `resolveReadOnlyWorkspaceSkillMounts` and `ensureSandboxWorkspace`

**Exact steps or command run after this patch**: `node scripts/run-vitest.mjs src/agents/sandbox/workspace-mounts.test.ts`

**Evidence before fix**:


**Evidence after fix**:
```text
[test] starting test/vitest/vitest.agents.config.ts

 RUN  v4.1.8 /home/0668001395/openclawProject1


 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  12:51:45
   Duration  954ms (transform 464ms, setup 370ms, import 229ms, tests 113ms, environment 0ms)

[test] passed 1 Vitest shard in 10.45s
```

**Observed result after fix**: `resolveReadOnlyWorkspaceSkillMounts` returns read-only mount entries for `skills` and `.agents/skills` directories even when the host directories did not exist before `ensureSandboxWorkspace` was called. The sandbox container always receives read-only skill overlays.

**What was not tested**: Live Docker sandbox container spawn was not tested — only the mount-resolution logic and directory-creation path were verified at the unit level with real filesystem operations (tmpdir). Actual container runtime behavior with a Docker daemon was not exercised.

**Repro confirmation**: A new test case on origin/main fails because `resolveReadOnlyWorkspaceSkillMounts` returns empty mounts when `skills` directories don't exist. After the patch, the same scenario produces the correct read-only mount entries because `ensureSandboxWorkspace` creates the directories before mount resolution.

### Root Cause

`ensureSandboxWorkspace` (in `src/agents/sandbox/workspace.ts`) creates the workspace directory and seeds bootstrap files but never ensures that `skills` and `.agents/skills` subdirectories exist. When these directories are missing at sandbox spawn time, `isExistingWorkspaceSkillMountSource` in `workspace-mounts.ts` catches the `ENOENT` error from `lstatSync` and returns `false`, causing `resolveReadOnlyWorkspaceSkillMounts` to silently omit the read-only overlay. The sandbox container then inherits those paths as writable sub-directories of the `/workspace` mount.

### Risk / Mitigation

- **Risk**: Creating empty `skills` directories could affect agents that use directory existence as a signal.
  **Mitigation**: The existing code path in `ensureAgentWorkspace` already handles empty/missing skills directories gracefully — `readdir` on an empty directory returns `[]` and the code treats that as "no workspace skills", same as a missing directory.
- **Risk**: The fix creates directories on the host filesystem that persist after sandbox teardown.
  **Mitigation**: This is the intended behavior — the directories represent the agent's skill storage location and should persist across sessions. The read-only mount prevents sandbox mutation; the host-side directory is the source of truth.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] agents (sandbox workspace bootstrapper)
- [x] sandbox (mount resolution)

### Regression Test Plan

- `node scripts/run-vitest.mjs src/agents/sandbox/workspace-mounts.test.ts`

### Review Findings Addressed

N/A (initial submission)

### Linked Issue/PR

Fixes #94425
