### PR TITLE
fix(imessage): strip leading echo corruption markers in the persisted echo cache

### DIFF
--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -1,4 +1,5 @@
 // Imessage plugin module implements echo cache behavior.
+import { stripLeadingEchoTextCorruptionMarkers } from "./echo-text-corruption.js";
 import { hasPersistedIMessageEcho } from "./persisted-echo-cache.js";
 
 type SentMessageLookup = {
@@ -34,20 +35,6 @@ export type SentMessageCache = {
 // duplicate delivery (noisy but not lossy) — never message loss.
 const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
-
-function isLeadingEchoTextCorruptionMarker(code: number): boolean {
-  return (
-    code === 0x0000 || code === 0xfeff || code === 0xfffd || code === 0xfffe || code === 0xffff
-  );
-}
-
-function stripLeadingEchoTextCorruptionMarkers(text: string): string {
-  let offset = 0;
-  while (offset < text.length && isLeadingEchoTextCorruptionMarker(text.charCodeAt(offset))) {
-    offset += 1;
-  }
-  return offset === 0 ? text : text.slice(offset);
-}
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {

--- a/extensions/imessage/src/monitor/echo-text-corruption.ts
+++ b/extensions/imessage/src/monitor/echo-text-corruption.ts
@@ -1,0 +1,19 @@
+// Imessage plugin shared helper: strip leading attributedBody corruption markers from echo text.
+// The in-memory (echo-cache) and persisted (persisted-echo-cache) echo-dedupe paths must normalize
+// identically, so a reflected own-message echo whose attributedBody decoded with a leading
+// NUL/replacement marker still matches the clean stored send. Kept here (a leaf module with no
+// imports) so the persisted path can reuse it without an echo-cache <-> persisted-echo-cache cycle.
+
+function isLeadingEchoTextCorruptionMarker(code: number): boolean {
+  return (
+    code === 0x0000 || code === 0xfeff || code === 0xfffd || code === 0xfffe || code === 0xffff
+  );
+}
+
+export function stripLeadingEchoTextCorruptionMarkers(text: string): string {
+  let offset = 0;
+  while (offset < text.length && isLeadingEchoTextCorruptionMarker(text.charCodeAt(offset))) {
+    offset += 1;
+  }
+  return offset === 0 ? text : text.slice(offset);
+}

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -91,6 +91,21 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1555", { text: "Delayed\u0000echo reply" })).toBe(false);
   });
 
+  it("matches a delayed reflected echo with leading corruption markers via the persisted cache", () => {
+    // The persisted 12h cache is the only matcher once the 4s in-memory text TTL expires, so it
+    // must strip leading attributedBody corruption markers exactly like the in-memory key (#93511).
+    const scope = "acct:imessage:+1555";
+    const markers = String.fromCharCode(0x0000, 0xfffd, 0xfffe, 0xffff, 0xfeff);
+    rememberPersistedIMessageEcho({ scope, text: "Delayed echo reply" });
+
+    expect(hasPersistedIMessageEcho({ scope, text: "Delayed echo reply" })).toBe(true);
+    expect(hasPersistedIMessageEcho({ scope, text: `${markers}Delayed echo reply` })).toBe(true);
+    // Leading-only: a mid-string marker stays distinct.
+    expect(
+      hasPersistedIMessageEcho({ scope, text: `Delayed${String.fromCharCode(0x0000)}echo reply` }),
+    ).toBe(false);
+  });
+
   it("matches by outbound message id and ignores placeholder ids", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getIMessageRuntime } from "../runtime.js";
+import { stripLeadingEchoTextCorruptionMarkers } from "./echo-text-corruption.js";
 
 type PersistedEchoEntry = {
   scope: string;
@@ -26,7 +27,14 @@ export const IMESSAGE_SENT_ECHOES_MAX_ENTRIES = 256;
 type PersistedEchoStore = PluginStateSyncKeyedStore<PersistedEchoEntry>;
 
 function normalizeText(text: string | undefined): string | undefined {
-  const normalized = text?.replace(/\r\n?/g, "\n").trim();
+  if (!text) {
+    return undefined;
+  }
+  // Match the in-memory echo-cache key so a reflected echo with a leading attributedBody
+  // corruption marker still matches the clean stored send (the persisted sibling of #93511).
+  const normalized = stripLeadingEchoTextCorruptionMarkers(
+    text.replace(/\r\n?/g, "\n").trim(),
+  ).trim();
   return normalized || undefined;
 }
 


### PR DESCRIPTION
## Summary

The persisted iMessage echo-dedupe cache (`extensions/imessage/src/monitor/persisted-echo-cache.ts` `normalizeText`) normalized text with CRLF->LF + trim only -- **not** the leading attributedBody corruption-marker stripping that the in-memory echo cache applies (`echo-cache.ts` `normalizeEchoTextKey`, added in #93511). The persisted 12h cache is the **only** matcher once the 4s in-memory text TTL (`SENT_MESSAGE_TEXT_TTL_MS`) expires, so a delayed reflected own-message echo whose `attributedBody` decoded with a leading NUL (`0x0000`) / replacement (`0xFFFD`/`0xFFFE`/`0xFFFF`) / BOM (`0xFEFF`) marker did **not** match the clean stored send -- the agent's own message was re-ingested as a fresh inbound, causing a self-reply loop.

The two helpers (`isLeadingEchoTextCorruptionMarker`, `stripLeadingEchoTextCorruptionMarkers`) lived in `echo-cache.ts`, which already imports `persisted-echo-cache.ts` -- so importing them back would be a cycle. This extracts them into a new **leaf** module `echo-text-corruption.ts` (no imports), imports it in both echo caches, and applies the strip in the persisted `normalizeText`. Both caches now normalize identically.

### Changes
- `echo-text-corruption.ts` -- new leaf module with the shared marker-stripping
- `echo-cache.ts` -- import the helpers from it (behavior unchanged, -13 LOC)
- `persisted-echo-cache.ts` -- import + apply the strip in `normalizeText`
- `monitor-provider.echo-cache.test.ts` -- regression test exercising the persisted path directly

## Real behavior proof

Behavior addressed: a delayed reflected echo with a leading corruption marker was not deduped by the persisted cache (the only matcher past the 4s in-memory TTL), causing a self-reply loop; the persisted key now strips the markers like the in-memory key.

Real environment tested: Node 22.22.1, no model / channel / network. The harness imports the real `stripLeadingEchoTextCorruptionMarkers` from the new leaf module and computes the persisted dedup-key (`strip(text.replace(/\r\n?/g,"\n").trim()).trim()`) before (origin/main, no strip) vs after (this change), comparing a corrupted reflected echo's key to the clean stored send.

Exact steps or command run after this patch:
```bash
# im-proof.mts imports the real shared helper and computes the persisted normalizeText key
# (origin/main no-strip vs this fix) for a corrupted reflected echo and the clean stored send:
tsx im-proof.mts
```

Evidence after fix:
```
stored clean send key: "Delayed echo reply"
BEFORE FIX: corrupted echo persisted-key = "<NUL/FFFD/FFFE/FFFF/BOM>Delayed echo reply" -> matches stored send? false
AFTER FIX:  corrupted echo persisted-key = "Delayed echo reply"                          -> matches stored send? true
```

Observed result after fix: with the leading NUL/FFFD/FFFE/FFFF/BOM markers stripped, the corrupted echo's persisted key equals the clean stored send's key, so the persisted cache deduplicates it (no self-reply). A mid-string marker is left intact (stays distinct), matching the in-memory behavior.

What was not tested: a live iMessage round-trip on macOS Messages -- no iMessage credentials were used. The persisted-layer dedup is covered by the colocated regression test (which fails with the persisted change reverted and passes with it), and the marker-stripping mechanism by the model-free harness above.

## Additional checks

`monitor-provider.echo-cache.test.ts` runs 14 cases -- the new persisted-path case (calling `rememberPersistedIMessageEcho` + `hasPersistedIMessageEcho` directly, so it genuinely exercises the persisted path the in-memory #93511 cases skip) plus the existing cases. Formatter and static analysis pass for the changed files.
