### PR TITLE
fix: add OTel reply latency decomposition

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-f24065e760a9fafbd2a50962beba4d752b2d6166043170d37cdd6137640e7eef  plugin-sdk-api-baseline.json
-89a332c206f639d5faef730bac2d23f75751b306419e5dfeae1b731166bbc41c  plugin-sdk-api-baseline.jsonl
+ca8e23781c709b84235ede47d5f1e67b3a224e68943516441308315f3c34f660  plugin-sdk-api-baseline.json
+e5f03df38299ca1678b8316eb70e7376e5d314b11414c9e499f4e9efea80e632  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -120,14 +120,25 @@ scenario with the `diagnostics-otel` plugin enabled, then asserts traces,
 metrics, and logs are exported. It decodes the exported protobuf trace spans
 and checks the release-critical shape:
 `openclaw.run`, `openclaw.harness.run`, a latest GenAI semantic-convention
-model-call span, `openclaw.context.assembled`, and `openclaw.message.delivery`
-must be present. The smoke forces
+model-call span, `openclaw.context.assembled`, `openclaw.reply.phase`, and
+`openclaw.message.processed` must be present. The smoke forces
 `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`, so the model-call
 span must use the `{gen_ai.operation.name} {gen_ai.request.model}` name;
 model calls must not export `StreamAbandoned` on successful turns; raw diagnostic IDs and
 `openclaw.content.*` attributes must stay out of the trace. The raw OTLP
 payloads must not contain the prompt sentinel, response sentinel, or QA session
-key. It writes `otel-smoke-summary.json` next to the QA suite artifacts.
+key.
+
+The summary file includes a `latencyReport` built from the decoded trace/span
+IDs and OTLP span timestamps. It reports count, median, p95, and max for total
+message processing, pre-model overhead, model-call duration, post-model tail
+delivery, context assembly, and reply phase group buckets (`dispatch`,
+`resolver`, and `pre_model`). If no core `openclaw.message.delivery` span is
+present, the post-model tail uses the end of `openclaw.message.processed`. Use
+that report when comparing channel reply
+latency changes; it is measurement-only and should not be treated as an
+optimization benchmark by itself. The full JSON is written to
+`otel-smoke-summary.json` next to the QA suite artifacts.
 
 For a collector-backed OpenTelemetry smoke, run:
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -216,6 +216,8 @@ on the public diagnostic event bus.
 - `openclaw.message.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.outcome`)
 - `openclaw.message.delivery.started` (counter, attrs: `openclaw.channel`, `openclaw.delivery.kind`)
 - `openclaw.message.delivery.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.delivery.kind`, `openclaw.outcome`, `openclaw.errorCategory`)
+- `openclaw.reply.phase.duration_ms` (histogram, attrs: `openclaw.reply.phase`, `openclaw.reply.phase_group`, `openclaw.outcome`, optional `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.trigger`, `openclaw.errorCategory`)
+- `openclaw.context.assembly.duration_ms` (histogram, attrs: `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.trigger`)
 
 ### Talk
 
@@ -341,10 +343,13 @@ Liveness warnings also emit:
   - `openclaw.channel`, `openclaw.outcome`, `openclaw.reason`
 - `openclaw.message.delivery`
   - `openclaw.channel`, `openclaw.delivery.kind`, `openclaw.outcome`, `openclaw.errorCategory`, `openclaw.delivery.result_count`
+- `openclaw.reply.phase`
+  - `openclaw.reply.phase`, `openclaw.reply.phase_group`, `openclaw.outcome`, optional `openclaw.channel`, `openclaw.provider`, `openclaw.model`, `openclaw.trigger`, `openclaw.errorCategory`
+  - Phase names come from a closed OpenClaw-owned allowlist; aggregate wrapper phases and raw run/session/message identifiers are not exported.
 - `openclaw.session.stuck`
   - `openclaw.state`, `openclaw.ageMs`, `openclaw.queueDepth`
 - `openclaw.context.assembled`
-  - `openclaw.prompt.size`, `openclaw.history.size`, `openclaw.context.tokens`, `openclaw.errorCategory` (no prompt, history, response, or session-key content)
+  - Prompt and history size attributes such as `openclaw.context.message_count`, `openclaw.context.history_text_chars`, `openclaw.context.prompt_chars`, `openclaw.context.prompt_images`, and token-budget fields when known (no prompt, history, response, or session-key content)
 - `openclaw.tool.loop`
   - `openclaw.toolName`, `openclaw.outcome`, `openclaw.iterations`, `openclaw.errorCategory` (no loop messages, params, or tool output)
 - `openclaw.memory.pressure`

--- a/extensions/diagnostics-otel/api.ts
+++ b/extensions/diagnostics-otel/api.ts
@@ -9,6 +9,7 @@ export {
   isValidDiagnosticTraceId,
   onDiagnosticEvent,
   parseDiagnosticTraceparent,
+  resolveDiagnosticReplyPhaseGroup,
   type DiagnosticEventMetadata,
   type DiagnosticEventPayload,
   type DiagnosticTraceContext,

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2459,6 +2459,7 @@ describe("diagnostics-otel service", () => {
       systemPromptChars: 789,
       promptChars: 42,
       promptImages: 1,
+      durationMs: 37,
       contextTokenBudget: 128_000,
       reserveTokens: 4096,
       trace: {
@@ -2489,6 +2490,14 @@ describe("diagnostics-otel service", () => {
     expect(contextOptions?.attributes?.["openclaw.context.reserve_tokens"]).toBe(4096);
     expect(contextOptions?.attributes).toBeTypeOf("object");
     expect(contextOptions?.startTime).toBeTypeOf("number");
+    const contextDuration = lastHistogramRecord("openclaw.context.assembly.duration_ms");
+    expect(contextDuration?.[0]).toBe(37);
+    expect(contextDuration?.[1]).toMatchObject({
+      "openclaw.channel": "webchat",
+      "openclaw.model": "gpt-5.4",
+      "openclaw.provider": "openai",
+      "openclaw.trigger": "message",
+    });
     expect(JSON.stringify(contextCall)).not.toContain("session-key");
     expect(JSON.stringify(contextCall)).not.toContain("prompt text");
     const linkedSpanContext = firstSetSpanContext();
@@ -4033,6 +4042,117 @@ describe("diagnostics-otel service", () => {
     expect(deliveryOptions?.attributes?.["openclaw.outcome"]).toBe("completed");
     expect(deliveryOptions?.attributes?.["openclaw.delivery.result_count"]).toBe(1);
     expect(deliveryOptions?.startTime).toBeTypeOf("number");
+    await service.stop?.(ctx);
+  });
+
+  test("exports reply phase spans and metrics with bounded attributes", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      durationMs: 999,
+      outcome: "completed",
+      channel: "telegram",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      durationMs: Number.NaN,
+      outcome: "completed",
+      channel: "telegram",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      durationMs: 999,
+      outcome: "secret" as never,
+      channel: "telegram",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.secret_user_input" as never,
+      phaseGroup: "pre_model",
+      durationMs: 999,
+      outcome: "completed",
+      channel: "telegram",
+    });
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      durationMs: 42,
+      outcome: "completed",
+      channel: "telegram",
+      provider: "openai",
+      model: "gpt-5.5",
+      trigger: "message",
+      runId: "run-secret",
+      sessionKey: "session-secret",
+      sessionId: "session-id",
+      trace: {
+        traceId: TRACE_ID,
+        spanId: GRANDCHILD_SPAN_ID,
+        parentSpanId: SPAN_ID,
+        traceFlags: "01",
+      },
+    });
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.memory_flush",
+      phaseGroup: "pre_model",
+      durationMs: 12,
+      outcome: "error",
+      errorCategory: "TypeError",
+      channel: "telegram/custom" as never,
+    });
+    await flushDiagnosticEvents();
+
+    const records = telemetryState.histograms.get("openclaw.reply.phase.duration_ms")?.record.mock
+      .calls as Array<[unknown, Record<string, unknown>]>;
+    expect(records).toHaveLength(2);
+    expect(records[0]?.[0]).toBe(42);
+    expect(records[0]?.[1]).toMatchObject({
+      "openclaw.reply.phase": "reply.build_prompt_bodies",
+      "openclaw.reply.phase_group": "pre_model",
+      "openclaw.outcome": "completed",
+      "openclaw.channel": "telegram",
+      "openclaw.provider": "openai",
+      "openclaw.model": "gpt-5.5",
+      "openclaw.trigger": "message",
+    });
+    expect(records[1]?.[0]).toBe(12);
+    expect(records[1]?.[1]).toMatchObject({
+      "openclaw.reply.phase": "reply.memory_flush",
+      "openclaw.reply.phase_group": "pre_model",
+      "openclaw.outcome": "error",
+      "openclaw.channel": "unknown",
+      "openclaw.errorCategory": "TypeError",
+    });
+
+    const replyPhaseSpanCalls = telemetryState.tracer.startSpan.mock.calls.filter(
+      (call) => call[0] === "openclaw.reply.phase",
+    );
+    expect(replyPhaseSpanCalls).toHaveLength(2);
+    const firstOptions = replyPhaseSpanCalls[0]?.[1] as
+      | { attributes?: Record<string, unknown>; startTime?: unknown }
+      | undefined;
+    expect(firstOptions?.attributes).toMatchObject(records[0]?.[1] ?? {});
+    expect(firstOptions?.startTime).toBeTypeOf("number");
+    expect(JSON.stringify(firstOptions?.attributes)).not.toContain("run-secret");
+    expect(JSON.stringify(firstOptions?.attributes)).not.toContain("session-secret");
+    const errorSpan = telemetryState.spans.find(
+      (span) => span.name === "openclaw.reply.phase" && span.setStatus.mock.calls.length > 0,
+    );
+    expect(errorSpan?.setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: "TypeError",
+    });
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -41,6 +41,7 @@ import {
   isValidDiagnosticTraceFlags,
   isValidDiagnosticTraceId,
   redactSensitiveText,
+  resolveDiagnosticReplyPhaseGroup,
 } from "../api.js";
 
 const DEFAULT_SERVICE_NAME = "openclaw";
