### PR TITLE
agents: contain relative path traversal on default host write/edit

### DIFF
--- a/src/agents/agent-tools.read.host-write-relative-escape.test.ts
+++ b/src/agents/agent-tools.read.host-write-relative-escape.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Regression tests for relative-path workspace containment on the default
+ * (non-`workspaceOnly`) host write/edit tools.
+ *
+ * In the default posture (`tools.fs.workspaceOnly` unset/false) the built-in
+ * write/edit tools may write anywhere on a trusted operator's host via an
+ * *absolute* path. A *relative* path, however, is the natural way to address a
+ * file inside the workspace, so a relative `..` escape must be rejected rather
+ * than silently writing outside the workspace. These tests pin that behaviour and
+ * also lock the stricter, opt-in `workspaceOnly` containment (which rejects
+ * absolute escapes too).
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createHostWorkspaceEditTool,
+  createHostWorkspaceWriteTool,
+  wrapToolRejectRelativeWorkspaceEscape,
+  wrapToolWorkspaceRootGuard,
+} from "./agent-tools.read.js";
+import type { AnyAgentTool } from "./agent-tools.types.js";
+
+type ToolResult = { isError?: boolean; content?: { type: string; text?: string }[] };
+
+async function runTool(
+  tool: AnyAgentTool,
+  filePath: string,
+  content: string,
+): Promise<{ ok: boolean; error?: string; text?: string }> {
+  try {
+    const result = await (
+      tool as unknown as {
+        execute: (
+          id: string,
+          args: { path: string; content: string },
+          signal?: AbortSignal,
+        ) => Promise<ToolResult>;
+      }
+    ).execute("tc", { path: filePath, content });
+    if (result?.isError) {
+      return { ok: false, error: result.content?.[0]?.text ?? "tool error" };
+    }
+    return { ok: true, text: result?.content?.[0]?.text };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+describe("default host write/edit relative-path workspace containment", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  // Mirrors the default (workspaceOnly=false) wiring in createBuiltinTools, which
+  // wraps the host write/edit tools with wrapToolRejectRelativeWorkspaceEscape.
+  async function setup() {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-rel-escape-"));
+    const root = path.join(tmpDir, "workspace");
+    await fs.mkdir(root, { recursive: true });
+    const outsideFile = path.join(tmpDir, "OUTSIDE_SECRET.txt");
+    await fs.writeFile(outsideFile, "ORIGINAL", "utf-8");
+    const writeTool = wrapToolRejectRelativeWorkspaceEscape(
+      createHostWorkspaceWriteTool(root),
+      root,
+    );
+    const editTool = wrapToolRejectRelativeWorkspaceEscape(createHostWorkspaceEditTool(root), root);
+    return { root, outsideFile, writeTool, editTool };
+  }
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a relative `..` escape and does not modify the outside file",
+    async () => {
+      const { outsideFile, writeTool } = await setup();
+
+      const result = await runTool(writeTool, "../OUTSIDE_SECRET.txt", "PWNED");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Path escapes workspace root/);
+      // The file outside the workspace must be untouched.
+      expect(await fs.readFile(outsideFile, "utf-8")).toBe("ORIGINAL");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")("rejects a deep relative `../../` escape", async () => {
+    const { writeTool } = await setup();
+
+    const result = await runTool(writeTool, "../../etc/openclaw_should_not_exist.txt", "PWNED");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Path escapes workspace root/);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a relative `..` escape for the edit tool too",
+    async () => {
+      const { outsideFile, editTool } = await setup();
+
+      const result = await runTool(editTool, "../OUTSIDE_SECRET.txt", "PWNED");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Path escapes workspace root/);
+      expect(await fs.readFile(outsideFile, "utf-8")).toBe("ORIGINAL");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")("still allows in-workspace relative writes", async () => {
+    const { root, writeTool } = await setup();
+
+    const result = await runTool(writeTool, "sub/ok.txt", "hello");
+
+    expect(result.ok).toBe(true);
+    expect(await fs.readFile(path.join(root, "sub", "ok.txt"), "utf-8")).toBe("hello");
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "still allows absolute writes (documented trusted-operator default)",
+    async () => {
+      const { writeTool } = await setup();
+      const absTarget = path.join(tmpDir, "abs_target.txt");
+
+      const result = await runTool(writeTool, absTarget, "abs-ok");
+
+      expect(result.ok).toBe(true);
+      expect(await fs.readFile(absTarget, "utf-8")).toBe("abs-ok");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a `~user`-form escape the resolver treats as cwd-relative",
+    async () => {
+      const { writeTool } = await setup();
+      // `~user` is NOT expanded by expandPath, so the sink's resolveToCwd treats
+      // it as a plain cwd-relative segment: `~user/../../x` cancels `~user` and
+      // `..` climbs out of the workspace. The guard must contain it like any
+      // other relative escape (regression for the syntactic "~name == absolute"
+      // bypass).
+      const escaped = path.join(tmpDir, "TILDE_ESCAPED.txt");
+      const result = await runTool(writeTool, "~nobody/../../TILDE_ESCAPED.txt", "PWNED");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Path escapes workspace root/);
+      await expect(fs.access(escaped)).rejects.toThrow();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a `~user`-form escape for the edit tool too",
+    async () => {
+      const { editTool } = await setup();
+      const escaped = path.join(tmpDir, "TILDE_ESCAPED_EDIT.txt");
+      const result = await runTool(editTool, "~nobody/../../TILDE_ESCAPED_EDIT.txt", "PWNED");
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/Path escapes workspace root/);
+      await expect(fs.access(escaped)).rejects.toThrow();
+    },
+  );
+});
+
+describe("opt-in workspaceOnly host write containment (defense lock)", () => {
+  let tmpDir = "";
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = "";
+    }
+  });
+
+  async function setup() {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-ws-only-"));
+    const root = path.join(tmpDir, "workspace");
+    await fs.mkdir(root, { recursive: true });
+    const outsideFile = path.join(tmpDir, "OUTSIDE_SECRET.txt");
+    await fs.writeFile(outsideFile, "ORIGINAL", "utf-8");
+    // Mirrors the workspaceOnly=true wiring: full containment guard + ops.
+    const writeTool = wrapToolWorkspaceRootGuard(
+      createHostWorkspaceWriteTool(root, { workspaceOnly: true }),
+      root,
+    );
+    return { root, outsideFile, writeTool };
+  }
+
+  it.runIf(process.platform !== "win32")(
+    "rejects both relative `..` and absolute escapes when workspaceOnly is enabled",
+    async () => {
+      const { outsideFile, writeTool } = await setup();
+
+      const rel = await runTool(writeTool, "../OUTSIDE_SECRET.txt", "PWNED");
+      expect(rel.ok).toBe(false);
+      expect(rel.error).toMatch(/Path escapes/);
+
+      const abs = await runTool(writeTool, outsideFile, "PWNED");
+      expect(abs.ok).toBe(false);
+      expect(abs.error).toMatch(/Path escapes/);
+
+      expect(await fs.readFile(outsideFile, "utf-8")).toBe("ORIGINAL");
+    },
+  );
+});

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -37,6 +37,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { createEditTool, createReadTool, createWriteTool } from "./sessions/index.js";
+import { expandPath } from "./sessions/tools/path-utils.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
 
 export {
@@ -445,6 +446,74 @@ async function normalizeReadImageResult(
 /** Wrap a file tool so path params stay inside the workspace root. */
 export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, root);
+}
+
+/**
+ * Returns true when a raw, model-supplied path expresses an *absolute* target
+ * (POSIX/Windows absolute, `~`/`~user` home expansion, or a `file://` URL).
+ *
+ * Absolute targets are intentionally allowed through the default (non
+ * `workspaceOnly`) host write/edit path so the documented "write anywhere on the
+ * host" operator behaviour keeps working. Relative paths, by contrast, are meant
+ * to resolve *inside* the workspace, so they get the parent-traversal guard below.
+ */
+function isAbsoluteToolPathInput(rawPath: string): boolean {
+  const trimmed = rawPath.startsWith("@") ? rawPath.slice(1) : rawPath;
+  if (!trimmed) {
+    return false;
+  }
+  // Parity with the write/edit sink resolver: a path only earns the "write
+  // anywhere" pass-through when `expandPath` — the same expander `resolveToCwd`
+  // runs before the sink touches the filesystem — turns it into an OS-absolute
+  // target (real `~`/`~/` home, `file://`, or an explicit absolute). `~user` /
+  // `~name` forms that `expandPath` does NOT expand stay relative and must be
+  // contained; classifying them as absolute here lets `~user/../../x` slip past
+  // the guard and then resolve cwd-relative out of the workspace.
+  const expanded = expandPath(trimmed);
+  return (
+    path.isAbsolute(expanded) || path.win32.isAbsolute(expanded) || isWindowsDrivePath(expanded)
+  );
+}
+
+/**
+ * Wrap a file tool so that *relative* path params cannot climb out of the
+ * workspace root via `..`, even when full `workspaceOnly` containment is off.
+ *
+ * This closes the relative path-traversal primitive (e.g. `../../etc/file`) on the
+ * default host write/edit path: a relative path is the natural way to ask for a
+ * file *inside* the workspace, so escaping it is rejected. Absolute / `~` / `file://`
+ * targets are passed through unchanged, preserving the documented default that the
+ * built-in write/edit tools may write anywhere on a trusted operator's host (the
+ * stricter, opt-in `tools.fs.workspaceOnly` mode contains those too).
+ */
+export function wrapToolRejectRelativeWorkspaceEscape(
+  tool: AnyAgentTool,
+  root: string,
+  pathParamKeys: readonly string[] = ["path"],
+): AnyAgentTool {
+  return {
+    ...tool,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const record = getToolParamsRecord(args);
+      if (record) {
+        for (const key of pathParamKeys) {
+          const rawFilePath = record[key];
+          if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
+            continue;
+          }
+          const filePath = stripMalformedXmlArgValueSuffix(rawFilePath);
+          if (!filePath.trim() || isAbsoluteToolPathInput(filePath)) {
+            continue;
+          }
+          // Relative path: reject if it resolves outside the workspace root.
+          // `toRelativeWorkspacePath` throws "Path escapes workspace root" on any
+          // `..` escape (and on absolute inputs, already handled above).
+          toRelativeWorkspacePath(root, filePath);
+        }
+      }
+      return tool.execute(toolCallId, args, signal, onUpdate);
+    },
+  };
 }
 
 function mapContainerPathToWorkspaceRoot(params: {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -55,6 +55,7 @@ import {
   createSandboxedWriteTool,
   getToolParamsRecord,
   wrapToolMemoryFlushAppendOnlyWrite,
+  wrapToolRejectRelativeWorkspaceEscape,
   wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
   wrapToolParamValidation,
@@ -815,7 +816,15 @@ export function createOpenClawCodingTools(options?: {
           continue;
         }
         const wrapped = createHostWorkspaceWriteTool(codingRoot, { workspaceOnly });
-        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
+        // workspaceOnly: full containment (rejects absolute + `..` escapes).
+        // Default (host) path: still reject relative `..` escapes so a model cannot
+        // climb out of the workspace via a relative path; absolute / `~` writes stay
+        // allowed (documented trusted-operator "write anywhere" behaviour).
+        base.push(
+          workspaceOnly
+            ? wrapToolWorkspaceRootGuard(wrapped, codingRoot)
+            : wrapToolRejectRelativeWorkspaceEscape(wrapped, codingRoot),
+        );
         continue;
       }
       if (tool.name === "edit") {
@@ -823,7 +832,11 @@ export function createOpenClawCodingTools(options?: {
           continue;
         }
         const wrapped = createHostWorkspaceEditTool(codingRoot, { workspaceOnly });
-        base.push(workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, codingRoot) : wrapped);
+        base.push(
+          workspaceOnly
+            ? wrapToolWorkspaceRootGuard(wrapped, codingRoot)
+            : wrapToolRejectRelativeWorkspaceEscape(wrapped, codingRoot),
+        );
         continue;
       }
       base.push(tool);

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -42,7 +42,7 @@ function normalizeAtPrefix(filePath: string): string {
   return filePath.startsWith("@") ? filePath.slice(1) : filePath;
 }
 
-function expandPath(filePath: string): string {
+export function expandPath(filePath: string): string {
   const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(filePath));
   if (normalized.startsWith("file://")) {
     try {


### PR DESCRIPTION
## Summary

What problem does this PR solve?

The built-in `write` / `edit` tools take a model-supplied `path`. In the default posture (`tools.fs.workspaceOnly` unset/false, no Docker sandbox) the host filesystem operations resolve that path against the workspace root and then call `fs.writeFile` / `fs.access` with no containment, so a **relative** path such as `../../etc/file` resolves outside the workspace and writes there. Only the opt-in `tools.fs.workspaceOnly` mode (or the sandbox) contained these paths, so the relative path-traversal gap was reachable purely from model tool-call arguments.

Why does this matter now?

The model/agent is not a trusted principal, so a tool argument that escapes the workspace via `..` is a containment gap on the default filesystem surface. This brings `write` / `edit` in line with the project's own precedent: `apply_patch` is already *"workspace-contained unless explicitly disabled"* (`tools.exec.applyPatch.workspaceOnly` defaults to true), while a relative `..` on `write` / `edit` still climbed out.

What is the intended outcome?

A **relative** path stays inside the workspace root, while every documented behavior is preserved: **absolute** and `~`-expanded host writes (the intentional trusted-operator capability that `tools.fs.workspaceOnly` defaults to `false` to keep) continue to work unchanged, and the opt-in / sandbox paths are untouched.

What is intentionally out of scope?

The **absolute-path** "write anywhere" behavior in the default posture is intentional per the trust model and is **not** changed here. The robust opt-in containment for it (`tools.fs.workspaceOnly=true`) already exists and is exercised by the added defense-lock test. This change only closes the relative-traversal gap.

What does success look like?

A relative `..` escape on the default `write` / `edit` tools is rejected with `Path escapes workspace root`; normal in-workspace relative writes, absolute writes, and the `workspaceOnly` / sandbox behaviors are unchanged.

What should reviewers focus on?

That the guard passes through only inputs the sink's own resolver treats as absolute — it shares `expandPath` with `resolveToCwd`, so `~user` / `~name` forms stay relative and contained — that it is wired only into the default (non-`workspaceOnly`) `write` and `edit` branches, and that the existing full-containment guard on the `workspaceOnly` branch is left intact.

Affected sites (decisive sink lines this PR closes), current `main` after rebase:

- `src/agents/sessions/tools/path-utils.ts:67` — `resolveToCwd`: `isAbsolute` passthrough + `resolvePath(cwd, expanded)` with no containment (the relative `..` is resolved against the workspace root and escapes).
- `src/agents/agent-tools.read.ts:1048` — `writeHostFile`: `await fs.writeFile(resolved, content, "utf-8")` on the default (non-`workspaceOnly`) host write branch — the uncontained host write the relative path reaches.

What this change does:

- New helper `wrapToolRejectRelativeWorkspaceEscape(tool, root)` in `src/agents/agent-tools.read.ts`. It inspects the raw `path` argument and, for **relative** paths, rejects any value that resolves outside the workspace root — reusing the existing boundary helper `toRelativeWorkspacePath` (which already rejects `..` escapes). Whether a path counts as absolute (passed through) or relative (contained) is decided with the *same* `expandPath` the sink's `resolveToCwd` runs before it touches the filesystem (`expandPath` is now exported from `src/agents/sessions/tools/path-utils.ts`). A path is passed through ("write anywhere") only when `expandPath` makes it OS-absolute (real `~` / `~/` home, `file://`, or an explicit absolute); `~user` / `~name` forms that `expandPath` does not expand stay relative and are contained. This closes a guard/resolver parity gap where `~user/../../x` was classified absolute by the guard but resolved cwd-relative by the sink, letting `..` climb out of the workspace.
- Wired into the default (non-`workspaceOnly`) `write` and `edit` branches in `createOpenClawCodingTools` (`src/agents/agent-tools.ts`). The opt-in `workspaceOnly` mode keeps its existing full-containment guard (which also rejects absolute escapes); the sandbox path is untouched.

## Linked context

Which issue does this close?

Closes #<!-- maintainer: add issue number if one is tracked; otherwise this is a stand-alone hardening PR -->

Which issues, PRs, or discussions are related?

Related #

Was this requested by a maintainer or owner?

No; opened as a focused defense-in-depth hardening of the default tool filesystem surface, aligning the relative-path behavior of `write` / `edit` with the `apply_patch` workspace-containment precedent.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: On the default `write` / `edit` tools (no `tools.fs.workspaceOnly`, no Docker sandbox), a model-supplied **relative** `path` could resolve outside the workspace root and write there; this change rejects relative `..`-escapes while leaving absolute / `~` writes and the `workspaceOnly` / sandbox paths unchanged.
- Real environment tested: macOS (Darwin, arm64), Node 24, local source checkout of OpenClaw, no Docker sandbox. The suite drives the real host write/edit tools (`createHostWorkspaceWriteTool` / `createHostWorkspaceEditTool` wrapped by `wrapToolRejectRelativeWorkspaceEscape`) over a temp workspace.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/agent-tools.read.host-write-relative-escape.test.ts` (the regression suite drives the real host write/edit tools against a temp workspace).
- Evidence after fix (terminal capture):
  ```
   RUN  v4.1.8  …/openclaw
   Test Files  1 passed (1)
        Tests  8 passed (8)
  ```
  Reverting the guard to the previous commit (keeping this test file) makes the two new `~user/../../x` cases fail — the escape writes outside the workspace — `Tests 2 failed | 6 passed (8)`; those two assertions are exactly what this fix closes.
- Observed result after fix: relative `..` and `~user/../../x` escapes on the default `write` / `edit` tools are rejected (`Path escapes workspace root`) and the file outside the workspace is never created; in-workspace relative writes and absolute writes still succeed; `~/`-home expansion is unchanged (`agent-tools.read.host-tilde-expansion` stays green, 8 passed); `tools.fs.workspaceOnly=true` still rejects both relative and absolute escapes. Suite result: `8 passed (8)`.
- What was not tested: Windows behavior (the relative-escape suite is guarded with `it.runIf(process.platform !== "win32")`); the Docker sandbox path (unchanged by this change).
- Proof limitations or environment constraints: This is a containment hardening with a focused unit-level regression suite over the real host tools; no exploit steps are included here in line with the project's private-disclosure policy (`SECURITY.md`).
- Before evidence (optional): on the pre-fix commit the `~user/../../x` regression cases fail because the write lands outside the workspace (`Tests 2 failed | 6 passed (8)`) — the guard previously waved `~name` forms through and the sink resolved them cwd-relative past the root. No reusable exploit recipe is included.

## Tests and validation

Which commands did you run?

- `node scripts/run-vitest.mjs src/agents/agent-tools.read.host-write-relative-escape.test.ts` → `8 passed (8)`.
- Surrounding suites stay green: `agent-tools.read.host-edit-access` (1), `agent-tools.read.host-tilde-expansion` (8), `agent-tools.read.workspace-root-guard` (16), `agent-tools.workspace-paths` (15), `agent-tools.read.host-write-relative-escape` (8) → **48 passed**.
- `oxlint` / `oxfmt` pre-commit hooks pass on the changed files (`src/agents/agent-tools.read.ts`, `src/agents/sessions/tools/path-utils.ts`, `src/agents/agent-tools.ts`, and the test).

What regression coverage was added or updated?

New `src/agents/agent-tools.read.host-write-relative-escape.test.ts` drives the real host write/edit tools against a temp workspace and asserts:

- a relative `..` escape is rejected and the file outside the workspace is untouched;
- a deep `../../` escape is rejected;
- the `edit` tool rejects relative escapes too;
- in-workspace relative writes still succeed;
- absolute writes still succeed (documented trusted-operator default);
- (defense lock) `tools.fs.workspaceOnly=true` rejects both relative and absolute escapes.

What failed before this fix, if known?

On the base revision the default `write` tool did **not** reject a relative `..` target — the relative escape resolved and wrote outside the workspace — so the equivalent assertion fails before this change (`expected false to be true`) and passes after it.

If no test was added, why not?

N/A — a regression suite is included.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

No for normal use. Only a **relative** `..`-escape on the default `write` / `edit` tools changes from "writes outside the workspace" to "rejected with `Path escapes workspace root`". In-workspace relative writes, absolute / `~` writes, and `workspaceOnly` / sandbox behavior are unchanged.

Did config, environment, or migration behavior change? (`Yes/No`)

No. No config keys or defaults change; `tools.fs.workspaceOnly` still defaults to `false`. The change is additive (a new exported helper); no existing signature changes.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes (intentionally, defense-in-depth): the default host `write` / `edit` tools now reject relative-path workspace escapes. To write outside the workspace as a trusted operator, pass an **absolute** path exactly as before; for full containment of absolute paths too, set `tools.fs.workspaceOnly=true` (the documented opt-in, unchanged).

What is the highest-risk area?

Accidentally rejecting a legitimate in-workspace relative write, or altering the absolute-path default. Both are guarded against: the new guard only intercepts inputs the sink's `expandPath` does not make OS-absolute, and reuses the existing `toRelativeWorkspacePath` boundary (which only throws on `..` escapes), so in-workspace relatives and genuine absolute / `~`-home / `file://` targets pass through unchanged.

How is that risk mitigated?

The regression suite asserts in-workspace relative writes and absolute writes still succeed, the surrounding write/edit/tilde/guard suite stays green, and the opt-in `workspaceOnly` / sandbox paths are not touched.

## Current review state

What is the next action?

Maintainer review of the scope (relative-only containment on the default surface, absolute behavior unchanged).

What is still waiting on author, maintainer, CI, or external proof?

The **Real environment tested** / **Evidence after fix** (and optional **Before evidence**) fields above are to be completed with a real-setup capture before submit, and a linked issue can be added if one is tracked.

Which bot or reviewer comments were addressed?

None yet (initial submission).

