### PR TITLE
fix: expand leading tilde in exec workdir paths

### DIFF
--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -8,7 +8,7 @@ import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion";
-import { sliceUtf16Safe } from "../utils.js";
+import { resolveUserPath, sliceUtf16Safe } from "../utils.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxBackendExecSpec } from "./sandbox/backend-handle.types.js";
 
@@ -183,10 +183,11 @@ function normalizeContainerPath(input: string): string {
 export function resolveWorkdir(workdir: string, warnings: string[]) {
   const current = safeCwd();
   const fallback = current ?? homedir();
+  const resolved = resolveUserPath(workdir);
   try {
-    const stats = statSync(workdir);
+    const stats = statSync(resolved);
     if (stats.isDirectory()) {
-      return workdir;
+      return resolved;
     }
   } catch {
     // ignore, fallback below


### PR DESCRIPTION
## Summary

Fixes #94434 — exec workdir with leading `~` was treated literally, causing the path check to fail and the command to run from an unintended fallback directory. Use `resolveUserPath` to expand `~` before checking the directory.

## Root Cause

`resolveWorkdir` in `bash-tools.shared.ts` called `statSync(workdir)` on the raw path without expanding `~` (a shell feature not handled by Node.js `statSync`). The path check always failed for `~/` paths, falling through to the fallback directory.

## Fix

Call `resolveUserPath(workdir)` before `statSync` to expand the leading `~` consistently with other user-facing path inputs.

## Testing

- `src/agents/bash-tools.shared.test.ts` — 11 tests passed
- Lint: clean (oxlint)

## Real behavior proof

**Behavior or issue addressed**: exec workdir `~/path` silently falls back to wrong directory.

**Real environment tested**: Windows 10 LTSC 2019, Node.js v24.14.0, OpenClaw worktree on main.

**Exact steps or command run after this patch**:
```bash
npx oxlint --config .oxlintrc.json src/agents/bash-tools.shared.ts
node scripts/run-vitest.mjs src/agents/bash-tools.shared.test.ts
```

**Evidence after fix**:
```
Lint: no issues found
bash-tools.shared.test.ts: 11 tests passed
```

**Observed result after fix**: `resolveWorkdir` now expands `~` before checking path existence.

**What was not tested**: Full E2E exec with `~/` workdir path (no agent available).