@@ -125,6 +126,7 @@ type ModelCallLifecycleDiagnosticEvent = Extract<
   DiagnosticEventPayload,
   { type: "model.call.completed" | "model.call.error" }
 >;
+type ReplyPhaseDiagnosticEvent = Extract<DiagnosticEventPayload, { type: "reply.phase.completed" }>;
 type ModelFailoverDiagnosticEvent = Extract<DiagnosticEventPayload, { type: "model.failover" }>;
 type HarnessRunDiagnosticEvent = Extract<
   DiagnosticEventPayload,
@@ -1157,11 +1159,7 @@ function assignOtelSecurityAttributes(
       );
     }
     if (evt.policy.decision) {
-      assignOtelLogAttribute(
-        attributes,
-        "openclaw.security.policy.decision",
-        evt.policy.decision,
-      );
+      assignOtelLogAttribute(attributes, "openclaw.security.policy.decision", evt.policy.decision);
     }
     if (evt.policy.reason) {
       assignOtelLogAttribute(
@@ -1180,11 +1178,7 @@ function assignOtelSecurityAttributes(
       );
     }
     if (evt.control.family) {
-      assignOtelLogAttribute(
-        attributes,
-        "openclaw.security.control.family",
-        evt.control.family,
-      );
+      assignOtelLogAttribute(attributes, "openclaw.security.control.family", evt.control.family);
     }
   }
   assignOtelSecurityEventAttributes(attributes, evt.attributes);
@@ -1493,10 +1487,24 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         unit: "ms",
         description: "Agent harness lifecycle duration",
       });
+      const replyPhaseDurationHistogram = meter.createHistogram(
+        "openclaw.reply.phase.duration_ms",
+        {
+          unit: "ms",
+          description: "Auto-reply phase duration",
+        },
+      );
       const contextHistogram = meter.createHistogram("openclaw.context.tokens", {
         unit: "1",
         description: "Context window size and usage",
       });
