### PR TITLE
fix(exec): fail invalid explicit workdir before running

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a1103bfa257bb0193841e193a379b4cadc7641fa10bf1b8de05a182c4993080d  plugin-sdk-api-baseline.json
-e3d06e2bf9859d343f2f3ae706d6988cd579453f181d154756cfb3f273e45341  plugin-sdk-api-baseline.jsonl
+5c47d7218693956f24998235cdd32ed3a4c6166f44d1ce9cc73eafe61623b662  plugin-sdk-api-baseline.json
+49c01af6322b211fd0c43a2396e871d946b5b2de4f32715ef9574a0ba7e8c7c6  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9d5b34975270bb2d16748002c1441ab48fde81af8eb12cc8eb3e341c862232ff  plugin-sdk-api-baseline.json
-f1a6ff189498d955cad6d6fb912eb4cad7aeb628f89c51d0745e146fe0d163d6  plugin-sdk-api-baseline.jsonl
+a1103bfa257bb0193841e193a379b4cadc7641fa10bf1b8de05a182c4993080d  plugin-sdk-api-baseline.json
+e3d06e2bf9859d343f2f3ae706d6988cd579453f181d154756cfb3f273e45341  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-5c47d7218693956f24998235cdd32ed3a4c6166f44d1ce9cc73eafe61623b662  plugin-sdk-api-baseline.json
-49c01af6322b211fd0c43a2396e871d946b5b2de4f32715ef9574a0ba7e8c7c6  plugin-sdk-api-baseline.jsonl
+abdff20b710c6b0fecb5af25603d7cfad7ade80600ca374ebe38f69d78933b50  plugin-sdk-api-baseline.json
+630367961e4d14463020f588564c23308159ae2de6e4301418b2b0c471797e70  plugin-sdk-api-baseline.jsonl

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -1,0 +1,167 @@
+// Openshell tests cover backend-owned exec workdir validation behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { CreateSandboxBackendParams } from "openclaw/plugin-sdk/sandbox";
+import {
+  createSandboxBrowserConfig,
+  createSandboxPruneConfig,
+  createSandboxSshConfig,
+} from "openclaw/plugin-sdk/test-fixtures";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenShellSandboxBackendFactory } from "./backend.js";
+import { resolveOpenShellPluginConfig } from "./config.js";
+
+const sdkMocks = vi.hoisted(() => ({
+  runSshSandboxCommand: vi.fn(),
+  disposeSshSandboxSession: vi.fn(),
+}));
+
+const cliMocks = vi.hoisted(() => ({
+  runOpenShellCli: vi.fn(),
+  createOpenShellSshSession: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/sandbox", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/sandbox")>();
+  return {
+    ...actual,
+    runSshSandboxCommand: sdkMocks.runSshSandboxCommand,
+    disposeSshSandboxSession: sdkMocks.disposeSshSandboxSession,
+  };
+});
+
+vi.mock("./cli.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./cli.js")>();
+  return {
+    ...actual,
+    runOpenShellCli: cliMocks.runOpenShellCli,
+    createOpenShellSshSession: cliMocks.createOpenShellSshSession,
+  };
+});
+
+const tempDirs: string[] = [];
+
+function createOpenShellBackendSandboxConfig(): CreateSandboxBackendParams["cfg"] {
+  return {
+    mode: "all",
+    backend: "openshell",
+    scope: "session",
+    workspaceAccess: "rw",
+    workspaceRoot: "/tmp/openclaw-sandboxes",
+    docker: {
+      image: "openclaw-sandbox:bookworm-slim",
+      containerPrefix: "openclaw-sbx-",
+      workdir: "/workspace",
+      readOnlyRoot: false,
+      tmpfs: [],
+      network: "none",
+      capDrop: [],
+      binds: [],
+      env: {},
+    },
+    ssh: createSandboxSshConfig("/tmp/openclaw-sandboxes"),
+    browser: createSandboxBrowserConfig(),
+    tools: { allow: ["*"], deny: [] },
+    prune: createSandboxPruneConfig(),
+  };
+}
+
+async function makeTempDir(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("openshell backend exec workdir validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cliMocks.createOpenShellSshSession.mockResolvedValue({
+      command: "ssh",
+      configPath: "/tmp/openclaw-openshell-test-ssh-config",
+      host: "openshell-test",
+    });
+    cliMocks.runOpenShellCli.mockResolvedValue({
+      code: 0,
+      stdout: "",
+      stderr: "",
+    });
+    sdkMocks.runSshSandboxCommand.mockImplementation(async ({ remoteCommand }) => ({
+      stdout: String(remoteCommand).includes("openclaw-validate-workdir")
+        ? Buffer.from("/workspace\n")
+        : Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    }));
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("reuses validation-time workspace preparation for the following exec", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed", "utf8");
+    const backendFactory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({
+        command: "openshell",
+        mode: "mirror",
+      }),
+    });
+    const backend = await backendFactory({
+      sessionKey: "agent:main:turn",
+      scopeKey: "agent:main",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    await expect(backend.validateWorkdir?.("/workspace")).resolves.toBe("/workspace");
+    const execSpec = await backend.buildExecSpec({
+      command: "pwd",
+      workdir: "/workspace",
+      env: {},
+      usePty: false,
+    });
+
+    const uploadCalls = cliMocks.runOpenShellCli.mock.calls.filter(
+      ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
+    );
+    expect(uploadCalls).toHaveLength(1);
+    expect(execSpec.argv).toContain("openshell-test");
+  });
+
+  it("does not reuse validation-time workspace preparation after discard", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed", "utf8");
+    const backendFactory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({
+        command: "openshell",
+        mode: "mirror",
+      }),
+    });
+    const backend = await backendFactory({
+      sessionKey: "agent:main:turn",
+      scopeKey: "agent:main",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    await expect(backend.validateWorkdir?.("/workspace")).resolves.toBe("/workspace");
+    backend.discardPreparedWorkdir?.("/workspace");
+    await backend.buildExecSpec({
+      command: "pwd",
+      workdir: "/workspace",
+      env: {},
+      usePty: false,
+    });
+
+    const uploadCalls = cliMocks.runOpenShellCli.mock.calls.filter(
+      ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
+    );
+    expect(uploadCalls).toHaveLength(2);
+  });
+});

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -1,6 +1,5 @@
 // Openshell tests cover backend-owned exec workdir validation behavior.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { CreateSandboxBackendParams } from "openclaw/plugin-sdk/sandbox";
 import {
@@ -9,6 +8,7 @@ import {
   createSandboxSshConfig,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir as makeTrackedTempDir } from "../../../test/helpers/temp-dir.js";
 import { createOpenShellSandboxBackendFactory } from "./backend.js";
 import { resolveOpenShellPluginConfig } from "./config.js";
 
@@ -68,9 +68,7 @@ function createOpenShellBackendSandboxConfig(): CreateSandboxBackendParams["cfg"
 }
 
 async function makeTempDir(prefix: string) {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  tempDirs.push(dir);
-  return dir;
+  return makeTrackedTempDir(tempDirs, prefix);
 }
 
 describe("openshell backend exec workdir validation", () => {

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -1,5 +1,6 @@
 // Openshell tests cover backend-owned exec workdir validation behavior.
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type { CreateSandboxBackendParams } from "openclaw/plugin-sdk/sandbox";
 import {
@@ -8,7 +9,6 @@ import {
   createSandboxSshConfig,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { makeTempDir as makeTrackedTempDir } from "../../../test/helpers/temp-dir.js";
 import { createOpenShellSandboxBackendFactory } from "./backend.js";
 import { resolveOpenShellPluginConfig } from "./config.js";
 
@@ -68,7 +68,9 @@ function createOpenShellBackendSandboxConfig(): CreateSandboxBackendParams["cfg"
 }
 
 async function makeTempDir(prefix: string) {
-  return makeTrackedTempDir(tempDirs, prefix);
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
 }
 
 describe("openshell backend exec workdir validation", () => {

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -22,6 +22,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import type { OpenShellSandboxBackend } from "./backend.types.js";
 import {
   buildValidatedExecRemoteCommand,
+  buildRemoteWorkdirValidationCommand,
   buildRemoteCommand,
   createOpenShellSshSession,
   runOpenShellCli,
@@ -280,6 +281,13 @@ async function createOpenShellSandboxBackend(params: {
     mode: params.pluginConfig.mode,
     configLabel: params.pluginConfig.from,
     configLabelKind: "Source",
+    workdirValidation: "backend",
+    validateWorkdir: async (workdir) => await impl.validateWorkdir(workdir),
+    discardPreparedWorkdir: (workdir) => impl.discardPreparedWorkdir(workdir),
+    workdirRoots: [
+      params.pluginConfig.remoteWorkspaceDir,
+      params.pluginConfig.remoteAgentWorkspaceDir,
+    ],
     buildExecSpec: async ({ command, workdir, env, usePty }) => {
       const pending = await impl.prepareExec({ command, workdir, env, usePty });
       return {
@@ -318,6 +326,10 @@ async function createOpenShellSandboxBackend(params: {
 
 class OpenShellSandboxBackendImpl {
   private ensurePromise: Promise<void> | null = null;
+  private preparedRemoteWorkspaceForNextExec: {
+    workdir: string;
+    promise: Promise<void>;
+  } | null = null;
   private remoteSeedPending = false;
 
   constructor(
@@ -339,6 +351,10 @@ class OpenShellSandboxBackendImpl {
       mode: this.params.execContext.config.mode,
       configLabel: this.params.execContext.config.from,
       configLabelKind: "Source",
+      workdirValidation: "backend",
+      validateWorkdir: async (workdir) => await this.validateWorkdir(workdir),
+      discardPreparedWorkdir: (workdir) => this.discardPreparedWorkdir(workdir),
+      workdirRoots: [this.params.remoteWorkspaceDir, this.params.remoteAgentWorkspaceDir],
       remoteWorkspaceDir: this.params.remoteWorkspaceDir,
       remoteAgentWorkspaceDir: this.params.remoteAgentWorkspaceDir,
       buildExecSpec: async ({ command, workdir, env, usePty }) => {
@@ -382,20 +398,14 @@ class OpenShellSandboxBackendImpl {
     env: Record<string, string>;
     usePty: boolean;
   }): Promise<{ argv: string[]; token: PendingExec }> {
+    const remoteWorkdir = params.workdir ?? this.params.remoteWorkspaceDir;
+    const preparedWorkspace = this.consumePreparedRemoteWorkspaceForNextExec(remoteWorkdir);
     const remoteCommand = buildValidatedExecRemoteCommand({
       command: params.command,
-      workdir: params.workdir ?? this.params.remoteWorkspaceDir,
+      workdir: remoteWorkdir,
       env: params.env,
     });
-    await this.ensureSandboxExists();
-    if (this.params.execContext.config.mode === "mirror") {
-      await this.syncWorkspaceToRemote();
-    } else {
-      const seeded = await this.maybeSeedRemoteWorkspace();
-      if (!seeded) {
-        await this.syncSkillsWorkspaceToRemote();
-      }
-    }
+    await (preparedWorkspace ?? this.prepareRemoteWorkspaceForExec());
     const sshSession = await createOpenShellSshSession({
       context: this.params.execContext,
     });
@@ -412,6 +422,85 @@ class OpenShellSandboxBackendImpl {
       ],
       token: { sshSession },
     };
+  }
+
+  async validateWorkdir(workdir: string): Promise<string | null> {
+    const preparedWorkspace = this.prepareRemoteWorkspaceForExec();
+    const reusablePreparation = { workdir, promise: preparedWorkspace };
+    this.preparedRemoteWorkspaceForNextExec = reusablePreparation;
+    try {
+      await preparedWorkspace;
+      const sshSession = await createOpenShellSshSession({
+        context: this.params.execContext,
+      });
+      try {
+        const result = await runSshSandboxCommand({
+          session: sshSession,
+          remoteCommand: buildRemoteWorkdirValidationCommand({
+            workdir,
+            root: this.resolveWorkdirValidationRoot(workdir),
+          }),
+          allowFailure: true,
+        });
+        const resolvedWorkdir = result.code === 0 ? result.stdout.toString("utf8").trim() : "";
+        if (this.preparedRemoteWorkspaceForNextExec === reusablePreparation) {
+          this.preparedRemoteWorkspaceForNextExec = resolvedWorkdir
+            ? { workdir: resolvedWorkdir, promise: preparedWorkspace }
+            : null;
+        }
+        return resolvedWorkdir || null;
+      } finally {
+        await disposeSshSandboxSession(sshSession);
+      }
+    } catch (error) {
+      if (this.preparedRemoteWorkspaceForNextExec === reusablePreparation) {
+        this.preparedRemoteWorkspaceForNextExec = null;
+      }
+      throw error;
+    }
+  }
+
+  private resolveWorkdirValidationRoot(workdir: string): string {
+    try {
+      const normalized = normalizeRemotePath(workdir);
+      const roots = [
+        normalizeRemotePath(this.params.remoteAgentWorkspaceDir),
+        normalizeRemotePath(this.params.remoteWorkspaceDir),
+      ].toSorted((a, b) => b.length - a.length);
+      return (
+        roots.find((root) => isRemotePathInside(root, normalized)) ?? this.params.remoteWorkspaceDir
+      );
+    } catch {
+      return this.params.remoteWorkspaceDir;
+    }
+  }
+
+  private consumePreparedRemoteWorkspaceForNextExec(workdir: string): Promise<void> | null {
+    const preparedWorkspace = this.preparedRemoteWorkspaceForNextExec;
+    if (!preparedWorkspace || preparedWorkspace.workdir !== workdir) {
+      this.preparedRemoteWorkspaceForNextExec = null;
+      return null;
+    }
+    this.preparedRemoteWorkspaceForNextExec = null;
+    return preparedWorkspace.promise;
+  }
+
+  discardPreparedWorkdir(workdir: string): void {
+    if (this.preparedRemoteWorkspaceForNextExec?.workdir === workdir) {
+      this.preparedRemoteWorkspaceForNextExec = null;
+    }
+  }
+
+  private async prepareRemoteWorkspaceForExec(): Promise<void> {
+    await this.ensureSandboxExists();
+    if (this.params.execContext.config.mode === "mirror") {
+      await this.syncWorkspaceToRemote();
+      return;
+    }
+    const seeded = await this.maybeSeedRemoteWorkspace();
+    if (!seeded) {
+      await this.syncSkillsWorkspaceToRemote();
+    }
   }
 
   async finalizeExec(token?: PendingExec): Promise<void> {

--- a/extensions/openshell/src/cli.ts
+++ b/extensions/openshell/src/cli.ts
@@ -9,6 +9,7 @@ import type { ResolvedOpenShellPluginConfig } from "./config.js";
 
 export {
   buildExecRemoteCommand,
+  buildRemoteWorkdirValidationCommand,
   buildValidatedExecRemoteCommand,
   shellEscape,
 } from "openclaw/plugin-sdk/sandbox";

--- a/scripts/lib/plugin-sdk-doc-metadata.ts
+++ b/scripts/lib/plugin-sdk-doc-metadata.ts
@@ -21,6 +21,9 @@ export const pluginSdkDocMetadata = {
   health: {
     category: "core",
   },
+  sandbox: {
+    category: "runtime",
+  },
   "approval-runtime": {
     category: "runtime",
   },

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,8 +202,8 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10382),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5211),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10386),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5212),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       3247,

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -3,6 +3,8 @@
  * Exercises result coercion, error wrapping, client delegation, and conflict
  * detection at the ToolDefinition boundary.
  */
+import os from "node:os";
+import path from "node:path";
 import type { AgentTool } from "openclaw/plugin-sdk/agent-core";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
@@ -14,6 +16,7 @@ import {
   toToolDefinitions,
 } from "./agent-tool-definition-adapter.js";
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
+import { createExecTool } from "./bash-tools.exec.js";
 import type { ClientToolDefinition } from "./embedded-agent-runner/run/params.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
@@ -91,6 +94,154 @@ describe("agent tool definition adapter", () => {
     expect(details?.status).toBe("error");
     expect(details?.tool).toBe("exec");
     expect(details?.error).toBe("nope");
+  });
+
+  it("preserves exec deny before prepared workdir failures", async () => {
+    const tool = createExecTool({
+      security: "deny",
+      ask: "off",
+    });
+    const [definition] = toToolDefinitions([tool]);
+    const missingWorkdir = path.join(os.tmpdir(), `openclaw-missing-denied-cwd-${Date.now()}`);
+
+    const existing = await definition!.execute(
+      "call-denied-existing-cwd",
+      {
+        command: "echo denied",
+        workdir: process.cwd(),
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    const missing = await definition!.execute(
+      "call-denied-missing-cwd",
+      {
+        command: "echo denied",
+        workdir: missingWorkdir,
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    const expected = {
+      status: "error",
+      error: "exec denied: host=gateway security=deny",
+    };
+    expect(existing.details).toMatchObject(expected);
+    expect(missing.details).toMatchObject(expected);
+    expect(JSON.stringify(missing)).not.toContain("unavailable or not a directory");
+  });
+
+  it("does not validate backend sandbox workdirs before exec deny", async () => {
+    const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "deny",
+      ask: "off",
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir: process.cwd(),
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+      },
+    });
+    const [definition] = toToolDefinitions([tool]);
+
+    const result = await definition!.execute(
+      "call-denied-backend-cwd",
+      {
+        command: "echo denied",
+        workdir: "/remote/workspace/generated",
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "exec denied: host=sandbox security=deny",
+    });
+    expect(validateWorkdir).not.toHaveBeenCalled();
+  });
+
+  it("does not throw WeakMap errors when preparing malformed exec params", async () => {
+    const tool = createExecTool({
+      security: "full",
+      ask: "off",
+    });
+    const [definition] = toToolDefinitions([tool]);
+
+    const result = await definition!.execute(
+      "call-malformed-exec-params",
+      "not-an-object",
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "Provide a command to start.",
+    });
+  });
+
+  it("reports malformed exec params when elevated logging is enabled", async () => {
+    const tool = createExecTool({
+      security: "full",
+      ask: "off",
+      elevated: { enabled: true, allowed: true, defaultLevel: "on" },
+    });
+    const [definition] = toToolDefinitions([tool]);
+
+    const result = await definition!.execute(
+      "call-malformed-elevated-exec-params",
+      {},
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "Provide a command to start.",
+    });
+  });
+
+  it("does not validate backend sandbox workdirs before malformed exec params fail", async () => {
+    const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir: process.cwd(),
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+      },
+    });
+    const [definition] = toToolDefinitions([tool]);
+
+    const result = await definition!.execute(
+      "call-malformed-backend-sandbox-exec-params",
+      {
+        workdir: "/remote/workspace/generated",
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "Provide a command to start.",
+    });
+    expect(validateWorkdir).not.toHaveBeenCalled();
   });
 
   it("coerces details-only tool results to include content", async () => {

--- a/src/agents/agent-tool-definition-adapter.test.ts
+++ b/src/agents/agent-tool-definition-adapter.test.ts
@@ -104,7 +104,7 @@ describe("agent tool definition adapter", () => {
     const [definition] = toToolDefinitions([tool]);
     const missingWorkdir = path.join(os.tmpdir(), `openclaw-missing-denied-cwd-${Date.now()}`);
 
-    const existing = await definition!.execute(
+    const existing = await definition.execute(
       "call-denied-existing-cwd",
       {
         command: "echo denied",
@@ -114,7 +114,7 @@ describe("agent tool definition adapter", () => {
       undefined,
       extensionContext,
     );
-    const missing = await definition!.execute(
+    const missing = await definition.execute(
       "call-denied-missing-cwd",
       {
         command: "echo denied",
@@ -150,7 +150,7 @@ describe("agent tool definition adapter", () => {
     });
     const [definition] = toToolDefinitions([tool]);
 
-    const result = await definition!.execute(
+    const result = await definition.execute(
       "call-denied-backend-cwd",
       {
         command: "echo denied",
@@ -175,7 +175,7 @@ describe("agent tool definition adapter", () => {
     });
     const [definition] = toToolDefinitions([tool]);
 
-    const result = await definition!.execute(
+    const result = await definition.execute(
       "call-malformed-exec-params",
       "not-an-object",
       undefined,
@@ -197,7 +197,7 @@ describe("agent tool definition adapter", () => {
     });
     const [definition] = toToolDefinitions([tool]);
 
-    const result = await definition!.execute(
+    const result = await definition.execute(
       "call-malformed-elevated-exec-params",
       {},
       undefined,
@@ -227,7 +227,7 @@ describe("agent tool definition adapter", () => {
     });
     const [definition] = toToolDefinitions([tool]);
 
-    const result = await definition!.execute(
+    const result = await definition.execute(
       "call-malformed-backend-sandbox-exec-params",
       {
         workdir: "/remote/workspace/generated",

--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -3,11 +3,11 @@
  * Verifies per-agent exec host policy affects lazy exec/process behavior.
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
@@ -49,8 +49,10 @@ function requireExecTool(tools: ReturnType<typeof createOpenClawCodingTools>) {
   return execTool;
 }
 
+const tempDirs = createTempDirTracker();
+
 function createTempAgentDirs(prefix: string) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  const root = tempDirs.make(`${prefix}-`);
   const workspaceDir = path.join(root, "workspace");
   const agentDir = path.join(root, "agent");
   fs.mkdirSync(workspaceDir, { recursive: true });
@@ -61,6 +63,10 @@ function createTempAgentDirs(prefix: string) {
 describe("Agent-specific exec tool defaults", () => {
   beforeEach(() => {
     setActivePluginRegistry(createSessionConversationTestRegistry());
+  });
+
+  afterEach(() => {
+    tempDirs.cleanup();
   });
 
   it("should run exec synchronously when process is denied", async () => {

--- a/src/agents/agent-tools-agent-config.exec.test.ts
+++ b/src/agents/agent-tools-agent-config.exec.test.ts
@@ -2,6 +2,9 @@
  * Tests agent-specific exec defaults in assembled coding tools.
  * Verifies per-agent exec host policy affects lazy exec/process behavior.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
@@ -46,6 +49,15 @@ function requireExecTool(tools: ReturnType<typeof createOpenClawCodingTools>) {
   return execTool;
 }
 
+function createTempAgentDirs(prefix: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+  const workspaceDir = path.join(root, "workspace");
+  const agentDir = path.join(root, "agent");
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.mkdirSync(agentDir, { recursive: true });
+  return { workspaceDir, agentDir };
+}
+
 describe("Agent-specific exec tool defaults", () => {
   beforeEach(() => {
     setActivePluginRegistry(createSessionConversationTestRegistry());
@@ -66,8 +78,7 @@ describe("Agent-specific exec tool defaults", () => {
     const tools = createOpenClawCodingTools({
       config: cfg,
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main",
-      agentDir: "/tmp/agent-main",
+      ...createTempAgentDirs("test-main"),
     });
     const execTool = requireExecTool(tools);
 
@@ -91,8 +102,7 @@ describe("Agent-specific exec tool defaults", () => {
         },
       },
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-implicit-gateway",
-      agentDir: "/tmp/agent-main-implicit-gateway",
+      ...createTempAgentDirs("test-main-implicit-gateway"),
     });
     const execTool = requireExecTool(tools);
 
@@ -113,8 +123,7 @@ describe("Agent-specific exec tool defaults", () => {
         },
       },
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-mode-deny",
-      agentDir: "/tmp/agent-main-mode-deny",
+      ...createTempAgentDirs("test-main-mode-deny"),
     });
     const execTool = requireExecTool(tools);
 
@@ -135,8 +144,7 @@ describe("Agent-specific exec tool defaults", () => {
         },
       },
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-mode-call-security",
-      agentDir: "/tmp/agent-main-mode-call-security",
+      ...createTempAgentDirs("test-main-mode-call-security"),
     });
     const execTool = requireExecTool(tools);
 
@@ -171,8 +179,7 @@ describe("Agent-specific exec tool defaults", () => {
         },
       },
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-mode-partial-agent",
-      agentDir: "/tmp/agent-main-mode-partial-agent",
+      ...createTempAgentDirs("test-main-mode-partial-agent"),
     });
     const execTool = requireExecTool(tools);
 
@@ -197,8 +204,7 @@ describe("Agent-specific exec tool defaults", () => {
         security: "deny",
       },
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-session-legacy-override",
-      agentDir: "/tmp/agent-main-session-legacy-override",
+      ...createTempAgentDirs("test-main-session-legacy-override"),
     });
     const execTool = requireExecTool(tools);
 
@@ -213,8 +219,7 @@ describe("Agent-specific exec tool defaults", () => {
     const tools = createOpenClawCodingTools({
       config: {},
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-fail-closed",
-      agentDir: "/tmp/agent-main-fail-closed",
+      ...createTempAgentDirs("test-main-fail-closed"),
     });
     const execTool = requireExecTool(tools);
     await expect(
@@ -234,8 +239,7 @@ describe("Agent-specific exec tool defaults", () => {
     const mainTools = createOpenClawCodingTools({
       config: cfg,
       sessionKey: "agent:main:main",
-      workspaceDir: "/tmp/test-main-exec-defaults",
-      agentDir: "/tmp/agent-main-exec-defaults",
+      ...createTempAgentDirs("test-main-exec-defaults"),
     });
     const mainExecTool = requireExecTool(mainTools);
     const mainResult = await mainExecTool.execute("call-main-default", {
@@ -254,8 +258,7 @@ describe("Agent-specific exec tool defaults", () => {
     const helperTools = createOpenClawCodingTools({
       config: cfg,
       sessionKey: "agent:helper:main",
-      workspaceDir: "/tmp/test-helper-exec-defaults",
-      agentDir: "/tmp/agent-helper-exec-defaults",
+      ...createTempAgentDirs("test-helper-exec-defaults"),
     });
     const helperExecTool = requireExecTool(helperTools);
     const helperResult = await helperExecTool.execute("call-helper-default", {
@@ -280,8 +283,7 @@ describe("Agent-specific exec tool defaults", () => {
       config: cfg,
       agentId: "main",
       sessionKey: "run-opaque-123",
-      workspaceDir: "/tmp/test-main-opaque-session",
-      agentDir: "/tmp/agent-main-opaque-session",
+      ...createTempAgentDirs("test-main-opaque-session"),
     });
     const execTool = requireExecTool(tools);
     const result = await execTool.execute("call-main-opaque-session", {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -854,6 +854,12 @@ export function createOpenClawCodingTools(options?: {
               containerName: sandbox.containerName,
               workspaceDir: sandbox.workspaceDir,
               containerWorkdir: sandbox.containerWorkdir,
+              workdirValidation: sandbox.backend?.workdirValidation,
+              validateWorkdir: sandbox.backend?.validateWorkdir?.bind(sandbox.backend),
+              discardPreparedWorkdir: sandbox.backend?.discardPreparedWorkdir?.bind(
+                sandbox.backend,
+              ),
+              workdirRoots: sandbox.backend?.workdirRoots,
               env: sandbox.backend?.env ?? sandbox.docker.env,
               buildExecSpec: sandbox.backend?.buildExecSpec.bind(sandbox.backend),
               finalizeExec: sandbox.backend?.finalizeExec?.bind(sandbox.backend),

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { ProcessSupervisor, SpawnInput } from "../process/supervisor/index.js";
 import { captureEnv } from "../test-utils/env.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.js";
@@ -29,6 +30,7 @@ const isWin = process.platform === "win32";
 const defaultShell = isWin
   ? undefined
   : process.env.OPENCLAW_TEST_SHELL || resolveShellFromPath("bash") || process.env.SHELL || "sh";
+const tempDirs = createTempDirTracker();
 
 function requireTextContent(
   result: Awaited<ReturnType<ReturnType<typeof createExecTool>["execute"]>>,
@@ -131,6 +133,7 @@ describe("exec foreground failures", () => {
     vi.useRealTimers();
     envSnapshot?.restore();
     envSnapshot = undefined;
+    tempDirs.cleanup();
   });
 
   it("returns a failed text result when the default timeout is exceeded", async () => {
@@ -261,7 +264,7 @@ describe("exec foreground failures", () => {
   });
 
   it("returns a failed result for unavailable configured sandbox workdirs before launching", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     try {
       await expectUnavailableWorkdir({
         workdir: "/workspace/missing",
@@ -282,7 +285,7 @@ describe("exec foreground failures", () => {
   });
 
   it("defaults omitted sandbox workdirs to the sandbox workspace", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     mockSuccessfulSpawn();
 
     const tool = createExecTool({
@@ -318,7 +321,7 @@ describe("exec foreground failures", () => {
   });
 
   it("lets backend-validated sandbox workdirs reach the backend without host stat fallback", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
       async (params) => ({
         argv: ["remote-shell", params.command],
@@ -365,7 +368,7 @@ describe("exec foreground failures", () => {
   });
 
   it("rejects unsafe commands before backend workdir validation", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
       async (params) => ({
         argv: ["remote-shell", params.command],
@@ -413,7 +416,7 @@ describe("exec foreground failures", () => {
   });
 
   it("does not preflight remote-only backend workdirs from the local workspace root", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     fs.writeFileSync(path.join(workspaceDir, "script.py"), "print($TOKEN)\n");
     const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
       async (params) => ({
@@ -459,7 +462,7 @@ describe("exec foreground failures", () => {
   });
 
   it("uses the mapped host cwd for existing relative backend-validated sandbox workdirs", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     const srcDir = path.join(workspaceDir, "src");
     fs.mkdirSync(srcDir);
     const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
@@ -508,7 +511,7 @@ describe("exec foreground failures", () => {
   });
 
   it("fails backend-validated sandbox workdirs before launch when backend validation rejects", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
     const validateWorkdir = vi.fn<NonNullable<BashSandboxConfig["validateWorkdir"]>>(
       async () => null,
     );
@@ -555,8 +558,8 @@ describe("exec foreground failures", () => {
   });
 
   it("returns a failed result for unavailable explicit sandbox workdirs before launching a command", async () => {
-    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
-    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-workdir-"));
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workdir-");
+    const outsideDir = tempDirs.make("openclaw-outside-workdir-");
     fs.writeFileSync(path.join(workspaceDir, "not-dir"), "not a directory");
     try {
       for (const workdir of ["/workspace/missing", "   ", "/workspace/not-dir", outsideDir]) {

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -364,7 +364,7 @@ describe("exec foreground failures", () => {
     }
   });
 
-  it("discards backend-validated sandbox workdirs when command validation aborts", async () => {
+  it("rejects unsafe commands before backend workdir validation", async () => {
     const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
     const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
       async (params) => ({
@@ -403,8 +403,8 @@ describe("exec foreground failures", () => {
         }),
       ).rejects.toThrow("exec cannot run /approve commands");
 
-      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
-      expect(discardPreparedWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
+      expect(validateWorkdir).not.toHaveBeenCalled();
+      expect(discardPreparedWorkdir).not.toHaveBeenCalled();
       expect(buildExecSpec).not.toHaveBeenCalled();
       expect(supervisorMock.spawn).not.toHaveBeenCalled();
     } finally {

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -3,18 +3,22 @@
  * Verifies failed process outcomes surface useful text/details for shell
  * errors, timeouts, signals, and runtime failures.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SpawnInput } from "../process/supervisor/index.js";
+import type { ProcessSupervisor, SpawnInput } from "../process/supervisor/index.js";
 import { captureEnv } from "../test-utils/env.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.js";
 import { createExecTool } from "./bash-tools.exec.js";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import { resolveShellFromPath } from "./shell-utils.js";
 
 const supervisorMock = vi.hoisted(() => ({
-  spawn: vi.fn(),
-  cancel: vi.fn(),
-  cancelScope: vi.fn(),
-  getRecord: vi.fn(),
+  spawn: vi.fn<ProcessSupervisor["spawn"]>(),
+  cancel: vi.fn<ProcessSupervisor["cancel"]>(),
+  cancelScope: vi.fn<ProcessSupervisor["cancelScope"]>(),
+  getRecord: vi.fn<ProcessSupervisor["getRecord"]>(),
 }));
 
 vi.mock("../process/supervisor/index.js", () => ({
@@ -45,6 +49,66 @@ function requireFailedDetails(
     throw new Error(`expected failed details, got ${details.status}`);
   }
   return details;
+}
+
+function mockSuccessfulSpawn(stdout = "ok\n") {
+  supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => ({
+    runId: input.runId ?? "call-success",
+    pid: 1234,
+    startedAtMs: Date.now(),
+    stdin: {
+      write: vi.fn(),
+      end: vi.fn(),
+      destroy: vi.fn(),
+    },
+    wait: vi.fn(async () => ({
+      reason: "exit" as const,
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 1,
+      stdout,
+      stderr: "",
+      timedOut: false,
+      noOutputTimedOut: false,
+    })),
+    cancel: vi.fn(),
+  }));
+}
+
+async function expectUnavailableWorkdir(params: {
+  workdir: string;
+  toolDefaults?: Parameters<typeof createExecTool>[0];
+  executeArgs?: Partial<Parameters<ReturnType<typeof createExecTool>["execute"]>[1]>;
+  cleanup?: () => void;
+}) {
+  const tool = createExecTool({
+    security: "full",
+    ask: "off",
+    allowBackground: false,
+    ...params.toolDefaults,
+  });
+
+  try {
+    const executeArgs = params.executeArgs ?? { workdir: params.workdir };
+    const result = await tool.execute("call-unavailable-workdir", {
+      command: "echo should-not-run",
+      ...executeArgs,
+    });
+
+    const text = requireTextContent(result);
+    expect(text).toContain(`workdir "${params.workdir}" is unavailable or not a directory`);
+    expect(text).toContain("command was not executed");
+    expect(text).toContain("workdir is treated as a literal path");
+    expect(text).toContain('shell expansions such as "~" are not applied');
+    const details = requireFailedDetails(result.details);
+    expect(details.exitCode).toBeNull();
+    expect(details.timedOut).toBe(false);
+    expect(details.aggregated).toBe("");
+    expect(details.cwd).toBe(params.workdir);
+    expect(supervisorMock.spawn).not.toHaveBeenCalled();
+  } finally {
+    params.cleanup?.();
+  }
 }
 
 describe("exec foreground failures", () => {
@@ -142,6 +206,376 @@ describe("exec foreground failures", () => {
       await expect(tool.execute("call-invalid-host", malformedArgs)).rejects.toThrow(
         testCase.message,
       );
+    }
+  });
+
+  it("returns a failed result for unavailable explicit host workdirs before launching", async () => {
+    const missingWorkdir = path.join(
+      os.tmpdir(),
+      `openclaw-missing-workdir-${process.pid}-${Date.now()}`,
+    );
+    fs.rmSync(missingWorkdir, { recursive: true, force: true });
+
+    const fileWorkdir = path.join(
+      os.tmpdir(),
+      `openclaw-file-workdir-${process.pid}-${Date.now()}`,
+    );
+    fs.writeFileSync(fileWorkdir, "not a directory");
+
+    try {
+      for (const workdir of [missingWorkdir, "   ", fileWorkdir]) {
+        await expectUnavailableWorkdir({ workdir });
+        supervisorMock.spawn.mockClear();
+      }
+    } finally {
+      fs.rmSync(fileWorkdir, { force: true });
+    }
+  });
+
+  it("returns a failed result for unavailable configured host workdirs before launching", async () => {
+    const missingDefaultWorkdir = path.join(
+      os.tmpdir(),
+      `openclaw-missing-default-workdir-${process.pid}-${Date.now()}`,
+    );
+    fs.rmSync(missingDefaultWorkdir, { recursive: true, force: true });
+
+    await expectUnavailableWorkdir({
+      workdir: missingDefaultWorkdir,
+      toolDefaults: { cwd: missingDefaultWorkdir },
+      executeArgs: {},
+    });
+  });
+
+  it("returns a failed result when the current gateway cwd is unavailable", async () => {
+    const cwdSpy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("current cwd unavailable");
+    });
+    try {
+      await expectUnavailableWorkdir({
+        workdir: "current working directory",
+        executeArgs: {},
+      });
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+
+  it("returns a failed result for unavailable configured sandbox workdirs before launching", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    try {
+      await expectUnavailableWorkdir({
+        workdir: "/workspace/missing",
+        toolDefaults: {
+          cwd: "/workspace/missing",
+          host: "sandbox",
+          sandbox: {
+            containerName: "sandbox-workdir-test",
+            workspaceDir,
+            containerWorkdir: "/workspace",
+          },
+        },
+        executeArgs: {},
+      });
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults omitted sandbox workdirs to the sandbox workspace", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    mockSuccessfulSpawn();
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      sandbox: {
+        containerName: "sandbox-workdir-test",
+        workspaceDir,
+        containerWorkdir: "/workspace",
+      },
+    });
+
+    try {
+      const result = await tool.execute("call-sandbox-default-workdir", {
+        command: "echo ok",
+      });
+
+      expect(result.details.status).toBe("completed");
+      expect(result.details.cwd).toBe(workspaceDir);
+      expect(supervisorMock.spawn).toHaveBeenCalledOnce();
+      const input = supervisorMock.spawn.mock.calls[0]?.[0];
+      expect(input?.cwd).toBe(workspaceDir);
+      expect(input?.mode).toBe("child");
+      if (input?.mode === "child") {
+        expect(input.argv).toContain("-w");
+        expect(input.argv).toContain("/workspace");
+      }
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("lets backend-validated sandbox workdirs reach the backend without host stat fallback", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
+      async (params) => ({
+        argv: ["remote-shell", params.command],
+        env: {},
+        stdinMode: "pipe-open" as const,
+      }),
+    );
+    const validateWorkdir = vi.fn<NonNullable<BashSandboxConfig["validateWorkdir"]>>(
+      async (workdir) => workdir,
+    );
+    mockSuccessfulSpawn();
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir,
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+        buildExecSpec,
+      },
+    });
+
+    try {
+      const result = await tool.execute("call-remote-sandbox-workdir", {
+        command: "echo ok",
+        workdir: "/remote/workspace/generated",
+      });
+
+      expect(result.details.status).toBe("completed");
+      expect(result.details.cwd).toBe(workspaceDir);
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
+      expect(buildExecSpec).toHaveBeenCalledOnce();
+      expect(buildExecSpec.mock.calls[0]?.[0]?.workdir).toBe("/remote/workspace/generated");
+      expect(supervisorMock.spawn).toHaveBeenCalledOnce();
+      expect(supervisorMock.spawn.mock.calls[0]?.[0]?.cwd).toBe(workspaceDir);
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("discards backend-validated sandbox workdirs when command validation aborts", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
+      async (params) => ({
+        argv: ["remote-shell", params.command],
+        env: {},
+        stdinMode: "pipe-open" as const,
+      }),
+    );
+    const validateWorkdir = vi.fn<NonNullable<BashSandboxConfig["validateWorkdir"]>>(
+      async (workdir) => workdir,
+    );
+    const discardPreparedWorkdir =
+      vi.fn<NonNullable<BashSandboxConfig["discardPreparedWorkdir"]>>();
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir,
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+        discardPreparedWorkdir,
+        buildExecSpec,
+      },
+    });
+
+    try {
+      await expect(
+        tool.execute("call-remote-sandbox-rejected-command", {
+          command: "/approve approval-1 deny",
+          workdir: "/remote/workspace/generated",
+        }),
+      ).rejects.toThrow("exec cannot run /approve commands");
+
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
+      expect(discardPreparedWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
+      expect(buildExecSpec).not.toHaveBeenCalled();
+      expect(supervisorMock.spawn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not preflight remote-only backend workdirs from the local workspace root", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    fs.writeFileSync(path.join(workspaceDir, "script.py"), "print($TOKEN)\n");
+    const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
+      async (params) => ({
+        argv: ["remote-shell", params.command],
+        env: {},
+        stdinMode: "pipe-open" as const,
+      }),
+    );
+    const validateWorkdir = vi.fn<NonNullable<BashSandboxConfig["validateWorkdir"]>>(
+      async (workdir) => workdir,
+    );
+    mockSuccessfulSpawn();
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir,
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+        buildExecSpec,
+      },
+    });
+
+    try {
+      const result = await tool.execute("call-remote-only-script", {
+        command: "python script.py",
+        workdir: "/remote/workspace/generated",
+      });
+
+      expect(result.details.status).toBe("completed");
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
+      expect(buildExecSpec).toHaveBeenCalledOnce();
+      expect(buildExecSpec.mock.calls[0]?.[0]?.workdir).toBe("/remote/workspace/generated");
+      expect(supervisorMock.spawn).toHaveBeenCalledOnce();
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the mapped host cwd for existing relative backend-validated sandbox workdirs", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const srcDir = path.join(workspaceDir, "src");
+    fs.mkdirSync(srcDir);
+    const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
+      async (params) => ({
+        argv: ["remote-shell", params.command],
+        env: {},
+        stdinMode: "pipe-open" as const,
+      }),
+    );
+    const validateWorkdir = vi.fn<NonNullable<BashSandboxConfig["validateWorkdir"]>>(
+      async (workdir) => workdir,
+    );
+    mockSuccessfulSpawn();
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir,
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+        buildExecSpec,
+      },
+    });
+
+    try {
+      const result = await tool.execute("call-relative-remote-sandbox-workdir", {
+        command: "echo ok",
+        workdir: "src",
+      });
+
+      expect(result.details.status).toBe("completed");
+      expect(result.details.cwd).toBe(srcDir);
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/src");
+      expect(buildExecSpec).toHaveBeenCalledOnce();
+      expect(buildExecSpec.mock.calls[0]?.[0]?.workdir).toBe("/remote/workspace/src");
+      expect(supervisorMock.spawn).toHaveBeenCalledOnce();
+      expect(supervisorMock.spawn.mock.calls[0]?.[0]?.cwd).toBe(srcDir);
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails backend-validated sandbox workdirs before launch when backend validation rejects", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const validateWorkdir = vi.fn<NonNullable<BashSandboxConfig["validateWorkdir"]>>(
+      async () => null,
+    );
+    const buildExecSpec = vi.fn<NonNullable<BashSandboxConfig["buildExecSpec"]>>(
+      async (params) => ({
+        argv: ["remote-shell", params.command],
+        env: {},
+        stdinMode: "pipe-open" as const,
+      }),
+    );
+
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir,
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+        buildExecSpec,
+      },
+    });
+
+    try {
+      const result = await tool.execute("call-remote-sandbox-workdir", {
+        command: "echo ok",
+        workdir: "/remote/workspace/generated",
+      });
+
+      expect(result.details).toMatchObject({
+        status: "failed",
+        cwd: "/remote/workspace/generated",
+      });
+      expect(JSON.stringify(result)).toContain("unavailable or not a directory");
+      expect(validateWorkdir).toHaveBeenCalledOnce();
+      expect(buildExecSpec).not.toHaveBeenCalled();
+      expect(supervisorMock.spawn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a failed result for unavailable explicit sandbox workdirs before launching a command", async () => {
+    const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sandbox-workdir-"));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-outside-workdir-"));
+    fs.writeFileSync(path.join(workspaceDir, "not-dir"), "not a directory");
+    try {
+      for (const workdir of ["/workspace/missing", "   ", "/workspace/not-dir", outsideDir]) {
+        await expectUnavailableWorkdir({
+          workdir,
+          toolDefaults: {
+            host: "sandbox",
+            sandbox: {
+              containerName: "sandbox-workdir-test",
+              workspaceDir,
+              containerWorkdir: "/workspace",
+            },
+          },
+        });
+        supervisorMock.spawn.mockClear();
+      }
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
     }
   });
 });

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -2716,7 +2716,10 @@ describe("executeNodeHostCommand", () => {
     expect(requireGatewayCommand("system.run.prepare").params?.params?.env).toEqual({
       FOO: "bar",
     });
-    expect(requireRunParams(requireGatewayCommand("system.run")).env).toEqual({ FOO: "bar" });
+    expect(requireGatewayCommand("system.run.prepare").params?.params?.cwd).toBe("/tmp/work");
+    const runParams = requireRunParams(requireGatewayCommand("system.run"));
+    expect(runParams.env).toEqual({ FOO: "bar" });
+    expect(runParams.cwd).toBe("/tmp/work");
     const evalEnvs = evaluateShellAllowlistMock.mock.calls.map(
       ([raw]) => (raw as ShellAllowlistMockParams).env,
     );
@@ -2745,10 +2748,29 @@ describe("executeNodeHostCommand", () => {
     const runParams = requireRunParams(call);
     expect(runParams.command).toEqual(["/bin/sh", "-lc", "bun ./script.ts"]);
     expect(runParams.rawCommand).toBe("bun ./script.ts");
+    expect(runParams.cwd).toBe("/tmp/work");
     expect(typeof runParams.runId).toBe("string");
     expect(runParams.suppressNotifyOnExit).toBe(true);
     expect(runParams.timeoutMs).toBe(30_000);
     expect(Object.hasOwn(runParams, "systemRunPlan")).toBe(false);
+  });
+
+  it("omits cwd from direct node system.run when workdir is undefined", async () => {
+    await executeNodeHostCommand({
+      command: "bun ./script.ts",
+      workdir: undefined,
+      env: {},
+      security: "full",
+      ask: "off",
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    const runParams = requireRunParams(requireGatewayCall(0));
+    expect(Object.hasOwn(runParams, "cwd")).toBe(false);
   });
 
   it("rejects disconnected node targets before invoking system.run", async () => {

--- a/src/agents/bash-tools.exec-workdir.test.ts
+++ b/src/agents/bash-tools.exec-workdir.test.ts
@@ -1,0 +1,569 @@
+/**
+ * Exec workdir resolver tests.
+ * Verifies cwd selection and validation before exec launches or remote node
+ * forwarding.
+ */
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveExecWorkdir } from "./bash-tools.exec-workdir.js";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
+
+async function withTempDir(run: (dir: string) => Promise<void>) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-exec-workdir-"));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function sandboxConfig(workspaceDir: string): BashSandboxConfig {
+  return {
+    containerName: "sandbox-workdir-test",
+    workspaceDir,
+    containerWorkdir: "/workspace",
+  };
+}
+
+function backendSandboxConfig(
+  workspaceDir: string,
+  params?: {
+    containerWorkdir?: string;
+    workdirRoots?: readonly string[];
+    validateWorkdir?: BashSandboxConfig["validateWorkdir"];
+  },
+): BashSandboxConfig {
+  return {
+    ...sandboxConfig(workspaceDir),
+    containerWorkdir: params?.containerWorkdir ?? "/remote/workspace",
+    workdirValidation: "backend",
+    workdirRoots: params?.workdirRoots,
+    validateWorkdir: params?.validateWorkdir ?? (async (workdir) => workdir),
+  };
+}
+
+describe("resolveExecWorkdir", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects blank explicit local workdirs", async () => {
+    await expect(
+      resolveExecWorkdir({
+        host: "gateway",
+        workdir: "   ",
+      }),
+    ).resolves.toEqual({ kind: "unavailable", requestedCwd: "   " });
+  });
+
+  it("rejects missing explicit local workdirs without fallback", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const missing = path.join(workspaceDir, "missing");
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          workdir: missing,
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: missing });
+    });
+  });
+
+  it("rejects file explicit local workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const fileWorkdir = path.join(workspaceDir, "not-dir");
+      await writeFile(fileWorkdir, "not a directory");
+
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          workdir: fileWorkdir,
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: fileWorkdir });
+    });
+  });
+
+  it("resolves valid explicit local workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          workdir: ` ${workspaceDir} `,
+        }),
+      ).resolves.toEqual({ kind: "local", hostCwd: workspaceDir });
+    });
+  });
+
+  it("uses configured local cwd when workdir is omitted", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          defaultCwd: workspaceDir,
+        }),
+      ).resolves.toEqual({ kind: "local", hostCwd: workspaceDir });
+    });
+  });
+
+  it("uses current cwd for omitted local workdir only when no default exists", async () => {
+    await withTempDir(async (workspaceDir) => {
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+        }),
+      ).resolves.toEqual({ kind: "local", hostCwd: workspaceDir });
+    });
+  });
+
+  it("fails omitted local workdir when current cwd is unavailable", async () => {
+    vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("cwd unavailable");
+    });
+
+    await expect(
+      resolveExecWorkdir({
+        host: "gateway",
+      }),
+    ).resolves.toEqual({ kind: "unavailable", requestedCwd: "current working directory" });
+  });
+
+  it("rejects missing configured local cwd without falling back to current cwd", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const missingDefault = path.join(workspaceDir, "missing-default");
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          defaultCwd: missingDefault,
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: missingDefault });
+    });
+  });
+
+  it("uses the sandbox workspace when sandbox workdir is omitted", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/workspace",
+        scriptPreflightCwd: workspaceDir,
+      });
+    });
+  });
+
+  it("rejects missing explicit sandbox workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/workspace/missing",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: "/workspace/missing" });
+    });
+  });
+
+  it("rejects missing configured sandbox workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          defaultCwd: "/workspace/missing",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: "/workspace/missing" });
+    });
+  });
+
+  it("rejects file sandbox workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await writeFile(path.join(workspaceDir, "not-dir"), "not a directory");
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/workspace/not-dir",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: "/workspace/not-dir" });
+    });
+  });
+
+  it("rejects sandbox workdirs that escape the workspace", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await withTempDir(async (outsideDir) => {
+        await expect(
+          resolveExecWorkdir({
+            host: "sandbox",
+            workdir: outsideDir,
+            sandbox: sandboxConfig(workspaceDir),
+          }),
+        ).resolves.toEqual({ kind: "unavailable", requestedCwd: outsideDir });
+      });
+    });
+  });
+
+  it("rejects sandbox workdirs with parent-directory segments", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "missing/..",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: "missing/.." });
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/workspace/missing/..",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({ kind: "unavailable", requestedCwd: "/workspace/missing/.." });
+    });
+  });
+
+  it("rejects sandbox workdir symlinks that escape the workspace", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await withTempDir(async (outsideDir) => {
+        await symlink(outsideDir, path.join(workspaceDir, "escape"), "dir");
+
+        await expect(
+          resolveExecWorkdir({
+            host: "sandbox",
+            workdir: "/workspace/escape",
+            sandbox: sandboxConfig(workspaceDir),
+          }),
+        ).resolves.toEqual({ kind: "unavailable", requestedCwd: "/workspace/escape" });
+      });
+    });
+  });
+
+  it("resolves relative sandbox workdirs under the workspace", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const srcDir = path.join(workspaceDir, "src");
+      await mkdir(srcDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "src",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: srcDir,
+        containerCwd: "/workspace/src",
+        scriptPreflightCwd: srcDir,
+      });
+    });
+  });
+
+  it("supports custom sandbox container workdir prefixes", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const projectDir = path.join(workspaceDir, "project");
+      await mkdir(projectDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/sandbox-root/project",
+          sandbox: {
+            ...sandboxConfig(workspaceDir),
+            containerWorkdir: "/sandbox-root",
+          },
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: projectDir,
+        containerCwd: "/sandbox-root/project",
+        scriptPreflightCwd: projectDir,
+      });
+    });
+  });
+
+  it("lets backend-validated sandboxes use remote-only container workdirs", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/remote/workspace/generated",
+          sandbox: backendSandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/remote/workspace/generated",
+        scriptPreflightCwd: null,
+      });
+    });
+  });
+
+  it("normalizes backend-validated sandbox workdir roots with trailing slashes", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/remote/workspace/generated",
+          sandbox: backendSandboxConfig(workspaceDir, {
+            containerWorkdir: "/remote/workspace/",
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/remote/workspace/generated",
+        scriptPreflightCwd: null,
+      });
+    });
+  });
+
+  it("lets backend-validated sandboxes use declared alternate remote roots", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/agent/project",
+          sandbox: backendSandboxConfig(workspaceDir, {
+            workdirRoots: ["/agent"],
+            validateWorkdir,
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/agent/project",
+        scriptPreflightCwd: null,
+      });
+      expect(validateWorkdir).toHaveBeenCalledWith("/agent/project");
+    });
+  });
+
+  it("resolves relative backend-validated sandbox workdirs under the remote workspace", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "remote-only",
+          sandbox: backendSandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/remote/workspace/remote-only",
+        scriptPreflightCwd: null,
+      });
+    });
+  });
+
+  it("keeps existing relative backend-validated sandbox workdirs aligned with the local mirror", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const localDir = path.join(workspaceDir, "src");
+      await mkdir(localDir);
+      const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "src",
+          sandbox: backendSandboxConfig(workspaceDir, { validateWorkdir }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: localDir,
+        containerCwd: "/remote/workspace/src",
+        scriptPreflightCwd: localDir,
+      });
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/src");
+    });
+  });
+
+  it("defers stale relative backend-validated sandbox workdirs to the backend", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const localFile = path.join(workspaceDir, "build");
+      await writeFile(localFile, "stale local mirror file");
+      const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "build",
+          sandbox: backendSandboxConfig(workspaceDir, { validateWorkdir }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/remote/workspace/build",
+        scriptPreflightCwd: null,
+      });
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/build");
+    });
+  });
+
+  it("accepts backend-validated absolute workdirs when the remote workspace root is slash", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/generated",
+          sandbox: backendSandboxConfig(workspaceDir, {
+            containerWorkdir: "/",
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/generated",
+        scriptPreflightCwd: null,
+      });
+    });
+  });
+
+  it("maps host workspace paths for backend-validated sandboxes when they exist locally", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const localDir = path.join(workspaceDir, "src");
+      await mkdir(localDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: localDir,
+          sandbox: backendSandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: localDir,
+        containerCwd: "/remote/workspace/src",
+        scriptPreflightCwd: localDir,
+      });
+    });
+  });
+
+  it("rejects backend-validated sandbox host paths that symlink outside the workspace", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await withTempDir(async (outsideDir) => {
+        const escape = path.join(workspaceDir, "escape");
+        await symlink(outsideDir, escape, "dir");
+
+        await expect(
+          resolveExecWorkdir({
+            host: "sandbox",
+            workdir: escape,
+            sandbox: backendSandboxConfig(workspaceDir),
+          }),
+        ).resolves.toEqual({
+          kind: "unavailable",
+          requestedCwd: escape,
+        });
+      });
+    });
+  });
+
+  it("prefers existing host workspace paths over matching backend container prefixes", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const localDir = path.join(workspaceDir, "src");
+      await mkdir(localDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: localDir,
+          sandbox: backendSandboxConfig(workspaceDir, {
+            containerWorkdir: workspaceDir,
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: localDir,
+        containerCwd: `${workspaceDir}/src`,
+        scriptPreflightCwd: localDir,
+      });
+    });
+  });
+
+  it("rejects backend-validated sandbox workdirs outside local and remote workspace roots", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/other/remote/workspace",
+          sandbox: backendSandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "unavailable",
+        requestedCwd: "/other/remote/workspace",
+      });
+    });
+  });
+
+  it("rejects backend-validated sandbox workdirs with parent-directory segments", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/remote/workspace/missing/..",
+          sandbox: backendSandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "unavailable",
+        requestedCwd: "/remote/workspace/missing/..",
+      });
+    });
+  });
+
+  it("rejects backend-validated sandbox workdirs when the backend validator fails", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "/remote/workspace/missing",
+          sandbox: backendSandboxConfig(workspaceDir, {
+            validateWorkdir: async () => null,
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "unavailable",
+        requestedCwd: "/remote/workspace/missing",
+      });
+    });
+  });
+
+  it("omits node cwd when node workdir is omitted", async () => {
+    await expect(
+      resolveExecWorkdir({
+        host: "node",
+        defaultCwd: "/gateway/default",
+      }),
+    ).resolves.toEqual({ kind: "node" });
+  });
+
+  it("forwards explicit node cwd without local validation", async () => {
+    await expect(
+      resolveExecWorkdir({
+        host: "node",
+        workdir: "/remote/node/workspace",
+        defaultCwd: "/gateway/default",
+      }),
+    ).resolves.toEqual({ kind: "node", remoteCwd: "/remote/node/workspace" });
+  });
+
+  it("rejects blank explicit node workdirs", async () => {
+    await expect(
+      resolveExecWorkdir({
+        host: "node",
+        workdir: "   ",
+      }),
+    ).resolves.toEqual({ kind: "unavailable", requestedCwd: "   " });
+  });
+});

