### PR TITLE
fix(memory-wiki): retry transient source-page rewrite race instead of aborting wiki_status

### DIFF
--- a/extensions/memory-wiki/src/okf.ts
+++ b/extensions/memory-wiki/src/okf.ts
@@ -20,6 +20,7 @@ import {
   WIKI_RELATED_START_MARKER,
 } from "./markdown.js";
 import { resolveMemoryWikiTimestamp } from "./time.js";
+import { isRegularFileStat, writeGuardedVaultPage } from "./vault-page-write.js";
 import { initializeMemoryWikiVault } from "./vault.js";
 
 const OKF_RESERVED_FILENAMES = new Set(["index.md", "log.md"]);
@@ -31,11 +32,6 @@ const OKF_RELATED_SECTION_PATTERN = new RegExp(
 );
 const OKF_VOLATILE_TIMESTAMP_LINE_PATTERN = /^(?:importedAt|updatedAt): .*\n/gm;
 const OKF_HASH_CHARS = 8;
-
-type FileStatLike = {
-  isFile?: unknown;
-  nlink?: unknown;
-};
 
 type OkfConceptDocument = {
   conceptId: string;
@@ -86,18 +82,6 @@ function toPosixPath(value: string): string {
 
 function trimMarkdownExtension(value: string): string {
   return value.replace(/\.md$/i, "");
-}
-
-function isRegularFileStat(value: unknown): value is FileStatLike & { nlink: number } {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const stat = value as FileStatLike;
-  const isFile =
-    typeof stat.isFile === "function"
-      ? (stat.isFile as () => boolean).call(stat)
-      : stat.isFile === true;
-  return isFile && typeof stat.nlink === "number";
 }
 
 type OkfBundleMetadata = {
@@ -344,11 +328,12 @@ function safeDecodeOkfLinkPath(value: string | undefined): string {
 function getMarkdownDestinationSuffix(destination: string): string {
   const queryIndex = destination.indexOf("?");
   const fragmentIndex = destination.indexOf("#");
-  const suffixIndex = queryIndex === -1
-    ? fragmentIndex
-    : fragmentIndex === -1
-      ? queryIndex
-      : Math.min(queryIndex, fragmentIndex);
+  const suffixIndex =
+    queryIndex === -1
+      ? fragmentIndex
+      : fragmentIndex === -1
+        ? queryIndex
+        : Math.min(queryIndex, fragmentIndex);
   return suffixIndex === -1 ? "" : destination.slice(suffixIndex);
 }
 
@@ -481,25 +466,13 @@ async function writeOkfConceptPage(params: {
   ) {
     return { changed: false, created: !pageStat };
   }
-  try {
-    if (isRegularFileStat(pageStat) && pageStat.nlink > 1) {
-      await vault.remove(params.pagePath);
-    }
-    await vault.write(params.pagePath, params.content);
-  } catch (error) {
-    if (error instanceof FsSafeError) {
-      if (error.code !== "symlink" && error.code !== "path-alias") {
-        throw new Error(
-          `Refusing to write OKF concept page (${error.code}): ${params.pagePath}: ${error.message}`,
-          { cause: error },
-        );
-      }
-      throw new Error(`Refusing to write OKF concept page through symlink: ${params.pagePath}`, {
-        cause: error,
-      });
-    }
-    throw error;
-  }
+  await writeGuardedVaultPage({
+    vault,
+    pagePath: params.pagePath,
+    content: params.content,
+    pageStat,
+    pageLabel: "OKF concept page",
+  });
   return { changed: true, created: !pageStat };
 }
 

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -7,25 +7,9 @@ import {
   shouldSkipImportedSourceWrite,
   type MemoryWikiImportedSourceGroup,
 } from "./source-sync-state.js";
+import { writeGuardedVaultPage } from "./vault-page-write.js";
 
 type ImportedSourceState = Parameters<typeof shouldSkipImportedSourceWrite>[0]["state"];
-
-type FileStatLike = {
-  isFile?: unknown;
-  nlink?: unknown;
-};
-
-function isRegularFileStat(value: unknown): value is FileStatLike & { nlink: number } {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const stat = value as FileStatLike;
-  const isFile =
-    typeof stat.isFile === "function"
-      ? (stat.isFile as () => boolean).call(stat)
-      : stat.isFile === true;
-  return isFile && typeof stat.nlink === "number";
-}
 
 export async function writeImportedSourcePage(params: {
   vaultRoot: string;
@@ -69,26 +53,13 @@ export async function writeImportedSourcePage(params: {
   const rendered = params.buildRendered(raw, updatedAt);
   const existing = pageStat ? await vault.readText(params.pagePath).catch(() => "") : "";
   if (existing !== rendered) {
-    try {
-      if (isRegularFileStat(pageStat) && pageStat.nlink > 1) {
-        await vault.remove(params.pagePath);
-      }
-      await vault.write(params.pagePath, rendered);
-    } catch (error) {
-      if (error instanceof FsSafeError) {
-        if (error.code !== "symlink" && error.code !== "path-alias") {
-          throw new Error(
-            `Refusing to write imported source page (${error.code}): ${params.pagePath}: ${error.message}`,
-            { cause: error },
-          );
-        }
-        throw new Error(
-          `Refusing to write imported source page through symlink: ${params.pagePath}`,
-          { cause: error },
-        );
-      }
-      throw error;
-    }
+    await writeGuardedVaultPage({
+      vault,
+      pagePath: params.pagePath,
+      content: rendered,
+      pageStat,
+      pageLabel: "imported source page",
+    });
   }
 
   setImportedSourceEntry({

--- a/extensions/memory-wiki/src/vault-page-write.test.ts
+++ b/extensions/memory-wiki/src/vault-page-write.test.ts
@@ -1,0 +1,94 @@
+// Memory Wiki tests cover the shared guarded vault page write helper.
+import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { writeGuardedVaultPage } from "./vault-page-write.js";
+
+type FakeVault = Parameters<typeof writeGuardedVaultPage>[0]["vault"];
+
+function fakeVault(write: () => Promise<void>): {
+  vault: FakeVault;
+  remove: ReturnType<typeof vi.fn>;
+} {
+  const remove = vi.fn(async () => {});
+  return { vault: { write: vi.fn(write), remove } as unknown as FakeVault, remove };
+}
+
+describe("writeGuardedVaultPage", () => {
+  it("recovers from a transient concurrent-rewrite path-mismatch by retrying", async () => {
+    let attempts = 0;
+    const { vault } = fakeVault(async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        // A concurrent atomic rewrite replaces the page mid-operation.
+        throw new FsSafeError("path-mismatch", "unable to resolve opened file path");
+      }
+    });
+
+    await expect(
+      writeGuardedVaultPage({
+        vault,
+        pagePath: "sources/page.md",
+        content: "body",
+        pageStat: null,
+        pageLabel: "imported source page",
+      }),
+    ).resolves.toBeUndefined();
+    expect(attempts).toBe(3);
+  });
+
+  it("rethrows a labeled error when the path-mismatch persists across attempts", async () => {
+    const { vault } = fakeVault(async () => {
+      throw new FsSafeError("path-mismatch", "unable to resolve opened file path");
+    });
+
+    await expect(
+      writeGuardedVaultPage({
+        vault,
+        pagePath: "sources/page.md",
+        content: "body",
+        pageStat: null,
+        pageLabel: "imported source page",
+      }),
+    ).rejects.toThrow(
+      /Refusing to write imported source page \(path-mismatch\): sources\/page\.md/u,
+    );
+  });
+
+  it("does not retry persistent non-race guard failures and keeps fatal wording", async () => {
+    const { vault } = fakeVault(async () => {
+      throw new FsSafeError("not-file", "target is not a regular file");
+    });
+
+    await expect(
+      writeGuardedVaultPage({
+        vault,
+        pagePath: "concepts/page.md",
+        content: "body",
+        pageStat: null,
+        pageLabel: "OKF concept page",
+      }),
+    ).rejects.toThrow(/Refusing to write OKF concept page \(not-file\): concepts\/page\.md/u);
+    expect((vault as unknown as { write: ReturnType<typeof vi.fn> }).write).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("maps symlink and path-alias swaps to the symlink wording without retrying", async () => {
+    const { vault } = fakeVault(async () => {
+      throw new FsSafeError("symlink", "page resolved through a symlink");
+    });
+
+    await expect(
+      writeGuardedVaultPage({
+        vault,
+        pagePath: "sources/page.md",
+        content: "body",
+        pageStat: null,
+        pageLabel: "imported source page",
+      }),
+    ).rejects.toThrow(/Refusing to write imported source page through symlink: sources\/page\.md/u);
+    expect((vault as unknown as { write: ReturnType<typeof vi.fn> }).write).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+});

--- a/extensions/memory-wiki/src/vault-page-write.ts
+++ b/extensions/memory-wiki/src/vault-page-write.ts
@@ -1,0 +1,77 @@
+// Memory Wiki plugin module: shared guarded write for vault pages.
+import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
+import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
+
+type VaultRoot = Awaited<ReturnType<typeof fsRoot>>;
+
+export type FileStatLike = {
+  isFile?: unknown;
+  nlink?: unknown;
+};
+
+export function isRegularFileStat(value: unknown): value is FileStatLike & { nlink: number } {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const stat = value as FileStatLike;
+  const isFile =
+    typeof stat.isFile === "function"
+      ? (stat.isFile as () => boolean).call(stat)
+      : stat.isFile === true;
+  return isFile && typeof stat.nlink === "number";
+}
+
+// A concurrent atomic rewrite (write-temp + rename) of the same vault page by
+// the memory bridge re-export makes fs-safe's opened-fd identity check fail with
+// `path-mismatch` (see @openclaw/fs-safe opened-realpath): the file we opened is
+// replaced under us mid-operation. It is transient (resolves sub-ms) and benign,
+// so a short retry closes the window. Symlink/path-alias swaps and persistent
+// guard failures (e.g. a directory collision) carry their own code and still
+// hard-fail unchanged below.
+const isConcurrentRewriteRace = (error: unknown): boolean =>
+  error instanceof FsSafeError && error.code === "path-mismatch";
+
+/**
+ * Write `content` to a vault page, breaking an accidental hardlink first, and map
+ * fs-safe guard failures to a labeled error. A transient concurrent-rewrite race
+ * is retried briefly; on exhaustion (or any other guard failure) the error
+ * propagates so the caller's safety contract is unchanged.
+ */
+export async function writeGuardedVaultPage(params: {
+  vault: VaultRoot;
+  pagePath: string;
+  content: string;
+  pageStat: unknown;
+  pageLabel: string;
+}): Promise<void> {
+  try {
+    await retryAsync(
+      async () => {
+        if (isRegularFileStat(params.pageStat) && params.pageStat.nlink > 1) {
+          await params.vault.remove(params.pagePath);
+        }
+        await params.vault.write(params.pagePath, params.content);
+      },
+      {
+        attempts: 3,
+        minDelayMs: 25,
+        maxDelayMs: 50,
+        label: `memory-wiki write ${params.pageLabel} ${params.pagePath}`,
+        shouldRetry: isConcurrentRewriteRace,
+      },
+    );
+  } catch (error) {
+    if (error instanceof FsSafeError) {
+      if (error.code !== "symlink" && error.code !== "path-alias") {
+        throw new Error(
+          `Refusing to write ${params.pageLabel} (${error.code}): ${params.pagePath}: ${error.message}`,
+          { cause: error },
+        );
+      }
+      throw new Error(`Refusing to write ${params.pageLabel} through symlink: ${params.pagePath}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes `wiki_status` (and bridge source sync) intermittently aborting with `Refusing to write imported source page (path-mismatch)` when the memory-wiki bridge re-exports a source page at the same instant the sync writes it.
- The page write now retries briefly on the transient `path-mismatch` race (a concurrent atomic `write-temp + rename` replacing the file mid-operation) instead of treating it as fatal. Persistent guard failures (directory collision, `not-file`, `not-empty`) and symlink/path-alias swaps still hard-fail exactly as before.
- Extracts the duplicated guarded-write logic shared by `source-page-shared.ts` and `okf.ts` into one helper (`writeGuardedVaultPage`), so the fix covers both write paths and removes the copy.

## Linked context

Closes #92134

## Real behavior proof

<!-- before(bug reproduced) -> premise(cause is real) -> after(fix works) -->

- Behavior or issue addressed: a transient concurrent atomic rewrite of a memory-wiki source page made the whole `wiki_status` / bridge source-sync call abort with `path-mismatch`, dropping the status card; re-running a moment later succeeded.
- Real environment tested: real filesystem repro driving the real `@openclaw/fs-safe` vault root (`openclaw/plugin-sdk/security-runtime`) with a real `write-temp + rename` burst; the "old" arm runs the verbatim origin/main single-write code path, the "new" arm runs the shipped `writeGuardedVaultPage`. Not a stub of the failing component.
- Root cause / premise evidence: `path-mismatch` here comes from `@openclaw/fs-safe` `opened-realpath` (`resolveOpenedFileRealPathForHandle`, `node_modules/@openclaw/fs-safe/dist/opened-realpath.js:41` → `throw new FsSafeError("path-mismatch", "unable to resolve opened file path")`): the opened fd's inode can no longer be found by path after a concurrent atomic rename. Symlink/hardlink swaps surface on distinct codes (`symlink`/`path-alias`/`hardlink`) and are rejected earlier via `O_NOFOLLOW`, so retrying only `path-mismatch` does not weaken the identity guard. The sibling memory read path already treats `path-mismatch` as transient (`packages/memory-host-sdk/src/host/read-file.ts:54` `isFileDisappearedDuringReadError`); only the write path was the outlier.
- Before evidence (bug reproduced on main): the origin/main single-write path aborts on every write that lands inside the rewrite window.
- Exact steps or command run after this patch: `node --import tsx /tmp/repro-92134.ts` (bounded concurrent rename burst per trial, single write landing inside the window).
- Evidence after fix: terminal output below — the new retry path recovers every write while the old path aborts every write on the same real-filesystem workload.

```
OLD (origin/main single write): 0/60 writes ok, 60 path-mismatch aborts
NEW (writeGuardedVaultPage retry): 60/60 writes ok, 0 path-mismatch aborts

result: old aborts=60, new aborts=0
REPRODUCED + FIXED
```

- Observed result after fix: with a real concurrent atomic-rename burst, the old single-write behavior aborts 60/60 with `path-mismatch`, while `writeGuardedVaultPage` completes 60/60 with 0 aborts. Result was stable across repeated runs.
- What was not tested: not exercised against a live multi-process gateway with a real bridge export daemon; the concurrent rewrite is reproduced with a real-filesystem rename burst rather than a second OpenClaw process.
- Proof limitations or environment constraints: the race is timing-dependent; the repro uses a bounded rewrite window shorter than the retry span so the window settles before retries exhaust, matching the reported "burst of a few seconds" shape.

## Tests and validation

- `git diff --check`
- `node scripts/run-vitest.mjs extensions/memory-wiki` (174 passed, including new `vault-page-write.test.ts` and the existing directory-collision / symlink guard tests)
- `pnpm tsgo:extensions`

## Risk checklist

Did user-visible behavior change? `Yes` — a transient concurrent-rewrite no longer aborts `wiki_status`; persistent failures still error.

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No` — the fs-safe identity guard is unchanged; only `path-mismatch` (a benign rename race, distinct from `symlink`/`path-alias`/`hardlink`) is retried, then rethrown unchanged on exhaustion.

Highest-risk area: masking a genuine persistent guard failure as transient.

How is that risk mitigated? Only `path-mismatch` is retried, with a small bounded backoff; on exhaustion the original labeled error is rethrown, so persistent directory/`not-file` collisions still fail exactly as before (covered by existing tests that still pass).

Current review state: maintainer review and CI.

AI-assisted (Claude). Proof above was run manually.