+      const contextAssemblyDurationHistogram = meter.createHistogram(
+        "openclaw.context.assembly.duration_ms",
+        {
+          unit: "ms",
+          description: "Context assembly duration",
+        },
+      );
       const webhookReceivedCounter = meter.createCounter("openclaw.webhook.received", {
         unit: "1",
         description: "Webhook requests received",
@@ -2552,6 +2560,54 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         span.end(evt.ts);
       };
 
+      const recordReplyPhaseCompleted = (
+        evt: ReplyPhaseDiagnosticEvent,
+        metadata: DiagnosticEventMetadata,
+      ) => {
+        if (!metadata.trusted) {
+          return;
+        }
+        if (
+          (evt.outcome !== "completed" && evt.outcome !== "error") ||
+          !Number.isFinite(evt.durationMs) ||
+          evt.durationMs < 0
+        ) {
+          return;
+        }
+        const phaseGroup = resolveDiagnosticReplyPhaseGroup(evt.phase);
+        if (!phaseGroup || evt.phaseGroup !== phaseGroup) {
+          return;
+        }
+        const attrs = {
+          "openclaw.reply.phase": evt.phase,
+          "openclaw.reply.phase_group": phaseGroup,
+          "openclaw.outcome": evt.outcome,
+          ...(evt.channel ? { "openclaw.channel": lowCardinalityAttr(evt.channel) } : {}),
+          ...(evt.provider ? { "openclaw.provider": lowCardinalityAttr(evt.provider) } : {}),
+          ...(evt.model ? { "openclaw.model": lowCardinalityAttr(evt.model) } : {}),
+          ...(evt.trigger ? { "openclaw.trigger": lowCardinalityAttr(evt.trigger) } : {}),
+          ...(evt.errorCategory
+            ? { "openclaw.errorCategory": lowCardinalityAttr(evt.errorCategory, "other") }
+            : {}),
+        };
+        replyPhaseDurationHistogram.record(evt.durationMs, attrs);
+        if (!tracesEnabled) {
+          return;
+        }
+        const span = spanWithDuration("openclaw.reply.phase", attrs, evt.durationMs, {
+          parentContext: activeInternalOrTrustedContext(evt, metadata),
+          endTimeMs: evt.ts,
+        });
+        if (evt.outcome === "error") {
+          const errorType = lowCardinalityAttr(evt.errorCategory, "other");
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: errorType,
+          });
+        }
+        span.end(evt.ts);
+      };
+
       const recordRunStarted = (
         evt: Extract<DiagnosticEventPayload, { type: "run.started" }>,
         metadata: DiagnosticEventMetadata,
@@ -2976,6 +3032,13 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         evt: Extract<DiagnosticEventPayload, { type: "context.assembled" }>,
         metadata: DiagnosticEventMetadata,
       ) => {
+        const durationMs = Math.max(0, evt.durationMs ?? 0);
+        contextAssemblyDurationHistogram.record(durationMs, {
+          "openclaw.channel": lowCardinalityAttr(evt.channel),
+          "openclaw.model": lowCardinalityAttr(evt.model),
+          "openclaw.provider": lowCardinalityAttr(evt.provider),
+          "openclaw.trigger": lowCardinalityAttr(evt.trigger),
+        });
         if (!tracesEnabled) {
           return;
         }
@@ -2995,7 +3058,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (evt.reserveTokens !== undefined) {
           spanAttrs["openclaw.context.reserve_tokens"] = evt.reserveTokens;
         }
-        const span = spanWithDuration("openclaw.context.assembled", spanAttrs, 0, {
+        const span = spanWithDuration("openclaw.context.assembled", spanAttrs, durationMs, {
           parentContext: activeTrustedParentContext(evt, metadata),
           endTimeMs: evt.ts,
         });
@@ -3581,6 +3644,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               return;
             case "message.delivery.error":
               recordMessageDeliveryError(evt, metadata);
+              return;
+            case "reply.phase.completed":
+              recordReplyPhaseCompleted(evt, metadata);
               return;
             case "talk.event":
               recordTalkEvent(evt, metadata);

--- a/qa/scenarios/runtime/otel-trace-smoke.yaml
+++ b/qa/scenarios/runtime/otel-trace-smoke.yaml
@@ -62,14 +62,15 @@ flow:
         - set: startCursor
           value:
             expr: state.getSnapshot().messages.length
-        - call: runAgentPrompt
+        - call: state.addInboundMessage
           args:
-            - ref: env
-            - sessionKey: agent:qa:otel-trace-smoke
-              message:
+            - conversation:
+                id: qa-operator
+                kind: direct
+              senderId: qa-operator
+              senderName: QA Operator
+              text:
                 expr: config.prompt
-              timeoutMs:
-                expr: liveTurnTimeoutMs(env, 30000)
         - call: waitForCondition
           saveAs: outbound
           args:

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -87,7 +87,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "outbound-send-deps": 4,
   "outbound-runtime": 16,
   "file-access-runtime": 2,
-  "infra-runtime": 584,
+  "infra-runtime": 589,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
@@ -161,11 +161,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 320),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10301),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10307),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5171),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3244,
+      3249,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4496,6 +4496,7 @@ export async function runEmbeddedAttempt(
             systemPromptChars: systemLen,
             promptChars: promptLen,
             promptImages: imageResult.images.length,
+            durationMs: Date.now() - promptStartedAt,
             contextTokenBudget,
             reserveTokens,
             trace: freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(runTrace)),

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -38,7 +38,6 @@ import {
   createChildDiagnosticTraceContext,
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
-import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { PluginHookReplyUsageState } from "../../plugins/hook-types.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
@@ -119,6 +118,7 @@ import {
 } from "./queue.js";
 import { createReplyMediaContext } from "./reply-media-paths.js";
 import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
+import { measureReplyPhaseDiagnostics } from "./reply-phase-diagnostics.js";
 import {
   replyRunRegistry,
   runAfterReplyOperationClear,
@@ -1213,10 +1213,15 @@ export async function runReplyAgent(params: {
     blockStreamingEnabled,
   };
   const traceAgentPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
+    measureReplyPhaseDiagnostics(name, run, {
+      timelinePhase: "agent-turn",
       config: followupRun.run.config,
       attributes: traceAttributes,
+      channel: followupRun.run.messageProvider,
+      provider: followupRun.run.provider,
+      model: followupRun.run.model,
+      sessionKey: sessionKey ?? followupRun.run.sessionKey,
+      sessionId: followupRun.run.sessionId,
     });
   const effectiveShouldSteer = !isHeartbeat && !effectiveResetTriggered && shouldSteer;
   const effectiveShouldFollowup = !effectiveResetTriggered && shouldFollowup;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -62,7 +62,6 @@ import {
   toPluginMessageReceivedEvent,
 } from "../../hooks/message-hook-mappers.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
-import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { isAbortError } from "../../infra/unhandled-rejections.js";
@@ -154,6 +153,7 @@ import type {
   ReplyDispatcher,
 } from "./reply-dispatcher.types.js";
 import { readDispatcherFailedCounts } from "./reply-dispatcher.types.js";
+import { measureReplyPhaseDiagnostics } from "./reply-phase-diagnostics.js";
 import {
   forceClearReplyRunBySessionId,
   replyRunRegistry,
@@ -1128,10 +1128,13 @@ export async function dispatchReplyFromConfig(
   });
   const traceReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
     replyHotPathTiming.measure(name, () =>
-      measureDiagnosticsTimelineSpan(name, run, {
-        phase: "agent-turn",
+      measureReplyPhaseDiagnostics(name, run, {
+        timelinePhase: "agent-turn",
         config: cfg,
         attributes: traceAttributes,
+        channel,
+        runId: params.replyOptions?.runId,
+        sessionKey,
       }),
     );
   let agentDispatchStartedAt = 0;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -30,7 +30,6 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import { resolveSilentReplySettings } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import {
   isAcpSessionKey,
@@ -87,6 +86,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { buildReplyPromptEnvelope, buildReplyPromptEnvelopeBase } from "./prompt-prelude.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings-runtime.js";
+import { measureReplyPhaseDiagnostics } from "./reply-phase-diagnostics.js";
 import {
   REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
   abortReplyRunBySessionId,
@@ -510,10 +510,15 @@ export async function runPreparedReply(
     queueMode: perMessageQueueMode ?? "configured",
   };
   const traceRunPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
-    measureDiagnosticsTimelineSpan(name, run, {
-      phase: "agent-turn",
+    measureReplyPhaseDiagnostics(name, run, {
+      timelinePhase: "agent-turn",
       config: cfg,
       attributes: traceAttributes,
+      channel: sessionCtx.Provider,
+      provider,
+      model,
+      sessionKey,
+      sessionId,
     });
   const promptSessionCtx = resolvePromptSessionContextForSystemEvent({
     sessionCtx,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -17,7 +17,6 @@ import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, getRuntimeConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
-import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildAgentHookContextChannelFields } from "../../plugins/hook-agent-context.js";
@@ -51,6 +50,7 @@ import { hasInboundMedia, hasInboundMediaForUnderstanding } from "./inbound-medi
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
 import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import { measureReplyPhaseDiagnostics } from "./reply-phase-diagnostics.js";
 import { createReplyTimingTracker } from "./reply-timing-tracker.js";
 import { initSessionState } from "./session.js";
 import {
@@ -314,10 +314,12 @@ export async function getReplyFromConfig(
     });
   const traceGetReplyPhase = <T>(name: string, run: () => Promise<T> | T): Promise<T> =>
     resolverTiming.measure(name, () =>
-      measureDiagnosticsTimelineSpan(name, run, {
-        phase: "agent-turn",
+      measureReplyPhaseDiagnostics(name, run, {
+        timelinePhase: "agent-turn",
         config: cfg,
         attributes: traceAttributes,
+        channel: traceAttributes.surface,
+        sessionKey: resolverTimingSessionKey,
       }),
     );
   const mergedSkillFilter = resolverTiming.measureSync("reply.resolve_skill_filter", () =>

--- a/src/auto-reply/reply/reply-phase-diagnostics.test.ts
+++ b/src/auto-reply/reply/reply-phase-diagnostics.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import { measureReplyPhaseDiagnostics } from "./reply-phase-diagnostics.js";
+
+function diagnosticsConfig(enabled = true): OpenClawConfig {
+  return { diagnostics: { enabled } } as OpenClawConfig;
+}
+
+describe("measureReplyPhaseDiagnostics", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  afterEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  async function collectReplyPhaseEvents(run: () => Promise<void>) {
+    const events: Extract<DiagnosticEventPayload, { type: "reply.phase.completed" }>[] = [];
+    const stop = onTrustedInternalDiagnosticEvent((event) => {
+      if (event.type === "reply.phase.completed") {
+        events.push(event);
+      }
+    });
+    try {
+      await run();
+      await waitForDiagnosticEventsDrained();
+      return events;
+    } finally {
+      stop();
+    }
+  }
+
+  it("emits completed events for allowlisted reply phases", async () => {
+    const events = await collectReplyPhaseEvents(async () => {
+      await expect(
+        measureReplyPhaseDiagnostics("reply.build_prompt_bodies", () => "ok", {
+          channel: "telegram",
+          config: diagnosticsConfig(),
+          model: "gpt-5.5",
+          provider: "openai",
+          sessionKey: "session-key",
+        }),
+      ).resolves.toBe("ok");
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      outcome: "completed",
+      channel: "telegram",
+      provider: "openai",
+      model: "gpt-5.5",
+      sessionKey: "session-key",
+    });
+    expect(events[0]?.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("emits error events before rethrowing", async () => {
+    const error = new TypeError("bad phase");
+    const events = await collectReplyPhaseEvents(async () => {
+      await expect(
+        measureReplyPhaseDiagnostics(
+          "reply.memory_flush",
+          () => {
+            throw error;
+          },
+          {
+            config: diagnosticsConfig(),
+          },
+        ),
+      ).rejects.toBe(error);
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      phase: "reply.memory_flush",
+      phaseGroup: "pre_model",
+      outcome: "error",
+      errorCategory: "TypeError",
+    });
+  });
+
+  it("does not emit events for aggregate wrapper names or disabled diagnostics", async () => {
+    const events = await collectReplyPhaseEvents(async () => {
+      await measureReplyPhaseDiagnostics("reply.run_prepared_reply", () => "aggregate", {
+        config: diagnosticsConfig(),
+      });
+      await measureReplyPhaseDiagnostics("reply.build_prompt_bodies", () => "disabled", {
+        config: diagnosticsConfig(false),
+      });
+    });
+
+    expect(events).toEqual([]);
+  });
+});

--- a/src/auto-reply/reply/reply-phase-diagnostics.ts
+++ b/src/auto-reply/reply/reply-phase-diagnostics.ts
@@ -1,0 +1,90 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { diagnosticErrorCategory } from "../../infra/diagnostic-error-metadata.js";
+import {
+  type DiagnosticReplyPhaseName,
+  emitTrustedDiagnosticEvent,
+  isDiagnosticsEnabled,
+  resolveDiagnosticReplyPhaseGroup,
+} from "../../infra/diagnostic-events.js";
+import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+
+type ReplyPhaseTimelineAttributes = Record<string, string | number | boolean | null>;
+
+type ReplyPhaseDiagnosticsOptions = {
+  attributes?: ReplyPhaseTimelineAttributes;
+  channel?: string;
+  config?: OpenClawConfig;
+  model?: string;
+  provider?: string;
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  timelinePhase?: string;
+  trigger?: string;
+};
+
+function optionalStringAttr(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function emitReplyPhaseCompleted(
+  phase: string,
+  durationMs: number,
+  outcome: "completed" | "error",
+  options: ReplyPhaseDiagnosticsOptions,
+  error?: unknown,
+) {
+  if (!isDiagnosticsEnabled(options.config)) {
+    return;
+  }
+  const phaseGroup = resolveDiagnosticReplyPhaseGroup(phase);
+  if (!phaseGroup) {
+    return;
+  }
+  emitTrustedDiagnosticEvent({
+    type: "reply.phase.completed",
+    phase: phase as DiagnosticReplyPhaseName,
+    phaseGroup,
+    durationMs: Math.max(0, durationMs),
+    outcome,
+    ...(optionalStringAttr(options.channel)
+      ? { channel: optionalStringAttr(options.channel) }
+      : {}),
+    ...(optionalStringAttr(options.provider)
+      ? { provider: optionalStringAttr(options.provider) }
+      : {}),
+    ...(optionalStringAttr(options.model) ? { model: optionalStringAttr(options.model) } : {}),
+    ...(optionalStringAttr(options.trigger)
+      ? { trigger: optionalStringAttr(options.trigger) }
+      : {}),
+    ...(optionalStringAttr(options.runId) ? { runId: optionalStringAttr(options.runId) } : {}),
+    ...(optionalStringAttr(options.sessionKey)
+      ? { sessionKey: optionalStringAttr(options.sessionKey) }
+      : {}),
+    ...(optionalStringAttr(options.sessionId)
+      ? { sessionId: optionalStringAttr(options.sessionId) }
+      : {}),
+    ...(outcome === "error" ? { errorCategory: diagnosticErrorCategory(error) } : {}),
+  });
+}
+
+export async function measureReplyPhaseDiagnostics<T>(
+  phase: string,
+  run: () => Promise<T> | T,
+  options: ReplyPhaseDiagnosticsOptions,
+): Promise<T> {
+  const startedAt = performance.now();
+  try {
+    const result = await measureDiagnosticsTimelineSpan(phase, run, {
+      ...(options.timelinePhase ? { phase: options.timelinePhase } : {}),
+      ...(options.config ? { config: options.config } : {}),
+      ...(options.attributes ? { attributes: options.attributes } : {}),
+    });
+    emitReplyPhaseCompleted(phase, performance.now() - startedAt, "completed", options);
+    return result;
+  } catch (error) {
+    emitReplyPhaseCompleted(phase, performance.now() - startedAt, "error", options, error);
+    throw error;
+  }
+}

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -497,8 +497,12 @@ describe("diagnostic-events", () => {
 
   it("dispatches high-frequency tool and model lifecycle events asynchronously", async () => {
     const events: string[] = [];
+    const trustedEvents: string[] = [];
     onDiagnosticEvent((event) => {
       events.push(event.type);
+    });
+    onTrustedInternalDiagnosticEvent((event) => {
+      trustedEvents.push(event.type);
     });
 
     emitDiagnosticEvent({
@@ -512,12 +516,20 @@ describe("diagnostic-events", () => {
       provider: "openai",
       model: "gpt-5.4",
     });
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      durationMs: 4,
+      outcome: "completed",
+    });
 
     expect(events).toStrictEqual([]);
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
     expect(events).toEqual(["tool.execution.started", "model.call.started"]);
+    expect(trustedEvents).toContain("reply.phase.completed");
   });
 
   it("yields between large high-frequency diagnostic event bursts", async () => {
@@ -687,7 +699,15 @@ describe("diagnostic-events", () => {
       durationMs: 1,
     });
 
-    for (let index = 0; index < 9_999; index += 1) {
+    emitTrustedDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.build_prompt_bodies",
+      phaseGroup: "pre_model",
+      durationMs: 4,
+      outcome: "completed",
+    });
+
+    for (let index = 0; index < 9_998; index += 1) {
       emitDiagnosticEvent({
         type: "model.call.started",
         runId: `saturation-run-${index}`,
@@ -742,6 +762,7 @@ describe("diagnostic-events", () => {
       },
     ]);
     expect(events.filter((event) => event.type === "model.call.started")).toHaveLength(9_998);
+    expect(events.filter((event) => event.type === "reply.phase.completed")).toHaveLength(0);
   });
 
   it("emits a bounded summary when async diagnostics are dropped at saturation", async () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -228,6 +228,61 @@ export type DiagnosticMessageDeliveryErrorEvent = DiagnosticMessageDeliveryBaseE
   errorCategory: string;
 };
 
+export const DIAGNOSTIC_REPLY_PHASE_GROUP_BY_NAME = {
+  "reply.load_runtime_plugins": "dispatch",
+  "reply.ensure_runtime_plugins": "dispatch",
+  "reply.before_dispatch_hooks": "dispatch",
+  "reply.reply_dispatch_hooks": "dispatch",
+  "reply.load_reply_resolver": "dispatch",
+  "reply.native_slash_command_fast_path": "resolver",
+  "reply.ensure_workspace": "resolver",
+  "reply.stage_remote_media_pre_understanding": "resolver",
+  "reply.apply_media_understanding": "resolver",
+  "reply.apply_link_understanding": "resolver",
+  "reply.init_session_state": "resolver",
+  "reply.resolve_directives": "resolver",
+  "reply.handle_inline_actions": "resolver",
+  "reply.before_agent_reply_hooks": "pre_model",
+  "reply.stage_media": "pre_model",
+  "reply.resolve_thinking_catalog_for_hint": "pre_model",
+  "reply.ensure_skill_snapshot": "pre_model",
+  "reply.build_prompt_bodies": "pre_model",
+  "reply.resolve_default_thinking": "pre_model",
+  "reply.resolve_thinking_catalog": "pre_model",
+  "reply.load_embedded_agent_runtime": "pre_model",
+  "reply.resolve_auth_profile": "pre_model",
+  "reply.load_agent_runner_runtime": "pre_model",
+  "reply.resolve_current_turn_images": "pre_model",
+  "reply.preflight_compaction": "pre_model",
+  "reply.memory_flush": "pre_model",
+} as const;
+
+export type DiagnosticReplyPhaseName = keyof typeof DIAGNOSTIC_REPLY_PHASE_GROUP_BY_NAME;
+export type DiagnosticReplyPhaseGroup =
+  (typeof DIAGNOSTIC_REPLY_PHASE_GROUP_BY_NAME)[DiagnosticReplyPhaseName];
+
+export function resolveDiagnosticReplyPhaseGroup(
+  phase: string,
+): DiagnosticReplyPhaseGroup | undefined {
+  return DIAGNOSTIC_REPLY_PHASE_GROUP_BY_NAME[phase as DiagnosticReplyPhaseName];
+}
+
+export type DiagnosticReplyPhaseCompletedEvent = DiagnosticBaseEvent & {
+  type: "reply.phase.completed";
+  phase: DiagnosticReplyPhaseName;
+  phaseGroup: DiagnosticReplyPhaseGroup;
+  durationMs: number;
+  outcome: "completed" | "error";
+  channel?: string;
+  provider?: string;
+  model?: string;
+  trigger?: string;
+  runId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  errorCategory?: string;
+};
+
 export type DiagnosticTalkEvent = DiagnosticBaseEvent & {
   type: "talk.event";
   sessionId?: string;
@@ -632,6 +687,7 @@ export type DiagnosticContextAssembledEvent = DiagnosticBaseEvent & {
   systemPromptChars: number;
   promptChars: number;
   promptImages: number;
+  durationMs?: number;
   contextTokenBudget?: number;
   reserveTokens?: number;
 };
@@ -725,6 +781,7 @@ export type DiagnosticEventPayload =
   | DiagnosticMessageDeliveryStartedEvent
   | DiagnosticMessageDeliveryCompletedEvent
   | DiagnosticMessageDeliveryErrorEvent
+  | DiagnosticReplyPhaseCompletedEvent
   | DiagnosticTalkEvent
   | DiagnosticSessionStateEvent
   | DiagnosticSessionLongRunningEvent
@@ -844,6 +901,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "message.delivery.started",
   "message.delivery.completed",
   "message.delivery.error",
+  "reply.phase.completed",
   "talk.event",
   "model.call.started",
   "model.call.completed",

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -149,7 +149,7 @@ describe("diagnostic stability recorder", () => {
 
     emitDiagnosticEvent({
       type: "reply.phase.completed",
-      phase: "reply.dispatch_from_config",
+      phase: "reply.load_runtime_plugins",
       phaseGroup: "dispatch",
       durationMs: 123,
       outcome: "error",
@@ -172,7 +172,7 @@ describe("diagnostic stability recorder", () => {
     expectFields(snapshot.events[0], {
       type: "reply.phase.completed",
       channel: "telegram",
-      phase: "reply.dispatch_from_config",
+      phase: "reply.load_runtime_plugins",
       durationMs: 123,
       outcome: "error",
       reason: "reply_timeout",

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -144,6 +144,44 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.events[1]).not.toHaveProperty("reason");
   });
 
+  it("records reply phase completions without raw run or session identifiers", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitDiagnosticEvent({
+      type: "reply.phase.completed",
+      phase: "reply.dispatch_from_config",
+      phaseGroup: "dispatch",
+      durationMs: 123,
+      outcome: "error",
+      channel: "telegram",
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-secret",
+      sessionKey: "agent:main:telegram:direct:u1",
+      sessionId: "session-secret",
+      errorCategory: "reply_timeout",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({ limit: 10 });
+
+    expect(snapshot.summary.byType).toMatchObject({
+      "reply.phase.completed": 1,
+    });
+    expectFields(snapshot.events[0], {
+      type: "reply.phase.completed",
+      channel: "telegram",
+      phase: "reply.dispatch_from_config",
+      durationMs: 123,
+      outcome: "error",
+      reason: "reply_timeout",
+    });
+    expect(snapshot.events[0]).not.toHaveProperty("runId");
+    expect(snapshot.events[0]).not.toHaveProperty("sessionKey");
+    expect(snapshot.events[0]).not.toHaveProperty("sessionId");
+  });
+
   it("summarizes inbound delivery proof events without message content", () => {
     startDiagnosticStabilityRecorder();
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -268,6 +268,13 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.outcome = "error";
       assignReasonCode(record, event.errorCategory);
       break;
+    case "reply.phase.completed":
+      record.channel = event.channel;
+      record.phase = event.phase;
+      record.durationMs = event.durationMs;
+      record.outcome = event.outcome;
+      assignReasonCode(record, event.errorCategory);
+      break;
     case "talk.event":
       record.talkEventType = event.talkEventType;
       record.mode = event.mode;

--- a/src/plugin-sdk/diagnostic-runtime.ts
+++ b/src/plugin-sdk/diagnostic-runtime.ts
@@ -18,6 +18,7 @@ export {
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
+  resolveDiagnosticReplyPhaseGroup,
   waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
 export { resolveDiagnosticModelContentCapturePolicy } from "../infra/diagnostic-llm-content.js";

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -31,7 +31,12 @@ type OtlpKeyValue = {
 
 type OtlpSpan = {
   name?: string;
+  traceId?: Uint8Array;
+  spanId?: Uint8Array;
   parentSpanId?: Uint8Array;
+  kind?: number;
+  startTimeUnixNano?: bigint;
+  endTimeUnixNano?: bigint;
   attributes?: OtlpKeyValue[];
 };
 
@@ -69,6 +74,15 @@ type CapturedRequest = {
 type CapturedSpan = {
   name: string;
   parent: boolean;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string;
+  kind?: number;
+  startUnixNano?: string;
+  endUnixNano?: string;
+  startMs?: number;
+  endMs?: number;
+  durationMs?: number;
   attributes: Record<string, string | number | boolean | string[]>;
 };
 
@@ -94,9 +108,21 @@ const REQUIRED_SPAN_NAMES = [
   "openclaw.run",
   "openclaw.harness.run",
   "openclaw.context.assembled",
-  "openclaw.message.delivery",
+  "openclaw.message.processed",
+  "openclaw.reply.phase",
 ] as const;
-const REQUIRED_METRIC_NAMES = ["openclaw.harness.duration_ms"] as const;
+const REQUIRED_METRIC_NAMES = [
+  "openclaw.harness.duration_ms",
+  "openclaw.reply.phase.duration_ms",
+] as const;
+const REQUIRED_LATENCY_SEGMENT_NAMES = [
+  "totalProcessing",
+  "preModel",
+  "modelCall",
+  "postModelDelivery",
+  "contextAssembly",
+] as const;
+const REQUIRED_REPLY_PHASE_GROUP_NAMES = ["dispatch", "resolver", "pre_model"] as const;
 const DISALLOWED_ATTRIBUTE_KEYS = new Set([
   "openclaw.runId",
   "openclaw.chatId",
@@ -360,6 +386,24 @@ function spanAttributes(span: OtlpSpan): Record<string, string | number | boolea
   return attributes;
 }
 
+function bytesToHex(bytes: Uint8Array | undefined): string {
+  return bytes && bytes.length > 0 ? Buffer.from(bytes).toString("hex") : "";
+}
+
+function unixNanoToMs(value: bigint | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Number(value) / 1_000_000;
+}
+
+function durationMsFromUnixNano(start: bigint | undefined, end: bigint | undefined) {
+  if (start === undefined || end === undefined || end < start) {
+    return undefined;
+  }
+  return Number(end - start) / 1_000_000;
+}
+
 class ProtoReader {
   private readonly buffer: Uint8Array;
   private offset = 0;
@@ -387,6 +431,20 @@ class ProtoReader {
         return result;
       }
       shift += 7;
+    }
+    throw new Error("truncated protobuf varint");
+  }
+
+  varintBigInt(): bigint {
+    let result = 0n;
+    let shift = 0n;
+    while (this.offset < this.buffer.length) {
+      const byte = this.buffer[this.offset++];
+      result += BigInt(byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) {
+        return result;
+      }
+      shift += 7n;
     }
     throw new Error("truncated protobuf varint");
   }
@@ -420,6 +478,12 @@ class ProtoReader {
     const start = this.advance(8, "fixed64");
     const view = new DataView(this.buffer.buffer, this.buffer.byteOffset + start, 8);
     return view.getFloat64(0, true);
+  }
+
+  fixed64BigInt(): bigint {
+    const start = this.advance(8, "fixed64");
+    const view = new DataView(this.buffer.buffer, this.buffer.byteOffset + start, 8);
+    return (BigInt(view.getUint32(4, true)) << 32n) + BigInt(view.getUint32(0, true));
   }
 
   skip(wire: number) {
@@ -512,10 +576,24 @@ function decodeSpan(message: Uint8Array): OtlpSpan {
   const span: OtlpSpan = {};
   while (!reader.done()) {
     const { field, wire } = reader.tag();
-    if (field === 4 && wire === 2) {
+    if (field === 1 && wire === 2) {
+      span.traceId = reader.bytes();
+    } else if (field === 2 && wire === 2) {
+      span.spanId = reader.bytes();
+    } else if (field === 4 && wire === 2) {
       span.parentSpanId = reader.bytes();
     } else if (field === 5 && wire === 2) {
       span.name = reader.string();
+    } else if (field === 6 && wire === 0) {
+      span.kind = reader.varint();
+    } else if (field === 7 && wire === 1) {
+      span.startTimeUnixNano = reader.fixed64BigInt();
+    } else if (field === 7 && wire === 0) {
+      span.startTimeUnixNano = reader.varintBigInt();
+    } else if (field === 8 && wire === 1) {
+      span.endTimeUnixNano = reader.fixed64BigInt();
+    } else if (field === 8 && wire === 0) {
+      span.endTimeUnixNano = reader.varintBigInt();
     } else if (field === 9 && wire === 2) {
       span.attributes ??= [];
       span.attributes.push(decodeKeyValue(reader.bytes()));
@@ -573,9 +651,25 @@ function decodeTraceRequest(body: Buffer): CapturedSpan[] {
         if (!name) {
           continue;
         }
+        const startMs = unixNanoToMs(span.startTimeUnixNano);
+        const endMs = unixNanoToMs(span.endTimeUnixNano);
+        const durationMs = durationMsFromUnixNano(span.startTimeUnixNano, span.endTimeUnixNano);
         spans.push({
           name,
           parent: (span.parentSpanId?.length ?? 0) > 0,
+          traceId: bytesToHex(span.traceId),
+          spanId: bytesToHex(span.spanId),
+          parentSpanId: bytesToHex(span.parentSpanId),
+          ...(span.kind !== undefined ? { kind: span.kind } : {}),
+          ...(span.startTimeUnixNano !== undefined
+            ? { startUnixNano: span.startTimeUnixNano.toString() }
+            : {}),
+          ...(span.endTimeUnixNano !== undefined
+            ? { endUnixNano: span.endTimeUnixNano.toString() }
+            : {}),
+          ...(startMs !== undefined ? { startMs } : {}),
+          ...(endMs !== undefined ? { endMs } : {}),
+          ...(durationMs !== undefined ? { durationMs } : {}),
           attributes: spanAttributes(span),
         });
       }
@@ -1384,6 +1478,169 @@ function formatBoundedList(values: readonly string[], maxItems: number): string 
   return `${visible.join(", ")}${suffix}`;
 }
 
+type DurationSummary = {
+  count: number;
+  medianMs?: number;
+  p95Ms?: number;
+  maxMs?: number;
+};
+
+type QaLatencyReport = {
+  traceCount: number;
+  segments: {
+    totalProcessing: DurationSummary;
+    preModel: DurationSummary;
+    modelCall: DurationSummary;
+    postModelDelivery: DurationSummary;
+    contextAssembly: DurationSummary;
+  };
+  replyPhaseGroups: Record<string, DurationSummary>;
+};
+
+function roundedMs(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function summarizeDurations(values: readonly number[]): DurationSummary {
+  const sorted = values
+    .filter(Number.isFinite)
+    .map(roundedMs)
+    .toSorted((a, b) => a - b);
+  if (sorted.length === 0) {
+    return { count: 0 };
+  }
+  const percentile = (rank: number) => sorted[Math.min(sorted.length - 1, Math.ceil(rank) - 1)];
+  return {
+    count: sorted.length,
+    medianMs: percentile(sorted.length * 0.5),
+    p95Ms: percentile(sorted.length * 0.95),
+    maxMs: sorted[sorted.length - 1],
+  };
+}
+
+function spanDuration(span: CapturedSpan | undefined): number | undefined {
+  return typeof span?.durationMs === "number" && Number.isFinite(span.durationMs)
+    ? span.durationMs
+    : undefined;
+}
+
+function spanStart(span: CapturedSpan | undefined): number | undefined {
+  return typeof span?.startMs === "number" && Number.isFinite(span.startMs)
+    ? span.startMs
+    : undefined;
+}
+
+function spanEnd(span: CapturedSpan | undefined): number | undefined {
+  return typeof span?.endMs === "number" && Number.isFinite(span.endMs) ? span.endMs : undefined;
+}
+
+function positiveDeltaMs(end: number | undefined, start: number | undefined): number | undefined {
+  if (end === undefined || start === undefined || end < start) {
+    return undefined;
+  }
+  return end - start;
+}
+
+function pushDuration(target: number[], value: number | undefined): void {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    target.push(value);
+  }
+}
+
+function attributeString(span: CapturedSpan, key: string): string | undefined {
+  const value = span.attributes[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function firstSpanByName(spans: readonly CapturedSpan[], name: string): CapturedSpan | undefined {
+  return spans.find((span) => span.name === name);
+}
+
+function buildLatencyReport(spans: readonly CapturedSpan[]): QaLatencyReport {
+  const byTrace = new Map<string, CapturedSpan[]>();
+  for (const span of spans) {
+    if (!span.traceId) {
+      continue;
+    }
+    const group = byTrace.get(span.traceId) ?? [];
+    group.push(span);
+    byTrace.set(span.traceId, group);
+  }
+
+  const totalProcessing: number[] = [];
+  const preModel: number[] = [];
+  const modelCall: number[] = [];
+  const postModelDelivery: number[] = [];
+  const contextAssembly: number[] = [];
+  const replyPhaseGroupDurations = new Map<string, number[]>();
+
+  for (const traceSpans of byTrace.values()) {
+    const messageProcessed = firstSpanByName(traceSpans, "openclaw.message.processed");
+    const contextAssembled = firstSpanByName(traceSpans, "openclaw.context.assembled");
+    const modelSpan = traceSpans.find(isLatestGenAiModelCallSpan);
+    const delivery = firstSpanByName(traceSpans, "openclaw.message.delivery");
+    const postModelEnd = delivery ?? messageProcessed;
+    const groupTotals = new Map<string, number>();
+
+    pushDuration(totalProcessing, spanDuration(messageProcessed));
+    pushDuration(modelCall, spanDuration(modelSpan));
+    pushDuration(contextAssembly, spanDuration(contextAssembled));
+    pushDuration(preModel, positiveDeltaMs(spanStart(modelSpan), spanStart(messageProcessed)));
+    pushDuration(postModelDelivery, positiveDeltaMs(spanEnd(postModelEnd), spanEnd(modelSpan)));
+
+    for (const span of traceSpans.filter(
+      (candidate) => candidate.name === "openclaw.reply.phase",
+    )) {
+      const phaseGroup = attributeString(span, "openclaw.reply.phase_group") ?? "unknown";
+      const duration = spanDuration(span);
+      if (duration === undefined) {
+        continue;
+      }
+      groupTotals.set(phaseGroup, (groupTotals.get(phaseGroup) ?? 0) + duration);
+    }
+    for (const [phaseGroup, duration] of groupTotals) {
+      const values = replyPhaseGroupDurations.get(phaseGroup) ?? [];
+      values.push(duration);
+      replyPhaseGroupDurations.set(phaseGroup, values);
+    }
+  }
+
+  const replyPhaseGroups: Record<string, DurationSummary> = {};
+  for (const group of ["dispatch", "resolver", "pre_model", "unknown"]) {
+    const values = replyPhaseGroupDurations.get(group);
+    if (values || group !== "unknown") {
+      replyPhaseGroups[group] = summarizeDurations(values ?? []);
+    }
+  }
+
+  return {
+    traceCount: byTrace.size,
+    segments: {
+      totalProcessing: summarizeDurations(totalProcessing),
+      preModel: summarizeDurations(preModel),
+      modelCall: summarizeDurations(modelCall),
+      postModelDelivery: summarizeDurations(postModelDelivery),
+      contextAssembly: summarizeDurations(contextAssembly),
+    },
+    replyPhaseGroups,
+  };
+}
+
+function latencyReportFailures(report: QaLatencyReport): string[] {
+  const failures: string[] = [];
+  for (const segment of REQUIRED_LATENCY_SEGMENT_NAMES) {
+    if ((report.segments[segment]?.count ?? 0) <= 0) {
+      failures.push(`latency report missing ${segment} bucket`);
+    }
+  }
+  for (const group of REQUIRED_REPLY_PHASE_GROUP_NAMES) {
+    if ((report.replyPhaseGroups[group]?.count ?? 0) <= 0) {
+      failures.push(`latency report missing ${group} reply phase group`);
+    }
+  }
+  return failures;
+}
+
 function assertSmoke(params: {
   childExitCode: number;
   disallowedBodyNeedles: string[];
@@ -1440,6 +1697,7 @@ function assertSmoke(params: {
       failures.push(`missing required metric ${name}`);
     }
   }
+  failures.push(...latencyReportFailures(buildLatencyReport(params.spans)));
   const correlatedLogRecords = params.logRecords.filter(
     (record) => record.traceId && record.spanId,
   );
@@ -1564,6 +1822,7 @@ async function main() {
     requests: receiver.capturedRequests,
     bodyText: receiver.capturedBodyText,
   });
+  const latencyReport = buildLatencyReport(receiver.capturedSpans);
   const summary = {
     passed: assertion.passed,
     failures: assertion.failures,
@@ -1583,6 +1842,7 @@ async function main() {
     signalRequestCounts: assertion.signalRequestCounts,
     modelSpanCount: assertion.modelSpanCount,
     modelErrorSpanCount: assertion.modelErrorSpanCount,
+    latencyReport,
     disallowedAttributeKeys: assertion.disallowedAttributeKeys,
     contentAttributeKeys: assertion.contentAttributeKeys,
     leakContexts: assertion.leakContexts,
@@ -1596,6 +1856,13 @@ async function main() {
     spans: receiver.capturedSpans.map((span) => ({
       name: span.name,
       parent: span.parent,
+      traceId: span.traceId,
+      spanId: span.spanId,
+      parentSpanId: span.parentSpanId,
+      kind: span.kind,
+      durationMs: span.durationMs,
+      startUnixNano: span.startUnixNano,
+      endUnixNano: span.endUnixNano,
       attributeKeys: Object.keys(span.attributes).toSorted(),
     })),
     logBodyKinds: [
@@ -1648,7 +1915,9 @@ async function main() {
 export const testing = {
   appendCapturedBodyText,
   assertSmoke,
+  buildLatencyReport,
   createBoundedTextAccumulator,
+  decodeTraceRequest,
   decodeRequestBody,
   parseArgs,
   readPositiveIntegerEnv,

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -140,6 +140,7 @@ const DISALLOWED_ATTRIBUTE_KEYS = new Set([
   "openclaw.tool_call_id",
 ]);
 const DISALLOWED_BODY_NEEDLES = ["OTEL-QA-SECRET", "OTEL-QA-OK"];
+const QA_OTEL_SMOKE_QA_CHANNEL_SESSION_KEY = "qa-agent:direct:dm:qa-operator";
 const COLLECTOR_OUTPUT_TAIL_BYTES = 16_000;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
 const MAX_OTLP_COMPRESSED_BODY_BYTES = readPositiveIntegerEnv(
@@ -253,6 +254,7 @@ function parseArgs(argv: string[]): CliOptions {
 function disallowedBodyNeedles(options: CliOptions): string[] {
   const scenarioId = options.scenarioId.trim();
   const needles = new Set(DISALLOWED_BODY_NEEDLES);
+  needles.add(QA_OTEL_SMOKE_QA_CHANNEL_SESSION_KEY);
   if (scenarioId) {
     needles.add(`agent:qa:${scenarioId}`);
     needles.add(`Agent:qa:${scenarioId}`);
@@ -1919,6 +1921,7 @@ export const testing = {
   createBoundedTextAccumulator,
   decodeTraceRequest,
   decodeRequestBody,
+  disallowedBodyNeedles,
   parseArgs,
   readPositiveIntegerEnv,
   readRequestBody,

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -140,6 +140,7 @@ const DISALLOWED_ATTRIBUTE_KEYS = new Set([
   "openclaw.tool_call_id",
 ]);
 const DISALLOWED_BODY_NEEDLES = ["OTEL-QA-SECRET", "OTEL-QA-OK"];
+const QA_OTEL_SMOKE_CHANNEL_SESSION_KEY = "agent:qa:main";
 const QA_OTEL_SMOKE_QA_CHANNEL_SESSION_KEY = "qa-agent:direct:dm:qa-operator";
 const COLLECTOR_OUTPUT_TAIL_BYTES = 16_000;
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/u;
@@ -254,6 +255,7 @@ function parseArgs(argv: string[]): CliOptions {
 function disallowedBodyNeedles(options: CliOptions): string[] {
   const scenarioId = options.scenarioId.trim();
   const needles = new Set(DISALLOWED_BODY_NEEDLES);
+  needles.add(QA_OTEL_SMOKE_CHANNEL_SESSION_KEY);
   needles.add(QA_OTEL_SMOKE_QA_CHANNEL_SESSION_KEY);
   if (scenarioId) {
     needles.add(`agent:qa:${scenarioId}`);

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -35,6 +35,59 @@ describe("qa-otel-smoke receiver bounds", () => {
     );
   });
 
+  function span(
+    name: string,
+    parent: boolean,
+    attributes: Record<string, string | number | boolean | string[]> = {},
+    timing: { startMs?: number; durationMs?: number } = {},
+    kind = 1,
+  ) {
+    const startMs = timing.startMs ?? 0;
+    const durationMs = timing.durationMs ?? 1;
+    return {
+      name,
+      parent,
+      traceId: "trace",
+      spanId: `${name}-span`,
+      parentSpanId: parent ? "parent" : "",
+      kind,
+      startMs,
+      endMs: startMs + durationMs,
+      startUnixNano: String(startMs * 1_000_000),
+      endUnixNano: String((startMs + durationMs) * 1_000_000),
+      durationMs,
+      attributes,
+    };
+  }
+
+  function protoVarint(value: number): Buffer {
+    const bytes: number[] = [];
+    let remaining = value;
+    while (remaining >= 0x80) {
+      bytes.push((remaining & 0x7f) | 0x80);
+      remaining = Math.floor(remaining / 0x80);
+    }
+    bytes.push(remaining);
+    return Buffer.from(bytes);
+  }
+
+  function protoBytes(field: number, value: Buffer | string): Buffer {
+    const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value, "utf8");
+    return Buffer.concat([protoVarint((field << 3) | 2), protoVarint(buffer.length), buffer]);
+  }
+
+  function protoFixed64(field: number, value: bigint): Buffer {
+    const buffer = Buffer.alloc(8);
+    buffer.writeUInt32LE(Number(value & 0xffffffffn), 0);
+    buffer.writeUInt32LE(Number(value >> 32n), 4);
+    return Buffer.concat([protoVarint((field << 3) | 1), buffer]);
+  }
+
+  function otlpStringAttribute(key: string, value: string): Buffer {
+    const anyValue = protoBytes(1, value);
+    return protoBytes(9, Buffer.concat([protoBytes(1, key), protoBytes(2, anyValue)]));
+  }
+
   function makePassingSmokeAssertionInput(): Parameters<typeof testing.assertSmoke>[0] {
     return {
       bodyText: {
@@ -49,7 +102,10 @@ describe("qa-otel-smoke receiver bounds", () => {
           spanId: "span",
         },
       ],
-      metrics: [{ name: "openclaw.harness.duration_ms" }],
+      metrics: [
+        { name: "openclaw.harness.duration_ms" },
+        { name: "openclaw.reply.phase.duration_ms" },
+      ],
       requests: [
         {
           path: "/v1/traces",
@@ -83,20 +139,49 @@ describe("qa-otel-smoke receiver bounds", () => {
         },
       ],
       spans: [
-        { name: "openclaw.run", parent: false, attributes: {} },
-        { name: "openclaw.harness.run", parent: true, attributes: {} },
-        { name: "openclaw.context.assembled", parent: true, attributes: {} },
-        { name: "openclaw.message.delivery", parent: true, attributes: {} },
-        {
-          name: "chat gpt-5.5",
-          parent: true,
-          attributes: {
+        span("openclaw.run", false),
+        span("openclaw.message.processed", false, {}, { startMs: 0, durationMs: 100 }),
+        span("openclaw.harness.run", true),
+        span("openclaw.context.assembled", true, {}, { startMs: 10, durationMs: 20 }),
+        span(
+          "openclaw.reply.phase",
+          true,
+          {
+            "openclaw.reply.phase": "reply.load_runtime_plugins",
+            "openclaw.reply.phase_group": "dispatch",
+          },
+          { startMs: 5, durationMs: 5 },
+        ),
+        span(
+          "openclaw.reply.phase",
+          true,
+          {
+            "openclaw.reply.phase": "reply.init_session_state",
+            "openclaw.reply.phase_group": "resolver",
+          },
+          { startMs: 12, durationMs: 7 },
+        ),
+        span(
+          "openclaw.reply.phase",
+          true,
+          {
+            "openclaw.reply.phase": "reply.build_prompt_bodies",
+            "openclaw.reply.phase_group": "pre_model",
+          },
+          { startMs: 20, durationMs: 15 },
+        ),
+        span("openclaw.message.delivery", true, {}, { startMs: 80, durationMs: 20 }),
+        span(
+          "chat gpt-5.5",
+          true,
+          {
             "gen_ai.operation.name": "chat",
             "gen_ai.request.model": "gpt-5.5",
             "openclaw.model": "gpt-5.5",
             "openclaw.provider": "openai",
           },
-        },
+          { startMs: 40, durationMs: 30 },
+        ),
       ],
     };
   }
@@ -167,6 +252,38 @@ describe("qa-otel-smoke receiver bounds", () => {
     expect(captured.traces?.[0]).toContain("[captured body text truncated to last 16 bytes]");
     expect(captured.traces?.[0]).toContain("b".repeat(16));
     expect(captured.traces?.[0]).not.toContain("a".repeat(20));
+  });
+
+  it("decodes OTLP trace ids, span ids, parent ids, and timestamps", () => {
+    const spanPayload = Buffer.concat([
+      protoBytes(1, Buffer.from("11111111111111111111111111111111", "hex")),
+      protoBytes(2, Buffer.from("2222222222222222", "hex")),
+      protoBytes(4, Buffer.from("3333333333333333", "hex")),
+      protoBytes(5, "openclaw.reply.phase"),
+      protoVarint((6 << 3) | 0),
+      protoVarint(3),
+      protoFixed64(7, 1_000_000_000n),
+      protoFixed64(8, 1_250_000_000n),
+      otlpStringAttribute("openclaw.reply.phase_group", "pre_model"),
+    ]);
+    const body = protoBytes(1, protoBytes(2, protoBytes(2, spanPayload)));
+
+    expect(testing.decodeTraceRequest(body)).toEqual([
+      expect.objectContaining({
+        name: "openclaw.reply.phase",
+        parent: true,
+        traceId: "11111111111111111111111111111111",
+        spanId: "2222222222222222",
+        parentSpanId: "3333333333333333",
+        kind: 3,
+        startUnixNano: "1000000000",
+        endUnixNano: "1250000000",
+        durationMs: 250,
+        attributes: {
+          "openclaw.reply.phase_group": "pre_model",
+        },
+      }),
+    ]);
   });
 
   it("returns a bounded failure for malformed local OTLP protobuf", async () => {
@@ -302,6 +419,71 @@ describe("qa-otel-smoke receiver bounds", () => {
 
     expect(assertion.passed).toBe(true);
     expect(assertion.failures).toEqual([]);
+  });
+
+  it("reports latency segments and reply phase group buckets from captured spans", () => {
+    const input = makePassingSmokeAssertionInput();
+
+    expect(testing.buildLatencyReport(input.spans)).toMatchObject({
+      traceCount: 1,
+      segments: {
+        totalProcessing: { count: 1, medianMs: 100, p95Ms: 100, maxMs: 100 },
+        preModel: { count: 1, medianMs: 40, p95Ms: 40, maxMs: 40 },
+        modelCall: { count: 1, medianMs: 30, p95Ms: 30, maxMs: 30 },
+        postModelDelivery: { count: 1, medianMs: 30, p95Ms: 30, maxMs: 30 },
+        contextAssembly: { count: 1, medianMs: 20, p95Ms: 20, maxMs: 20 },
+      },
+      replyPhaseGroups: {
+        dispatch: { count: 1, medianMs: 5, p95Ms: 5, maxMs: 5 },
+        resolver: { count: 1, medianMs: 7, p95Ms: 7, maxMs: 7 },
+        pre_model: { count: 1, medianMs: 15, p95Ms: 15, maxMs: 15 },
+      },
+    });
+  });
+
+  it("fails when required latency report buckets cannot be computed", () => {
+    const input = makePassingSmokeAssertionInput();
+    input.spans = input.spans.map((span) => {
+      const { startMs, endMs, durationMs, startUnixNano, endUnixNano, ...rest } = span;
+      void startMs;
+      void endMs;
+      void durationMs;
+      void startUnixNano;
+      void endUnixNano;
+      return rest;
+    });
+
+    const assertion = testing.assertSmoke(input);
+
+    expect(assertion.passed).toBe(false);
+    expect(assertion.failures).toContain("latency report missing totalProcessing bucket");
+    expect(assertion.failures).toContain("latency report missing preModel bucket");
+    expect(assertion.failures).toContain("latency report missing dispatch reply phase group");
+  });
+
+  it("reports the post-model tail from message processing when no delivery span exists", () => {
+    const input = makePassingSmokeAssertionInput();
+    input.spans = input.spans.filter((candidate) => candidate.name !== "openclaw.message.delivery");
+
+    expect(testing.assertSmoke(input).passed).toBe(true);
+    expect(testing.buildLatencyReport(input.spans).segments.postModelDelivery).toMatchObject({
+      count: 1,
+      medianMs: 30,
+      p95Ms: 30,
+      maxMs: 30,
+    });
+  });
+
+  it("requires the message processing span used by latency reporting", () => {
+    const input = makePassingSmokeAssertionInput();
+    input.spans = input.spans.filter(
+      (candidate) => candidate.name !== "openclaw.message.processed",
+    );
+
+    const assertion = testing.assertSmoke(input);
+
+    expect(assertion.passed).toBe(false);
+    expect(assertion.failures).toContain("missing required span openclaw.message.processed");
   });
 
   it("still fails when OTLP log payload text leaks scenario content", () => {

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -204,6 +204,12 @@ describe("qa-otel-smoke receiver bounds", () => {
     });
   });
 
+  it("checks the qa-channel smoke session key for raw OTLP leaks", () => {
+    expect(testing.disallowedBodyNeedles(testing.parseArgs([]))).toEqual(
+      expect.arrayContaining(["agent:qa:otel-trace-smoke", "qa-agent:direct:dm:qa-operator"]),
+    );
+  });
+
   it("parses body-size limit env values as strict positive integers", () => {
     expect(testing.readPositiveIntegerEnv("OTEL_TEST_LIMIT", 64, {})).toBe(64);
     expect(
@@ -497,6 +503,21 @@ describe("qa-otel-smoke receiver bounds", () => {
     expect(assertion.passed).toBe(false);
     expect(assertion.failures).toContain("OTLP logs payload leaked content: OTEL-QA-SECRET");
     expect(assertion.leakContexts.logs?.[0]).toContain("[needle]");
+  });
+
+  it("still fails when OTLP raw payload text leaks the qa-channel session key", () => {
+    const input = makePassingSmokeAssertionInput();
+    input.disallowedBodyNeedles = testing.disallowedBodyNeedles(testing.parseArgs([]));
+    input.bodyText = {
+      traces: ["trace payload leaked qa-agent:direct:dm:qa-operator"],
+    };
+
+    const assertion = testing.assertSmoke(input);
+
+    expect(assertion.passed).toBe(false);
+    expect(assertion.failures).toContain(
+      "OTLP traces payload leaked content: qa-agent:direct:dm:qa-operator",
+    );
   });
 
   it("still requires OTLP log records to carry trace correlation", () => {

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -206,7 +206,11 @@ describe("qa-otel-smoke receiver bounds", () => {
 
   it("checks the qa-channel smoke session key for raw OTLP leaks", () => {
     expect(testing.disallowedBodyNeedles(testing.parseArgs([]))).toEqual(
-      expect.arrayContaining(["agent:qa:otel-trace-smoke", "qa-agent:direct:dm:qa-operator"]),
+      expect.arrayContaining([
+        "agent:qa:otel-trace-smoke",
+        "agent:qa:main",
+        "qa-agent:direct:dm:qa-operator",
+      ]),
     );
   });
 
@@ -449,8 +453,8 @@ describe("qa-otel-smoke receiver bounds", () => {
 
   it("fails when required latency report buckets cannot be computed", () => {
     const input = makePassingSmokeAssertionInput();
-    input.spans = input.spans.map((span) => {
-      const { startMs, endMs, durationMs, startUnixNano, endUnixNano, ...rest } = span;
+    input.spans = input.spans.map((capturedSpan) => {
+      const { startMs, endMs, durationMs, startUnixNano, endUnixNano, ...rest } = capturedSpan;
       void startMs;
       void endMs;
       void durationMs;
@@ -509,15 +513,13 @@ describe("qa-otel-smoke receiver bounds", () => {
     const input = makePassingSmokeAssertionInput();
     input.disallowedBodyNeedles = testing.disallowedBodyNeedles(testing.parseArgs([]));
     input.bodyText = {
-      traces: ["trace payload leaked qa-agent:direct:dm:qa-operator"],
+      traces: ["trace payload leaked agent:qa:main"],
     };
 
     const assertion = testing.assertSmoke(input);
 
     expect(assertion.passed).toBe(false);
-    expect(assertion.failures).toContain(
-      "OTLP traces payload leaked content: qa-agent:direct:dm:qa-operator",
-    );
+    expect(assertion.failures).toContain("OTLP traces payload leaked content: agent:qa:main");
   });
 
   it("still requires OTLP log records to carry trace correlation", () => {


### PR DESCRIPTION
## Summary
- Add bounded `reply.phase.completed` diagnostics for allowlisted auto-reply phases while preserving the existing timeline span behavior.
- Export trusted reply-phase and context-assembly duration spans/metrics through `diagnostics-otel` with low-cardinality attributes.
- Update the OTel smoke scenario and runtime assertions to exercise QA-channel inbound replies, decode trace/span metadata, and report latency buckets.

Fixes #88812

## Real behavior proof
Behavior addressed: OTel smoke now captures model-call-adjacent latency decomposition through reply phase diagnostics, plus context assembly duration.
Real environment tested: Local OpenClaw QA OTel smoke with local collector.
Exact steps or command run after this patch: `pnpm qa:otel:smoke -- --collector local --output-dir .artifacts/qa-otel-smoke-88812`
Evidence after fix: smoke passed with `spans=35 metrics=39 logs=10 traces=3 metricRequests=4 logRequests=3`; latency report included nonzero `totalProcessing`, `preModel`, `modelCall`, `postModelDelivery`, `contextAssembly`, and `replyPhaseGroups.dispatch/resolver/pre_model` buckets.
Observed result after fix: the QA-channel inbound reply flow produced `openclaw.message.processed`, `openclaw.reply.phase`, and `openclaw.context.assembly` telemetry with timing data.
What was not tested: broad full-suite CI locally; this was kept to focused proof plus real smoke for the touched telemetry surface.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-phase-diagnostics.test.ts src/infra/diagnostic-events.test.ts extensions/diagnostics-otel/src/service.test.ts test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts`
- `pnpm qa:otel:smoke -- --collector local --output-dir .artifacts/qa-otel-smoke-88812`
- `pnpm docs:check-mdx`
- `pnpm format:docs:check`
- `pnpm exec oxfmt --check docs/concepts/qa-e2e-automation.md docs/gateway/opentelemetry.md extensions/diagnostics-otel/api.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-otel/src/service.ts src/agents/embedded-agent-runner/run/attempt.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/reply-phase-diagnostics.test.ts src/auto-reply/reply/reply-phase-diagnostics.ts src/infra/diagnostic-events.test.ts src/infra/diagnostic-events.ts src/plugin-sdk/diagnostic-runtime.ts test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm plugin-sdk:check-exports`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Note: full `pnpm format:check` currently reports unrelated pre-existing formatting drift outside this patch; scoped touched-file formatting checks passed.

## AI assistance
This PR was implemented with AI assistance. No sanitized transcript logs are included in the PR body.
