### PR TITLE
fix(sandbox): ensure skill mount dirs exist before read-only mount resolution

### DIFF
--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -12,7 +12,11 @@ import {
 } from "./config-hash.js";
 import { collectDockerFlagValues } from "./test-args.js";
 import type { SandboxConfig } from "./types.js";
-import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
+import {
+  resolveReadOnlyWorkspaceSkillMounts,
+  formatReadOnlyWorkspaceSkillMountHashState,
+  SANDBOX_MOUNT_FORMAT_VERSION,
+} from "./workspace-mounts.js";
 
 type SpawnCall = {
   command: string;
@@ -176,6 +180,28 @@ function createSandboxConfig(
   };
 }
 
+function computeExpectedSandboxHash(
+  cfg: SandboxConfig,
+  workspaceDir: string,
+  dockerEnvPolicyEpoch?: number,
+): string {
+  const mounts = resolveReadOnlyWorkspaceSkillMounts({
+    workspaceDir,
+    agentWorkspaceDir: workspaceDir,
+    workdir: cfg.docker.workdir,
+    workspaceAccess: cfg.workspaceAccess,
+  });
+  return computeSandboxConfigHash({
+    docker: cfg.docker,
+    dockerEnvPolicyEpoch,
+    workspaceAccess: cfg.workspaceAccess,
+    workspaceDir,
+    agentWorkspaceDir: workspaceDir,
+    mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
+    readOnlyWorkspaceSkillMounts: formatReadOnlyWorkspaceSkillMountHashState(mounts),
+  });
+}
+
 async function ensureSandboxCreateCallForTest(params: {
   cfg: SandboxConfig;
   workspaceDir?: string;
@@ -222,22 +248,8 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     const oldCfg = createSandboxConfig(["1.1.1.1", "8.8.8.8"], [`${workspaceDir}:/workspace:rw`]);
     const newCfg = createSandboxConfig(["8.8.8.8", "1.1.1.1"], [`${workspaceDir}:/workspace:rw`]);
 
-    const oldHash = computeSandboxConfigHash({
-      docker: oldCfg.docker,
-      workspaceAccess: oldCfg.workspaceAccess,
-      workspaceDir,
-      agentWorkspaceDir: workspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
-    });
-    const newHash = computeSandboxConfigHash({
-      docker: newCfg.docker,
-      workspaceAccess: newCfg.workspaceAccess,
-      workspaceDir,
-      agentWorkspaceDir: workspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
-    });
+    const oldHash = computeExpectedSandboxHash(oldCfg, workspaceDir);
+    const newHash = computeExpectedSandboxHash(newCfg, workspaceDir);
     expect(newHash).not.toBe(oldHash);
 
     spawnState.labelHash = oldHash;
@@ -283,23 +295,12 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     });
     cfg.docker.binds = [`${workspaceDir}:/workspace:rw`];
 
-    const oldHash = computeSandboxConfigHash({
-      docker: cfg.docker,
-      workspaceAccess: cfg.workspaceAccess,
+    const oldHash = computeExpectedSandboxHash(cfg, workspaceDir);
+    const newHash = computeExpectedSandboxHash(
+      cfg,
       workspaceDir,
-      agentWorkspaceDir: workspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
-    });
-    const newHash = computeSandboxConfigHash({
-      docker: cfg.docker,
-      dockerEnvPolicyEpoch: SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
-      workspaceAccess: cfg.workspaceAccess,
-      workspaceDir,
-      agentWorkspaceDir: workspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
-    });
+      SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
+    );
     expect(newHash).not.toBe(oldHash);
 
     spawnState.labelHash = oldHash;
@@ -328,14 +329,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     const customUserFile = path.join(customRoot, "USER.md");
     const cfg = createSandboxConfig(["1.1.1.1"], [`${customUserFile}:/workspace/USER.md:ro`]);
     cfg.docker.dangerouslyAllowExternalBindSources = true;
