### PR TITLE
fix(agents): expand leading tilde in exec workdir

### DIFF
--- a/src/agents/bash-tools.shared.test.ts
+++ b/src/agents/bash-tools.shared.test.ts
@@ -1,13 +1,20 @@
+import { existsSync, statSync as statSyncCb } from "node:fs";
 /**
  * Shared bash-tool helper tests.
  * Covers strict env parsing and sandbox workdir mapping between container and
  * host workspace paths.
  */
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, statSync } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deriveSessionName, readEnvInt, resolveSandboxWorkdir } from "./bash-tools.shared.js";
+import {
+  deriveSessionName,
+  expandTilde,
+  readEnvInt,
+  resolveSandboxWorkdir,
+  resolveWorkdir,
+} from "./bash-tools.shared.js";
 
 async function withTempDir(run: (dir: string) => Promise<void>) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-bash-workdir-"));
@@ -142,5 +149,123 @@ describe("deriveSessionName", () => {
       expect(typeof label).toBe("string");
       expect(elapsedMs).toBeLessThan(100);
     }
+  });
+});
+
+describe("expandTilde", () => {
+  const homeDir = os.homedir();
+
+  it("expands ~ to home directory", () => {
+    expect(expandTilde("~")).toBe(homeDir);
+  });
+
+  it("expands ~/path to homeDir/path", () => {
+    expect(expandTilde("~/test/path")).toBe(`${homeDir}/test/path`);
+    expect(expandTilde("~/Documents/file.txt")).toBe(`${homeDir}/Documents/file.txt`);
+  });
+
+  it("leaves absolute paths unchanged", () => {
+    expect(expandTilde("/usr/local/bin")).toBe("/usr/local/bin");
+    expect(expandTilde("/home/user/test")).toBe("/home/user/test");
+  });
+
+  it("leaves relative paths unchanged", () => {
+    expect(expandTilde("src/index.ts")).toBe("src/index.ts");
+    expect(expandTilde("./local/path")).toBe("./local/path");
+    expect(expandTilde("../parent/path")).toBe("../parent/path");
+  });
+
+  it("handles empty string", () => {
+    expect(expandTilde("")).toBe("");
+  });
+
+  it("does not expand ~user syntax (not supported)", () => {
+    expect(expandTilde("~otheruser")).toBe("~otheruser");
+    expect(expandTilde("~otheruser/path")).toBe("~otheruser/path");
+  });
+
+  it("handles tilde in the middle or end of path", () => {
+    // These should not be expanded as they're not leading tildes
+    expect(expandTilde("/path/to/~cache")).toBe("/path/to/~cache");
+    expect(expandTilde("file~backup.txt")).toBe("file~backup.txt");
+  });
+});
+
+describe("resolveWorkdir", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns existing absolute path if valid directory", () => {
+    const tmpDir = path.join(os.tmpdir(), `openclaw-test-${Date.now()}`);
+    try {
+      require("node:fs").mkdirSync(tmpDir, { recursive: true });
+      const warnings: string[] = [];
+      const result = resolveWorkdir(tmpDir, warnings);
+      expect(result).toBe(tmpDir);
+      expect(warnings).toEqual([]);
+    } finally {
+      require("node:fs").rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back for invalid relative path", async () => {
+    const tmpDir = path.join(os.tmpdir(), `openclaw-test-${Date.now()}`);
+    try {
+      await mkdir(tmpDir, { recursive: true });
+      const warnings: string[] = [];
+      // Test with a relative path that doesn't exist from any reasonable cwd
+      const result = resolveWorkdir("nonexistent_subdir_12345", warnings);
+      // Should fall back to cwd or homedir since the path doesn't exist
+      expect([process.cwd(), os.homedir()].includes(result)).toBe(true);
+      expect(warnings.length).toBe(1);
+      expect(warnings[0]).toMatch(/Warning: workdir "nonexistent_subdir_\d+" is unavailable/);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("expands ~ to home directory and returns it if valid", () => {
+    const warnings: string[] = [];
+    const result = resolveWorkdir("~", warnings);
+    expect(result).toBe(os.homedir());
+    expect(warnings).toEqual([]);
+  });
+
+  it("expands ~/path and returns it if valid directory", async () => {
+    const testSubdir = `openclaw-test-${Date.now()}`;
+    const testPath = path.join(os.homedir(), testSubdir);
+    try {
+      await mkdir(testPath, { recursive: true });
+      const warnings: string[] = [];
+      const result = resolveWorkdir(`~/${testSubdir}`, warnings);
+      expect(result).toBe(testPath);
+      expect(warnings).toEqual([]);
+    } finally {
+      await rm(testPath, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back with warning when expanded ~ path does not exist", () => {
+    const warnings: string[] = [];
+    const result = resolveWorkdir("~/nonexistent_dir_12345", warnings);
+    // Should fall back to cwd or homedir
+    expect(result).toBe(process.cwd() ?? os.homedir());
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/Warning: workdir "~\/nonexistent_dir_\d+" is unavailable/);
+  });
+
+  it("falls back with warning for invalid absolute path", () => {
+    const warnings: string[] = [];
+    const result = resolveWorkdir("/nonexistent/path/12345", warnings);
+    expect(result).toBe(process.cwd() ?? os.homedir());
+    expect(warnings.length).toBe(1);
+  });
+
+  it("falls back with warning for invalid relative path", () => {
+    const warnings: string[] = [];
+    const result = resolveWorkdir("nonexistent/relative/path", warnings);
+    expect(result).toBe(process.cwd() ?? os.homedir());
+    expect(warnings.length).toBe(1);
   });
 });

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -179,14 +179,32 @@ function normalizeContainerPath(input: string): string {
   return path.posix.normalize(normalized);
 }
 
+/** Expands a leading ~ or ~/ to the user's home directory. */
+export function expandTilde(input: string): string {
+  if (!input) {
+    return input;
+  }
+  if (input === "~") {
+    return homedir();
+  }
+  if (input.startsWith("~/")) {
+    return homedir() + input.slice(1);
+  }
+  return input;
+}
+
 /** Resolves a host workdir, falling back to a safe cwd/home path with a warning. */
 export function resolveWorkdir(workdir: string, warnings: string[]) {
   const current = safeCwd();
   const fallback = current ?? homedir();
+
+  // Expand leading tilde before validating the path
+  const expandedWorkdir = expandTilde(workdir);
+
   try {
-    const stats = statSync(workdir);
+    const stats = statSync(expandedWorkdir);
     if (stats.isDirectory()) {
-      return workdir;
+      return expandedWorkdir;
     }
   } catch {
     // ignore, fallback below


### PR DESCRIPTION
## Summary

Fixes issue #94434 where the `exec` tool does not expand a leading tilde (`~`) in the `workdir` parameter, causing commands to execute from an unintended fallback directory.

The fix adds an `expandTilde()` helper function that expands `~` and `~/path` to the user's home directory before validating the workdir path. This allows models to safely use tilde notation in workdir paths.

Fixes #94434

## Real behavior proof

**Behavior addressed**: Exec tool calls with `workdir: "~/path"` were failing because the tilde was not expanded, causing path validation to fail and fall back to a different directory while still attempting to execute relative commands.

**Real setup tested**:
- **Runtime**: Node.js test environment with Vitest
- **Test file**: `src/agents/bash-tools.shared.test.ts`

**Exact steps or command run after fix**:

```bash
pnpm test src/agents/bash-tools.shared.test.ts
```

**After-fix evidence**:

```
 RUN  v4.1.8 /home/.../issue-94434

 ✓ src/agents/bash-tools.shared.test.ts (25 tests) 240ms

 Test Files  1 passed (1)
      Tests  25 passed (25)
   Duration  1.38s
```

**Observed result after the fix**: All new unit tests pass, including:
- `expandTilde("~")` returns home directory
- `expandTilde("~/Documents")` returns `${homedir}/Documents`
- `resolveWorkdir("~/existing_dir", warnings)` expands and validates successfully
- `resolveWorkdir("~/nonexistent", warnings)` falls back with appropriate warning

**What was not tested**: Live agent runs with actual model-generated tool calls (requires integration/E2E setup)

## Tests and validation

Added 14 new unit tests covering all edge cases of tilde expansion and workdir resolution. All existing tests continue to pass.

## Risk checklist

Did user-visible behavior change? `No` - Only fixes previously broken behavior

Did config, environment, or migration behavior change? `No`

Did security, auth, secrets, network, or tool execution behavior change? `No`

What is the highest-risk area?
- Minimal risk: The change only affects paths starting with `~` or `~/`, which were previously broken

How is that risk mitigated?
- Comprehensive unit test coverage (14 new tests)
- Narrow scope: only modifies `resolveWorkdir()` and adds `expandTilde()` helper

## Current review state

What is the next action?
- Maintainer review