--- a/src/agents/bash-tools.exec-workdir.test.ts
+++ b/src/agents/bash-tools.exec-workdir.test.ts
@@ -474,6 +474,29 @@ describe("resolveExecWorkdir", () => {
     });
   });
 
+  it("maps missing absolute host workspace paths before backend validation", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const missingRemoteDir = path.join(workspaceDir, "generated");
+      const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: missingRemoteDir,
+          sandbox: backendSandboxConfig(workspaceDir, {
+            validateWorkdir,
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/remote/workspace/generated",
+        scriptPreflightCwd: null,
+      });
+      expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/generated");
+    });
+  });
+
   it("rejects backend-validated sandbox host paths that symlink outside the workspace", async () => {
     await withTempDir(async (workspaceDir) => {
       await withTempDir(async (outsideDir) => {

--- a/src/agents/bash-tools.exec-workdir.test.ts
+++ b/src/agents/bash-tools.exec-workdir.test.ts
@@ -450,6 +450,30 @@ describe("resolveExecWorkdir", () => {
     });
   });
 
+  it("defers missing absolute backend workdirs to remote validation when roots overlap", async () => {
+    await withTempDir(async (workspaceDir) => {
+      const missingRemoteDir = path.join(workspaceDir, "generated");
+      const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: missingRemoteDir,
+          sandbox: backendSandboxConfig(workspaceDir, {
+            containerWorkdir: workspaceDir,
+            validateWorkdir,
+          }),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: missingRemoteDir,
+        scriptPreflightCwd: null,
+      });
+      expect(validateWorkdir).toHaveBeenCalledWith(missingRemoteDir);
+    });
+  });
+
   it("rejects backend-validated sandbox host paths that symlink outside the workspace", async () => {
     await withTempDir(async (workspaceDir) => {
       await withTempDir(async (outsideDir) => {

--- a/src/agents/bash-tools.exec-workdir.ts
+++ b/src/agents/bash-tools.exec-workdir.ts
@@ -33,6 +33,11 @@ type BackendHostWorkdirCandidate = {
   failIfInvalid: boolean;
 };
 
+type ExistingHostWorkspacePathResult =
+  | { kind: "available"; workdir: SandboxWorkdir }
+  | { kind: "missing" }
+  | { kind: "invalid" };
+
 function normalizeExplicitWorkdirInput(workdir: string | undefined): NormalizedWorkdirInput {
   if (workdir === undefined) {
     return { kind: "omitted" };
@@ -153,7 +158,7 @@ function resolveBackendContainerWorkdir(params: {
 async function mapExistingHostWorkspacePath(params: {
   hostPath: string;
   sandbox: BashSandboxConfig;
-}): Promise<SandboxWorkdir | null> {
+}): Promise<ExistingHostWorkspacePathResult> {
   let resolved: Awaited<ReturnType<typeof assertSandboxPath>>;
   try {
     resolved = await assertSandboxPath({
@@ -162,17 +167,23 @@ async function mapExistingHostWorkspacePath(params: {
       root: params.sandbox.workspaceDir,
     });
   } catch {
-    return null;
+    return { kind: "invalid" };
   }
-  const hostCwd = resolveExistingHostWorkdir(resolved.resolved);
-  if (!hostCwd) {
-    return null;
+  const stats = safeStatSync(resolved.resolved);
+  if (!stats) {
+    return { kind: "missing" };
+  }
+  if (!stats.isDirectory()) {
+    return { kind: "invalid" };
   }
   const relative = resolved.relative ? resolved.relative.split(path.sep).join(path.posix.sep) : "";
   return {
-    hostCwd,
-    containerCwd: joinContainerWorkdir(params.sandbox.containerWorkdir, relative),
-    scriptPreflightCwd: hostCwd,
+    kind: "available",
+    workdir: {
+      hostCwd: resolved.resolved,
+      containerCwd: joinContainerWorkdir(params.sandbox.containerWorkdir, relative),
+      scriptPreflightCwd: resolved.resolved,
+    },
   };
 }
 
@@ -232,13 +243,13 @@ async function resolveBackendValidatedSandboxWorkdir(params: {
       hostPath: hostCandidate.hostPath,
       sandbox: params.sandbox,
     });
-    if (mappedWorkdir) {
+    if (mappedWorkdir.kind === "available") {
       return await validateBackendWorkdir({
-        workdir: mappedWorkdir,
+        workdir: mappedWorkdir.workdir,
         sandbox: params.sandbox,
       });
     }
-    if (hostCandidate.failIfInvalid) {
+    if (hostCandidate.failIfInvalid && mappedWorkdir.kind === "invalid") {
       return null;
     }
   }

--- a/src/agents/bash-tools.exec-workdir.ts
+++ b/src/agents/bash-tools.exec-workdir.ts
@@ -1,0 +1,354 @@
+/**
+ * Internal exec workdir resolver.
+ * Owns cwd selection and validation before exec approval, hooks, preflight, or
+ * process launch can observe an invalid selected working directory.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ExecHost } from "../infra/exec-approvals.js";
+import { safeStatSync } from "../infra/path-guards.js";
+import type { BashSandboxConfig } from "./bash-tools.shared.js";
+import { assertSandboxPath } from "./sandbox-paths.js";
+
+export type ExecWorkdirResolution =
+  | { kind: "local"; hostCwd: string }
+  | { kind: "sandbox"; hostCwd: string; containerCwd: string; scriptPreflightCwd: string | null }
+  | { kind: "node"; remoteCwd?: string }
+  | { kind: "unavailable"; requestedCwd: string };
+
+type NormalizedWorkdirInput =
+  | { kind: "omitted" }
+  | { kind: "blank"; raw: string }
+  | { kind: "specified"; value: string };
+
+type SandboxWorkdir = {
+  hostCwd: string;
+  containerCwd: string;
+  scriptPreflightCwd: string | null;
+};
+
+type BackendHostWorkdirCandidate = {
+  hostPath: string;
+  failIfInvalid: boolean;
+};
+
+function normalizeExplicitWorkdirInput(workdir: string | undefined): NormalizedWorkdirInput {
+  if (workdir === undefined) {
+    return { kind: "omitted" };
+  }
+  const value = normalizeOptionalString(workdir);
+  return value ? { kind: "specified", value } : { kind: "blank", raw: workdir };
+}
+
+function unavailable(requestedCwd: string): ExecWorkdirResolution {
+  return { kind: "unavailable", requestedCwd };
+}
+
+function resolveExistingHostWorkdir(workdir: string): string | null {
+  const stats = safeStatSync(workdir);
+  return stats?.isDirectory() ? workdir : null;
+}
+
+function isHostPathInsideRoot(params: { root: string; candidate: string }): boolean {
+  const root = path.resolve(params.root);
+  const candidate = path.resolve(params.candidate);
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function safeCurrentCwd(): string | null {
+  try {
+    return process.cwd();
+  } catch {
+    return null;
+  }
+}
+
+function mapContainerWorkdirToHost(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): string | undefined {
+  const workdir = normalizeContainerPath(params.workdir);
+  const containerRoot = normalizeContainerPath(params.sandbox.containerWorkdir);
+  if (containerRoot === ".") {
+    return undefined;
+  }
+  if (workdir === containerRoot) {
+    return path.resolve(params.sandbox.workspaceDir);
+  }
+  if (!workdir.startsWith(`${containerRoot}/`)) {
+    return undefined;
+  }
+  const rel = workdir
+    .slice(containerRoot.length + 1)
+    .split("/")
+    .filter(Boolean);
+  return path.resolve(params.sandbox.workspaceDir, ...rel);
+}
+
+function normalizeContainerPath(input: string): string {
+  const normalized = input.trim().replace(/\\/g, "/");
+  if (!normalized) {
+    return ".";
+  }
+  const posixPath = path.posix.normalize(normalized);
+  return posixPath === "/" ? posixPath : posixPath.replace(/\/+$/g, "");
+}
+
+function joinContainerWorkdir(containerWorkdir: string, relative: string): string {
+  return relative ? path.posix.join(containerWorkdir, relative) : containerWorkdir;
+}
+
+function hasParentPathSegment(input: string): boolean {
+  return input
+    .replace(/\\/g, "/")
+    .split("/")
+    .some((segment) => segment === "..");
+}
+
+function isContainerWorkdirInsideRoot(params: { root: string; workdir: string }): boolean {
+  const root = normalizeContainerPath(params.root);
+  const workdir = normalizeContainerPath(params.workdir);
+  if (root === "/") {
+    return path.posix.isAbsolute(workdir);
+  }
+  return workdir === root || workdir.startsWith(`${root}/`);
+}
+
+function resolveBackendWorkdirRoots(sandbox: BashSandboxConfig): string[] {
+  const roots: string[] = [];
+  const addRoot = (root: string | undefined) => {
+    const normalized = normalizeContainerPath(root ?? "");
+    if (normalized === "." || !path.posix.isAbsolute(normalized) || roots.includes(normalized)) {
+      return;
+    }
+    roots.push(normalized);
+  };
+  addRoot(sandbox.containerWorkdir);
+  for (const root of sandbox.workdirRoots ?? []) {
+    addRoot(root);
+  }
+  return roots;
+}
+
+function resolveBackendContainerWorkdir(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): string | null {
+  const containerRoot = normalizeContainerPath(params.sandbox.containerWorkdir);
+  const backendRoots = resolveBackendWorkdirRoots(params.sandbox);
+  const requested = normalizeContainerPath(params.workdir);
+  if (path.posix.isAbsolute(requested)) {
+    return backendRoots.some((root) => isContainerWorkdirInsideRoot({ root, workdir: requested }))
+      ? requested
+      : null;
+  }
+  if (requested === ".." || requested.startsWith("../")) {
+    return null;
+  }
+  return joinContainerWorkdir(containerRoot, requested === "." ? "" : requested);
+}
+
+async function mapExistingHostWorkspacePath(params: {
+  hostPath: string;
+  sandbox: BashSandboxConfig;
+}): Promise<SandboxWorkdir | null> {
+  let resolved: Awaited<ReturnType<typeof assertSandboxPath>>;
+  try {
+    resolved = await assertSandboxPath({
+      filePath: params.hostPath,
+      cwd: params.sandbox.workspaceDir,
+      root: params.sandbox.workspaceDir,
+    });
+  } catch {
+    return null;
+  }
+  const hostCwd = resolveExistingHostWorkdir(resolved.resolved);
+  if (!hostCwd) {
+    return null;
+  }
+  const relative = resolved.relative ? resolved.relative.split(path.sep).join(path.posix.sep) : "";
+  return {
+    hostCwd,
+    containerCwd: joinContainerWorkdir(params.sandbox.containerWorkdir, relative),
+    scriptPreflightCwd: hostCwd,
+  };
+}
+
+async function validateBackendWorkdir(params: {
+  workdir: SandboxWorkdir;
+  sandbox: BashSandboxConfig;
+}): Promise<SandboxWorkdir | null> {
+  const containerCwd = await params.sandbox.validateWorkdir?.(params.workdir.containerCwd);
+  return containerCwd
+    ? {
+        hostCwd: params.workdir.hostCwd,
+        containerCwd,
+        scriptPreflightCwd: params.workdir.scriptPreflightCwd,
+      }
+    : null;
+}
+
+function resolveBackendHostWorkdirCandidate(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): BackendHostWorkdirCandidate | null {
+  if (!path.isAbsolute(params.workdir)) {
+    return {
+      hostPath: path.resolve(params.sandbox.workspaceDir, params.workdir),
+      failIfInvalid: false,
+    };
+  }
+  const hostPath = path.resolve(params.workdir);
+  if (
+    isHostPathInsideRoot({
+      root: params.sandbox.workspaceDir,
+      candidate: hostPath,
+    })
+  ) {
+    return { hostPath, failIfInvalid: true };
+  }
+  const containerMappedHostPath = mapContainerWorkdirToHost({
+    workdir: params.workdir,
+    sandbox: params.sandbox,
+  });
+  return containerMappedHostPath
+    ? { hostPath: containerMappedHostPath, failIfInvalid: false }
+    : null;
+}
+
+async function resolveBackendValidatedSandboxWorkdir(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): Promise<SandboxWorkdir | null> {
+  const workspaceHostCwd = resolveExistingHostWorkdir(params.sandbox.workspaceDir);
+  if (!workspaceHostCwd) {
+    return null;
+  }
+  const hostCandidate = resolveBackendHostWorkdirCandidate(params);
+  if (hostCandidate) {
+    const mappedWorkdir = await mapExistingHostWorkspacePath({
+      hostPath: hostCandidate.hostPath,
+      sandbox: params.sandbox,
+    });
+    if (mappedWorkdir) {
+      return await validateBackendWorkdir({
+        workdir: mappedWorkdir,
+        sandbox: params.sandbox,
+      });
+    }
+    if (hostCandidate.failIfInvalid) {
+      return null;
+    }
+  }
+  const containerCwd = resolveBackendContainerWorkdir(params);
+  if (containerCwd) {
+    return await validateBackendWorkdir({
+      workdir: {
+        hostCwd: workspaceHostCwd,
+        containerCwd,
+        scriptPreflightCwd: null,
+      },
+      sandbox: params.sandbox,
+    });
+  }
+  return null;
+}
+
+async function resolveHostValidatedSandboxWorkdir(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): Promise<SandboxWorkdir | null> {
+  const mappedHostWorkdir = mapContainerWorkdirToHost({
+    workdir: params.workdir,
+    sandbox: params.sandbox,
+  });
+  const candidateWorkdir = mappedHostWorkdir ?? params.workdir;
+  try {
+    const resolved = await assertSandboxPath({
+      filePath: candidateWorkdir,
+      cwd: params.sandbox.workspaceDir,
+      root: params.sandbox.workspaceDir,
+    });
+    const stats = await fs.stat(resolved.resolved);
+    if (!stats.isDirectory()) {
+      return null;
+    }
+    const relative = resolved.relative
+      ? resolved.relative.split(path.sep).join(path.posix.sep)
+      : "";
+    const containerCwd = joinContainerWorkdir(params.sandbox.containerWorkdir, relative);
+    return { hostCwd: resolved.resolved, containerCwd, scriptPreflightCwd: resolved.resolved };
+  } catch {
+    return null;
+  }
+}
+
+async function resolveSandboxWorkdir(params: {
+  workdir: string;
+  sandbox: BashSandboxConfig;
+}): Promise<SandboxWorkdir | null> {
+  if (hasParentPathSegment(params.workdir)) {
+    return null;
+  }
+  if (params.sandbox.workdirValidation === "backend") {
+    return await resolveBackendValidatedSandboxWorkdir(params);
+  }
+  return await resolveHostValidatedSandboxWorkdir(params);
+}
+
+export function formatUnavailableWorkdirFailure(workdir: string): string {
+  return [
+    `workdir "${workdir}" is unavailable or not a directory: command was not executed.`,
+    'workdir is treated as a literal path; shell expansions such as "~" are not applied.',
+    "Use an existing directory, omit an explicit workdir to use the default cwd, or update the configured default cwd.",
+  ].join(" ");
+}
+
+export async function resolveExecWorkdir(params: {
+  host: ExecHost;
+  workdir?: string;
+  defaultCwd?: string;
+  sandbox?: BashSandboxConfig;
+}): Promise<ExecWorkdirResolution> {
+  const explicitWorkdir = normalizeExplicitWorkdirInput(params.workdir);
+  if (explicitWorkdir.kind === "blank") {
+    return unavailable(explicitWorkdir.raw);
+  }
+
+  if (params.host === "node") {
+    return explicitWorkdir.kind === "specified"
+      ? { kind: "node", remoteCwd: explicitWorkdir.value }
+      : { kind: "node" };
+  }
+
+  const defaultCwd = normalizeOptionalString(params.defaultCwd);
+  if (params.host === "sandbox") {
+    const sandbox = params.sandbox;
+    if (!sandbox) {
+      throw new Error("exec internal error: sandbox workdir resolution requires sandbox config");
+    }
+    const requestedCwd =
+      explicitWorkdir.kind === "specified"
+        ? explicitWorkdir.value
+        : (defaultCwd ?? sandbox.containerWorkdir);
+    const resolved = await resolveSandboxWorkdir({ workdir: requestedCwd, sandbox });
+    return resolved
+      ? {
+          kind: "sandbox",
+          hostCwd: resolved.hostCwd,
+          containerCwd: resolved.containerCwd,
+          scriptPreflightCwd: resolved.scriptPreflightCwd,
+        }
+      : unavailable(requestedCwd);
+  }
+
+  const requestedCwd =
+    explicitWorkdir.kind === "specified" ? explicitWorkdir.value : (defaultCwd ?? safeCurrentCwd());
+  if (!requestedCwd) {
+    return unavailable("current working directory");
+  }
+  const resolved = resolveExistingHostWorkdir(requestedCwd);
+  return resolved ? { kind: "local", hostCwd: resolved } : unavailable(requestedCwd);
+}

--- a/src/agents/bash-tools.exec-workdir.ts
+++ b/src/agents/bash-tools.exec-workdir.ts
@@ -35,7 +35,7 @@ type BackendHostWorkdirCandidate = {
 
 type ExistingHostWorkspacePathResult =
   | { kind: "available"; workdir: SandboxWorkdir }
-  | { kind: "missing" }
+  | { kind: "missing"; relative: string }
   | { kind: "invalid" };
 
 function normalizeExplicitWorkdirInput(workdir: string | undefined): NormalizedWorkdirInput {
@@ -171,7 +171,10 @@ async function mapExistingHostWorkspacePath(params: {
   }
   const stats = safeStatSync(resolved.resolved);
   if (!stats) {
-    return { kind: "missing" };
+    return {
+      kind: "missing",
+      relative: resolved.relative ? resolved.relative.split(path.sep).join(path.posix.sep) : "",
+    };
   }
   if (!stats.isDirectory()) {
     return { kind: "invalid" };
@@ -246,6 +249,19 @@ async function resolveBackendValidatedSandboxWorkdir(params: {
     if (mappedWorkdir.kind === "available") {
       return await validateBackendWorkdir({
         workdir: mappedWorkdir.workdir,
+        sandbox: params.sandbox,
+      });
+    }
+    if (mappedWorkdir.kind === "missing") {
+      return await validateBackendWorkdir({
+        workdir: {
+          hostCwd: workspaceHostCwd,
+          containerCwd: joinContainerWorkdir(
+            params.sandbox.containerWorkdir,
+            mappedWorkdir.relative,
+          ),
+          scriptPreflightCwd: null,
+        },
         sandbox: params.sandbox,
       });
     }

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -232,8 +232,10 @@ describe("exec PATH login shell merge", () => {
     const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
 
     expect(result.details?.status).toBe("failed");
-    expect(value).toContain(`workdir "${missingWorkdir}" is unavailable`);
+    expect(value).toContain(`workdir "${missingWorkdir}" not found`);
     expect(value).toContain("command was not executed");
+    expect(value).toContain("workdir is treated as a literal path");
+    expect(value).toContain('shell expansions such as "~" are not applied');
     expect(value).not.toMatch(/^ok/);
   });
 

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -232,7 +232,7 @@ describe("exec PATH login shell merge", () => {
     const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
 
     expect(result.details?.status).toBe("failed");
-    expect(value).toContain(`workdir "${missingWorkdir}" not found`);
+    expect(value).toContain(`workdir "${missingWorkdir}" is unavailable or not a directory`);
     expect(value).toContain("command was not executed");
     expect(value).toContain("workdir is treated as a literal path");
     expect(value).toContain('shell expansions such as "~" are not applied');

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -216,6 +216,27 @@ describe("exec PATH login shell merge", () => {
     }
   });
 
+  it("fails without running when an explicit workdir is unavailable", async () => {
+    const missingWorkdir = path.join(
+      os.tmpdir(),
+      `openclaw-missing-workdir-${process.pid}-${Date.now()}`,
+    );
+    fs.rmSync(missingWorkdir, { recursive: true, force: true });
+
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+    const result = await tool.execute("call-missing-workdir", {
+      command: "echo ok",
+      workdir: missingWorkdir,
+      yieldMs: FOREGROUND_TEST_YIELD_MS,
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(result.details?.status).toBe("failed");
+    expect(value).toContain(`workdir "${missingWorkdir}" is unavailable`);
+    expect(value).toContain("command was not executed");
+    expect(value).not.toBe("ok");
+  });
+
   it("merges login-shell PATH for host=gateway", async () => {
     if (isWin) {
       return;

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -234,7 +234,7 @@ describe("exec PATH login shell merge", () => {
     expect(result.details?.status).toBe("failed");
     expect(value).toContain(`workdir "${missingWorkdir}" is unavailable`);
     expect(value).toContain("command was not executed");
-    expect(value).not.toBe("ok");
+    expect(value).not.toMatch(/^ok/);
   });
 
   it("merges login-shell PATH for host=gateway", async () => {

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -471,6 +471,51 @@ describe("exec resolve_exec_env hook wiring", () => {
     expect(mocks.spawnInputs).toHaveLength(0);
   });
 
+  it("defers resolve_exec_env for backend sandboxes until workdir validation succeeds", async () => {
+    const validateWorkdir = vi.fn(async () => null);
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async () => ({ PLUGIN_SAFE: "yes" })),
+      runBeforeToolCall: vi.fn(async () => undefined),
+    };
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir: process.cwd(),
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+      },
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    const result = await definition.execute(
+      "call-backend-invalid-cwd-before-env",
+      {
+        command: "echo ok",
+        workdir: "/remote/workspace/missing",
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(mocks.hookRunner.runBeforeToolCall!).toHaveBeenCalledOnce();
+    expect(validateWorkdir).toHaveBeenCalledWith("/remote/workspace/missing");
+    expect(mocks.hookRunner.runResolveExecEnv!).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
   it("lets lazy before_tool_call see invalid workdirs before failing unchanged params", async () => {
     mocks.hookRunner = {
       hasHooks: vi.fn(

--- a/src/agents/bash-tools.exec.resolve-env-hook.test.ts
+++ b/src/agents/bash-tools.exec.resolve-env-hook.test.ts
@@ -5,6 +5,7 @@
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { OPENCLAW_CLI_ENV_VALUE } from "../infra/openclaw-exec-env.js";
+import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
 import type { ExtensionContext } from "./sessions/index.js";
 
 declare module "../plugins/hook-types.js" {
@@ -14,6 +15,10 @@ declare module "../plugins/hook-types.js" {
 }
 
 const CHANNEL_CONTEXT_ENV_KEY = "OPENCLAW_CHANNEL_CONTEXT";
+type CapturedNodeHostParams = Pick<
+  ExecuteNodeHostCommandParams,
+  "env" | "requestedEnv" | "workdir"
+>;
 
 const mocks = vi.hoisted(() => ({
   hookRunner: undefined as
@@ -28,10 +33,7 @@ const mocks = vi.hoisted(() => ({
     env: Record<string, string>;
     requestedEnv?: Record<string, string>;
   }>,
-  nodeHostParams: [] as Array<{
-    env: Record<string, string>;
-    requestedEnv?: Record<string, string>;
-  }>,
+  nodeHostParams: [] as CapturedNodeHostParams[],
   spawnInputs: [] as Array<{
     env?: Record<string, string>;
   }>,
@@ -64,10 +66,11 @@ vi.mock("./bash-tools.exec-host-gateway.js", () => ({
 
 vi.mock("./bash-tools.exec-host-node.js", () => ({
   executeNodeHostCommand: vi.fn(
-    async (params: { env: Record<string, string>; requestedEnv?: Record<string, string> }) => {
+    async (params: Pick<ExecuteNodeHostCommandParams, "env" | "requestedEnv" | "workdir">) => {
       mocks.nodeHostParams.push({
         env: { ...params.env },
         requestedEnv: params.requestedEnv ? { ...params.requestedEnv } : undefined,
+        workdir: params.workdir,
       });
       return {
         content: [{ type: "text", text: "node ok" }],
@@ -272,6 +275,260 @@ describe("exec resolve_exec_env hook wiring", () => {
     expect(mocks.nodeHostParams[0]?.env).not.toHaveProperty("LD_PRELOAD");
   });
 
+  it("does not forward configured gateway cwd defaults to node host requests", async () => {
+    const tool = createExecTool({
+      cwd: "/gateway/default/that/node/cannot/use",
+      host: "node",
+      security: "full",
+      ask: "off",
+    });
+
+    await tool.execute("call-node-default-cwd", {
+      command: "echo ok",
+    });
+
+    expect(mocks.nodeHostParams[0]?.workdir).toBeUndefined();
+  });
+
+  it("fails blank explicit node host workdirs before node invocation", async () => {
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+    });
+
+    const result = await tool.execute("call-node-blank-cwd", {
+      command: "echo ok",
+      workdir: "   ",
+    });
+    const text = result.content.find((entry) => entry.type === "text")?.text ?? "";
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(text).toContain('workdir "   " is unavailable or not a directory');
+    expect(text).toContain("command was not executed");
+    expect(mocks.nodeHostParams).toHaveLength(0);
+  });
+
+  it("prevalidates node workdirs before resolving exec env when a backend sandbox exists", async () => {
+    installResolveExecEnvHook({ PLUGIN_SAFE: "yes" });
+    const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir: process.cwd(),
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+      },
+    });
+
+    const result = await tool.execute("call-node-invalid-cwd-with-backend-sandbox", {
+      command: "echo ok",
+      workdir: "   ",
+    });
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(mocks.hookRunner?.runResolveExecEnv).not.toHaveBeenCalled();
+    expect(validateWorkdir).not.toHaveBeenCalled();
+    expect(mocks.nodeHostParams).toHaveLength(0);
+  });
+
+  it("fails invalid workdirs before resolving exec env", async () => {
+    installResolveExecEnvHook({ PLUGIN_SAFE: "yes" });
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+    });
+
+    const result = await tool.execute("call-invalid-cwd-before-env", {
+      command: "echo ok",
+      workdir: "   ",
+    });
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(mocks.hookRunner?.runResolveExecEnv).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
+  it("prevalidates gateway workdirs before resolving exec env when a backend sandbox exists", async () => {
+    installResolveExecEnvHook({ PLUGIN_SAFE: "yes" });
+    const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir: process.cwd(),
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+      },
+    });
+
+    const result = await tool.execute("call-gateway-invalid-cwd-with-backend-sandbox", {
+      command: "echo ok",
+      workdir: "   ",
+    });
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(mocks.hookRunner?.runResolveExecEnv).not.toHaveBeenCalled();
+    expect(validateWorkdir).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
+  it("lets before_tool_call see invalid wrapped workdirs before failing unchanged params", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async () => ({ PLUGIN_SAFE: "yes" })),
+      runBeforeToolCall: vi.fn(async () => undefined),
+    };
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    const result = await definition.execute(
+      "call-invalid-wrapped-cwd-before-hooks",
+      {
+        command: "echo ok",
+        workdir: "   ",
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+    const text = result.content.find((entry) => entry.type === "text")?.text ?? "";
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(text).toContain('workdir "   " is unavailable or not a directory');
+    expect(mocks.hookRunner.runBeforeToolCall!).toHaveBeenCalledTimes(1);
+    expect(mocks.hookRunner.runResolveExecEnv!).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
+  it("does not validate backend sandbox workdirs before before_tool_call veto", async () => {
+    const validateWorkdir = vi.fn(async (workdir: string) => workdir);
+    mocks.hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_tool_call"),
+      runBeforeToolCall: vi.fn(async () => ({
+        block: true,
+        blockReason: "blocked by test hook",
+      })),
+    };
+    const tool = createExecTool({
+      host: "sandbox",
+      security: "full",
+      ask: "off",
+      sandbox: {
+        containerName: "remote-sandbox-workdir-test",
+        workspaceDir: process.cwd(),
+        containerWorkdir: "/remote/workspace",
+        workdirValidation: "backend",
+        validateWorkdir,
+      },
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    const result = await definition.execute(
+      "call-backend-cwd-vetoed-before-validation",
+      {
+        command: "echo ok",
+        workdir: "/remote/workspace/generated",
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+
+    expect(
+      result.details as { status?: unknown; deniedReason?: unknown } | undefined,
+    ).toMatchObject({
+      status: "blocked",
+      deniedReason: "plugin-before-tool-call",
+    });
+    expect(mocks.hookRunner.runBeforeToolCall!).toHaveBeenCalledOnce();
+    expect(validateWorkdir).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
+  it("lets lazy before_tool_call see invalid workdirs before failing unchanged params", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async () => ({ LAZY_PLUGIN_SAFE: "yes" })),
+      runBeforeToolCall: vi.fn(async () => undefined),
+    };
+
+    const exec = createOpenClawCodingTools({
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+      cwd: process.cwd(),
+      exec: { host: "gateway", security: "full", ask: "off" },
+    }).find((tool) => tool.name === "exec");
+    expect(exec).toBeDefined();
+    const [definition] = toToolDefinitions([exec!], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+      channelId: "chat-1",
+    });
+
+    const result = await definition.execute(
+      "call-invalid-lazy-cwd-before-hooks",
+      {
+        command: "echo ok",
+        workdir: "   ",
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+    const text = result.content.find((entry) => entry.type === "text")?.text ?? "";
+
+    expect((result.details as { status?: unknown } | undefined)?.status).toBe("failed");
+    expect(text).toContain('workdir "   " is unavailable or not a directory');
+    expect(mocks.hookRunner.runBeforeToolCall!).toHaveBeenCalledTimes(1);
+    expect(mocks.hookRunner.runResolveExecEnv!).not.toHaveBeenCalled();
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
+  });
+
+  it("forwards explicit node host workdirs without local gateway validation", async () => {
+    const remoteWorkdir = "/remote/node/workspace";
+    const tool = createExecTool({
+      host: "node",
+      security: "full",
+      ask: "off",
+    });
+
+    await tool.execute("call-node-explicit-cwd", {
+      command: "echo ok",
+      workdir: remoteWorkdir,
+    });
+
+    expect(mocks.nodeHostParams[0]?.workdir).toBe(remoteWorkdir);
+  });
+
   it("keeps plugin env out of before_tool_call params before execution", async () => {
     mocks.hookRunner = {
       hasHooks: vi.fn(
@@ -420,6 +677,57 @@ describe("exec resolve_exec_env hook wiring", () => {
       REQUEST_SAFE: "request",
     });
     expect(mocks.nodeHostParams[0]?.requestedEnv).not.toHaveProperty("GATEWAY_PLUGIN_SAFE");
+  });
+
+  it("lets before_tool_call reroute gateway-invalid workdirs to node host execution", async () => {
+    mocks.hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: string) => hookName === "resolve_exec_env" || hookName === "before_tool_call",
+      ),
+      runResolveExecEnv: vi.fn(async (event: { host: "gateway" | "sandbox" | "node" }) =>
+        event.host === "node" ? { NODE_PLUGIN_SAFE: "node" } : { GATEWAY_PLUGIN_SAFE: "gateway" },
+      ),
+      runBeforeToolCall: vi.fn(async (event: { params: Record<string, unknown> }) => ({
+        params: { ...event.params, host: "node" },
+      })),
+    };
+
+    const tool = createExecTool({
+      host: "auto",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+    const [definition] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:telegram:chat-1",
+    });
+
+    await definition.execute(
+      "call-host-rewrite-with-remote-cwd",
+      {
+        command: "echo ok",
+        env: { REQUEST_SAFE: "request" },
+        workdir: "/remote/node/workspace",
+      },
+      undefined,
+      undefined,
+      testExtensionContext,
+    );
+
+    expect(mocks.hookRunner.runBeforeToolCall!).toHaveBeenCalledOnce();
+    expect(mocks.hookRunner.runResolveExecEnv!).toHaveBeenCalledOnce();
+    expect(mocks.hookRunner.runResolveExecEnv!).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "node" }),
+      expect.anything(),
+    );
+    expect(mocks.nodeHostParams[0]?.requestedEnv).toEqual({
+      NODE_PLUGIN_SAFE: "node",
+      REQUEST_SAFE: "request",
+    });
+    expect(mocks.nodeHostParams[0]?.workdir).toBe("/remote/node/workspace");
+    expect(mocks.gatewayParams).toHaveLength(0);
+    expect(mocks.spawnInputs).toHaveLength(0);
   });
 
   it("lets before_tool_call rewrite host when no resolve_exec_env hook is registered", async () => {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1399,6 +1399,16 @@ export function createExecTool(
       resolution,
     });
   };
+  const shouldDeferResolveExecEnvUntilWorkdirValidated = (params: ExecToolArgs): boolean => {
+    try {
+      return (
+        resolveHostForParams(params) === "sandbox" &&
+        defaults?.sandbox?.workdirValidation === "backend"
+      );
+    } catch {
+      return false;
+    }
+  };
   const prepareParamsWithResolvedExecEnv = async (
     rawArgs: unknown,
     context?: { hookContext?: HookContext },
@@ -1463,6 +1473,9 @@ export function createExecTool(
       const params = await prepareParamsWithResolvedExecWorkdir(args);
       const workdirState = getResolvedExecWorkdirPreparedState(params);
       if (workdirState?.resolution.kind === "unavailable") {
+        return params;
+      }
+      if (shouldDeferResolveExecEnvUntilWorkdirValidated(params)) {
         return params;
       }
       return prepareParamsWithResolvedExecEnv(params, {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1600,6 +1600,8 @@ export function createExecTool(
           ? (resolveExistingWorkdir(rawWorkdir) ?? undefined)
           : resolveWorkdir(rawWorkdir, warnings);
         if (!workdir) {
+          // Workdir availability is a precondition for execution, so fail before
+          // any command-side validation.
           return buildExecForegroundResult({
             outcome: {
               status: "failed",

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1667,6 +1667,7 @@ export function createExecTool(
       if (!params.command) {
         throw new Error("Provide a command to start.");
       }
+      await rejectUnsafeExecControlShellCommand(params.command);
       let workdir: string | undefined;
       let scriptPreflightCwd: string | null = null;
       let containerWorkdir = sandbox?.containerWorkdir;
@@ -1709,7 +1710,6 @@ export function createExecTool(
         if (elevatedRequested) {
           logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
         }
-        await rejectUnsafeExecControlShellCommand(params.command);
         if (!resolveExecEnvPrepared) {
           params = await prepareParamsWithResolvedExecEnv(params);
         }

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -77,7 +77,9 @@ import {
   buildSandboxEnv,
   clampWithDefault,
   coerceEnv,
+  formatUnavailableWorkdirFailure,
   readEnvInt,
+  resolveExistingWorkdir,
   resolveSandboxWorkdir,
   resolveWorkdir,
   truncateMiddle,
@@ -1416,6 +1418,7 @@ export function createExecTool(
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
       const warnings: string[] = [];
+      const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const approvalWarningText = normalizeOptionalString(defaults?.approvalWarningText);
       if (approvalWarningText) {
         warnings.push(approvalWarningText);
@@ -1593,7 +1596,24 @@ export function createExecTool(
         workdir = explicitWorkdir;
       } else {
         const rawWorkdir = explicitWorkdir ?? defaultWorkdir ?? process.cwd();
-        workdir = resolveWorkdir(rawWorkdir, warnings);
+        workdir = explicitWorkdir
+          ? (resolveExistingWorkdir(rawWorkdir) ?? undefined)
+          : resolveWorkdir(rawWorkdir, warnings);
+        if (!workdir) {
+          return buildExecForegroundResult({
+            outcome: {
+              status: "failed",
+              exitCode: null,
+              exitSignal: null,
+              durationMs: 0,
+              aggregated: "",
+              timedOut: false,
+              failureKind: "runtime-error",
+              reason: formatUnavailableWorkdirFailure(rawWorkdir),
+            },
+            warningText: getWarningText(),
+          });
+        }
       }
       await rejectUnsafeExecControlShellCommand(params.command);
 
@@ -1770,7 +1790,6 @@ export function createExecTool(
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
       const effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
-      const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -63,25 +63,28 @@ import {
   DEFAULT_MAX_OUTPUT,
   DEFAULT_PATH,
   DEFAULT_PENDING_MAX_OUTPUT,
+  type ExecProcessHandle,
   type ExecProcessOutcome,
   applyPathPrepend,
   applyShellPath,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
+  buildExecRuntimeErrorOutcome,
   runExecProcess,
   execSchema,
 } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDefaults, ExecToolDetails } from "./bash-tools.exec-types.js";
 import {
+  type ExecWorkdirResolution,
+  formatUnavailableWorkdirFailure,
+  resolveExecWorkdir,
+} from "./bash-tools.exec-workdir.js";
+import {
   buildSandboxEnv,
   clampWithDefault,
   coerceEnv,
-  formatUnavailableWorkdirFailure,
   readEnvInt,
-  resolveExistingWorkdir,
-  resolveSandboxWorkdir,
-  resolveWorkdir,
   truncateMiddle,
 } from "./bash-tools.shared.js";
 import { createModelExecAutoReviewer } from "./exec-auto-reviewer.js";
@@ -140,6 +143,15 @@ type ResolvedExecEnvPreparedState = {
   pluginEnv?: Record<string, string>;
 };
 const resolvedExecEnvPreparedStates = new WeakMap<ExecToolArgs, ResolvedExecEnvPreparedState>();
+type ResolvedExecWorkdirPreparedState = {
+  host: ExecHost;
+  inputWorkdir?: string;
+  resolution: ExecWorkdirResolution;
+};
+const resolvedExecWorkdirPreparedStates = new WeakMap<
+  ExecToolArgs,
+  ResolvedExecWorkdirPreparedState
+>();
 
 const XML_ARG_VALUE_EXEC_PARAM_KEYS = [
   "command",
@@ -187,6 +199,20 @@ function getResolvedExecEnvPreparedState(
 
 function isResolveExecEnvPrepared(params: ExecToolArgs): boolean {
   return Boolean(getResolvedExecEnvPreparedState(params));
+}
+
+function markResolvedExecWorkdirPrepared<T extends ExecToolArgs>(
+  params: T,
+  state: ResolvedExecWorkdirPreparedState,
+): T {
+  resolvedExecWorkdirPreparedStates.set(params, state);
+  return params;
+}
+
+function getResolvedExecWorkdirPreparedState(
+  params: ExecToolArgs,
+): ResolvedExecWorkdirPreparedState | undefined {
+  return resolvedExecWorkdirPreparedStates.get(params);
 }
 
 function buildExecForegroundResult(params: {
@@ -1327,6 +1353,52 @@ export function createExecTool(
       sandboxAvailable: Boolean(defaults?.sandbox),
     }).effectiveHost;
   };
+  const buildUnavailableWorkdirResult = (params: {
+    cwd: string;
+    startedAt?: number;
+    warningText?: string;
+  }) =>
+    buildExecForegroundResult({
+      outcome: buildExecRuntimeErrorOutcome({
+        error: formatUnavailableWorkdirFailure(params.cwd),
+        aggregated: "",
+        durationMs: params.startedAt ? Date.now() - params.startedAt : 0,
+      }),
+      cwd: params.cwd,
+      warningText: params.warningText,
+    });
+  const prepareParamsWithResolvedExecWorkdir = async (rawArgs: unknown): Promise<ExecToolArgs> => {
+    if (typeof rawArgs !== "object" || rawArgs === null || Array.isArray(rawArgs)) {
+      return rawArgs as ExecToolArgs;
+    }
+    const params = stripMalformedXmlArgValueSuffixFromKeys(
+      rawArgs as ExecToolArgs,
+      XML_ARG_VALUE_EXEC_PARAM_KEYS,
+    );
+    let host: ExecHost;
+    try {
+      host = resolveHostForParams(params);
+    } catch {
+      return params;
+    }
+    if (host === "sandbox" && !defaults?.sandbox) {
+      return params;
+    }
+    if (host === "sandbox" && defaults?.sandbox?.workdirValidation === "backend") {
+      return params;
+    }
+    const resolution = await resolveExecWorkdir({
+      host,
+      workdir: params.workdir,
+      defaultCwd: defaults?.cwd,
+      sandbox: defaults?.sandbox,
+    });
+    return markResolvedExecWorkdirPrepared(params, {
+      host,
+      inputWorkdir: params.workdir,
+      resolution,
+    });
+  };
   const prepareParamsWithResolvedExecEnv = async (
     rawArgs: unknown,
     context?: { hookContext?: HookContext },
@@ -1387,33 +1459,57 @@ export function createExecTool(
       return describeExecTool({ agentId, hasCronTool: defaults?.hasCronTool === true });
     },
     parameters: execSchema,
-    prepareBeforeToolCallParams: async (args, context) =>
-      prepareParamsWithResolvedExecEnv(args, {
+    prepareBeforeToolCallParams: async (args, context) => {
+      const params = await prepareParamsWithResolvedExecWorkdir(args);
+      const workdirState = getResolvedExecWorkdirPreparedState(params);
+      if (workdirState?.resolution.kind === "unavailable") {
+        return params;
+      }
+      return prepareParamsWithResolvedExecEnv(params, {
         hookContext: context.hookContext as HookContext | undefined,
-      }),
-    finalizeBeforeToolCallParams: (params, preparedParams) =>
-      (() => {
-        const state = getResolvedExecEnvPreparedState(preparedParams as ExecToolArgs);
-        if (!state) {
-          return params;
-        }
-        const execParams = params as ExecToolArgs;
-        if (state.host && execParams.command && resolveHostForParams(execParams) !== state.host) {
+      });
+    },
+    finalizeBeforeToolCallParams: (params, preparedParams) => {
+      const execParams = params as ExecToolArgs;
+      const envState = getResolvedExecEnvPreparedState(preparedParams as ExecToolArgs);
+      const workdirState = getResolvedExecWorkdirPreparedState(preparedParams as ExecToolArgs);
+      if (!envState && !workdirState) {
+        return params;
+      }
+      let host: ExecHost | undefined;
+      const resolveFinalHost = () => {
+        host ??= resolveHostForParams(execParams);
+        return host;
+      };
+      try {
+        if (envState?.host && execParams.command && resolveFinalHost() !== envState.host) {
           return { ...execParams };
         }
-        return markResolveExecEnvPrepared(execParams, state);
-      })(),
-    execute: async (_toolCallId, args, signal, onUpdate) => {
-      const params = isResolveExecEnvPrepared(args as ExecToolArgs)
-        ? stripMalformedXmlArgValueSuffixFromKeys(
-            args as ExecToolArgs,
-            XML_ARG_VALUE_EXEC_PARAM_KEYS,
-          )
-        : await prepareParamsWithResolvedExecEnv(args);
-
-      if (!params.command) {
-        throw new Error("Provide a command to start.");
+        if (
+          workdirState &&
+          (resolveFinalHost() !== workdirState.host ||
+            execParams.workdir !== workdirState.inputWorkdir)
+        ) {
+          return { ...execParams };
+        }
+      } catch {
+        return { ...execParams };
       }
+      if (envState) {
+        markResolveExecEnvPrepared(execParams, envState);
+      }
+      if (workdirState) {
+        markResolvedExecWorkdirPrepared(execParams, workdirState);
+      }
+      return execParams;
+    },
+    execute: async (_toolCallId, args, signal, onUpdate) => {
+      let params = stripMalformedXmlArgValueSuffixFromKeys(
+        args as ExecToolArgs,
+        XML_ARG_VALUE_EXEC_PARAM_KEYS,
+      );
+      const resolveExecEnvPrepared = isResolveExecEnvPrepared(args as ExecToolArgs);
+      const preparedWorkdirState = getResolvedExecWorkdirPreparedState(params);
 
       const maxOutput = DEFAULT_MAX_OUTPUT;
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
@@ -1423,6 +1519,7 @@ export function createExecTool(
       if (approvalWarningText) {
         warnings.push(approvalWarningText);
       }
+      const startedAt = Date.now();
       let execCommandOverride: string | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
@@ -1494,9 +1591,6 @@ export function createExecTool(
               .join("\n"),
           );
         }
-      }
-      if (elevatedRequested) {
-        logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
       }
       const requestedTarget = requireValidExecTarget(params.host);
       const target = resolveExecTarget({
@@ -1570,259 +1664,268 @@ export function createExecTool(
           ].join("\n"),
         );
       }
-      const explicitWorkdir = normalizeOptionalString(params.workdir);
-      const defaultWorkdir = normalizeOptionalString(defaults?.cwd);
+      if (!params.command) {
+        throw new Error("Provide a command to start.");
+      }
       let workdir: string | undefined;
+      let scriptPreflightCwd: string | null = null;
       let containerWorkdir = sandbox?.containerWorkdir;
-      if (sandbox) {
-        const sandboxWorkdir = explicitWorkdir ?? defaultWorkdir ?? process.cwd();
-        const resolved = await resolveSandboxWorkdir({
-          workdir: sandboxWorkdir,
-          sandbox,
-          warnings,
+      let discardPreparedSandboxWorkdir: (() => void) | null = null;
+      const workdirResolution =
+        preparedWorkdirState?.host === host
+          ? preparedWorkdirState.resolution
+          : await resolveExecWorkdir({
+              host,
+              workdir: params.workdir,
+              defaultCwd: defaults?.cwd,
+              sandbox,
+            });
+      if (workdirResolution.kind === "unavailable") {
+        return buildUnavailableWorkdirResult({
+          cwd: workdirResolution.requestedCwd,
+          startedAt,
+          warningText: warnings.join("\n"),
         });
-        workdir = resolved.hostWorkdir;
-        containerWorkdir = resolved.containerWorkdir;
-      } else if (host === "node") {
-        // For remote node execution, only forward a cwd that was explicitly
-        // requested on the tool call. The gateway's workspace root is wired in as a
-        // local default, but it is not meaningful on the remote node and would
-        // recreate the cross-platform approval failure this path is fixing.
-        // When no explicit cwd was given, the gateway's own
-        // process.cwd() is meaningless on the remote node (especially cross-platform,
-        // e.g. Linux gateway + Windows node) and would cause
-        // "SYSTEM_RUN_DENIED: approval requires an existing canonical cwd".
-        // Passing undefined lets the node use its own default working directory.
-        workdir = explicitWorkdir;
+      }
+      if (workdirResolution.kind === "sandbox") {
+        workdir = workdirResolution.hostCwd;
+        containerWorkdir = workdirResolution.containerCwd;
+        scriptPreflightCwd = workdirResolution.scriptPreflightCwd;
+        if (sandbox?.discardPreparedWorkdir && sandbox.workdirValidation === "backend") {
+          const preparedContainerWorkdir = containerWorkdir;
+          discardPreparedSandboxWorkdir = () => {
+            sandbox.discardPreparedWorkdir?.(preparedContainerWorkdir);
+          };
+        }
+      } else if (workdirResolution.kind === "local") {
+        workdir = workdirResolution.hostCwd;
+        scriptPreflightCwd = workdirResolution.hostCwd;
       } else {
-        const rawWorkdir = explicitWorkdir ?? defaultWorkdir ?? process.cwd();
-        workdir = explicitWorkdir
-          ? (resolveExistingWorkdir(rawWorkdir) ?? undefined)
-          : resolveWorkdir(rawWorkdir, warnings);
-        if (!workdir) {
-          // Workdir availability is a precondition for execution, so fail before
-          // any command-side validation.
-          return buildExecForegroundResult({
-            outcome: {
-              status: "failed",
-              exitCode: null,
-              exitSignal: null,
-              durationMs: 0,
-              aggregated: "",
-              timedOut: false,
-              failureKind: "runtime-error",
-              reason: formatUnavailableWorkdirFailure(rawWorkdir),
-            },
-            warningText: getWarningText(),
+        workdir = workdirResolution.remoteCwd;
+      }
+      let run: ExecProcessHandle;
+      let effectiveTimeout: number;
+      try {
+        if (elevatedRequested) {
+          logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
+        }
+        await rejectUnsafeExecControlShellCommand(params.command);
+        if (!resolveExecEnvPrepared) {
+          params = await prepareParamsWithResolvedExecEnv(params);
+        }
+
+        const inheritedBaseEnv = coerceEnv(process.env);
+        const resolvedExecEnvState = getResolvedExecEnvPreparedState(params);
+        const channelContextEnv = buildChannelContextEnv(defaults?.channelContext);
+        const requestedEnv: Record<string, string> | undefined =
+          params.env !== undefined ||
+          resolvedExecEnvState?.pluginEnv !== undefined ||
+          channelContextEnv !== undefined
+            ? { ...params.env, ...resolvedExecEnvState?.pluginEnv, ...channelContextEnv }
+            : undefined;
+        const hostEnvResult =
+          host === "sandbox"
+            ? null
+            : sanitizeHostExecEnvWithDiagnostics({
+                baseEnv: inheritedBaseEnv,
+                overrides: requestedEnv,
+                blockPathOverrides: true,
+              });
+        if (
+          hostEnvResult &&
+          requestedEnv &&
+          (hostEnvResult.rejectedOverrideBlockedKeys.length > 0 ||
+            hostEnvResult.rejectedOverrideInvalidKeys.length > 0)
+        ) {
+          const blockedKeys = hostEnvResult.rejectedOverrideBlockedKeys;
+          const invalidKeys = hostEnvResult.rejectedOverrideInvalidKeys;
+          const pathBlocked = blockedKeys.includes("PATH");
+          if (pathBlocked && blockedKeys.length === 1 && invalidKeys.length === 0) {
+            throw new Error(
+              "Security Violation: Custom 'PATH' variable is forbidden during host execution.",
+            );
+          }
+          if (blockedKeys.length === 1 && invalidKeys.length === 0) {
+            throw new Error(
+              `Security Violation: Environment variable '${blockedKeys[0]}' is forbidden during host execution.`,
+            );
+          }
+          const details: string[] = [];
+          if (blockedKeys.length > 0) {
+            details.push(`blocked override keys: ${blockedKeys.join(", ")}`);
+          }
+          if (invalidKeys.length > 0) {
+            details.push(`invalid non-portable override keys: ${invalidKeys.join(", ")}`);
+          }
+          const suffix = details.join("; ");
+          if (pathBlocked) {
+            throw new Error(
+              `Security Violation: Custom 'PATH' variable is forbidden during host execution (${suffix}).`,
+            );
+          }
+          throw new Error(`Security Violation: ${suffix}.`);
+        }
+
+        const env =
+          sandbox && host === "sandbox"
+            ? buildSandboxEnv({
+                defaultPath: DEFAULT_PATH,
+                paramsEnv: requestedEnv,
+                sandboxEnv: sandbox.env,
+                containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
+              })
+            : (hostEnvResult?.env ?? inheritedBaseEnv);
+
+        if (!sandbox && host === "gateway" && !requestedEnv?.PATH) {
+          const shellPath = getShellPathFromLoginShell({
+            env: process.env,
+            timeoutMs: resolveShellEnvFallbackTimeoutMs(process.env),
+          });
+          applyShellPath(env, shellPath);
+        }
+
+        // `tools.exec.pathPrepend` is only meaningful when exec runs locally (gateway) or in the sandbox.
+        // Node hosts intentionally ignore request-scoped PATH overrides, so don't pretend this applies.
+        if (host === "node" && defaultPathPrepend.length > 0) {
+          warnings.push(
+            "Warning: tools.exec.pathPrepend is ignored for host=node. Configure PATH on the node host/service instead.",
+          );
+        } else {
+          applyPathPrepend(env, defaultPathPrepend);
+        }
+
+        if (host === "node") {
+          return executeNodeHostCommand({
+            command: params.command,
+            workdir,
+            env,
+            requestedEnv,
+            requestedNode: params.node?.trim(),
+            boundNode: defaults?.node?.trim(),
+            sessionKey: defaults?.sessionKey,
+            sessionId: defaults?.sessionId,
+            sessionStore: defaults?.sessionStore,
+            bashElevated: elevatedDefaults,
+            approvalReviewerDeviceId: defaults?.approvalReviewerDeviceId,
+            turnSourceChannel: defaults?.messageProvider,
+            turnSourceTo: defaults?.currentChannelId,
+            turnSourceAccountId: defaults?.accountId,
+            turnSourceThreadId: defaults?.currentThreadTs,
+            agentId,
+            security,
+            ask,
+            autoReview,
+            autoReviewer,
+            strictInlineEval: defaults?.strictInlineEval,
+            commandHighlighting: defaults?.commandHighlighting,
+            trigger: defaults?.trigger,
+            timeoutSec: params.timeout,
+            defaultTimeoutSec,
+            approvalRunningNoticeMs,
+            warnings,
+            notifySessionKey,
+            notifyOnExit,
+            trustedSafeBinDirs,
           });
         }
-      }
-      await rejectUnsafeExecControlShellCommand(params.command);
 
-      const inheritedBaseEnv = coerceEnv(process.env);
-      const resolvedExecEnvState = getResolvedExecEnvPreparedState(params);
-      const channelContextEnv = buildChannelContextEnv(defaults?.channelContext);
-      const requestedEnv: Record<string, string> | undefined =
-        params.env !== undefined ||
-        resolvedExecEnvState?.pluginEnv !== undefined ||
-        channelContextEnv !== undefined
-          ? { ...params.env, ...resolvedExecEnvState?.pluginEnv, ...channelContextEnv }
-          : undefined;
-      const hostEnvResult =
-        host === "sandbox"
-          ? null
-          : sanitizeHostExecEnvWithDiagnostics({
-              baseEnv: inheritedBaseEnv,
-              overrides: requestedEnv,
-              blockPathOverrides: true,
-            });
-      if (
-        hostEnvResult &&
-        requestedEnv &&
-        (hostEnvResult.rejectedOverrideBlockedKeys.length > 0 ||
-          hostEnvResult.rejectedOverrideInvalidKeys.length > 0)
-      ) {
-        const blockedKeys = hostEnvResult.rejectedOverrideBlockedKeys;
-        const invalidKeys = hostEnvResult.rejectedOverrideInvalidKeys;
-        const pathBlocked = blockedKeys.includes("PATH");
-        if (pathBlocked && blockedKeys.length === 1 && invalidKeys.length === 0) {
-          throw new Error(
-            "Security Violation: Custom 'PATH' variable is forbidden during host execution.",
-          );
+        if (!workdir) {
+          throw new Error("exec internal error: local execution requires a resolved workdir");
         }
-        if (blockedKeys.length === 1 && invalidKeys.length === 0) {
-          throw new Error(
-            `Security Violation: Environment variable '${blockedKeys[0]}' is forbidden during host execution.`,
-          );
-        }
-        const details: string[] = [];
-        if (blockedKeys.length > 0) {
-          details.push(`blocked override keys: ${blockedKeys.join(", ")}`);
-        }
-        if (invalidKeys.length > 0) {
-          details.push(`invalid non-portable override keys: ${invalidKeys.join(", ")}`);
-        }
-        const suffix = details.join("; ");
-        if (pathBlocked) {
-          throw new Error(
-            `Security Violation: Custom 'PATH' variable is forbidden during host execution (${suffix}).`,
-          );
-        }
-        throw new Error(`Security Violation: ${suffix}.`);
-      }
 
-      const env =
-        sandbox && host === "sandbox"
-          ? buildSandboxEnv({
-              defaultPath: DEFAULT_PATH,
-              paramsEnv: requestedEnv,
-              sandboxEnv: sandbox.env,
-              containerWorkdir: containerWorkdir ?? sandbox.containerWorkdir,
-            })
-          : (hostEnvResult?.env ?? inheritedBaseEnv);
+        if (host === "gateway" && !bypassApprovals) {
+          const gatewayResult = await processGatewayAllowlist({
+            command: params.command,
+            workdir,
+            env,
+            pathPrepend: defaultPathPrepend,
+            requestedEnv,
+            pty: params.pty === true && !sandbox,
+            timeoutSec: params.timeout,
+            defaultTimeoutSec,
+            security,
+            ask,
+            autoReview,
+            autoReviewer,
+            safeBins,
+            safeBinProfiles,
+            strictInlineEval: defaults?.strictInlineEval,
+            commandHighlighting: defaults?.commandHighlighting,
+            trigger: defaults?.trigger,
+            agentId,
+            sessionKey: defaults?.sessionKey,
+            sessionId: defaults?.sessionId,
+            sessionStore: defaults?.sessionStore,
+            bashElevated: elevatedDefaults,
+            approvalReviewerDeviceId: defaults?.approvalReviewerDeviceId,
+            turnSourceChannel: defaults?.messageProvider,
+            turnSourceTo: defaults?.currentChannelId,
+            turnSourceAccountId: defaults?.accountId,
+            turnSourceThreadId: defaults?.currentThreadTs,
+            scopeKey: defaults?.scopeKey,
+            approvalFollowupText: defaults?.approvalFollowupText,
+            approvalFollowup: defaults?.approvalFollowup,
+            approvalFollowupMode: defaults?.approvalFollowupMode,
+            warnings,
+            notifySessionKey,
+            approvalRunningNoticeMs,
+            maxOutput,
+            pendingMaxOutput,
+            trustedSafeBinDirs,
+          });
+          if (gatewayResult.pendingResult) {
+            return gatewayResult.pendingResult;
+          }
+          if (gatewayResult.deniedResult) {
+            return gatewayResult.deniedResult;
+          }
+          execCommandOverride = gatewayResult.execCommandOverride;
+          if (gatewayResult.allowWithoutEnforcedCommand) {
+            execCommandOverride = undefined;
+          }
+        }
 
-      if (!sandbox && host === "gateway" && !requestedEnv?.PATH) {
-        const shellPath = getShellPathFromLoginShell({
-          env: process.env,
-          timeoutMs: resolveShellEnvFallbackTimeoutMs(process.env),
-        });
-        applyShellPath(env, shellPath);
-      }
+        const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
+        effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
+        const usePty = params.pty === true && !sandbox;
 
-      // `tools.exec.pathPrepend` is only meaningful when exec runs locally (gateway) or in the sandbox.
-      // Node hosts intentionally ignore request-scoped PATH overrides, so don't pretend this applies.
-      if (host === "node" && defaultPathPrepend.length > 0) {
-        warnings.push(
-          "Warning: tools.exec.pathPrepend is ignored for host=node. Configure PATH on the node host/service instead.",
-        );
-      } else {
-        applyPathPrepend(env, defaultPathPrepend);
-      }
+        // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
+        // before we execute and burn tokens in cron loops.
+        if (scriptPreflightCwd && !shouldSkipExecScriptPreflight({ host, security, ask })) {
+          await validateScriptFileForShellBleed({
+            command: params.command,
+            workdir: scriptPreflightCwd,
+          });
+        }
 
-      if (host === "node") {
-        return executeNodeHostCommand({
+        run = await runExecProcess({
           command: params.command,
-          workdir,
-          env,
-          requestedEnv,
-          requestedNode: params.node?.trim(),
-          boundNode: defaults?.node?.trim(),
-          sessionKey: defaults?.sessionKey,
-          sessionId: defaults?.sessionId,
-          sessionStore: defaults?.sessionStore,
-          bashElevated: elevatedDefaults,
-          approvalReviewerDeviceId: defaults?.approvalReviewerDeviceId,
-          turnSourceChannel: defaults?.messageProvider,
-          turnSourceTo: defaults?.currentChannelId,
-          turnSourceAccountId: defaults?.accountId,
-          turnSourceThreadId: defaults?.currentThreadTs,
-          agentId,
-          security,
-          ask,
-          autoReview,
-          autoReviewer,
-          strictInlineEval: defaults?.strictInlineEval,
-          commandHighlighting: defaults?.commandHighlighting,
-          trigger: defaults?.trigger,
-          timeoutSec: params.timeout,
-          defaultTimeoutSec,
-          approvalRunningNoticeMs,
-          warnings,
-          notifySessionKey,
-          notifyOnExit,
-          trustedSafeBinDirs,
-        });
-      }
-
-      if (!workdir) {
-        throw new Error("exec internal error: local execution requires a resolved workdir");
-      }
-
-      if (host === "gateway" && !bypassApprovals) {
-        const gatewayResult = await processGatewayAllowlist({
-          command: params.command,
+          execCommand: execCommandOverride,
           workdir,
           env,
           pathPrepend: defaultPathPrepend,
-          requestedEnv,
-          pty: params.pty === true && !sandbox,
-          timeoutSec: params.timeout,
-          defaultTimeoutSec,
-          security,
-          ask,
-          autoReview,
-          autoReviewer,
-          safeBins,
-          safeBinProfiles,
-          strictInlineEval: defaults?.strictInlineEval,
-          commandHighlighting: defaults?.commandHighlighting,
-          trigger: defaults?.trigger,
-          agentId,
-          sessionKey: defaults?.sessionKey,
-          sessionId: defaults?.sessionId,
-          sessionStore: defaults?.sessionStore,
-          bashElevated: elevatedDefaults,
-          approvalReviewerDeviceId: defaults?.approvalReviewerDeviceId,
-          turnSourceChannel: defaults?.messageProvider,
-          turnSourceTo: defaults?.currentChannelId,
-          turnSourceAccountId: defaults?.accountId,
-          turnSourceThreadId: defaults?.currentThreadTs,
-          scopeKey: defaults?.scopeKey,
-          approvalFollowupText: defaults?.approvalFollowupText,
-          approvalFollowup: defaults?.approvalFollowup,
-          approvalFollowupMode: defaults?.approvalFollowupMode,
+          sandbox,
+          containerWorkdir,
+          usePty,
           warnings,
-          notifySessionKey,
-          approvalRunningNoticeMs,
           maxOutput,
           pendingMaxOutput,
-          trustedSafeBinDirs,
+          notifyOnExit,
+          notifyOnExitEmptySuccess,
+          scopeKey: defaults?.scopeKey,
+          sessionKey: notifySessionKey,
+          mainKey: defaults?.mainKey,
+          sessionScope: defaults?.sessionScope,
+          eventRouting: defaults?.eventRouting,
+          notifyDeliveryContext,
+          timeoutSec: effectiveTimeout,
+          onUpdate,
         });
-        if (gatewayResult.pendingResult) {
-          return gatewayResult.pendingResult;
-        }
-        if (gatewayResult.deniedResult) {
-          return gatewayResult.deniedResult;
-        }
-        execCommandOverride = gatewayResult.execCommandOverride;
-        if (gatewayResult.allowWithoutEnforcedCommand) {
-          execCommandOverride = undefined;
-        }
+        discardPreparedSandboxWorkdir = null;
+      } catch (error) {
+        discardPreparedSandboxWorkdir?.();
+        throw error;
       }
-
-      const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
-      const effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
-      const usePty = params.pty === true && !sandbox;
-
-      // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
-      // before we execute and burn tokens in cron loops.
-      if (!shouldSkipExecScriptPreflight({ host, security, ask })) {
-        await validateScriptFileForShellBleed({ command: params.command, workdir });
-      }
-
-      const run = await runExecProcess({
-        command: params.command,
-        execCommand: execCommandOverride,
-        workdir,
-        env,
-        pathPrepend: defaultPathPrepend,
-        sandbox,
-        containerWorkdir,
-        usePty,
-        warnings,
-        maxOutput,
-        pendingMaxOutput,
-        notifyOnExit,
-        notifyOnExitEmptySuccess,
-        scopeKey: defaults?.scopeKey,
-        sessionKey: notifySessionKey,
-        mainKey: defaults?.mainKey,
-        sessionScope: defaults?.sessionScope,
-        eventRouting: defaults?.eventRouting,
-        notifyDeliveryContext,
-        timeoutSec: effectiveTimeout,
-        onUpdate,
-      });
 
       let yielded = false;
       let yieldTimer: NodeJS.Timeout | null = null;

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -12,7 +12,12 @@ const EXEC_TOOL_HOST_VALUES = ["auto", "sandbox", "gateway", "node"] as const;
 /** Parameters accepted by the exec tool. */
 export const execSchema = Type.Object({
   command: Type.String({ description: "Shell command to execute" }),
-  workdir: Type.Optional(Type.String({ description: "Working directory (defaults to cwd)" })),
+  workdir: Type.Optional(
+    Type.String({
+      description:
+        "Working directory. Blank/whitespace values are invalid; omit to use the default cwd.",
+    }),
+  ),
   env: Type.Optional(Type.Record(Type.String(), Type.String())),
   yieldMs: Type.Optional(
     Type.Number({

--- a/src/agents/bash-tools.shared.test.ts
+++ b/src/agents/bash-tools.shared.test.ts
@@ -1,24 +1,11 @@
 /**
  * Shared bash-tool helper tests.
- * Covers strict env parsing and sandbox workdir mapping between container and
- * host workspace paths.
+ * Covers strict env parsing and compact session labels.
  */
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deriveSessionName, readEnvInt, resolveSandboxWorkdir } from "./bash-tools.shared.js";
+import { deriveSessionName, readEnvInt } from "./bash-tools.shared.js";
 
-async function withTempDir(run: (dir: string) => Promise<void>) {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-bash-workdir-"));
-  try {
-    await run(dir);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-}
-
-describe("resolveSandboxWorkdir", () => {
+describe("readEnvInt", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -55,67 +42,6 @@ describe("resolveSandboxWorkdir", () => {
     vi.stubEnv("OPENCLAW_BASH_YIELD_MS", "9007199254740993");
 
     expect(readEnvInt("OPENCLAW_BASH_YIELD_MS", "PI_BASH_YIELD_MS")).toBeUndefined();
-  });
-
-  it("maps container root workdir to host workspace", async () => {
-    await withTempDir(async (workspaceDir) => {
-      const warnings: string[] = [];
-      const resolved = await resolveSandboxWorkdir({
-        workdir: "/workspace",
-        sandbox: {
-          containerName: "sandbox-1",
-          workspaceDir,
-          containerWorkdir: "/workspace",
-        },
-        warnings,
-      });
-
-      expect(resolved.hostWorkdir).toBe(workspaceDir);
-      expect(resolved.containerWorkdir).toBe("/workspace");
-      expect(warnings).toStrictEqual([]);
-    });
-  });
-
-  it("maps nested container workdir under the container workspace", async () => {
-    await withTempDir(async (workspaceDir) => {
-      const nested = path.join(workspaceDir, "scripts", "runner");
-      await mkdir(nested, { recursive: true });
-      const warnings: string[] = [];
-      const resolved = await resolveSandboxWorkdir({
-        workdir: "/workspace/scripts/runner",
-        sandbox: {
-          containerName: "sandbox-2",
-          workspaceDir,
-          containerWorkdir: "/workspace",
-        },
-        warnings,
-      });
-
-      expect(resolved.hostWorkdir).toBe(nested);
-      expect(resolved.containerWorkdir).toBe("/workspace/scripts/runner");
-      expect(warnings).toStrictEqual([]);
-    });
-  });
-
-  it("supports custom container workdir prefixes", async () => {
-    await withTempDir(async (workspaceDir) => {
-      const nested = path.join(workspaceDir, "project");
-      await mkdir(nested, { recursive: true });
-      const warnings: string[] = [];
-      const resolved = await resolveSandboxWorkdir({
-        workdir: "/sandbox-root/project",
-        sandbox: {
-          containerName: "sandbox-3",
-          workspaceDir,
-          containerWorkdir: "/sandbox-root",
-        },
-        warnings,
-      });
-
-      expect(resolved.hostWorkdir).toBe(nested);
-      expect(resolved.containerWorkdir).toBe("/sandbox-root/project");
-      expect(warnings).toStrictEqual([]);
-    });
   });
 });
 

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -1,16 +1,15 @@
 /**
  * Shared helpers for bash exec/process tools.
- * Owns sandbox workdir mapping, Docker exec argument construction, output
- * slicing, environment coercion, and compact session labels.
+ * Owns Docker exec argument construction, output slicing, environment
+ * coercion, and compact session labels.
  */
-import { existsSync, statSync } from "node:fs";
-import fs from "node:fs/promises";
-import { homedir } from "node:os";
-import path from "node:path";
 import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion";
 import { sliceUtf16Safe } from "../utils.js";
-import { assertSandboxPath } from "./sandbox-paths.js";
-import type { SandboxBackendExecSpec } from "./sandbox/backend-handle.types.js";
+import type {
+  SandboxBackendExecSpec,
+  SandboxBackendWorkdirValidation,
+  SandboxBackendWorkdirValidator,
+} from "./sandbox/backend-handle.types.js";
 
 const CHUNK_LIMIT = 8 * 1024;
 
@@ -19,6 +18,10 @@ export type BashSandboxConfig = {
   containerName: string;
   workspaceDir: string;
   containerWorkdir: string;
+  workdirValidation?: SandboxBackendWorkdirValidation;
+  validateWorkdir?: SandboxBackendWorkdirValidator;
+  discardPreparedWorkdir?: (workdir: string) => void;
+  workdirRoots?: readonly string[];
   env?: Record<string, string>;
   buildExecSpec?: (params: {
     command: string;
@@ -107,117 +110,6 @@ export function buildDockerExecArgs(params: {
   // Use absolute path for sh to avoid dependency on PATH resolution during exec.
   args.push(params.containerName, "/bin/sh", "-lc", `${pathExport}${params.command}`);
   return args;
-}
-
-/** Resolves a requested workdir to both host and container paths for a sandbox. */
-export async function resolveSandboxWorkdir(params: {
-  workdir: string;
-  sandbox: BashSandboxConfig;
-  warnings: string[];
-}) {
-  const fallback = params.sandbox.workspaceDir;
-  const mappedHostWorkdir = mapContainerWorkdirToHost({
-    workdir: params.workdir,
-    sandbox: params.sandbox,
-  });
-  const candidateWorkdir = mappedHostWorkdir ?? params.workdir;
-  try {
-    const resolved = await assertSandboxPath({
-      filePath: candidateWorkdir,
-      cwd: process.cwd(),
-      root: params.sandbox.workspaceDir,
-    });
-    const stats = await fs.stat(resolved.resolved);
-    if (!stats.isDirectory()) {
-      throw new Error("workdir is not a directory");
-    }
-    const relative = resolved.relative
-      ? resolved.relative.split(path.sep).join(path.posix.sep)
-      : "";
-    const containerWorkdir = relative
-      ? path.posix.join(params.sandbox.containerWorkdir, relative)
-      : params.sandbox.containerWorkdir;
-    return { hostWorkdir: resolved.resolved, containerWorkdir };
-  } catch {
-    params.warnings.push(
-      `Warning: workdir "${params.workdir}" is unavailable; using "${fallback}".`,
-    );
-    return {
-      hostWorkdir: fallback,
-      containerWorkdir: params.sandbox.containerWorkdir,
-    };
-  }
-}
-
-function mapContainerWorkdirToHost(params: {
-  workdir: string;
-  sandbox: BashSandboxConfig;
-}): string | undefined {
-  const workdir = normalizeContainerPath(params.workdir);
-  const containerRoot = normalizeContainerPath(params.sandbox.containerWorkdir);
-  if (containerRoot === ".") {
-    return undefined;
-  }
-  if (workdir === containerRoot) {
-    return path.resolve(params.sandbox.workspaceDir);
-  }
-  if (!workdir.startsWith(`${containerRoot}/`)) {
-    return undefined;
-  }
-  const rel = workdir
-    .slice(containerRoot.length + 1)
-    .split("/")
-    .filter(Boolean);
-  return path.resolve(params.sandbox.workspaceDir, ...rel);
-}
-
-function normalizeContainerPath(input: string): string {
-  const normalized = input.trim().replace(/\\/g, "/");
-  if (!normalized) {
-    return ".";
-  }
-  return path.posix.normalize(normalized);
-}
-
-/** Returns a host workdir only when it exists and is a directory. */
-export function resolveExistingWorkdir(workdir: string): string | null {
-  try {
-    const stats = statSync(workdir);
-    if (stats.isDirectory()) {
-      return workdir;
-    }
-  } catch {
-    // caller decides whether unavailable workdirs should fail or fall back
-  }
-  return null;
-}
-
-export function formatUnavailableWorkdirFailure(workdir: string) {
-  return [
-    `workdir "${workdir}" not found: command was not executed.`,
-    'workdir is treated as a literal path; shell expansions such as "~" are not applied. Use an existing path or omit workdir.',
-  ].join(" ");
-}
-
-/** Resolves a host workdir, falling back to a safe cwd/home path with a warning. */
-export function resolveWorkdir(workdir: string, warnings: string[]) {
-  const current = safeCwd();
-  const fallback = current ?? homedir();
-  const resolved = resolveExistingWorkdir(workdir);
-  if (resolved) {
-    return resolved;
-  }
-  warnings.push(`Warning: workdir "${workdir}" is unavailable; using "${fallback}".`);
-  return fallback;
-}
-
-function safeCwd() {
-  try {
-    const cwd = process.cwd();
-    return existsSync(cwd) ? cwd : null;
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -193,7 +193,10 @@ export function resolveExistingWorkdir(workdir: string): string | null {
 }
 
 export function formatUnavailableWorkdirFailure(workdir: string) {
-  return `workdir "${workdir}" is unavailable; command was not executed.`;
+  return [
+    `workdir "${workdir}" not found: command was not executed.`,
+    'workdir is treated as a literal path; shell expansions such as "~" are not applied. Use an existing path or omit workdir.',
+  ].join(" ");
 }
 
 /** Resolves a host workdir, falling back to a safe cwd/home path with a warning. */

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -179,17 +179,30 @@ function normalizeContainerPath(input: string): string {
   return path.posix.normalize(normalized);
 }
 
-/** Resolves a host workdir, falling back to a safe cwd/home path with a warning. */
-export function resolveWorkdir(workdir: string, warnings: string[]) {
-  const current = safeCwd();
-  const fallback = current ?? homedir();
+/** Returns a host workdir only when it exists and is a directory. */
+export function resolveExistingWorkdir(workdir: string): string | null {
   try {
     const stats = statSync(workdir);
     if (stats.isDirectory()) {
       return workdir;
     }
   } catch {
-    // ignore, fallback below
+    // caller decides whether unavailable workdirs should fail or fall back
+  }
+  return null;
+}
+
+export function formatUnavailableWorkdirFailure(workdir: string) {
+  return `workdir "${workdir}" is unavailable; command was not executed.`;
+}
+
+/** Resolves a host workdir, falling back to a safe cwd/home path with a warning. */
+export function resolveWorkdir(workdir: string, warnings: string[]) {
+  const current = safeCwd();
+  const fallback = current ?? homedir();
+  const resolved = resolveExistingWorkdir(workdir);
+  if (resolved) {
+    return resolved;
   }
   warnings.push(`Warning: workdir "${workdir}" is unavailable; using "${fallback}".`);
   return fallback;

--- a/src/agents/sandbox.ts
+++ b/src/agents/sandbox.ts
@@ -43,6 +43,7 @@ export { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-
 export type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./sandbox/fs-bridge.js";
 export {
   buildExecRemoteCommand,
+  buildRemoteWorkdirValidationCommand,
   buildRemoteCommand,
   buildSshSandboxArgv,
   buildValidatedExecRemoteCommand,
@@ -52,6 +53,7 @@ export {
   runSshSandboxCommand,
   shellEscape,
   uploadDirectoryToSshTarget,
+  VALIDATE_REMOTE_WORKDIR_SCRIPT,
 } from "./sandbox/ssh.js";
 export { sanitizeEnvVars } from "./sandbox/sanitize-env-vars.js";
 export { createRemoteShellSandboxFsBridge } from "./sandbox/remote-fs-bridge.js";
@@ -68,9 +70,12 @@ export type {
   SandboxBackendHandle,
   SandboxBackendId,
   SandboxBackendManager,
+  SandboxBackendPreparedWorkdirDiscarder,
   SandboxBackendRegistration,
   SandboxBackendRuntimeInfo,
+  SandboxBackendWorkdirValidation,
   SandboxBackendWorkdirResolver,
+  SandboxBackendWorkdirValidator,
 } from "./sandbox/backend.js";
 export type { RemoteShellSandboxHandle } from "./sandbox/remote-fs-bridge.js";
 export type {

--- a/src/agents/sandbox/backend-handle.types.ts
+++ b/src/agents/sandbox/backend-handle.types.ts
@@ -67,7 +67,8 @@ export type SandboxBackendHandle = {
   /**
    * Remote backends own cwd existence checks because valid runtime paths may
    * not exist in the local workspace mirror. Backend validation must be paired
-   * with validateWorkdir so cwd is proved before exec hooks and launch.
+   * with validateWorkdir so cwd is proved after before_tool_call adjustments
+   * and before env resolution, approval, preflight, and launch.
    */
   workdirValidation?: SandboxBackendWorkdirValidation;
   validateWorkdir?: SandboxBackendWorkdirValidator;

--- a/src/agents/sandbox/backend-handle.types.ts
+++ b/src/agents/sandbox/backend-handle.types.ts
@@ -18,6 +18,11 @@ export type SandboxBackendExecSpec = {
   finalizeToken?: unknown;
 };
 
+export type SandboxBackendWorkdirValidation = "host" | "backend";
+
+export type SandboxBackendWorkdirValidator = (workdir: string) => Promise<string | null>;
+export type SandboxBackendPreparedWorkdirDiscarder = (workdir: string) => void;
+
 /** Parameters for backend-managed shell commands used by fs bridges and probes. */
 export type SandboxBackendCommandParams = {
   script: string;
@@ -59,6 +64,17 @@ export type SandboxBackendHandle = {
   env?: Record<string, string>;
   configLabel?: string;
   configLabelKind?: string;
+  /**
+   * Remote backends own cwd existence checks because valid runtime paths may
+   * not exist in the local workspace mirror. Backend validation must be paired
+   * with validateWorkdir so cwd is proved before exec hooks and launch.
+   */
+  workdirValidation?: SandboxBackendWorkdirValidation;
+  validateWorkdir?: SandboxBackendWorkdirValidator;
+  /** Discard one-shot state created while validating a backend-owned cwd. */
+  discardPreparedWorkdir?: SandboxBackendPreparedWorkdirDiscarder;
+  /** Remote cwd roots managed by backend validation. Defaults to workdir. */
+  workdirRoots?: readonly string[];
   capabilities?: {
     browser?: boolean;
   };

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -20,6 +20,7 @@ export type {
   SandboxBackendManager,
   SandboxBackendRegistration,
   SandboxBackendRuntimeInfo,
+  SandboxBackendWorkdirValidation,
   SandboxBackendWorkdirResolver,
 } from "./backend.types.js";
 export type {
@@ -27,6 +28,8 @@ export type {
   SandboxBackendCommandResult,
   SandboxBackendExecSpec,
   SandboxBackendHandle,
+  SandboxBackendPreparedWorkdirDiscarder,
+  SandboxBackendWorkdirValidator,
 } from "./backend-handle.types.js";
 
 const SANDBOX_BACKEND_FACTORIES_STATE_KEY = Symbol.for("openclaw.sandboxBackendFactories");

--- a/src/agents/sandbox/backend.types.ts
+++ b/src/agents/sandbox/backend.types.ts
@@ -68,5 +68,8 @@ export type {
   SandboxBackendCommandParams,
   SandboxBackendCommandResult,
   SandboxBackendExecSpec,
+  SandboxBackendPreparedWorkdirDiscarder,
+  SandboxBackendWorkdirValidation,
+  SandboxBackendWorkdirValidator,
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -33,7 +33,8 @@ vi.mock("./ssh.js", async () => {
   };
 });
 
-const { createSshSandboxBackend, sshSandboxBackendManager } = await import("./ssh-backend.js");
+const { createSshSandboxBackend, resolveSshRuntimePaths, sshSandboxBackendManager } =
+  await import("./ssh-backend.js");
 const tempDirs: string[] = [];
 
 async function createTempDir(prefix: string): Promise<string> {
@@ -339,6 +340,173 @@ describe("ssh sandbox backend", () => {
     });
     expect(sshMocks.createSshSandboxSessionFromSettings).toHaveBeenCalledTimes(2);
     expect(sshMocks.disposeSshSandboxSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("validates remote workdirs before exec accepts backend-owned cwd", async () => {
+    sshMocks.runSshSandboxCommand
+      .mockResolvedValueOnce({
+        stdout: Buffer.from("1\n"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.from("/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/workspace/src\n"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from("remote directory not found\n"),
+        code: 1,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.from("/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/agent/src\n"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      });
+
+    const backend = await createSshSandboxBackend({
+      sessionKey: "agent:worker:task",
+      scopeKey: "agent:worker",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg: createBackendSandboxConfig({
+        target: "peter@example.com:2222",
+      }),
+    });
+
+    await expect(
+      backend.validateWorkdir?.(
+        "/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/workspace/src",
+      ),
+    ).resolves.toBe("/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/workspace/src");
+    await expect(
+      backend.validateWorkdir?.(
+        "/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/workspace/missing",
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      backend.validateWorkdir?.("/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/agent/src"),
+    ).resolves.toBe("/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/agent/src");
+
+    const validationCommand = String(requireSshRunCommandParams(1).remoteCommand);
+    expect(validationCommand).toContain("openclaw-validate-workdir");
+    expect(validationCommand).toContain("remote directory must stay under root");
+    const agentValidationCommand = String(requireSshRunCommandParams(3).remoteCommand);
+    expect(agentValidationCommand).toContain(
+      "/remote/openclaw/openclaw-ssh-agent-worker-abcd1234/agent",
+    );
+  });
+
+  it("refreshes materialized skills before validating a skills workdir", async () => {
+    const skillsWorkspaceDir = await createTempDir("openclaw-ssh-skills-");
+    await fs.mkdir(path.join(skillsWorkspaceDir, "skills", "demo"), { recursive: true });
+    const runtimePaths = resolveSshRuntimePaths("/remote/openclaw", "agent:worker");
+    const skillsWorkdir = path.posix.join(runtimePaths.remoteSkillsWorkspaceDir, "skills", "demo");
+    sshMocks.runSshSandboxCommand
+      .mockResolvedValueOnce({
+        stdout: Buffer.from("1\n"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.from(`${skillsWorkdir}\n`),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      });
+
+    const backend = await createSshSandboxBackend({
+      sessionKey: "agent:worker:task",
+      scopeKey: "agent:worker",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      skillsWorkspaceDir,
+      cfg: createBackendSandboxConfig({
+        target: "peter@example.com:2222",
+      }),
+    });
+
+    await expect(backend.validateWorkdir?.(skillsWorkdir)).resolves.toBe(skillsWorkdir);
+    const execSpec = await backend.buildExecSpec({
+      command: "pwd",
+      workdir: skillsWorkdir,
+      env: {},
+      usePty: false,
+    });
+
+    expect(sshMocks.uploadDirectoryToSshTarget).toHaveBeenCalledOnce();
+    const skillsUploadParams = requireSshUploadParams(0, "skills upload params");
+    expect(skillsUploadParams.localDir).toBe(skillsWorkspaceDir);
+    expect(skillsUploadParams.remoteDir).toBe(runtimePaths.remoteSkillsWorkspaceDir);
+    expect(execSpec.argv.at(-1)).toContain(skillsWorkdir);
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
+  });
+
+  it("discards validated materialized skills refreshes that do not launch", async () => {
+    const skillsWorkspaceDir = await createTempDir("openclaw-ssh-skills-");
+    await fs.mkdir(path.join(skillsWorkspaceDir, "skills", "demo"), { recursive: true });
+    const runtimePaths = resolveSshRuntimePaths("/remote/openclaw", "agent:worker");
+    const skillsWorkdir = path.posix.join(runtimePaths.remoteSkillsWorkspaceDir, "skills", "demo");
+    sshMocks.runSshSandboxCommand
+      .mockResolvedValueOnce({
+        stdout: Buffer.from("1\n"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.from(`${skillsWorkdir}\n`),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      });
+
+    const backend = await createSshSandboxBackend({
+      sessionKey: "agent:worker:task",
+      scopeKey: "agent:worker",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      skillsWorkspaceDir,
+      cfg: createBackendSandboxConfig({
+        target: "peter@example.com:2222",
+      }),
+    });
+
+    await expect(backend.validateWorkdir?.(skillsWorkdir)).resolves.toBe(skillsWorkdir);
+    backend.discardPreparedWorkdir?.(skillsWorkdir);
+
+    const execSpec = await backend.buildExecSpec({
+      command: "pwd",
+      workdir: skillsWorkdir,
+      env: {},
+      usePty: false,
+    });
+
+    expect(sshMocks.uploadDirectoryToSshTarget).toHaveBeenCalledTimes(2);
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: execSpec.finalizeToken,
+    });
   });
 
   it("refreshes materialized skills before each exec and remote fs command", async () => {

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -23,6 +23,7 @@ import {
 import { sanitizeEnvVars } from "./sanitize-env-vars.js";
 import {
   buildRemoteCommand,
+  buildRemoteWorkdirValidationCommand,
   buildSshSandboxArgv,
   buildValidatedExecRemoteCommand,
   createSshSandboxSessionFromSettings,
@@ -132,6 +133,7 @@ export async function createSshSandboxBackend(
 
 class SshSandboxBackendImpl {
   private ensurePromise: Promise<void> | null = null;
+  private refreshedSkillsForNextExecWorkdir: string | null = null;
 
   constructor(
     private readonly params: {
@@ -150,18 +152,28 @@ class SshSandboxBackendImpl {
       env: this.params.createParams.cfg.docker.env,
       configLabel: this.params.target,
       configLabelKind: "Target",
+      workdirValidation: "backend",
+      validateWorkdir: async (workdir) => await this.validateWorkdir(workdir),
+      discardPreparedWorkdir: (workdir) => this.discardPreparedWorkdir(workdir),
+      workdirRoots: [
+        this.params.runtimePaths.remoteWorkspaceDir,
+        this.params.runtimePaths.remoteAgentWorkspaceDir,
+      ],
       remoteWorkspaceDir: this.params.runtimePaths.remoteWorkspaceDir,
       remoteAgentWorkspaceDir: this.params.runtimePaths.remoteAgentWorkspaceDir,
       buildExecSpec: async ({ command, workdir, env, usePty }) => {
+        const remoteWorkdir = workdir ?? this.params.runtimePaths.remoteWorkspaceDir;
         const remoteCommand = buildValidatedExecRemoteCommand({
           command,
-          workdir: workdir ?? this.params.runtimePaths.remoteWorkspaceDir,
+          workdir: remoteWorkdir,
           env,
         });
         await this.ensureRuntime();
         const sshSession = await this.createSession();
         try {
-          await this.refreshRemoteSkillsWorkspace(sshSession);
+          if (!this.consumeRefreshedSkillsForNextExec(remoteWorkdir)) {
+            await this.refreshRemoteSkillsWorkspace(sshSession);
+          }
           return {
             argv: buildSshSandboxArgv({
               session: sshSession,
@@ -252,6 +264,68 @@ class SshSandboxBackendImpl {
     }
   }
 
+  private async validateWorkdir(workdir: string): Promise<string | null> {
+    await this.ensureRuntime();
+    const session = await this.createSession();
+    let refreshedSkillsForWorkdir: string | null = null;
+    try {
+      if (isRemotePathInsideRoot(this.params.runtimePaths.remoteSkillsWorkspaceDir, workdir)) {
+        await this.refreshRemoteSkillsWorkspace(session);
+        refreshedSkillsForWorkdir = workdir;
+        this.refreshedSkillsForNextExecWorkdir = workdir;
+      }
+      const result = await runSshSandboxCommand({
+        session,
+        remoteCommand: buildRemoteWorkdirValidationCommand({
+          workdir,
+          root: this.resolveWorkdirValidationRoot(workdir),
+        }),
+        allowFailure: true,
+      });
+      const resolvedWorkdir = result.code === 0 ? result.stdout.toString("utf8").trim() : "";
+      if (refreshedSkillsForWorkdir) {
+        this.refreshedSkillsForNextExecWorkdir = resolvedWorkdir || null;
+      }
+      return resolvedWorkdir || null;
+    } catch (error) {
+      if (
+        refreshedSkillsForWorkdir &&
+        this.refreshedSkillsForNextExecWorkdir === refreshedSkillsForWorkdir
+      ) {
+        this.refreshedSkillsForNextExecWorkdir = null;
+      }
+      throw error;
+    } finally {
+      await disposeSshSandboxSession(session);
+    }
+  }
+
+  private discardPreparedWorkdir(workdir: string): void {
+    if (this.refreshedSkillsForNextExecWorkdir === workdir) {
+      this.refreshedSkillsForNextExecWorkdir = null;
+    }
+  }
+
+  private consumeRefreshedSkillsForNextExec(workdir: string): boolean {
+    if (this.refreshedSkillsForNextExecWorkdir !== workdir) {
+      this.refreshedSkillsForNextExecWorkdir = null;
+      return false;
+    }
+    this.refreshedSkillsForNextExecWorkdir = null;
+    return true;
+  }
+
+  private resolveWorkdirValidationRoot(workdir: string): string {
+    const roots = [
+      this.params.runtimePaths.remoteAgentWorkspaceDir,
+      this.params.runtimePaths.remoteWorkspaceDir,
+    ];
+    return (
+      roots.find((root) => isRemotePathInsideRoot(root, workdir)) ??
+      this.params.runtimePaths.remoteWorkspaceDir
+    );
+  }
+
   private async refreshRemoteSkillsWorkspace(session: SshSandboxSession): Promise<void> {
     if (
       this.params.createParams.cfg.workspaceAccess !== "rw" ||
@@ -331,6 +405,22 @@ async function isExistingDirectory(dir: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function normalizeRemotePath(input: string): string {
+  const normalized = path.posix.normalize(input.replace(/\\/g, "/"));
+  return normalized === "/" ? normalized : normalized.replace(/\/+$/g, "");
+}
+
+function isRemotePathInsideRoot(root: string, candidate: string): boolean {
+  const normalizedRoot = normalizeRemotePath(root);
+  const normalizedCandidate = normalizeRemotePath(candidate);
+  return (
+    normalizedCandidate === normalizedRoot ||
+    (normalizedRoot === "/"
+      ? normalizedCandidate.startsWith("/")
+      : normalizedCandidate.startsWith(`${normalizedRoot}/`))
+  );
 }
 
 export function resolveSshRuntimePaths(

--- a/src/agents/sandbox/ssh.test.ts
+++ b/src/agents/sandbox/ssh.test.ts
@@ -9,12 +9,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { makeTempDir } from "../../../test/helpers/temp-dir.js";
 import {
   buildExecRemoteCommand,
+  buildRemoteWorkdirValidationCommand,
   buildValidatedExecRemoteCommand,
   createSshSandboxSessionFromSettings,
   disposeSshSandboxSession,
   ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT,
   type SshSandboxSession,
   uploadDirectoryToSshTarget,
+  VALIDATE_REMOTE_WORKDIR_SCRIPT,
 } from "./ssh.js";
 
 const sessions: SshSandboxSession[] = [];
@@ -236,6 +238,87 @@ describe("sandbox ssh helpers", () => {
       expect(stdout.trim().split("\n")).toEqual([target, root, path.join(target, "proof")]);
     },
   );
+
+  it.runIf(process.platform !== "win32")(
+    "validates exec workdirs without creating missing directories",
+    async () => {
+      const root = makeTempDir(tempDirs, "openclaw-ssh-workdir-");
+      const project = path.join(root, "workspace", "project");
+      await fs.mkdir(project, { recursive: true });
+      const canonicalProject = await fs.realpath(project);
+
+      const { stdout } = await execFileAsync("/bin/sh", [
+        "-c",
+        VALIDATE_REMOTE_WORKDIR_SCRIPT,
+        "openclaw-validate-workdir",
+        project,
+        path.join(root, "workspace"),
+      ]);
+
+      expect(stdout.trim()).toBe(canonicalProject);
+      await expect(
+        execFileAsync("/bin/sh", [
+          "-c",
+          VALIDATE_REMOTE_WORKDIR_SCRIPT,
+          "openclaw-validate-workdir",
+          path.join(root, "workspace", "missing"),
+          path.join(root, "workspace"),
+        ]),
+      ).rejects.toThrow(/remote directory not found/);
+      await expect(fs.stat(path.join(root, "workspace", "missing"))).rejects.toThrow();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects symlinked exec workdirs inside the trusted remote root",
+    async () => {
+      const root = makeTempDir(tempDirs, "openclaw-ssh-workdir-");
+      const workspace = path.join(root, "workspace");
+      await fs.mkdir(workspace, { recursive: true });
+      await fs.symlink(root, path.join(workspace, "escape"));
+
+      await expect(
+        execFileAsync("/bin/sh", [
+          "-c",
+          VALIDATE_REMOTE_WORKDIR_SCRIPT,
+          "openclaw-validate-workdir",
+          path.join(workspace, "escape"),
+          workspace,
+        ]),
+      ).rejects.toThrow(/unsafe remote directory symlink/);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "validates exec workdirs when the trusted remote root is slash",
+    async () => {
+      const root = makeTempDir(tempDirs, "openclaw-ssh-root-");
+      const project = path.join(root, "project");
+      await fs.mkdir(project, { recursive: true });
+      const canonicalProject = await fs.realpath(project);
+
+      const { stdout } = await execFileAsync("/bin/sh", [
+        "-c",
+        VALIDATE_REMOTE_WORKDIR_SCRIPT,
+        "openclaw-validate-workdir",
+        canonicalProject,
+        "/",
+      ]);
+
+      expect(stdout.trim()).toBe(canonicalProject);
+    },
+  );
+
+  it("builds remote workdir validation commands with quoted literal paths", () => {
+    const command = buildRemoteWorkdirValidationCommand({
+      workdir: "/remote/workspace/project one",
+      root: "/remote/workspace",
+    });
+
+    expect(command).toContain("openclaw-validate-workdir");
+    expect(command).toContain("project one");
+    expect(command).toContain("remote directory must be absolute");
+  });
 
   it.runIf(process.platform !== "win32")(
     "rejects symlinked directories inside the trusted remote root",

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -308,6 +308,60 @@ export function buildValidatedExecRemoteCommand(params: {
   return buildExecRemoteCommand(params);
 }
 
+export const VALIDATE_REMOTE_WORKDIR_SCRIPT = [
+  "set -e",
+  'target="$1"',
+  'root="$2"',
+  'case "$target" in /*) ;; *) echo "remote directory must be absolute: $target" >&2; exit 1 ;; esac',
+  'case "$root" in /*) ;; *) echo "remote root must be absolute: $root" >&2; exit 1 ;; esac',
+  'target="${target%/}"',
+  'root="${root%/}"',
+  '[ -n "$target" ] || target="/"',
+  '[ -n "$root" ] || root="/"',
+  'if [ "$root" != "/" ]; then',
+  '  case "$target/" in "$root"/*|"$root/") ;; *) echo "remote directory must stay under root: $target" >&2; exit 1 ;; esac',
+  "fi",
+  'for path_to_check in "$target" "$root"; do',
+  '  relative="${path_to_check#/}"',
+  '  while [ -n "$relative" ]; do',
+  '    part="${relative%%/*}"',
+  '    if [ "$part" = "$relative" ]; then relative=""; else relative="${relative#*/}"; fi',
+  '    [ -n "$part" ] || continue',
+  '    case "$part" in "."|"..") echo "unsafe remote directory component: $part" >&2; exit 1 ;; esac',
+  "  done",
+  "done",
+  'if [ -L "$root" ]; then echo "unsafe remote root symlink: $root" >&2; exit 1; fi',
+  'if [ ! -d "$root" ]; then echo "remote root not found: $root" >&2; exit 1; fi',
+  'canonical_root="$(cd "$root" && pwd -P)"',
+  'relative="${target#"$root"}"',
+  'relative="${relative#/}"',
+  'current="$canonical_root"',
+  'while [ -n "$relative" ]; do',
+  '  part="${relative%%/*}"',
+  '  if [ "$part" = "$relative" ]; then relative=""; else relative="${relative#*/}"; fi',
+  '  [ -n "$part" ] || continue',
+  '  if [ "$current" = "/" ]; then next="/$part"; else next="$current/$part"; fi',
+  '  if [ -L "$next" ]; then echo "unsafe remote directory symlink: $next" >&2; exit 1; fi',
+  '  if [ ! -d "$next" ]; then echo "remote directory not found: $next" >&2; exit 1; fi',
+  '  current="$next"',
+  "done",
+  'printf "%s\\n" "$current"',
+].join("\n");
+
+export function buildRemoteWorkdirValidationCommand(params: {
+  workdir: string;
+  root: string;
+}): string {
+  return buildRemoteCommand([
+    "/bin/sh",
+    "-c",
+    VALIDATE_REMOTE_WORKDIR_SCRIPT,
+    "openclaw-validate-workdir",
+    params.workdir,
+    params.root,
+  ]);
+}
+
 function createExecCommandFrame(kind: ExecCommandFrame["kind"], parenDepth = 0): ExecCommandFrame {
   return { kind, quote: "plain", escaping: false, parenDepth };
 }

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -52,7 +52,6 @@ export {
   sanitizeEnvVars,
   shellEscape,
   uploadDirectoryToSshTarget,
-  VALIDATE_REMOTE_WORKDIR_SCRIPT,
 } from "../agents/sandbox.js";
 
 export {

--- a/src/plugin-sdk/sandbox.ts
+++ b/src/plugin-sdk/sandbox.ts
@@ -14,9 +14,12 @@ export type {
   SandboxBackendHandle,
   SandboxBackendId,
   SandboxBackendManager,
+  SandboxBackendPreparedWorkdirDiscarder,
   SandboxBackendRegistration,
   SandboxBackendRuntimeInfo,
+  SandboxBackendWorkdirValidation,
   SandboxBackendWorkdirResolver,
+  SandboxBackendWorkdirValidator,
   SandboxContext,
   SandboxResolvedPath,
   SandboxSshConfig,
@@ -27,6 +30,7 @@ export type { OpenClawConfig } from "../config/config.js";
 
 export {
   buildExecRemoteCommand,
+  buildRemoteWorkdirValidationCommand,
   buildRemoteCommand,
   buildSshSandboxArgv,
   buildValidatedExecRemoteCommand,
@@ -48,6 +52,7 @@ export {
   sanitizeEnvVars,
   shellEscape,
   uploadDirectoryToSshTarget,
+  VALIDATE_REMOTE_WORKDIR_SCRIPT,
 } from "../agents/sandbox.js";
 
 export {

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -927,6 +927,8 @@ describe("test-projects args", () => {
         forwardedArgs: [],
         includePatterns: [
           "src/agents/agent-bundle-mcp-runtime.test.ts",
+          "src/agents/agent-tools-agent-config.exec.test.ts",
+          "src/agents/bash-tools.exec-foreground-failures.test.ts",
           "src/agents/models-config.file-mode.test.ts",
           "src/agents/sandbox/ssh.test.ts",
         ],

--- a/test/scripts/plugin-sdk-surface-report.test.ts
+++ b/test/scripts/plugin-sdk-surface-report.test.ts
@@ -23,10 +23,9 @@ type PublicSurfaceCounts = {
 function readDefaultPublicSurfaceBudgets(): PublicSurfaceCounts {
   const source = readFileSync("scripts/plugin-sdk-surface-report.mjs", "utf8");
   const readFallback = (budgetKey: string) => {
-    const match = new RegExp(
-      `${budgetKey}:\\s*readBudgetEnv\\(\\s*"[^"]+",\\s*(\\d+)`,
-      "u",
-    ).exec(source);
+    const match = new RegExp(`${budgetKey}:\\s*readBudgetEnv\\(\\s*"[^"]+",\\s*(\\d+)`, "u").exec(
+      source,
+    );
     if (match === null || match[1] === undefined) {
       throw new Error(`failed to read default ${budgetKey} budget`);
     }
@@ -138,7 +137,7 @@ describe("plugin SDK surface report", () => {
   });
 
   it("keeps generated package declarations out of source surface counts", () => {
-    const budget = readCurrentPublicSurfaceCounts().callableExports;
+    const budget = readDefaultPublicSurfaceBudgets().callableExports;
     const result = runSurfaceReport({
       OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS: String(budget - 1),
     });


### PR DESCRIPTION
## Summary
- Return a failed exec result when an explicit local `workdir` is unavailable instead of falling back to another directory.
- Keep fallback behavior for implicit/default workdirs, and add a regression test that verifies the command is not run.

Closes #94434

## Real behavior proof
- **Behavior or issue addressed:** Explicit invalid local `exec.workdir` no longer falls back to another directory and no longer executes the command from the wrong location.
- **Real environment tested:** Local OpenClaw checkout at PR head `60a5c0456baea74b07a8852abb8fccd4c1ad6c50`, Linux `6.17.0-121035-tuxedo`, Node `v22.22.1`, `host=gateway`, `security=full`, `ask=off`.
- **Exact steps or command run after this patch:** Ran a live `node --import tsx --input-type=module` script that imported the actual `createExecTool` from `src/agents/bash-tools.exec.ts`, called `tool.execute(...)` with an explicit missing `workdir`, and used a command that would write a marker file if it executed.
- **Evidence after fix:** Live terminal output from the patched checkout:

```json
{
  "timestamp": "2026-06-18T06:47:19.941Z",
  "commit": "60a5c0456baea74b07a8852abb8fccd4c1ad6c50",
  "openclawVersion": "2026.6.2",
  "platform": "linux 6.17.0-121035-tuxedo",
  "nodeVersion": "v22.22.1",
  "host": "gateway",
  "requestedWorkdir": "/tmp/openclaw-exec-proof-UJ3k3G/missing-workdir",
  "workdirExistsBeforeCall": false,
  "commandWouldCreateMarker": "/tmp/openclaw-exec-proof-UJ3k3G/should-not-exist.txt",
  "resultStatus": "failed",
  "resultExitCode": null,
  "markerExistsAfterCall": false,
  "toolText": "workdir \"/tmp/openclaw-exec-proof-UJ3k3G/missing-workdir\" not found: command was not executed. workdir is treated as a literal path; shell expansions such as \"~\" are not applied. Use an existing path or omit workdir."
}
```

- **Observed result after fix:** The exec tool returned `status=failed`, reported `workdir "..." not found: command was not executed`, and `markerExistsAfterCall=false`, proving the command did not run from any fallback directory.
- **What was not tested:** No additional gaps.

## Tests
- `corepack pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/bash-tools.exec.path.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.shared.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.path.test.ts`
- `corepack pnpm tsgo:core && corepack pnpm tsgo:test:src`