-    const expectedHash = computeSandboxConfigHash({
-      docker: cfg.docker,
-      workspaceAccess: cfg.workspaceAccess,
-      workspaceDir,
-      agentWorkspaceDir: workspaceDir,
-      mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
-      readOnlyWorkspaceSkillMounts: [],
-    });
+    const expectedHash = computeExpectedSandboxHash(cfg, workspaceDir);
 
     spawnState.inspectRunning = false;
     spawnState.labelHash = "stale-hash";

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -64,7 +64,12 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith(workspaceDir));
-    expect(mounts).toEqual([`${workspaceDir}:/workspace:z`]);
+    expect(mounts).toEqual([
+      `${workspaceDir}:/workspace:z`,
+      `${path.join(workspaceDir, "skills")}:/workspace/skills:ro,z`,
+      `${path.join(workspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
+      `${path.join(workspaceDir, ".openclaw", "sandbox-skills", "skills")}:/workspace/.openclaw/sandbox-skills/skills:ro,z`,
+    ]);
   });
 
   it("marks split agent workspace mounts shared for SELinux", () => {
@@ -101,6 +106,8 @@ describe("appendWorkspaceMountArgs", () => {
     expect(mounts).toEqual([
       `${agentWorkspaceDir}:/workspace:z`,
       `${path.join(agentWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+      `${path.join(agentWorkspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
+      `${path.join(agentWorkspaceDir, ".openclaw", "sandbox-skills", "skills")}:/workspace/.openclaw/sandbox-skills/skills:ro,z`,
     ]);
   });
 
@@ -122,7 +129,11 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
-    expect(mounts).toEqual([`${agentWorkspaceDir}:/workspace:z`]);
+    expect(mounts).toEqual([
+      `${agentWorkspaceDir}:/workspace:z`,
+      `${path.join(agentWorkspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
+      `${path.join(agentWorkspaceDir, ".openclaw", "sandbox-skills", "skills")}:/workspace/.openclaw/sandbox-skills/skills:ro,z`,
+    ]);
   });
 
   it.runIf(process.platform !== "win32")(
@@ -143,7 +154,11 @@ describe("appendWorkspaceMountArgs", () => {
       });
 
       const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
-      expect(mounts).toEqual([`${agentWorkspaceDir}:/workspace:z`]);
+      expect(mounts).toEqual([
+        `${agentWorkspaceDir}:/workspace:z`,
+        `${path.join(agentWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+        `${path.join(agentWorkspaceDir, ".openclaw", "sandbox-skills", "skills")}:/workspace/.openclaw/sandbox-skills/skills:ro,z`,
+      ]);
     },
   );
 
@@ -169,7 +184,9 @@ describe("appendWorkspaceMountArgs", () => {
     const mounts = args.filter((arg) => arg.startsWith(agentWorkspaceDir));
     expect(mounts).toEqual([
       `${agentWorkspaceDir}:/workspace:z`,
+      `${path.join(agentWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
       `${path.join(agentWorkspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
+      `${path.join(agentWorkspaceDir, ".openclaw", "sandbox-skills", "skills")}:/workspace/.openclaw/sandbox-skills/skills:ro,z`,
     ]);
   });
 
@@ -195,6 +212,8 @@ describe("appendWorkspaceMountArgs", () => {
     );
     expect(mounts).toEqual([
       `${agentWorkspaceDir}:/workspace:z`,
+      `${path.join(agentWorkspaceDir, "skills")}:/workspace/skills:ro,z`,
+      `${path.join(agentWorkspaceDir, ".agents", "skills")}:/workspace/.agents/skills:ro,z`,
       `${materializedSkillsDir}:/workspace/.openclaw/sandbox-skills/skills:ro,z`,
     ]);
   });

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -74,7 +74,8 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
   // RW workspaces mount the project as writable, but skill sources remain read-only so agent
   // instructions are visible without letting sandbox commands mutate them.
   const materializedSkillsWorkspaceDir =
-    params.skillsWorkspaceDir ?? resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
+    params.skillsWorkspaceDir ??
+    resolveMaterializedSandboxSkillsWorkspaceDir(params.agentWorkspaceDir);
   const mounts = [
     {
       hostPath: path.join(params.agentWorkspaceDir, "skills"),
@@ -96,6 +97,16 @@ export function resolveReadOnlyWorkspaceSkillMounts(params: {
       rootDir: materializedSkillsWorkspaceDir,
     },
   ];
+
+  // Ensure skill mount source directories exist so read-only mounts are always
+  // applied, even on first agent launch when directories haven't been created yet.
+  for (const mount of mounts) {
+    try {
+      fs.mkdirSync(mount.hostPath, { recursive: true });
+    } catch {
+      // skip — isExistingWorkspaceSkillMountSource will filter it out
+    }
+  }
 
   return mounts
     .filter((mount) =>


### PR DESCRIPTION
## Summary

- Ensures sandbox skill directories (skills, .agents/skills, .openclaw/sandbox-skills) are created before isExistingWorkspaceSkillMountSource checks them
- Fixes a vulnerability where these directories didn't exist on first agent launch, causing the read-only mount to be skipped and making skill sources writable inside the sandbox

Fixes #94425

## Real behavior proof (required for external PRs)

**Behavior addressed**: On first sandbox agent launch, skill source directories don't exist yet because ensureAgentWorkspace doesn't create them. isExistingWorkspaceSkillMountSource returns false for non-existent directories, so resolveReadOnlyWorkspaceSkillMounts returns an empty list - the read-only overlay mount is skipped entirely.

**Real setup tested**:
- **Runtime**: node (unit test suite)

**Exact steps or command run after fix**:

```
pnpm vitest run src/agents/sandbox/workspace-mounts.test.ts src/agents/sandbox/docker.config-hash-recreate.test.ts src/agents/sandbox/config-hash.test.ts src/agents/sandbox/browser.create.test.ts src/agents/agent-tools.sandbox-mounted-paths.workspace-only.test.ts
```

**After-fix evidence**:

```
PASS (26) FAIL (0) - workspace-mounts.test.ts
PASS (16) FAIL (0) - docker.config-hash-recreate.test.ts
PASS (11) FAIL (0) - config-hash.test.ts
PASS (36) FAIL (0) - browser.create.test.ts
PASS (12) FAIL (0) - agent-tools.sandbox-mounted-paths.workspace-only.test.ts
```

**Observed result after the fix**: All 101 tests pass across 5 test files. The mkdirSync loop creates all 3 skill directories before isExistingWorkspaceSkillMountSource filtering, so read-only mounts are consistently applied even on first launch.

**What was not tested**: Full Docker sandbox end-to-end (requires Docker daemon). The fix is validated through unit tests.

**Proof limitations or environment constraints**: Unit tests verify the mount arg output matches expectations; a Docker integration test would additionally confirm the container layers compose correctly.

## Tests and validation

All 5 test files pass (101 tests total):
- workspace-mounts.test.ts - 26 tests covering all 3 skill mount sources
- docker.config-hash-recreate.test.ts - 16 tests covering config-hash consistency
- config-hash.test.ts - 11 tests for mount format version stability
- browser.create.test.ts - 36 tests including browser skill overlay ordering
- agent-tools.sandbox-mounted-paths.workspace-only.test.ts - 12 workspace-only guard tests

## Risk checklist

Did user-visible behavior change? (No)
- Internal sandbox security hardening only

Did config, environment, or migration behavior change? (No)

Did security, auth, secrets, network, or tool execution behavior change? (Yes)
- Sandbox skill directories are now always read-only, even on first agent launch
- Prevents sandboxed agents from modifying skill instructions

What is the highest-risk area?
- Existing sandbox containers created before this fix had writable skill dirs. After upgrade, newly created containers will have read-only skills

How is that risk mitigated?
- Read-only skill mounts are an established security pattern in the codebase; this fix ensures they are applied consistently. No running sandbox state changes.

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- Docker integration test (requires Docker daemon, not available in this environment)

Which bot or reviewer comments were addressed?
- N/A